### PR TITLE
Fix focal point drag not working on firefox

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
@@ -148,6 +148,10 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 
 	#handleGridDrag(event: PointerEvent) {
 		if (this.disabled || this.hideFocalPoint) return;
+		if (event.button !== 0) {
+			// This is not a primary mouse button click, so lets not do anything.
+			return;
+		}
 
 		const grid = this.wrapperElement;
 		const handle = this.focalPointElement;
@@ -179,7 +183,7 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 
 	#changeFocalPoint(event: PointerEvent) {
 		if (this.disabled || this.hideFocalPoint) return;
-		if (event.pointerType === 'mouse' && event.button !== 0) {
+		if (event.button !== 0) {
 			// This is not a primary mouse button click, so lets not do anything.
 			return;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
@@ -148,7 +148,7 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 
 	#handleGridDrag(event: PointerEvent) {
 		if (this.disabled || this.hideFocalPoint) return;
-
+		
 		const grid = this.wrapperElement;
 		const handle = this.focalPointElement;
 
@@ -169,12 +169,33 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 
 				this.coords.x = x;
 				this.coords.y = y;
-
+				
 				this.#setFocalPoint(x, y, width, height);
 			},
 			onStop: () => (this._isDraggingGridHandle = false),
 			initialEvent: event,
 		});
+	}
+
+	#changeFocalPoint(event: PointerEvent){
+		if (this.disabled || this.hideFocalPoint) return;
+
+		const grid = this.wrapperElement;
+		const handle = this.focalPointElement;
+
+		if (!grid) return;
+
+		handle?.focus();
+
+		const dims = grid.getBoundingClientRect();
+		const defaultView = grid.ownerDocument.defaultView!;
+		const { width, height } = grid.getBoundingClientRect();
+		const offsetX = dims.left + defaultView.scrollX;
+		const offsetY = dims.top + defaultView.scrollY;
+
+		const x = event.pageX - offsetX;
+		const y = event.pageY - offsetY;
+		this.#setFocalPoint(x, y, width, height);
 	}
 
 	#handleGridKeyDown(event: KeyboardEvent) {
@@ -215,7 +236,7 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 	override render() {
 		if (!this.src) return nothing;
 		return html`
-			<div id="wrapper" @mousedown=${this.#handleGridDrag} @touchstart=${this.#handleGridDrag}>
+			<div id="wrapper" @click=${this.#changeFocalPoint} @mousedown=${this.#handleGridDrag} @touchstart=${this.#handleGridDrag}>
 				<img id="image" @keydown=${() => nothing} src=${this.src} alt="" />
 				<span
 					id="focal-point"

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
@@ -148,7 +148,7 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 
 	#handleGridDrag(event: PointerEvent) {
 		if (this.disabled || this.hideFocalPoint) return;
-		
+
 		const grid = this.wrapperElement;
 		const handle = this.focalPointElement;
 
@@ -169,7 +169,7 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 
 				this.coords.x = x;
 				this.coords.y = y;
-				
+
 				this.#setFocalPoint(x, y, width, height);
 			},
 			onStop: () => (this._isDraggingGridHandle = false),
@@ -177,8 +177,12 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 		});
 	}
 
-	#changeFocalPoint(event: PointerEvent){
+	#changeFocalPoint(event: PointerEvent) {
 		if (this.disabled || this.hideFocalPoint) return;
+		if (event.pointerType === 'mouse' && event.button !== 0) {
+			// This is not a primary mouse button click, so lets not do anything.
+			return;
+		}
 
 		const grid = this.wrapperElement;
 		const handle = this.focalPointElement;
@@ -236,7 +240,11 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 	override render() {
 		if (!this.src) return nothing;
 		return html`
-			<div id="wrapper" @click=${this.#changeFocalPoint} @mousedown=${this.#handleGridDrag} @touchstart=${this.#handleGridDrag}>
+			<div
+				id="wrapper"
+				@click=${this.#changeFocalPoint}
+				@mousedown=${this.#handleGridDrag}
+				@touchstart=${this.#handleGridDrag}>
 				<img id="image" @keydown=${() => nothing} src=${this.src} alt="" />
 				<span
 					id="focal-point"


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
There is currently a bug that prevents random clicking to select a new focal point for an image (on both Chrome and Firefox). This PR fixed that issue by adding a method to listen to the click event to change the focal point.

<!-- Thanks for contributing to Umbraco CMS! -->
