### PR TITLE
V15: Improve the dropzone for Image Cropper

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
@@ -52,7 +52,8 @@ export class UmbInputImageCropperFieldElement extends UmbLitElement {
 		this.#file = file;
 		if (file) {
 			this.fileDataUrl = URL.createObjectURL(file);
-		} else {
+		} else if (this.fileDataUrl) {
+			URL.revokeObjectURL(this.fileDataUrl);
 			this.fileDataUrl = undefined;
 		}
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
@@ -51,8 +51,7 @@ export class UmbInputImageCropperFieldElement extends UmbLitElement {
 	set file(file: File | undefined) {
 		this.#file = file;
 		if (file) {
-			const blob = new Blob([file]);
-			this.fileDataUrl = URL.createObjectURL(blob);
+			this.fileDataUrl = URL.createObjectURL(file);
 		} else {
 			this.fileDataUrl = undefined;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
@@ -7,11 +7,10 @@ import type {
 	UmbImageCropperFocalPoint,
 	UmbImageCropperPropertyEditorValue,
 } from './types.js';
-
-import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
-import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { css, customElement, html, property, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UMB_APP_CONTEXT } from '@umbraco-cms/backoffice/app';
 
 import './image-cropper-focus-setter.element.js';
 import './image-cropper-preview.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
@@ -93,6 +93,13 @@ export class UmbInputImageCropperFieldElement extends UmbLitElement {
 		});
 	}
 
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		if (this.fileDataUrl) {
+			URL.revokeObjectURL(this.fileDataUrl);
+		}
+	}
+
 	protected onCropClick(crop: any) {
 		const index = this.crops.findIndex((c) => c.alias === crop.alias);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-preview.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-preview.element.ts
@@ -18,12 +18,12 @@ export class UmbImageCropperPreviewElement extends UmbLitElement {
 	label?: string;
 
 	@property({ attribute: false })
-	get focalPoint() {
-		return this.#focalPoint;
-	}
 	set focalPoint(value) {
 		this.#focalPoint = value;
 		this.#onFocalPointUpdated();
+	}
+	get focalPoint() {
+		return this.#focalPoint;
 	}
 
 	#focalPoint: UmbImageCropperFocalPoint = { left: 0.5, top: 0.5 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -1,20 +1,18 @@
-import type { UmbInputImageCropperFieldElement } from './image-cropper-field.element.js';
 import type { UmbImageCropperPropertyEditorValue } from './types.js';
-
-import {
-	type UmbDropzoneChangeEvent,
-	type UmbInputDropzoneElement,
-	type UmbUploadableItem,
-	UmbFileDropzoneItemStatus,
-	UmbInputDropzoneDashedStyles,
-} from '@umbraco-cms/backoffice/dropzone';
-import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import type { UmbInputImageCropperFieldElement } from './image-cropper-field.element.js';
 import { css, customElement, html, ifDefined, property, state } from '@umbraco-cms/backoffice/external/lit';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { assignToFrozenObject } from '@umbraco-cms/backoffice/observable-api';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbFileDropzoneItemStatus, UmbInputDropzoneDashedStyles } from '@umbraco-cms/backoffice/dropzone';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbTemporaryFileConfigRepository } from '@umbraco-cms/backoffice/temporary-file';
 import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import type {
+	UmbDropzoneChangeEvent,
+	UmbInputDropzoneElement,
+	UmbUploadableItem,
+} from '@umbraco-cms/backoffice/dropzone';
 
 import './image-cropper-field.element.js';
 import './image-cropper-focus-setter.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -2,20 +2,26 @@ import type { MediaValueType } from '../../property-editors/upload-field/types.j
 import type { ManifestFileUploadPreview } from './file-upload-preview.extension.js';
 import { getMimeTypeFromExtension } from './utils.js';
 import {
-	UmbFileDropzoneItemStatus,
-	UmbInputDropzoneDashedStyles,
-	type UmbDropzoneChangeEvent,
-	type UmbInputDropzoneElement,
-	type UmbUploadableFile,
-} from '@umbraco-cms/backoffice/dropzone';
+	css,
+	html,
+	nothing,
+	ifDefined,
+	customElement,
+	property,
+	query,
+	state,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
+import { formatBytes, stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbExtensionsManifestInitializer } from '@umbraco-cms/backoffice/extension-api';
-import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
-import { css, customElement, html, ifDefined, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
+import { UmbTemporaryFileManager, TemporaryFileStatus } from '@umbraco-cms/backoffice/temporary-file';
+import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
+import type { UmbTemporaryFileModel } from '@umbraco-cms/backoffice/temporary-file';
+import type { UUIFileDropzoneElement, UUIFileDropzoneEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-input-upload-field')
 export class UmbInputUploadFieldElement extends UmbLitElement {
@@ -26,7 +32,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	get value(): MediaValueType {
 		return {
 			src: this.#src,
-			temporaryFileId: this._file?.temporaryFile.temporaryUnique,
+			temporaryFileId: this.temporaryFile?.temporaryUnique,
 		};
 	}
 	#src = '';
@@ -36,26 +42,30 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	 * @type {Array<string>}
 	 * @default
 	 */
-	@property({
-		type: Array,
-		attribute: 'allowed-file-extensions',
-		converter(value) {
-			if (typeof value === 'string') {
-				return value.split(',').map((ext) => ext.trim());
-			}
-			return value;
-		},
-	})
-	allowedFileExtensions?: Array<string>;
+	@property({ type: Array })
+	set allowedFileExtensions(value: Array<string>) {
+		this.#setExtensions(value);
+	}
+	get allowedFileExtensions(): Array<string> | undefined {
+		return this._extensions;
+	}
 
 	@state()
-	private _file?: UmbUploadableFile;
+	public temporaryFile?: UmbTemporaryFileModel;
+
+	@state()
+	private _progress = 0;
 
 	@state()
 	private _extensions?: string[];
 
 	@state()
 	private _previewAlias?: string;
+
+	@query('#dropzone')
+	private _dropzone?: UUIFileDropzoneElement;
+
+	#manager = new UmbTemporaryFileManager(this);
 
 	#manifests: Array<ManifestFileUploadPreview> = [];
 
@@ -77,6 +87,15 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 		return this.#manifests;
 	}
 
+	#setExtensions(extensions: Array<string>) {
+		if (!extensions?.length) {
+			this._extensions = undefined;
+			return;
+		}
+		// TODO: The dropzone uui component does not support file extensions without a dot. Remove this when it does.
+		this._extensions = extensions?.map((extension) => `.${extension}`);
+	}
+
 	async #setPreviewAlias(): Promise<void> {
 		this._previewAlias = await this.#getPreviewElementAlias();
 	}
@@ -89,8 +108,8 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 		)?.alias;
 
 		let mimeType: string | null = null;
