### PR TITLE
Feature: Content Type Workspace Editor Header Element

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/global-components/content-type-workspace-editor-header.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/global-components/content-type-workspace-editor-header.element.ts
@@ -1,0 +1,156 @@
+import { UMB_CONTENT_TYPE_WORKSPACE_CONTEXT } from '../workspace/content-type-workspace.context-token.js';
+import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
+import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
+import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/icon';
+import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
+import { umbBindToValidation } from '@umbraco-cms/backoffice/validation';
+
+@customElement('umb-content-type-workspace-editor-header')
+export class UmbContentTypeWorkspaceEditorHeaderElement extends UmbLitElement {
+	@state()
+	private _name?: string;
+
+	@state()
+	private _alias?: string;
+
+	@state()
+	private _description?: string;
+
+	@state()
+	private _icon?: string;
+
+	@state()
+	private _isNew?: boolean;
+
+	#workspaceContext?: typeof UMB_CONTENT_TYPE_WORKSPACE_CONTEXT.TYPE;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_CONTENT_TYPE_WORKSPACE_CONTEXT, (instance) => {
+			this.#workspaceContext = instance;
+			this.#observeContentType();
+		});
+	}
+
+	#observeContentType() {
+		if (!this.#workspaceContext) return;
+		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
+		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
+		this.observe(
+			this.#workspaceContext.description,
+			(description) => (this._description = description),
+			'_observeDescription',
+		);
+		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
+		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
+	}
+
+	private async _handleIconClick() {
+		const [alias, color] = this._icon?.replace('color-', '')?.split(' ') ?? [];
+		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
+		const modalContext = modalManager.open(this, UMB_ICON_PICKER_MODAL, {
+			value: {
+				icon: alias,
+				color: color,
+			},
+		});
+
+		modalContext?.onSubmit().then((saved) => {
+			if (saved.icon && saved.color) {
+				this.#workspaceContext?.setIcon(`${saved.icon} color-${saved.color}`);
+			} else if (saved.icon) {
+				this.#workspaceContext?.setIcon(saved.icon);
+			}
+		});
+	}
+
+	#onNameAndAliasChange(event: InputEvent & { target: UmbInputWithAliasElement }) {
+		this.#workspaceContext?.setName(event.target.value ?? '');
+		this.#workspaceContext?.setAlias(event.target.alias ?? '');
+	}
+
+	#onDescriptionChange(event: InputEvent & { target: UUITextareaElement }) {
+		this.#workspaceContext?.setDescription(event.target.value.toString() ?? '');
+	}
+
+	override render() {
+		return html`
+			<div id="header">
+				<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
+					<umb-icon name=${ifDefined(this._icon)}></umb-icon>
+				</uui-button>
+
+				<div id="editors">
+					<umb-input-with-alias
+						id="name"
+						label=${this.localize.term('placeholders_entername')}
+						.value=${this._name}
+						.alias=${this._alias}
+						?auto-generate-alias=${this._isNew}
+						@change=${this.#onNameAndAliasChange}
+						required
+						${umbBindToValidation(this, '$.name', this._name)}
+						${umbFocus()}>
+					</umb-input-with-alias>
+
+					<uui-input
+						id="description"
+						.label=${this.localize.term('placeholders_enterDescription')}
+						.value=${this._description}
+						.placeholder=${this.localize.term('placeholders_enterDescription')}
+						@input=${this.#onDescriptionChange}></uui-input>
+				</div>
+			</div>
+		`;
+	}
+
+	static override styles = [
+		css`
+			:host {
+				display: contents;
+			}
+
+			#header {
+				display: flex;
+				flex: 1 1 auto;
+				gap: var(--uui-size-space-2);
+			}
+
+			#editors {
+				display: flex;
+				flex: 1 1 auto;
+				flex-direction: column;
+				gap: var(--uui-size-space-1);
+			}
+
+			#name {
+				width: 100%;
+			}
+
+			#description {
+				width: 100%;
+				--uui-input-height: var(--uui-size-8);
+				--uui-input-border-color: transparent;
+			}
+
+			#description:hover {
+				--uui-input-border-color: var(--uui-color-border);
+			}
+
+			#icon {
+				font-size: var(--uui-size-8);
+				height: 60px;
+				width: 60px;
+			}
+		`,
+	];
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-content-type-workspace-editor-header': UmbContentTypeWorkspaceEditorHeaderElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/global-components/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/global-components/index.ts
@@ -1,0 +1,3 @@
+import './content-type-workspace-editor-header.element.js';
+
+export * from './content-type-workspace-editor-header.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/index.ts
@@ -1,4 +1,5 @@
 export * from './constants.js';
