### PR TITLE
Added uui-box around ungrouped properties during block editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-tab.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-tab.element.ts
@@ -78,10 +78,12 @@ export class UmbBlockWorkspaceViewEditTabElement extends UmbLitElement {
 	override render() {
 		return html`
 			${this._hasProperties
-				? html` <umb-block-workspace-view-edit-properties
-						.managerName=${this.#managerName}
-						data-mark="property-group:root"
-						.containerId=${this._containerId}></umb-block-workspace-view-edit-properties>`
+				? html`<uui-box>
+								<umb-block-workspace-view-edit-properties
+								.managerName=${this.#managerName}
+								data-mark="property-group:root"
+								.containerId=${this._containerId}></umb-block-workspace-view-edit-properties>
+							</uui-box>`
 				: ''}
 			${this.hideSingleGroup && this._groups.length === 1
 				? this.renderGroup(this._groups[0])


### PR DESCRIPTION
Fixes this issue: https://github.com/umbraco/Umbraco-CMS/issues/18571

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Wrapping ungrouped properties with uui-box when editing a block.

Before:

![umb-fix-before](https://github.com/user-attachments/assets/b2090af5-9034-49b0-8dc7-3c7a9cb55c87)

After:
![umb-fix-after](https://github.com/user-attachments/assets/e679bb19-57a8-4e3b-a098-4d7a07fd0d3f)

Steps to reproduce can be found in the issue: https://github.com/umbraco/Umbraco-CMS/issues/18571

