### PR TITLE
Added missing translations for dictionary import

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -623,13 +623,15 @@ export default {
 	},
 	dictionary: {
 		importDictionaryItemHelp:
-			'\n      To import a dictionary item, find the ".udt" file on your computer by clicking the\n      "Import" button (you\'ll be asked for confirmation on the next screen)\n    ',
+			'To import a dictionary item, find the ".udt" file on your computer by clicking the "Add" button (you\'ll be asked for confirmation on the next screen).',
 		itemDoesNotExists: 'Dictionary item does not exist.',
 		parentDoesNotExists: 'Parent item does not exist.',
 		noItems: 'There are no dictionary items.',
 		noItemsInFile: 'There are no dictionary items in this file.',
 		noItemsFound: 'There were no dictionary items found.',
 		createNew: 'Create dictionary item',
+		pickFile: 'Select file',
+		pickFileRequired: 'Please select a ".udt" file',
 	},
 	dictionaryItem: {
 		description: "Edit the different language versions for the dictionary item '%0%' below",

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -625,13 +625,15 @@ export default {
 	},
 	dictionary: {
 		importDictionaryItemHelp:
-			'\n      To import a dictionary item, find the ".udt" file on your computer by clicking the\n      "Import" button (you\'ll be asked for confirmation on the next screen)\n    ',
+			'To import a dictionary item, find the ".udt" file on your computer by clicking the "Add" button (you\'ll be asked for confirmation on the next screen).',
 		itemDoesNotExists: 'Dictionary item does not exist.',
 		parentDoesNotExists: 'Parent item does not exist.',
 		noItems: 'There are no dictionary items.',
 		noItemsInFile: 'There are no dictionary items in this file.',
 		noItemsFound: 'There were no dictionary items found.',
 		createNew: 'Create dictionary item',
+		pickFile: 'Select file',
+		pickFileRequired: 'Please select a ".udt" file',
 	},
 	dictionaryItem: {
 		description: "Edit the different language versions for the dictionary item '%0%' below",

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/entity-action/import/import-dictionary-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/entity-action/import/import-dictionary-modal.element.ts
@@ -175,14 +175,14 @@ export class UmbImportDictionaryModalLayout extends UmbModalBaseElement<
 			<uui-form>
 				<form id="form" name="form" @submit=${this.#onUpload}>
 					<uui-form-layout-item>
-						<uui-label for="file" slot="label" required>${this.localize.term('formFileUpload_pickFile')}</uui-label>
+						<uui-label for="file" slot="label" required>${this.localize.term('dictionary_pickFile')}</uui-label>
 						<uui-input-file
 							accept=".udt"
 							name="file"
 							id="file"
 							@input=${this.#onFileInput}
 							required
-							required-message=${this.localize.term('formFileUpload_pickFile')}></uui-input-file>
+							required-message=${this.localize.term('dictionary_pickFileRequired')}></uui-input-file>
 					</uui-form-layout-item>
 				</form>
 			</uui-form>`;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18543

### Description
Adds missing dictionary import translation keys and aligns instructions with UI.
