### PR TITLE
Removes one of the two duplicate ContentPublishingNotification publishings

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1267,7 +1267,7 @@ public class ContentService : RepositoryService, IContentService
         // we need to guard against unsaved changes before proceeding; the content will be saved, but we're not firing any saved notifications
         if (HasUnsavedChanges(content))
         {
-            return new PublishResult(PublishResultType.FailedPublishUnsavedChanges, EventMessagesFactory.Get(), content);
+            return new PublishResult(PublishResultType.FailedPublishUnsavedChanges, evtMsgs, content);
         }
 
         if (content.Name != null && content.Name.Length > 255)
@@ -1324,13 +1324,8 @@ public class ContentService : RepositoryService, IContentService
 
             // Change state to publishing
             content.PublishedState = PublishedState.Publishing;
-            var publishingNotification = new ContentPublishingNotification(content, evtMsgs);
-            if (scope.Notifications.PublishCancelable(publishingNotification))
-            {
-                return new PublishResult(PublishResultType.FailedPublishCancelledByEvent, evtMsgs, content);
-            }
 
-            PublishResult result = CommitDocumentChangesInternal(scope, content, evtMsgs, allLangs, publishingNotification.State, userId);
+            PublishResult result = CommitDocumentChangesInternal(scope, content, evtMsgs, allLangs, new Dictionary<string, object?>(), userId);
             scope.Complete();
             return result;
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18696

### Description
The linked issue surfaces that we are currently issuing two content publishing notifications, when there should just be one.  In this PR I've removed the first of these.

Looking back at 13, I think I can see how it came about.  In that version "Save and Publish" was a single operation at the service level, and the notification that I've removed previously was a "ContentSavingNotification".  It was converted to a "ContentPublishingNotification" when the method was changed to just do a "Publish", but we were already issuing one of these later in the operation.  So I believe it's correct we remove the first one, which is what I've done in this PR.

**To Test:**

- Create a simple handler for the `ContentPublishingNotification` such as the following, and verify that it logs only one message.
- Test that if the notification is cancelled, the publishing does not succeed:
    - You should expect a notification in the UI.
    - And if you view the published website, the update should not be visible.

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Web.UI.Custom;

public class TestingComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentPublishingNotification, ContentPublishingNotificationHandler>();
    }
}

public class ContentPublishingNotificationHandler : INotificationHandler<ContentPublishingNotification>
{
    private readonly ILogger<ContentPublishingNotification> _logger;

    public ContentPublishingNotificationHandler(ILogger<ContentPublishingNotification> logger) => _logger = logger;

    public void Handle(ContentPublishingNotification notification)
    {
        foreach (IContent entity in notification.PublishedEntities)
        {
            _logger.LogInformation($"Publishing content: {entity.Name} ({entity.Id})");

            if (entity.Name is not null && entity.Name.InvariantContains("invalid"))
            {
                notification.Cancel = true;
                return;
            }
        }
    }
}
