### PR TITLE
Fix bug RTE code editor modal - pretty print not working

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/monaco-editor/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/monaco-editor/index.ts
@@ -6,18 +6,18 @@ import styles from 'monaco-editor/min/vs/editor/editor.main.css?inline';
 const initializeWorkers = () => {
 	self.MonacoEnvironment = {
 		getWorker(workerId: string, label: string): Promise<Worker> | Worker {
-			let url = '/umbraco/backoffice/monaco-editor/esm/vs/editor/editor.worker.js';
+			let url = '/umbraco/backoffice/monaco-editor/vs/editor/editor.worker.js';
 			if (label === 'json') {
-				url = '/umbraco/backoffice/monaco-editor/esm/vs/language/json/json.worker.js';
+				url = '/umbraco/backoffice/monaco-editor/vs/language/json/json.worker.js';
 			}
 			if (label === 'css' || label === 'scss' || label === 'less') {
-				url = '/umbraco/backoffice/monaco-editor/esm/vs/language/css/css.worker.js';
+				url = '/umbraco/backoffice/monaco-editor/vs/language/css/css.worker.js';
 			}
 			if (label === 'html' || label === 'handlebars' || label === 'razor') {
-				url = '/umbraco/backoffice/monaco-editor/esm/vs/language/html/html.worker.js';
+				url = '/umbraco/backoffice/monaco-editor/vs/language/html/html.worker.js';
 			}
 			if (label === 'typescript' || label === 'javascript') {
-				url = '/umbraco/backoffice/monaco-editor/esm/vs/language/typescript/ts.worker.js';
+				url = '/umbraco/backoffice/monaco-editor/vs/language/typescript/ts.worker.js';
 			}
 			return new Worker(url, { name: workerId, type: 'module' });
 		},

--- a/src/Umbraco.Web.UI.Client/src/rollup.config.js
+++ b/src/Umbraco.Web.UI.Client/src/rollup.config.js
@@ -52,6 +52,10 @@ console.log('--- Copying TinyMCE i18n done ---');
 // Copy monaco-editor
 console.log('--- Copying monaco-editor ---');
 cpSync('./node_modules/monaco-editor/esm/vs/editor/editor.worker.js', `${DIST_DIRECTORY}/monaco-editor/vs/editor/editor.worker.js`);
+cpSync('./node_modules/monaco-editor/esm/vs/base', `${DIST_DIRECTORY}/monaco-editor/vs/base`, { recursive: true });
+cpSync('./node_modules/monaco-editor/esm/vs/nls.js', `${DIST_DIRECTORY}/monaco-editor/vs/nls.js`, { recursive: true });
+cpSync('./node_modules/monaco-editor/esm/vs/nls.messages.js', `${DIST_DIRECTORY}/monaco-editor/vs/nls.messages.js`, { recursive: true });
+cpSync('./node_modules/monaco-editor/esm/vs/editor/common', `${DIST_DIRECTORY}/monaco-editor/vs/editor/common`, { recursive: true });
 cpSync('./node_modules/monaco-editor/esm/vs/language', `${DIST_DIRECTORY}/monaco-editor/vs/language`, { recursive: true });
 cpSync('./node_modules/monaco-editor/min/vs/base/browser/ui/codicons', `${DIST_DIRECTORY}/assets/fonts`, { recursive: true });
 console.log('--- Copying monaco-editor done ---');

--- a/src/Umbraco.Web.UI.Client/vite.config.ts
+++ b/src/Umbraco.Web.UI.Client/vite.config.ts
@@ -35,7 +35,7 @@ export const plugins: PluginOption[] = [
 			},
 			{
 				src: 'node_modules/monaco-editor/esm/**/*',
-				dest: 'umbraco/backoffice/monaco-editor/esm',
+				dest: 'umbraco/backoffice/monaco-editor/vs',
 			},
 		],
 	}),


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

**Reason**: The cause of this error is due to missing copy files from `node_modules `to `dist-cms` while running build. In addition, the path pointing to js files in web worker has an extra `esm` in it. This leads to not being able to load some js files needed by monoca-editor.

**Solution**: 
Add missing js files to copy from monaco-editor in `rollup.config.js.`
Remove `esm` in the path to some js files.

**How to test?**
Before:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/d045a439-e446-4dd4-9285-883e64b3eebb" />
After fixed:
<img width="622" alt="image" src="https://github.com/user-attachments/assets/8a81fcdc-cf7e-4142-a750-1ceb14c266d6" />

<!-- Thanks for contributing to Umbraco CMS! -->
