### PR TITLE
Adds MemberTwoFactorLoginService

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -422,6 +422,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             // Two factor providers
             Services.AddUnique<ITwoFactorLoginService, TwoFactorLoginService>();
             Services.AddUnique<IUserTwoFactorLoginService, UserTwoFactorLoginService>();
+            Services.AddUnique<IMemberTwoFactorLoginService, MemberTwoFactorLoginService>();
 
             // Add Query services
             Services.AddUnique<IDocumentRecycleBinQueryService, DocumentRecycleBinQueryService>();

--- a/src/Umbraco.Core/Services/IMemberTwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/IMemberTwoFactorLoginService.cs
@@ -1,0 +1,37 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Core.Services;
+
+/// <summary>
+/// A member specific Two factor service, that ensures the member exists before doing the job.
+/// </summary>
+public interface IMemberTwoFactorLoginService
+{
+    /// <summary>
+    /// Disables a specific two factor provider on a specific member.
+    /// </summary>
+    Task<Attempt<TwoFactorOperationStatus>> DisableAsync(Guid memberKey, string providerName);
+
+    /// <summary>
+    /// Gets the two factor providers on a specific member.
+    /// </summary>
+    Task<Attempt<IEnumerable<UserTwoFactorProviderModel>, TwoFactorOperationStatus>> GetProviderNamesAsync(Guid memberKey);
+
+    /// <remarks>
+    ///     The returned type can be anything depending on the setup providers. You will need to cast it to the type handled by
+    ///     the provider.
+    /// </remarks>
+    Task<Attempt<ISetupTwoFactorModel, TwoFactorOperationStatus>> GetSetupInfoAsync(Guid memberKey, string providerName);
+
+    /// <summary>
+    /// Validates and Saves.
+    /// </summary>
+    Task<Attempt<TwoFactorOperationStatus>> ValidateAndSaveAsync(string providerName, Guid memberKey, string modelSecret, string modelCode);
+
+    /// <summary>
+    /// Disables 2FA with Code.
+    /// </summary>
+    Task<Attempt<TwoFactorOperationStatus>> DisableByCodeAsync(string providerName, Guid memberKey, string code);
+}

--- a/src/Umbraco.Core/Services/ITwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/ITwoFactorLoginService.cs
@@ -29,7 +29,7 @@ public interface ITwoFactorLoginService : IService
     ///     The returned type can be anything depending on the setup providers. You will need to cast it to the type handled by
     ///     the provider.
     /// </remarks>
-    [Obsolete("Use IUserTwoFactorLoginService.GetSetupInfoAsync. This will be removed in Umbraco 15.")]
+    [Obsolete("Use IUserTwoFactorLoginService.GetSetupInfoAsync or IMemberTwoFactorLoginService.GetSetupInfoAsync. Scheduled for removal in Umbraco 16.")]
     Task<object?> GetSetupInfoAsync(Guid userOrMemberKey, string providerName);
 
     /// <summary>
@@ -60,13 +60,13 @@ public interface ITwoFactorLoginService : IService
     /// <summary>
     /// Disables 2FA with Code.
     /// </summary>
-    [Obsolete("Use IUserTwoFactorLoginService.DisableByCodeAsync. This will be removed in Umbraco 15.")]
+    [Obsolete("Use IUserTwoFactorLoginService.DisableByCodeAsync or IMemberTwoFactorLoginService.DisableByCodeAsync. Scheduled for removal in Umbraco 16.")]
     Task<bool> DisableWithCodeAsync(string providerName, Guid userOrMemberKey, string code);
 
     /// <summary>
     /// Validates and Saves.
     /// </summary>
-    [Obsolete("Use IUserTwoFactorLoginService.ValidateAndSaveAsync. This will be removed in Umbraco 15.")]
+    [Obsolete("Use IUserTwoFactorLoginService.ValidateAndSaveAsync or IMemberTwoFactorLoginService.ValidateAndSaveAsync. Scheduled for removal in Umbraco 16.")]
     Task<bool> ValidateAndSaveAsync(string providerName, Guid userKey, string secret, string code);
 
 }

