### PR TITLE
Adds allow-same-origin to preview IFRAME

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/preview/preview.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/preview/preview.element.ts
@@ -63,7 +63,7 @@ export class UmbPreviewElement extends UmbLitElement {
 						src=${this._previewUrl}
 						title="Page preview"
 						@load=${this.#onIFrameLoad}
-						sandbox="allow-scripts"></iframe>
+						sandbox="allow-scripts allow-same-origin"></iframe>
 				</div>
 			</div>
 			<div id="menu">


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18887

### Description
Scripts marked with `type="module"` currently fail when previewed due to CORS issues as described in the linked issue.  This can be resolved by amending the `sandbox` element of the preview IFRAME.

### Testing

See the linked issue.

Consider security implications.  I can't see any downside here as preview is for authenticated users and uses templates provided by the developer's of the Umbraco website.
