### PR TITLE
Check we have matched a preview URL by ID when exiting preview

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
@@ -217,10 +217,8 @@ public partial class PreviewController : Controller
 
         // are we attempting a redirect to the default route (by ID with optional culture)?
         Match match = DefaultPreviewRedirectRegex().Match(redir ?? string.Empty);
-        if (match.Success)
+        if (match.Success && int.TryParse(match.Groups["id"].Value, out int id))
         {
-            var id = int.Parse(match.Groups["id"].Value);
-
             // first try to resolve the published URL
             if (_umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? umbracoContext) &&
                 umbracoContext.Content is not null)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
I found this issue when testing the 13.8 RC.  It's not a regression introduced in 13.8 as far as I can tell, but still something we could fix up.

You can reproduce by:

- Open up a page on the front-end website.
- In another tab, open the backoffice, edit that page and click "Save and Preview"
- Refresh the first page and you'll see the "View published version?" dialog
- Click "View Published Version" and that would lead to an error as we attempt to parse a non-integer value as an integer.

With the PR in place this will no longer error.
