### PR TITLE
V13: bumped imagesharp to prevent CVE-2025-27598

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,7 +73,7 @@
     <PackageVersion Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.Map" Version="1.0.2" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.3" />
     <PackageVersion Include="Smidge.InMemory" Version="4.4.0" />
     <PackageVersion Include="Smidge.Nuglify" Version="4.5.1" />

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.9, 3)" />
+    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.10, 3)" />
     <PackageReference Include="SixLabors.ImageSharp.Web" VersionOverride="[2.0.2, 3)" />
   </ItemGroup>
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
Updated dependencies for SixLabors.ImageSharp:
SixLabors.ImageSharp@3.1.6 -> 3.1.7
SixLabors.ImageSharp@2.1.9 -> 2.1.10

https://github.com/advisories/GHSA-2cmq-823j-5qj8