### PR TITLE
V15: Dropzone single mode should only allow one file at a time

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
@@ -74,6 +74,16 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 
 	protected _manager = new UmbDropzoneManager(this);
 
+	/**
+	 * Determines if the dropzone should be disabled.
+	 * If the dropzone is disabled, it will not accept any uploads.
+	 * It is considered disabled if the `disabled` property is set or if `multiple` is set to `false` and there is already an upload in progress.
+	 * @returns {boolean} True if the dropzone should not accept uploads, otherwise false.
+	 */
+	get #isDisabled(): boolean {
+		return this.disabled || (!this.multiple && this._progressItems.length > 0);
+	}
+
 	constructor() {
 		super();
 
@@ -107,7 +117,7 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 	 * Opens the file browse dialog.
 	 */
 	public browse(): void {
-		if (this.disabled) return;
+		if (this.#isDisabled) return;
 		this._dropzone?.browse();
 	}
 
@@ -119,7 +129,7 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 				label=${this.label}
 				accept=${ifDefined(this.accept)}
 				?multiple=${this.multiple}
-				?disabled=${this.disabled}
+				?disabled=${this.#isDisabled}
 				?disallowFolderUpload=${this.disableFolderUpload}
 				@change=${this.onUpload}
 				@click=${this.#handleBrowse}>
@@ -132,7 +142,6 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 	}
 
 	protected renderUploader() {
-		if (this.disabled) return nothing;
 		if (!this._progressItems?.length) return nothing;
 
 		return html`
@@ -209,7 +218,7 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 	protected async onUpload(e: UUIFileDropzoneEvent) {
 		e.stopImmediatePropagation();
 
-		if (this.disabled) return;
+		if (this.#isDisabled) return;
 		if (!e.detail.files.length && !e.detail.folders.length) return;
 
 		const uploadables = this._manager.createTemporaryFiles(e.detail.files);
@@ -250,6 +259,11 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 				width: 100%;
 				inset: 0;
 				backdrop-filter: opacity(1); /* Removes the built in blur effect */
+
+				&[disabled] {
+					opacity: 0.5;
+					pointer-events: none;
+				}
 			}
 
 			#uploader {


### PR DESCRIPTION
## Description

It is currently possible to drag another file over a "single-mode" dropzone whilst an upload is pending because the **multiple** property is only sent to the internal dropzone as `?multiple`, meaning that only one file could be selected _at a time_. However, we would like its behavior to reflect that `multiple = false` means only one file _ever_ can be uploaded, unless you clear that file.

This disables the internal dropzone if `multiple = false` and an upload is in progress. You need to clear the files/queue before trying to upload something else, unless multiple=true.

A bonus feature is that we allow to show the "uploader UI" to be shown even though the dropzone is disabled, because otherwise the files would be hidden.

## How to test

1. This is best tested by creating a new media item as the File type and uploading a large enough file, so that you have time to select a second file before the first finishes.

## Caveat

One thought is that if a previous upload is in a non-complete state, then we would allow a second file to be uploaded. It could be that you had cancelled a file or its type was ultimately not accepted. I would like an opinion on that.