--- a/src/Umbraco.Core/Services/MemberTwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/MemberTwoFactorLoginService.cs
@@ -1,0 +1,72 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Core.Services;
+
+/// <inheritdoc cref="Umbraco.Cms.Core.Services.IMemberTwoFactorLoginService" />
+internal class MemberTwoFactorLoginService : TwoFactorLoginServiceBase, IMemberTwoFactorLoginService
+{
+    private readonly IMemberService _memberService;
+
+    public MemberTwoFactorLoginService(
+        ITwoFactorLoginService twoFactorLoginService,
+        IEnumerable<ITwoFactorProvider> twoFactorSetupGenerators,
+        IMemberService memberService,
+        ICoreScopeProvider scopeProvider)
+        : base(twoFactorLoginService, twoFactorSetupGenerators, scopeProvider) =>
+        _memberService = memberService;
+
+    /// <inheritdoc cref="IMemberTwoFactorLoginService.DisableAsync" />
+    public override async Task<Attempt<TwoFactorOperationStatus>> DisableAsync(Guid memberKey, string providerName)
+    {
+        IMember? member = _memberService.GetByKey(memberKey);
+
+        if (member is null)
+        {
+            return Attempt.Fail(TwoFactorOperationStatus.UserNotFound);
+        }
+
+        return await base.DisableAsync(memberKey, providerName);
+    }
+
+    /// <inheritdoc cref="IMemberTwoFactorLoginService.GetProviderNamesAsync" />
+    public override async Task<Attempt<IEnumerable<UserTwoFactorProviderModel>, TwoFactorOperationStatus>> GetProviderNamesAsync(Guid memberKey)
+    {
+        IMember? member = _memberService.GetByKey(memberKey);
+
+        if (member is null)
+        {
+            return Attempt.FailWithStatus(TwoFactorOperationStatus.UserNotFound, Enumerable.Empty<UserTwoFactorProviderModel>());
+        }
+
+        return await base.GetProviderNamesAsync(memberKey);
+    }
+
+    /// <inheritdoc cref="IMemberTwoFactorLoginService.GetSetupInfoAsync" />
+    public override async Task<Attempt<ISetupTwoFactorModel, TwoFactorOperationStatus>> GetSetupInfoAsync(Guid memberKey, string providerName)
+    {
+        IMember? member = _memberService.GetByKey(memberKey);
+
+        if (member is null)
+        {
+            return Attempt.FailWithStatus<ISetupTwoFactorModel, TwoFactorOperationStatus>(TwoFactorOperationStatus.UserNotFound, new NoopSetupTwoFactorModel());
+        }
+
+        return await base.GetSetupInfoAsync(memberKey, providerName);
+    }
+
+    /// <inheritdoc cref="IMemberTwoFactorLoginService.ValidateAndSaveAsync" />
+    public override async Task<Attempt<TwoFactorOperationStatus>> ValidateAndSaveAsync(string providerName, Guid memberKey, string secret, string code)
+    {
+        IMember? member = _memberService.GetByKey(memberKey);
+
+        if (member is null)
+        {
+            return Attempt.Fail(TwoFactorOperationStatus.UserNotFound);
+        }
+
+        return await base.ValidateAndSaveAsync(providerName, memberKey, secret, code);
+    }
+}

--- a/src/Umbraco.Core/Services/UserTwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/UserTwoFactorLoginService.cs
@@ -32,7 +32,7 @@ internal class UserTwoFactorLoginService : TwoFactorLoginServiceBase, IUserTwoFa
         return await base.DisableAsync(userKey, providerName);
     }
 
-    /// <inheritdoc cref="IUserTwoFactorLoginService.DisableAsync" />
+    /// <inheritdoc cref="IUserTwoFactorLoginService.GetProviderNamesAsync" />
     public override async Task<Attempt<IEnumerable<UserTwoFactorProviderModel>, TwoFactorOperationStatus>> GetProviderNamesAsync(Guid userKey)
     {
         IUser? user = await _userService.GetAsync(userKey);
@@ -45,7 +45,7 @@ internal class UserTwoFactorLoginService : TwoFactorLoginServiceBase, IUserTwoFa
         return await base.GetProviderNamesAsync(userKey);
     }
 
