### PR TITLE
Prevents attempt to move an item to itself as a parent

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -5,13 +5,8 @@ import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UMB_TREE_PICKER_MODAL } from '@umbraco-cms/backoffice/tree';
-import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
-import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionMoveToKind> {
-
-	readonly #localization = new UmbLocalizationController(this._host);
-
 	override async execute() {
 		if (!this.args.unique) throw new Error('Unique is not available');
 		if (!this.args.entityType) throw new Error('Entity Type is not available');
@@ -21,18 +16,13 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 			data: {
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
+				pickableFilter: (treeItem) => treeItem.unique !== this.args.unique,
 			},
 		});
 
 		const value = await modalContext.onSubmit();
 		const destinationUnique = value.selection[0];
 		if (destinationUnique === undefined) throw new Error('Destination Unique is not available');
-
-		if (destinationUnique === this.args.unique) {
-			const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-			notificationContext!.peek('danger', { data: { message: this.#localization.term("defaultdialogs_cannotMoveToSelf") } });
-			return;
-		}
 
 		const moveRepository = await createExtensionApiByAlias<UmbMoveRepository>(this, this.args.meta.moveRepositoryAlias);
 		if (!moveRepository) throw new Error('Move Repository is not available');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.token.ts
@@ -1,4 +1,4 @@
-import type { UmbTreeStartNode } from '../types.js';
+import type { UmbTreeItemModel, UmbTreeStartNode } from '../types.js';
 import { UMB_TREE_PICKER_MODAL_ALIAS } from './constants.js';
 import type { UmbPickerModalData, UmbPickerModalValue } from '@umbraco-cms/backoffice/modal';
 import type { UmbWorkspaceModalData } from '@umbraco-cms/backoffice/workspace';
@@ -14,7 +14,7 @@ export interface UmbTreePickerModalCreateActionData<PathPatternParamsType extend
 }
 
 export interface UmbTreePickerModalData<
-	TreeItemType,
+	TreeItemType = UmbTreeItemModel,
 	PathPatternParamsType extends UmbPathPatternParamsType = UmbPathPatternParamsType,
 > extends UmbPickerModalData<TreeItemType> {
 	hideTreeRoot?: boolean;
@@ -28,7 +28,7 @@ export interface UmbTreePickerModalData<
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UmbTreePickerModalValue extends UmbPickerModalValue {}
 
-export const UMB_TREE_PICKER_MODAL = new UmbModalToken<UmbTreePickerModalData<unknown>, UmbTreePickerModalValue>(
+export const UMB_TREE_PICKER_MODAL = new UmbModalToken<UmbTreePickerModalData, UmbTreePickerModalValue>(
 	UMB_TREE_PICKER_MODAL_ALIAS,
 	{
 		modal: {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18544

### Description
The linked issue notes that it's possible to select the current item as the parent for a move, which isn't valid.

Ideally this would be solved via the `pickableFilter` I would imagine, but I had trouble getting that to work.  So instead have just checked for this condition after selection and presented a friendlier error message.

It would be better to not allow selection in the first place, so if you can find a way to do that, please do, and close this!  But if it's actually tricky, this would probably be an improvement on what we have currently.
