### PR TITLE
Only validate invariant properties when strictly necessary

### DIFF
--- a/src/Umbraco.Core/Services/PropertyValidationService.cs
+++ b/src/Umbraco.Core/Services/PropertyValidationService.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.Models;
@@ -17,6 +19,8 @@ public class PropertyValidationService : IPropertyValidationService
     private readonly PropertyEditorCollection _propertyEditors;
     private readonly IValueEditorCache _valueEditorCache;
     private readonly ICultureDictionary _cultureDictionary;
+    private readonly ILanguageService _languageService;
+    private readonly ContentSettings _contentSettings;
 
     [Obsolete("Use the constructor that accepts ICultureDictionary. Will be removed in V15.")]
     public PropertyValidationService(
@@ -28,18 +32,40 @@ public class PropertyValidationService : IPropertyValidationService
     {
     }
 
+    [Obsolete("Use the constructor that accepts ILanguageService and ContentSettings options. Will be removed in V17.")]
     public PropertyValidationService(
         PropertyEditorCollection propertyEditors,
         IDataTypeService dataTypeService,
         ILocalizedTextService textService,
         IValueEditorCache valueEditorCache,
         ICultureDictionary cultureDictionary)
+        : this(
+            propertyEditors,
+            dataTypeService,
+            textService,
+            valueEditorCache,
+            cultureDictionary,
+            StaticServiceProvider.Instance.GetRequiredService<ILanguageService>(),
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<ContentSettings>>())
+    {
+    }
+
+    public PropertyValidationService(
+        PropertyEditorCollection propertyEditors,
+        IDataTypeService dataTypeService,
+        ILocalizedTextService textService,
+        IValueEditorCache valueEditorCache,
+        ICultureDictionary cultureDictionary,
+        ILanguageService languageService,
+        IOptions<ContentSettings> contentSettings)
     {
         _propertyEditors = propertyEditors;
         _dataTypeService = dataTypeService;
         _textService = textService;
         _valueEditorCache = valueEditorCache;
         _cultureDictionary = cultureDictionary;
+        _languageService = languageService;
+        _contentSettings = contentSettings.Value;
     }
 
     /// <inheritdoc />
@@ -64,6 +90,19 @@ public class PropertyValidationService : IPropertyValidationService
         {
             throw new InvalidOperationException("No property editor found by alias " +
                                                 propertyType.PropertyEditorAlias);
+        }
+
+        // only validate culture invariant properties if
+        // - AllowEditInvariantFromNonDefault is true, or
+        // - the default language is being validated, or
+        // - the underlying data editor supports partial property value merging (e.g. block level variance)
+        var defaultCulture = _languageService.GetDefaultIsoCodeAsync().GetAwaiter().GetResult();
+        if (propertyType.VariesByCulture() is false
+            && _contentSettings.AllowEditInvariantFromNonDefault is false
+            && validationContext.CulturesBeingValidated.InvariantContains(defaultCulture) is false
+            && dataEditor.CanMergePartialPropertyValues(propertyType) is false)
+        {
+            return [];
         }
 
         return ValidatePropertyValue(dataEditor, dataType, postedValue, propertyType.Mandatory, propertyType.ValidationRegExp, propertyType.MandatoryMessage, propertyType.ValidationRegExpMessage, validationContext);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Validation.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Validation.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Integration.Attributes;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.PropertyEditors;
 
@@ -172,7 +173,15 @@ internal partial class BlockListElementLevelVariationTests
     }
 
     [Test]
-    public async Task Can_Validate_Invalid_Properties_Specific_Culture_Only()
+    [ConfigureBuilder(ActionName = nameof(ConfigureAllowEditInvariantFromNonDefaultTrue))]
+    public async Task Can_Validate_Invalid_Properties_Specific_Culture_Only_With_AllowEditInvariantFromNonDefault()
+        => await Can_Validate_Invalid_Properties_Specific_Culture_Only();
+
+    [Test]
+    public async Task Can_Validate_Invalid_Properties_Specific_Culture_Only_Without_AllowEditInvariantFromNonDefault()
+        => await Can_Validate_Invalid_Properties_Specific_Culture_Only();
+
+    private async Task Can_Validate_Invalid_Properties_Specific_Culture_Only()
     {
         var elementType = CreateElementTypeWithValidation();
         var blockListDataType = await CreateBlockListDataType(elementType);
@@ -214,6 +223,8 @@ internal partial class BlockListElementLevelVariationTests
             contentType,
             new[] { "en-US" });
 
