### PR TITLE
Make preview check for delivery API content case insensitive

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestPreviewService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestPreviewService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Umbraco.Cms.Core.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Services;
@@ -11,5 +11,5 @@ internal sealed class RequestPreviewService : RequestHeaderHandler, IRequestPrev
     }
 
     /// <inheritdoc />
-    public bool IsPreview() => GetHeaderValue("Preview") == "true";
+    public bool IsPreview() => string.Equals(GetHeaderValue("Preview"), "true", StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Services/RequestPreviewServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Services/RequestPreviewServiceTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Delivery.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Delivery.Services;
+
+[TestFixture]
+public class RequestPreviewServiceTests
+{
+    [TestCase(null, false)]
+    [TestCase("", false)]
+    [TestCase("false", false)]
+    [TestCase("true", true)]
+    [TestCase("True", true)]
+    public void IsPreview_Returns_Expected_Result(string? headerValue, bool expected)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["Preview"] = headerValue;
+
+        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        httpContextAccessorMock
+            .Setup(x => x.HttpContext)
+            .Returns(httpContext);
+        var sut = new RequestPreviewService(httpContextAccessorMock.Object);
+
+        var result = sut.IsPreview();
+
+        Assert.AreEqual(expected, result);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/18730

### Description
This PR makes the preview check for delivery API content case insensitive, thus supporting `true` or `True` as is required in the linked issue.

**To Test:**

- See "Steps to Reproduce" in the linked issue.