-    /// <inheritdoc cref="IUserTwoFactorLoginService.DisableAsync" />
+    /// <inheritdoc cref="IUserTwoFactorLoginService.GetSetupInfoAsync" />
     public override async Task<Attempt<ISetupTwoFactorModel, TwoFactorOperationStatus>> GetSetupInfoAsync(Guid userKey, string providerName)
     {
         IUser? user = await _userService.GetAsync(userKey);
@@ -58,7 +58,7 @@ internal class UserTwoFactorLoginService : TwoFactorLoginServiceBase, IUserTwoFa
         return await base.GetSetupInfoAsync(userKey, providerName);
     }
 
-    /// <inheritdoc cref="IUserTwoFactorLoginService.DisableAsync" />
+    /// <inheritdoc cref="IUserTwoFactorLoginService.ValidateAndSaveAsync" />
     public override async Task<Attempt<TwoFactorOperationStatus>> ValidateAndSaveAsync(string providerName, Guid userKey, string secret, string code)
     {
         IUser? user = await _userService.GetAsync(userKey);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18803

### Description
The linked issue indicates that we aren't currently consistent in the obsoletions on `ITwoFactorLoginService` in that we have a newer implementation for users but not members.  This PR adds that.

### Testing

I've tested by setting up [member two factor authentication as per our documentation](https://docs.umbraco.com/umbraco-cms/reference/security/two-factor-authentication) and verified all still works as expected.  I used the following adapted template so we no longer need to use the obsoleted methods.

```
@using Umbraco.Cms.Core.Services;
@using Umbraco.Cms.Core.Services.OperationStatus
@using Umbraco.Cms.Web.UI.Custom.Google2FA
@using Umbraco.Cms.Web.Website.Controllers;
@using Umbraco.Cms.Web.Website.Models;
@inject MemberModelBuilderFactory memberModelBuilderFactory
@inject ITwoFactorLoginService twoFactorLoginService
@inject IMemberTwoFactorLoginService memberTwoFactorLoginService
@{
    // Build a profile model to edit
    var profileModel = await memberModelBuilderFactory
        .CreateProfileModel()
        .BuildForCurrentMemberAsync();

    // Show all two factor providers
    var providerNames = twoFactorLoginService.GetAllProviderNames();
    if (providerNames.Any())
    {
        <div asp-validation-summary="All" class="text-danger"></div>
        foreach (var providerName in providerNames)
        {
            var setupDataAttempt = await memberTwoFactorLoginService.GetSetupInfoAsync(profileModel!.Key, providerName);
            if (setupDataAttempt.Success is false && setupDataAttempt.Status == TwoFactorOperationStatus.UserNotFound)
            {
                <p>Unexpected error: member not found.</p>
            }

            // If the provider is already setup, a button to disable the authentication is shown.
            if (setupDataAttempt.Success is false && setupDataAttempt.Status == TwoFactorOperationStatus.ProviderAlreadySetup)
            {
                @using (Html.BeginUmbracoForm<UmbTwoFactorLoginController>(nameof(UmbTwoFactorLoginController.Disable)))
                {
                    <input type="hidden" name="providerName" value="@providerName" />
                    <button type="submit">Disable @providerName</button>
                }
            }
            // If setup succeeds UI for how to set up the App Authenticator is shown.
            else if (setupDataAttempt.Success && setupDataAttempt.Result is QrCodeSetupData qrCodeSetupData)
            {
                @using (Html.BeginUmbracoForm<UmbTwoFactorLoginController>(nameof(UmbTwoFactorLoginController.ValidateAndSaveSetup)))
                {
                    <h3>Setup @providerName</h3>
                    <img src="@qrCodeSetupData.SetupCode!.QrCodeSetupImageUrl" />
                    <p>Scan the code above with your authenticator app <br /> and enter the resulting code here to validate:</p>
                    <input type="hidden" name="providerName" value="@providerName" />
                    <input type="hidden" name="secret" value="@qrCodeSetupData.Secret" />
                    <input type="text" name="code" />
                    <button type="submit">Validate & save</button>
                }
            }
            else
            {
                <p>Unexpected error. Setup result is @(setupDataAttempt.Success ? "success" : "fail") with status of @setupDataAttempt.Status.</p>
            }
        }
    }
}
```

Given I've tested this and we haven't changed any existing code I think it'll be enough to visually inspect for review.

### Documentation

The documentation page linked above should be updated with this code sample once this is merged and targeted for a release.

