### PR TITLE
UX: Make discard changes button red

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da-dk.ts
@@ -442,7 +442,7 @@ export default {
 	prompt: {
 		stay: 'Bliv',
 		discardChanges: 'Kassér ændringer',
-		unsavedChanges: 'Du har ikke-gemte ændringer',
+		unsavedChanges: 'Kassér ugemte ændringer',
 		unsavedChangesWarning:
 			'Er du sikker på du vil navigere væk fra denne side? - du har ikke-gemte\n      ændringer\n    ',
 		confirmListViewPublish: 'Udgivelse vil gøre de valgte sider synlige på sitet.',
@@ -1221,7 +1221,8 @@ export default {
 		colorsTitle: 'Farver',
 		colorsDescription: 'Tilføj, fjern eller sorter farver',
 		showLabelTitle: 'Inkluder label?',
-		showLabelDescription: 'Gemmer farver som et Json-objekt, der både indeholder farvens hex streng og label, i stedet for kun at gemme hex strengen.',
+		showLabelDescription:
+			'Gemmer farver som et Json-objekt, der både indeholder farvens hex streng og label, i stedet for kun at gemme hex strengen.',
 	},
 	contentPicker: {
 		allowedItemTypes: 'Du kan kun vælge følgende type(r) dokumenter: %0%',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -472,7 +472,7 @@ export default {
 	prompt: {
 		stay: 'Stay',
 		discardChanges: 'Discard changes',
-		unsavedChanges: 'You have unsaved changes',
+		unsavedChanges: 'Discard unsaved changes',
 		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? You have unsaved changes',
 		confirmListViewPublish: 'Publishing will make the selected items visible on the site.',
 		confirmListViewUnpublish:
@@ -1247,7 +1247,8 @@ export default {
 		colorsTitle: 'Colors',
 		colorsDescription: 'Add, remove or sort colors',
 		showLabelTitle: 'Include labels?',
-		showLabelDescription: 'Stores colors as a JSON object containing both the color hex string and label, rather than just the hex string.',
+		showLabelDescription:
+			'Stores colors as a JSON object containing both the color hex string and label, rather than just the hex string.',
 	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -462,7 +462,7 @@ export default {
 	prompt: {
 		stay: 'Stay',
 		discardChanges: 'Discard changes',
-		unsavedChanges: 'You have unsaved changes',
+		unsavedChanges: 'Discard unsaved changes',
 		unsavedChangesWarning:
 			'Are you sure you want to navigate away from this page? - you have unsaved\n      changes\n    ',
 		confirmListViewPublish: 'Publishing will make the selected items visible on the site.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/he-il.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/he-il.ts
@@ -132,7 +132,7 @@ export default {
 	prompt: {
 		stay: 'Stay',
 		discardChanges: 'Discard changes',
-		unsavedChanges: 'You have unsaved changes',
+		unsavedChanges: 'Discard unsaved changes',
 		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
 	},
 	bulk: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ja-jp.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ja-jp.ts
@@ -181,7 +181,7 @@ export default {
 	prompt: {
 		stay: 'Stay',
 		discardChanges: 'Discard changes',
-		unsavedChanges: 'You have unsaved changes',
+		unsavedChanges: 'Discard unsaved changes',
 		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
 	},
 	bulk: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ko-kr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ko-kr.ts
@@ -132,7 +132,7 @@ export default {
 	prompt: {
 		stay: 'Stay',
 		discardChanges: 'Discard changes',
-		unsavedChanges: 'You have unsaved changes',
+		unsavedChanges: 'Discard unsaved changes',
 		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
 	},
 	bulk: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt-br.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt-br.ts
@@ -132,7 +132,7 @@ export default {
 	prompt: {
 		stay: 'Stay',
 		discardChanges: 'Discard changes',
-		unsavedChanges: 'You have unsaved changes',
+		unsavedChanges: 'Discard unsaved changes',
 		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
 	},
 	bulk: {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/common/discard-changes/discard-changes-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/common/discard-changes/discard-changes-modal.element.ts
@@ -16,7 +16,7 @@ export class UmbDiscardChangesModalElement extends UmbModalBaseElement {
 				<uui-button
 					slot="actions"
 					id="confirm"
-					color="positive"
+					color="danger"
 					look="primary"
 					label=${this.localize.term('prompt_discardChanges')}
 					@click=${this._submitModal}></uui-button>


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/18761

Summary some might press the green button in a fast reaction. So to make the dialog message clear the button will be changed from green to red. Making the message very clear, underlining that "you are discarding something by this action".

And then changing the headline slightly, so it fits with the action.
![image](https://github.com/user-attachments/assets/6707096c-2ff5-4fcb-99b2-c6b577ebdb56)

