### PR TITLE
V15 QA reduced amount of browser downloaded on pipeline to reduce download time

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -593,7 +593,7 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Install Playwright and dependencies
-          - pwsh: npx playwright install-deps chromium
+          - pwsh: npx playwright install chromium
             displayName: Install Playwright only with Chromium browser
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
@@ -760,7 +760,7 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Install Playwright and dependencies
-          - pwsh: npx playwright install-deps chromium
+          - pwsh: npx playwright install chromium
             displayName: Install Playwright only with Chromium browser
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -593,8 +593,8 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Install Playwright and dependencies
-          - pwsh: npx playwright install --with-deps
-            displayName: Install Playwright
+          - pwsh: npx playwright install-deps chromium
+            displayName: Install Playwright only with Chromium browser
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
@@ -639,7 +639,7 @@ stages:
               testResultsFormat: 'JUnit'
               testResultsFiles: '*.xml'
               searchFolder: "tests/Umbraco.Tests.AcceptanceTest/results"
-              testRunTitle: "$(Agent.JobName)"   
+              testRunTitle: "$(Agent.JobName)"
 
       - job:
         displayName: E2E Tests (SQL Server)
@@ -760,8 +760,8 @@ stages:
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Install Playwright and dependencies
-          - pwsh: npx playwright install --with-deps
-            displayName: Install Playwright
+          - pwsh: npx playwright install-deps chromium
+            displayName: Install Playwright only with Chromium browser
             workingDirectory: tests/Umbraco.Tests.AcceptanceTest
 
           # Test
@@ -806,7 +806,7 @@ stages:
             inputs:
               targetPath: $(Build.ArtifactStagingDirectory)
               artifact: "Acceptance Test Results - $(Agent.JobName) - Attempt #$(System.JobAttempt)"
-          
+
           # Publish test results
           - task: PublishTestResults@2
             displayName: "Publish test results"


### PR DESCRIPTION
Updated so we only download the chromium browser for our E2E tests as it is the only browser we currently test with