### PR TITLE
Server-side validation for multiple text strings property editor.

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -389,6 +389,9 @@
     <key alias="duplicateUsername">Username '%0%' is already taken</key>
     <key alias="outOfRangeMinimum">The value %0% is less than the allowed minimum value of %1%</key>
     <key alias="outOfRangeMaximum">The value %0% is greater than the allowed maximum value of %1%</key>
+    <key alias="outOfRangeSingleItemMinimum">The 1 item provided is less than the allowed minimum of %1%</key>
+    <key alias="outOfRangeMultipleItemsMinimum">The %0% items provided are less than the allowed minimum of %1%</key>
+    <key alias="outOfRangeMultipleItemsMaximum">The %0% items provided are greater than the allowed maximum of %1%</key>
     <key alias="invalidStep">The value %0% does not correspond with the configured step value of %1% and minimum value of %2%</key>
     <key alias="unexpectedRange">The value %0% is not expected to contain a range</key>
     <key alias="invalidRange">The value %0% is not expected to have a to value less than the from value</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -387,6 +387,9 @@
     <key alias="duplicateUsername">Username '%0%' is already taken</key>
     <key alias="outOfRangeMinimum">The value %0% is less than the allowed minimum value of %1%</key>
     <key alias="outOfRangeMaximum">The value %0% is greater than the allowed maximum value of %1%</key>
+    <key alias="outOfRangeSingleItemMinimum">The 1 item provided is less than the allowed minimum of %1%</key>
+    <key alias="outOfRangeMultipleItemsMinimum">The %0% items provided are less than the allowed minimum of %1%</key>
+    <key alias="outOfRangeMultipleItemsMaximum">The %0% items provided are greater than the allowed maximum of %1%</key>
     <key alias="invalidStep">The value %0% does not correspond with the configured step value of %1% and minimum value of %2%</key>
     <key alias="unexpectedRange">The value %0% is not expected to contain a range</key>
     <key alias="invalidRange">The value %0% is not expected to have a to value less than the from value</key>

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -6,14 +6,17 @@ using Umbraco.Cms.Core.Exceptions;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.Models.Validation;
 using Umbraco.Cms.Core.PropertyEditors.Validators;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
 /// <summary>
