### PR TITLE
Tiptap RTE: Table column/row bubble menu

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-umb-bubble-menu.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-umb-bubble-menu.extension.ts
@@ -1,0 +1,109 @@
+import type { UUIPopoverContainerElement } from '../../uui/index.js';
+import { Extension } from '@tiptap/core';
+import { Editor } from '@tiptap/core';
+import { EditorState, Plugin, PluginKey } from '@tiptap/pm/state';
+import { EditorView } from '@tiptap/pm/view';
+import type { PluginView } from '@tiptap/pm/state';
+
+export interface UmbTiptapBubbleMenuElement extends HTMLElement {
+	editor?: Editor;
+}
+
+export type UmbBubbleMenuPluginProps = {
+	unique: string;
+	placement?: UUIPopoverContainerElement['placement'];
+	elementName?: string | null;
+	shouldShow?:
+		| ((props: { editor: Editor; view: EditorView; state: EditorState; from: number; to: number }) => boolean)
+		| null;
+};
+
+export type UmbBubbleMenuOptions = UmbBubbleMenuPluginProps;
+
+export const UmbBubbleMenu = Extension.create<UmbBubbleMenuOptions>({
+	name: 'umbBubbleMenu',
+
+	addOptions() {
+		return {
+			unique: 'umb-tiptap-menu',
+			placement: 'top',
+			elementName: null,
+			shouldShow: null,
+		};
+	},
+
+	addProseMirrorPlugins() {
+		if (!this.options.unique || !this.options.elementName) {
+			return [];
+		}
+
+		return [
+			UmbBubbleMenuPlugin(this.editor, {
+				unique: this.options.unique,
+				placement: this.options.placement,
+				elementName: this.options.elementName,
+				shouldShow: this.options.shouldShow,
+			}),
+		];
+	},
+});
+
+class UmbBubbleMenuPluginView implements PluginView {
+	#editor: Editor;
+
+	#popover: UUIPopoverContainerElement;
+
+	#shouldShow: UmbBubbleMenuPluginProps['shouldShow'];
+
+	constructor(editor: Editor, view: EditorView, props: UmbBubbleMenuPluginProps) {
+		this.#editor = editor;
+
+		this.#shouldShow = props.shouldShow ?? null;
+
+		this.#popover = document.createElement('uui-popover-container') as UUIPopoverContainerElement;
+		this.#popover.id = props.unique;
+		this.#popover.setAttribute('placement', props.placement ?? 'top');
+		this.#popover.setAttribute('popover', 'manual');
+
+		if (props.elementName) {
+			const menu = document.createElement(props.elementName) as UmbTiptapBubbleMenuElement;
+			menu.editor = editor;
+			this.#popover.appendChild(menu);
+		}
+
+		view.dom.parentNode?.appendChild(this.#popover);
+
+		this.update(view, null);
+	}
+
+	update(view: EditorView, prevState: EditorState | null) {
+		const editor = this.#editor;
+
+		const { state } = view;
+		const { selection } = state;
+
+		const { ranges } = selection;
+		const from = Math.min(...ranges.map((range) => range.$from.pos));
+		const to = Math.max(...ranges.map((range) => range.$to.pos));
+
+		const shouldShow = this.#shouldShow?.({ editor, view, state, from, to });
+
+		if (!shouldShow) {
+			this.#popover.hidePopover();
+		} else {
+			this.#popover.showPopover();
+		}
+	}
+
+	destroy() {
+		this.#popover.remove();
+	}
+}
+
+export const UmbBubbleMenuPlugin = (editor: Editor, props: UmbBubbleMenuPluginProps) => {
+	return new Plugin({
+		view(editorView) {
+			return new UmbBubbleMenuPluginView(editor, editorView, props);
+		},
+	});
+};

--- a/src/Umbraco.Web.UI.Client/src/external/tiptap/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/tiptap/index.ts
@@ -37,6 +37,7 @@ export * from './extensions/tiptap-html-global-attributes.extension.js';
 export * from './extensions/tiptap-text-direction-extension.js';
 export * from './extensions/tiptap-text-indent-extension.js';
 export * from './extensions/tiptap-trailing-node.extension.js';
+export * from './extensions/tiptap-umb-bubble-menu.extension.js';
 export * from './extensions/tiptap-umb-embedded-media.extension.js';
 export * from './extensions/tiptap-umb-image.extension.js';
 export * from './extensions/tiptap-umb-link.extension.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/cascading-menu-popover/cascading-menu-popover.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/cascading-menu-popover/cascading-menu-popover.element.ts
@@ -100,7 +100,7 @@ export class UmbCascadingMenuPopoverElement extends UUIPopoverContainerElement {
 			:host {
 				--uui-menu-item-flat-structure: 1;
 
-				background: var(--uui-color-surface);
+				background-color: var(--uui-color-surface);
 				border-radius: var(--uui-border-radius);
 				box-shadow: var(--uui-shadow-depth-3);
 				padding: var(--uui-size-space-1);

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/base.ts
@@ -59,7 +59,6 @@ export abstract class UmbTiptapToolbarElementApiBase extends UmbControllerBase i
 	 * @see {ManifestTiptapToolbarExtension}
 	 * @param {Editor} editor The editor instance.
 	 */
-
 	public abstract execute(editor?: Editor): void;
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/manifests.ts
@@ -645,12 +645,11 @@ const toolbarExtensions: Array<UmbExtensionManifest> = [
 	},
 ];
 
-const extensions = [
+export const manifests = [
+	...kinds,
 	...coreExtensions,
 	...toolbarExtensions,
 	...blockExtensions,
 	...styleSelectExtensions,
 	...tableExtensions,
 ];
-
-export const manifests = [...kinds, ...extensions];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/components/table-column-menu.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/components/table-column-menu.element.ts
@@ -1,9 +1,9 @@
 import { css, customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { Editor } from '@umbraco-cms/backoffice/external/tiptap';
+import type { Editor, UmbTiptapBubbleMenuElement } from '@umbraco-cms/backoffice/external/tiptap';
 
 @customElement('umb-tiptap-table-column-menu')
-export class UmbTableColumnMenuElement extends UmbLitElement {
+export class UmbTiptapTableColumnMenuElement extends UmbLitElement implements UmbTiptapBubbleMenuElement {
 	@property({ attribute: false })
 	editor?: Editor;
 
@@ -41,10 +41,10 @@ export class UmbTableColumnMenuElement extends UmbLitElement {
 	];
 }
 
-export { UmbTableColumnMenuElement as element };
+export default UmbTiptapTableColumnMenuElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-tiptap-table-column-menu': UmbTableColumnMenuElement;
+		'umb-tiptap-table-column-menu': UmbTiptapTableColumnMenuElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/components/table-column-menu.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/components/table-column-menu.element.ts
@@ -1,0 +1,50 @@
+import { css, customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { Editor } from '@umbraco-cms/backoffice/external/tiptap';
+
+@customElement('umb-tiptap-table-column-menu')
+export class UmbTableColumnMenuElement extends UmbLitElement {
+	@property({ attribute: false })
+	editor?: Editor;
+
+	#onAddColumnBefore = () => this.editor?.chain().focus().addColumnBefore().run();
+	#onAddColumnAfter = () => this.editor?.chain().focus().addColumnAfter().run();
+	#onDeleteColumn = () => this.editor?.chain().focus().deleteColumn().run();
+
+	override render() {
+		return html`
+			<uui-menu-item label="Add column before" @click=${this.#onAddColumnBefore}>
+				<uui-icon slot="icon" name="icon-navigation-first"></uui-icon>
+			</uui-menu-item>
+			<uui-menu-item label="Add column after" @click=${this.#onAddColumnAfter}>
+				<uui-icon slot="icon" name="icon-tab-key"></uui-icon>
+			</uui-menu-item>
+			<uui-menu-item label="Delete column" @click=${this.#onDeleteColumn}>
+				<uui-icon slot="icon" name="icon-trash"></uui-icon>
+			</uui-menu-item>
+		`;
+	}
+
+	static override readonly styles = [
+		css`
+			:host {
+				--uui-menu-item-flat-structure: 1;
+
+				display: flex;
+				flex-direction: column;
+
+				background-color: var(--uui-color-surface);
+				border-radius: var(--uui-border-radius);
+				box-shadow: var(--uui-shadow-depth-3);
+			}
+		`,
+	];
+}
+
+export { UmbTableColumnMenuElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-tiptap-table-column-menu': UmbTableColumnMenuElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/components/table-row-menu.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/components/table-row-menu.element.ts
@@ -1,0 +1,50 @@
+import { css, customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { Editor, UmbTiptapBubbleMenuElement } from '@umbraco-cms/backoffice/external/tiptap';
+
+@customElement('umb-tiptap-table-row-menu')
+export class UmbTiptapTableRowMenuElement extends UmbLitElement implements UmbTiptapBubbleMenuElement {
+	@property({ attribute: false })
+	editor?: Editor;
+
+	#onAddRowBefore = () => this.editor?.chain().focus().addRowBefore().run();
+	#onAddRowAfter = () => this.editor?.chain().focus().addRowAfter().run();
+	#onDeleteRow = () => this.editor?.chain().focus().deleteRow().run();
+
+	override render() {
+		return html`
+			<uui-menu-item label="Add row before" @click=${this.#onAddRowBefore}>
+				<uui-icon slot="icon" name="icon-page-up"></uui-icon>
+			</uui-menu-item>
+			<uui-menu-item label="Add row after" @click=${this.#onAddRowAfter}>
+				<uui-icon slot="icon" name="icon-page-down"></uui-icon>
+			</uui-menu-item>
+			<uui-menu-item label="Delete row" @click=${this.#onDeleteRow}>
+				<uui-icon slot="icon" name="icon-trash"></uui-icon>
+			</uui-menu-item>
+		`;
+	}
+
+	static override readonly styles = [
+		css`
+			:host {
+				--uui-menu-item-flat-structure: 1;
+
+				display: flex;
+				flex-direction: column;
+
+				background-color: var(--uui-color-surface);
+				border-radius: var(--uui-border-radius);
+				box-shadow: var(--uui-shadow-depth-3);
+			}
+		`,
+	];
+}
+
+export default UmbTiptapTableRowMenuElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-tiptap-table-row-menu': UmbTiptapTableRowMenuElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/manifests.ts
@@ -47,8 +47,8 @@ const toolbarExtensions: Array<UmbExtensionManifest> = [
 				{
 					label: 'Row',
 					items: [
-						{ label: 'Add row before', data: 'addRowBefore' },
-						{ label: 'Add row after', data: 'addRowAfter' },
+						{ label: 'Add row before', icon: 'icon-page-up', data: 'addRowBefore' },
+						{ label: 'Add row after', icon: 'icon-page-down', data: 'addRowAfter' },
 						{ label: 'Delete row', icon: 'icon-trash', data: 'deleteRow' },
 						{ label: 'Toggle header row', data: 'toggleHeaderRow' },
 					],
@@ -56,8 +56,8 @@ const toolbarExtensions: Array<UmbExtensionManifest> = [
 				{
 					label: 'Column',
 					items: [
-						{ label: 'Add column before', data: 'addColumnBefore' },
-						{ label: 'Add column after', data: 'addColumnAfter' },
+						{ label: 'Add column before', icon: 'icon-navigation-first', data: 'addColumnBefore' },
+						{ label: 'Add column after', icon: 'icon-tab-key', data: 'addColumnAfter' },
 						{ label: 'Delete column', icon: 'icon-trash', data: 'deleteColumn' },
 						{ label: 'Toggle header column', data: 'toggleHeaderColumn' },
 					],

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/table.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/table.tiptap-api.ts
@@ -2,6 +2,8 @@ import { UmbTiptapExtensionApiBase } from '../base.js';
 import { css } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTable, UmbTableHeader, UmbTableRow, UmbTableCell } from '@umbraco-cms/backoffice/external/tiptap';
 
+import './components/table-column-menu.element.js';
+
 export default class UmbTiptapTableExtensionApi extends UmbTiptapExtensionApiBase {
 	getTiptapExtensions = () => [UmbTable, UmbTableHeader, UmbTableRow, UmbTableCell];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/table.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/table.tiptap-api.ts
@@ -3,6 +3,7 @@ import { css } from '@umbraco-cms/backoffice/external/lit';
 import { UmbTable, UmbTableHeader, UmbTableRow, UmbTableCell } from '@umbraco-cms/backoffice/external/tiptap';
 
 import './components/table-column-menu.element.js';
+import './components/table-row-menu.element.js';
 
 export default class UmbTiptapTableExtensionApi extends UmbTiptapExtensionApiBase {
 	getTiptapExtensions = () => [UmbTable, UmbTableHeader, UmbTableRow, UmbTableCell];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/table.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/table/table.tiptap-toolbar-api.ts
@@ -6,18 +6,25 @@ import './components/table-insert.element.js';
 
 export class UmbTiptapToolbarTableExtensionApi extends UmbTiptapToolbarElementApiBase {
 	#commands: Record<string, (editor?: Editor) => void> = {
+		// Cells
 		mergeCells: (editor) => editor?.chain().focus().mergeCells().run(),
 		splitCell: (editor) => editor?.chain().focus().splitCell().run(),
 		mergeOrSplit: (editor) => editor?.chain().focus().mergeOrSplit().run(),
 		toggleHeaderCell: (editor) => editor?.chain().focus().toggleHeaderCell().run(),
+
+		// Rows
 		addRowBefore: (editor) => editor?.chain().focus().addRowBefore().run(),
 		addRowAfter: (editor) => editor?.chain().focus().addRowAfter().run(),
 		deleteRow: (editor) => editor?.chain().focus().deleteRow().run(),
 		toggleHeaderRow: (editor) => editor?.chain().focus().toggleHeaderRow().run(),
+
+		// Columns
 		addColumnBefore: (editor) => editor?.chain().focus().addColumnBefore().run(),
 		addColumnAfter: (editor) => editor?.chain().focus().addColumnAfter().run(),
 		deleteColumn: (editor) => editor?.chain().focus().deleteColumn().run(),
 		toggleHeaderColumn: (editor) => editor?.chain().focus().toggleHeaderColumn().run(),
+
+		// Table
 		deleteTable: (editor) => editor?.chain().focus().deleteTable().run(),
 	};
 


### PR DESCRIPTION
### Description

Adds a contextual actions menu (bubble menu) when selecting a table's column or row in the Tiptap RTE.

https://github.com/user-attachments/assets/b513edf7-9bd3-4788-bf14-de4b796b9aef

#### How to test?

If using the mock data, then go to the "All RTEs" page and see how it works. If using the server, then configure the Tiptap RTE with the "Table" extension enabled and try it out on a document that has `<table>` content.
