### PR TITLE
Remove syslib003 & syslib0051 obsoleted code dependencies

### DIFF
--- a/src/Umbraco.Core/Exceptions/DataOperationException.cs
+++ b/src/Umbraco.Core/Exceptions/DataOperationException.cs
@@ -6,7 +6,6 @@ namespace Umbraco.Cms.Core.Exceptions;
 /// </summary>
 /// <typeparam name="T"></typeparam>
 /// <seealso cref="System.Exception" />
-[Serializable]
 public class DataOperationException<T> : Exception
     where T : Enum
 {
@@ -58,22 +57,6 @@ public class DataOperationException<T> : Exception
         Operation = operation;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="DataOperationException{T}" /> class.
-    /// </summary>
-    /// <param name="info">
-    ///     The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object
-    ///     data about the exception being thrown.
-    /// </param>
-    /// <param name="context">
-    ///     The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual
-    ///     information about the source or destination.
-    /// </param>
-    /// <exception cref="ArgumentNullException">info</exception>
-    protected DataOperationException(SerializationInfo info, StreamingContext context)
-        : base(info, context) =>
-        Operation = (T)Enum.Parse(typeof(T), info.GetString(nameof(Operation)) ?? string.Empty);
-
-    /// <summary>
     ///     Gets the operation.
     /// </summary>
     /// <value>
@@ -83,29 +66,4 @@ public class DataOperationException<T> : Exception
     ///     This object should be serializable to prevent a <see cref="SerializationException" /> to be thrown.
     /// </remarks>
     public T? Operation { get; private set; }
-
-    /// <summary>
-    ///     When overridden in a derived class, sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with
-    ///     information about the exception.
-    /// </summary>
-    /// <param name="info">
-    ///     The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object
-    ///     data about the exception being thrown.
-    /// </param>
-    /// <param name="context">
-    ///     The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual
-    ///     information about the source or destination.
-    /// </param>
-    /// <exception cref="ArgumentNullException">info</exception>
-    public override void GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-        if (info == null)
-        {
-            throw new ArgumentNullException(nameof(info));
-        }
-
-        info.AddValue(nameof(Operation), Operation is not null ? Enum.GetName(typeof(T), Operation) : string.Empty);
-
-        base.GetObjectData(info, context);
-    }
 }

--- a/src/Umbraco.Core/Exceptions/InvalidCompositionException.cs
+++ b/src/Umbraco.Core/Exceptions/InvalidCompositionException.cs
@@ -8,7 +8,6 @@ namespace Umbraco.Cms.Core.Exceptions;
 ///     The exception that is thrown when a composition is invalid.
 /// </summary>
 /// <seealso cref="System.Exception" />
-[Serializable]
 public class InvalidCompositionException : Exception
 {
     /// <summary>
@@ -78,26 +77,6 @@ public class InvalidCompositionException : Exception
     }
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="InvalidCompositionException" /> class.
-    /// </summary>
-    /// <param name="info">
-    ///     The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object
-    ///     data about the exception being thrown.
-    /// </param>
-    /// <param name="context">
-    ///     The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual
-    ///     information about the source or destination.
-    /// </param>
-    protected InvalidCompositionException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
-    {
-        ContentTypeAlias = info.GetString(nameof(ContentTypeAlias));
-        AddedCompositionAlias = info.GetString(nameof(AddedCompositionAlias));
-        PropertyTypeAliases = (string[]?)info.GetValue(nameof(PropertyTypeAliases), typeof(string[]));
-        PropertyGroupAliases = (string[]?)info.GetValue(nameof(PropertyGroupAliases), typeof(string[]));
-    }
-
-    /// <summary>
     ///     Gets the content type alias.
     /// </summary>
     /// <value>
@@ -128,34 +107,6 @@ public class InvalidCompositionException : Exception
     ///     The property group aliases.
     /// </value>
     public string[]? PropertyGroupAliases { get; }