-		if (this._file?.temporaryFile.file) {
-			mimeType = this._file.temporaryFile.file.type;
+		if (this.temporaryFile?.file) {
+			mimeType = this.temporaryFile.file.type;
 		} else {
 			mimeType = this.#getMimeTypeFromPath(this.value.src);
 		}
@@ -132,39 +151,113 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 		return getMimeTypeFromExtension('.' + extension);
 	}
 
-	async #onUpload(e: UmbDropzoneChangeEvent) {
+	async #onUpload(e: UUIFileDropzoneEvent) {
+		try {
+			//Property Editor for Upload field will always only have one file.
+			this.temporaryFile = {
+				temporaryUnique: UmbId.new(),
+				status: TemporaryFileStatus.WAITING,
+				file: e.detail.files[0],
+				onProgress: (p) => {
+					this._progress = Math.ceil(p);
+				},
+				abortController: new AbortController(),
+			};
+
+			const uploaded = await this.#manager.uploadOne(this.temporaryFile);
+
+			if (uploaded.status === TemporaryFileStatus.SUCCESS) {
+				this.temporaryFile.status = TemporaryFileStatus.SUCCESS;
+
+				const blobUrl = URL.createObjectURL(this.temporaryFile.file);
+				this.value = { src: blobUrl };
+
+				this.dispatchEvent(new UmbChangeEvent());
+			} else {
+				this.temporaryFile.status = TemporaryFileStatus.ERROR;
+				this.requestUpdate('temporaryFile');
+			}
+		} catch {
+			// If we still have a temporary file, set it to error.
+			if (this.temporaryFile) {
+				this.temporaryFile.status = TemporaryFileStatus.ERROR;
+				this.requestUpdate('temporaryFile');
+			}
+
+			// If the error was caused by the upload being aborted, do not show an error message.
+		}
+	}
+
+	#handleBrowse(e: Event) {
+		if (!this._dropzone) return;
 		e.stopImmediatePropagation();
