### PR TITLE
Added obsoletion messages for unused interface and implementation for cache rebuilds.

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/PostMigrations/CacheRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PostMigrations/CacheRebuilder.cs
@@ -7,6 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.PostMigrations;
 /// <summary>
 ///     Implements <see cref="ICacheRebuilder" /> in Umbraco.Web (rebuilding).
 /// </summary>
+[Obsolete("This is no longer used. Scheduled for removal in Umbraco 17.")]
 public class CacheRebuilder : ICacheRebuilder
 {
     private readonly DistributedCache _distributedCache;

--- a/src/Umbraco.Infrastructure/Migrations/PostMigrations/ICacheRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PostMigrations/ICacheRebuilder.cs
@@ -10,6 +10,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.PostMigrations;
 ///         be refactored, really.
 ///     </para>
 /// </remarks>
+[Obsolete("This is no longer used. Scheduled for removal in Umbraco 17.")]
 public interface ICacheRebuilder
 {
     /// <summary>


### PR DESCRIPTION
This adds a couple of obsoletion messages for unused code, that I've marked for removal in 17, related to the already obsoleted post migration functionality.