### PR TITLE
V16: Removed deprecated `ITwoFactorLoginService` methods 

### DIFF
--- a/src/Umbraco.Core/Services/ITwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/ITwoFactorLoginService.cs
@@ -23,16 +23,6 @@ public interface ITwoFactorLoginService : IService
     Task<string?> GetSecretForUserAndProviderAsync(Guid userOrMemberKey, string providerName);
 
     /// <summary>
-    ///     Gets the setup info for a specific user or member and a specific provider.
-    /// </summary>
-    /// <remarks>
-    ///     The returned type can be anything depending on the setup providers. You will need to cast it to the type handled by
-    ///     the provider.
-    /// </remarks>
-    [Obsolete("Use IUserTwoFactorLoginService.GetSetupInfoAsync or IMemberTwoFactorLoginService.GetSetupInfoAsync. Scheduled for removal in Umbraco 16.")]
-    Task<object?> GetSetupInfoAsync(Guid userOrMemberKey, string providerName);
-
-    /// <summary>
     ///     Gets all registered providers names.
     /// </summary>
     IEnumerable<string> GetAllProviderNames();
@@ -56,17 +46,4 @@ public interface ITwoFactorLoginService : IService
     /// Gets all the enabled 2FA providers for the user or member with the specified key.
     /// </summary>
     Task<IEnumerable<string>> GetEnabledTwoFactorProviderNamesAsync(Guid userOrMemberKey);
-
-    /// <summary>
-    /// Disables 2FA with Code.
-    /// </summary>
-    [Obsolete("Use IUserTwoFactorLoginService.DisableByCodeAsync or IMemberTwoFactorLoginService.DisableByCodeAsync. Scheduled for removal in Umbraco 16.")]
-    Task<bool> DisableWithCodeAsync(string providerName, Guid userOrMemberKey, string code);
-
-    /// <summary>
-    /// Validates and Saves.
-    /// </summary>
-    [Obsolete("Use IUserTwoFactorLoginService.ValidateAndSaveAsync or IMemberTwoFactorLoginService.ValidateAndSaveAsync. Scheduled for removal in Umbraco 16.")]
-    Task<bool> ValidateAndSaveAsync(string providerName, Guid userKey, string secret, string code);
-
 }


### PR DESCRIPTION
### Description

Removed the deprecated `GetSetupInfoAsync`, `DisableWithCodeAsync` and `ValidateAndSaveAsync` methods from `ITwoFactorLoginService`. These had been previously removed in #18661, but got re-added in recent a merge-up from the `v15/dev` branch (commit: 1e5d29e667bf2434908029ec3d1c6301b72c3994).
