### PR TITLE
Fixed issue with slider max validation using default 0 value

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Models.Validation;
 using Umbraco.Cms.Core.PropertyEditors.Validation;
-using Umbraco.Cms.Core.PropertyEditors.Validators;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
@@ -261,7 +260,7 @@ public class SliderPropertyEditor : DataEditor
                         ["value"]);
                 }
 
-                if (sliderRange.To > sliderConfiguration.MaximumValue)
+                if (sliderConfiguration.MaximumValue != 0 && sliderRange.To > sliderConfiguration.MaximumValue)
                 {
                     yield return new ValidationResult(
                         LocalizedTextService.Localize("validation", "outOfRangeMaximum", [sliderRange.To.ToString(), sliderConfiguration.MaximumValue.ToString()]),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/SliderValueEditorTests.cs
@@ -205,6 +205,21 @@ public class SliderValueEditorTests
         }
     }
 
+    [Test]
+    public void Max_Item_Validation_Respects_0_As_Unlimited()
+    {
+        var value = new JsonObject
+        {
+            { "from", 1.0m },
+            { "to", 1.0m },
+        };
+        var editor = CreateValueEditor();
+        editor.ConfigurationObject = new SliderConfiguration();
+
+        var result = editor.Validate(value, false, null, PropertyValidationContext.Empty());
+        Assert.IsEmpty(result);
+    }
+
     [TestCase(0.2, 1.3, 1.7, true)]
     [TestCase(0.2, 1.4, 1.7, false)]
     [TestCase(0.2, 1.3, 1.6, false)]


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
Found in testing the release candidate with the starter kit - we need to handle a non-configured maximum for the slider which will be considered as zero.

@nikolajlauridsen - this is a similar issue that you found with a later property editor where we support maximum validation on the server.