### PR TITLE
Only prevent the unpublish or delete of a related item when configured to do so if it is related as a child, not as a parent

### DIFF
--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
@@ -198,7 +198,7 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
             return await Task.FromResult(Attempt.FailWithStatus<TContent?, ContentEditingOperationStatus>(status, content));
         }
 
-        if (disabledWhenReferenced && _relationService.IsRelated(content.Id))
+        if (disabledWhenReferenced && _relationService.IsRelated(content.Id, RelationDirectionFilter.Child))
         {
             return Attempt.FailWithStatus<TContent?, ContentEditingOperationStatus>(referenceFailStatus, content);
         }

--- a/src/Umbraco.Core/Services/ContentPublishingService.cs
+++ b/src/Umbraco.Core/Services/ContentPublishingService.cs
@@ -311,7 +311,7 @@ internal sealed class ContentPublishingService : IContentPublishingService
             return Attempt.Fail(ContentPublishingOperationStatus.ContentNotFound);
         }
 
-        if (_contentSettings.DisableUnpublishWhenReferenced && _relationService.IsRelated(content.Id))
+        if (_contentSettings.DisableUnpublishWhenReferenced && _relationService.IsRelated(content.Id, RelationDirectionFilter.Child))
         {
             scope.Complete();
             return Attempt<ContentPublishingOperationStatus>.Fail(ContentPublishingOperationStatus.CannotUnpublishWhenReferenced);

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2767,7 +2767,7 @@ public class ContentService : RepositoryService, IContentService
             {
                 foreach (IContent content in contents)
                 {
-                    if (_contentSettings.DisableDeleteWhenReferenced && _relationService.IsRelated(content.Id))
+                    if (_contentSettings.DisableDeleteWhenReferenced && _relationService.IsRelated(content.Id, RelationDirectionFilter.Child))
                     {
                         continue;
                     }

--- a/src/Umbraco.Core/Services/IRelationService.cs
+++ b/src/Umbraco.Core/Services/IRelationService.cs
@@ -4,6 +4,17 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Core.Services;
 
+/// <summary>
+/// Definition of relation directions used as a filter when requesting if a given item has relations.
+/// </summary>
+[Flags]
+public enum RelationDirectionFilter
+{
+    Parent = 1,
+    Child = 2,
+    Any = Parent | Child
+}
+
 public interface IRelationService : IService
 {
     /// <summary>
@@ -297,7 +308,19 @@ public interface IRelationService : IService
     /// </summary>
     /// <param name="id">Id of an object to check relations for</param>
     /// <returns>Returns <c>True</c> if any relations exists with the given Id, otherwise <c>False</c></returns>
+    [Obsolete("Please use the overload taking a RelationDirectionFilter parameter. Scheduled for removal in Umbraco 17.")]
     bool IsRelated(int id);
+
+    /// <summary>
+    ///     Checks whether any relations exists for the passed in Id and direction.
+    /// </summary>
+    /// <param name="id">Id of an object to check relations for</param>
+    /// <param name="directionFilter">Indicates whether to check for relations as parent, child or in either direction.</param>
+    /// <returns>Returns <c>True</c> if any relations exists with the given Id, otherwise <c>False</c></returns>
+    bool IsRelated(int id, RelationDirectionFilter directionFilter)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => IsRelated(id);
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     ///     Checks whether two items are related

--- a/src/Umbraco.Core/Services/RelationService.cs
+++ b/src/Umbraco.Core/Services/RelationService.cs
@@ -499,11 +499,28 @@ public class RelationService : RepositoryService, IRelationService
     }
 
     /// <inheritdoc />
-    public bool IsRelated(int id)
+    public bool IsRelated(int id) => IsRelated(id, RelationDirectionFilter.Any);
+
+    /// <inheritdoc />
+    public bool IsRelated(int id, RelationDirectionFilter directionFilter)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            IQuery<IRelation> query = Query<IRelation>().Where(x => x.ParentId == id || x.ChildId == id);
+            IQuery<IRelation> query = Query<IRelation>();
+
+            if (directionFilter == RelationDirectionFilter.Parent)
+            {
+                query = query.Where(x => x.ParentId == id);
+            }
+            else if (directionFilter == RelationDirectionFilter.Child)
+            {
+                query = query.Where(x => x.ChildId == id);
+            }
+            else
+            {
+                query = query.Where(x => x.ParentId == id || x.ChildId == id);
+            }
+
             return _relationRepository.Get(query).Any();
         }
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Unpublish.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Unpublish.cs
@@ -1,14 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Integration.Attributes;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
 public partial class ContentPublishingServiceTests
 {
+    public static new void ConfigureDisableUnpublishWhenReferencedTrue(IUmbracoBuilder builder)
+        => builder.Services.Configure<ContentSettings>(config =>
+            config.DisableUnpublishWhenReferenced = true);
+
     [Test]
     public async Task Can_Unpublish_Root()
     {
@@ -90,6 +98,40 @@ public partial class ContentPublishingServiceTests
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.CancelledByEvent, result.Result);
         VerifyIsPublished(Textpage.Key);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureDisableUnpublishWhenReferencedTrue))]
