### PR TITLE
Remove async await where not needed

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByIdsContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByIdsContentApiController.cs
@@ -58,6 +58,6 @@ public class ByIdsContentApiController : ContentApiItemControllerBase
             .WhereNotNull()
             .ToArray();
 
-        return await Task.FromResult(Ok(apiContentItems));
+        return Ok(apiContentItems);
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
@@ -117,7 +117,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
                 return deniedAccessResult;
             }
 
-            return await Task.FromResult(Ok(ApiContentResponseBuilder.Build(contentItem)));
+            return Ok(ApiContentResponseBuilder.Build(contentItem));
         }
 
         IApiContentRoute? redirectRoute = _requestRedirectService.GetRedirectRoute(path);

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Media/ByIdMediaApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Media/ByIdMediaApiController.cs
@@ -24,8 +24,8 @@ public class ByIdMediaApiController : MediaApiControllerBase
     [ProducesResponseType(typeof(IApiMediaWithCropsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Obsolete("Please use version 2 of this API. Will be removed in V15.")]
-    public async Task<IActionResult> ById(Guid id)
-        => await HandleRequest(id);
+    public Task<IActionResult> ById(Guid id)
+        => Task.FromResult(HandleRequest(id));
 
     /// <summary>
     ///     Gets a media item by id.
@@ -36,16 +36,16 @@ public class ByIdMediaApiController : MediaApiControllerBase
     [MapToApiVersion("2.0")]
     [ProducesResponseType(typeof(IApiMediaWithCropsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> ByIdV20(Guid id)
-        => await HandleRequest(id);
+    public Task<IActionResult> ByIdV20(Guid id)
+        => Task.FromResult(HandleRequest(id));
 
-    private async Task<IActionResult> HandleRequest(Guid id)
+    private IActionResult HandleRequest(Guid id)
     {
         IPublishedContent? media = PublishedMediaCache.GetById(id);
 
         if (media is null)
         {
-            return await Task.FromResult(NotFound());
+            return NotFound();
         }
 
         return Ok(BuildApiMediaWithCrops(media));

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Media/ByIdsMediaApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Media/ByIdsMediaApiController.cs
@@ -36,7 +36,7 @@ public class ByIdsMediaApiController : MediaApiControllerBase
     public async Task<IActionResult> ItemsV20([FromQuery(Name = "id")] HashSet<Guid> ids)
         => await HandleRequest(ids);
 
-    private async Task<IActionResult> HandleRequest(HashSet<Guid> ids)
+    private Task<IActionResult> HandleRequest(HashSet<Guid> ids)
     {
         IPublishedContent[] mediaItems = ids
             .Select(PublishedMediaCache.GetById)
@@ -47,6 +47,6 @@ public class ByIdsMediaApiController : MediaApiControllerBase
             .Select(BuildApiMediaWithCrops)
             .ToArray();
 
-        return await Task.FromResult(Ok(apiMediaItems));
+        return Task.FromResult<IActionResult>(Ok(apiMediaItems));
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Media/ByPathMediaApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Media/ByPathMediaApiController.cs
@@ -27,8 +27,8 @@ public class ByPathMediaApiController : MediaApiControllerBase
     [ProducesResponseType(typeof(IApiMediaWithCropsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Obsolete("Please use version 2 of this API. Will be removed in V15.")]
-    public async Task<IActionResult> ByPath(string path)
-        => await HandleRequest(path);
+    public Task<IActionResult> ByPath(string path)
+        => Task.FromResult(HandleRequest(path));
 
     /// <summary>
     ///     Gets a media item by its path.
@@ -39,17 +39,17 @@ public class ByPathMediaApiController : MediaApiControllerBase
     [MapToApiVersion("2.0")]
     [ProducesResponseType(typeof(IApiMediaWithCropsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> ByPathV20(string path)
-        => await HandleRequest(path);
+    public Task<IActionResult> ByPathV20(string path)
+        => Task.FromResult(HandleRequest(path));
 
-    private async Task<IActionResult> HandleRequest(string path)
+    private IActionResult HandleRequest(string path)
     {
         path = DecodePath(path);
 
         IPublishedContent? media = _apiMediaQueryService.GetByPath(path);
         if (media is null)
         {
-            return await Task.FromResult(NotFound());
+            return NotFound();
         }
 
         return Ok(BuildApiMediaWithCrops(media));

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Media/QueryMediaApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Media/QueryMediaApiController.cs
@@ -32,13 +32,13 @@ public class QueryMediaApiController : MediaApiControllerBase
     [ProducesResponseType(typeof(PagedViewModel<IApiMediaWithCropsResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [Obsolete("Please use version 2 of this API. Will be removed in V15.")]
-    public async Task<IActionResult> Query(
+    public Task<IActionResult> Query(
         string? fetch,
         [FromQuery] string[] filter,
         [FromQuery] string[] sort,
         int skip = 0,
         int take = 10)
-        => await HandleRequest(fetch, filter, sort, skip, take);
+        => Task.FromResult(HandleRequest(fetch, filter, sort, skip, take));
 
     /// <summary>
     ///     Gets a paginated list of media item(s) from query.
@@ -53,15 +53,15 @@ public class QueryMediaApiController : MediaApiControllerBase
     [MapToApiVersion("2.0")]
     [ProducesResponseType(typeof(PagedViewModel<IApiMediaWithCropsResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> QueryV20(
+    public Task<IActionResult> QueryV20(
         string? fetch,
         [FromQuery] string[] filter,
         [FromQuery] string[] sort,
         int skip = 0,
         int take = 10)
-        => await HandleRequest(fetch, filter, sort, skip, take);
+        => Task.FromResult(HandleRequest(fetch, filter, sort, skip, take));
 
-    private async Task<IActionResult> HandleRequest(string? fetch, string[] filter, string[] sort, int skip, int take)
+    private IActionResult HandleRequest(string? fetch, string[] filter, string[] sort, int skip, int take)
     {
         Attempt<PagedModel<Guid>, ApiMediaQueryOperationStatus> queryAttempt = _apiMediaQueryService.ExecuteQuery(fetch, filter, sort, skip, take);
 
@@ -79,6 +79,6 @@ public class QueryMediaApiController : MediaApiControllerBase
             Items = mediaItems.Select(BuildApiMediaWithCrops)
         };
 
-        return await Task.FromResult(Ok(model));
+        return Ok(model);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Culture/AllCultureController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Culture/AllCultureController.cs
@@ -28,7 +28,7 @@ public class AllCultureController : CultureControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<CultureReponseModel>), StatusCodes.Status200OK)]
-    public async Task<PagedViewModel<CultureReponseModel>> GetAll(CancellationToken cancellationToken, int skip = 0, int take = 100)
+    public Task<PagedViewModel<CultureReponseModel>> GetAll(CancellationToken cancellationToken, int skip = 0, int take = 100)
     {
         CultureInfo[] all = _cultureService.GetValidCultureInfos();
 
@@ -38,6 +38,6 @@ public class AllCultureController : CultureControllerBase
             Total = all.Length
         };
 
-        return await Task.FromResult(viewModel);
+        return Task.FromResult(viewModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/AllDictionaryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/AllDictionaryController.cs
@@ -38,6 +38,6 @@ public class AllDictionaryController : DictionaryControllerBase
             Total = items.Length,
             Items = _umbracoMapper.MapEnumerable<IDictionaryItem, DictionaryOverviewResponseModel>(items.Skip(skip).Take(take))
         };
-        return await Task.FromResult(model);
+        return model;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
@@ -24,13 +24,13 @@ public class ItemDocumentItemController : DocumentItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DocumentItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Ok(Enumerable.Empty<DocumentItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<DocumentItemResponseModel>()));
         }
 
         IEnumerable<IDocumentEntitySlim> documents = _entityService
@@ -38,6 +38,6 @@ public class ItemDocumentItemController : DocumentItemControllerBase
             .OfType<IDocumentEntitySlim>();
 
         IEnumerable<DocumentItemResponseModel> documentItemResponseModels = documents.Select(_documentPresentationFactory.CreateItemResponseModel);
-        return await Task.FromResult(Ok(documentItemResponseModels));
+        return Task.FromResult<IActionResult>(Ok(documentItemResponseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using Asp.Versioning;
+﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
@@ -47,7 +46,7 @@ public class SearchDocumentItemController : DocumentItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> SearchWithTrashed(
+    public Task<IActionResult> SearchWithTrashed(
         CancellationToken cancellationToken,
         string query,
         bool? trashed = null,
@@ -63,6 +62,6 @@ public class SearchDocumentItemController : DocumentItemControllerBase
             Total = searchResult.Total,
         };
 
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<IActionResult>(Ok(result));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateNotificationsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateNotificationsController.cs
@@ -35,6 +35,6 @@ public class UpdateNotificationsController : DocumentControllerBase
         }
 
         _notificationService.SetNotifications(_backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser, content, updateModel.SubscribedActionIds);
-        return await Task.FromResult(Ok());
+        return Ok();
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/ItemDocumentBlueprintController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentBlueprint/Item/ItemDocumentBlueprintController.cs
@@ -25,13 +25,13 @@ public class ItemDocumentBlueprintController : DocumentBlueprintItemControllerBa
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DocumentBlueprintItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Ok(Enumerable.Empty<DocumentBlueprintItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<DocumentBlueprintItemResponseModel>()));
         }
 
         IEnumerable<IDocumentEntitySlim> documents = _entityService
@@ -39,6 +39,6 @@ public class ItemDocumentBlueprintController : DocumentBlueprintItemControllerBa
             .Select(x => x as IDocumentEntitySlim)
             .WhereNotNull();
         IEnumerable<DocumentBlueprintItemResponseModel> responseModels = documents.Select(x => _documentPresentationFactory.CreateBlueprintItemResponseModel(x));
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/ItemDocumentTypeItemController.cs
@@ -23,17 +23,17 @@ public class ItemDocumentTypeItemController : DocumentTypeItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<DocumentTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Ok(Enumerable.Empty<DocumentTypeItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<DocumentTypeItemResponseModel>()));
         }
 
         IEnumerable<IContentType> contentTypes = _contentTypeService.GetMany(ids);
         List<DocumentTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IContentType, DocumentTypeItemResponseModel>(contentTypes);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/DynamicRoot/GetQueryStepsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DynamicRoot/GetQueryStepsController.cs
@@ -21,10 +21,10 @@ public class GetQueryStepsController : DynamicRootControllerBase
     [HttpGet($"steps")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetQuerySteps(CancellationToken cancellationToken)
+    public Task<IActionResult> GetQuerySteps(CancellationToken cancellationToken)
     {
         IEnumerable<string> querySteps = _dynamicRootQueryStepCollection.Select(x => x.SupportedDirectionAlias);
 
-        return await Task.FromResult(Ok(querySteps));
+        return Task.FromResult<IActionResult>(Ok(querySteps));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/ExecuteActionHealthCheckController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/ExecuteActionHealthCheckController.cs
@@ -63,6 +63,6 @@ public class ExecuteActionHealthCheckController : HealthCheckControllerBase
 
         HealthCheckStatus result = await healthCheck.ExecuteActionAsync(_umbracoMapper.Map<HealthCheckAction>(action)!);
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<HealthCheckResultResponseModel>(result)));
+        return Ok(_umbracoMapper.Map<HealthCheckResultResponseModel>(result));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/AllHealthCheckGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/AllHealthCheckGroupController.cs
@@ -31,7 +31,7 @@ public class AllHealthCheckGroupController : HealthCheckGroupControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<HealthCheckGroupResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<HealthCheckGroupResponseModel>>> All(
+    public Task<ActionResult<PagedViewModel<HealthCheckGroupResponseModel>>> All(
         CancellationToken cancellationToken,
         int skip = 0,
         int take = 100)
@@ -46,6 +46,6 @@ public class AllHealthCheckGroupController : HealthCheckGroupControllerBase
             Items = _umbracoMapper.MapEnumerable<IGrouping<string?, Core.HealthChecks.HealthCheck>, HealthCheckGroupResponseModel>(groups.Skip(skip).Take(take))
         };
 
-        return await Task.FromResult(Ok(viewModel));
+        return Task.FromResult<ActionResult<PagedViewModel<HealthCheckGroupResponseModel>>>(Ok(viewModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/ByNameHealthCheckGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/HealthCheck/Group/ByNameHealthCheckGroupController.cs
@@ -31,7 +31,7 @@ public class ByNameHealthCheckGroupController : HealthCheckGroupControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(HealthCheckGroupPresentationModel), StatusCodes.Status200OK)]
-    public async Task<IActionResult> ByName(
+    public Task<IActionResult> ByName(
         CancellationToken cancellationToken,
         string name)
     {
@@ -42,9 +42,9 @@ public class ByNameHealthCheckGroupController : HealthCheckGroupControllerBase
 
         if (group is null)
         {
-            return HealthCheckGroupNotFound();
+            return Task.FromResult(HealthCheckGroupNotFound());
         }
 
-        return await Task.FromResult(Ok(_umbracoMapper.Map<HealthCheckGroupPresentationModel>(group)));
+        return Task.FromResult<IActionResult>(Ok(_umbracoMapper.Map<HealthCheckGroupPresentationModel>(group)));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/DetailsIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/DetailsIndexerController.cs
@@ -34,11 +34,11 @@ public class DetailsIndexerController : IndexerControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(IndexResponseModel), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IndexResponseModel?>> Details(CancellationToken cancellationToken, string indexName)
+    public Task<ActionResult<IndexResponseModel?>> Details(CancellationToken cancellationToken, string indexName)
     {
         if (_examineManager.TryGetIndex(indexName, out IIndex? index))
         {
-            return await Task.FromResult(_indexPresentationFactory.Create(index!));
+            return Task.FromResult<ActionResult<IndexResponseModel?>>(_indexPresentationFactory.Create(index!));
         }
 
         var invalidModelProblem = new ProblemDetails
@@ -49,7 +49,6 @@ public class DetailsIndexerController : IndexerControllerBase
             Type = "Error",
         };
 
-        return await Task.FromResult(NotFound(invalidModelProblem));
-
+        return Task.FromResult<ActionResult<IndexResponseModel?>>(NotFound(invalidModelProblem));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Indexer/RebuildIndexerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Indexer/RebuildIndexerController.cs
@@ -36,7 +36,7 @@ public class RebuildIndexerController : IndexerControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IActionResult> Rebuild(CancellationToken cancellationToken, string indexName)
+    public Task<IActionResult> Rebuild(CancellationToken cancellationToken, string indexName)
     {
         if (!_examineManager.TryGetIndex(indexName, out IIndex? index))
         {
@@ -48,7 +48,7 @@ public class RebuildIndexerController : IndexerControllerBase
                 Type = "Error",
             };
 
-            return await Task.FromResult(NotFound(invalidModelProblem));
+            return Task.FromResult<IActionResult>(NotFound(invalidModelProblem));
         }
 
         if (!_indexingRebuilderService.CanRebuild(index.Name))
@@ -62,14 +62,14 @@ public class RebuildIndexerController : IndexerControllerBase
                 Type = "Error",
             };
 
-            return await Task.FromResult(BadRequest(invalidModelProblem));
+            return Task.FromResult<IActionResult>(BadRequest(invalidModelProblem));
         }
 
         _logger.LogInformation("Rebuilding index '{IndexName}'", indexName);
 
         if (_indexingRebuilderService.TryRebuild(index, indexName))
         {
-            return await Task.FromResult(Ok());
+            return Task.FromResult<IActionResult>(Ok());
         }
 
         var problemDetails = new ProblemDetails
@@ -80,6 +80,6 @@ public class RebuildIndexerController : IndexerControllerBase
             Type = "Error",
         };
 
-        return await Task.FromResult(Conflict(problemDetails));
+        return Task.FromResult<IActionResult>(Conflict(problemDetails));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllSinkLevelLogViewerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/LogViewer/AllSinkLevelLogViewerController.cs
@@ -30,7 +30,7 @@ public class AllSinkLevelLogViewerController : LogViewerControllerBase
     [HttpGet("level")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<LoggerResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<LoggerResponseModel>>> AllLogLevels(
+    public Task<ActionResult<PagedViewModel<LoggerResponseModel>>> AllLogLevels(
         CancellationToken cancellationToken,
         int skip = 0,
         int take = 100)
@@ -45,6 +45,6 @@ public class AllSinkLevelLogViewerController : LogViewerControllerBase
             Items = _umbracoMapper.MapEnumerable<KeyValuePair<string, LogLevel>, LoggerResponseModel>(logLevels.Skip(skip).Take(take))
         };
 
-        return await Task.FromResult(Ok(viewModel));
+        return Task.FromResult<ActionResult<PagedViewModel<LoggerResponseModel>>>(Ok(viewModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/ItemMediaItemController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Media.Item;
-using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
@@ -25,13 +24,13 @@ public class ItemMediaItemController : MediaItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MediaItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Ok(Enumerable.Empty<MediaItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<MediaItemResponseModel>()));
         }
 
         IEnumerable<IMediaEntitySlim> media = _entityService
@@ -39,6 +38,6 @@ public class ItemMediaItemController : MediaItemControllerBase
             .OfType<IMediaEntitySlim>();
 
         IEnumerable<MediaItemResponseModel> responseModels = media.Select(_mediaPresentationFactory.CreateItemResponseModel);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -40,7 +40,7 @@ public class SearchMediaItemController : MediaItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> SearchFromParentWithAllowedTypes(CancellationToken cancellationToken, string query, bool? trashed = null, int skip = 0, int take = 100, Guid? parentId = null, [FromQuery]IEnumerable<Guid>? allowedMediaTypes = null)
+    public Task<IActionResult> SearchFromParentWithAllowedTypes(CancellationToken cancellationToken, string query, bool? trashed = null, int skip = 0, int take = 100, Guid? parentId = null, [FromQuery]IEnumerable<Guid>? allowedMediaTypes = null)
     {
         PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Media, query, parentId, allowedMediaTypes, trashed, skip, take);
         var result = new PagedModel<MediaItemResponseModel>
@@ -49,6 +49,6 @@ public class SearchMediaItemController : MediaItemControllerBase
             Total = searchResult.Total,
         };
 
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<IActionResult>(Ok(result));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaUrlController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/MediaUrlController.cs
@@ -25,10 +25,10 @@ public class MediaUrlController : MediaControllerBase
     [MapToApiVersion("1.0")]
     [HttpGet("urls")]
     [ProducesResponseType(typeof(IEnumerable<MediaUrlInfoResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetUrls([FromQuery(Name = "id")] HashSet<Guid> ids)
+    public Task<IActionResult> GetUrls([FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         IEnumerable<IMedia> items = _mediaService.GetByIds(ids);
 
-        return await Task.FromResult(Ok(_mediaUrlFactory.CreateUrlSets(items)));
+        return Task.FromResult<IActionResult>(Ok(_mediaUrlFactory.CreateUrlSets(items)));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/ByKeyMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/ByKeyMediaTypeController.cs
@@ -34,6 +34,6 @@ public class ByKeyMediaTypeController : MediaTypeControllerBase
         }
 
         MediaTypeResponseModel model = _umbracoMapper.Map<MediaTypeResponseModel>(mediaType)!;
-        return await Task.FromResult(Ok(model));
+        return Ok(model);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/ItemMediaTypeItemController.cs
@@ -23,17 +23,17 @@ public class ItemMediaTypeItemController : MediaTypeItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MediaTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Ok(Enumerable.Empty<MediaTypeItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<MediaTypeItemResponseModel>()));
         }
 
         IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetMany(ids);
         List<MediaTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(mediaTypes);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
@@ -27,12 +27,12 @@ public class SearchMediaTypeItemController : MediaTypeItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MediaTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+    public Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
     {
         PagedModel<IEntitySlim> searchResult = _entitySearchService.Search(UmbracoObjectTypes.MediaType, query, skip, take);
         if (searchResult.Items.Any() is false)
         {
-            return await Task.FromResult(Ok(new PagedModel<MediaTypeItemResponseModel> { Total = searchResult.Total }));
+            return Task.FromResult<IActionResult>(Ok(new PagedModel<MediaTypeItemResponseModel> { Total = searchResult.Total }));
         }
 
         IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray().EmptyNull());
@@ -42,6 +42,6 @@ public class SearchMediaTypeItemController : MediaTypeItemControllerBase
             Total = searchResult.Total
         };
 
-        return Ok(result);
+        return Task.FromResult<IActionResult>(Ok(result));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/ItemMemberItemController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.Member.Item;
-using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
@@ -25,13 +24,13 @@ public class ItemMemberItemController : MemberItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<MemberItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Ok(Enumerable.Empty<MemberItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<MemberItemResponseModel>()));
         }
 
         IEnumerable<IMemberEntitySlim> members = _entityService
@@ -39,6 +38,6 @@ public class ItemMemberItemController : MemberItemControllerBase
             .OfType<IMemberEntitySlim>();
 
         IEnumerable<MemberItemResponseModel> responseModels = members.Select(_memberPresentationFactory.CreateItemResponseModel);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/SearchMemberItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/SearchMemberItemController.cs
@@ -29,7 +29,7 @@ public class SearchMemberItemController : MemberItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MemberItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> SearchWithAllowedTypes(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, [FromQuery]IEnumerable<Guid>? allowedMemberTypes = null)
+    public Task<IActionResult> SearchWithAllowedTypes(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, [FromQuery]IEnumerable<Guid>? allowedMemberTypes = null)
     {
         PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Member, query, null, allowedMemberTypes, skip, take);
         var result = new PagedModel<MemberItemResponseModel>
@@ -38,6 +38,6 @@ public class SearchMemberItemController : MemberItemControllerBase
             Total = searchResult.Total
         };
 
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<IActionResult>(Ok(result));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/AllMemberGroupController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberGroup/AllMemberGroupController.cs
@@ -36,6 +36,6 @@ public class AllMemberGroupController : MemberGroupControllerBase
             Items = _mapper.MapEnumerable<IMemberGroup, MemberGroupResponseModel>(memberGroups.Skip(skip).Take(take)),
         };
 
-        return await Task.FromResult(Ok(viewModel));
+        return Ok(viewModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
@@ -26,12 +26,12 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MemberTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+    public Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
     {
         PagedModel<IEntitySlim> searchResult = _entitySearchService.Search(UmbracoObjectTypes.MemberType, query, skip, take);
         if (searchResult.Items.Any() is false)
         {
-            return await Task.FromResult(Ok(new PagedModel<MemberTypeItemResponseModel> { Total = searchResult.Total }));
+            return Task.FromResult<IActionResult>(Ok(new PagedModel<MemberTypeItemResponseModel> { Total = searchResult.Total }));
         }
 
         IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray());
@@ -41,6 +41,6 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
             Total = searchResult.Total
         };
 
-        return Ok(result);
+        return Task.FromResult<IActionResult>(Ok(result));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/GetModelsBuilderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/GetModelsBuilderController.cs
@@ -16,6 +16,6 @@ public class GetModelsBuilderController : ModelsBuilderControllerBase
     [HttpGet("dashboard")]
     [ProducesResponseType(typeof(ModelsBuilderResponseModel), StatusCodes.Status200OK)]
     [MapToApiVersion("1.0")]
-    public async Task<ActionResult<ModelsBuilderResponseModel>> GetDashboard(CancellationToken cancellationToken)
-        => await Task.FromResult(Ok(_modelsBuilderPresentationFactory.Create()));
+    public Task<ActionResult<ModelsBuilderResponseModel>> GetDashboard(CancellationToken cancellationToken)
+        => Task.FromResult<ActionResult<ModelsBuilderResponseModel>>(Ok(_modelsBuilderPresentationFactory.Create()));
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/StatusModelsBuilderController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ModelsBuilder/StatusModelsBuilderController.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Asp.Versioning;
+﻿using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Infrastructure.ModelsBuilder;
@@ -18,7 +17,7 @@ public class StatusModelsBuilderController : ModelsBuilderControllerBase
     [HttpGet("status")]
     [ProducesResponseType(typeof(OutOfDateStatusResponseModel), StatusCodes.Status200OK)]
     [MapToApiVersion("1.0")]
-    public async Task<ActionResult<OutOfDateStatusResponseModel>> GetModelsOutOfDateStatus(CancellationToken cancellationToken)
+    public Task<ActionResult<OutOfDateStatusResponseModel>> GetModelsOutOfDateStatus(CancellationToken cancellationToken)
     {
         OutOfDateStatusResponseModel status = _outOfDateModelsStatus.IsEnabled
             ? _outOfDateModelsStatus.IsOutOfDate
@@ -26,6 +25,6 @@ public class StatusModelsBuilderController : ModelsBuilderControllerBase
                 : new OutOfDateStatusResponseModel { Status = OutOfDateType.Current }
             : new OutOfDateStatusResponseModel { Status = OutOfDateType.Unknown };
 
-        return await Task.FromResult(Ok(status));
+        return Task.FromResult<ActionResult<OutOfDateStatusResponseModel>>(Ok(status));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/AllowedObjectTypesController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ObjectTypes/AllowedObjectTypesController.cs
@@ -17,11 +17,11 @@ public class AllowedObjectTypesController : ObjectTypesControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<ObjectTypeResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Allowed(CancellationToken cancellationToken, int skip = 0, int take = 100)
+    public Task<IActionResult> Allowed(CancellationToken cancellationToken, int skip = 0, int take = 100)
     {
         ObjectTypeResponseModel[] objectTypes = _objectTypePresentationFactory.Create().ToArray();
 
-        return await Task.FromResult(Ok(new PagedViewModel<ObjectTypeResponseModel>
+        return Task.FromResult<IActionResult>(Ok(new PagedViewModel<ObjectTypeResponseModel>
         {
             Total = objectTypes.Length,
             Items = objectTypes.Skip(skip).Take(take),

--- a/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/AllCreatedPackageController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Package/Created/AllCreatedPackageController.cs
@@ -44,6 +44,6 @@ public class AllCreatedPackageController : CreatedPackageControllerBase
             Items = _umbracoMapper.MapEnumerable<PackageDefinition, PackageDefinitionResponseModel>(createdPackages.Items)
         };
 
-        return await Task.FromResult(Ok(viewModel));
+        return Ok(viewModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/ItemPartialViewItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Item/ItemPartialViewItemController.cs
@@ -18,17 +18,17 @@ public class ItemPartialViewItemController : PartialViewItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<PartialViewItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
         if (paths.Count is 0)
         {
-            return Ok(Enumerable.Empty<PartialViewItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<PartialViewItemResponseModel>()));
         }
 
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<PartialViewItemResponseModel> responseModels = _fileItemPresentationFactory.CreatePartialViewItemResponseModels(paths);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/RebuildPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/RebuildPublishedCacheController.cs
@@ -15,7 +15,7 @@ public class RebuildPublishedCacheController : PublishedCacheControllerBase
     [HttpPost("rebuild")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IActionResult> Rebuild(CancellationToken cancellationToken)
+    public Task<IActionResult> Rebuild(CancellationToken cancellationToken)
     {
         if (_databaseCacheRebuilder.IsRebuilding())
         {
@@ -27,10 +27,10 @@ public class RebuildPublishedCacheController : PublishedCacheControllerBase
                 Type = "Error",
             };
 
-            return await Task.FromResult(Conflict(problemDetails));
+            return Task.FromResult<IActionResult>(Conflict(problemDetails));
         }
 
         _databaseCacheRebuilder.Rebuild(true);
-        return await Task.FromResult(Ok());
+        return Task.FromResult<IActionResult>(Ok());
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/ReloadPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/ReloadPublishedCacheController.cs
@@ -16,10 +16,10 @@ public class ReloadPublishedCacheController : PublishedCacheControllerBase
     [HttpPost("reload")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IActionResult> Reload(CancellationToken cancellationToken)
+    public Task<IActionResult> Reload(CancellationToken cancellationToken)
     {
         _distributedCache.RefreshAllPublishedSnapshot();
-        return await Task.FromResult(Ok());
+        return Task.FromResult<IActionResult>(Ok());
     }
 }
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RecycleBin/RecycleBinControllerBase.cs
@@ -23,17 +23,17 @@ public abstract class RecycleBinControllerBase<TItem> : ContentControllerBase
 
     protected abstract Guid RecycleBinRootKey { get; }
 
-    protected async Task<ActionResult<PagedViewModel<TItem>>> GetRoot(int skip, int take)
+    protected Task<ActionResult<PagedViewModel<TItem>>> GetRoot(int skip, int take)
     {
         IEntitySlim[] rootEntities = GetPagedRootEntities(skip, take, out var totalItems);
 
         TItem[] treeItemViewModels = MapRecycleBinViewModels(null, rootEntities);
 
         PagedViewModel<TItem> result = PagedViewModel(treeItemViewModels, totalItems);
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<ActionResult<PagedViewModel<TItem>>>(Ok(result));
     }
 
-    protected async Task<ActionResult<PagedViewModel<TItem>>> GetChildren(Guid parentKey, int skip, int take)
+    protected Task<ActionResult<PagedViewModel<TItem>>> GetChildren(Guid parentKey, int skip, int take)
     {
         IEntitySlim[] children = GetPagedChildEntities(parentKey, skip, take, out var totalItems);
 
@@ -41,7 +41,7 @@ public abstract class RecycleBinControllerBase<TItem> : ContentControllerBase
 
         PagedViewModel<TItem> result = PagedViewModel(treeItemViewModels, totalItems);
 
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<ActionResult<PagedViewModel<TItem>>>(Ok(result));
     }
 
     protected virtual TItem MapRecycleBinViewModel(Guid? parentKey, IEntitySlim entity)
@@ -133,6 +133,6 @@ public abstract class RecycleBinControllerBase<TItem> : ContentControllerBase
     private TItem[] MapRecycleBinViewModels(Guid? parentKey, IEntitySlim[] entities)
         => entities.Select(entity => MapRecycleBinViewModel(parentKey, entity)).ToArray();
 
-    private PagedViewModel<TItem> PagedViewModel(IEnumerable<TItem> treeItemViewModels, long totalItems)
+    private static PagedViewModel<TItem> PagedViewModel(IEnumerable<TItem> treeItemViewModels, long totalItems)
         => new() { Total = totalItems, Items = treeItemViewModels };
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByRelationTypeKeyRelationController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Relation/ByRelationTypeKeyRelationController.cs
@@ -43,16 +43,15 @@ public class ByRelationTypeKeyRelationController : RelationControllerBase
 
         if (relationsAttempt.Success is false)
         {
-            return await Task.FromResult(RelationOperationStatusResult(relationsAttempt.Status));
+            return RelationOperationStatusResult(relationsAttempt.Status);
         }
 
         IEnumerable<RelationResponseModel> mappedRelations = relationsAttempt.Result.Items.Select(_relationPresentationFactory.Create);
 
-        return await Task.FromResult(Ok(new PagedViewModel<RelationResponseModel>
+        return Ok(new PagedViewModel<RelationResponseModel>
         {
             Total = relationsAttempt.Result.Total,
             Items = mappedRelations,
-        }));
-
+        });
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/ByKeyRelationTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/ByKeyRelationTypeController.cs
@@ -24,16 +24,16 @@ public class ByKeyRelationTypeController : RelationTypeControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(RelationTypeResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> ByKey(CancellationToken cancellationToken, Guid id)
+    public Task<IActionResult> ByKey(CancellationToken cancellationToken, Guid id)
     {
         IRelationType? relationType = _relationService.GetRelationTypeById(id);
         if (relationType is null)
         {
-            return RelationTypeNotFound();
+            return Task.FromResult(RelationTypeNotFound());
         }
 
         RelationTypeResponseModel mappedRelationType = _mapper.Map<RelationTypeResponseModel>(relationType)!;
 
-        return await Task.FromResult(Ok(mappedRelationType));
+        return Task.FromResult<IActionResult>(Ok(mappedRelationType));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RelationType/Item/ItemRelationTypeItemController.cs
@@ -23,13 +23,13 @@ public class ItemRelationTypeItemController : RelationTypeItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<RelationTypeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "id")] HashSet<Guid> ids)
     {
         if (ids.Count is 0)
         {
-            return Ok(Enumerable.Empty<RelationTypeItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<RelationTypeItemResponseModel>()));
         }
 
         // relation service does not allow fetching a collection of relation types by their ids; instead it relies
@@ -40,6 +40,6 @@ public class ItemRelationTypeItemController : RelationTypeItemControllerBase
 
         List<RelationTypeItemResponseModel> responseModels = _mapper.MapEnumerable<IRelationType, RelationTypeItemResponseModel>(relationTypes);
 
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Item/ItemScriptItemController.cs
@@ -18,17 +18,17 @@ public class ItemScriptItemController : ScriptItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<ScriptItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
         if (paths.Count is 0)
         {
-            return Ok(Enumerable.Empty<ScriptItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<ScriptItemResponseModel>()));
         }
 
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<ScriptItemResponseModel> responseModels = _fileItemPresentationFactory.CreateScriptItemResponseModels(paths);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/AllSearcherController.cs
@@ -22,7 +22,7 @@ public class AllSearcherController : SearcherControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<SearcherResponse>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<PagedViewModel<SearcherResponse>>> All(
+    public Task<ActionResult<PagedViewModel<SearcherResponse>>> All(
         CancellationToken cancellationToken,
         int skip = 0,
         int take = 100)
@@ -37,6 +37,6 @@ public class AllSearcherController : SearcherControllerBase
             Total = searchers.Count,
         };
 
-        return await Task.FromResult(Ok(viewModel));
+        return Task.FromResult<ActionResult<PagedViewModel<SearcherResponse>>>(Ok(viewModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Searcher/QuerySearcherController.cs
@@ -1,7 +1,6 @@
 ﻿using Asp.Versioning;
 using Examine;
 using Examine.Lucene.Search;
-using Examine.Search;
 using Lucene.Net.QueryParsers.Classic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -23,7 +22,7 @@ public class QuerySearcherController : SearcherControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<SearchResultResponseModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<PagedViewModel<SearchResultResponseModel>>> Query(
+    public Task<ActionResult<PagedViewModel<SearchResultResponseModel>>> Query(
         CancellationToken cancellationToken,
         string searcherName,
         string? term,
@@ -34,7 +33,7 @@ public class QuerySearcherController : SearcherControllerBase
 
         if (term.IsNullOrWhiteSpace())
         {
-            return new PagedViewModel<SearchResultResponseModel>();
+            return Task.FromResult<ActionResult<PagedViewModel<SearchResultResponseModel>>>(new PagedViewModel<SearchResultResponseModel>());
         }
 
         if (!_examineManagerService.TryFindSearcher(searcherName, out ISearcher searcher))
@@ -47,7 +46,7 @@ public class QuerySearcherController : SearcherControllerBase
                 Type = "Error",
             };
 
-            return NotFound(invalidModelProblem);
+            return Task.FromResult<ActionResult<PagedViewModel<SearchResultResponseModel>>>(NotFound(invalidModelProblem));
         }
 
         ISearchResults results;
@@ -71,10 +70,10 @@ public class QuerySearcherController : SearcherControllerBase
                 Type = "Error",
             };
 
-            return BadRequest(invalidModelProblem);
+            return Task.FromResult<ActionResult<PagedViewModel<SearchResultResponseModel>>>(BadRequest(invalidModelProblem));
         }
 
-        return await Task.FromResult(new PagedViewModel<SearchResultResponseModel>
+        return Task.FromResult<ActionResult<PagedViewModel<SearchResultResponseModel>>>(new PagedViewModel<SearchResultResponseModel>
         {
             Total = results.TotalItemCount,
             Items = results.Select(x => new SearchResultResponseModel

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ConfigurationSecurityController.cs
@@ -20,13 +20,13 @@ public class ConfigurationSecurityController : SecurityControllerBase
     [HttpGet("configuration")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(SecurityConfigurationResponseModel), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Configuration(CancellationToken cancellationToken)
+    public Task<IActionResult> Configuration(CancellationToken cancellationToken)
     {
         var viewModel = new SecurityConfigurationResponseModel
         {
             PasswordConfiguration = _passwordConfigurationPresentationFactory.CreatePasswordConfigurationResponseModel(),
         };
 
-        return await Task.FromResult(Ok(viewModel));
+        return Task.FromResult<IActionResult>(Ok(viewModel));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/StatusServerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/StatusServerController.cs
@@ -19,6 +19,6 @@ public class StatusServerController : ServerControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ServerStatusResponseModel), StatusCodes.Status200OK)]
-    public async Task<ActionResult<ServerStatusResponseModel>> Get(CancellationToken cancellationToken) =>
-        await Task.FromResult(new ServerStatusResponseModel { ServerStatus = _runtimeState.Level });
+    public Task<ActionResult<ServerStatusResponseModel>> Get(CancellationToken cancellationToken) =>
+        Task.FromResult<ActionResult<ServerStatusResponseModel>>(new ServerStatusResponseModel { ServerStatus = _runtimeState.Level });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/StaticFile/Item/ItemStaticFileItemController.cs
@@ -18,17 +18,17 @@ public class ItemStaticFileItemController : StaticFileItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<StaticFileItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
         if (paths.Count is 0)
         {
-            return Ok(Enumerable.Empty<StaticFileItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<StaticFileItemResponseModel>()));
         }
 
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<StaticFileItemResponseModel> responseModels = _fileItemPresentationFactory.CreateStaticFileItemResponseModels(paths);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Item/ItemStylesheetItemController.cs
@@ -18,17 +18,17 @@ public class ItemStylesheetItemController : StylesheetItemControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(IEnumerable<StylesheetItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Item(
+    public Task<IActionResult> Item(
         CancellationToken cancellationToken,
         [FromQuery(Name = "path")] HashSet<string> paths)
     {
         if (paths.Count is 0)
         {
-            return Ok(Enumerable.Empty<StylesheetItemResponseModel>());
+            return Task.FromResult<IActionResult>(Ok(Enumerable.Empty<StylesheetItemResponseModel>()));
         }
 
         paths = paths.Select(path => path.VirtualPathToSystemPath()).ToHashSet();
         IEnumerable<StylesheetItemResponseModel> responseModels = _fileItemPresentationFactory.CreateStylesheetItemResponseModels(paths);
-        return await Task.FromResult(Ok(responseModels));
+        return Task.FromResult<IActionResult>(Ok(responseModels));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tag/ByQueryTagController.cs
@@ -42,6 +42,6 @@ public class ByQueryTagController : TagControllerBase
             Total = responseModels.Count,
         };
 
-        return await Task.FromResult(Ok(pagedViewModel));
+        return Ok(pagedViewModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/AllTelemetryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/AllTelemetryController.cs
@@ -13,13 +13,13 @@ public class AllTelemetryController : TelemetryControllerBase
     [HttpGet]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<TelemetryResponseModel>), StatusCodes.Status200OK)]
-    public async Task<PagedViewModel<TelemetryResponseModel>> GetAll(
+    public Task<PagedViewModel<TelemetryResponseModel>> GetAll(
         CancellationToken cancellationToken,
         int skip = 0,
         int take = 100)
     {
         TelemetryLevel[] levels = Enum.GetValues<TelemetryLevel>();
-        return await Task.FromResult(new PagedViewModel<TelemetryResponseModel>
+        return Task.FromResult(new PagedViewModel<TelemetryResponseModel>
         {
             Total = levels.Length,
             Items = levels.Skip(skip).Take(take).Select(level => new TelemetryResponseModel { TelemetryLevel = level }),

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/GetTelemetryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/GetTelemetryController.cs
@@ -16,6 +16,6 @@ public class GetTelemetryController : TelemetryControllerBase
     [HttpGet("level")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(TelemetryResponseModel), StatusCodes.Status200OK)]
-    public async Task<TelemetryRepresentationBase> Get(CancellationToken cancellationToken)
-        => await Task.FromResult(new TelemetryResponseModel { TelemetryLevel = _metricsConsentService.GetConsentLevel() });
+    public Task<TelemetryRepresentationBase> Get(CancellationToken cancellationToken)
+        => Task.FromResult<TelemetryRepresentationBase>(new TelemetryResponseModel { TelemetryLevel = _metricsConsentService.GetConsentLevel() });
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/SetTelemetryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Telemetry/SetTelemetryController.cs
@@ -34,6 +34,6 @@ public class SetTelemetryController : TelemetryControllerBase
         }
 
         await _metricsConsentService.SetConsentLevelAsync(telemetryRepresentationBase.TelemetryLevel);
-        return await Task.FromResult(Ok());
+        return Ok();
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/ExecuteTemplateQueryController.cs
@@ -81,7 +81,7 @@ public class ExecuteTemplateQueryController : TemplateQueryControllerBase
     [HttpPost("execute")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(TemplateQueryResultResponseModel), StatusCodes.Status200OK)]
-    public async Task<ActionResult<TemplateQueryResultResponseModel>> Execute(
+    public Task<ActionResult<TemplateQueryResultResponseModel>> Execute(
         CancellationToken cancellationToken,
         TemplateQueryExecuteModel query)
     {
@@ -97,7 +97,7 @@ public class ExecuteTemplateQueryController : TemplateQueryControllerBase
             .GetMany(results.Select(content => content.ContentType.Key).Distinct())
             .ToDictionary(contentType => contentType.Key, contentType => contentType.Icon);
 
-        return await Task.FromResult(Ok(new TemplateQueryResultResponseModel
+        return Task.FromResult<ActionResult<TemplateQueryResultResponseModel>>(Ok(new TemplateQueryResultResponseModel
         {
             QueryExpression = queryExpression.ToString(),
             ResultCount = results.Count,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Query/SettingsTemplateQueryController.cs
@@ -17,7 +17,7 @@ public class SettingsTemplateQueryController : TemplateQueryControllerBase
     [HttpGet("settings")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(TemplateQuerySettingsResponseModel), StatusCodes.Status200OK)]
-    public async Task<ActionResult<TemplateQuerySettingsResponseModel>> Settings(CancellationToken cancellationToken)
+    public Task<ActionResult<TemplateQuerySettingsResponseModel>> Settings(CancellationToken cancellationToken)
     {
         var contentTypeAliases = _contentTypeService
             .GetAll()
@@ -29,7 +29,7 @@ public class SettingsTemplateQueryController : TemplateQueryControllerBase
 
         IEnumerable<TemplateQueryOperatorViewModel> operators = GetOperators();
 
-        return await Task.FromResult(Ok(new TemplateQuerySettingsResponseModel
+        return Task.FromResult<ActionResult<TemplateQuerySettingsResponseModel>>(Ok(new TemplateQuerySettingsResponseModel
         {
             DocumentTypeAliases = contentTypeAliases,
             Properties = properties,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
@@ -22,24 +22,24 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
 
     protected virtual Ordering ItemOrdering => Ordering.By(nameof(Infrastructure.Persistence.Dtos.NodeDto.Text));
 
-    protected async Task<ActionResult<PagedViewModel<TItem>>> GetRoot(int skip, int take)
+    protected Task<ActionResult<PagedViewModel<TItem>>> GetRoot(int skip, int take)
     {
         IEntitySlim[] rootEntities = GetPagedRootEntities(skip, take, out var totalItems);
 
         TItem[] treeItemViewModels = MapTreeItemViewModels(null, rootEntities);
 
         PagedViewModel<TItem> result = PagedViewModel(treeItemViewModels, totalItems);
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<ActionResult<PagedViewModel<TItem>>>(Ok(result));
     }
 
-    protected async Task<ActionResult<PagedViewModel<TItem>>> GetChildren(Guid parentId, int skip, int take)
+    protected Task<ActionResult<PagedViewModel<TItem>>> GetChildren(Guid parentId, int skip, int take)
     {
         IEntitySlim[] children = GetPagedChildEntities(parentId, skip, take, out var totalItems);
 
         TItem[] treeItemViewModels = MapTreeItemViewModels(parentId, children);
 
         PagedViewModel<TItem> result = PagedViewModel(treeItemViewModels, totalItems);
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<ActionResult<PagedViewModel<TItem>>>(Ok(result));
     }
 
     protected virtual async Task<ActionResult<IEnumerable<TItem>>> GetAncestors(Guid descendantKey, bool includeSelf = true)
@@ -60,13 +60,13 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
         return Ok(result);
     }
 
-    protected virtual async Task<IEntitySlim[]> GetAncestorEntitiesAsync(Guid descendantKey, bool includeSelf)
+    protected virtual Task<IEntitySlim[]> GetAncestorEntitiesAsync(Guid descendantKey, bool includeSelf)
     {
         IEntitySlim? entity = EntityService.Get(descendantKey, ItemObjectType);
         if (entity is null)
         {
             // not much else we can do here but return nothing
-            return await Task.FromResult(Array.Empty<IEntitySlim>());
+            return Task.FromResult(Array.Empty<IEntitySlim>());
         }
 
         var ancestorIds = entity.AncestorIds();
@@ -76,7 +76,7 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
             : Array.Empty<IEntitySlim>();
         ancestors = ancestors.Union(includeSelf ? new[] { entity } : Array.Empty<IEntitySlim>());
 
-        return ancestors.OrderBy(item => item.Level).ToArray();
+        return Task.FromResult(ancestors.OrderBy(item => item.Level).ToArray());
     }
 
     protected virtual IEntitySlim[] GetPagedRootEntities(int skip, int take, out long totalItems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FileSystemTreeControllerBase.cs
@@ -12,28 +12,28 @@ public abstract class FileSystemTreeControllerBase : ManagementApiControllerBase
 {
     protected abstract IFileSystem FileSystem { get; }
 
-    protected async Task<ActionResult<PagedViewModel<FileSystemTreeItemPresentationModel>>> GetRoot(int skip, int take)
+    protected Task<ActionResult<PagedViewModel<FileSystemTreeItemPresentationModel>>> GetRoot(int skip, int take)
     {
         FileSystemTreeItemPresentationModel[] viewModels = GetPathViewModels(string.Empty, skip, take, out var totalItems);
 
         PagedViewModel<FileSystemTreeItemPresentationModel> result = PagedViewModel(viewModels, totalItems);
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<ActionResult<PagedViewModel<FileSystemTreeItemPresentationModel>>>(Ok(result));
     }
 
-    protected async Task<ActionResult<PagedViewModel<FileSystemTreeItemPresentationModel>>> GetChildren(string path, int skip, int take)
+    protected Task<ActionResult<PagedViewModel<FileSystemTreeItemPresentationModel>>> GetChildren(string path, int skip, int take)
     {
         FileSystemTreeItemPresentationModel[] viewModels = GetPathViewModels(path, skip, take, out var totalItems);
 
         PagedViewModel<FileSystemTreeItemPresentationModel> result = PagedViewModel(viewModels, totalItems);
-        return await Task.FromResult(Ok(result));
+        return Task.FromResult<ActionResult<PagedViewModel<FileSystemTreeItemPresentationModel>>>(Ok(result));
     }
 
-    protected virtual async Task<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>> GetAncestors(string path, bool includeSelf = true)
+    protected virtual Task<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>> GetAncestors(string path, bool includeSelf = true)
     {
         path = path.VirtualPathToSystemPath();
         FileSystemTreeItemPresentationModel[] models = GetAncestorModels(path, includeSelf);
 
-        return await Task.FromResult(Ok(models));
+        return Task.FromResult<ActionResult<IEnumerable<FileSystemTreeItemPresentationModel>>>(Ok(models));
     }
 
     protected virtual FileSystemTreeItemPresentationModel[] GetAncestorModels(string path, bool includeSelf)
@@ -92,7 +92,7 @@ public abstract class FileSystemTreeControllerBase : ManagementApiControllerBase
         ? Path.GetFileName(itemPath)
         : FileSystem.GetFileName(itemPath);
 
-    private PagedViewModel<FileSystemTreeItemPresentationModel> PagedViewModel(IEnumerable<FileSystemTreeItemPresentationModel> viewModels, long totalItems)
+    private static PagedViewModel<FileSystemTreeItemPresentationModel> PagedViewModel(IEnumerable<FileSystemTreeItemPresentationModel> viewModels, long totalItems)
         => new() { Total = totalItems, Items = viewModels };
 
     private FileSystemTreeItemPresentationModel MapViewModel(string path, string name, bool isFolder)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
@@ -63,14 +63,14 @@ public abstract class FolderTreeControllerBase<TItem> : NamedEntityTreeControlle
         return viewModel;
     }
 
-    protected override async Task<IEntitySlim[]> GetAncestorEntitiesAsync(Guid descendantKey, bool includeSelf = true)
+    protected override Task<IEntitySlim[]> GetAncestorEntitiesAsync(Guid descendantKey, bool includeSelf = true)
     {
         IEntitySlim? entity = EntityService.Get(descendantKey, ItemObjectType)
                               ?? EntityService.Get(descendantKey, FolderObjectType);
         if (entity is null)
         {
             // not much else we can do here but return nothing
-            return await Task.FromResult(Array.Empty<IEntitySlim>());
+            return Task.FromResult(Array.Empty<IEntitySlim>());
         }
 
         var ancestorIds = entity.AncestorIds();
@@ -83,7 +83,7 @@ public abstract class FolderTreeControllerBase<TItem> : NamedEntityTreeControlle
             : Array.Empty<IEntitySlim>();
         ancestors = ancestors.Union(includeSelf ? new[] { entity } : Array.Empty<IEntitySlim>());
 
-        return ancestors.OrderBy(item => item.Level).ToArray();
+        return Task.FromResult(ancestors.OrderBy(item => item.Level).ToArray());
     }
 
     private IEntitySlim[] GetEntities(Guid? parentKey, int skip, int take, out long totalItems)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/SettingsUpgradeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Upgrade/SettingsUpgradeController.cs
@@ -26,7 +26,7 @@ public class SettingsUpgradeController : UpgradeControllerBase
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(UpgradeSettingsResponseModel), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status428PreconditionRequired)]
-    public async Task<ActionResult<UpgradeSettingsResponseModel>> Settings(CancellationToken cancellationToken)
+    public Task<ActionResult<UpgradeSettingsResponseModel>> Settings(CancellationToken cancellationToken)
     {
         // TODO: Async - We need to figure out what we want to do with async endpoints that doesn't do anything async
         // We want these to be async for future use (Ideally we'll have more async things),
@@ -34,6 +34,6 @@ public class SettingsUpgradeController : UpgradeControllerBase
         UpgradeSettingsModel upgradeSettings = _upgradeSettingsFactory.GetUpgradeSettings();
         UpgradeSettingsResponseModel responseModel = _mapper.Map<UpgradeSettingsResponseModel>(upgradeSettings)!;
 
-        return await Task.FromResult(responseModel);
+        return Task.FromResult<ActionResult<UpgradeSettingsResponseModel>>(responseModel);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/UrlSegment/ResizeImagingController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/UrlSegment/ResizeImagingController.cs
@@ -23,10 +23,10 @@ public class ResizeImagingController : ImagingControllerBase
     [MapToApiVersion("1.0")]
     [HttpGet("resize/urls")]
     [ProducesResponseType(typeof(IEnumerable<MediaUrlInfoResponseModel>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Urls([FromQuery(Name = "id")] HashSet<Guid> ids, int height = 200, int width = 200, ImageCropMode? mode = null)
+    public Task<IActionResult> Urls([FromQuery(Name = "id")] HashSet<Guid> ids, int height = 200, int width = 200, ImageCropMode? mode = null)
     {
         IEnumerable<IMedia> items = _mediaService.GetByIds(ids);
 
-        return await Task.FromResult(Ok(_reziseImageUrlFactory.CreateUrlSets(items, height, width, mode)));
+        return Task.FromResult<IActionResult>(Ok(_reziseImageUrlFactory.CreateUrlSets(items, height, width, mode)));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentNotificationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentNotificationPresentationFactory.cs
@@ -19,15 +19,15 @@ internal sealed class DocumentNotificationPresentationFactory : IDocumentNotific
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    public async Task<IEnumerable<DocumentNotificationResponseModel>> CreateNotificationModelsAsync(IContent content)
+    public Task<IEnumerable<DocumentNotificationResponseModel>> CreateNotificationModelsAsync(IContent content)
     {
         var subscribedActionIds = _notificationService
                                           .GetUserNotifications(_backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser, content.Path)?
                                           .Select(n => n.Action)
                                           .ToArray()
-                                      ?? Array.Empty<string>();
+                                      ?? [];
 
-        return await Task.FromResult(_actionCollection
+        return Task.FromResult<IEnumerable<DocumentNotificationResponseModel>>(_actionCollection
             .Where(action => action.ShowInNotifier)
             .Select(action => new DocumentNotificationResponseModel
             {

--- a/src/Umbraco.Cms.Api.Management/Factories/RelationTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/RelationTypePresentationFactory.cs
@@ -40,7 +40,7 @@ public class RelationTypePresentationFactory : IRelationTypePresentationFactory
         _scopeProvider = scopeProvider;
     }
 
-    public async Task<IEnumerable<IReferenceResponseModel>> CreateReferenceResponseModelsAsync(
+    public Task<IEnumerable<IReferenceResponseModel>> CreateReferenceResponseModelsAsync(
         IEnumerable<RelationItemModel> relationItemModels)
     {
         IReadOnlyCollection<RelationItemModel> relationItemModelsCollection = relationItemModels.ToArray();
@@ -62,7 +62,7 @@ public class RelationTypePresentationFactory : IRelationTypePresentationFactory
                 _ => _umbracoMapper.Map<DefaultReferenceResponseModel>(relationItemModel),
             }).WhereNotNull().ToArray();
 
-        return await Task.FromResult(result);
+        return Task.FromResult<IEnumerable<IReferenceResponseModel>>(result);
     }
 
     private IReferenceResponseModel? MapDocumentReference(RelationItemModel relationItemModel,

--- a/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UserPresentationFactory.cs
@@ -96,7 +96,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             Kind = user.Kind
         };
 
-    public async Task<UserCreateModel> CreateCreationModelAsync(CreateUserRequestModel requestModel)
+    public Task<UserCreateModel> CreateCreationModelAsync(CreateUserRequestModel requestModel)
     {
         var createModel = new UserCreateModel
         {
@@ -108,10 +108,10 @@ public class UserPresentationFactory : IUserPresentationFactory
             Kind = requestModel.Kind
         };
 
-        return await Task.FromResult(createModel);
+        return Task.FromResult(createModel);
     }
 
-    public async Task<UserInviteModel> CreateInviteModelAsync(InviteUserRequestModel requestModel)
+    public Task<UserInviteModel> CreateInviteModelAsync(InviteUserRequestModel requestModel)
     {
         var inviteModel = new UserInviteModel
         {
@@ -122,10 +122,10 @@ public class UserPresentationFactory : IUserPresentationFactory
             Message = requestModel.Message,
         };
 
-        return await Task.FromResult(inviteModel);
+        return Task.FromResult(inviteModel);
     }
 
-    public async Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel)
+    public Task<UserResendInviteModel> CreateResendInviteModelAsync(ResendInviteUserRequestModel requestModel)
     {
         var inviteModel = new UserResendInviteModel
         {
@@ -133,10 +133,10 @@ public class UserPresentationFactory : IUserPresentationFactory
             Message = requestModel.Message,
         };
 
-        return await Task.FromResult(inviteModel);
+        return Task.FromResult(inviteModel);
     }
 
-    public async Task<CurrenUserConfigurationResponseModel> CreateCurrentUserConfigurationModelAsync()
+    public Task<CurrenUserConfigurationResponseModel> CreateCurrentUserConfigurationModelAsync()
     {
         var model = new CurrenUserConfigurationResponseModel
         {
@@ -149,7 +149,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             AllowTwoFactor = _externalLoginProviders.HasDenyLocalLogin() is false,
         };
 
-        return await Task.FromResult(model);
+        return Task.FromResult(model);
     }
 
     public Task<UserConfigurationResponseModel> CreateUserConfigurationModelAsync() =>
@@ -165,7 +165,7 @@ public class UserPresentationFactory : IUserPresentationFactory
             AllowTwoFactor = _externalLoginProviders.HasDenyLocalLogin() is false,
         });
 
-    public async Task<UserUpdateModel> CreateUpdateModelAsync(Guid existingUserKey, UpdateUserRequestModel updateModel)
+    public Task<UserUpdateModel> CreateUpdateModelAsync(Guid existingUserKey, UpdateUserRequestModel updateModel)
     {
         var model = new UserUpdateModel
         {
@@ -182,7 +182,7 @@ public class UserPresentationFactory : IUserPresentationFactory
 
         model.UserGroupKeys = updateModel.UserGroupIds.Select(x => x.Id).ToHashSet();
 
-        return await Task.FromResult(model);
+        return Task.FromResult(model);
     }
 
     public async Task<CurrentUserResponseModel> CreateCurrentUserResponseModelAsync(IUser user)
@@ -202,7 +202,7 @@ public class UserPresentationFactory : IUserPresentationFactory
 
         var allowedSections = presentationGroups.SelectMany(x => x.Sections).ToHashSet();
 
-        return await Task.FromResult(new CurrentUserResponseModel()
+        return new CurrentUserResponseModel
         {
             Id = presentationUser.Id,
             Email = presentationUser.Email,
@@ -222,17 +222,17 @@ public class UserPresentationFactory : IUserPresentationFactory
             AllowedSections = allowedSections,
             IsAdmin = user.IsAdmin(),
             UserGroupIds = presentationUser.UserGroupIds,
-        });
+        };
     }
 
-    public async Task<CalculatedUserStartNodesResponseModel> CreateCalculatedUserStartNodesResponseModelAsync(IUser user)
+    public Task<CalculatedUserStartNodesResponseModel> CreateCalculatedUserStartNodesResponseModelAsync(IUser user)
     {
         var mediaStartNodeIds = user.CalculateMediaStartNodeIds(_entityService, _appCaches);
         ISet<ReferenceByIdModel> mediaStartNodeKeys = GetKeysFromIds(mediaStartNodeIds, UmbracoObjectTypes.Media);
         var contentStartNodeIds = user.CalculateContentStartNodeIds(_entityService, _appCaches);
         ISet<ReferenceByIdModel> documentStartNodeKeys = GetKeysFromIds(contentStartNodeIds, UmbracoObjectTypes.Document);
 
-        return await Task.FromResult(new CalculatedUserStartNodesResponseModel()
+        return Task.FromResult(new CalculatedUserStartNodesResponseModel()
         {
             Id = user.Key,
             MediaStartNodeIds = mediaStartNodeKeys,
@@ -242,7 +242,7 @@ public class UserPresentationFactory : IUserPresentationFactory
         });
     }
 
-    private ISet<ReferenceByIdModel> GetKeysFromIds(IEnumerable<int>? ids, UmbracoObjectTypes type)
+    private HashSet<ReferenceByIdModel> GetKeysFromIds(IEnumerable<int>? ids, UmbracoObjectTypes type)
     {
         IEnumerable<ReferenceByIdModel>? models = ids?
             .Select(x => _entityService.GetKey(x, type))
@@ -251,10 +251,10 @@ public class UserPresentationFactory : IUserPresentationFactory
             .Select(x => new ReferenceByIdModel(x));
 
         return models is null
-            ? new HashSet<ReferenceByIdModel>()
-            : new HashSet<ReferenceByIdModel>(models);
+            ? []
+            : [..models];
     }
 
-    private bool HasRootAccess(IEnumerable<int>? startNodeIds)
+    private static bool HasRootAccess(IEnumerable<int>? startNodeIds)
         => startNodeIds?.Contains(Constants.System.Root) is true;
 }

--- a/src/Umbraco.Core/Security/Authorization/FeatureAuthorizer.cs
+++ b/src/Umbraco.Core/Security/Authorization/FeatureAuthorizer.cs
@@ -10,6 +10,6 @@ internal sealed class FeatureAuthorizer : IFeatureAuthorizer
     public FeatureAuthorizer(UmbracoFeatures umbracoFeatures) => _umbracoFeatures = umbracoFeatures;
 
     /// <inheritdoc />
-    public async Task<bool> IsDeniedAsync(Type type) =>
-        await Task.FromResult(_umbracoFeatures.IsControllerEnabled(type) is false);
+    public Task<bool> IsDeniedAsync(Type type) =>
+        Task.FromResult(_umbracoFeatures.IsControllerEnabled(type) is false);
 }

--- a/src/Umbraco.Core/Services/AuditService.cs
+++ b/src/Umbraco.Core/Services/AuditService.cs
@@ -225,7 +225,7 @@ public sealed class AuditService : RepositoryService, IAuditService
         if (userId < Constants.Security.SuperUserId)
         {
             totalRecords = 0;
-            return Enumerable.Empty<IAuditItem>();
+            return [];
         }
 
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
@@ -236,7 +236,7 @@ public sealed class AuditService : RepositoryService, IAuditService
         }
     }
 
-    public async Task<PagedModel<IAuditItem>> GetItemsByKeyAsync(
+    public Task<PagedModel<IAuditItem>> GetItemsByKeyAsync(
         Guid entityKey,
         UmbracoObjectTypes entityType,
         int skip,
@@ -258,7 +258,7 @@ public sealed class AuditService : RepositoryService, IAuditService
             Attempt<int> keyToIdAttempt = _entityService.GetId(entityKey, entityType);
             if (keyToIdAttempt.Success is false)
             {
-                return await Task.FromResult(new PagedModel<IAuditItem> { Items = Enumerable.Empty<IAuditItem>(), Total = 0 });
+                return Task.FromResult(new PagedModel<IAuditItem> { Items = Enumerable.Empty<IAuditItem>(), Total = 0 });
             }
 
             using (ScopeProvider.CreateCoreScope(autoComplete: true))
@@ -268,7 +268,7 @@ public sealed class AuditService : RepositoryService, IAuditService
                 PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
 
                 IEnumerable<IAuditItem> auditItems = _auditRepository.GetPagedResultsByQuery(query, pageNumber, pageSize, out var totalRecords, orderDirection, auditTypeFilter, customFilter);
-                return new PagedModel<IAuditItem> { Items = auditItems, Total = totalRecords };
+                return Task.FromResult(new PagedModel<IAuditItem> { Items = auditItems, Total = totalRecords });
             }
         }
 
@@ -294,7 +294,7 @@ public sealed class AuditService : RepositoryService, IAuditService
 
         if (user is null)
         {
-            return await Task.FromResult(new PagedModel<IAuditItem>());
+            return new PagedModel<IAuditItem>();
         }
 
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
@@ -304,7 +304,7 @@ public sealed class AuditService : RepositoryService, IAuditService
             PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
 
             IEnumerable<IAuditItem> auditItems = _auditRepository.GetPagedResultsByQuery(query, pageNumber, pageSize, out var totalRecords, orderDirection, auditTypeFilter, customFilter);
-            return await Task.FromResult(new PagedModel<IAuditItem> { Items = auditItems, Total = totalRecords });
+            return new PagedModel<IAuditItem> { Items = auditItems, Total = totalRecords };
         }
     }
 
@@ -386,7 +386,7 @@ public sealed class AuditService : RepositoryService, IAuditService
     {
         if (_isAvailable.Value == false)
         {
-            return Enumerable.Empty<IAuditEntry>();
+            return [];
         }
 
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
@@ -401,7 +401,7 @@ public sealed class AuditService : RepositoryService, IAuditService
         if (_isAvailable.Value == false)
         {
             records = 0;
-            return Enumerable.Empty<IAuditEntry>();
+            return [];
         }
 
         using (ScopeProvider.CreateCoreScope(autoComplete: true))

--- a/src/Umbraco.Core/Services/ContentBlueprintEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentBlueprintEditingService.cs
@@ -29,10 +29,10 @@ internal sealed class ContentBlueprintEditingService
         : base(contentService, contentTypeService, propertyEditorCollection, dataTypeService, logger, scopeProvider, userIdKeyResolver, validationService, optionsMonitor, relationService)
         => _containerService = containerService;
 
-    public async Task<IContent?> GetAsync(Guid key)
+    public Task<IContent?> GetAsync(Guid key)
     {
         IContent? blueprint = ContentService.GetBlueprintById(key);
-        return await Task.FromResult(blueprint);
+        return Task.FromResult(blueprint);
     }
 
     public async Task<Attempt<PagedModel<IContent>?, ContentEditingOperationStatus>> GetPagedByContentTypeAsync(Guid contentTypeKey, int skip, int take)

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -58,10 +58,10 @@ internal sealed class ContentEditingService
         _languageService = languageService;
     }
 
-    public async Task<IContent?> GetAsync(Guid key)
+    public Task<IContent?> GetAsync(Guid key)
     {
         IContent? content = ContentService.GetById(key);
-        return await Task.FromResult(content);
+        return Task.FromResult(content);
     }
 
     [Obsolete("Please use the validate update method that is not obsoleted. Will be removed in V16.")]

--- a/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
@@ -62,7 +62,7 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
 
         if (contentId.HasValue is false)
         {
-            return await Task.FromResult(ContentEditingOperationStatus.NotFound);
+            return ContentEditingOperationStatus.NotFound;
         }
 
         const int pageSize = 500;

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
@@ -142,9 +142,9 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return Attempt.SucceedWithStatus<TContentType?, ContentTypeOperationStatus>(ContentTypeOperationStatus.Success, contentType);
     }
 
-    protected virtual async Task<ContentTypeOperationStatus> AdditionalCreateValidationAsync(
+    protected virtual Task<ContentTypeOperationStatus> AdditionalCreateValidationAsync(
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
-        => await Task.FromResult(ContentTypeOperationStatus.Success);
+        => Task.FromResult(ContentTypeOperationStatus.Success);
 
     #region Sanitization
 
@@ -337,7 +337,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return ContentTypeOperationStatus.Success;
     }
 
-    private ContentTypeOperationStatus ValidateProperties(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
+    private static ContentTypeOperationStatus ValidateProperties(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
     {
         // grab all content types used for composition and/or inheritance
         Guid[] allCompositionKeys = KeysForCompositionTypes(model, CompositionType.Composition, CompositionType.Inheritance);
@@ -356,7 +356,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return ContentTypeOperationStatus.Success;
     }
 
-    private ContentTypeOperationStatus ValidateContainers(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
+    private static ContentTypeOperationStatus ValidateContainers(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
     {
         if (model.Containers.Any(container => Enum.TryParse<PropertyGroupType>(container.Type, out _) is false))
         {
@@ -411,7 +411,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return ContentTypeAliasIsInUse(alias) is false;
     }
 
-    private bool IsReservedContentTypeAlias(string alias)
+    private static bool IsReservedContentTypeAlias(string alias)
     {
         var reservedAliases = new[] { "system" };
         return reservedAliases.InvariantContains(alias);
@@ -465,7 +465,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return contentType;
     }
 
-    private void UpdateAllowedContentTypes(
+    private static void UpdateAllowedContentTypes(
         TContentType contentType,
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model,
         IContentTypeComposition[] allContentTypeCompositions)
@@ -564,7 +564,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         }
     }
 
-    private string PropertyGroupAlias(string? containerName)
+    private static string PropertyGroupAlias(string? containerName)
     {
         if (containerName.IsNullOrWhiteSpace())
         {
@@ -616,7 +616,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return propertyType;
     }
 
-    private void UpdateCompositions(
+    private static void UpdateCompositions(
         TContentType contentType,
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model,
         IContentTypeComposition[] allContentTypeCompositions)
@@ -649,7 +649,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         }
     }
 
-    private void UpdateParentContentType(
+    private static void UpdateParentContentType(
         TContentType contentType,
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model,
         IContentTypeComposition[] allContentTypeCompositions)
@@ -668,7 +668,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
 
     #region Shared between model validation and model update
 
-    private Guid[] GetDataTypeKeys(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
+    private static Guid[] GetDataTypeKeys(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
         => model.Properties.Select(property => property.DataTypeKey).Distinct().ToArray();
 
     private async Task<IDataType[]> GetDataTypesAsync(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
@@ -676,7 +676,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         Guid[] dataTypeKeys = GetDataTypeKeys(model);
         return dataTypeKeys.Any()
             ? (await _dataTypeService.GetAllAsync(GetDataTypeKeys(model))).ToArray()
-            : Array.Empty<IDataType>();
+            : [];
     }
 
     private int? GetParentId(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, Guid? containerKey)
@@ -702,7 +702,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return Constants.System.Root;
     }
 
-    private Guid[] KeysForCompositionTypes(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, params CompositionType[] compositionTypes)
+    private static Guid[] KeysForCompositionTypes(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, params CompositionType[] compositionTypes)
         => model.Compositions
             .Where(c => compositionTypes.Contains(c.CompositionType))
             .Select(c => c.Key)

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
@@ -20,27 +20,27 @@ public class ElementSwitchValidator : IElementSwitchValidator
         _dataTypeService = dataTypeService;
     }
 
-    public async Task<bool> AncestorsAreAlignedAsync(IContentType contentType)
+    public Task<bool> AncestorsAreAlignedAsync(IContentType contentType)
     {
         // this call does not return the system roots
         var ancestorIds = contentType.AncestorIds();
         if (ancestorIds.Length == 0)
         {
             // if there are no ancestors, validation passes
-            return true;
+            return Task.FromResult(true);
         }
 
         // if there are any ancestors where IsElement is different from the contentType, the validation fails
-        return await Task.FromResult(_contentTypeService.GetMany(ancestorIds)
+        return Task.FromResult(_contentTypeService.GetMany(ancestorIds)
             .Any(ancestor => ancestor.IsElement != contentType.IsElement) is false);
     }
 
-    public async Task<bool> DescendantsAreAlignedAsync(IContentType contentType)
+    public Task<bool> DescendantsAreAlignedAsync(IContentType contentType)
     {
         IEnumerable<IContentType> descendants = _contentTypeService.GetDescendants(contentType.Id, false);
 
         // if there are any descendants where IsElement is different from the contentType, the validation fails
-        return await Task.FromResult(descendants.Any(descendant => descendant.IsElement != contentType.IsElement) is false);
+        return Task.FromResult(descendants.Any(descendant => descendant.IsElement != contentType.IsElement) is false);
     }
 
     public async Task<bool> ElementToDocumentNotUsedInBlockStructuresAsync(IContentTypeBase contentType)
@@ -59,8 +59,8 @@ public class ElementSwitchValidator : IElementSwitchValidator
                 .ConfiguredElementTypeKeys().Contains(contentType.Key)) is false;
     }
 
-    public async Task<bool> DocumentToElementHasNoContentAsync(IContentTypeBase contentType) =>
+    public Task<bool> DocumentToElementHasNoContentAsync(IContentTypeBase contentType) =>
 
         // if any content for the content type exists, the validation fails.
-        await Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
+        Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
 }

--- a/src/Umbraco.Core/Services/ContentVersionService.cs
+++ b/src/Umbraco.Core/Services/ContentVersionService.cs
@@ -15,7 +15,7 @@ using Umbraco.Extensions;
 // ReSharper disable once CheckNamespace
 namespace Umbraco.Cms.Core.Services;
 
-internal class ContentVersionService : IContentVersionService
+internal sealed class ContentVersionService : IContentVersionService
 {
     private readonly IAuditRepository _auditRepository;
     private readonly IContentVersionCleanupPolicy _contentVersionCleanupPolicy;
@@ -112,46 +112,46 @@ internal class ContentVersionService : IContentVersionService
     public void SetPreventCleanup(int versionId, bool preventCleanup, int userId = Constants.Security.SuperUserId)
         => HandleSetPreventCleanup(versionId, preventCleanup, userId);
 
-    public async Task<Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>> GetPagedContentVersionsAsync(Guid contentId, string? culture, int skip, int take)
+    public Task<Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>> GetPagedContentVersionsAsync(Guid contentId, string? culture, int skip, int take)
     {
-        IEntitySlim? document = await Task.FromResult(_entityService.Get(contentId, UmbracoObjectTypes.Document));
+        IEntitySlim? document = _entityService.Get(contentId, UmbracoObjectTypes.Document);
         if (document is null)
         {
-            return Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.ContentNotFound);
+            return Task.FromResult(Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.ContentNotFound));
         }
 
         if (PaginationConverter.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize) == false)
         {
-            return Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.InvalidSkipTake);
+            return Task.FromResult(Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.InvalidSkipTake));
         }
 
         IEnumerable<ContentVersionMeta>? versions =
-            await Task.FromResult(HandleGetPagedContentVersions(
+            HandleGetPagedContentVersions(
                 document.Id,
                 pageNumber,
                 pageSize,
                 out var total,
-                culture));
+                culture);
 
         if (versions is null)
         {
-            return Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.NotFound);
+            return Task.FromResult(Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus.NotFound));
         }
 
-        return Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Succeed(
-            ContentVersionOperationStatus.Success, new PagedModel<ContentVersionMeta>(total, versions));
+        return Task.FromResult(Attempt<PagedModel<ContentVersionMeta>?, ContentVersionOperationStatus>.Succeed(
+            ContentVersionOperationStatus.Success, new PagedModel<ContentVersionMeta>(total, versions)));
     }
 
-    public async Task<Attempt<IContent?, ContentVersionOperationStatus>> GetAsync(Guid versionId)
+    public Task<Attempt<IContent?, ContentVersionOperationStatus>> GetAsync(Guid versionId)
     {
-        IContent? version = await Task.FromResult(_contentService.GetVersion(versionId.ToInt()));
+        IContent? version = _contentService.GetVersion(versionId.ToInt());
         if (version is null)
         {
-            return Attempt<IContent?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus
-                .NotFound);
+            return Task.FromResult(Attempt<IContent?, ContentVersionOperationStatus>.Fail(ContentVersionOperationStatus
+                .NotFound));
         }
 
-        return Attempt<IContent?, ContentVersionOperationStatus>.Succeed(ContentVersionOperationStatus.Success, version);
+        return Task.FromResult(Attempt<IContent?, ContentVersionOperationStatus>.Succeed(ContentVersionOperationStatus.Success, version));
     }
 
     public async Task<Attempt<ContentVersionOperationStatus>> SetPreventCleanupAsync(Guid versionId, bool preventCleanup, Guid userKey)

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -323,13 +323,13 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<IDataType>> GetByEditorAliasAsync(string[] propertyEditorAlias)
+        public Task<IEnumerable<IDataType>> GetByEditorAliasAsync(string[] propertyEditorAlias)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
             IQuery<IDataType> query = Query<IDataType>().Where(x => propertyEditorAlias.Contains(x.EditorAlias));
             IEnumerable<IDataType> dataTypes = _dataTypeRepository.Get(query).ToArray();
             ConvertMissingEditorsOfDataTypesToLabels(dataTypes);
-            return await Task.FromResult(dataTypes);
+            return Task.FromResult(dataTypes);
         }
 
         /// <inheritdoc />
@@ -690,17 +690,17 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public async Task<Attempt<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus>> GetReferencesAsync(Guid id)
+        public Task<Attempt<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus>> GetReferencesAsync(Guid id)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete:true);
             IDataType? dataType = GetDataTypeFromRepository(id);
             if (dataType == null)
             {
-                return Attempt.FailWithStatus<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus>(DataTypeOperationStatus.NotFound, new Dictionary<Udi, IEnumerable<string>>());
+                return Task.FromResult(Attempt.FailWithStatus<IReadOnlyDictionary<Udi, IEnumerable<string>>, DataTypeOperationStatus>(DataTypeOperationStatus.NotFound, new Dictionary<Udi, IEnumerable<string>>()));
             }
 
             IReadOnlyDictionary<Udi, IEnumerable<string>> usages = _dataTypeRepository.FindUsages(dataType.Id);
-            return await Task.FromResult(Attempt.SucceedWithStatus(DataTypeOperationStatus.Success, usages));
+            return Task.FromResult(Attempt.SucceedWithStatus(DataTypeOperationStatus.Success, usages));
         }
 
         public IReadOnlyDictionary<Udi, IEnumerable<string>> GetListViewReferences(int id)

--- a/src/Umbraco.Core/Services/DictionaryItemService.cs
+++ b/src/Umbraco.Core/Services/DictionaryItemService.cs
@@ -33,42 +33,42 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
     }
 
     /// <inheritdoc />
-    public async Task<IDictionaryItem?> GetAsync(Guid id)
+    public Task<IDictionaryItem?> GetAsync(Guid id)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IDictionaryItem? item = _dictionaryRepository.Get(id);
-            return await Task.FromResult(item);
+            return Task.FromResult(item);
         }
     }
 
     /// <inheritdoc />
-    public async Task<IDictionaryItem?> GetAsync(string key)
+    public Task<IDictionaryItem?> GetAsync(string key)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IDictionaryItem? item = _dictionaryRepository.Get(key);
-            return await Task.FromResult(item);
+            return Task.FromResult(item);
         }
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<IDictionaryItem>> GetManyAsync(params Guid[] ids)
+    public Task<IEnumerable<IDictionaryItem>> GetManyAsync(params Guid[] ids)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IEnumerable<IDictionaryItem> items = _dictionaryRepository.GetMany(ids).ToArray();
-            return await Task.FromResult(items);
+            return Task.FromResult(items);
         }
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<IDictionaryItem>> GetManyAsync(params string[] keys)
+    public Task<IEnumerable<IDictionaryItem>> GetManyAsync(params string[] keys)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IEnumerable<IDictionaryItem> items = _dictionaryRepository.GetManyByKeys(keys).ToArray();
-            return await Task.FromResult(items);
+            return Task.FromResult(items);
         }
     }
 
@@ -83,8 +83,8 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
         if (take == 0)
         {
             return parentId is null
-                ? new PagedModel<IDictionaryItem>(await CountRootAsync(), Enumerable.Empty<IDictionaryItem>())
-                : new PagedModel<IDictionaryItem>(await CountChildrenAsync(parentId.Value), Enumerable.Empty<IDictionaryItem>());
+                ? new PagedModel<IDictionaryItem>(await CountRootAsync(), [])
+                : new PagedModel<IDictionaryItem>(await CountChildrenAsync(parentId.Value), []);
         }
 
         IDictionaryItem[] items = (parentId is null
@@ -99,36 +99,36 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<IDictionaryItem>> GetChildrenAsync(Guid parentId)
-        => await GetByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == parentId));
+    public Task<IEnumerable<IDictionaryItem>> GetChildrenAsync(Guid parentId)
+        => Task.FromResult<IEnumerable<IDictionaryItem>>(GetByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == parentId)));
 
-    public async Task<int> CountChildrenAsync(Guid parentId)
-        => await CountByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == parentId));
+    public Task<int> CountChildrenAsync(Guid parentId)
+        => Task.FromResult(CountByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == parentId)));
 
     /// <inheritdoc />
-    public async Task<IEnumerable<IDictionaryItem>> GetDescendantsAsync(Guid? parentId, string? filter = null)
+    public Task<IEnumerable<IDictionaryItem>> GetDescendantsAsync(Guid? parentId, string? filter = null)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IDictionaryItem[] items = _dictionaryRepository.GetDictionaryItemDescendants(parentId, filter).ToArray();
-            return await Task.FromResult(items);
+            return Task.FromResult<IEnumerable<IDictionaryItem>>(items);
         }
     }
 
     /// <inheritdoc/>
-    public async Task<IEnumerable<IDictionaryItem>> GetAtRootAsync()
-        => await GetByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == null));
+    public Task<IEnumerable<IDictionaryItem>> GetAtRootAsync()
+        => Task.FromResult<IEnumerable<IDictionaryItem>>(GetByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == null)));
 
