### PR TITLE
Update 01_bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -6,8 +6,8 @@ body:
 - type: input
   id: "version"
   attributes:
-    label: "Which Umbraco version are you using? (Please write the *exact* version, example: 10.1.0)"
-    description: "Use the help icon in the Umbraco backoffice to find the version you're using"
+    label: "Which Umbraco version are you using?"
+    description: "Please write the *exact* version, example: `10.1.0`. Use the help icon in the Umbraco backoffice to find the version you're using"
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
To avoid loosing the ability to hover and discover the version name. I suggest to move the invitation for writing the full version number into the description.

Avoiding this:
![image](https://github.com/user-attachments/assets/ef0a1826-4e0b-4c11-8424-71cf273796a2)

(Sorry I was not able to imitate how the result of this PR will be.

But this is how it should look when creating a issue after this has been merged:
![image](https://github.com/user-attachments/assets/4ef5920d-5cf5-4ed8-9c22-55ceddb52c65)
