### PR TITLE
Corrects obsoletion message on ITwoFactorLoginService.

### DIFF
--- a/src/Umbraco.Core/Services/ITwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/ITwoFactorLoginService.cs
@@ -29,7 +29,7 @@ public interface ITwoFactorLoginService : IService
     ///     The returned type can be anything depending on the setup providers. You will need to cast it to the type handled by
     ///     the provider.
     /// </remarks>
-    [Obsolete("Use IUserTwoFactorLoginService.GetSetupInfoWithStatusAsync. This will be removed in Umbraco 15.")]
+    [Obsolete("Use IUserTwoFactorLoginService.GetSetupInfoAsync. This will be removed in Umbraco 15.")]
     Task<object?> GetSetupInfoAsync(Guid userOrMemberKey, string providerName);
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18622

### Description
The linked issue points out an error in an obsoletion message pointing to an incorrectly named method.  This PR fixes that such that it references the [correct name](https://github.com/umbraco/Umbraco-CMS/blob/7ef11621dd8e4197f45d83cff38c8d0b425415f1/src/Umbraco.Core/Services/IUserTwoFactorLoginService.cs#L26).