### PR TITLE
Updates dependency on Examine to 3.7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,8 +45,8 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="7.1.1" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.1.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageVersion Include="Examine" Version="3.5.0" />
-    <PackageVersion Include="Examine.Core" Version="3.5.0" />
+    <PackageVersion Include="Examine" Version="3.7.0" />
+    <PackageVersion Include="Examine.Core" Version="3.7.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="MailKit" Version="4.8.0" />


### PR DESCRIPTION
Updates to the [latest Examine release](https://github.com/Shazwazza/Examine/releases/tag/v3.7.0) which has fixes for issues surfacing in Umbraco.

To test I've verified that I can still interrogate and rebuild indexes in the backoffice and a simple search implementation based on what we use on umbraco.com still functions as before.