### PR TITLE
15.3: Hotfix: Localization culture alias case-insensitive check

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -67,7 +67,9 @@ export class UmbLocalizationRegistry {
 				if (!translations.length) return;
 
 				if (diff.length) {
-					const filteredTranslations = translations.filter((t) => diff.some((ext) => ext.meta.culture === t.$code));
+					const filteredTranslations = translations.filter((t) =>
+						diff.some((ext) => ext.meta.culture.toLowerCase() === t.$code),
+					);
 					umbLocalizationManager.registerManyLocalizations(filteredTranslations);
 				}
 


### PR DESCRIPTION
### Description

Fixes #18801.

The localization registry filters out the translations by matching the manifest's culture alias, but it was case-sensitive. This patch makes the check case-insensitive by making the culture alias to be lowercase.
