### PR TITLE
V15: Workspace buttons cannot be overwritten in all cases

### DIFF
--- a/src/Umbraco.Web.UI.Client/public-assets/App_Plugins/custom-bundle-package/index.js
+++ b/src/Umbraco.Web.UI.Client/public-assets/App_Plugins/custom-bundle-package/index.js
@@ -1,9 +1,9 @@
-export const manifests: Array<UmbExtensionManifest> = [
+export const manifests = [
 	{
 		type: 'section',
 		alias: 'MyBundle.Section.Custom',
 		name: 'Custom Section',
-		js: '/App_Plugins/section.js',
+		element: () => import('./section.js'),
 		weight: 1,
 		meta: {
 			label: 'My Bundle Section',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action-menu/workspace-action-menu.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action-menu/workspace-action-menu.element.ts
@@ -27,34 +27,32 @@ export class UmbWorkspaceActionMenuElement extends UmbLitElement {
 	}
 
 	override render() {
-		return this.items?.length
-			? html`
-					<uui-button
-						id="popover-trigger"
-						popovertarget="workspace-action-popover"
-						look="${this.look}"
-						color="${this.color}"
-						label=${this.localize.term('visuallyHiddenTexts_tabExpand')}
-						compact>
-						<uui-symbol-expand id="expand-symbol" .open=${this._popoverOpen}></uui-symbol-expand>
-					</uui-button>
-					<uui-popover-container
-						id="workspace-action-popover"
-						margin="6"
-						placement="top-end"
-						@toggle=${this.#onPopoverToggle}>
-						<umb-popover-layout>
-							<uui-scroll-container>
-								${repeat(
-									this.items,
-									(ext) => ext.alias,
-									(ext) => ext.component,
-								)}
-							</uui-scroll-container>
-						</umb-popover-layout>
-					</uui-popover-container>
-				`
-			: nothing;
+		if (!this.items?.length) return nothing;
+
+		return html`<uui-button
+				id="popover-trigger"
+				popovertarget="workspace-action-popover"
+				look="${this.look}"
+				color="${this.color}"
+				label=${this.localize.term('visuallyHiddenTexts_tabExpand')}
+				compact>
+				<uui-symbol-expand id="expand-symbol" .open=${this._popoverOpen}></uui-symbol-expand>
+			</uui-button>
+			<uui-popover-container
+				id="workspace-action-popover"
+				margin="6"
+				placement="top-end"
+				@toggle=${this.#onPopoverToggle}>
+				<umb-popover-layout>
+					<uui-scroll-container>
+						${repeat(
+							this.items,
+							(ext) => ext.alias,
+							(ext) => ext.component,
+						)}
+					</uui-scroll-container>
+				</umb-popover-layout>
+			</uui-popover-container>`;
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts
@@ -90,7 +90,10 @@ export class UmbWorkspaceActionElement<
 			// TODO: This works on one level for now, which will be enough for the current use case. However, you can overwrite the overwrites, so we need to make this recursive. Perhaps we could move this to the extensions initializer.
 			// Add overwrites so that we can show any previously registered actions on the original workspace action
 			if (this.#manifest.overwrites) {
-				for (const alias of this.#manifest.overwrites) {
+				const overwrites = Array.isArray(this.#manifest.overwrites)
+					? this.#manifest.overwrites
+					: [this.#manifest.overwrites];
+				for (const alias of overwrites) {
 					aliases.add(alias);
 				}
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts
@@ -13,6 +13,7 @@ import {
 	type UmbExtensionElementAndApiInitializer,
 	UmbExtensionsElementAndApiInitializer,
 } from '@umbraco-cms/backoffice/extension-api';
+import { stringOrStringArrayIntersects } from '@umbraco-cms/backoffice/utils';
 
 import '../../workspace-action-menu/index.js';
 
@@ -148,11 +149,7 @@ export class UmbWorkspaceActionElement<
 			umbExtensionsRegistry,
 			'workspaceActionMenuItem',
 			ExtensionApiArgsMethod,
-			(action) => {
-				return Array.isArray(action.forWorkspaceActions)
-					? action.forWorkspaceActions.some((alias) => aliases.includes(alias))
-					: aliases.includes(action.forWorkspaceActions);
-			},
+			(action) => stringOrStringArrayIntersects(action.forWorkspaceActions, aliases),
 			(extensionControllers) => {
 				this._items = extensionControllers;
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts
@@ -39,7 +39,6 @@ export class UmbWorkspaceActionElement<
 			this._href = value?.meta.href;
 			this._additionalOptions = value?.meta.additionalOptions;
 			this.#createAliases();
-			this.requestUpdate('manifest', oldValue);
 		}
 	}
 	public get manifest() {


### PR DESCRIPTION
## Description

Fixes #16700

Fixes [AB#48884](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/48884) (internal HQ tracker)

This pull request includes several changes to improve code readability and maintainability in the `Umbraco.Web.UI.Client` project. The most important changes include refactoring import statements, improving condition checks, and simplifying code logic.

Code readability and maintainability:

* [`src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action-menu/workspace-action-menu.element.ts`](diffhunk://#diff-a876568cbfcba7766d103e269be6d6d5d8a5851068b5e730a9a4f5a9c1ff81bcL30-R32): Simplified the `render` method by removing redundant ternary operator and using early return for better readability. [[1]](diffhunk://#diff-a876568cbfcba7766d103e269be6d6d5d8a5851068b5e730a9a4f5a9c1ff81bcL30-R32) [[2]](diffhunk://#diff-a876568cbfcba7766d103e269be6d6d5d8a5851068b5e730a9a4f5a9c1ff81bcL55-R55)

* [`src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts`](diffhunk://#diff-077e22777d1626ab52bc538c4a98400f853e0299cd6d0168f0677a95a6a7d6ddR16): Added a new utility import `stringOrStringArrayIntersects` to simplify the logic for checking intersection of arrays or strings. [[1]](diffhunk://#diff-077e22777d1626ab52bc538c4a98400f853e0299cd6d0168f0677a95a6a7d6ddR16) [[2]](diffhunk://#diff-077e22777d1626ab52bc538c4a98400f853e0299cd6d0168f0677a95a6a7d6ddL148-R151)

* [`src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts`](diffhunk://#diff-077e22777d1626ab52bc538c4a98400f853e0299cd6d0168f0677a95a6a7d6ddL41): Updated the `manifest` setter to remove unnecessary `requestUpdate` call.

* [`src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action/default/workspace-action-default-kind.element.ts`](diffhunk://#diff-077e22777d1626ab52bc538c4a98400f853e0299cd6d0168f0677a95a6a7d6ddL93-R96): Refactored the handling of `overwrites` to ensure it works correctly with both arrays and single values.

## How to test
See the description in the linked issue.

## Screenshots

![image](https://github.com/user-attachments/assets/4c86e520-cfba-46dc-845e-5e4c094d6c95)
