### PR TITLE
Remove admin permission on user configuration, allowing users with user section access only to manage users and groups

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/ConfigurationUserController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/ConfigurationUserController.cs
@@ -1,15 +1,12 @@
-﻿using Asp.Versioning;
-using Microsoft.AspNetCore.Authorization;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.User;
-using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.User;
 
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.RequireAdminAccess)]
 public class ConfigurationUserController : UserControllerBase
 {
     private readonly IUserPresentationFactory _userPresentationFactory;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Support request ([link for HQ](https://umbraco.slack.com/archives/C02JJQU9B/p1742910633947649))

### Description
You currently can't create a "User Manager" role - i.e. a set of users that only have access to the Users section.  Whilst you can create the group, a user in it can't access the user's section without being an administrator.  It appears that the only issue here is that a management API endpoint to retrieve configuration for user information is locked down to administrators only.

I've loosened this in this PR, such that it's now restricted to those with access to the Users section.

The endpoint exposes the following - so not something we need to hide from someone with access to the Users section but not being an administrator:

```
public class UserConfigurationResponseModel
{
    public bool CanInviteUsers { get; set; }

    public bool UsernameIsEmail { get; set; }

    public required PasswordConfigurationResponseModel PasswordConfiguration { get; set; }

    public bool AllowChangePassword { get; set; }

    public bool AllowTwoFactor { get; set; }
}
```

I notice once I've fixed this, I can edit users and groups but only deal with groups that I'm in myself, so issues around being able to elevate permissions have already been considered.

### Testing

- Create a user group that only has access to the Users section
- Create a user that is part of only this group
- Login as that user and verify that you can access the Users section and manage users and user groups.

