### PR TITLE
style adjustments for Icon Picker, make it look like another input

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/icon-picker/property-editor-ui-icon-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/icon-picker/property-editor-ui-icon-picker.element.ts
@@ -56,9 +56,8 @@ export class UmbPropertyEditorUIIconPickerElement extends UmbLitElement implemen
 			<uui-button
 				compact
 				label=${this.localize.term('defaultdialogs_selectIcon')}
-				look="secondary"
-				@click=${this._openModal}
-				style="margin-right: var(--uui-size-space-3)">
+				look="outline"
+				@click=${this._openModal}>
 				${this._color
 					? html` <uui-icon name="${this._icon}" style="color:var(${extractUmbColorVariable(this._color)})"></uui-icon>`
 					: html` <uui-icon name="${this._icon}"></uui-icon>`}


### PR DESCRIPTION
Aligning Icon Picker style with other inputs
result:
![image](https://github.com/user-attachments/assets/8dbb4a44-32c9-4911-8bcc-1adcb6fc3de6)
