### PR TITLE
15.3: Hotfix: Awaits Open Content Picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
@@ -46,7 +46,7 @@ export class UmbDocumentPickerInputContext extends UmbPickerInputContext<
 			...pickerData?.search?.queryParams,
 		};
 
-		super.openPicker(combinedPickerData);
+		await super.openPicker(combinedPickerData);
 	}
 
 	#pickableFilter = (

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.context.ts
@@ -44,7 +44,7 @@ export class UmbMediaPickerInputContext extends UmbPickerInputContext<
 			...pickerData?.search?.queryParams,
 		};
 
-		super.openPicker(combinedPickerData);
+		await super.openPicker(combinedPickerData);
 	}
 
 	#pickableFilter = (

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/components/input-member/input-member.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/components/input-member/input-member.context.ts
@@ -48,7 +48,7 @@ export class UmbMemberPickerInputContext extends UmbPickerInputContext<
 			...pickerData?.search?.queryParams,
 		};
 
-		super.openPicker(combinedPickerData);
+		await super.openPicker(combinedPickerData);
 	}
 
 	#pickableFilter = (


### PR DESCRIPTION
### Description

Fixes #18493.

Awaits the `super.openPicker()` call for Document, Media and Member picker contexts.
