### PR TITLE
Populate parent key on move and copy notifications

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -2621,8 +2622,8 @@ public class ContentService : RepositoryService, IContentService
                 throw new InvalidOperationException("Parent does not exist or is trashed."); // causes rollback
             }
 
-            // FIXME: Use MoveEventInfo that also takes a parent key when implementing move with parentKey.
-            var moveEventInfo = new MoveEventInfo<IContent>(content, content.Path, parentId);
+            TryGetParentKey(parentId, out Guid? parentKey);
+            var moveEventInfo = new MoveEventInfo<IContent>(content, content.Path, parentId, parentKey);
 
             var movingNotification = new ContentMovingNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingNotification))
@@ -2652,9 +2653,12 @@ public class ContentService : RepositoryService, IContentService
                 new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshBranch, eventMessages));
 
             // changes
-            // FIXME: Use MoveEventInfo that also takes a parent key when implementing move with parentKey.
             MoveEventInfo<IContent>[] moveInfo = moves
-                .Select(x => new MoveEventInfo<IContent>(x.Item1, x.Item2, x.Item1.ParentId))
+                .Select(x =>
+                {
+                    TryGetParentKey(x.Item1.ParentId, out Guid? itemParentKey);
+                    return new MoveEventInfo<IContent>(x.Item1, x.Item2, x.Item1.ParentId, itemParentKey);
+                })
                 .ToArray();
 
             scope.Notifications.Publish(
@@ -2834,8 +2838,8 @@ public class ContentService : RepositoryService, IContentService
 
         using (ICoreScope scope = ScopeProvider.CreateCoreScope())
         {
-            // FIXME: Pass parent key in constructor too when proper Copy method is implemented
-            if (scope.Notifications.PublishCancelable(new ContentCopyingNotification(content, copy, parentId, eventMessages)))
+            TryGetParentKey(parentId, out Guid? parentKey);
+            if (scope.Notifications.PublishCancelable(new ContentCopyingNotification(content, copy, parentId, parentKey, eventMessages)))
             {
                 scope.Complete();
                 return null;
@@ -2907,8 +2911,7 @@ public class ContentService : RepositoryService, IContentService
                         IContent descendantCopy = descendant.DeepCloneWithResetIdentities();
                         descendantCopy.ParentId = parentId;
 
-                        // FIXME: Pass parent key in constructor too when proper Copy method is implemented
-                        if (scope.Notifications.PublishCancelable(new ContentCopyingNotification(descendant, descendantCopy, parentId, eventMessages)))
+                        if (scope.Notifications.PublishCancelable(new ContentCopyingNotification(descendant, descendantCopy, parentId, parentKey, eventMessages)))
                         {
                             continue;
                         }
@@ -2946,7 +2949,7 @@ public class ContentService : RepositoryService, IContentService
             foreach (Tuple<IContent, IContent> x in CollectionsMarshal.AsSpan(copies))
             {
                 // FIXME: Pass parent key in constructor too when proper Copy method is implemented
-                scope.Notifications.Publish(new ContentCopiedNotification(x.Item1, x.Item2, parentId, relateToOriginal, eventMessages));
+                scope.Notifications.Publish(new ContentCopiedNotification(x.Item1, x.Item2, parentId, parentKey, relateToOriginal, eventMessages));
             }
 
             Audit(AuditType.Copy, userId, content.Id);
@@ -2955,6 +2958,13 @@ public class ContentService : RepositoryService, IContentService
         }
 
         return copy;
+    }
+
+    private bool TryGetParentKey(int parentId, [NotNullWhen(true)] out Guid? parentKey)
+    {
+        Attempt<Guid> parentKeyAttempt = _idKeyMap.GetKeyForId(parentId, UmbracoObjectTypes.Document);
+        parentKey = parentKeyAttempt.Success ? parentKeyAttempt.Result : null;
+        return parentKeyAttempt.Success;
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2948,7 +2948,6 @@ public class ContentService : RepositoryService, IContentService
                 new ContentTreeChangeNotification(copy, TreeChangeTypes.RefreshBranch, eventMessages));
             foreach (Tuple<IContent, IContent> x in CollectionsMarshal.AsSpan(copies))
             {
-                // FIXME: Pass parent key in constructor too when proper Copy method is implemented
                 scope.Notifications.Publish(new ContentCopiedNotification(x.Item1, x.Item2, parentId, parentKey, relateToOriginal, eventMessages));
             }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18834

### Description
The linked issue demonstrated a problem with a package relying on a property for the parent item that we aren't populating on the copy and move notifications, even though it's the non-obsolete version of the property that they are using.

There's clearly a much bigger refactor to do at some point here - removing all references to integer IDs and replacing them with GUIDs - but for now seems like it makes sense to use the `IIdKeyMap` to populate the parent ID properties as integers and GUIDs.  That's what I've done in this PR.

### Testing
Can be tested using the following notification handler and inspecting the log messages after a move and copy operation is carried out in the backoffice.

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;

public class ContentMoveOrCopyNotificationHandler :
    INotificationHandler<ContentCopyingNotification>,
    INotificationHandler<ContentCopiedNotification>,
    INotificationHandler<ContentMovingNotification>,
    INotificationHandler<ContentMovedNotification>
{
    private readonly ILogger<ContentMoveOrCopyNotificationHandler> _logger;

    public ContentMoveOrCopyNotificationHandler(ILogger<ContentMoveOrCopyNotificationHandler> logger) => _logger = logger;

    public void Handle(ContentCopyingNotification notification) =>
        _logger.LogInformation(
            $"Copying content: {notification.Original.Name} ({notification.Original.Id}) to {notification.Copy.Name} ({notification.Copy.Id} under parent with Id {notification.ParentId} and key {notification.ParentKey})");

    public void Handle(ContentCopiedNotification notification) =>
        _logger.LogInformation(
            $"Copied content: {notification.Original.Name} ({notification.Original.Id}) to {notification.Copy.Name} ({notification.Copy.Id} under parent with Id {notification.ParentId} and key {notification.ParentKey})");

    public void Handle(ContentMovingNotification notification)
    {
        foreach (MoveEventInfo<IContent> item in notification.MoveInfoCollection)
        {
            _logger.LogInformation(
                $"Moving content: {item.Entity.Name} ({item.Entity.Id}) under parent with Id {item.NewParentId} and key {item.NewParentKey})");
        }
    }

    public void Handle(ContentMovedNotification notification)
    {
        foreach (MoveEventInfo<IContent> item in notification.MoveInfoCollection)
        {
            _logger.LogInformation(
                $"Moved content: {item.Entity.Name} ({item.Entity.Id}) under parent with Id {item.NewParentId} and key {item.NewParentKey})");
        }
    }
}

public class TestingComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentCopyingNotification, ContentMoveOrCopyNotificationHandler>();
        builder.AddNotificationHandler<ContentCopiedNotification, ContentMoveOrCopyNotificationHandler>();
        builder.AddNotificationHandler<ContentMovingNotification, ContentMoveOrCopyNotificationHandler>();
        builder.AddNotificationHandler<ContentMovedNotification, ContentMoveOrCopyNotificationHandler>();
    }
}
```
