### PR TITLE
Use uui-dialog-layout for all save + publishing dialogs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/save-modal/document-save-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/modals/save-modal/document-save-modal.element.ts
@@ -56,7 +56,7 @@ export class UmbDocumentSaveModalElement extends UmbModalBaseElement<
 	}
 
 	override render() {
-		return html`<umb-body-layout headline=${this.localize.term('content_saveModalTitle')}>
+		return html`<uui-dialog-layout headline=${this.localize.term('content_saveModalTitle')}>
 			<p id="subtitle">
 				<umb-localize key="content_variantsToSave">Choose which variants to be saved.</umb-localize>
 			</p>
@@ -74,7 +74,7 @@ export class UmbDocumentSaveModalElement extends UmbModalBaseElement<
 					color="positive"
 					@click=${this.#submit}></uui-button>
 			</div>
-		</umb-body-layout> `;
+		</uui-dialog-layout> `;
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish-with-descendants/modal/document-publish-with-descendants-modal.element.ts
@@ -96,7 +96,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 	}
 
 	override render() {
-		return html`<umb-body-layout headline=${this.localize.term('buttons_publishDescendants')}>
+		return html`<uui-dialog-layout headline=${this.localize.term('buttons_publishDescendants')}>
 			<p id="subtitle">
 				${this._options.length === 1
 					? html`<umb-localize
@@ -136,7 +136,7 @@ export class UmbDocumentPublishWithDescendantsModalElement extends UmbModalBaseE
 					?disabled=${this._hasNotSelectedMandatory}
 					@click=${this.#submit}></uui-button>
 			</div>
-		</umb-body-layout> `;
+		</uui-dialog-layout> `;
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/modal/document-publish-modal.element.ts
@@ -88,7 +88,7 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 	}
 
 	override render() {
-		return html`<umb-body-layout headline=${this.localize.term('content_readyToPublish')}>
+		return html`<uui-dialog-layout headline=${this.localize.term('content_readyToPublish')}>
 			<p id="subtitle">
 				<umb-localize key="content_variantsToPublish">Which variants would you like to publish?</umb-localize>
 			</p>
@@ -107,7 +107,7 @@ export class UmbDocumentPublishModalElement extends UmbModalBaseElement<
 					?disabled=${this._hasNotSelectedMandatory}
 					@click=${this.#submit}></uui-button>
 			</div>
-		</umb-body-layout>`;
+		</uui-dialog-layout>`;
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -157,7 +157,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 	}
 
 	override render() {
-		return html`<umb-body-layout headline=${this.localize.term('general_scheduledPublishing')}>
+		return html`<uui-dialog-layout headline=${this.localize.term('general_scheduledPublishing')}>
 			<p id="subtitle">
 				${when(
 					this._options.length > 1,
@@ -184,7 +184,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 					?disabled=${!this._selection.length || this._hasNotSelectedMandatory}
 					@click=${this.#submit}></uui-button>
 			</div>
-		</umb-body-layout> `;
+		</uui-dialog-layout> `;
 	}
 
 	#renderOptions() {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/modal/document-unpublish-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/modal/document-unpublish-modal.element.ts
@@ -144,7 +144,7 @@ export class UmbDocumentUnpublishModalElement extends UmbModalBaseElement<
 	};
 
 	override render() {
-		return html`<umb-body-layout headline=${this.localize.term('content_unpublish')}>
+		return html`<uui-dialog-layout headline=${this.localize.term('content_unpublish')}>
 			${!this._isInvariant
 				? html`
 						<p id="subtitle">
@@ -193,7 +193,7 @@ export class UmbDocumentUnpublishModalElement extends UmbModalBaseElement<
 					color="warning"
 					@click=${this.#submit}></uui-button>
 			</div>
-		</umb-body-layout> `;
+		</uui-dialog-layout> `;
 	}
 
 	static override styles = [


### PR DESCRIPTION
Align the UX for "center" dialogs by switching from 'umb-body-layout' to' uui-dialog-layout'.