-
-		const target = e.target as UmbInputDropzoneElement;
-		const file = target.value?.[0];
-
-		if (file?.status !== UmbFileDropzoneItemStatus.COMPLETE) return;
-
-		this._file = file as UmbUploadableFile;
-
-		const blobUrl = URL.createObjectURL(this._file.temporaryFile.file);
-		this.value = { src: blobUrl };
-
-		this.dispatchEvent(new UmbChangeEvent());
+		this._dropzone.browse();
 	}
 
 	override render() {
-		if (!this._file && !this.value.src) {
-			//return this.#renderDropzone();
+		if (!this.temporaryFile && !this.value.src) {
+			return this.#renderDropzone();
 		}
 
 		return html`
-			${this.#renderDropzone()} ${this.value.src && this._previewAlias ? this.#renderFile(this.value.src) : nothing}
+			${this.temporaryFile ? this.#renderUploader() : nothing}
+			${this.value.src && this._previewAlias ? this.#renderFile(this.value.src) : nothing}
 		`;
 	}
 
 	#renderDropzone() {
 		return html`
-			<umb-input-dropzone
+			<uui-file-dropzone
 				id="dropzone"
-				disable-folder-upload
-				accept=${ifDefined(this._extensions?.join(','))}
-				@change=${this.#onUpload}></umb-input-dropzone>
+				label="dropzone"
+				disallowFolderUpload
+				accept=${ifDefined(this._extensions?.join(', '))}
+				@change=${this.#onUpload}
+				@click=${this.#handleBrowse}>
+				<uui-button label=${this.localize.term('media_clickToUpload')} @click=${this.#handleBrowse}></uui-button>
+			</uui-file-dropzone>
+		`;
+	}
+
+	#renderUploader() {
+		if (!this.temporaryFile) return nothing;
+
+		return html`
+			<div id="temporaryFile">
+				<div id="fileIcon">
+					${when(
+						this.temporaryFile.status === TemporaryFileStatus.SUCCESS,
+						() => html`<umb-icon name="check" color="green"></umb-icon>`,
+					)}
+					${when(
+						this.temporaryFile.status === TemporaryFileStatus.ERROR,
+						() => html`<umb-icon name="wrong" color="red"></umb-icon>`,
+					)}
+				</div>
+				<div id="fileDetails">
+					<div id="fileName">${this.temporaryFile.file.name}</div>
+					<div id="fileSize">${formatBytes(this.temporaryFile.file.size, { decimals: 2 })}: ${this._progress}%</div>
+					${when(
+						this.temporaryFile.status === TemporaryFileStatus.WAITING,
+						() => html`<div id="progress"><uui-loader-bar progress=${this._progress}></uui-loader-bar></div>`,
+					)}
+					${when(
+						this.temporaryFile.status === TemporaryFileStatus.ERROR,
+						() => html`<div id="error">An error occured</div>`,
+					)}
+				</div>
+				<div id="fileActions">
+					${when(
+						this.temporaryFile.status === TemporaryFileStatus.WAITING,
+						() => html`
+							<uui-button compact @click=${this.#handleRemove} label=${this.localize.term('general_cancel')}>
+								<uui-icon name="remove"></uui-icon>${this.localize.term('general_cancel')}
+							</uui-button>
+						`,
+						() => this.#renderButtonRemove(),
+					)}
+				</div>
+			</div>
 		`;
 	}
 
@@ -174,7 +267,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 				<div id="wrapperInner">
 					<umb-extension-slot
 						type="fileUploadPreview"
-						.props=${{ path: src, file: this._file?.temporaryFile.file }}
+						.props=${{ path: src, file: this.temporaryFile?.file }}
 						.filter=${(manifest: ManifestFileUploadPreview) => manifest.alias === this._previewAlias}>
 					</umb-extension-slot>
 				</div>
@@ -193,16 +286,15 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 
 	#handleRemove() {
 		// If the upload promise happens to be in progress, cancel it.
-		this._file?.temporaryFile.abortController?.abort();
+		this.temporaryFile?.abortController?.abort();
 
 		this.value = { src: undefined };
-		this._file = undefined;
+		this.temporaryFile = undefined;
+		this._progress = 0;
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
 	static override readonly styles = [
-		UmbTextStyles,
-		UmbInputDropzoneDashedStyles,
 		css`
 			:host {
 				position: relative;
@@ -230,6 +322,51 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 				display: flex;
 				width: fit-content;
 				max-width: 100%;
+			}
+
+			#temporaryFile {
+				display: grid;
+				grid-template-columns: auto auto auto;
+				width: fit-content;
+				max-width: 100%;
+				margin: var(--uui-size-layout-1) 0;
+				padding: var(--uui-size-space-3);
+				border: 1px dashed var(--uui-color-divider-emphasis);
+			}
+
+			#fileIcon,
+			#fileActions {
+				place-self: center center;
+				padding: 0 var(--uui-size-layout-1);
+			}
+
+			#fileName {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				font-size: var(--uui-size-5);
+			}
+
+			#fileSize {
+				font-size: var(--uui-font-size-small);
+				color: var(--uui-color-text-alt);
+			}
+
+			#error {
+				color: var(--uui-color-danger);
+			}
+
+			uui-file-dropzone {
+				position: relative;
+				display: block;
+				padding: 3px; /** Dropzone background is blurry and covers slightly into other elements. Hack to avoid this */
+			}
+			uui-file-dropzone::after {
+				content: '';
+				position: absolute;
+				inset: 0;
+				cursor: pointer;
+				border: 1px dashed var(--uui-color-divider-emphasis);
 			}
 		`,
 	];


### PR DESCRIPTION
## Description

The Image Cropper now uses the new dropzone input `<umb-dropzone-input />` to share the logic and user experience. The dropzone input features an uploader UI with manual and auto cancel of uploads, and users can follow the upload progress.

Additionally, the Image Cropper now supports hosting the Backoffice on another URL by prefixing the image URLs with the server URL.

Lastly, an update has been made to read the object URL directly from the `File` object rather than try to load the entire image into memory. This is usually not a problem for images, but we fixed it elsewhere as well, allowing browsers to handle files in the gigabyte range.

Fixes [AB#49148](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/49148)

## How to test
1. Create an Image Cropper property and verify that you can drag & drop files
2. Try, if you can, to navigate away from the page as a large upload is in progress and verify, that the network request was cancelled