-    public async Task<int> CountRootAsync()
-        => await CountByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == null));
+    public Task<int> CountRootAsync()
+        => Task.FromResult(CountByQueryAsync(Query<IDictionaryItem>().Where(x => x.ParentId == null)));
 
     /// <inheritdoc/>
-    public async Task<bool> ExistsAsync(string key)
+    public Task<bool> ExistsAsync(string key)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IDictionaryItem? item = _dictionaryRepository.Get(key);
-            return await Task.FromResult(item != null);
+            return Task.FromResult(item != null);
         }
     }
 
@@ -203,7 +203,7 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             Audit(AuditType.Delete, "Delete DictionaryItem", currentUserId, dictionaryItem.Id, nameof(DictionaryItem));
 
             scope.Complete();
-            return await Task.FromResult(Attempt.SucceedWithStatus<IDictionaryItem?, DictionaryItemOperationStatus>(DictionaryItemOperationStatus.Success, dictionaryItem));
+            return Attempt.SucceedWithStatus<IDictionaryItem?, DictionaryItemOperationStatus>(DictionaryItemOperationStatus.Success, dictionaryItem);
         }
     }
 
@@ -265,16 +265,16 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             Audit(AuditType.Move, "Move DictionaryItem", currentUserId, dictionaryItem.Id, nameof(DictionaryItem));
             scope.Complete();
 
