### PR TITLE
Reverts UI updates from publish with descendants dialog (15)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/PublishDocumentWithDescendantsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/PublishDocumentWithDescendantsController.cs
@@ -69,11 +69,6 @@ public class PublishDocumentWithDescendantsController : DocumentControllerBase
             publishBranchFilter |= PublishBranchFilter.IncludeUnpublished;
         }
 
-        if (requestModel.ForceRepublish)
-        {
-            publishBranchFilter |= PublishBranchFilter.ForceRepublish;
-        }
-
         return publishBranchFilter;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -42851,15 +42851,11 @@
       "PublishDocumentWithDescendantsRequestModel": {
         "required": [
           "cultures",
-          "forceRepublish",
           "includeUnpublishedDescendants"
         ],
         "type": "object",
         "properties": {
           "includeUnpublishedDescendants": {
-            "type": "boolean"
-          },
-          "forceRepublish": {
             "type": "boolean"
           },
           "cultures": {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/PublishDocumentWithDescendantsRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/PublishDocumentWithDescendantsRequestModel.cs
@@ -4,7 +4,5 @@ public class PublishDocumentWithDescendantsRequestModel
 {
     public bool IncludeUnpublishedDescendants { get; set; }
 
-    public bool ForceRepublish { get; set; }
-
     public required IEnumerable<string> Cultures { get; set; }
 }

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -298,9 +298,6 @@ export default {
 		removeTextBox: 'Fjern denne tekstboks',
 		contentRoot: 'Indholdsrod',
 		includeUnpublished: 'Inkluder ikke-udgivet indhold.',
-		forceRepublish: 'Udgiv uændrede elementer.',
-		forceRepublishWarning: 'ADVARSEL: Udgivelse af alle sider under denne i indholdstræet, uanset om de er ændret eller ej, kan være en ressourcekrævende og langvarig proces.',
-		forceRepublishAdvisory: 'Dette bør ikke være nødvendigt under normale omstændigheder, så fortsæt kun med denne handling, hvis du er sikker på, at det er nødvendigt.',
 		isSensitiveValue:
 			'Denne værdi er skjult.Hvis du har brug for adgang til at se denne værdi, bedes du\n      kontakte din web-administrator.\n    ',
 		isSensitiveValue_short: 'Denne værdi er skjult.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -320,9 +320,6 @@ export default {
 		removeTextBox: 'Remove this text box',
 		contentRoot: 'Content root',
 		includeUnpublished: 'Include unpublished content items.',
-		forceRepublish: 'Publish unchanged items.',
-		forceRepublishWarning: 'WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.',
-		forceRepublishAdvisory: 'This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.',
 		isSensitiveValue:
 			'This value is hidden. If you need access to view this value please contact your\n      website administrator.\n    ',
 		isSensitiveValue_short: 'This value is hidden.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -317,9 +317,6 @@ export default {
 		removeTextBox: 'Remove this text box',
 		contentRoot: 'Content root',
 		includeUnpublished: 'Include unpublished content items.',
-		forceRepublish: 'Publish unchanged items.',
-		forceRepublishWarning: 'WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.',
-		forceRepublishAdvisory: 'This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.',
 		isSensitiveValue:
 			'This value is hidden. If you need access to view this value please contact your\n      website administrator.\n    ',
 		isSensitiveValue_short: 'This value is hidden.',

--- a/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
@@ -2050,7 +2050,6 @@ export type PublishDocumentRequestModel = {
 
 export type PublishDocumentWithDescendantsRequestModel = {
     includeUnpublishedDescendants: boolean;
-    forceRepublish: boolean;
     cultures: Array<(string)>;
 };
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -18,7 +18,6 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 > {
 	#selectionManager = new UmbSelectionManager<string>(this);
 	#includeUnpublishedDescendants = false;
-	#forceRepublish = false;
 
 	@state()
 	_options: Array<UmbDocumentVariantOptionModel> = [];
@@ -84,25 +83,11 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 		this.#includeUnpublishedDescendants = !this.#includeUnpublishedDescendants;
 	}
 
-	async #onForceRepublishChange() {
-		this.#forceRepublish = !this.#forceRepublish;
-	}
-
 	async #submit() {
-
-		if (this.#forceRepublish) {
-			await umbConfirmModal(this, {
-				headline: this.localize.term('content_forceRepublishWarning'),
-				content: this.localize.term('content_forceRepublishAdvisory'),
-				color: 'warning',
-				confirmLabel: this.localize.term('actions_publish'),
-			});
-		}
 
 		this.value = {
 			selection: this.#selectionManager.getSelection(),
 			includeUnpublishedDescendants: this.#includeUnpublishedDescendants,
-			forceRepublish: this.#forceRepublish,
 		};
 		this.modalContext?.submit();
 	}
@@ -141,14 +126,6 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 					label=${this.localize.term('content_includeUnpublished')}
 					?checked=${this.value?.includeUnpublishedDescendants}
 					@change=${this.#onIncludeUnpublishedDescendantsChange}></uui-toggle>
-			</uui-form-layout-item>
-
-			<uui-form-layout-item>
-				<uui-toggle
-					id="forceRepublish"
-					label=${this.localize.term('content_forceRepublish')}
-					?checked=${this.value?.forceRepublish}
-					@change=${this.#onForceRepublishChange}></uui-toggle>
 			</uui-form-layout-item>
 
 			<div slot="actions">

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -5,7 +5,7 @@ import type {
 	UmbDocumentPublishWithDescendantsModalValue,
 } from './document-publish-with-descendants-modal.token.js';
 import { css, customElement, html, state } from '@umbraco-cms/backoffice/external/lit';
-import { umbConfirmModal, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbSelectionManager } from '@umbraco-cms/backoffice/utils';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.token.ts
@@ -8,7 +8,6 @@ export interface UmbDocumentPublishWithDescendantsModalData extends UmbDocumentV
 
 export interface UmbDocumentPublishWithDescendantsModalValue extends UmbDocumentVariantPickerValue {
 	includeUnpublishedDescendants?: boolean;
-	forceRepublish?: boolean;
 }
 
 export const UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL = new UmbModalToken<

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.repository.ts
@@ -71,14 +71,12 @@ export class UmbDocumentPublishingRepository extends UmbRepositoryBase {
 	 * @param id
 	 * @param variantIds
 	 * @param includeUnpublishedDescendants
-	 * @param forceRepublish
 	 * @memberof UmbDocumentPublishingRepository
 	 */
 	async publishWithDescendants(
 		id: string,
 		variantIds: Array<UmbVariantId>,
 		includeUnpublishedDescendants: boolean,
-		forceRepublish: boolean,
 	) {
 		if (!id) throw new Error('id is missing');
 		if (!variantIds) throw new Error('variant IDs are missing');
@@ -88,7 +86,6 @@ export class UmbDocumentPublishingRepository extends UmbRepositoryBase {
 			id,
 			variantIds,
 			includeUnpublishedDescendants,
-			forceRepublish,
 		);
 
 		if (!error) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
@@ -92,21 +92,18 @@ export class UmbDocumentPublishingServerDataSource {
 	 * @param unique
 	 * @param variantIds
 	 * @param includeUnpublishedDescendants
-	 * @param forceRepublish
 	 * @memberof UmbDocumentPublishingServerDataSource
 	 */
 	async publishWithDescendants(
 		unique: string,
 		variantIds: Array<UmbVariantId>,
 		includeUnpublishedDescendants: boolean,
-		forceRepublish: boolean,
 	) {
 		if (!unique) throw new Error('Id is missing');
 
 		const requestBody: PublishDocumentWithDescendantsRequestModel = {
 			cultures: variantIds.map((variant) => variant.toCultureString()),
 			includeUnpublishedDescendants,
-			forceRepublish,
 		};
 
 		return tryExecuteAndNotify(

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -229,7 +229,6 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase<UmbDoc
 			unique,
 			variantIds,
 			result.includeUnpublishedDescendants ?? false,
-			result.forceRepublish ?? false,
 		);
 
 		if (!error) {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Relates to: https://github.com/umbraco/Umbraco-CMS/issues/13739

### Description
Following discussions and release candidate feedback it's been decided that the publish with descendants dialog should not be updated as was proposed in https://github.com/umbraco/Umbraco-CMS/pull/18410

This PR reverts the UI aspects of these changes, so the service level methods are available but we don't clutter the UI for editors that won't normally have need of this option.

**To Test:**

- Verify that the publish descendants dialog now shows only the option to publish unpublished documents, and that the functionality works as expected when selecting or not selecting this option.

_Should be cherry-picked into `release/15.3` when approved and merged._
