### PR TITLE
v15: Remove duplicate webhook registration

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -64,7 +64,6 @@ public static partial class UmbracoBuilderExtensions
                 .AddWebhooks()
                 .AddServer()
                 .AddCorsPolicy()
-                .AddWebhooks()
                 .AddPreview()
                 .AddServerEvents()
                 .AddPasswordConfiguration()


### PR DESCRIPTION
# Notes
- Removes duplicate registration of Webhooks, seems like this has been there a long time due to a merge conflict 🙈 
Thanks to @bjarnef for raising this 😁 


