### PR TITLE
Fixes multiple available constructors exception for execute template query constructor

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Text;
 using Asp.Versioning;
@@ -28,6 +28,7 @@ public class ExecuteTemplateQueryController : TemplateQueryControllerBase
 
     private static readonly string _indent = $"{Environment.NewLine}    ";
 
+    [ActivatorUtilitiesConstructor]
     public ExecuteTemplateQueryController(
         IPublishedContentQuery publishedContentQuery,
         IPublishedValueFallback publishedValueFallback,


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18536

### Description
This fixes the exception triggered for this controller that has obsoleted constructors but none marked as the active one.

Looking at the history you may also be able to remove one of the obsolete constructors as it seems both obsoletions were done in the same PR.

_Should be cherry-picked into the release branch once approved and merged._