+    public async Task Cannot_Unpublish_When_Content_Is_Related_As_A_Child_And_Configured_To_Disable_When_Related()
+    {
+        await ContentPublishingService.PublishAsync(Textpage.Key, MakeModel(_allCultures), Constants.Security.SuperUserKey);
+        VerifyIsPublished(Textpage.Key);
+
+        // Setup a relation where the page being unpublished is related to another page as a child (e.g. the other page has a picker and has selected this page).
+        RelationService.Relate(Subpage, Textpage, Constants.Conventions.RelationTypes.RelatedDocumentAlias);
+
+        var result = await ContentPublishingService.UnpublishAsync(Textpage.Key, null, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentPublishingOperationStatus.CannotUnpublishWhenReferenced, result.Result);
+        VerifyIsPublished(Textpage.Key);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureDisableUnpublishWhenReferencedTrue))]
+    public async Task Can_Unpublish_When_Content_Is_Related_As_A_Parent_And_Configured_To_Disable_When_Related()
+    {
+        await ContentPublishingService.PublishAsync(Textpage.Key, MakeModel(_allCultures), Constants.Security.SuperUserKey);
+        VerifyIsPublished(Textpage.Key);
+
+        // Setup a relation where the page being unpublished is related to another page as a parent (e.g. this page has a picker and has selected the other page).
+        RelationService.Relate(Textpage, Subpage, Constants.Conventions.RelationTypes.RelatedDocumentAlias);
+
+        var result = await ContentPublishingService.UnpublishAsync(Textpage.Key, null, Constants.Security.SuperUserKey);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ContentPublishingOperationStatus.Success, result.Result);
+        VerifyIsNotPublished(Textpage.Key);
     }
 
     [Test]
@@ -228,8 +270,6 @@ public partial class ContentPublishingServiceTests
         content = ContentService.GetById(content.Key)!;
         Assert.AreEqual(0, content.PublishedCultures.Count());
     }
-
-
 
     [Test]
     public async Task Can_Unpublish_Non_Mandatory_Cultures()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -19,6 +19,8 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 public partial class ContentPublishingServiceTests : UmbracoIntegrationTestWithContent
 {
     private IContentPublishingService ContentPublishingService => GetRequiredService<IContentPublishingService>();
+
+    private IRelationService RelationService => GetRequiredService<IRelationService>();
 
     private static readonly ISet<string> _allCultures = new HashSet<string>(){ "*" };
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18877

### Description
On investigating the linked issue I could see that when we have configuration to prevent delete or unpublish when there's a relation, we are checking for a relation in both directions.  But we should only disable the operation if the item is related as a child.

In other words, given document A and B where B has a picker that selects A, and given `DisableXWhenReferenced` is set to `true`, on delete or unpublish:

- A should be prevented
- B should be allowed

I've implemented that in this PR by extending the `IRelationService.IsRelated` message to accept a parameter indicating whether we are checking for a relation as parent, a child, or either.  And used the "as child" option for this checks.

### Testing
See the reproduction steps in the linked issue and verify that the appropriate unpublish and delete operations are allowed.