### PR TITLE
Fix issue text overflow when user name is too long

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/users/umb-user-cards.less
@@ -89,11 +89,16 @@
 
 
 .umb-user-card__name {
-    font-size: 15px;
-    font-weight: bold;
-    text-align: center;
-    margin-bottom: 2px;
-    word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 15px;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 2px;
+  word-wrap: break-word;
 }
 
 .umb-user-card__group {
@@ -106,4 +111,13 @@
     font-size: 13px;
     text-align: center;
     margin-top: auto;
+}
+
+.umb-user-name__last-login {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
+++ b/src/Umbraco.Web.UI.Client/src/views/users/views/users/users.html
@@ -196,7 +196,7 @@
                             <umb-avatar size="l" color="secondary" name="{{user.name}}" img-src="{{user.avatars[2]}}" img-srcset="{{user.avatars[3]}} 2x, {{user.avatars[4]}} 3x">
                             </umb-avatar>
                         </div>
-                        <div class="umb-user-card__name">{{user.name}}</div>
+                        <div title="{{user.name}}" class="umb-user-card__name">{{user.name}}</div>
                     </a>
                     <div class="umb-user-card__group">
                         <span ng-repeat="userGroup in user.userGroups">{{ userGroup.name }}<span ng-if="!$last">, </span></span>
@@ -209,9 +209,10 @@
                             {{ user.formattedLastLogin }}
                         </div>
                         <div ng-if="!user.formattedLastLogin">
-                            <div>{{ user.name | umbWordLimit:1 }}
-                                <localize key="user_noLogin">has not logged in yet</localize>
-                            </div>
+                          <div class="umb-user-name__last-login" title="{{ user.name | umbWordLimit:1 }}">
+                            {{ user.name | umbWordLimit:1 }}
+                          </div>
+                          <localize key="user_noLogin">has not logged in yet</localize>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This PR fixes the issue https://github.com/umbraco/Umbraco-CMS/issues/18535
We will display the user name with an ellipsis at the end and when hovering, the user can see the full text.

Result after fixed:
<img width="589" alt="image" src="https://github.com/user-attachments/assets/2acde418-112e-45cb-875f-1a932785f7cc" />


<!-- Thanks for contributing to Umbraco CMS! -->