+export * from './global-components/index.js';
 export * from './repository/index.js';
 export * from './structure/index.js';
 export * from './workspace/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/content-type-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/content-type-workspace-context-base.ts
@@ -252,6 +252,14 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 		this.structure.updateOwnerContentType({ compositions } as Partial<DetailModelType>);
 	}
 
+	/**
+	 * Gets the icon of the content type
+	 * @returns { string | undefined } The icon of the content type
+	 */
+	public getIcon(): string | undefined {
+		return this.structure.getOwnerContentType()?.icon;
+	}
+
 	// TODO: manage setting icon color alias?
 	public setIcon(icon: string) {
 		this.structure.updateOwnerContentType({ icon } as Partial<DetailModelType>);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/content-type-workspace-context.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/content-type-workspace-context.interface.ts
@@ -21,9 +21,18 @@ export interface UmbContentTypeWorkspaceContext<ContentTypeType extends UmbConte
 
 	readonly structure: UmbContentTypeStructureManager<ContentTypeType>;
 
+	getAlias(): string | undefined;
 	setAlias(alias: string): void;
+
+	getCompositions(): Array<UmbContentTypeCompositionModel> | undefined;
 	setCompositions(compositions: Array<UmbContentTypeCompositionModel>): void;
+
+	getDescription(): string | undefined;
 	setDescription(description: string): void;
+
+	getIcon(): string | undefined;
 	setIcon(icon: string): void;
+
+	getName(): string | undefined;
 	setName(name: string): void;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/content-type-workspace-context.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/content-type-workspace-context.interface.ts
@@ -8,7 +8,6 @@ export interface UmbContentTypeWorkspaceContext<ContentTypeType extends UmbConte
 	readonly IS_CONTENT_TYPE_WORKSPACE_CONTEXT: true;
 
 	readonly name: Observable<string | undefined>;
-	getName(): string | undefined;
 	readonly alias: Observable<string | undefined>;
 	readonly description: Observable<string | undefined>;
 	readonly icon: Observable<string | undefined>;
@@ -23,6 +22,8 @@ export interface UmbContentTypeWorkspaceContext<ContentTypeType extends UmbConte
 	readonly structure: UmbContentTypeStructureManager<ContentTypeType>;
 
 	setAlias(alias: string): void;
-
 	setCompositions(compositions: Array<UmbContentTypeCompositionModel>): void;
+	setDescription(description: string): void;
+	setIcon(icon: string): void;
+	setName(name: string): void;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace-editor.element.ts
@@ -1,110 +1,12 @@
-import { UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT } from './document-type-workspace.context-token.js';
-import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
-import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
-import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import { UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/icon';
-import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
-import { umbBindToValidation } from '@umbraco-cms/backoffice/validation';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 
 @customElement('umb-document-type-workspace-editor')
 export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
-	@state()
-	private _name?: string;
-
-	@state()
-	private _alias?: string;
-
-	@state()
-	private _description?: string;
-
-	@state()
-	private _icon?: string;
-
-	@state()
-	private _isNew?: boolean;
-
-	#workspaceContext?: typeof UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT.TYPE;
-
-	constructor() {
-		super();
-
-		this.consumeContext(UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT, (instance) => {
-			this.#workspaceContext = instance;
-			this.#observeDocumentType();
-		});
-	}
-
-	#observeDocumentType() {
-		if (!this.#workspaceContext) return;
-		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
-		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
-		this.observe(
-			this.#workspaceContext.description,
-			(description) => (this._description = description),
-			'_observeDescription',
-		);
-		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
-		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
-	}
-
-	private async _handleIconClick() {
-		const [alias, color] = this._icon?.replace('color-', '')?.split(' ') ?? [];
-		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-		const modalContext = modalManager.open(this, UMB_ICON_PICKER_MODAL, {
-			value: {
-				icon: alias,
-				color: color,
-			},
-		});
-
-		modalContext?.onSubmit().then((saved) => {
-			if (saved.icon && saved.color) {
-				this.#workspaceContext?.setIcon(`${saved.icon} color-${saved.color}`);
-			} else if (saved.icon) {
-				this.#workspaceContext?.setIcon(saved.icon);
-			}
-		});
-	}
-
-	#onNameAndAliasChange(event: InputEvent & { target: UmbInputWithAliasElement }) {
-		this.#workspaceContext?.setName(event.target.value ?? '');
-		this.#workspaceContext?.setAlias(event.target.alias ?? '');
-	}
-
-	#onDescriptionChange(event: InputEvent & { target: UUITextareaElement }) {
-		this.#workspaceContext?.setDescription(event.target.value.toString() ?? '');
-	}
-
 	override render() {
 		return html`
 			<umb-entity-detail-workspace-editor>
-				<div id="header" slot="header">
-					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
-						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
-					</uui-button>
-
-					<div id="editors">
-						<umb-input-with-alias
-							id="name"
-							label=${this.localize.term('placeholders_entername')}
-							.value=${this._name}
-							.alias=${this._alias}
-							?auto-generate-alias=${this._isNew}
-							@change=${this.#onNameAndAliasChange}
-							required
-							${umbBindToValidation(this, '$.name', this._name)}
-							${umbFocus()}>
-						</umb-input-with-alias>
-
-						<uui-input
-							id="description"
-							.label=${this.localize.term('placeholders_enterDescription')}
-							.value=${this._description}
-							.placeholder=${this.localize.term('placeholders_enterDescription')}
-							@input=${this.#onDescriptionChange}></uui-input>
-					</div>
-				</div>
+				<umb-content-type-workspace-editor-header slot="header"></umb-content-type-workspace-editor-header>
 			</umb-entity-detail-workspace-editor>
 		`;
 	}
