### PR TITLE
Move registration of delivery API component to infrastructure to resolve issue resolve it from controller

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -62,7 +62,6 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddTransient<IMemberApplicationManager, MemberApplicationManager>();
         builder.Services.AddTransient<IRequestMemberAccessService, RequestMemberAccessService>();
         builder.Services.AddTransient<ICurrentMemberClaimsProvider, CurrentMemberClaimsProvider>();
-        builder.Services.AddScoped<IMemberClientCredentialsManager, MemberClientCredentialsManager>();
 
         builder.Services.ConfigureOptions<ConfigureUmbracoDeliveryApiSwaggerGenOptions>();
         builder.AddUmbracoApiOpenApiUI();

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -448,6 +448,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IApiRichTextMarkupParser, ApiRichTextMarkupParser>();
         builder.Services.AddSingleton<IApiPropertyRenderer, ApiPropertyRenderer>();
         builder.Services.AddSingleton<IApiDocumentUrlService, ApiDocumentUrlService>();
+        builder.Services.AddScoped<IMemberClientCredentialsManager, MemberClientCredentialsManager>();
 
         return builder;
     }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolve an internally reported issue.

### Description
After clean-up of an obsolete constructor for Umbraco 16, this error pops up if you try to start Umbraco without the [delivery API enabled in the `Program.cs` file](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api#enable-the-content-delivery-api).

![image](https://github.com/user-attachments/assets/bfc632e7-ed1e-4e01-96fa-9e288af6cf91)

To fix I've moved the registration of this component up into the infrastructure project.  This is where it's already defined and implemented, so it works fine.  I'm not sure though why it didn't work before, as the controller that was throwing the error is only used as part of the delivery API.  But I guess it's something to do with controller registration that these delivery API controllers are still loaded into the application even if the delivery API itself isn't enabled.