### PR TITLE
Dictionary cleanup: Remove duplicate keys for discard changes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -469,18 +469,6 @@ export default {
 		visit: 'Visit',
 		welcome: 'Welcome',
 	},
-	prompt: {
-		stay: 'Stay',
-		discardChanges: 'Discard changes',
-		unsavedChanges: 'Discard unsaved changes',
-		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? You have unsaved changes',
-		confirmListViewPublish: 'Publishing will make the selected items visible on the site.',
-		confirmListViewUnpublish:
-			'Unpublishing will remove the selected items and all their descendants from the\n      site.\n    ',
-		confirmUnpublish: 'Unpublishing will remove this page and all its descendants from the site.',
-		doctypeChangeWarning:
-			'You have unsaved changes. Making changes to the Document Type will discard the\n      changes.\n    ',
-	},
 	bulk: {
 		done: 'Done',
 		deletedItem: 'Deleted %0% item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -463,14 +463,11 @@ export default {
 		stay: 'Stay',
 		discardChanges: 'Discard changes',
 		unsavedChanges: 'Discard unsaved changes',
-		unsavedChangesWarning:
-			'Are you sure you want to navigate away from this page? - you have unsaved\n      changes\n    ',
+		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? You have unsaved changes',
 		confirmListViewPublish: 'Publishing will make the selected items visible on the site.',
-		confirmListViewUnpublish:
-			'Unpublishing will remove the selected items and all their descendants from the\n      site.\n    ',
+		confirmListViewUnpublish: 'Unpublishing will remove the selected items and all their descendants from the site.',
 		confirmUnpublish: 'Unpublishing will remove this page and all its descendants from the site.',
-		doctypeChangeWarning:
-			'You have unsaved changes. Making changes to the Document Type will discard the\n      changes.\n    ',
+		doctypeChangeWarning: 'You have unsaved changes. Making changes to the Document Type will discard the changes.',
 	},
 	bulk: {
 		done: 'Done',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/he-il.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/he-il.ts
@@ -129,12 +129,6 @@ export default {
 		visit: 'בקר',
 		welcome: 'ברוכים הבאים',
 	},
-	prompt: {
-		stay: 'Stay',
-		discardChanges: 'Discard changes',
-		unsavedChanges: 'Discard unsaved changes',
-		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
-	},
 	bulk: {
 		done: 'Done',
 		deletedItem: 'Deleted %0% item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ja-jp.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ja-jp.ts
@@ -178,12 +178,6 @@ export default {
 		visit: '訪れる',
 		welcome: 'ようこそ',
 	},
-	prompt: {
-		stay: 'Stay',
-		discardChanges: 'Discard changes',
-		unsavedChanges: 'Discard unsaved changes',
-		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
-	},
 	bulk: {
 		done: 'Done',
 		deletedItem: 'Deleted %0% item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ko-kr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ko-kr.ts
@@ -129,12 +129,6 @@ export default {
 		visit: '방문',
 		welcome: '환영합니다',
 	},
-	prompt: {
-		stay: 'Stay',
-		discardChanges: 'Discard changes',
-		unsavedChanges: 'Discard unsaved changes',
-		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
-	},
 	bulk: {
 		done: 'Done',
 		deletedItem: 'Deleted %0% item',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt-br.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt-br.ts
@@ -129,12 +129,6 @@ export default {
 		visit: 'Visitar',
 		welcome: 'Bem Vindo(a)',
 	},
-	prompt: {
-		stay: 'Stay',
-		discardChanges: 'Discard changes',
-		unsavedChanges: 'Discard unsaved changes',
-		unsavedChangesWarning: 'Are you sure you want to navigate away from this page? - you have unsaved changes',
-	},
 	bulk: {
 		done: 'Done',
 		deletedItem: 'Deleted %0% item',


### PR DESCRIPTION
The localizations were the same across all the files so I have removed the duplicated code.