### PR TITLE
Look-up redirect in content finder for multi-lingual sites using path and legacy route prefixed with the integer ID of the node with domains defined

### DIFF
--- a/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
@@ -53,18 +53,27 @@ public class ContentFinderByRedirectUrl : IContentFinder
             return false;
         }
 
-        var route = frequest.Domain != null
-            ? frequest.Domain.ContentId +
-              DomainUtilities.PathRelativeToDomain(frequest.Domain.Uri, frequest.AbsolutePathDecoded)
-            : frequest.AbsolutePathDecoded;
-
+        var route = frequest.AbsolutePathDecoded;
         IRedirectUrl? redirectUrl = await _redirectUrlService.GetMostRecentRedirectUrlAsync(route, frequest.Culture);
 
-        if (redirectUrl == null)
+        if (redirectUrl is null)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
                 _logger.LogDebug("No match for route: {Route}", route);
+            }
+
+            // Pre-15 routes under domains were stored with the integer ID of the content where the domains were defined as the first part of the route,
+            // so if we haven't found a redirect, try using that format too.
+            if (frequest.Domain is not null)
+            {
+                route = frequest.Domain.ContentId + DomainUtilities.PathRelativeToDomain(frequest.Domain.Uri, frequest.AbsolutePathDecoded);
+                redirectUrl = await _redirectUrlService.GetMostRecentRedirectUrlAsync(route, frequest.Culture);
+
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("No match for route with domain: {Route}", route);
+                }
             }
 
             return false;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Looks to resolve: https://github.com/umbraco/Umbraco-CMS/issues/18714

### Description
The linked issue raises an issue with redirects on websites where domains are defined in the content tree.  I've traced it to a difference in what we store in the `umbracoRedirectUrl.url` column when a redirect rule is added.

For a URL of `/en/test`:

- With 13 we store e.g. `1057/test` - where the number is the integer ID of the node where the domain is defined.
- With 15 we store `/en/test`

The difference has come about because the `RedirectTracker` component in 15 uses `IPublishedUrlProvider.GetUrl()`, whereas in 13 we used `IPublishedCache.GetRouteById`.

Given we in theory could have a mix of redirect URLs in an upgraded site, I've fixed in this PR by amending the content finder, so we look up both formats.

Concerned though I may be missing some cases, as presumably there was a reason for originally storing this integer ID prefix in the original implementation and not simply the mapping from the old path to the document.


