### PR TITLE
V15: File upload should use better Image & SVG preview

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -245,6 +245,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 				grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 				gap: var(--uui-size-space-4);
 				box-sizing: border-box;
+				margin-bottom: var(--uui-size-space-3);
 			}
 
 			#wrapper:has(umb-input-upload-field-file) {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -256,8 +256,7 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 			#wrapperInner {
 				position: relative;
 				display: flex;
-				width: fit-content;
-				max-width: 100%;
+				width: 100%;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-audio.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-audio.element.ts
@@ -6,10 +6,14 @@ export default class UmbInputUploadFieldAudioElement extends UmbLitElement {
 	@property({ type: String })
 	path = '';
 
+	get #label() {
+		return this.path.split('/').pop() ?? '';
+	}
+
 	override render() {
 		if (!this.path) return html`<uui-loader></uui-loader>`;
 
-		return html`<audio controls src=${this.path}></audio>`;
+		return html`<audio controls src=${this.path} title=${this.#label}></audio>`;
 	}
 
 	static override readonly styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-image.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-image.element.ts
@@ -6,28 +6,43 @@ export default class UmbInputUploadFieldImageElement extends UmbLitElement {
 	@property({ type: String })
 	path = '';
 
+	get #label() {
+		return this.path.split('/').pop() ?? '';
+	}
+
 	override render() {
 		if (!this.path) return html`<uui-loader></uui-loader>`;
 
-		return html`<img src=${this.path} alt="" />`;
+		const label = this.#label;
+
+		return html`<uui-card-media id="card" .name=${label} href="${this.path}" target="_blank">
+			<img id="image" src=${this.path} alt="${label}" loading="lazy" />
+		</uui-card-media>`;
 	}
 
 	static override readonly styles = [
 		css`
 			:host {
-				display: flex;
-				height: 100%;
 				position: relative;
-				width: fit-content;
+				min-height: 240px;
 				max-height: 400px;
+				width: fit-content;
+				max-width: 100%;
 			}
 
-			img {
-				max-width: 100%;
-				max-height: 100%;
+			#card {
+				width: 100%;
+				height: 100%;
+			}
+
+			#image {
 				object-fit: contain;
 				width: auto;
-				height: auto;
+				height: 100%;
+				background-color: #fff;
+				background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" fill-opacity=".1"><path d="M50 0h50v50H50zM0 50h50v50H0z"/></svg>');
+				background-repeat: repeat;
+				background-size: 10px 10px;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
@@ -13,8 +13,10 @@ export default class UmbInputUploadFieldSvgElement extends UmbLitElement {
 	override render() {
 		if (!this.path) return html`<uui-loader></uui-loader>`;
 
-		return html`<uui-card-media id="card" .name=${this.#label} href="${this.path}" target="_blank">
-			<img id="image" src=${this.path} alt="svg" />
+		const label = this.#label;
+
+		return html`<uui-card-media id="card" .name=${label} href="${this.path}" target="_blank">
+			<img id="image" src=${this.path} alt="${label}" loading="lazy" />
 		</uui-card-media>`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
@@ -13,14 +13,30 @@ export default class UmbInputUploadFieldSvgElement extends UmbLitElement {
 	override render() {
 		if (!this.path) return html`<uui-loader></uui-loader>`;
 
-		return html`<uui-card-media .name=${this.#label} href="${this.path}" target="_blank">
+		return html`<uui-card-media id="card" .name=${this.#label} href="${this.path}" target="_blank">
 			<img id="image" src=${this.path} alt="svg" />
 		</uui-card-media>`;
 	}
 
 	static override readonly styles = [
 		css`
+			:host {
+				position: relative;
+				min-height: 240px;
+				max-height: 400px;
+				width: fit-content;
+				max-width: 100%;
+			}
+
+			#card {
+				width: 100%;
+				height: 100%;
+			}
+
 			#image {
+				object-fit: contain;
+				width: auto;
+				height: 100%;
 				background-color: #fff;
 				background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" fill-opacity=".1"><path d="M50 0h50v50H50zM0 50h50v50H0z"/></svg>');
 				background-repeat: repeat;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
@@ -6,33 +6,25 @@ export default class UmbInputUploadFieldSvgElement extends UmbLitElement {
 	@property({ type: String })
 	path = '';
 
+	get #label() {
+		return this.path.split('/').pop() ?? '';
+	}
+
 	override render() {
 		if (!this.path) return html`<uui-loader></uui-loader>`;
 
-		return html`<img src=${this.path} alt="svg" />`;
+		return html`<uui-card-media .name=${this.#label} href="${this.path}" target="_blank">
+			<img id="image" src=${this.path} alt="svg" />
+		</uui-card-media>`;
 	}
 
 	static override readonly styles = [
 		css`
-			:host {
-				display: flex;
+			#image {
 				background-color: #fff;
 				background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" fill-opacity=".1"><path d="M50 0h50v50H50zM0 50h50v50H0z"/></svg>');
 				background-repeat: repeat;
 				background-size: 10px 10px;
-				height: 100%;
-				min-height: 240px;
-				position: relative;
-				width: fit-content;
-				max-height: 240px;
-			}
-
-			img {
-				max-width: 100%;
-				max-height: 100%;
-				object-fit: contain;
-				width: auto;
-				height: auto;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-video.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-video.element.ts
@@ -6,11 +6,15 @@ export default class UmbInputUploadFieldVideoElement extends UmbLitElement {
 	@property({ type: String })
 	path = '';
 
+	get #label() {
+		return this.path.split('/').pop() ?? '';
+	}
+
 	override render() {
 		if (!this.path) return html`<uui-loader></uui-loader>`;
 
 		return html`
-			<video controls>
+			<video controls title=${this.#label}>
 				<source src=${this.path} />
 				Video format not supported
 			</video>


### PR DESCRIPTION
## Description

Similar to #18899, this changes the preview of SVGs on the Upload Field to use `<uui-card-media />`.

Fixes #18861

## Changes

- Adds same preview for SVG and Image using `<uui-card-media />`
- Adds `loading="lazy"` on SVG and Image
- Ensures that neither SVG nor Image can exceed its bounds (try testing with `width: 10000px` for example)
- Adds a `title` attribute on Audio and Video

## Screenshots

<details>
<summary>JPG/PNG</summary>

🔴  **BEFORE**
![image](https://github.com/user-attachments/assets/533b2f2f-c0ec-4551-9377-73480bd563be)


✅  **AFTER**
![image](https://github.com/user-attachments/assets/f077734e-f5b3-43fa-84cf-23d0b45ceb42)
</details>

<details>
<summary>SVG</summary>

🔴  **BEFORE**

![image](https://github.com/user-attachments/assets/95fd0c8c-7ad5-4e89-b0cb-0c9e7a2d3935)


✅  **AFTER**
![image](https://github.com/user-attachments/assets/be789e51-32da-4a7a-8df7-1c04608f3049)
</details>