### PR TITLE
Fix Rich text block validation path

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
@@ -51,6 +51,12 @@ public abstract class BlockEditorValidatorBase<TValue, TLayout> : ComplexEditorV
         return elementTypeValidation;
     }
 
+    protected virtual string ContentDataGroupJsonPath =>
+        nameof(BlockValue<TLayout>.ContentData).ToFirstLowerInvariant();
+
+    protected virtual string SettingsDataGroupJsonPath =>
+        nameof(BlockValue<TLayout>.SettingsData).ToFirstLowerInvariant();
+
     private IEnumerable<ElementTypeValidationModel> GetBlockEditorDataValidation(BlockEditorData<TValue, TLayout> blockEditorData, string? culture, string? segment)
     {
         // There is no guarantee that the client will post data for every property defined in the Element Type but we still
@@ -74,8 +80,8 @@ public abstract class BlockEditorValidatorBase<TValue, TLayout> : ComplexEditorV
 
         var itemDataGroups = new[]
         {
-            new { Path = nameof(BlockValue<TLayout>.ContentData).ToFirstLowerInvariant(), Items = blockEditorData.BlockValue.ContentData.Where(cd => exposedContentKeys.Contains(cd.Key)).ToArray() },
-            new { Path = nameof(BlockValue<TLayout>.SettingsData).ToFirstLowerInvariant(), Items = blockEditorData.BlockValue.SettingsData.Where(sd => exposedSettingsKeys.Contains(sd.Key)).ToArray() }
+            new { Path = ContentDataGroupJsonPath, Items = blockEditorData.BlockValue.ContentData.Where(cd => exposedContentKeys.Contains(cd.Key)).ToArray() },
+            new { Path = SettingsDataGroupJsonPath, Items = blockEditorData.BlockValue.SettingsData.Where(sd => exposedSettingsKeys.Contains(sd.Key)).ToArray() }
         };
 
         var valuesJsonPathPart = nameof(BlockItemData.Values).ToFirstLowerInvariant();

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorBlockValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorBlockValidator.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.Validation;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
@@ -25,6 +26,12 @@ internal class RichTextEditorBlockValidator: BlockEditorValidatorBase<RichTextBl
         _jsonSerializer = jsonSerializer;
         _logger = logger;
     }
+
+    protected override string ContentDataGroupJsonPath =>
+        $"{nameof(RichTextEditorValue.Blocks).ToFirstLowerInvariant()}.{nameof(RichTextBlockValue.ContentData).ToFirstLowerInvariant()}";
+
+    protected override string SettingsDataGroupJsonPath =>
+        $"{nameof(RichTextEditorValue.Blocks).ToFirstLowerInvariant()}.{nameof(RichTextBlockValue.SettingsData).ToFirstLowerInvariant()}";
 
     protected override IEnumerable<ElementTypeValidationModel> GetElementTypeValidation(object? value, PropertyValidationContext validationContext)
     {

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorBlockValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorBlockValidator.cs
@@ -28,10 +28,10 @@ internal class RichTextEditorBlockValidator: BlockEditorValidatorBase<RichTextBl
     }
 
     protected override string ContentDataGroupJsonPath =>
-        $"{nameof(RichTextEditorValue.Blocks).ToFirstLowerInvariant()}.{nameof(RichTextBlockValue.ContentData).ToFirstLowerInvariant()}";
+        $"{nameof(RichTextEditorValue.Blocks).ToFirstLowerInvariant()}.{base.ContentDataGroupJsonPath}";
 
     protected override string SettingsDataGroupJsonPath =>
-        $"{nameof(RichTextEditorValue.Blocks).ToFirstLowerInvariant()}.{nameof(RichTextBlockValue.SettingsData).ToFirstLowerInvariant()}";
+        $"{nameof(RichTextEditorValue.Blocks).ToFirstLowerInvariant()}.{base.SettingsDataGroupJsonPath}";
 
     protected override IEnumerable<ElementTypeValidationModel> GetElementTypeValidation(object? value, PropertyValidationContext validationContext)
     {


### PR DESCRIPTION
### Description
The base implementation of the block validator does not take into account that the actual implementation can wrap its content/settings data in another object.
This causes issues with the jsonpath returned in validation messages not matching with the actual property path.

To fix this, the hardcoded mapping was moved into a get only overridable string.

The RTE block validator can now signal the correct path to the base class with an override.

### Testing
Ask Niels 😅
Or setup a doctype with a blocklist/grid and an RTE using the same element doctype that has properties with validation that fails on the backend. Create the node add a block to each property => Save and publish => the validate endpoint should return a jsonpath for the invalid properties in the RTE block that starts with `$...value.blocks.contentData...` instead of `$...value.contentData...`
