### PR TITLE
Render folders before files in static files picker

### DIFF
--- a/src/Umbraco.Web.BackOffice/Trees/StaticFilesTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/StaticFilesTreeController.cs
@@ -98,16 +98,6 @@ public class StaticFilesTreeController : TreeController
 
     private void AddPhysicalFiles(string path, FormCollection queryStrings, TreeNodeCollection nodes)
     {
-        IEnumerable<string> files = _fileSystem.GetFiles(path)
-            .Where(x => x.StartsWith(AppPlugins) || x.StartsWith(Webroot));
-
-        foreach (var file in files)
-        {
-            var name = Path.GetFileName(file);
-            TreeNode node = CreateTreeNode(WebUtility.UrlEncode(file), path, queryStrings, name, Constants.Icons.DefaultIcon, false);
-            nodes.Add(node);
-        }
-
         IEnumerable<string> directories = _fileSystem.GetDirectories(path);
 
         foreach (var directory in directories)
@@ -115,6 +105,16 @@ public class StaticFilesTreeController : TreeController
             var hasChildren = _fileSystem.GetFiles(directory).Any() || _fileSystem.GetDirectories(directory).Any();
             var name = Path.GetFileName(directory);
             TreeNode node = CreateTreeNode(WebUtility.UrlEncode(directory), path, queryStrings, name, Constants.Icons.Folder, hasChildren);
+            nodes.Add(node);
+        }
+
+        IEnumerable<string> files = _fileSystem.GetFiles(path)
+            .Where(x => x.StartsWith(AppPlugins) || x.StartsWith(Webroot));
+
+        foreach (var file in files)
+        {
+            var name = Path.GetFileName(file);
+            TreeNode node = CreateTreeNode(WebUtility.UrlEncode(file), path, queryStrings, name, Constants.Icons.DefaultIcon, false);
             nodes.Add(node);
         }
     }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18698

### Description
The linked issue notes that the files are rendered before the folders in the list of child items when using a static file picker.  This corrects that, so the folders appear first - which is more expected from viewing file systems and aligns with those coming from the file provider ("wwwroot" folder) that are presented below.

Here's the new ordering:

![image](https://github.com/user-attachments/assets/4ae31ca8-06f4-4c6f-8e44-ce0e45df243c)

**To Test:**

- Add some files and folders into `App_Plugins`
- From a data type based on a block list, select one of the available blocks and attempt to choose a "Custom stylesheet"