+        // NOTE: since the default culture is being validated, we expect the same result regardless
+        //       of the AllowEditInvariantFromNonDefault configuration
         var errors = result.ValidationErrors.ToArray();
         Assert.Multiple(() =>
         {
@@ -338,7 +349,15 @@ internal partial class BlockListElementLevelVariationTests
     }
 
     [Test]
-    public async Task Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only()
+    [ConfigureBuilder(ActionName = nameof(ConfigureAllowEditInvariantFromNonDefaultTrue))]
+    public async Task Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only_With_AllowEditInvariantFromNonDefault()
+        => Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(true);
+
+    [Test]
+    public async Task Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only_Without_AllowEditInvariantFromNonDefault()
+        => Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(false);
+
+    private async Task Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(bool expectedInvariantValidationErrors)
     {
         var (rootElementType, nestedElementType) = await CreateElementTypeWithValidationAndNestedBlocksAsync();
         var rootBlockListDataType = await CreateBlockListDataType(rootElementType);
@@ -448,19 +467,39 @@ internal partial class BlockListElementLevelVariationTests
             new[] { "da-DK" });
 
         var errors = result.ValidationErrors.ToArray();
-        Assert.Multiple(() =>
+
+        // NOTE: since the default culture is not being validated, we expect different results depending
+        //       on the AllowEditInvariantFromNonDefault configuration
+
+        if (expectedInvariantValidationErrors)
         {
-            Assert.AreEqual(6, errors.Length);
-            Assert.IsTrue(errors.All(error => error.Alias == "blocks" && error.Culture == null && error.Segment == null));
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(6, errors.Length);
+                Assert.IsTrue(errors.All(error => error.Alias == "blocks" && error.Culture == null && error.Segment == null));
 
-            Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[0].value.contentData[0].values[?(@.alias == 'invariantText' && @.culture == null && @.segment == null)].value"));
-            Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[0].value.contentData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
-            Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[0].value.contentData[0].values[?(@.alias == 'invariantText' && @.culture == null && @.segment == null)].value"));
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[0].value.contentData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
 
-            Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".settingsData[0].values[0].value.settingsData[0].values[?(@.alias == 'invariantText' && @.culture == null && @.segment == null)].value"));
-            Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".settingsData[0].values[0].value.settingsData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
-            Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".settingsData[0].values[?(@.alias == 'invariantText' && @.culture == null && @.segment == null)].value"));
-        });
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".settingsData[0].values[0].value.settingsData[0].values[?(@.alias == 'invariantText' && @.culture == null && @.segment == null)].value"));
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".settingsData[0].values[0].value.settingsData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".settingsData[0].values[?(@.alias == 'invariantText' && @.culture == null && @.segment == null)].value"));
+            });
+        }
+        else
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(3, errors.Length);
+                Assert.IsTrue(errors.All(error => error.Alias == "blocks" && error.Culture == null && error.Segment == null));
+
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[0].value.contentData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".contentData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
+
+                Assert.IsNotNull(errors.FirstOrDefault(error => error.JsonPath == ".settingsData[0].values[0].value.settingsData[0].values[?(@.alias == 'variantText' && @.culture == 'da-DK' && @.segment == null)].value"));
+            });
+        }
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.cs
@@ -1,5 +1,7 @@
-﻿using NUnit.Framework;
+﻿using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentPublishing;
@@ -109,6 +111,41 @@ public partial class ContentPublishingServiceTests : UmbracoIntegrationTestWithC
         return (langEn, langDa, contentType);
     }
 
