### PR TITLE
Restrict valid API user client IDs to 100 characters

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ClientCredentials/ClientCredentialsUserControllerBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Core.Security.OperationStatus;
 
@@ -20,7 +20,7 @@ public abstract class ClientCredentialsUserControllerBase : UserControllerBase
                 .Build()),
             BackOfficeUserClientCredentialsOperationStatus.InvalidClientId => BadRequest(problemDetailsBuilder
                 .WithTitle("Invalid client ID")
-                .WithDetail("The specified client ID is invalid. A valid client ID can only contain [a-z], [A-Z], [0-9], and [-._~]. Furthermore, including the prefix it cannot be longer than 255 characters.")
+                .WithDetail("The specified client ID is invalid. A valid client ID can only contain [a-z], [A-Z], [0-9], and [-._~]. Furthermore, including the prefix it cannot be longer than 100 characters.")
                 .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown client credentials operation status.")

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2680,7 +2680,7 @@ internal partial class UserService : RepositoryService, IUserService
         }
     }
 
-    [GeneratedRegex(@"^[\w\d\-\._~]{1,255}$")]
+    [GeneratedRegex(@"^[\w\d\-\._~]{1,100}$")]
     private static partial Regex ValidClientId();
 
     #endregion

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.cs
@@ -1004,8 +1004,21 @@ public class UserServiceTests : UmbracoIntegrationTest
     [TestCase("@", UserClientCredentialsOperationStatus.InvalidClientId)]
     [TestCase("[", UserClientCredentialsOperationStatus.InvalidClientId)]
     [TestCase("]", UserClientCredentialsOperationStatus.InvalidClientId)]
-    [TestCase("More_Than_255_characters_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", UserClientCredentialsOperationStatus.InvalidClientId)]
     public async Task Can_Use_Only_Unreserved_Characters_For_ClientId(string clientId, UserClientCredentialsOperationStatus expectedResult)
+    {
+        // Arrange
+        var user = await CreateTestUser(UserKind.Api);
+
+        // Act
+        var result = await UserService.AddClientIdAsync(user.Key, clientId);
+
+        // Assert
+        Assert.AreEqual(expectedResult, result);
+    }
+
+    [TestCase("Less_Than_100_characters_0123456789012345678901234567890123456789012345678901234567890123456789", UserClientCredentialsOperationStatus.Success)]
+    [TestCase("More_Than_100_characters_01234567890123456789012345678901234567890123456789012345678901234567890123456789", UserClientCredentialsOperationStatus.InvalidClientId)]
+    public async Task Cannot_Create_Too_Long_ClientId(string clientId, UserClientCredentialsOperationStatus expectedResult)
     {
         // Arrange
         var user = await CreateTestUser(UserKind.Api);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: [17506](https://github.com/umbraco/Umbraco-CMS/issues/17506)

### Description
This issue already had a fix https://github.com/umbraco/Umbraco-CMS/pull/17536, but it looks like it didn't go far enough.

In this PR a max characters of 255 was set for a client ID, allowing it to fit into the `umbracoUser2ClientId.clientId` field.

But it's also written to `umbracoOpenIddictApplications.ClientId`, and that only allows 100 characters.

So this PR reduces the limit to 100 character and updates the message and testss.

**To Test:**

- Follow reproduction steps in https://github.com/umbraco/Umbraco-CMS/issues/17506