### PR TITLE
Bugfix: Document granular user permission preset

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
@@ -2,7 +2,7 @@ import type { UmbDocumentUserPermissionModel } from '../types.js';
 import { UmbDocumentItemRepository } from '../../item/index.js';
 import type { UmbDocumentItemModel } from '../../item/types.js';
 import { UMB_DOCUMENT_PICKER_MODAL } from '../../constants.js';
-import { css, customElement, html, repeat, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, property, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
@@ -26,6 +26,9 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 		const uniques = value.map((item) => item.document.id);
 		this.#observePickedDocuments(uniques);
 	}
+
+	@property({ type: Array, attribute: false })
+	fallbackPermissions: Array<string> = [];
 
 	@state()
 	private _items?: Array<UmbDocumentItemModel>;
@@ -118,10 +121,17 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 		return documentItem;
 	}
 
-	async #selectEntityUserPermissionsForDocument(item: UmbDocumentItemModel, allowedVerbs: Array<string> = []) {
+	async #selectEntityUserPermissionsForDocument(item: UmbDocumentItemModel, allowedVerbs?: Array<string>) {
 		// TODO: get correct variant name
 		const name = item.variants[0]?.name;
 		const headline = name ? `Permissions for ${name}` : 'Permissions';
+		const fallbackVerbs = this.#getFallbackPermissionVerbsForEntityType(item.entityType).flatMap(
+			(permission) => permission.meta.verbs,
+		);
+
+		const uniqueFallbackVerbs = [...new Set([...fallbackVerbs])];
+
+		const value = allowedVerbs || uniqueFallbackVerbs;
 
 		this.#entityUserPermissionModalContext = this.#modalManagerContext?.open(this, UMB_ENTITY_USER_PERMISSION_MODAL, {
 			data: {
@@ -130,7 +140,7 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 				headline,
 			},
 			value: {
-				allowedVerbs,
+				allowedVerbs: value,
 			},
 		});
 
@@ -224,16 +234,25 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 		if (!permission) return;
 
 		return umbExtensionsRegistry
-			.getAllExtensions()
-			.filter((manifest) => manifest.type === 'entityUserPermission')
-			.filter((manifest) =>
-				(manifest as ManifestEntityUserPermission).meta.verbs.every((verb) => permission.verbs.includes(verb)),
+			.getByTypeAndFilter('entityUserPermission', (manifest) =>
+				manifest.meta.verbs.every((verb) => permission.verbs.includes(verb)),
 			)
 			.map((m) => {
 				const manifest = m as ManifestEntityUserPermission;
 				return manifest.meta.label ? this.localize.string(manifest.meta.label) : manifest.name;
 			})
 			.join(', ');
+	}
+
+	#getFallbackPermissionVerbsForEntityType(entityType: string) {
+		// get all permissions that are allowed for the entity type and have at least one of the fallback permissions
+		// this is used to determine the default permissions for a document
+		return umbExtensionsRegistry.getByTypeAndFilter(
+			'entityUserPermission',
+			(manifest) =>
+				manifest.forEntityTypes.includes(entityType) &&
+				this.fallbackPermissions.map((verb) => manifest.meta.verbs.includes(verb)).includes(true),
+		);
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
@@ -121,7 +121,7 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 		return documentItem;
 	}
 
-	async #selectEntityUserPermissionsForDocument(item: UmbDocumentItemModel, allowedVerbs?: Array<string>) {
+	async #selectEntityUserPermissionsForDocument(item: UmbDocumentItemModel, allowedVerbs: Array<string> = []) {
 		// TODO: get correct variant name
 		const name = item.variants[0]?.name;
 		const headline = name ? `Permissions for ${name}` : 'Permissions';
@@ -131,16 +131,17 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 
 		const uniqueFallbackVerbs = [...new Set([...fallbackVerbs])];
 