+    private async Task<IContentType> SetupVariantInvariantTest()
+    {
+        var langDa = new LanguageBuilder()
+            .WithCultureInfo("da-DK")
+            .Build();
+        await LanguageService.CreateAsync(langDa, Constants.Security.SuperUserKey);
+
+        var key = Guid.NewGuid();
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("variantInvariantContent")
+            .WithName("Variant Invariant Content")
+            .WithKey(key)
+            .WithContentVariation(ContentVariation.Culture)
+            .AddAllowedContentType()
+            .WithKey(key)
+            .WithAlias("variantInvariantContent")
+            .Done()
+            .AddPropertyType()
+            .WithAlias("variantValue")
+            .WithVariations(ContentVariation.Culture)
+            .WithMandatory(true)
+            .Done()
+            .AddPropertyType()
+            .WithAlias("invariantValue")
+            .WithVariations(ContentVariation.Nothing)
+            .WithMandatory(true)
+            .Done()
+            .Build();
+
+        contentType.AllowedAsRoot = true;
+        await ContentTypeService.SaveAsync(contentType, Constants.Security.SuperUserKey);
+
+        return contentType;
+    }
+
     protected override void CustomTestSetup(IUmbracoBuilder builder)
         => builder
             .AddNotificationHandler<ContentPublishingNotification, ContentNotificationHandler>()
@@ -132,4 +169,7 @@ public partial class ContentPublishingServiceTests : UmbracoIntegrationTestWithC
 
         public void Handle(ContentUnpublishingNotification notification) => UnpublishingContent?.Invoke(notification);
     }
+
+    public static void ConfigureAllowEditInvariantFromNonDefaultTrue(IUmbracoBuilder builder)
+        => builder.Services.Configure<ContentSettings>(config => config.AllowEditInvariantFromNonDefault = true);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -654,6 +656,8 @@ public class VariationTests
             dataTypeService,
             Mock.Of<ILocalizedTextService>(),
             new ValueEditorCache(),
-            Mock.Of<ICultureDictionary>());
+            Mock.Of<ICultureDictionary>(),
+            Mock.Of<ILanguageService>(),
+            Mock.Of<IOptions<ContentSettings>>());
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Services/PropertyValidationServiceTests.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Dictionary;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
@@ -44,7 +46,14 @@ public class PropertyValidationServiceTests
 
         var propEditors = new PropertyEditorCollection(new DataEditorCollection(() => new[] { dataEditor }));
 
-        validationService = new PropertyValidationService(propEditors, dataTypeService.Object, Mock.Of<ILocalizedTextService>(),new ValueEditorCache(), Mock.Of<ICultureDictionary>());
+        validationService = new PropertyValidationService(
+            propEditors,
+            dataTypeService.Object,
+            Mock.Of<ILocalizedTextService>(),
+            new ValueEditorCache(),
+            Mock.Of<ICultureDictionary>(),
+            Mock.Of<ILanguageService>(),
+            Mock.Of<IOptions<ContentSettings>>());
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When `AllowEditInvariantFromNonDefault` is `false` we should not force validate invariant properties, because effectively it becomes impossible to publish other variants, if an invariant property is invalid.

### Testing this PR

Verify that property validation works and adheres both to language permissions and `AllowEditInvariantFromNonDefault`. For example:

- When `AllowEditInvariantFromNonDefault` is `false`, invariant properties should only be validated when saving and/or publishing the default language.
- When `AllowEditInvariantFromNonDefault` is `true`, invariant properties should _always_ be validated.
- When `AllowEditInvariantFromNonDefault` is `false`, it should be possible to publish valid, non-default variants with invalid _invariant_ properties, provided that the invariant properties have been published once.
   - For example, if validation is added after the initial invariant publish, or if the invariant property data is updated to become invalid.
   - The invalid invariant property data should not be published as part of the operation, as that would go against the `AllowEditInvariantFromNonDefault` configuration value.
- ...get creative; think up more test cases.

Remember to test that all this applies to block level variance as well👍 