### PR TITLE
Change notification text when copying Block List Item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
@@ -99,7 +99,7 @@ export abstract class UmbDetailRepositoryBase<
 			this.#detailStore?.append(createdData);
 			this.#createSuccessNotification?.close();
 			// TODO: how do we handle generic notifications? Is this the correct place to do it?
-			const notification = { data: { message: `Created` } };
+			const notification = { data: { message: `Copied to clipboard` } };
 			this.#createSuccessNotification = this.#notificationContext!.peek('positive', notification);
 		}
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/18516

### Description

Changed the message in the notification when copying a block list item to make it more clear what the action does. Related to #18516 


<!-- Thanks for contributing to Umbraco CMS! -->