-            return await Task.FromResult(Attempt.SucceedWithStatus(DictionaryItemOperationStatus.Success, dictionaryItem));
+            return Attempt.SucceedWithStatus(DictionaryItemOperationStatus.Success, dictionaryItem);
         }
     }
 
-    private async Task<int> CountByQueryAsync(IQuery<IDictionaryItem> query)
+    private int CountByQueryAsync(IQuery<IDictionaryItem> query)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             var items = _dictionaryRepository.Count(query);
-            return await Task.FromResult(items);
+            return items;
         }
     }
 
@@ -326,16 +326,16 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             Audit(auditType, auditMessage, currentUserId, dictionaryItem.Id, nameof(DictionaryItem));
             scope.Complete();
 
-            return await Task.FromResult(Attempt.SucceedWithStatus(DictionaryItemOperationStatus.Success, dictionaryItem));
+            return Attempt.SucceedWithStatus(DictionaryItemOperationStatus.Success, dictionaryItem);
         }
     }
 
-    private async Task<IEnumerable<IDictionaryItem>> GetByQueryAsync(IQuery<IDictionaryItem> query)
+    private IDictionaryItem[] GetByQueryAsync(IQuery<IDictionaryItem> query)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IDictionaryItem[] items = _dictionaryRepository.Get(query).ToArray();
-            return await Task.FromResult(items);
+            return items;
         }
     }
 
