### PR TITLE
V15: Resolves "Save and Preview" backoffice refresh

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-culture.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-culture.element.ts
@@ -4,9 +4,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbLanguageCollectionRepository } from '@umbraco-cms/backoffice/language';
 import type { UmbLanguageDetailModel } from '@umbraco-cms/backoffice/language';
 
-const elementName = 'umb-preview-culture';
-
-@customElement(elementName)
+@customElement('umb-preview-culture')
 export class UmbPreviewCultureElement extends UmbLitElement {
 	#languageRepository = new UmbLanguageCollectionRepository(this);
 
@@ -98,6 +96,6 @@ export { UmbPreviewCultureElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbPreviewCultureElement;
+		'umb-preview-culture': UmbPreviewCultureElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-device.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-device.element.ts
@@ -10,9 +10,7 @@ export interface UmbPreviewDevice {
 	dimensions: { height: string; width: string };
 }
 
-const elementName = 'umb-preview-device';
-
-@customElement(elementName)
+@customElement('umb-preview-device')
 export class UmbPreviewDeviceElement extends UmbLitElement {
 	#devices: Array<UmbPreviewDevice> = [
 		{
@@ -144,6 +142,6 @@ export { UmbPreviewDeviceElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbPreviewDeviceElement;
+		'umb-preview-device': UmbPreviewDeviceElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-exit.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-exit.element.ts
@@ -2,8 +2,7 @@ import { UMB_PREVIEW_CONTEXT } from '../preview.context.js';
 import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const elementName = 'umb-preview-exit';
-@customElement(elementName)
+@customElement('umb-preview-exit')
 export class UmbPreviewExitElement extends UmbLitElement {
 	async #onClick() {
 		const previewContext = await this.getContext(UMB_PREVIEW_CONTEXT);
@@ -44,6 +43,6 @@ export { UmbPreviewExitElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbPreviewExitElement;
+		'umb-preview-exit': UmbPreviewExitElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-open-website.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/preview/apps/preview-open-website.element.ts
@@ -2,8 +2,7 @@ import { UMB_PREVIEW_CONTEXT } from '../preview.context.js';
 import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const elementName = 'umb-preview-open-website';
-@customElement(elementName)
+@customElement('umb-preview-open-website')
 export class UmbPreviewOpenWebsiteElement extends UmbLitElement {
 	async #onClick() {
 		const previewContext = await this.getContext(UMB_PREVIEW_CONTEXT);
@@ -44,6 +43,6 @@ export { UmbPreviewOpenWebsiteElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbPreviewOpenWebsiteElement;
+		'umb-preview-open-website': UmbPreviewOpenWebsiteElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/apps/preview/preview.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/preview/preview.element.ts
@@ -4,12 +4,10 @@ import { css, customElement, html, nothing, state, when } from '@umbraco-cms/bac
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const elementName = 'umb-preview';
-
 /**
  * @element umb-preview
  */
-@customElement(elementName)
+@customElement('umb-preview')
 export class UmbPreviewElement extends UmbLitElement {
 	#context = new UmbPreviewContext(this);
 
@@ -199,6 +197,6 @@ export default UmbPreviewElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbPreviewElement;
+		'umb-preview': UmbPreviewElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -35,7 +35,7 @@ import {
 import type { UmbDocumentTypeDetailModel } from '@umbraco-cms/backoffice/document-type';
 import { UmbIsTrashedEntityContext } from '@umbraco-cms/backoffice/recycle-bin';
 import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
-import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
+import { ensurePathEndsWithSlash, UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
 
 type ContentModel = UmbDocumentDetailModel;
@@ -289,7 +289,8 @@ export class UmbDocumentWorkspaceContext
 
 		const appContext = await this.getContext(UMB_APP_CONTEXT);
 
-		const previewUrl = new URL(appContext.getBackofficePath() + '/preview', appContext.getServerUrl());
+		const backofficePath = appContext.getBackofficePath();
+		const previewUrl = new URL(ensurePathEndsWithSlash(backofficePath) + 'preview', appContext.getServerUrl());
 		previewUrl.searchParams.set('id', unique);
 
 		if (culture && culture !== UMB_INVARIANT_CULTURE) {


### PR DESCRIPTION
### Description

Fixes [AB#48437](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/48437) (internal HQ tracker)

When pressing the "Save and preview" workspace action for a document, the preview will open in a new tab and the backoffice tab would refresh in certain circumstances.

It appears that the construction of the URL for the preview tab was being misconfigured if there were extra slashes in the path of the URL. Why this triggers the backoffice tab to refresh, I still can't say for sure. But with the preview URL fix in place, the "Save and preview" workspace action no longer forces a refresh.
