### PR TITLE
Adjusting some of the colors for the dark theme.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/css/dark.theme.css
+++ b/src/Umbraco.Web.UI.Client/src/css/dark.theme.css
@@ -16,7 +16,7 @@
 	--uui-color-focus: #316dca;
 	--uui-color-surface: #2d333b;
 	--uui-color-surface-alt: #373e47;
-	--uui-color-surface-emphasis: #434c56;
+	--uui-color-surface-emphasis: #333a42;
 	--uui-color-background: #21262e;
 	--uui-color-text: #eeeeef;
 	--uui-color-text-alt: #eeeeef;
@@ -29,8 +29,8 @@
 	--uui-color-divider-standalone: #434c56;
 	--uui-color-divider-emphasis: #545d68;
 	--uui-color-default: #316dca;
-	--uui-color-default-emphasis: #316dca;
-	--uui-color-default-standalone: #316dca;
+	--uui-color-default-emphasis: #5387d5;
+	--uui-color-default-standalone: #eeeeef;
 	--uui-color-default-contrast: #eeeeef;
 	--uui-color-warning: #af7c12;
 	--uui-color-warning-emphasis: #af7c12;


### PR DESCRIPTION
Adjusting some of the colors for the dark theme so the UI looks a bit better when using the dark theme.
This helps make the coloring a bit more aligned with the standard theme:

Before:
![image](https://github.com/user-attachments/assets/3f03a916-4226-4004-be04-b4b6d401f259)

After:
![image](https://github.com/user-attachments/assets/542676ec-db62-4154-8550-df79eb3cc03e)


It also fixes the number not being shown when using pagination:

Before:
![image](https://github.com/user-attachments/assets/30ba246f-349a-4656-a853-bf339efd8f92)

After:
![image](https://github.com/user-attachments/assets/cfe7779e-386b-4fcb-998f-294ddc8d5376)