@@ -345,7 +345,7 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
     private bool HasValidParent(IDictionaryItem dictionaryItem)
         => dictionaryItem.ParentId.HasValue == false || _dictionaryRepository.Get(dictionaryItem.ParentId.Value) != null;
 
-    private void RemoveInvalidTranslations(IDictionaryItem dictionaryItem, IEnumerable<ILanguage> allLanguages)
+    private static void RemoveInvalidTranslations(IDictionaryItem dictionaryItem, IEnumerable<ILanguage> allLanguages)
     {
         IDictionaryTranslation[] translationsAsArray = dictionaryItem.Translations.ToArray();
         if (translationsAsArray.Any() == false)

--- a/src/Umbraco.Core/Services/EntityTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/EntityTypeContainerService.cs
@@ -43,36 +43,36 @@ internal abstract class EntityTypeContainerService<TTreeEntity, TEntityContainer
     }
 
     /// <inheritdoc />
-    public async Task<EntityContainer?> GetAsync(Guid id)
+    public Task<EntityContainer?> GetAsync(Guid id)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         ReadLock(scope);
-        return await Task.FromResult(_entityContainerRepository.Get(id));
+        return Task.FromResult(_entityContainerRepository.Get(id));
     }
 
 
     /// <inheritdoc />
-    public async Task<IEnumerable<EntityContainer>> GetAsync(string name, int level)
+    public Task<IEnumerable<EntityContainer>> GetAsync(string name, int level)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         ReadLock(scope);
-        return await Task.FromResult(_entityContainerRepository.Get(name, level));
+        return Task.FromResult(_entityContainerRepository.Get(name, level));
     }
     /// <inheritdoc />
