### PR TITLE
Fixed typo in TinyMCE's da.js

### DIFF
--- a/src/Umbraco.Web.UI.Client/lib/tinymce/langs/da.js
+++ b/src/Umbraco.Web.UI.Client/lib/tinymce/langs/da.js
@@ -15,7 +15,7 @@ tinymce.addI18n('da',{
 "Strikethrough": "Gennemstreg",
 "Superscript": "H\u00e6vet",
 "Subscript": "S\u00e6nket",
-"Clear formatting": "Nulstil formattering",
+"Clear formatting": "Nulstil formatering",
 "Align left": "Venstrejusteret",
 "Align center": "Centreret",
 "Align right": "H\u00f8jrejusteret",


### PR DESCRIPTION
Not a lot to describe here. In TinyMCE in Umbraco 13, the **Clear formatting** label is spelled with two t's in Danish, where it only should be one (**formatering** instead of **formattering**).

![image](https://github.com/user-attachments/assets/7b6f8650-88f3-4b5b-be99-fa002f22019c)
