### PR TITLE
Fixes issue with macro rendering in an RTE when GUIDs are used for backoffice document routes

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/MacroRenderingController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/MacroRenderingController.cs
@@ -124,7 +124,7 @@ public class MacroRenderingController : UmbracoAuthorizedJsonController
         }
 
         IUmbracoContext umbracoContext = _umbracoContextAccessor.GetRequiredUmbracoContext();
-        IPublishedContent publishedContent = GetPagePublishedContent(pageId, umbracoContext);
+        IPublishedContent? publishedContent = GetPagePublishedContent(pageId, umbracoContext);
 
         //if it isn't supposed to be rendered in the editor then return an empty string
         //currently we cannot render a macro if the page doesn't yet exist


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/16129

### Description
Seems we do support backoffice routes using GUIDs in Umbraco 13, so this fixes an issue reported when making use of this with macro rendering.  I've amended the request to accept either a GUID or an integer when looking up the content the macros is rendering on.

**To Test:**

- Add a macro in an RTE that renders in the backoffice (e.g. using the simple Partial View Macro File below).
- Amend the URL of the backoffice page that renders the document for editing, amending the integer ID with the page's GUID.
- Make sure the macro renders and no error is thrown.

```
@inherits Umbraco.Cms.Web.Common.Macros.PartialViewMacroPage

<p>Test Macro Rendering</p>
```