-    public async Task<IEnumerable<EntityContainer>> GetAllAsync()
+    public Task<IEnumerable<EntityContainer>> GetAllAsync()
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         ReadLock(scope);
-        return await Task.FromResult(_entityContainerRepository.GetMany());
+        return Task.FromResult(_entityContainerRepository.GetMany());
     }
 
     /// <inheritdoc />
-    public async Task<EntityContainer?> GetParentAsync(EntityContainer container)
-        => await Task.FromResult(GetParent(container));
+    public Task<EntityContainer?> GetParentAsync(EntityContainer container)
+        => Task.FromResult(GetParent(container));
 
     /// <inheritdoc />
-    public async Task<EntityContainer?> GetParentAsync(TTreeEntity entity)
-        => await Task.FromResult(GetParent(entity));
+    public Task<EntityContainer?> GetParentAsync(TTreeEntity entity)
+        => Task.FromResult(GetParent(entity));
 
     /// <inheritdoc />
     public async Task<Attempt<EntityContainer?, EntityContainerOperationStatus>> CreateAsync(Guid? key, string name, Guid? parentKey, Guid userKey)

--- a/src/Umbraco.Core/Services/LanguageService.cs
+++ b/src/Umbraco.Core/Services/LanguageService.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -34,46 +33,46 @@ internal sealed class LanguageService : RepositoryService, ILanguageService
     }
 
     /// <inheritdoc />
