### PR TITLE
Clean-up obsoletions on MemberService

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberPickerValueConverter.cs
@@ -82,7 +82,7 @@ public class MemberPickerValueConverter : PropertyValueConverterBase, IDeliveryA
                 return null;
             }
 
-            IMember? m = _memberService.GetByKey(sourceUdi.Guid);
+            IMember? m = _memberService.GetById(sourceUdi.Guid);
             if (m == null)
             {
                 return null;

--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -131,7 +131,7 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase, IDe
                                     UmbracoObjectTypes.Member,
                                     id =>
                                     {
-                                        IMember? m = _memberService.GetByKey(guidUdi.Guid);
+                                        IMember? m = _memberService.GetById(guidUdi.Guid);
                                         if (m == null)
                                         {
                                             return null;

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -266,7 +266,8 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
     /// <returns>
     ///     <see cref="IMember" />
     /// </returns>
-    IMember? GetByKey(Guid id);
+    [Obsolete($"Use {nameof(GetById)}. Scheduled for removal in Umbraco 18.")]
+    IMember? GetByKey(Guid id) => GetById(id);
 
     /// <summary>
     ///     Gets a Member by its integer id

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -338,10 +338,6 @@ namespace Umbraco.Cms.Core.Services
             return GetMemberFromRepository(id);
         }
 
-        [Obsolete($"Use {nameof(GetById)}. Will be removed in V15.")]
-        public IMember? GetByKey(Guid id)
-            => GetById(id);
-
         /// <summary>
         /// Gets a list of paged <see cref="IMember"/> objects
         /// </summary>
@@ -395,7 +391,7 @@ namespace Umbraco.Cms.Core.Services
             Attempt<Guid> asGuid = id.TryConvertTo<Guid>();
             if (asGuid.Success)
             {
-                return GetByKey(asGuid.Result);
+                return GetById(asGuid.Result);
             }
 
             Attempt<int> asInt = id.TryConvertTo<int>();

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -850,7 +850,7 @@ namespace Umbraco.Cms.Core.Services
             return OperationResult.Attempt.Succeed(evtMsgs);
         }
 
-        [Obsolete($"Use the {nameof(Save)} method that yields an Attempt. Will be removed in V15.")]
+        /// <inheritdoc />
         public void Save(IEnumerable<IMember> members)
             => Save(members, Constants.Security.SuperUserId);
 

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -246,7 +246,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
                 throw new ArgumentNullException(nameof(user));
             }
 
-            IMember? found = _memberService.GetByKey(user.Key);
+            IMember? found = _memberService.GetById(user.Key);
             if (found != null)
             {
                 _memberService.Delete(found);
@@ -286,7 +286,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             return null;
         }
 
-        IMember? member = _memberService.GetByKey(user.Key);
+        IMember? member = _memberService.GetById(user.Key);
         if (member == null)
         {
             return null;
@@ -324,7 +324,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
         IMember? user = null;
         if (Guid.TryParse(userId, out Guid key))
         {
-            user = _memberService.GetByKey(key);
+            user = _memberService.GetById(key);
         }
         else if (TryResolveEntityIdFromIdentityId(userId, out int id))
         {
@@ -348,7 +348,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
 
         if (Guid.TryParse(identityId, out Guid key))
         {
-            IMember? member = _memberService.GetByKey(key);
+            IMember? member = _memberService.GetById(key);
             if (member is not null)
             {
                 entityId = member.Id;

--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -46,7 +46,7 @@ internal sealed class MemberEditingService : IMemberEditingService
     }
 
     public Task<IMember?> GetAsync(Guid key)
-        => Task.FromResult(_memberService.GetByKey(key));
+        => Task.FromResult(_memberService.GetById(key));
 
     public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCreateAsync(MemberCreateModel createModel)
         => await _memberContentEditingService.ValidateAsync(createModel, createModel.ContentTypeKey);
@@ -115,7 +115,7 @@ internal sealed class MemberEditingService : IMemberEditingService
     {
         var status = new MemberEditingStatus();
 
-        IMember? member = _memberService.GetByKey(key);
+        IMember? member = _memberService.GetById(key);
         if (member is null)
         {
             status.ContentEditingOperationStatus = ContentEditingOperationStatus.NotFound;

--- a/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
@@ -118,7 +118,7 @@ public class UmbProfileController : SurfaceController
 
         // now we can update the custom properties
         // TODO: Ideally we could do this all through our MemberIdentityUser
-        IMember? member = _memberService.GetByKey(currentMember.Key);
+        IMember? member = _memberService.GetById(currentMember.Key);
         if (member == null)
         {
             // should never happen

--- a/src/Umbraco.Web.Website/Controllers/UmbRegisterController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbRegisterController.cs
@@ -139,7 +139,7 @@ public class UmbRegisterController : SurfaceController
         {
             // Update the custom properties
             // TODO: See TODO in MembersIdentityUser, Should we support custom member properties for persistence/retrieval?
-            IMember? member = _memberService.GetByKey(identityUser.Key);
+            IMember? member = _memberService.GetById(identityUser.Key);
             if (member == null)
             {
                 // should never happen

--- a/src/Umbraco.Web.Website/Models/ProfileModelBuilder.cs
+++ b/src/Umbraco.Web.Website/Models/ProfileModelBuilder.cs
@@ -79,7 +79,7 @@ public class ProfileModelBuilder : MemberModelBuilderBase
         }
 
         // TODO: This wouldn't be required if we support exposing custom member properties on the MemberIdentityUser at the ASP.NET Identity level.
-        IMember? persistedMember = _memberService.GetByKey(member.Key);
+        IMember? persistedMember = _memberService.GetById(member.Key);
         if (persistedMember == null)
         {
             // should never happen

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberUserStoreTests.cs
@@ -243,7 +243,7 @@ public class MemberUserStoreTests
         };
 
         _mockMemberService.Setup(x => x.GetById(mockMember.Id)).Returns(mockMember);
-        _mockMemberService.Setup(x => x.GetByKey(mockMember.Key)).Returns(mockMember);
+        _mockMemberService.Setup(x => x.GetById(mockMember.Key)).Returns(mockMember);
         _mockMemberService.Setup(x => x.Delete(mockMember, Constants.Security.SuperUserId));
 
         // act
@@ -252,7 +252,7 @@ public class MemberUserStoreTests
         // assert
         Assert.IsTrue(identityResult.Succeeded);
         Assert.IsTrue(!identityResult.Errors.Any());
-        _mockMemberService.Verify(x => x.GetByKey(mockMember.Key));
+        _mockMemberService.Verify(x => x.GetById(mockMember.Key));
         _mockMemberService.Verify(x => x.Delete(mockMember, Constants.Security.SuperUserId));
         _mockMemberService.VerifyNoOtherCalls();
     }


### PR DESCRIPTION
Further clean-up task for Umbraco 16, which is based on this PR: https://github.com/umbraco/Umbraco-CMS/pull/18661

Here I've removed one obsoleted method in `MemberService` and added an obsoletion message onto it's definition in the interface.  I can't remove this as it wasn't already obsoleted.

In one other case I've removed an obsoletion as again it isn't obsoleted on the interface, and it's inconsistent as the equivalent method for a single member isn't obsoleted.  It's tricky to amend the interface as the change is to a return type, and that would mean introducing a new, non-obsolete method with a different name.  So I think that's better left for a future services refactor.