### PR TITLE
Added description to block list properties hide content editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/workspace/views/block-list-type-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/workspace/views/block-list-type-workspace-view.element.ts
@@ -75,7 +75,7 @@ export class UmbBlockListTypeWorkspaceViewSettingsElement extends UmbLitElement 
 				<umb-property
 					label=${this.localize.term('blockEditor_forceHideContentEditor')}
 					alias="forceHideContentEditorInOverlay"
-					description="Hide the content edit button and the content editor from the Block Editor overlay."
+					description=${this.localize.term('blockEditor_forceHideContentEditorHelp')}
 					property-editor-ui-alias="Umb.PropertyEditorUi.Toggle"></umb-property>
 			</uui-box>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/workspace/views/block-list-type-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/workspace/views/block-list-type-workspace-view.element.ts
@@ -75,6 +75,7 @@ export class UmbBlockListTypeWorkspaceViewSettingsElement extends UmbLitElement 
 				<umb-property
 					label=${this.localize.term('blockEditor_forceHideContentEditor')}
 					alias="forceHideContentEditorInOverlay"
+					description="Hide the content edit button and the content editor from the Block Editor overlay."
 					property-editor-ui-alias="Umb.PropertyEditorUi.Toggle"></umb-property>
 			</uui-box>
 		`;


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- [link to the issue here!](https://github.com/umbraco/Umbraco-CMS/commit/900938edd0b19355815e0bb26bf39482d9eb676e) -->

### Description
This PR fixes issue #17835.
Added a short description to the **hide content editor** section in the block element configuration


<!-- Thanks for contributing to Umbraco CMS! -->
