### PR TITLE
V13: attempted fix for Datepicker v13 issue #16008

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js
@@ -111,7 +111,7 @@ function dateTimePickerController($scope, angularHelper, dateHelper, validationM
       // $scope.hasDatetimePickerValue indicates that we had a value before the input was changed,
       // but now the input is empty.
       $scope.clearDate();
-    } else if ($scope.model.datetimePickerValue) {
+    } else if ($scope.model.datetimePickerInputValue) {
       var momentDate = moment($scope.model.datetimePickerInputValue, $scope.model.config.format, true);
       if (!momentDate || !momentDate.isValid()) {
         momentDate = moment(new Date($scope.model.datetimePickerInputValue));
@@ -120,7 +120,7 @@ function dateTimePickerController($scope, angularHelper, dateHelper, validationM
         setDate(momentDate);
       }
       setDatePickerVal();
-      flatPickr.setDate($scope.model.datetimePickerValue, false);
+      flatPickr.setDate($scope.model.datetimePickerInputValue, false);
     }
   }
 


### PR DESCRIPTION

- [ ] I have added steps to test this contribution in the description below

- Create a new doctype with a Date Picker
- Create a new node of that Doctype
- Paste or type a date that matches the format into the input field
- Save and publish node
- The value in the field is saved

If there's an existing issue for this PR then this fixes #16008 

### Description
Issue:
The inputChanged method in v13 failed to properly update model values when copying and pasting dates, as it referenced model.datetimePickerValue instead of the raw input value, model.datetimePickerInputValue, leading to incorrect handling and parsing of the input.
![datetimepickerissuebeforefix](https://github.com/user-attachments/assets/ce629281-f0ca-4048-86dd-c997e7153b6c)


Solution:

The logic was updated to use model.datetimePickerInputValue, which contains the raw string input from the user.

By using model.datetimePickerInputValue instead of model.datetimePickerValue, the method now correctly handles user input, ensuring that manually entered or pasted date values are properly parsed, validated, and reflected in the field.
![datetimepickerissue](https://github.com/user-attachments/assets/07178d4d-cca7-459c-a309-ca6a08f036d0)