-    public async Task<ILanguage?> GetAsync(string isoCode)
+    public Task<ILanguage?> GetAsync(string isoCode)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_languageRepository.GetByIsoCode(isoCode));
+            return Task.FromResult(_languageRepository.GetByIsoCode(isoCode));
         }
     }
 
     /// <inheritdoc />
-    public async Task<ILanguage?> GetDefaultLanguageAsync()
+    public Task<ILanguage?> GetDefaultLanguageAsync()
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_languageRepository.GetByIsoCode(_languageRepository.GetDefaultIsoCode()));
+            return Task.FromResult(_languageRepository.GetByIsoCode(_languageRepository.GetDefaultIsoCode()));
         }
     }
 
     /// <inheritdoc />
-    public async Task<string> GetDefaultIsoCodeAsync()
+    public Task<string> GetDefaultIsoCodeAsync()
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_languageRepository.GetDefaultIsoCode());
+            return Task.FromResult(_languageRepository.GetDefaultIsoCode());
         }
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ILanguage>> GetAllAsync()
+    public Task<IEnumerable<ILanguage>> GetAllAsync()
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_languageRepository.GetMany());
+            return Task.FromResult(_languageRepository.GetMany());
         }
     }
 
-    public async Task<string[]> GetIsoCodesByIdsAsync(ICollection<int> ids)
+    public Task<string[]> GetIsoCodesByIdsAsync(ICollection<int> ids)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete:true);
 
-        return await Task.FromResult(_languageRepository.GetIsoCodesByIds(ids, throwOnNotFound: true));
+        return Task.FromResult(_languageRepository.GetIsoCodesByIds(ids, throwOnNotFound: true));
     }
 
     public async Task<IEnumerable<ILanguage>> GetMultipleAsync(IEnumerable<string> isoCodes) => (await GetAllAsync()).Where(x => isoCodes.Contains(x.IsoCode));
@@ -163,7 +162,7 @@ internal sealed class LanguageService : RepositoryService, ILanguageService
             var currentUserId = await _userIdKeyResolver.GetAsync(userKey);
             Audit(AuditType.Delete, "Delete Language", currentUserId, language.Id, UmbracoObjectTypes.Language.GetName());
             scope.Complete();
-            return await Task.FromResult(Attempt.SucceedWithStatus<ILanguage?, LanguageOperationStatus>(LanguageOperationStatus.Success, language));
+            return Attempt.SucceedWithStatus<ILanguage?, LanguageOperationStatus>(LanguageOperationStatus.Success, language);
         }
     }
 
@@ -217,7 +216,7 @@ internal sealed class LanguageService : RepositoryService, ILanguageService
             Audit(auditType, auditMessage, currentUserId, language.Id, UmbracoObjectTypes.Language.GetName());
 
             scope.Complete();
-            return await Task.FromResult(Attempt.SucceedWithStatus(LanguageOperationStatus.Success, language));
+            return Attempt.SucceedWithStatus(LanguageOperationStatus.Success, language);
         }
     }
 
@@ -252,7 +251,7 @@ internal sealed class LanguageService : RepositoryService, ILanguageService
         return false;
     }
 
-    private bool CreatesCycle(ILanguage language, IDictionary<string, ILanguage> languagesByIsoCode)
+    private static bool CreatesCycle(ILanguage language, Dictionary<string, ILanguage> languagesByIsoCode)
     {
         // a new language is not referenced yet, so cannot be part of a cycle
         if (!language.HasIdentity)

--- a/src/Umbraco.Core/Services/LogViewerService.cs
+++ b/src/Umbraco.Core/Services/LogViewerService.cs
@@ -31,7 +31,7 @@ public class LogViewerService : ILogViewerService
     }
 
     /// <inheritdoc/>
-    public async Task<Attempt<PagedModel<ILogEntry>?, LogViewerOperationStatus>> GetPagedLogsAsync(
+    public Task<Attempt<PagedModel<ILogEntry>?, LogViewerOperationStatus>> GetPagedLogsAsync(
         DateTimeOffset? startDate,
         DateTimeOffset? endDate,
         int skip,
@@ -45,33 +45,33 @@ public class LogViewerService : ILogViewerService
         // We will need to stop the request if trying to do this on a 1GB file
         if (CanViewLogs(logTimePeriod) == false)
         {
-            return Attempt.FailWithStatus<PagedModel<ILogEntry>?, LogViewerOperationStatus>(
+            return Task.FromResult(Attempt.FailWithStatus<PagedModel<ILogEntry>?, LogViewerOperationStatus>(
                 LogViewerOperationStatus.CancelledByLogsSizeValidation,
-                null);
+                null));
         }
 
 
         PagedModel<ILogEntry> filteredLogs = GetFilteredLogs(logTimePeriod, filterExpression, logLevels, orderDirection, skip, take);
 
-        return Attempt.SucceedWithStatus<PagedModel<ILogEntry>?, LogViewerOperationStatus>(
+        return Task.FromResult(Attempt.SucceedWithStatus<PagedModel<ILogEntry>?, LogViewerOperationStatus>(
             LogViewerOperationStatus.Success,
-            filteredLogs);
+            filteredLogs));
     }
 
     /// <inheritdoc/>
-    public async Task<PagedModel<ILogViewerQuery>> GetSavedLogQueriesAsync(int skip, int take)
+    public Task<PagedModel<ILogViewerQuery>> GetSavedLogQueriesAsync(int skip, int take)
     {
         using ICoreScope scope = _provider.CreateCoreScope(autoComplete: true);
         ILogViewerQuery[] savedLogQueries = _logViewerQueryRepository.GetMany().ToArray();
         var pagedModel = new PagedModel<ILogViewerQuery>(savedLogQueries.Length, savedLogQueries.Skip(skip).Take(take));
-        return await Task.FromResult(pagedModel);
+        return Task.FromResult(pagedModel);
     }
 
     /// <inheritdoc/>
-    public async Task<ILogViewerQuery?> GetSavedLogQueryByNameAsync(string name)
+    public Task<ILogViewerQuery?> GetSavedLogQueryByNameAsync(string name)
     {
         using ICoreScope scope = _provider.CreateCoreScope(autoComplete: true);
-        return await Task.FromResult(_logViewerQueryRepository.GetByName(name));
+        return Task.FromResult(_logViewerQueryRepository.GetByName(name));
     }
 
     /// <inheritdoc/>
@@ -109,57 +109,57 @@ public class LogViewerService : ILogViewerService
     }
 
     /// <inheritdoc/>
