### PR TITLE
Used documented settings for the media seed cache

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -291,8 +291,8 @@ internal class MediaCacheService : IMediaCacheService
 
     private HybridCacheEntryOptions GetSeedEntryOptions() => new()
     {
-        Expiration = _cacheSettings.SeedCacheDuration,
-        LocalCacheExpiration = _cacheSettings.SeedCacheDuration,
+        Expiration = _cacheSettings.Entry.Media.SeedCacheDuration,
+        LocalCacheExpiration = _cacheSettings.Entry.Media.SeedCacheDuration,
     };
 
     private string GetCacheKey(Guid key, bool preview) => preview ? $"{key}+draft" : $"{key}";


### PR DESCRIPTION
### Prerequisites

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18717

### Description
The linked issue indicates that we aren't using the [cache settings that we document](https://docs.umbraco.com/umbraco-cms/reference/configuration/cache-settings#seedcacheduration) for seeding the hybrid cache for media.  This PR fixes that, aligning with what we have in `DocumentCacheService`.

Was wondering if this was a breaking concern - but seems to me that it's fixing a bug (i.e. we aren't using the setting we document), and worst case is that it'll revert to default values if someone is using the incorrect settings.