### PR TITLE
Feature: make route setup method part of resolve component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
@@ -160,7 +160,7 @@ export async function resolvePageComponent(route: IComponentRoute, info: IRoutin
 
 	// Setup the component using the callback.
 	if (route.setup != null) {
-		route.setup(component, info);
+		await route.setup(component, info);
 	}
 
 	return component;


### PR DESCRIPTION
Makes the setup method part of the Resolving Page Component Async call.
In other words, if it fails/gets rejected the whole route fails.

This can later be used to revert if a route fails, but for now it just gives clarity.

**Test notes:**
Add this to the setup method for dashboard in:
src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts

```setup: (component: UmbDashboardElement) => {
					component.manifest = manifest;
					if (manifest.alias === 'Umb.Dashboard.RedirectManagement') {
						throw new Error('Redirect Management Dashboard');
					}
				},```