@@ -115,39 +17,6 @@ export class UmbDocumentTypeWorkspaceEditorElement extends UmbLitElement {
 				display: block;
 				width: 100%;
 				height: 100%;
-			}
-
-			#header {
-				display: flex;
-				flex: 1 1 auto;
-				gap: var(--uui-size-space-2);
-			}
-
-			#editors {
-				display: flex;
-				flex: 1 1 auto;
-				flex-direction: column;
-				gap: var(--uui-size-space-1);
-			}
-
-			#name {
-				width: 100%;
-			}
-
-			#description {
-				width: 100%;
-				--uui-input-height: var(--uui-size-8);
-				--uui-input-border-color: transparent;
-			}
-
-			#description:hover {
-				--uui-input-border-color: var(--uui-color-border);
-			}
-
-			#icon {
-				font-size: var(--uui-size-8);
-				height: 60px;
-				width: 60px;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace-editor.element.ts
@@ -1,112 +1,12 @@
-import type { UmbMediaTypeWorkspaceContext } from './media-type-workspace.context.js';
-import { UMB_MEDIA_TYPE_WORKSPACE_CONTEXT } from './media-type-workspace.context-token.js';
-import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
-import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import { UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/icon';
-import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
-import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
+import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-media-type-workspace-editor')
 export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
-	@state()
-	private _name?: string;
-
-	@state()
-	private _description?: string;
-
-	@state()
-	private _alias?: string;
-
-	@state()
-	private _aliasLocked = true;
-
-	@state()
-	private _icon?: string;
-
-	@state()
-	private _isNew?: boolean;
-
-	#workspaceContext?: UmbMediaTypeWorkspaceContext;
-
-	constructor() {
-		super();
-
-		this.consumeContext(UMB_MEDIA_TYPE_WORKSPACE_CONTEXT, (context) => {
-			this.#workspaceContext = context;
-			this.#observeMediaType();
-		});
-	}
-
-	#observeMediaType() {
-		if (!this.#workspaceContext) return;
-		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
-		this.observe(
-			this.#workspaceContext.description,
-			(description) => (this._description = description),
-			'_observeDescription',
-		);
-		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
-		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
-		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
-	}
-
-	private async _handleIconClick() {
-		const [alias, color] = this._icon?.replace('color-', '')?.split(' ') ?? [];
-
-		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-		const modalContext = modalManager.open(this, UMB_ICON_PICKER_MODAL, {
-			value: {
-				icon: alias,
-				color: color,
-			},
-		});
-
-		modalContext?.onSubmit().then((saved) => {
-			if (saved.icon && saved.color) {
-				this.#workspaceContext?.setIcon(`${saved.icon} color-${saved.color}`);
-			} else if (saved.icon) {
-				this.#workspaceContext?.setIcon(saved.icon);
-			}
-		});
-	}
-
-	#onNameAndAliasChange(event: InputEvent & { target: UmbInputWithAliasElement }) {
-		this.#workspaceContext?.setName(event.target.value ?? '');
-		this.#workspaceContext?.setAlias(event.target.alias ?? '');
-	}
-
-	#onDescriptionChange(event: InputEvent & { target: UUITextareaElement }) {
-		this.#workspaceContext?.setDescription(event.target.value.toString() ?? '');
-	}
-
 	override render() {
 		return html`
 			<umb-entity-detail-workspace-editor>
-				<div id="header" slot="header">
-					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
-						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
-					</uui-button>
-
-					<div id="editors">
-						<umb-input-with-alias
-							id="name"
-							label=${this.localize.term('placeholders_entername')}
-							value=${this._name}
-							alias=${this._alias}
-							?auto-generate-alias=${this._isNew}
-							@change=${this.#onNameAndAliasChange}
-							${umbFocus()}>
-						</umb-input-with-alias>
-
-						<uui-input
-							id="description"
-							.label=${this.localize.term('placeholders_enterDescription')}
-							.value=${this._description}
-							.placeholder=${this.localize.term('placeholders_enterDescription')}
-							@input=${this.#onDescriptionChange}></uui-input>
-					</div>
-				</div>
+				<umb-content-type-workspace-editor-header slot="header"></umb-content-type-workspace-editor-header>
 			</umb-entity-detail-workspace-editor>
 		`;
 	}
