### PR TITLE
Obsolete a few unused things.

### DIFF
--- a/src/Umbraco.Core/Actions/IAction.cs
+++ b/src/Umbraco.Core/Actions/IAction.cs
@@ -37,6 +37,7 @@ public interface IAction : IDiscoverable
     /// <summary>
     ///     Gets the icon to display for this action
     /// </summary>
+    [Obsolete("No longer used. Scheduled for removal in V17.")]
     string Icon { get; }
 
     /// <summary>
@@ -51,5 +52,6 @@ public interface IAction : IDiscoverable
     /// <remarks>
     ///     Used in the UI when assigning permissions
     /// </remarks>
+    [Obsolete("No longer used. Scheduled for removal in V17.")]
     string? Category { get; }
 }

--- a/src/Umbraco.Core/Models/TemplateQuery/QueryResultModel.cs
+++ b/src/Umbraco.Core/Models/TemplateQuery/QueryResultModel.cs
@@ -1,5 +1,6 @@
 namespace Umbraco.Cms.Core.Models.TemplateQuery;
 
+[Obsolete("No longer used. Scheduled for removal in V17.")]
 public class QueryResultModel
 {
     public string? QueryExpression { get; set; }

--- a/src/Umbraco.Core/Models/TemplateQuery/TemplateQueryResult.cs
+++ b/src/Umbraco.Core/Models/TemplateQuery/TemplateQueryResult.cs
@@ -1,5 +1,6 @@
 namespace Umbraco.Cms.Core.Models.TemplateQuery;
 
+[Obsolete("No longer used. Scheduled for removal in V17.")]
 public class TemplateQueryResult
 {
     public string? Icon { get; set; }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Added obsoletion annotations to a few unused things from the days of the old backoffice - particularly things mentioning `Icon` 😆 

- [`IAction.Icon`](https://github.com/umbraco/Umbraco-CMS/blob/v15/dev/src/Umbraco.Core/Actions/IAction.cs#L40) and [`IAction.Category`](https://github.com/umbraco/Umbraco-CMS/blob/v15/dev/src/Umbraco.Core/Actions/IAction.cs#L54).
- [`QueryResultModel`](https://github.com/umbraco/Umbraco-CMS/blob/v15/dev/src/Umbraco.Core/Models/TemplateQuery/QueryResultModel.cs) and its contained [`TemplateQueryResult`](https://github.com/umbraco/Umbraco-CMS/blob/v15/dev/src/Umbraco.Core/Models/TemplateQuery/TemplateQueryResult.cs)

### Testing this PR

Verify that the above-mentioned things are indeed not referenced in the codebase 👍 