-    public async Task<Attempt<bool, LogViewerOperationStatus>> CanViewLogsAsync(DateTimeOffset? startDate, DateTimeOffset? endDate)
+    public Task<Attempt<bool, LogViewerOperationStatus>> CanViewLogsAsync(DateTimeOffset? startDate, DateTimeOffset? endDate)
     {
         LogTimePeriod logTimePeriod = GetTimePeriod(startDate, endDate);
         bool isAllowed = CanViewLogs(logTimePeriod);
 
         if (isAllowed == false)
         {
-            return Attempt.FailWithStatus(LogViewerOperationStatus.CancelledByLogsSizeValidation, isAllowed);
+            return Task.FromResult(Attempt.FailWithStatus(LogViewerOperationStatus.CancelledByLogsSizeValidation, isAllowed));
         }
 
-        return Attempt.SucceedWithStatus(LogViewerOperationStatus.Success, isAllowed);
+        return Task.FromResult(Attempt.SucceedWithStatus(LogViewerOperationStatus.Success, isAllowed));
     }
 
     /// <inheritdoc/>
-    public async Task<Attempt<LogLevelCounts?, LogViewerOperationStatus>> GetLogLevelCountsAsync(DateTimeOffset? startDate, DateTimeOffset? endDate)
+    public Task<Attempt<LogLevelCounts?, LogViewerOperationStatus>> GetLogLevelCountsAsync(DateTimeOffset? startDate, DateTimeOffset? endDate)
     {
         LogTimePeriod logTimePeriod = GetTimePeriod(startDate, endDate);
 
         // We will need to stop the request if trying to do this on a 1GB file
         if (CanViewLogs(logTimePeriod) == false)
         {
-            return Attempt.FailWithStatus<LogLevelCounts?, LogViewerOperationStatus>(
+            return Task.FromResult(Attempt.FailWithStatus<LogLevelCounts?, LogViewerOperationStatus>(
                 LogViewerOperationStatus.CancelledByLogsSizeValidation,
-                null);
+                null));
         }
 
         LogLevelCounts counter = _logViewerRepository.GetLogCount(logTimePeriod);
 
-        return Attempt.SucceedWithStatus<LogLevelCounts?, LogViewerOperationStatus>(
+        return Task.FromResult(Attempt.SucceedWithStatus<LogLevelCounts?, LogViewerOperationStatus>(
             LogViewerOperationStatus.Success,
-            counter);
+            counter));
     }
 
     /// <inheritdoc/>
-    public async Task<Attempt<PagedModel<LogTemplate>, LogViewerOperationStatus>> GetMessageTemplatesAsync(DateTimeOffset? startDate, DateTimeOffset? endDate, int skip, int take)
+    public Task<Attempt<PagedModel<LogTemplate>, LogViewerOperationStatus>> GetMessageTemplatesAsync(DateTimeOffset? startDate, DateTimeOffset? endDate, int skip, int take)
     {
         LogTimePeriod logTimePeriod = GetTimePeriod(startDate, endDate);
 
         // We will need to stop the request if trying to do this on a 1GB file
         if (CanViewLogs(logTimePeriod) == false)
         {
-            return Attempt.FailWithStatus<PagedModel<LogTemplate>, LogViewerOperationStatus>(
+            return Task.FromResult(Attempt.FailWithStatus<PagedModel<LogTemplate>, LogViewerOperationStatus>(
                 LogViewerOperationStatus.CancelledByLogsSizeValidation,
-                null!);
+                null!));
         }
 
         LogTemplate[] messageTemplates = _logViewerRepository.GetMessageTemplates(logTimePeriod);
 
-        return Attempt.SucceedWithStatus(
+        return Task.FromResult(Attempt.SucceedWithStatus(
             LogViewerOperationStatus.Success,
-            new PagedModel<LogTemplate>(messageTemplates.Length, messageTemplates.Skip(skip).Take(take)));
+            new PagedModel<LogTemplate>(messageTemplates.Length, messageTemplates.Skip(skip).Take(take))));
     }
 
     /// <inheritdoc/>
@@ -183,7 +183,7 @@ public class LogViewerService : ILogViewerService
     /// <param name="startDate">The start date for the date range (can be null).</param>
     /// <param name="endDate">The end date for the date range (can be null).</param>
     /// <returns>The LogTimePeriod object used to filter logs.</returns>
-    private LogTimePeriod GetTimePeriod(DateTimeOffset? startDate, DateTimeOffset? endDate)
+    private static LogTimePeriod GetTimePeriod(DateTimeOffset? startDate, DateTimeOffset? endDate)
     {
         if (startDate is null || endDate is null)
         {
@@ -277,5 +277,5 @@ public class LogViewerService : ILogViewerService
         };
     }
 
-    private string GetSearchPattern(DateTime day) => $"*{day:yyyyMMdd}*.json";
+    private static string GetSearchPattern(DateTime day) => $"*{day:yyyyMMdd}*.json";
 }

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -40,10 +40,10 @@ internal sealed class MediaEditingService
             relationService)
         => _logger = logger;
 
-    public async Task<IMedia?> GetAsync(Guid key)
+    public Task<IMedia?> GetAsync(Guid key)
     {
         IMedia? media = ContentService.GetById(key);
-        return await Task.FromResult(media);
+        return Task.FromResult(media);
     }
 
     public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateUpdateAsync(Guid key, MediaUpdateModel updateModel)

--- a/src/Umbraco.Core/Services/NoopSegmentService.cs
+++ b/src/Umbraco.Core/Services/NoopSegmentService.cs
@@ -5,9 +5,9 @@ namespace Umbraco.Cms.Core.Services;
 
 public class NoopSegmentService : ISegmentService
 {
-    public async Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100)
+    public Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100)
     {
-        return await Task.FromResult(Attempt.SucceedWithStatus<PagedModel<Segment>?, SegmentOperationStatus>(
+        return Task.FromResult(Attempt.SucceedWithStatus<PagedModel<Segment>?, SegmentOperationStatus>(
             SegmentOperationStatus.Success,
             new PagedModel<Segment> { Total = 0, Items = Enumerable.Empty<Segment>() }));
     }

--- a/src/Umbraco.Core/Services/PartialViewService.cs
+++ b/src/Umbraco.Core/Services/PartialViewService.cs
@@ -62,7 +62,7 @@ public class PartialViewService : FileServiceOperationBase<IPartialViewRepositor
         => new PartialView(path) { Content = content };
 
     /// <inheritdoc />
-    public async Task<PagedModel<PartialViewSnippetSlim>> GetSnippetsAsync(int skip, int take)
+    public Task<PagedModel<PartialViewSnippetSlim>> GetSnippetsAsync(int skip, int take)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         var result = new PagedModel<PartialViewSnippetSlim>(
@@ -72,15 +72,15 @@ public class PartialViewService : FileServiceOperationBase<IPartialViewRepositor
                 .Take(take)
                 .Select(snippet => new PartialViewSnippetSlim(snippet.Id, snippet.Name))
                 .ToArray());
-        return await Task.FromResult(result);
+        return Task.FromResult(result);
     }
 
     /// <inheritdoc />
-    public async Task<PartialViewSnippet?> GetSnippetAsync(string id)
+    public Task<PartialViewSnippet?> GetSnippetAsync(string id)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         PartialViewSnippet? snippet = _snippetCollection.FirstOrDefault(s => s.Id == id);
-        return await Task.FromResult(snippet);
+        return Task.FromResult(snippet);
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Services/Querying/ContentQueryService.cs
+++ b/src/Umbraco.Core/Services/Querying/ContentQueryService.cs
@@ -23,23 +23,23 @@ public class ContentQueryService : IContentQueryService
         _coreScopeProvider = coreScopeProvider;
     }
 
-    public async Task<Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>> GetWithSchedulesAsync(Guid id)
+    public Task<Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>> GetWithSchedulesAsync(Guid id)
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
 
-        IContent? content = await Task.FromResult(_contentService.GetById(id));
+        IContent? content = _contentService.GetById(id);
 
         if (content == null)
         {
-            return Attempt<ContentScheduleQueryResult, ContentQueryOperationStatus>.Fail(ContentQueryOperationStatus
-                .ContentNotFound);
+            return Task.FromResult(Attempt<ContentScheduleQueryResult, ContentQueryOperationStatus>.Fail(ContentQueryOperationStatus
+                .ContentNotFound));
         }
 
         ContentScheduleCollection schedules = _contentService.GetContentScheduleByContentId(id);
 
-        return Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>
+        return Task.FromResult(Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>
             .Succeed(
                 ContentQueryOperationStatus.Success,
-                new ContentScheduleQueryResult(content, schedules));
+                new ContentScheduleQueryResult(content, schedules)));
     }
 }

--- a/src/Umbraco.Core/Services/RelationService.cs
+++ b/src/Umbraco.Core/Services/RelationService.cs
@@ -126,22 +126,22 @@ public class RelationService : RepositoryService, IRelationService
     /// Gets the Relation types in a paged manner.
     /// Currently implements the paging in memory on the name property because the underlying repository does not support paging yet
     /// </summary>
-    public async Task<PagedModel<IRelationType>> GetPagedRelationTypesAsync(int skip, int take, params int[] ids)
+    public Task<PagedModel<IRelationType>> GetPagedRelationTypesAsync(int skip, int take, params int[] ids)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
 
         if (take == 0)
         {
-            return new PagedModel<IRelationType>(CountRelationTypes(), Enumerable.Empty<IRelationType>());
+            return Task.FromResult(new PagedModel<IRelationType>(CountRelationTypes(), []));
         }
 
-        IRelationType[] items = await Task.FromResult(_relationTypeRepository.GetMany(ids).ToArray());
+        IRelationType[] items = _relationTypeRepository.GetMany(ids).ToArray();
 
-        return new PagedModel<IRelationType>(
+        return Task.FromResult(new PagedModel<IRelationType>(
             items.Length,
             items.OrderBy(relationType => relationType.Name)
                 .Skip(skip)
-                .Take(take));
+                .Take(take)));
     }
 
     public int CountRelationTypes()
@@ -166,7 +166,7 @@ public class RelationService : RepositoryService, IRelationService
             IRelationType? relationType = GetRelationType(relationTypeAlias!);
             if (relationType == null)
             {
-                return Enumerable.Empty<IRelation>();
+                return [];
             }
 
             IQuery<IRelation> qry2 =
@@ -199,7 +199,7 @@ public class RelationService : RepositoryService, IRelationService
             IRelationType? relationType = GetRelationType(relationTypeAlias!);
             if (relationType == null)
             {
-                return Enumerable.Empty<IRelation>();
+                return [];
             }
 
             IQuery<IRelation> qry2 =
@@ -232,7 +232,7 @@ public class RelationService : RepositoryService, IRelationService
             IRelationType? relationType = GetRelationType(relationTypeAlias);
             if (relationType == null)
             {
-                return Enumerable.Empty<IRelation>();
+                return [];
             }
 
             IQuery<IRelation> query = Query<IRelation>().Where(x =>
@@ -266,7 +266,7 @@ public class RelationService : RepositoryService, IRelationService
         }
 
         return relationTypeIds.Count == 0
-            ? Enumerable.Empty<IRelation>()
+            ? []
             : GetRelationsByListOfTypeIds(relationTypeIds);
     }
 
@@ -276,7 +276,7 @@ public class RelationService : RepositoryService, IRelationService
         IRelationType? relationType = GetRelationType(relationTypeAlias);
 
         return relationType == null
-            ? Enumerable.Empty<IRelation>()
+            ? []
             : GetRelationsByListOfTypeIds(new[] { relationType.Id });
     }
 
@@ -308,21 +308,21 @@ public class RelationService : RepositoryService, IRelationService
         }
     }
 
-    public async Task<Attempt<PagedModel<IRelation>, RelationOperationStatus>> GetPagedByRelationTypeKeyAsync(Guid key, int skip, int take, Ordering? ordering = null)
+    public Task<Attempt<PagedModel<IRelation>, RelationOperationStatus>> GetPagedByRelationTypeKeyAsync(Guid key, int skip, int take, Ordering? ordering = null)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IRelationType? relationType = _relationTypeRepository.Get(key);
             if (relationType is null)
             {
-                return await Task.FromResult(Attempt.FailWithStatus<PagedModel<IRelation>, RelationOperationStatus>(RelationOperationStatus.RelationTypeNotFound, null!));
+                return Task.FromResult(Attempt.FailWithStatus<PagedModel<IRelation>, RelationOperationStatus>(RelationOperationStatus.RelationTypeNotFound, null!));
             }
 
             PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
 
             IQuery<IRelation> query = Query<IRelation>().Where(x => x.RelationTypeId == relationType.Id);
             IEnumerable<IRelation> relations = _relationRepository.GetPagedRelationsByQuery(query, pageNumber, pageSize, out var totalRecords, ordering);
-            return await Task.FromResult(Attempt.SucceedWithStatus(RelationOperationStatus.Success, new PagedModel<IRelation>(totalRecords, relations)));
+            return Task.FromResult(Attempt.SucceedWithStatus(RelationOperationStatus.Success, new PagedModel<IRelation>(totalRecords, relations)));
         }
     }
 
@@ -663,7 +663,7 @@ public class RelationService : RepositoryService, IRelationService
                 new RelationTypeSavedNotification(relationType, eventMessages).WithStateFrom(savingNotification));
         }
 
-        return await Task.FromResult(Attempt.SucceedWithStatus(RelationTypeOperationStatus.Success, relationType));
+        return Attempt.SucceedWithStatus(RelationTypeOperationStatus.Success, relationType);
     }
 
     /// <inheritdoc />
@@ -729,19 +729,17 @@ public class RelationService : RepositoryService, IRelationService
             Audit(AuditType.Delete, currentUser, relationType.Id, "Deleted relation type");
             scope.Notifications.Publish(new RelationTypeDeletedNotification(relationType, eventMessages).WithStateFrom(deletingNotification));
             scope.Complete();
-            return await Task.FromResult(Attempt.SucceedWithStatus<IRelationType?, RelationTypeOperationStatus>(RelationTypeOperationStatus.Success, relationType));
+            return Attempt.SucceedWithStatus<IRelationType?, RelationTypeOperationStatus>(RelationTypeOperationStatus.Success, relationType);
         }
     }
 
     /// <inheritdoc />
     public void DeleteRelationsOfType(IRelationType relationType)
     {
-        var relations = new List<IRelation>();
         using (ICoreScope scope = ScopeProvider.CreateCoreScope())
         {
             IQuery<IRelation> query = Query<IRelation>().Where(x => x.RelationTypeId == relationType.Id);
-            var allRelations = _relationRepository.Get(query).ToList();
-            relations.AddRange(allRelations);
+            List<IRelation> relations = _relationRepository.Get(query).ToList();
 
             // TODO: N+1, we should be able to do this in a single call
             foreach (IRelation relation in relations)
@@ -791,7 +789,7 @@ public class RelationService : RepositoryService, IRelationService
         }
     }
 
