### PR TITLE
Changed so the the logviewer's date input is using the umb-input-date…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/css/dark.theme.css
+++ b/src/Umbraco.Web.UI.Client/src/css/dark.theme.css
@@ -44,4 +44,5 @@
 	--uui-color-positive-emphasis: #347d39;
 	--uui-color-positive-standalone: #347d39;
 	--uui-color-positive-contrast: #eeeeef;
+	--uui-color-scheme: dark;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
@@ -1,4 +1,4 @@
-import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { customElement, css } from '@umbraco-cms/backoffice/external/lit';
 import { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 
 export type InputDateType = 'date' | 'time' | 'datetime-local';
@@ -28,6 +28,16 @@ export class UmbInputDateElement extends UUIInputElement {
 		super();
 		this.type = 'date'; // Default to 'date'
 	}
+
+	// Adding styles override to add a darkmode version.
+	static override styles = [
+		...UUIInputElement.styles,
+		css`
+			input {
+				color-scheme: var(--uui-color-scheme, normal);
+			}
+		`,
+	];
 }
 
 export default UmbInputDateElement;

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/components/log-viewer-date-range-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/components/log-viewer-date-range-selector.element.ts
@@ -70,7 +70,7 @@ export class UmbLogViewerDateRangeSelectorElement extends UmbLitElement {
 		return html`
 			<div class="input-container">
 				<uui-label for="start-date">From:</uui-label>
-				<input
+				<umb-input-date
 					@click=${(e: Event) => {
 						(e.target as HTMLInputElement).showPicker();
 					}}
@@ -78,11 +78,11 @@ export class UmbLogViewerDateRangeSelectorElement extends UmbLitElement {
 					type="date"
 					label="From"
 					.max=${this.#logViewerContext?.today ?? ''}
-					.value=${this._startDate} />
+					.value=${this._startDate}></umb-input-date>
 			</div>
 			<div class="input-container">
 				<uui-label for="end-date">To: </uui-label>
-				<input
+				<umb-input-date
 					@click=${(e: Event) => {
 						(e.target as HTMLInputElement).showPicker();
 					}}
@@ -91,7 +91,7 @@ export class UmbLogViewerDateRangeSelectorElement extends UmbLitElement {
 					label="To"
 					.min=${this._startDate}
 					.max=${this.#logViewerContext?.today ?? ''}
-					.value=${this._endDate} />
+					.value=${this._endDate}></umb-input-date>
 			</div>
 		`;
 	}
@@ -104,30 +104,14 @@ export class UmbLogViewerDateRangeSelectorElement extends UmbLitElement {
 				flex-direction: column;
 				gap: var(--uui-size-space-3);
 			}
-
-			input {
-				font-family: inherit;
-				padding: var(--uui-size-1) var(--uui-size-space-3);
-				font-size: inherit;
-				color: inherit;
-				border-radius: 0;
-				box-sizing: border-box;
-				border: none;
-				background: none;
+			umb-input-date {
 				width: 100%;
-				outline: none;
-				position: relative;
-				border-bottom: 2px solid transparent;
-			}
-
-			/* find out better validation for that  */
-			input:out-of-range {
-				border-color: var(--uui-color-danger);
 			}
 
 			:host([horizontal]) .input-container {
 				display: flex;
 				align-items: baseline;
+				gap: var(--uui-size-space-3);
 			}
 		`,
 	];


### PR DESCRIPTION


Issue: https://github.com/umbraco/Umbraco-CMS/issues/18371

### Description


* Changed so the the logviewer's date input is using the umb-input-date instead.
* Gave the umb-input-date a color-scheme property.
* Added the color-scheme dark, for the darkmode CSS.
* Removed the CSS used for the input custom input tag so it uses the standard umb-input-date.
* Added the extra CSS needed for the umb-input-date to look as it did before.
