### PR TITLE
Adds webp to mime type map to support preview on upload file property

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/utils.ts
@@ -744,6 +744,7 @@ export function getMimeTypeFromExtension(extension: string): string | null {
 		'.wbxml': 'application/vnd.wap.wbxml',
 		'.wcm': 'application/vnd.ms-works',
 		'.wdb': 'application/vnd.ms-works',
+		'.webp': 'image/webp',
 		'.wiz': 'application/msword',
 		'.wks': 'application/vnd.ms-works',
 		'.wm': 'video/x-ms-wm',


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18862

### Description
As described on the linked issue, the preview for the file upload property editor doesn't work for `.webp` files.

And as also indicated there, it's because we don't have the mime type defined for this.

### Testing

- Setup an upload file data type on a document type.
- Create content using that document type and upload a `.webp` image.
- Refresh and verify that the image preview is shown.
