### PR TITLE
Adds detail of how many characters you are over when validating text fields for length

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <language alias="da" intName="Danish" localName="dansk" lcid="6" culture="da-DK">
   <creator>
     <name>The Umbraco community</name>
@@ -125,7 +125,7 @@ Mange hilsner fra Umbraco robotten
     <key alias="outOfRangeMultipleItemsMaximum">De %0% enheder givet er større end det tilladte minimum af %1%.</key>
     <key alias="invalidStep">Værdien %0% passer ikke med den konfigureret trin værdi af %1% og mindste værdi af %2%.</key>
     <key alias="unexpectedRange">Værdien %0% forventes ikke at indeholde et spænd.</key>
-    <key alias="stringLengthExceeded">Tekststrengen er længere end den tilladte længde på %0% tegn.</key>
+    <key alias="stringLengthExceeded">Tekststrengen er længere end den tilladte længde på %0% tegn, %1% for mange.</key>
     <key alias="invalidRange">Værdien %0% forventes at have en værdi der er større end fra værdien.</key>
     <key alias="invalidObjectType">Det valgte indhold er af den forkerte type.</key>
     <key alias="notOneOfOptions">"Værdien '%0%' er ikke en af de tilgængelige valgmuligheder.</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -378,7 +378,7 @@
     <key alias="invalidPattern">Value is invalid, it does not match the correct pattern</key>
     <key alias="entriesShort"><![CDATA[Minimum %0% entries, requires <strong>%1%</strong> more.]]></key>
     <key alias="entriesExceed"><![CDATA[Maximum %0% entries, <strong>%1%</strong> too many.]]></key>
-    <key alias="stringLengthExceeded">The string length exceeds the maximum length of %0% characters.</key>
+    <key alias="stringLengthExceeded">The string length exceeds the maximum length of %0% characters, %1% too many.</key>
     <key alias="entriesAreasMismatch">The content amount requirements are not met for one or more areas.</key>
     <key alias="invalidMemberGroupName">Invalid member group name</key>
     <key alias="invalidUserGroupName">Invalid user group name</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -395,7 +395,7 @@
     <key alias="invalidRange">The value %0% is not expected to have a to value less than the from value</key>
     <key alias="entriesShort"><![CDATA[Minimum %0% entries, requires <strong>%1%</strong> more.]]></key>
     <key alias="entriesExceed"><![CDATA[Maximum %0% entries, <strong>%1%</strong> too many.]]></key>
-    <key alias="stringLengthExceeded">The string length exceeds the maximum length of %0% characters.</key>
+    <key alias="stringLengthExceeded">The string length exceeds the maximum length of %0% characters, %1% too many.</key>
     <key alias="entriesAreasMismatch">The content amount requirements are not met for one or more areas.</key>
     <key alias="invalidMediaType">The chosen media type is invalid.</key>
     <key alias="invalidContentType">The chosen content is of invalid type.</key>

--- a/src/Umbraco.Core/PropertyEditors/TextOnlyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/TextOnlyValueEditor.cs
@@ -110,7 +110,7 @@ public class TextOnlyValueEditor : DataValueEditor
                         _localizedTextService.Localize(
                             "validation",
                             "stringLengthExceeded",
-                            [maxCharacters.ToString()]),
+                            [maxCharacters.ToString(), (typedValue.Length - maxCharacters).ToString() ]),
                         ["value'"])
                 ];
             }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18720

### Description
As per raised issue, the validation message for text field length was a little friendlier in 13.  This PR updates it to align.

**To Test:**

- Create some content in a text field or text area.
- After the content has been created, amend the data type to set maximum length of less than the amount of characters entered.
- Attempt to re-publish the content, and you should see something like:

![image](https://github.com/user-attachments/assets/bd1a66c8-6a1e-4c57-9603-7e18f7a1cf9d)