@@ -117,39 +17,6 @@ export class UmbMediaTypeWorkspaceEditorElement extends UmbLitElement {
 				display: block;
 				width: 100%;
 				height: 100%;
-			}
-
-			#header {
-				display: flex;
-				flex: 1 1 auto;
-				gap: var(--uui-size-space-2);
-			}
-
-			#editors {
-				display: flex;
-				flex: 1 1 auto;
-				flex-direction: column;
-				gap: var(--uui-size-space-1);
-			}
-
-			#name {
-				width: 100%;
-			}
-
-			#description {
-				width: 100%;
-				--uui-input-height: var(--uui-size-8);
-				--uui-input-border-color: transparent;
-			}
-
-			#description:hover {
-				--uui-input-border-color: var(--uui-color-border);
-			}
-
-			#icon {
-				font-size: var(--uui-size-8);
-				height: 60px;
-				width: 60px;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace-editor.element.ts
@@ -1,107 +1,12 @@
-import { UMB_MEMBER_TYPE_WORKSPACE_CONTEXT } from './member-type-workspace.context-token.js';
-import type { UmbInputWithAliasElement } from '@umbraco-cms/backoffice/components';
-import { css, html, customElement, state, ifDefined } from '@umbraco-cms/backoffice/external/lit';
-import type { UUITextareaElement } from '@umbraco-cms/backoffice/external/uui';
-import { UmbLitElement, umbFocus } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import { UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/icon';
+import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-member-type-workspace-editor')
 export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
-	@state()
-	private _name?: string;
-
-	@state()
-	private _description?: string;
-
-	@state()
-	private _alias?: string;
-
-	@state()
-	private _icon?: string;
-
-	@state()
-	private _isNew?: boolean;
-
-	#workspaceContext?: typeof UMB_MEMBER_TYPE_WORKSPACE_CONTEXT.TYPE;
-
-	constructor() {
-		super();
-
-		this.consumeContext(UMB_MEMBER_TYPE_WORKSPACE_CONTEXT, (instance) => {
-			this.#workspaceContext = instance;
-			this.#observeMemberType();
-		});
-	}
-
-	#observeMemberType() {
-		if (!this.#workspaceContext) return;
-		this.observe(this.#workspaceContext.name, (name) => (this._name = name), '_observeName');
-		this.observe(
-			this.#workspaceContext.description,
-			(description) => (this._description = description),
-			'_observeDescription',
-		);
-		this.observe(this.#workspaceContext.alias, (alias) => (this._alias = alias), '_observeAlias');
-		this.observe(this.#workspaceContext.icon, (icon) => (this._icon = icon), '_observeIcon');
-		this.observe(this.#workspaceContext.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
-	}
-
-	private async _handleIconClick() {
-		const [alias, color] = this._icon?.replace('color-', '')?.split(' ') ?? [];
-		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-		const modalContext = modalManager.open(this, UMB_ICON_PICKER_MODAL, {
-			value: {
-				icon: alias,
-				color: color,
-			},
-		});
-
-		modalContext?.onSubmit().then((saved) => {
-			if (saved.icon && saved.color) {
-				this.#workspaceContext?.set('icon', `${saved.icon} color-${saved.color}`);
-			} else if (saved.icon) {
-				this.#workspaceContext?.set('icon', saved.icon);
-			}
-		});
-	}
-
-	#onNameAndAliasChange(event: InputEvent & { target: UmbInputWithAliasElement }) {
-		this.#workspaceContext?.setName(event.target.value ?? '');
-		this.#workspaceContext?.setAlias(event.target.alias ?? '');
-	}
-
-	#onDescriptionChange(event: InputEvent & { target: UUITextareaElement }) {
-		this.#workspaceContext?.setDescription(event.target.value.toString() ?? '');
-	}
-
 	override render() {
 		return html`
 			<umb-entity-detail-workspace-editor>
-				<div id="header" slot="header">
-					<uui-button id="icon" compact label="icon" look="outline" @click=${this._handleIconClick}>
-						<umb-icon name=${ifDefined(this._icon)}></umb-icon>
-					</uui-button>
-
-					<div id="editors">
-						<umb-input-with-alias
-							id="name"
-							label=${this.localize.term('placeholders_entername')}
-							value=${this._name}
-							alias=${this._alias}
-							?auto-generate-alias=${this._isNew}
-							@change=${this.#onNameAndAliasChange}
-							${umbFocus()}>
-						</umb-input-with-alias>
-
-						<uui-input
-							id="description"
-							.label=${this.localize.term('placeholders_enterDescription')}
-							.value=${this._description}
-							.placeholder=${this.localize.term('placeholders_enterDescription')}
-							@input=${this.#onDescriptionChange}></uui-input>
-					</div>
-				</div>
+				<umb-content-type-workspace-editor-header slot="header"></umb-content-type-workspace-editor-header>
 			</umb-entity-detail-workspace-editor>
 		`;
 	}
@@ -112,51 +17,6 @@ export class UmbMemberTypeWorkspaceEditorElement extends UmbLitElement {
 				display: block;
 				width: 100%;
 				height: 100%;
-			}
-
-			#header {
-				display: flex;
-				flex: 1 1 auto;
-				gap: var(--uui-size-space-2);
-			}
-
-			#editors {
-				display: flex;
-				flex: 1 1 auto;
-				flex-direction: column;
-				gap: var(--uui-size-space-1);
-			}
-
-			#name {
-				width: 100%;
-				flex: 1 1 auto;
-				align-items: center;
-			}
-
-			#description {
-				width: 100%;
-				--uui-input-height: var(--uui-size-8);
-				--uui-input-border-color: transparent;
-			}
-
-			#description:hover {
-				--uui-input-border-color: var(--uui-color-border);
-			}
-
-			#alias-lock {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				cursor: pointer;
-			}
-			#alias-lock uui-icon {
-				margin-bottom: 2px;
-			}
-
-			#icon {
-				font-size: var(--uui-size-8);
-				height: 60px;
-				width: 60px;
 			}
 		`,
 	];


### PR DESCRIPTION
This PR introduces a `<umb-content-type-workspace-editor-header>` element to align the three Content Type workspace headers.

With this element, it has been possible to remove some duplicated code.