### PR TITLE
Removed obsoleted group alias keys from being publicly available

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Security/ExternalSignInAutoLinkOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/ExternalSignInAutoLinkOptions.cs
@@ -17,7 +17,7 @@ public class ExternalSignInAutoLinkOptions
     ///     Initializes a new instance of the <see cref="ExternalSignInAutoLinkOptions" /> class.
     /// </summary>
     /// <param name="autoLinkExternalAccount"></param>
-    /// <param name="defaultUserGroups">If null, the default will be the 'editor' group</param>
+    /// <param name="defaultUserGroups">If null, the default will be no groups.</param>
     /// <param name="defaultCulture"></param>
     /// <param name="allowManualLinking"></param>
     public ExternalSignInAutoLinkOptions(
@@ -26,7 +26,7 @@ public class ExternalSignInAutoLinkOptions
         string? defaultCulture = null,
         bool allowManualLinking = true)
     {
-        DefaultUserGroups = defaultUserGroups ?? new[] { SecurityConstants.EditorGroupAlias };
+        DefaultUserGroups = defaultUserGroups ?? [];
         AutoLinkExternalAccount = autoLinkExternalAccount;
         AllowManualLinking = allowManualLinking;
         _defaultCulture = defaultCulture;

--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -34,18 +34,6 @@ public static partial class Constants
 
         public const string AdminGroupAlias = "admin";
 
-        [Obsolete("Use EditorGroupKey instead. Scheduled for removal in V15.")]
-        public const string EditorGroupAlias = "editor";
-
-        [Obsolete("Use SensitiveDataGroupKey instead. Scheduled for removal in V15.")]
-        public const string SensitiveDataGroupAlias = "sensitiveData";
-
-        [Obsolete("Use TranslatorGroupKey instead. Scheduled for removal in V15.")]
-        public const string TranslatorGroupAlias = "translator";
-
-        [Obsolete("Use WriterGroupKey instead. Scheduled for removal in V15.")]
-        public const string WriterGroupAlias = "writer";
-
         /// <summary>
         /// The key of the admin group
         /// </summary>

--- a/src/Umbraco.Core/Models/UserExtensions.cs
+++ b/src/Umbraco.Core/Models/UserExtensions.cs
@@ -137,7 +137,7 @@ public static class UserExtensions
             throw new ArgumentNullException("user");
         }
 
-        return user.Groups != null && user.Groups.Any(x => x.Alias == Constants.Security.SensitiveDataGroupAlias);
+        return user.Groups != null && user.Groups.Any(x => x.Key == Constants.Security.SensitiveDataGroupKey);
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -20,6 +20,14 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install;
 internal class DatabaseDataCreator
 {
 
+    internal const string EditorGroupAlias = "editor";
+
+    internal const string SensitiveDataGroupAlias = "sensitiveData";
+
+    internal const string TranslatorGroupAlias = "translator";
+
+    internal const string WriterGroupAlias = "writer";
+
     internal static readonly LogViewerQueryDto[] _defaultLogQueries =
     [
         new()
@@ -1217,7 +1225,7 @@ internal class DatabaseDataCreator
                 Key = Constants.Security.WriterGroupKey,
                 StartMediaId = -1,
                 StartContentId = -1,
-                Alias = Constants.Security.WriterGroupAlias,
+                Alias = WriterGroupAlias,
                 Name = "Writers",
                 CreateDate = DateTime.Now,
                 UpdateDate = DateTime.Now,
@@ -1234,7 +1242,7 @@ internal class DatabaseDataCreator
                 Key = Constants.Security.EditorGroupKey,
                 StartMediaId = -1,
                 StartContentId = -1,
-                Alias = Constants.Security.EditorGroupAlias,
+                Alias = EditorGroupAlias,
                 Name = "Editors",
                 CreateDate = DateTime.Now,
                 UpdateDate = DateTime.Now,
@@ -1251,7 +1259,7 @@ internal class DatabaseDataCreator
                 Key = Constants.Security.TranslatorGroupKey,
                 StartMediaId = -1,
                 StartContentId = -1,
-                Alias = Constants.Security.TranslatorGroupAlias,
+                Alias = TranslatorGroupAlias,
                 Name = "Translators",
                 CreateDate = DateTime.Now,
                 UpdateDate = DateTime.Now,
@@ -1266,7 +1274,7 @@ internal class DatabaseDataCreator
             {
                 Id = 5,
                 Key = Constants.Security.SensitiveDataGroupKey,
-                Alias = Constants.Security.SensitiveDataGroupAlias,
+                Alias = SensitiveDataGroupAlias,
                 Name = "Sensitive data",
                 CreateDate = DateTime.Now,
                 UpdateDate = DateTime.Now,

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Filter.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Filter.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 
@@ -242,7 +243,7 @@ internal sealed partial class UserServiceCrudTests
         var userService = CreateUserService();
         await CreateTestUsers(userService);
 
-        var writerGroup = await UserGroupService.GetAsync(Constants.Security.WriterGroupAlias);
+        var writerGroup = await UserGroupService.GetAsync(DatabaseDataCreator.WriterGroupAlias);
         var filter = new UserFilter
         {
             IncludedUserGroups = new HashSet<Guid> { writerGroup!.Key }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Infrastructure.Persistence.Mappers;
@@ -326,7 +327,7 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
                     out var totalRecs,
                     user => user.Id,
                     Direction.Ascending,
-                    excludeUserGroups: new[] { Constants.Security.TranslatorGroupAlias },
+                    excludeUserGroups: new[] { DatabaseDataCreator.TranslatorGroupAlias },
                     filter: provider.CreateQuery<IUser>().Where(x => x.Id > -1));
 
                 // Assert
@@ -363,8 +364,8 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
                     out var totalRecs,
                     user => user.Id,
                     Direction.Ascending,
-                    new[] { Constants.Security.AdminGroupAlias, Constants.Security.SensitiveDataGroupAlias },
-                    new[] { Constants.Security.TranslatorGroupAlias },
+                    new[] { Constants.Security.AdminGroupAlias, DatabaseDataCreator.SensitiveDataGroupAlias },
+                    new[] { DatabaseDataCreator.TranslatorGroupAlias },
                     filter: provider.CreateQuery<IUser>().Where(x => x.Id == -1));
 
                 // Assert

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserGroupServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserGroupServiceTests.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
 
@@ -90,11 +91,10 @@ public class UserGroupServiceTests
         });
     }
 