-///     Represents a multiple text string property editor.
+/// Represents a multiple text string property editor.
 /// </summary>
 [DataEditor(
     Constants.PropertyEditors.Aliases.MultipleTextstring,
@@ -24,7 +27,7 @@ public class MultipleTextStringPropertyEditor : DataEditor
     private readonly IIOHelper _ioHelper;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="MultipleTextStringPropertyEditor" /> class.
+    /// Initializes a new instance of the <see cref="MultipleTextStringPropertyEditor" /> class.
     /// </summary>
     public MultipleTextStringPropertyEditor(IIOHelper ioHelper, IDataValueEditorFactory dataValueEditorFactory)
         : base(dataValueEditorFactory)
@@ -42,37 +45,42 @@ public class MultipleTextStringPropertyEditor : DataEditor
         new MultipleTextStringConfigurationEditor(_ioHelper);
 
     /// <summary>
-    ///     Custom value editor so we can format the value for the editor and the database
+    /// Custom value editor so we can format the value for the editor and the database.
     /// </summary>
     internal class MultipleTextStringPropertyValueEditor : DataValueEditor
     {
-        private static readonly string NewLine = "\n";
-        private static readonly string[] NewLineDelimiters = { "\r\n", "\r", "\n" };
+        private static readonly string _newLine = "\n";
+        private static readonly string[] _newLineDelimiters = { "\r\n", "\r", "\n" };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultipleTextStringPropertyValueEditor"/> class.
+        /// </summary>
         public MultipleTextStringPropertyValueEditor(
             IShortStringHelper shortStringHelper,
             IJsonSerializer jsonSerializer,
             IIOHelper ioHelper,
-            DataEditorAttribute attribute)
+            DataEditorAttribute attribute,
+            ILocalizedTextService localizedTextService)
             : base(shortStringHelper, jsonSerializer, ioHelper, attribute)
         {
+            Validators.AddRange(new MinMaxValidator(localizedTextService));
         }
 
         /// <summary>
-        ///     A custom FormatValidator is used as for multiple text strings, each string should individually be checked
-        ///     against the configured regular expression, rather than the JSON representing all the strings as a whole.
+        /// A custom <see href="IValueFormatValidator" /> is used as for multiple text strings, each string should individually
+        /// be checked against the configured regular expression, rather than the JSON representing all the strings as a whole.
         /// </summary>
         public override IValueFormatValidator FormatValidator => new MultipleTextStringFormatValidator();
 
         /// <summary>
-        ///     The value passed in from the editor will be an array of simple objects so we'll need to parse them to get the
-        ///     string
+        /// The value passed in from the editor will be an array of simple objects so we'll need to parse them to get the
+        /// string.
         /// </summary>
         /// <param name="editorValue"></param>
         /// <param name="currentValue"></param>
         /// <returns></returns>
         /// <remarks>
-        ///     We will also check the pre-values here, if there are more items than what is allowed we'll just trim the end
+        /// We will also check the pre-values here, if there are more items than what is allowed we'll just trim the end.
         /// </remarks>
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
         {
@@ -93,30 +101,35 @@ public class MultipleTextStringPropertyEditor : DataEditor
             // only allow the max if over 0
             if (max > 0)
             {
-                return string.Join(NewLine, value.Take(max));
+                return string.Join(_newLine, value.Take(max));
             }
 
-            return string.Join(NewLine, value);
+            return string.Join(_newLine, value);
         }
 
+        /// <inheritdoc/>
         public override object ToEditor(IProperty property, string? culture = null, string? segment = null)
         {
             var value = property.GetValue(culture, segment);
 
             // The legacy property editor saved this data as new line delimited! strange but we have to maintain that.
             return value is string stringValue
-                ? stringValue.Split(NewLineDelimiters, StringSplitOptions.None)
+                ? stringValue.Split(_newLineDelimiters, StringSplitOptions.None)
                 : Array.Empty<string>();
         }
     }
 
+    /// <summary>
+    /// A custom <see href="IValueFormatValidator" /> to check each string against the configured format.
+    /// </summary>
     internal class MultipleTextStringFormatValidator : IValueFormatValidator
     {
+        /// <inheritdoc/>
         public IEnumerable<ValidationResult> ValidateFormat(object? value, string valueType, string format)
         {
             if (value is not IEnumerable<string> textStrings)
             {
-                return Enumerable.Empty<ValidationResult>();
+                return [];
             }
 
             var textStringValidator = new RegexValidator();
@@ -129,7 +142,60 @@ public class MultipleTextStringPropertyEditor : DataEditor
                 }
             }
 
-            return Enumerable.Empty<ValidationResult>();
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Validates the min/max configuration for the multiple text strings property editor.
+    /// </summary>
+    internal class MinMaxValidator : IValueValidator
+    {
+        private readonly ILocalizedTextService _localizedTextService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MinMaxValidator"/> class.
+        /// </summary>
+        public MinMaxValidator(ILocalizedTextService localizedTextService) => _localizedTextService = localizedTextService;
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext)
+        {
+            if (dataTypeConfiguration is not MultipleTextStringConfiguration multipleTextStringConfiguration)
+            {
+                yield break;
+            }
+
+            // If we have a null value, treat as an empty collection for minimum number validation.
+            if (value is not IEnumerable<string> stringValues)
+            {
+                stringValues = [];
+            }
+
+            var stringCount = stringValues.Count();
+
+            if (stringCount < multipleTextStringConfiguration.Min)
+            {
+                if (stringCount == 1)
+                {
+                    yield return new ValidationResult(
+                        _localizedTextService.Localize("validation", "outOfRangeSingleItemMinimum", [multipleTextStringConfiguration.Min.ToString()]),
+                        ["value"]);
+                }
+                else
+                {
+                    yield return new ValidationResult(
+                        _localizedTextService.Localize("validation", "outOfRangeMultipleItemsMinimum", [stringCount.ToString(), multipleTextStringConfiguration.Min.ToString()]),
+                        ["value"]);
+                }
+            }
+
+            if (stringCount > multipleTextStringConfiguration.Max)
+            {
+                yield return new ValidationResult(
+                    _localizedTextService.Localize("validation", "outOfRangeMultipleItemsMaximum", [stringCount.ToString(), multipleTextStringConfiguration.Max.ToString()]),
+                    ["value"]);
+            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
This adds server-side validation to the multiple text strings, to ensure that the number of entries provided matches the configured minimum and maximum.

As well as the unit tests, to verify manually I've used Swagger and manipulated values to the `PUT /umbraco/management/api/v1.1/document/{id}/validate` endpoint. You should find if you supply collection of strings above or below the configured range, you'll get a localized validation message in response.