### PR TITLE
Removed obsoletion properties on configuration response  models

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/ConfigurationMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/ConfigurationMediaController.cs
@@ -1,4 +1,4 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
@@ -7,6 +7,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Media;
 namespace Umbraco.Cms.Api.Management.Controllers.Media;
 
 [ApiVersion("1.0")]
+[Obsolete("No longer used. Scheduled for removal in Umbraco 18.")]
 public class ConfigurationMediaController : MediaControllerBase
 {
     private readonly IConfigurationPresentationFactory _configurationPresentationFactory;

--- a/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
@@ -40,7 +40,6 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
             DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
             AllowEditInvariantFromNonDefault = _contentSettings.AllowEditInvariantFromNonDefault,
             AllowNonExistingSegmentsCreation = _segmentSettings.AllowCreation,
-            ReservedFieldNames = _reservedFieldNamesService.GetDocumentReservedFieldNames(),
         };
 
     public DocumentTypeConfigurationResponseModel CreateDocumentTypeConfigurationResponseModel() =>
@@ -53,10 +52,7 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         };
 
     public MemberConfigurationResponseModel CreateMemberConfigurationResponseModel() =>
-        new()
-        {
-            ReservedFieldNames = _reservedFieldNamesService.GetMemberReservedFieldNames(),
-        };
+        new();
 
     public MemberTypeConfigurationResponseModel CreateMemberTypeConfigurationResponseModel() =>
         new()
@@ -69,7 +65,6 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         {
             DisableDeleteWhenReferenced = _contentSettings.DisableDeleteWhenReferenced,
             DisableUnpublishWhenReferenced = _contentSettings.DisableUnpublishWhenReferenced,
-            ReservedFieldNames = _reservedFieldNamesService.GetMediaReservedFieldNames(),
         };
 
     public MediaTypeConfigurationResponseModel CreateMediaTypeConfigurationResponseModel() =>

--- a/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType;
@@ -19,6 +19,7 @@ public interface IConfigurationPresentationFactory
     MemberTypeConfigurationResponseModel CreateMemberTypeConfigurationResponseModel()
         => throw new NotImplementedException();
 
+    [Obsolete("No longer used. Scheduled for removal in Umbraco 18.")]
     MediaConfigurationResponseModel CreateMediaConfigurationResponseModel();
 
     MediaTypeConfigurationResponseModel CreateMediaTypeConfigurationResponseModel()

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -16813,6 +16813,7 @@
             "description": "The authenticated user does not have access to this resource"
           }
         },
+        "deprecated": true,
         "security": [
           {
             "Backoffice User": [ ]
@@ -36735,8 +36736,7 @@
           "allowEditInvariantFromNonDefault",
           "allowNonExistingSegmentsCreation",
           "disableDeleteWhenReferenced",
-          "disableUnpublishWhenReferenced",
-          "reservedFieldNames"
+          "disableUnpublishWhenReferenced"
         ],
         "type": "object",
         "properties": {
@@ -36751,14 +36751,6 @@
           },
           "allowNonExistingSegmentsCreation": {
             "type": "boolean"
-          },
-          "reservedFieldNames": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "deprecated": true
           }
         },
         "additionalProperties": false
@@ -38942,8 +38934,7 @@
       "MediaConfigurationResponseModel": {
         "required": [
           "disableDeleteWhenReferenced",
-          "disableUnpublishWhenReferenced",
-          "reservedFieldNames"
+          "disableUnpublishWhenReferenced"
         ],
         "type": "object",
         "properties": {
@@ -38952,14 +38943,6 @@
           },
           "disableUnpublishWhenReferenced": {
             "type": "boolean"
-          },
-          "reservedFieldNames": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "deprecated": true
           }
         },
         "additionalProperties": false
@@ -39787,20 +39770,7 @@
         "additionalProperties": false
       },
       "MemberConfigurationResponseModel": {
-        "required": [
-          "reservedFieldNames"
-        ],
         "type": "object",
-        "properties": {
-          "reservedFieldNames": {
-            "uniqueItems": true,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "deprecated": true
-          }
-        },
         "additionalProperties": false
       },
       "MemberGroupItemResponseModel": {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
@@ -9,7 +9,4 @@ public class DocumentConfigurationResponseModel
     public required bool AllowEditInvariantFromNonDefault { get; set; }
 
     public required bool AllowNonExistingSegmentsCreation { get; set; }
-
-    [Obsolete("Use DocumentTypeConfigurationResponseModel.ReservedFieldNames from the ConfigurationDocumentTypeController endpoint instead.")]
-    public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaConfigurationResponseModel.cs
@@ -1,11 +1,8 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Media;
+namespace Umbraco.Cms.Api.Management.ViewModels.Media;
 
 public class MediaConfigurationResponseModel
 {
     public required bool DisableDeleteWhenReferenced { get; set; }
 
     public required bool DisableUnpublishWhenReferenced { get; set; }
-
-    [Obsolete("Use MediaTypeConfigurationResponseModel.ReservedFieldNames from the ConfigurationMediaTypeController endpoint instead.")]
-    public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/MemberConfigurationResponseModel.cs
@@ -1,7 +1,6 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Member;
+namespace Umbraco.Cms.Api.Management.ViewModels.Member;
 
+[Obsolete("No longer used. Scheduled for removal in Umbraco 18.")]
 public class MemberConfigurationResponseModel
 {
-    [Obsolete("Use MemberTypeConfigurationResponseModel.ReservedFieldNames from the ConfigurationMemberTypeController endpoint instead.")]
-    public required ISet<string> ReservedFieldNames { get; set; }
 }

--- a/src/Umbraco.Web.UI.Client/src/external/backend-api/src/sdk.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/backend-api/src/sdk.gen.ts
@@ -3768,6 +3768,7 @@ export class MediaService {
     }
     
     /**
+     * @deprecated
      * @returns unknown OK
      * @throws ApiError
      */

--- a/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/backend-api/src/types.gen.ts
@@ -647,10 +647,6 @@ export type DocumentConfigurationResponseModel = {
     disableUnpublishWhenReferenced: boolean;
     allowEditInvariantFromNonDefault: boolean;
     allowNonExistingSegmentsCreation: boolean;
-    /**
-     * @deprecated
-     */
-    reservedFieldNames: Array<(string)>;
 };
 
 export type DocumentItemResponseModel = {
@@ -1188,10 +1184,6 @@ export type MediaCollectionResponseModel = {
 export type MediaConfigurationResponseModel = {
     disableDeleteWhenReferenced: boolean;
     disableUnpublishWhenReferenced: boolean;
-    /**
-     * @deprecated
-     */
-    reservedFieldNames: Array<(string)>;
 };
 
 export type MediaItemResponseModel = {
@@ -1374,10 +1366,7 @@ export type MediaVariantResponseModel = {
 };
 
 export type MemberConfigurationResponseModel = {
-    /**
-     * @deprecated
-     */
-    reservedFieldNames: Array<(string)>;
+    [key: string]: unknown;
 };
 
 export type MemberGroupItemResponseModel = {

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.db.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.db.ts
@@ -48,7 +48,6 @@ export class UmbDocumentMockDB extends UmbEntityMockDbBase<UmbMockDocumentModel>
 			allowNonExistingSegmentsCreation: true,
 			disableDeleteWhenReferenced: true,
 			disableUnpublishWhenReferenced: true,
-			reservedFieldNames: [],
 		};
 	}
 }


### PR DESCRIPTION
Further clean-up task for Umbraco 16, which is based on this PR: https://github.com/umbraco/Umbraco-CMS/pull/18661

Here I've removed obsolete properties on the configuration response models.