-    // Obsoletion will be resolved when they are converted to internal consts.
     [TestCase(null, null, UserGroupOperationStatus.Success)]
     [TestCase(Constants.Security.AdminGroupKeyString, Constants.Security.AdminGroupAlias, UserGroupOperationStatus.CanNotUpdateAliasIsSystemUserGroup)]
-    [TestCase(Constants.Security.SensitiveDataGroupKeyString, Constants.Security.SensitiveDataGroupAlias, UserGroupOperationStatus.CanNotUpdateAliasIsSystemUserGroup)]
-    [TestCase(Constants.Security.TranslatorGroupString, Constants.Security.TranslatorGroupAlias, UserGroupOperationStatus.CanNotUpdateAliasIsSystemUserGroup)]
+    [TestCase(Constants.Security.SensitiveDataGroupKeyString, DatabaseDataCreator.SensitiveDataGroupAlias, UserGroupOperationStatus.CanNotUpdateAliasIsSystemUserGroup)]
+    [TestCase(Constants.Security.TranslatorGroupString, DatabaseDataCreator.TranslatorGroupAlias, UserGroupOperationStatus.CanNotUpdateAliasIsSystemUserGroup)]
     public async Task Can_Not_Update_SystemGroup_Alias(string? systemGroupKey, string? systemGroupAlias, UserGroupOperationStatus status)
     {
         // prep

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Editors/UserEditorAuthorizationHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Editors/UserEditorAuthorizationHelperTests.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Models.Membership.Permissions;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 
@@ -108,9 +109,9 @@ public class UserEditorAuthorizationHelperTests
     [Test]
     [TestCase(Constants.Security.AdminGroupAlias, Constants.Security.AdminGroupAlias, ExpectedResult = true)]
     [TestCase(Constants.Security.AdminGroupAlias, "SomethingElse", ExpectedResult = true)]
-    [TestCase(Constants.Security.EditorGroupAlias, Constants.Security.AdminGroupAlias, ExpectedResult = false)]
-    [TestCase(Constants.Security.EditorGroupAlias, "SomethingElse", ExpectedResult = false)]
-    [TestCase(Constants.Security.EditorGroupAlias, Constants.Security.EditorGroupAlias, ExpectedResult = true)]
+    [TestCase(DatabaseDataCreator.EditorGroupAlias, Constants.Security.AdminGroupAlias, ExpectedResult = false)]
+    [TestCase(DatabaseDataCreator.EditorGroupAlias, "SomethingElse", ExpectedResult = false)]
+    [TestCase(DatabaseDataCreator.EditorGroupAlias, DatabaseDataCreator.EditorGroupAlias, ExpectedResult = true)]
     public bool Can_only_add_user_groups_you_are_part_of_yourself_unless_you_are_admin(
         string groupAlias,
         string groupToAdd)


### PR DESCRIPTION
Further clean-up task for Umbraco 16, which is based on this PR: https://github.com/umbraco/Umbraco-CMS/pull/18661

Here I've removed the obsolete group alias keys from being publicly available and moved them into internal constants to be used for database seeding.  I've then updated the tests and checks that used aliases that could be switched to keys.

There's a behavioural change in that external login auto linking with no options provided will link a user with no groups rather than putting them in editors.  This seems reasonable though - it's best for implementors to be specific about this rather than them defaulting into a group that typically has full content permissions.