### PR TITLE
Reverts UI updates from publish with descendants dialog (13)

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -298,9 +298,6 @@
     <key alias="removeTextBox">Fjern denne tekstboks</key>
     <key alias="contentRoot">Indholdsrod</key>
     <key alias="includeUnpublished">Inkluder ikke-udgivet indhold.</key>
-    <key alias="forceRepublish">Udgiv uændrede elementer.</key>
-    <key alias="forceRepublishWarning">ADVARSEL: Udgivelse af alle sider under denne i indholdstræet, uanset om de er ændret eller ej, kan være en ressourcekrævende og langvarig proces.</key>
-    <key alias="forceRepublishAdvisory">Dette bør ikke være nødvendigt under normale omstændigheder, så fortsæt kun med denne handling, hvis du er sikker på, at det er nødvendigt.</key>
     <key alias="isSensitiveValue">Denne værdi er skjult. Hvis du har brug for adgang til at se denne værdi, bedes du
       kontakte din administrator.
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -309,9 +309,6 @@
     <key alias="removeTextBox">Remove this text box</key>
     <key alias="contentRoot">Content root</key>
     <key alias="includeUnpublished">Include unpublished content items.</key>
-    <key alias="forceRepublish">Publish unchanged items.</key>
-    <key alias="forceRepublishWarning">WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.</key>
-    <key alias="forceRepublishAdvisory">This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.</key>
     <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your
       website administrator.
     </key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -308,9 +308,6 @@
     <key alias="removeTextBox">Remove this text box</key>
     <key alias="contentRoot">Content root</key>
     <key alias="includeUnpublished">Include unpublished content items.</key>
-    <key alias="forceRepublish">Publish unchanged items.</key>
-    <key alias="forceRepublishWarning">WARNING: Publishing all pages below this one in the content tree, whether or not they have changed, can be an expensive and long-running operation.</key>
-    <key alias="forceRepublishAdvisory">This should not be necessary in normal circumstances so please only proceed with this option selected if you are certain it is required.</key>
     <key alias="isSensitiveValue">This value is hidden. If you need access to view this value please contact your
       website administrator.
     </key>

--- a/src/Umbraco.Core/Models/ContentEditing/ContentSaveAction.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentSaveAction.cs
@@ -59,43 +59,11 @@ public enum ContentSaveAction
     ///     Saves and publishes the content item including all descendants regardless of whether they have a published version
     ///     or not.
     /// </summary>
-    [Obsolete("This option is no longer used as the 'force' aspect has been extended into options for publishing unpublished and re-publishing changed content. Please use one of those options instead.")]
     PublishWithDescendantsForce = 10,
 
     /// <summary>
     ///     Creates and publishes the new content item including all descendants regardless of whether they have a published
     ///     version or not.
     /// </summary>
-    [Obsolete("This option is no longer used as the 'force' aspect has been extended into options for publishing unpublished and re-publishing changed content. Please use one of those options instead.")]
     PublishWithDescendantsForceNew = 11,
