### PR TITLE
Avoids collection was modified issue when flowing identities to the authenticated user's principal

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/HttpContextExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpContextExtensions.cs
@@ -68,7 +68,13 @@ public static class HttpContextExtensions
             // Otherwise we can't log in as both a member and a backoffice user
             // For instance if you've enabled basic auth.
             ClaimsPrincipal? authenticatedPrincipal = result.Principal;
-            IEnumerable<ClaimsIdentity> existingIdentities = httpContext.User.Identities.Where(x => x.IsAuthenticated && x.AuthenticationType != authenticatedPrincipal.Identity.AuthenticationType);
+
+            // Make sure to copy into a list before attempting to update the authenticated principal, so we don't attempt to modify
+            // the collection while iterating it.
+            // See: https://github.com/umbraco/Umbraco-CMS/issues/18509
+            var existingIdentities = httpContext.User.Identities
+                .Where(x => x.IsAuthenticated && x.AuthenticationType != authenticatedPrincipal.Identity.AuthenticationType)
+                .ToList();
             authenticatedPrincipal.AddIdentities(existingIdentities);
 
             httpContext.User = authenticatedPrincipal;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18509

### Description
It looks as if https://github.com/umbraco/Umbraco-CMS/pull/18206 introduced an issue in this situation, where you have a user authenticated via IIS basic authentication before attempting to sign-in to the backoffice.

I haven't been able to reproduce it using the public access feature on Umbraco Cloud.

I've been able to reproduce locally: https://github.com/umbraco/Umbraco-CMS/issues/18509#issuecomment-2694035510 - so these are the test steps.

When I try this process again with the code from this PR in place, I no longer see the issue.