-    private IEnumerable<IRelation> GetRelationsByListOfTypeIds(IEnumerable<int> relationTypeIds)
+    private List<IRelation> GetRelationsByListOfTypeIds(IEnumerable<int> relationTypeIds)
     {
         var relations = new List<IRelation>();
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Persistence.Querying;
@@ -19,7 +18,6 @@ public class TemplateService : RepositoryService, ITemplateService
     private readonly IAuditRepository _auditRepository;
     private readonly ITemplateContentParserService _templateContentParserService;
     private readonly IUserIdKeyResolver _userIdKeyResolver;
-    private readonly IDefaultViewContentProvider _defaultViewContentProvider;
 
     public TemplateService(
         ICoreScopeProvider provider,
@@ -29,8 +27,7 @@ public class TemplateService : RepositoryService, ITemplateService
         ITemplateRepository templateRepository,
         IAuditRepository auditRepository,
         ITemplateContentParserService templateContentParserService,
-        IUserIdKeyResolver userIdKeyResolver,
-        IDefaultViewContentProvider defaultViewContentProvider)
+        IUserIdKeyResolver userIdKeyResolver)
         : base(provider, loggerFactory, eventMessagesFactory)
     {
         _shortStringHelper = shortStringHelper;
@@ -38,7 +35,6 @@ public class TemplateService : RepositoryService, ITemplateService
         _auditRepository = auditRepository;
         _templateContentParserService = templateContentParserService;
         _userIdKeyResolver = userIdKeyResolver;
-        _defaultViewContentProvider = defaultViewContentProvider;
     }
 
     /// <inheritdoc />
@@ -86,7 +82,7 @@ public class TemplateService : RepositoryService, ITemplateService
             scope.Complete();
         }
 
-        return await Task.FromResult(Attempt.SucceedWithStatus(TemplateOperationStatus.Success, template));
+        return Attempt.SucceedWithStatus(TemplateOperationStatus.Success, template);
     }
 
     /// <inheritdoc />
@@ -126,11 +122,11 @@ public class TemplateService : RepositoryService, ITemplateService
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ITemplate>> GetAllAsync(params string[] aliases)
+    public Task<IEnumerable<ITemplate>> GetAllAsync(params string[] aliases)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_templateRepository.GetAll(aliases).OrderBy(x => x.Name));
+            return Task.FromResult<IEnumerable<ITemplate>>(_templateRepository.GetAll(aliases).OrderBy(x => x.Name));
         }
     }
 
@@ -151,48 +147,48 @@ public class TemplateService : RepositoryService, ITemplateService
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ITemplate>> GetChildrenAsync(int masterTemplateId)
+    public Task<IEnumerable<ITemplate>> GetChildrenAsync(int masterTemplateId)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_templateRepository.GetChildren(masterTemplateId).OrderBy(x => x.Name));
+            return Task.FromResult<IEnumerable<ITemplate>>(_templateRepository.GetChildren(masterTemplateId).OrderBy(x => x.Name));
         }
     }
 
     /// <inheritdoc />
-    public async Task<ITemplate?> GetAsync(string? alias)
+    public Task<ITemplate?> GetAsync(string? alias)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_templateRepository.Get(alias));
+            return Task.FromResult(_templateRepository.Get(alias));
         }
     }
 
     /// <inheritdoc />
-    public async Task<ITemplate?> GetAsync(int id)
+    public Task<ITemplate?> GetAsync(int id)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_templateRepository.Get(id));
+            return Task.FromResult(_templateRepository.Get(id));
         }
     }
 
     /// <inheritdoc />
-    public async Task<ITemplate?> GetAsync(Guid id)
+    public Task<ITemplate?> GetAsync(Guid id)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             IQuery<ITemplate>? query = Query<ITemplate>().Where(x => x.Key == id);
-            return await Task.FromResult(_templateRepository.Get(query)?.SingleOrDefault());
+            return Task.FromResult(_templateRepository.Get(query)?.SingleOrDefault());
         }
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<ITemplate>> GetDescendantsAsync(int masterTemplateId)
+    public Task<IEnumerable<ITemplate>> GetDescendantsAsync(int masterTemplateId)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_templateRepository.GetDescendants(masterTemplateId));
+            return Task.FromResult(_templateRepository.GetDescendants(masterTemplateId));
         }
     }
 
@@ -286,31 +282,31 @@ public class TemplateService : RepositoryService, ITemplateService
         => await DeleteAsync(async () => await GetAsync(key), userKey);
 
     /// <inheritdoc />
-    public async Task<Stream> GetFileContentStreamAsync(string filepath)
+    public Task<Stream> GetFileContentStreamAsync(string filepath)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_templateRepository.GetFileContentStream(filepath));
+            return Task.FromResult(_templateRepository.GetFileContentStream(filepath));
         }
     }
 
     /// <inheritdoc />
-    public async Task SetFileContentAsync(string filepath, Stream content)
+    public Task SetFileContentAsync(string filepath, Stream content)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope())
         {
             _templateRepository.SetFileContent(filepath, content);
             scope.Complete();
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
     }
 
     /// <inheritdoc />
-    public async Task<long> GetFileSizeAsync(string filepath)
+    public Task<long> GetFileSizeAsync(string filepath)
     {
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            return await Task.FromResult(_templateRepository.GetFileSize(filepath));
+            return Task.FromResult(_templateRepository.GetFileSize(filepath));
         }
     }
 

--- a/src/Umbraco.Core/Services/TrackedReferencesService.cs
+++ b/src/Umbraco.Core/Services/TrackedReferencesService.cs
@@ -83,13 +83,13 @@ public class TrackedReferencesService : ITrackedReferencesService
         return pagedModel;
     }
 
-    public async Task<PagedModel<RelationItemModel>> GetPagedRelationsForItemAsync(Guid key, long skip, long take, bool filterMustBeIsDependency)
+    public Task<PagedModel<RelationItemModel>> GetPagedRelationsForItemAsync(Guid key, long skip, long take, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
         IEnumerable<RelationItemModel> items = _trackedReferencesRepository.GetPagedRelationsForItem(key, skip, take, filterMustBeIsDependency, out var totalItems);
         var pagedModel = new PagedModel<RelationItemModel>(totalItems, items);
 
-        return await Task.FromResult(pagedModel);
+        return Task.FromResult(pagedModel);
     }
 
     [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
@@ -108,7 +108,7 @@ public class TrackedReferencesService : ITrackedReferencesService
         return pagedModel;
     }
 
-    public async Task<PagedModel<RelationItemModel>> GetPagedDescendantsInReferencesAsync(Guid parentKey, long skip, long take, bool filterMustBeIsDependency)
+    public Task<PagedModel<RelationItemModel>> GetPagedDescendantsInReferencesAsync(Guid parentKey, long skip, long take, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
 
@@ -120,7 +120,7 @@ public class TrackedReferencesService : ITrackedReferencesService
             out var totalItems);
         var pagedModel = new PagedModel<RelationItemModel>(totalItems, items);
 
-        return await Task.FromResult(pagedModel);
+        return Task.FromResult(pagedModel);
     }
 
     [Obsolete("Use overload that takes key instead of id. This will be removed in Umbraco 15.")]
@@ -133,13 +133,13 @@ public class TrackedReferencesService : ITrackedReferencesService
         return pagedModel;
     }
 
-    public async Task<PagedModel<RelationItemModel>> GetPagedItemsWithRelationsAsync(ISet<Guid> keys, long skip, long take, bool filterMustBeIsDependency)
+    public Task<PagedModel<RelationItemModel>> GetPagedItemsWithRelationsAsync(ISet<Guid> keys, long skip, long take, bool filterMustBeIsDependency)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
         IEnumerable<RelationItemModel> items = _trackedReferencesRepository.GetPagedItemsWithRelations(keys, skip, take, filterMustBeIsDependency, out var totalItems);
         var pagedModel = new PagedModel<RelationItemModel>(totalItems, items);
 
-        return await Task.FromResult(pagedModel);
+        return Task.FromResult(pagedModel);
     }
 
     public async Task<PagedModel<Guid>> GetPagedKeysWithDependentReferencesAsync(ISet<Guid> keys, Guid objectTypeId, long skip, long take)

--- a/src/Umbraco.Core/Services/WebProfilerService.cs
+++ b/src/Umbraco.Core/Services/WebProfilerService.cs
@@ -15,30 +15,30 @@ internal sealed class WebProfilerService : IWebProfilerService
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
-    public async Task<Attempt<bool, WebProfilerOperationStatus>> GetStatus()
+    public Task<Attempt<bool, WebProfilerOperationStatus>> GetStatus()
     {
         Attempt<int> userIdAttempt = GetExecutingUserId();
 
         if (userIdAttempt.Success is false)
         {
-            return Attempt.FailWithStatus(WebProfilerOperationStatus.ExecutingUserNotFound, false);
+            return Task.FromResult(Attempt.FailWithStatus(WebProfilerOperationStatus.ExecutingUserNotFound, false));
         }
 
         var result = _webProfilerRepository.GetStatus(userIdAttempt.Result);
-        return await Task.FromResult(Attempt.SucceedWithStatus(WebProfilerOperationStatus.Success, result));
+        return Task.FromResult(Attempt.SucceedWithStatus(WebProfilerOperationStatus.Success, result));
     }
 
-    public async Task<Attempt<bool, WebProfilerOperationStatus>> SetStatus(bool status)
+    public Task<Attempt<bool, WebProfilerOperationStatus>> SetStatus(bool status)
     {
         Attempt<int> userIdAttempt = GetExecutingUserId();
 
         if (userIdAttempt.Success is false)
         {
-            return Attempt.FailWithStatus(WebProfilerOperationStatus.ExecutingUserNotFound, false);
+            return Task.FromResult(Attempt.FailWithStatus(WebProfilerOperationStatus.ExecutingUserNotFound, false));
         }
 
         _webProfilerRepository.SetStatus(userIdAttempt.Result, status);
-        return await Task.FromResult(Attempt.SucceedWithStatus(WebProfilerOperationStatus.Success, status));
+        return Task.FromResult(Attempt.SucceedWithStatus(WebProfilerOperationStatus.Success, status));
     }
 
     private Attempt<int> GetExecutingUserId()

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeUsageRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeUsageRepository.cs
@@ -38,7 +38,7 @@ public class DataTypeUsageRepository : IDataTypeUsageRepository
         return database.ExecuteScalar<bool>(hasValueQuery);
     }
 
-    public async Task<bool> HasSavedValuesAsync(Guid dataTypeKey)
+    public Task<bool> HasSavedValuesAsync(Guid dataTypeKey)
     {
         IUmbracoDatabase? database = _scopeAccessor.AmbientScope?.Database;
 
@@ -59,6 +59,6 @@ public class DataTypeUsageRepository : IDataTypeUsageRepository
         Sql<ISqlContext> hasValueQuery = database.SqlContext.Sql()
             .SelectAnyIfExists(selectQuery);
 
-        return await Task.FromResult(database.ExecuteScalar<bool>(hasValueQuery));
+        return Task.FromResult(database.ExecuteScalar<bool>(hasValueQuery));
     }
 }

--- a/src/Umbraco.Infrastructure/Services/Implement/ContentListViewService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/ContentListViewService.cs
@@ -49,7 +49,7 @@ internal sealed class ContentListViewService : ContentListViewServiceBase<IConte
         return await GetListViewResultAsync(user, content, dataTypeKey, orderBy, orderCulture, orderDirection, filter, skip, take);
     }
 
-    protected override async Task<PagedModel<IContent>> GetPagedChildrenAsync(
+    protected override Task<PagedModel<IContent>> GetPagedChildrenAsync(
         int id,
         IQuery<IContent>? filter,
         Ordering? ordering,
@@ -58,13 +58,13 @@ internal sealed class ContentListViewService : ContentListViewServiceBase<IConte
     {
         PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
 
-        IEnumerable<IContent> items = await Task.FromResult(_contentService.GetPagedChildren(
+        IEnumerable<IContent> items = _contentService.GetPagedChildren(
             id,
             pageNumber,
             pageSize,
             out var total,
             filter,
-            ordering));
+            ordering);
 
         var pagedResult = new PagedModel<IContent>
         {
@@ -72,7 +72,7 @@ internal sealed class ContentListViewService : ContentListViewServiceBase<IConte
             Total = total,
         };
 
-        return pagedResult;
+        return Task.FromResult(pagedResult);
     }
 
     // We can use an authorizer here, as it already handles all the necessary checks for this filtering.

--- a/src/Umbraco.Infrastructure/Services/Implement/MediaListViewService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/MediaListViewService.cs
@@ -50,17 +50,17 @@ internal sealed class MediaListViewService : ContentListViewServiceBase<IMedia, 
         return await GetListViewResultAsync(user, media, dataTypeKey, orderBy, null, orderDirection, filter, skip, take);
     }
 
-    protected override async Task<PagedModel<IMedia>> GetPagedChildrenAsync(int id, IQuery<IMedia>? filter, Ordering? ordering, int skip, int take)
+    protected override Task<PagedModel<IMedia>> GetPagedChildrenAsync(int id, IQuery<IMedia>? filter, Ordering? ordering, int skip, int take)
     {
         PaginationHelper.ConvertSkipTakeToPaging(skip, take, out var pageNumber, out var pageSize);
 
-        IEnumerable<IMedia> items = await Task.FromResult(_mediaService.GetPagedChildren(
+        IEnumerable<IMedia> items = _mediaService.GetPagedChildren(
             id,
             pageNumber,
             pageSize,
             out var total,
             filter,
-            ordering));
+            ordering);
 
         var pagedResult = new PagedModel<IMedia>
         {
@@ -68,7 +68,7 @@ internal sealed class MediaListViewService : ContentListViewServiceBase<IMedia, 
             Total = total,
         };
 
-        return pagedResult;
+        return Task.FromResult(pagedResult);
     }
 
     // We can use an authorizer here, as it already handles all the necessary checks for this filtering.

--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -70,8 +70,8 @@ internal sealed class MemberEditingService : IMemberEditingService
         _securitySettings = securitySettings.Value;
     }
 
-    public async Task<IMember?> GetAsync(Guid key)
-        => await Task.FromResult(_memberService.GetByKey(key));
+    public Task<IMember?> GetAsync(Guid key)
+        => Task.FromResult(_memberService.GetByKey(key));
 
     public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCreateAsync(MemberCreateModel createModel)
         => await _memberContentEditingService.ValidateAsync(createModel, createModel.ContentTypeKey);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Remove async await where not needed.

I am aware that I have changed a lot of files, and it might not make a lot of performance difference in most places, but I wanted to eliminate the horrible `await Task.FromResult(` from the codebase, so it is never copied again.  
Many of the controller methods could be be made sync, but I supposed it would make it fail the signature change check.