-
-    /// <summary>
-    ///     Saves and publishes the content item including all descendants including publishing previously unpublished content.
-    /// </summary>
-    PublishWithDescendantsIncludeUnpublished = 12,
-
-    /// <summary>
-    ///     Saves and publishes the new content item including all descendants including publishing previously unpublished content.
-    /// </summary>
-    PublishWithDescendantsIncludeUnpublishedNew = 13,
-
-    /// <summary>
-    ///     Saves and publishes the content item including all descendants irrespective of whether there are any pending changes.
-    /// </summary>
-    PublishWithDescendantsForceRepublish = 14,
-
-    /// <summary>
-    ///     Saves and publishes the new content item including all descendants including publishing previously unpublished content.
-    /// </summary>
-    PublishWithDescendantsForceRepublishNew = 15,
-
-    /// <summary>
-    ///     Saves and publishes the content item including all descendants including publishing previously unpublished content and irrespective of whether there are any pending changes.
-    /// </summary>
-    PublishWithDescendantsIncludeUnpublishedAndForceRepublish = 16,
-
-    /// <summary>
-    ///     Saves and publishes the new content item including all descendants including publishing previously unpublished content and irrespective of whether there are any pending changes.
-    /// </summary>
-    PublishWithDescendantsIncludeUnpublishedAndForceRepublishNew = 17,
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/ContentController.cs
@@ -1007,24 +1007,14 @@ public class ContentController : ContentControllerBase
                 {
                     case ContentSaveAction.Publish:
                     case ContentSaveAction.PublishWithDescendants:
-#pragma warning disable CS0618 // Type or member is obsolete
                     case ContentSaveAction.PublishWithDescendantsForce:
-#pragma warning restore CS0618 // Type or member is obsolete
-                    case ContentSaveAction.PublishWithDescendantsIncludeUnpublished:
-                    case ContentSaveAction.PublishWithDescendantsForceRepublish:
-                    case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublish:
                     case ContentSaveAction.SendPublish:
                     case ContentSaveAction.Schedule:
                         contentItem.Action = ContentSaveAction.Save;
                         break;
                     case ContentSaveAction.PublishNew:
                     case ContentSaveAction.PublishWithDescendantsNew:
-#pragma warning disable CS0618 // Type or member is obsolete
                     case ContentSaveAction.PublishWithDescendantsForceNew:
-#pragma warning restore CS0618 // Type or member is obsolete
-                    case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedNew:
-                    case ContentSaveAction.PublishWithDescendantsForceRepublishNew:
-                    case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublishNew:
                     case ContentSaveAction.SendPublishNew:
                     case ContentSaveAction.ScheduleNew:
                         contentItem.Action = ContentSaveAction.SaveNew;
@@ -1158,16 +1148,8 @@ public class ContentController : ContentControllerBase
                 break;
             case ContentSaveAction.PublishWithDescendants:
             case ContentSaveAction.PublishWithDescendantsNew:
-#pragma warning disable CS0618 // Type or member is obsolete
             case ContentSaveAction.PublishWithDescendantsForce:
             case ContentSaveAction.PublishWithDescendantsForceNew:
-#pragma warning restore CS0618 // Type or member is obsolete
-            case ContentSaveAction.PublishWithDescendantsIncludeUnpublished:
-            case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedNew:
-            case ContentSaveAction.PublishWithDescendantsForceRepublish:
-            case ContentSaveAction.PublishWithDescendantsForceRepublishNew:
-            case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublish:
-            case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublishNew:
             {
                 if (!await ValidatePublishBranchPermissionsAsync(contentItem))
                 {
@@ -1238,24 +1220,13 @@ public class ContentController : ContentControllerBase
 
     private static PublishBranchFilter BuildPublishBranchFilter(ContentSaveAction contentSaveAction)
     {
-        var includeUnpublished = contentSaveAction == ContentSaveAction.PublishWithDescendantsIncludeUnpublished
-                               || contentSaveAction == ContentSaveAction.PublishWithDescendantsIncludeUnpublishedNew
-                               || contentSaveAction == ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublish
-                               || contentSaveAction == ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublishNew;
-        var forceRepublish = contentSaveAction == ContentSaveAction.PublishWithDescendantsForceRepublish
-                               || contentSaveAction == ContentSaveAction.PublishWithDescendantsForceRepublishNew
-                               || contentSaveAction == ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublish
-                               || contentSaveAction == ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublishNew;
+        var includeUnpublished = contentSaveAction == ContentSaveAction.PublishWithDescendantsForce
+                               || contentSaveAction == ContentSaveAction.PublishWithDescendantsForceNew;
 
         PublishBranchFilter publishBranchFilter = PublishBranchFilter.Default;
         if (includeUnpublished)
         {
             publishBranchFilter |= PublishBranchFilter.IncludeUnpublished;
-        }
-
-        if (forceRepublish)
-        {
-            publishBranchFilter |= PublishBranchFilter.ForceRepublish;
         }
 
         return publishBranchFilter;

--- a/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
+++ b/src/Umbraco.Web.BackOffice/Filters/ContentSaveValidationAttribute.cs
@@ -182,12 +182,7 @@ public sealed class ContentSaveValidationAttribute : TypeFilterAttribute
                     break;
                 case ContentSaveAction.Publish:
                 case ContentSaveAction.PublishWithDescendants:
-#pragma warning disable CS0618 // Type or member is obsolete
                 case ContentSaveAction.PublishWithDescendantsForce:
-#pragma warning restore CS0618 // Type or member is obsolete
-                case ContentSaveAction.PublishWithDescendantsIncludeUnpublished:
-                case ContentSaveAction.PublishWithDescendantsForceRepublish:
-                case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublish:
                     permissionToCheck.Add(ActionPublish.ActionLetter);
                     contentToCheck = contentItem.PersistedContent;
                     contentIdToCheck = contentToCheck?.Id ?? default;
@@ -237,12 +232,7 @@ public sealed class ContentSaveValidationAttribute : TypeFilterAttribute
                     break;
                 case ContentSaveAction.PublishNew:
                 case ContentSaveAction.PublishWithDescendantsNew:
-#pragma warning disable CS0618 // Type or member is obsolete
                 case ContentSaveAction.PublishWithDescendantsForceNew:
-#pragma warning restore CS0618 // Type or member is obsolete
-                case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedNew:
-                case ContentSaveAction.PublishWithDescendantsForceRepublishNew:
-                case ContentSaveAction.PublishWithDescendantsIncludeUnpublishedAndForceRepublishNew:
                     //Publish new requires both ActionNew AND ActionPublish
                     // TODO: Shouldn't publish also require ActionUpdate since it will definitely perform an update to publish but maybe that's just implied
 

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -963,7 +963,7 @@
                         //we need to return this promise so that the dialog can handle the result and wire up the validation response
                         return performSave({
                             saveMethod: function (content, create, files, showNotifications) {
-                                return contentResource.publishWithDescendants(content, create, model.includeUnpublished, model.forceRepublish, files, showNotifications);
+                                return contentResource.publishWithDescendants(content, create, model.includeUnpublished, files, showNotifications);
                             },
                             action: "publishDescendants",
                             showNotifications: false,

--- a/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
+++ b/src/Umbraco.Web.UI.Client/src/common/resources/content.resource.js
@@ -1003,18 +1003,14 @@ function contentResource($q, $http, umbDataFormatter, umbRequestHelper) {
         * @returns {Promise} resourcePromise object containing the saved content item.
         *
         */
-        publishWithDescendants: function (content, isNew, includeUnpublished, forceRepublish, files, showNotifications) {
+        publishWithDescendants: function (content, isNew, includeUnpublished, files, showNotifications) {
             var endpoint = umbRequestHelper.getApiUrl(
                 "contentApiBaseUrl",
                 "PostSave");
 
             var action = "publishWithDescendants";
-            if (includeUnpublished === true && forceRepublish === true) {
-                action += "IncludeUnpublishedAndForceRepublish";
-            } else if (includeUnpublished === true) {
-                action += "IncludeUnpublished";
-            } else if (forceRepublish === true) {
-                action += "ForceRepublish";
+            if (includeUnpublished === true) {
+                action += "Force";
             }
 
             return saveContentItem(content, action + (isNew ? "New" : ""), files, endpoint, showNotifications);

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.controller.js
@@ -5,12 +5,10 @@
 
         var vm = this;
         vm.includeUnpublished = $scope.model.includeUnpublished || false;
-        vm.forceRepublish = $scope.model.forceRepublish || false;
         vm.publishAll = false;
 
         vm.changeSelection = changeSelection;
         vm.toggleIncludeUnpublished = toggleIncludeUnpublished;
-        vm.toggleForceRepublish = toggleForceRepublish;
         vm.changePublishAllSelection = changePublishAllSelection;
 
         function onInit() {
@@ -28,11 +26,6 @@
             if (!vm.labels.includeUnpublished) {
                 localizationService.localize("content_includeUnpublished").then(value => {
                     vm.labels.includeUnpublished = value;
-                });
-            }
-            if (!vm.labels.forceRepublish) {
-                localizationService.localize("content_forceRepublish").then(value => {
-                    vm.labels.forceRepublish = value;
                 });
             }
 
@@ -72,11 +65,6 @@
         function toggleIncludeUnpublished() {
             vm.includeUnpublished = !vm.includeUnpublished;
             $scope.model.includeUnpublished = vm.includeUnpublished;
-        }
-
-        function toggleForceRepublish() {
-            vm.forceRepublish = !vm.forceRepublish;
-            $scope.model.forceRepublish = vm.forceRepublish;
         }
 
         /** Returns true if publishing is possible based on if there are un-published mandatory languages */

--- a/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
+++ b/src/Umbraco.Web.UI.Client/src/views/content/overlays/publishdescendants.html
@@ -16,22 +16,6 @@
                         show-labels="true">
             </umb-toggle>
         </div>
-
-        <div class="flex mb3">
-            <umb-toggle checked="vm.forceRepublish"
-                        on-click="vm.toggleForceRepublish()"
-                        class="mr2"
-                        input-id="includeUnpublished"
-                        label-on="{{vm.labels.forceRepublish}}"
-                        label-off="{{vm.labels.forceRepublish}}"
-                        label-position="right"
-                        show-labels="true">
-            </umb-toggle>
-        </div>
-        <div ng-if="vm.forceRepublish" class="umb-alert umb-alert--warning">
-            <p><localize key="content_forceRepublishWarning"></localize></p>
-            <p><localize key="content_forceRepublishAdvisory"></localize></p>
-        </div>
     </div>
 
     <div ng-if="vm.displayVariants.length > 1">
@@ -49,22 +33,6 @@
                         label-position="right"
                         show-labels="true">
             </umb-toggle>
-        </div>
-
-        <div class="flex mb3">
-            <umb-toggle checked="vm.forceRepublish"
-                        on-click="vm.toggleForceRepublish()"
-                        class="mr2"
-                        input-id="includeUnpublished"
-                        label-on="{{vm.labels.forceRepublish}}"
-                        label-off="{{vm.labels.forceRepublish}}"
-                        label-position="right"
-                        show-labels="true">
-            </umb-toggle>
-        </div>
-        <div ng-if="vm.forceRepublish" class="umb-alert umb-alert--warning">
-            <p><localize key="content_forceRepublishWarning"></localize></p>
-            <p><localize key="content_forceRepublishAdvisory"></localize></p>
         </div>
 
         <div class="umb-list umb-list--condensed">


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Relates to: https://github.com/umbraco/Umbraco-CMS/issues/13739

### Description
Following discussions and release candidate feedback it's been decided that the publish with descendants dialog should not be updated as was proposed in https://github.com/umbraco/Umbraco-CMS/pull/18409

This PR reverts the UI aspects of these changes, so the service level methods are available but we don't clutter the UI for editors that won't normally have need of this option.

**To Test:**

- Verify that the publish descendants dialog now shows only the option to publish unpublished documents, and that the functionality works as expected when selecting or not selecting this option.