### PR TITLE
Fixed issue where siblings of type at route are omitted from the result

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -3850,9 +3850,8 @@ public static class PublishedContentExtensions
 
         if (parentKey.HasValue)
         {
-            IEnumerable<Guid> childrenKeys;
             var foundChildrenKeys = contentTypeAlias is null
-                ? navigationQueryService.TryGetChildrenKeys(parentKey.Value, out childrenKeys)
+                ? navigationQueryService.TryGetChildrenKeys(parentKey.Value, out IEnumerable<Guid> childrenKeys)
                 : navigationQueryService.TryGetChildrenKeysOfType(parentKey.Value, contentTypeAlias, out childrenKeys);
 
             return foundChildrenKeys
@@ -3860,19 +3859,12 @@ public static class PublishedContentExtensions
                 : [];
         }
 
-        IEnumerable<Guid> rootKeys;
         var foundRootKeys = contentTypeAlias is null
-            ? navigationQueryService.TryGetRootKeys(out rootKeys)
+            ? navigationQueryService.TryGetRootKeys(out IEnumerable<Guid> rootKeys)
             : navigationQueryService.TryGetRootKeysOfType(contentTypeAlias, out rootKeys);
 
-        if (foundRootKeys)
-        {
-            IEnumerable<Guid> rootKeysArray = rootKeys as Guid[] ?? rootKeys.ToArray();
-            return rootKeysArray.Contains(content.Key)
-                ? publishedStatusFilteringService.FilterAvailable(rootKeysArray, culture)
-                : [];
-        }
-
-        return [];
+        return foundRootKeys
+            ? publishedStatusFilteringService.FilterAvailable(rootKeys, culture)
+            : [];
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18788

### Description
It looks like this error has crept in as part of https://github.com/umbraco/Umbraco-CMS/pull/18281.  As far as I can see we should be treating filtering out unpublished items at the root in the same was as we are for children in the method I've updated.

### Testing
Automated test would be nice for this I know - but we don't have any around the published content extensions at the moment, only the services they depend on.  So not sure it makes sense to embark on that (there are many of these extension of course).

To manually test, create items of different types at the root and experiment with code like the following:

```
@{
    var allSiblings = Model.Siblings();
    var siblingsOfType = Model.SiblingsOfType("testPage");

    <div>Siblings: @string.Join(", ", allSiblings.Select(x => x.Name))</div>
    <div>Siblings of type: @string.Join(", ", siblingsOfType.Select(x => x.Name))</div>
}
```

Previously the siblings of type would be empty; with this update they should be populated as expected.

@kjac - I'll ask you for review here if that's OK please as you made the PR I've noted and maybe can see if there was a reason I missed relating to how the root items were treated.