-
-    /// <summary>
-    ///     When overridden in a derived class, sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with
-    ///     information about the exception.
-    /// </summary>
-    /// <param name="info">
-    ///     The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object
-    ///     data about the exception being thrown.
-    /// </param>
-    /// <param name="context">
-    ///     The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual
-    ///     information about the source or destination.
-    /// </param>
-    /// <exception cref="ArgumentNullException">info</exception>
-    public override void GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-        if (info == null)
-        {
-            throw new ArgumentNullException(nameof(info));
-        }
-
-        info.AddValue(nameof(ContentTypeAlias), ContentTypeAlias);
-        info.AddValue(nameof(AddedCompositionAlias), AddedCompositionAlias);
-        info.AddValue(nameof(PropertyTypeAliases), PropertyTypeAliases);
-        info.AddValue(nameof(PropertyGroupAliases), PropertyGroupAliases);
-
-        base.GetObjectData(info, context);
-    }
 
     private static string FormatMessage(string contentTypeAlias, string? addedCompositionAlias, string[] propertyTypeAliases, string[] propertyGroupAliases)
     {

--- a/src/Umbraco.Core/Install/InstallException.cs
+++ b/src/Umbraco.Core/Install/InstallException.cs
@@ -6,7 +6,6 @@ namespace Umbraco.Cms.Core.Install;
 ///     Used for steps to be able to return a JSON structure back to the UI.
 /// </summary>
 /// <seealso cref="System.Exception" />
-[Serializable]
 public class InstallException : Exception
 {
     /// <summary>
@@ -62,21 +61,6 @@ public class InstallException : Exception
     }
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="InstallException" /> class.
-    /// </summary>
-    /// <param name="info">
-    ///     The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object
-    ///     data about the exception being thrown.
-    /// </param>
-    /// <param name="context">
-    ///     The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual
-    ///     information about the source or destination.
-    /// </param>
-    protected InstallException(SerializationInfo info, StreamingContext context)
-        : base(info, context) =>
-        View = info.GetString(nameof(View));
-
-    /// <summary>
     ///     Gets the view.
     /// </summary>
     /// <value>
@@ -94,29 +78,4 @@ public class InstallException : Exception
     ///     This object is not included when serializing.
     /// </remarks>
     public object? ViewModel { get; private set; }
-
-    /// <summary>
-    ///     When overridden in a derived class, sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with
-    ///     information about the exception.
-    /// </summary>
-    /// <param name="info">
-    ///     The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that holds the serialized object
-    ///     data about the exception being thrown.
-    /// </param>
-    /// <param name="context">
-    ///     The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual
-    ///     information about the source or destination.
-    /// </param>
-    /// <exception cref="ArgumentNullException">info</exception>
-    public override void GetObjectData(SerializationInfo info, StreamingContext context)
-    {
-        if (info == null)
-        {
-            throw new ArgumentNullException(nameof(info));
-        }
-
-        info.AddValue(nameof(View), View);
-
-        base.GetObjectData(info, context);
-    }
 }

--- a/src/Umbraco.Core/Semver/Semver.cs
+++ b/src/Umbraco.Core/Semver/Semver.cs
@@ -36,7 +36,6 @@ namespace Umbraco.Cms.Core.Semver
 #if NETSTANDARD
     public sealed class SemVersion : IComparable<SemVersion>, IComparable
 #else
-    [Serializable]
     public sealed class SemVersion : IComparable<SemVersion>, IComparable, ISerializable
 #endif
     {
@@ -51,29 +50,6 @@ namespace Umbraco.Cms.Core.Semver
                 RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture);
 #else
                 RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-#endif
-
-#if !NETSTANDARD
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="SemVersion" /> class.
-        /// </summary>
-        /// <param name="info"></param>
-        /// <param name="context"></param>
-        /// <exception cref="ArgumentNullException"></exception>
-        private SemVersion(SerializationInfo info, StreamingContext context)
-        {
-            if (info == null)
-            {
-                throw new ArgumentNullException("info");
-            }
-
-            SemVersion semVersion = Parse(info.GetString("SemVersion")!);
-            Major = semVersion.Major;
-            Minor = semVersion.Minor;
-            Patch = semVersion.Patch;
-            Prerelease = semVersion.Prerelease;
-            Build = semVersion.Build;
-        }
 #endif
 
         /// <summary>
@@ -525,7 +501,6 @@ namespace Umbraco.Cms.Core.Semver
         }
 
 #if !NETSTANDARD
-        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)


### PR DESCRIPTION
This PR removes some dependencies on obsoleted dotnet code that according to their docs wasn't working anymore anyway.

Followed guidance in https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0051 and https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0003
