### PR TITLE
Changes for the debug tag that makes it look better in dark mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-level-tag.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-level-tag.element.ts
@@ -16,8 +16,8 @@ export class UmbLogViewerLevelTagElement extends LitElement {
 	levelMap: Record<LogLevelModel, LevelMapStyles> = {
 		Verbose: { look: 'secondary' },
 		Debug: {
-			look: 'default',
-			style: 'background-color: var(--umb-log-viewer-debug-color); color: var(--uui-color-surface)',
+			look: 'primary',
+			style: 'background-color: var(--umb-log-viewer-debug-color)',
 		},
 		Information: { look: 'primary', color: 'positive' },
 		Warning: { look: 'primary', color: 'warning' },


### PR DESCRIPTION
I adjusted the colors so it ends up looking better on the dark theme.
It is now done in a similar way as the fatal tag.