### PR TITLE
V15: Support legacy allowPackageTelemetry option

### DIFF
--- a/src/Umbraco.Core/Manifest/PackageManifest.cs
+++ b/src/Umbraco.Core/Manifest/PackageManifest.cs
@@ -12,6 +12,9 @@ public class PackageManifest
 
     public bool AllowTelemetry { get; set; } = true;
 
+    [Obsolete("Use AllowTelemetry instead. This property will be removed in future versions.")]
+    public bool AllowPackageTelemetry { get; set; } = true;
+
     public required object[] Extensions { get; set; }
 
     public PackageManifestImportmap? Importmap { get; set; }

--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -353,7 +353,7 @@ public class PackagingService : IPackagingService
             }
 
             // Set additional values
-            installedPackage.AllowPackageTelemetry = packageManifest.AllowTelemetry;
+            installedPackage.AllowPackageTelemetry = packageManifest is { AllowTelemetry: true, AllowPackageTelemetry: true };
 
             if (!string.IsNullOrEmpty(packageManifest.Version))
             {

--- a/src/Umbraco.Web.UI.Client/src/json-schema/umbraco-package-schema.ts
+++ b/src/Umbraco.Web.UI.Client/src/json-schema/umbraco-package-schema.ts
@@ -28,6 +28,13 @@ export interface UmbracoPackage {
 	allowTelemetry?: boolean;
 
 	/**
+	 * @title Decides if the package sends telemetry data for collection
+	 * @default true
+	 * @deprecated Use allowTelemetry instead
+	 */
+	allowPackageTelemetry?: boolean;
+
+	/**
 	 * @title Decides if the package is allowed to be accessed by the public, e.g. on the login screen
 	 * @default false
 	 */


### PR DESCRIPTION
## Description

Due to an unfortunate mistake in the Umbraco.Cms.Targets generated JSON schema, we alluded to supporting `allowPackageTelemetry` in the JSON files, however the backend didn't support this, but it does now.