### PR TITLE
15.3: Hotfix: block grid custom views

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -446,7 +446,7 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	};
 
 	override render() {
-		return this.contentKey
+		return this.contentKey && (this._contentTypeAlias || this._unsupported)
 			? html`
 					${this.#renderCreateBeforeInlineButton()}
 					<div class="umb-block-grid__block" part="umb-block-grid__block">


### PR DESCRIPTION
The block grid editor doesn't render a Block grid custom view because of a race condition in the extension-slot filtering function.