### PR TITLE
Ensures date comparisons in schedule integration tests are made only on the datetime part to the second

### DIFF
--- a/src/Umbraco.Core/Extensions/DateTimeExtensions.cs
+++ b/src/Umbraco.Core/Extensions/DateTimeExtensions.cs
@@ -38,17 +38,17 @@ public static class DateTimeExtensions
     {
         if (truncateTo == DateTruncate.Year)
         {
-            return new DateTime(dt.Year, 1, 1);
+            return new DateTime(dt.Year, 1, 1, 0, 0, 0, dt.Kind);
         }
 
         if (truncateTo == DateTruncate.Month)
         {
-            return new DateTime(dt.Year, dt.Month, 1);
+            return new DateTime(dt.Year, dt.Month, 1, 0, 0, 0, dt.Kind);
         }
 
         if (truncateTo == DateTruncate.Day)
         {
-            return new DateTime(dt.Year, dt.Month, dt.Day);
+            return new DateTime(dt.Year, dt.Month, dt.Day, 0, 0, 0, dt.Kind);
         }
 
         if (truncateTo == DateTruncate.Hour)

--- a/src/Umbraco.Core/Extensions/DateTimeExtensions.cs
+++ b/src/Umbraco.Core/Extensions/DateTimeExtensions.cs
@@ -7,6 +7,9 @@ namespace Umbraco.Extensions;
 
 public static class DateTimeExtensions
 {
+    /// <summary>
+    /// Defines the levels to truncate a date to.
+    /// </summary>
     public enum DateTruncate
     {
         Year,
@@ -25,6 +28,12 @@ public static class DateTimeExtensions
     public static string ToIsoString(this DateTime dt) =>
         dt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
+    /// <summary>
+    /// Truncates the date to the specified level, i.e. if you pass in DateTruncate.Hour it will truncate the date to the hour.
+    /// </summary>
+    /// <param name="dt">The date.</param>
+    /// <param name="truncateTo">The level to truncate the date to.</param>
+    /// <returns>The truncated date.</returns>
     public static DateTime TruncateTo(this DateTime dt, DateTruncate truncateTo)
     {
         if (truncateTo == DateTruncate.Year)
@@ -44,14 +53,14 @@ public static class DateTimeExtensions
 
         if (truncateTo == DateTruncate.Hour)
         {
-            return new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, 0, 0);
+            return new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, 0, 0, dt.Kind);
         }
 
         if (truncateTo == DateTruncate.Minute)
         {
-            return new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, 0);
+            return new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, 0, dt.Kind);
         }
 
-        return new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second);
+        return new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, dt.Kind);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentPublishingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentPublishingServiceTests.cs
@@ -23,8 +23,8 @@ public class ContentPublishingServiceTests : UmbracoIntegrationTestWithContent
 {
     private const string UnknownCulture = "ke-Ke";
 
-    private readonly DateTime _schedulePublishDate = DateTime.UtcNow.AddDays(1);
-    private readonly DateTime _scheduleUnPublishDate = DateTime.UtcNow.AddDays(2);
+    private readonly DateTime _schedulePublishDate = DateTime.UtcNow.AddDays(1).Date;
+    private readonly DateTime _scheduleUnPublishDate = DateTime.UtcNow.AddDays(2).Date;
 
     [SetUp]
     public new void Setup() => ContentRepositoryBase.ThrowOnWarning = true;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentPublishingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentPublishingServiceTests.cs
@@ -1,4 +1,3 @@
-using Bogus.DataSets;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -23,8 +22,8 @@ public class ContentPublishingServiceTests : UmbracoIntegrationTestWithContent
 {
     private const string UnknownCulture = "ke-Ke";
 
-    private readonly DateTime _schedulePublishDate = DateTime.UtcNow.AddDays(1).Date;
-    private readonly DateTime _scheduleUnPublishDate = DateTime.UtcNow.AddDays(2).Date;
+    private readonly DateTime _schedulePublishDate = DateTime.UtcNow.AddDays(1).TruncateTo(DateTimeExtensions.DateTruncate.Second);
+    private readonly DateTime _scheduleUnPublishDate = DateTime.UtcNow.AddDays(2).TruncateTo(DateTimeExtensions.DateTruncate.Second);
 
     [SetUp]
     public new void Setup() => ContentRepositoryBase.ThrowOnWarning = true;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
We have started seeing failures on date comparisons in integration tests run on pipelines, where the extra part of the dates beyond the seconds is used, e.g.:

```
Expected: 2025-04-01 11:45:51.9524108
But was:  2025-04-01 11:45:51.953
```

This updates to ensure that only the date part is compared.

### Testing

Run the affected integration tests (or let the pipeline do it).

### Release

We can cherry-pick this into the 15.3.1 release branch.
