### PR TITLE
Updates sort property and direction together to avoid intermittent failures

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/modals/query-builder/query-builder-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/modals/query-builder/query-builder-modal.element.ts
@@ -73,6 +73,7 @@ export default class UmbTemplateQueryBuilderModalElement extends UmbModalBaseEle
 
 	#updateQueryRequest(update: Partial<UmbExecuteTemplateQueryRequestModel>) {
 		this._queryRequest = { ...this._queryRequest, ...update };
+		console.log(this._queryRequest);
 		this.#executeTemplateQuery();
 	}
 
@@ -135,29 +136,21 @@ export default class UmbTemplateQueryBuilderModalElement extends UmbModalBaseEle
 
 	#setSortProperty(event: Event) {
 		const target = event.target as UUIComboboxListElement;
-
-		if (!this._queryRequest.sort) this.#setSortDirection();
-
-		this.#updateQueryRequest({
-			sort: { ...this._queryRequest.sort, propertyAlias: target.value as string },
-		});
+		this.#setSort(target.value as string, this._queryRequest.sort?.direction as SortOrder ?? this._defaultSortDirection);
 	}
 
 	#setSortDirection() {
-		if (!this._queryRequest.sort?.direction) {
-			this.#updateQueryRequest({
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
-				sort: { ...this._queryRequest.sort, direction: this._defaultSortDirection },
-			});
-			return;
-		}
+		const direction = this._queryRequest.sort?.direction
+			? this._queryRequest.sort.direction === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending
+			: this._defaultSortDirection;
+		this.#setSort(this._queryRequest.sort?.propertyAlias ?? "", direction);
+	}
 
+	#setSort(propertyAlias: string, direction: SortOrder) {
 		this.#updateQueryRequest({
 			sort: {
-				...this._queryRequest.sort,
-				direction:
-					this._queryRequest.sort?.direction === SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending,
+				propertyAlias,
+				direction
 			},
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/modals/query-builder/query-builder-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/modals/query-builder/query-builder-modal.element.ts
@@ -73,7 +73,6 @@ export default class UmbTemplateQueryBuilderModalElement extends UmbModalBaseEle
 
 	#updateQueryRequest(update: Partial<UmbExecuteTemplateQueryRequestModel>) {
 		this._queryRequest = { ...this._queryRequest, ...update };
-		console.log(this._queryRequest);
 		this.#executeTemplateQuery();
 	}
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/18082

### Description
I couldn't quite put my finger on why we were getting an intermittent failure here, but seems likely it was related to the separate updates to the sort property and direction, each of which were triggering their own update and server call.  I've combined these in this PR so we update and refresh together, and I no longer see the issue any more.

To test - see reproduction steps on the linked issue.
