### PR TITLE
Fixes link for access to composition from document type property outside of group.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/views/design/content-type-design-editor-tab.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content-type/workspace/views/design/content-type-design-editor-tab.element.ts
@@ -173,7 +173,8 @@ export class UmbContentTypeDesignEditorTabElement extends UmbLitElement {
 					? html`
 							<uui-box class="${this._hasProperties ? '' : 'opaque'}">
 								<umb-content-type-design-editor-properties
-									.containerId=${this.containerId}></umb-content-type-design-editor-properties>
+									.containerId=${this.containerId}
+									.editContentTypePath=${this._editContentTypePath}></umb-content-type-design-editor-properties>
 							</uui-box>
 						`
 					: nothing


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18684

### Description
Took me a while to replicate this one, as I didn't see the issue with Umbraco's starter kit, only the "Clean" one used in the originally posted issue.  But turned out the difference was in properties that are in tabs but not in groups - in this case the root part of the link wasn't set.  It is now following this PR.

**To Test:**

- Create a property on a document type that sits in a tab but not in a group.
- Create a document type that uses this first document type as a composition.
- Make sure you can click the link from the property to access the composition in  a modal editor (see screenshots on linked issue).
