### PR TITLE
Tiptap RTE: Block extension enabled/disabled checkbox state

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-extensions-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/components/property-editor-ui-tiptap-extensions-configuration.element.ts
@@ -87,6 +87,8 @@ export class UmbPropertyEditorUiTiptapExtensionsConfigurationElement
 						this.#setValue(tmpValue);
 						this.#syncViewModel();
 					}
+
+					this.requestUpdate('_extensions');
 				},
 				'_observeBlocks',
 			);


### PR DESCRIPTION
### Description

Fixes #18541.

In the Tiptap configuration, the Block extension option detects whether it should be enabled or disabled (based on if there are any Blocks configured for the property-editor). On initial render, the checkbox is enabled, then once a re-render of the component is triggered, it'd become disabled.

This PR resolves this by manually triggering a re-render of the component once the Blocks state has been determined.
