### PR TITLE
Updates dashboard to use uui-box headline property/attribute & place

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/models-builder/models-builder-dashboard.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/models-builder/models-builder-dashboard.element.ts
@@ -56,17 +56,15 @@ export class UmbModelsBuilderDashboardElement extends UmbLitElement {
 
 	override render() {
 		return html`
-			<uui-box class="uui-text">
-				<div class="headline">
-					<h1 class="uui-h2">Models Builder</h1>
-					<uui-button
-						.state="${this._buttonStateReload}"
-						look="secondary"
-						label="Reload"
-						@click="${this._onDashboardReload}">
+			<uui-box headline="Models Builder" class="overview">
+				<uui-button
+					slot="header-actions"
+					.state="${this._buttonStateReload}"
+					look="secondary"
+					label="Reload"
+					@click="${this._onDashboardReload}">
 						Reload
 					</uui-button>
-				</div>
 				<p>Version: ${this._modelsBuilder?.version}</p>
 				<div class="models-description">
 					<p>ModelsBuilder is enabled with the following configuration:</p>
@@ -136,12 +134,6 @@ export class UmbModelsBuilderDashboardElement extends UmbLitElement {
 			:host {
 				display: block;
 				padding: var(--uui-size-layout-1);
-			}
-
-			.headline {
-				display: flex;
-				justify-content: space-between;
-				align-items: flex-start;
 			}
 
 			.models-description ul {


### PR DESCRIPTION
## Fix
Removes GIIANT header for models builder dashboard and uses UUI-box like other dashboards and sets headline property/attribute



## Before
<img width="1825" alt="Screenshot 2025-03-19 at 20 21 26" src="https://github.com/user-attachments/assets/99c4bd69-ad34-4102-b341-d162fb555e02" />


## After
<img width="1728" alt="Screenshot 2025-03-19 at 20 20 20" src="https://github.com/user-attachments/assets/9d4f4b38-44f0-49c7-9f71-929f29f5b3f5" />
