### PR TITLE
Check for NRT directory when populating LuceneIndexFolder for Examine Dashboard

### DIFF
--- a/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
+++ b/src/Umbraco.Examine.Lucene/LuceneIndexDiagnostics.cs
@@ -60,10 +60,17 @@ public class LuceneIndexDiagnostics : IIndexDiagnostics
                 ["LuceneDirectory"] = luceneDir.GetType().Name
             };
 
-            if (luceneDir is FSDirectory fsDir)
+            var directoryPath = luceneDir switch
+            {
+                NRTCachingDirectory nrtDir => nrtDir.Delegate.ToString(),
+                FSDirectory fsDir => fsDir.Directory.ToString(),
+                _ => null
+            };
+
+            if (directoryPath != null)
             {
                 var rootDir = _hostingEnvironment.ApplicationPhysicalPath;
-                d["LuceneIndexFolder"] = fsDir.Directory.ToString().ToLowerInvariant()
+                d["LuceneIndexFolder"] = directoryPath.ToLowerInvariant()
                     .TrimStart(rootDir.ToLowerInvariant()).Replace("\\", " /").EnsureStartsWith('/');
             }
 


### PR DESCRIPTION
The LuceneIndexFolder is not currently showing in the Examine Dashboard, this due to a change to the LuceneDirectory to use NRTCachingDirectory which was not being checked. This PR supports getting LuceneIndexFolder from a NRTCachingDirectory.

The NRTCachingDirectory contains additional information that may be useful to be able to view so I have not extracted only the file path from it but this could be done if deemed relevant. 

![image](https://github.com/user-attachments/assets/3aad973e-4e41-4c2c-ab9f-4401d28c382e)