-		const value = allowedVerbs || uniqueFallbackVerbs;
-
 		this.#entityUserPermissionModalContext = this.#modalManagerContext?.open(this, UMB_ENTITY_USER_PERMISSION_MODAL, {
 			data: {
 				unique: item.unique,
 				entityType: item.entityType,
 				headline,
+				preset: {
+					allowedVerbs: uniqueFallbackVerbs,
+				},
 			},
 			value: {
-				allowedVerbs: value,
+				allowedVerbs: allowedVerbs,
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
@@ -125,19 +125,14 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 		// TODO: get correct variant name
 		const name = item.variants[0]?.name;
 		const headline = name ? `Permissions for ${name}` : 'Permissions';
-		const fallbackVerbs = this.#getFallbackPermissionVerbsForEntityType(item.entityType).flatMap(
-			(permission) => permission.meta.verbs,
-		);
-
-		const uniqueFallbackVerbs = [...new Set([...fallbackVerbs])];
-
+		const fallbackVerbs = this.#getFallbackPermissionVerbsForEntityType(item.entityType);
 		this.#entityUserPermissionModalContext = this.#modalManagerContext?.open(this, UMB_ENTITY_USER_PERMISSION_MODAL, {
 			data: {
 				unique: item.unique,
 				entityType: item.entityType,
 				headline,
 				preset: {
-					allowedVerbs: uniqueFallbackVerbs,
+					allowedVerbs: fallbackVerbs,
 				},
 			},
 			value: {
@@ -248,12 +243,17 @@ export class UmbInputDocumentGranularUserPermissionElement extends UUIFormContro
 	#getFallbackPermissionVerbsForEntityType(entityType: string) {
 		// get all permissions that are allowed for the entity type and have at least one of the fallback permissions
 		// this is used to determine the default permissions for a document
-		return umbExtensionsRegistry.getByTypeAndFilter(
-			'entityUserPermission',
-			(manifest) =>
-				manifest.forEntityTypes.includes(entityType) &&
-				this.fallbackPermissions.map((verb) => manifest.meta.verbs.includes(verb)).includes(true),
-		);
+		const verbs = umbExtensionsRegistry
+			.getByTypeAndFilter(
+				'entityUserPermission',
+				(manifest) =>
+					manifest.forEntityTypes.includes(entityType) &&
+					this.fallbackPermissions.map((verb) => manifest.meta.verbs.includes(verb)).includes(true),
+			)
+			.flatMap((permission) => permission.meta.verbs);
+
+		// ensure that the verbs are unique
+		return [...new Set([...verbs])];
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
@@ -11,6 +11,9 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 	@state()
 	_userGroupPermissions?: Array<any>;
 
+	@state()
+	_userGroupFallbackPermissions?: Array<string>;
+
 	#workspaceContext?: typeof UMB_USER_GROUP_WORKSPACE_CONTEXT.TYPE;
 
 	constructor() {
@@ -23,6 +26,7 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 				this.#workspaceContext.data,
 				(userGroup) => {
 					this._userGroupPermissions = userGroup?.permissions;
+					this._userGroupFallbackPermissions = userGroup?.fallbackPermissions;
 				},
 				'umbUserGroupGranularPermissionObserver',
 			);
@@ -75,6 +79,7 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 			this._userGroupPermissions.filter((permission) => permission.$type === schemaType) || [];
 
 		(extension.component as any).permissions = permissionsForSchemaType;
+		(extension.component as any).fallbackPermissions = this._userGroupFallbackPermissions;
 		extension.component.addEventListener(UmbChangeEvent.TYPE, this.#onValueChange);
 
 		return html`

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/components/user-group-granular-permission-list.element.ts
@@ -59,6 +59,7 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 		if (!this._userGroupPermissions) return;
 		return html`<umb-extension-slot
 			type="userGranularPermission"
+			.props=${{ fallbackPermissions: this._userGroupFallbackPermissions }}
 			.renderMethod=${this.#renderProperty}></umb-extension-slot>`;
 	}
 
@@ -79,7 +80,6 @@ export class UmbUserGroupGranularPermissionListElement extends UmbLitElement {
 			this._userGroupPermissions.filter((permission) => permission.$type === schemaType) || [];
 
 		(extension.component as any).permissions = permissionsForSchemaType;
-		(extension.component as any).fallbackPermissions = this._userGroupFallbackPermissions;
 		extension.component.addEventListener(UmbChangeEvent.TYPE, this.#onValueChange);
 
 		return html`

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-permission/modals/settings/entity-user-permission-settings-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-permission/modals/settings/entity-user-permission-settings-modal.element.ts
@@ -16,6 +16,7 @@ export class UmbEntityUserPermissionSettingsModalElement extends UmbModalBaseEle
 		super.data = data;
 		this._entityType = data?.entityType;
 		this._headline = data?.headline ?? this._headline;
+		this._preset = data?.preset;
 	}
 
 	@state()
@@ -23,6 +24,17 @@ export class UmbEntityUserPermissionSettingsModalElement extends UmbModalBaseEle
 
 	@state()
 	_entityType?: string;
+
+	@state()
+	_preset?: UmbEntityUserPermissionSettingsModalValue;
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+
+		if (this._preset?.allowedVerbs) {
+			this.updateValue({ allowedVerbs: this._preset?.allowedVerbs });
+		}
+	}
 
 	#onPermissionChange(event: UmbSelectionChangeEvent) {
 		const target = event.target as any;

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-permission/modals/settings/entity-user-permission-settings-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-permission/modals/settings/entity-user-permission-settings-modal.token.ts
@@ -4,6 +4,7 @@ export interface UmbEntityUserPermissionSettingsModalData {
 	unique: string;
 	entityType: string;
 	headline?: string;
+	preset?: UmbEntityUserPermissionSettingsModalValue;
 }
 
 export type UmbEntityUserPermissionSettingsModalValue = {


### PR DESCRIPTION
This PR updates the the UX for document granular user permission to set the user group fallback permissions as a preset for the granular permissions.

See video for example:

https://github.com/user-attachments/assets/f68adfbf-542a-425d-9aac-211b14a13304



What to test:
* ensure that the toggles are correctly checked when adding/editing
* ensure that the correct permission verbs are persisted.

