### PR TITLE
Removed obsoletion of Utf8ToAsciiConverter.ToAsciiString overload

### DIFF
--- a/src/Umbraco.Core/Strings/Utf8ToAsciiConverter.cs
+++ b/src/Umbraco.Core/Strings/Utf8ToAsciiConverter.cs
@@ -11,11 +11,13 @@ namespace Umbraco.Cms.Core.Strings;
 /// </remarks>
 public static class Utf8ToAsciiConverter
 {
-    [Obsolete("Use ToAsciiString(ReadOnlySpan<char>..) instead")]
-    public static string ToAsciiString(string text, char fail = '?')
-    {
-        return ToAsciiString(text.AsSpan(), fail);
-    }
+    /// <summary>
+    ///     Converts an Utf8 string into an Ascii string.
+    /// </summary>
+    /// <param name="text">The text to convert.</param>
+    /// <param name="fail">The character to use to replace characters that cannot properly be converted.</param>
+    /// <returns>The converted text.</returns>
+    public static string ToAsciiString(string text, char fail = '?') => ToAsciiString(text.AsSpan(), fail);
 
     /// <summary>
     ///     Converts an Utf8 string into an Ascii string.


### PR DESCRIPTION
Further clean-up task for Umbraco 16, which is based on this PR: https://github.com/umbraco/Umbraco-CMS/pull/18661

Here I've just removed the obsoletion, as I think it was incorrectly applied in the first place.  It's the obsoleted method that we are calling from `DefaultShortStringHelper`, and if we change this to use the obsoleted one, all it does is move and repeat the `.ToSpan()` call.  So in this case I think it's cleaner the calling code can stick to working with strings, and just pass a string in, that can then defer to the optimized method.