### PR TITLE
Guard against element type mismatch at document type creation

### DIFF
--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
@@ -91,7 +91,12 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
             return Attempt.FailWithStatus<TContentType?, ContentTypeOperationStatus>(operationStatus, null);
         }
 
-        await AdditionalCreateValidationAsync(model);
+        // perform additional, content type specific validation
+        operationStatus = await AdditionalCreateValidationAsync(model);
+        if (operationStatus is not ContentTypeOperationStatus.Success)
+        {
+            return Attempt.FailWithStatus<TContentType?, ContentTypeOperationStatus>(operationStatus, null);
+        }
 
         // get the ID of the parent to create the content type under (we already validated that it exists)
         var parentId = GetParentId(model, containerKey) ?? throw new ArgumentException("Parent ID could not be found", nameof(model));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#16421 introduced guards against (and warnings for) element type mismatch for document types. Unfortunately, while the PR actually added guards at document type creation time, these guards were never actually applied 😢 

This PR fixes it.

### Testing this PR

You'll need to use Swagger UI to test this, as the backoffice client UI doesn't support creating inherited document types yet.

1. Create a document type.
2. Using Swagger UI, attempt to create a child element type to the document type.
3. Verify that this fails with a "mismatched" error status.

Now do the same, but with a parent element type and a child document type. The result should be the same.

You can use the following payload when testing with with Swagger UI. Remember to:

- Replace the parent document type key.
- Add your preferred document/element type alias (remember, no duplicates when testing).
- Set `isElement` according to the test case you're executing.

```json
{
    "allowedTemplates": [],
    "defaultTemplate": null,
    "cleanup": {
        "preventCleanup": false,
        "keepAllVersionsNewerThanDays": null,
        "keepLatestVersionPerDayForDays": null
    },
    "allowedDocumentTypes": [],
    "compositions": [{
            "documentType": {
                "id": "[insert parent document type key here]"
            },
            "compositionType": "Inheritance"
        }
    ],
    "alias": "[replace me]",
    "name": "Inherit Test",
    "description": null,
    "icon": "icon-bug color-red",
    "allowedAsRoot": false,
    "variesByCulture": false,
    "variesBySegment": false,
    "collection": null,
    "isElement": [true/false],
    "properties": [],
    "containers": []
}
```