### PR TITLE
Adds ancestor ID details on document tree and collection responses

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -52,7 +52,7 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
         if (entity is IDocumentEntitySlim documentEntitySlim)
         {
             responseModel.IsProtected = _publicAccessService.IsProtected(entity.Path);
-            responseModel.AncestorIds = GetAncestorIds(EntityService.GetPathKeys(entity));
+            responseModel.AncestorIds = EntityService.GetPathKeys(entity, omitSelf: true);
             responseModel.IsTrashed = entity.Trashed;
             responseModel.Id = entity.Key;
             responseModel.CreateDate = entity.CreateDate;
@@ -63,10 +63,6 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
 
         return responseModel;
     }
-
-    private Guid[] GetAncestorIds(Guid[] keys) =>
-        // Omit the last path key as that will be for the item itself.
-        keys.Take(keys.Length - 1).ToArray();
 
     protected override int[] GetUserStartNodeIds()
         => _backofficeSecurityAccessor

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Api.Management.Controllers.Tree;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.Services.Entities;
+using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -52,7 +53,8 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
         if (entity is IDocumentEntitySlim documentEntitySlim)
         {
             responseModel.IsProtected = _publicAccessService.IsProtected(entity.Path);
-            responseModel.AncestorIds = EntityService.GetPathKeys(entity, omitSelf: true);
+            responseModel.Ancestors = EntityService.GetPathKeys(entity, omitSelf: true)
+                .Select(x => new ReferenceByIdModel(x));
             responseModel.IsTrashed = entity.Trashed;
             responseModel.Id = entity.Key;
             responseModel.CreateDate = entity.CreateDate;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Tree/DocumentTreeControllerBase.cs
@@ -33,7 +33,7 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
         AppCaches appCaches,
         IBackOfficeSecurityAccessor backofficeSecurityAccessor,
         IDocumentPresentationFactory documentPresentationFactory)
-        : base(entityService, userStartNodeEntitiesService, dataTypeService)
+    : base(entityService, userStartNodeEntitiesService, dataTypeService)
     {
         _publicAccessService = publicAccessService;
         _appCaches = appCaches;
@@ -52,6 +52,7 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
         if (entity is IDocumentEntitySlim documentEntitySlim)
         {
             responseModel.IsProtected = _publicAccessService.IsProtected(entity.Path);
+            responseModel.AncestorIds = GetAncestorIds(EntityService.GetPathKeys(entity));
             responseModel.IsTrashed = entity.Trashed;
             responseModel.Id = entity.Key;
             responseModel.CreateDate = entity.CreateDate;
@@ -62,6 +63,10 @@ public abstract class DocumentTreeControllerBase : UserStartNodeTreeControllerBa
 
         return responseModel;
     }
+
+    private Guid[] GetAncestorIds(Guid[] keys) =>
+        // Omit the last path key as that will be for the item itself.
+        keys.Take(keys.Length - 1).ToArray();
 
     protected override int[] GetUserStartNodeIds()
         => _backofficeSecurityAccessor

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentCollectionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentCollectionPresentationFactory.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -41,7 +42,8 @@ public class DocumentCollectionPresentationFactory : ContentCollectionPresentati
             }
 
             item.IsProtected = _publicAccessService.IsProtected(matchingContentItem).Success;
-            item.AncestorIds = _entityService.GetPathKeys(matchingContentItem, omitSelf: true);
+            item.Ancestors = _entityService.GetPathKeys(matchingContentItem, omitSelf: true)
+                .Select(x => new ReferenceByIdModel(x));
         }
 
         return Task.CompletedTask;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentMapDefinition.cs
@@ -67,7 +67,7 @@ public class DocumentMapDefinition : ContentMapDefinition<IContent, DocumentValu
         target.IsTrashed = source.Trashed;
     }
 
-    // Umbraco.Code.MapAll -IsProtected
+    // Umbraco.Code.MapAll -IsProtected -AncestorIds
     private void Map(IContent source, DocumentCollectionResponseModel target, MapperContext context)
     {
         target.Id = source.Key;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Document/DocumentMapDefinition.cs
@@ -67,7 +67,7 @@ public class DocumentMapDefinition : ContentMapDefinition<IContent, DocumentValu
         target.IsTrashed = source.Trashed;
     }
 
-    // Umbraco.Code.MapAll -IsProtected -AncestorIds
+    // Umbraco.Code.MapAll -IsProtected -Ancestors
     private void Map(IContent source, DocumentCollectionResponseModel target, MapperContext context)
     {
         target.Id = source.Key;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -37088,7 +37088,7 @@
       },
       "DocumentCollectionResponseModel": {
         "required": [
-          "ancestorIds",
+          "ancestors",
           "documentType",
           "id",
           "isProtected",
@@ -37144,11 +37144,14 @@
           "isProtected": {
             "type": "boolean"
           },
-          "ancestorIds": {
+          "ancestors": {
             "type": "array",
             "items": {
-              "type": "string",
-              "format": "uuid"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ReferenceByIdModel"
+                }
+              ]
             }
           },
           "updater": {
@@ -37464,7 +37467,7 @@
       },
       "DocumentTreeItemResponseModel": {
         "required": [
-          "ancestorIds",
+          "ancestors",
           "createDate",
           "documentType",
           "hasChildren",
@@ -37504,11 +37507,14 @@
           "isProtected": {
             "type": "boolean"
           },
-          "ancestorIds": {
+          "ancestors": {
             "type": "array",
             "items": {
-              "type": "string",
-              "format": "uuid"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ReferenceByIdModel"
+                }
+              ]
             }
           },
           "documentType": {

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -37088,6 +37088,7 @@
       },
       "DocumentCollectionResponseModel": {
         "required": [
+          "ancestorIds",
           "documentType",
           "id",
           "isProtected",
@@ -37142,6 +37143,13 @@
           },
           "isProtected": {
             "type": "boolean"
+          },
+          "ancestorIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           },
           "updater": {
             "type": "string",
@@ -37456,6 +37464,7 @@
       },
       "DocumentTreeItemResponseModel": {
         "required": [
+          "ancestorIds",
           "createDate",
           "documentType",
           "hasChildren",
@@ -37494,6 +37503,13 @@
           },
           "isProtected": {
             "type": "boolean"
+          },
+          "ancestorIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           },
           "documentType": {
             "oneOf": [

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/Collection/DocumentCollectionResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/Collection/DocumentCollectionResponseModel.cs
@@ -11,7 +11,7 @@ public class DocumentCollectionResponseModel : ContentCollectionResponseModelBas
 
     public bool IsProtected { get; set; }
 
-    public Guid[] AncestorIds { get; set; } = [];
+    public IEnumerable<ReferenceByIdModel> Ancestors { get; set; } = [];
 
     public string? Updater { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/Collection/DocumentCollectionResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/Collection/DocumentCollectionResponseModel.cs
@@ -11,5 +11,7 @@ public class DocumentCollectionResponseModel : ContentCollectionResponseModelBas
 
     public bool IsProtected { get; set; }
 
+    public Guid[] AncestorIds { get; set; } = [];
+
     public string? Updater { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
@@ -7,7 +7,7 @@ public class DocumentTreeItemResponseModel : ContentTreeItemResponseModel
 {
     public bool IsProtected { get; set; }
 
-    public Guid[] AncestorIds { get; set; } = [];
+    public IEnumerable<ReferenceByIdModel> Ancestors { get; set; } = [];
 
     public DocumentTypeReferenceResponseModel DocumentType { get; set; } = new();
 

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Tree/DocumentTreeItemResponseModel.cs
@@ -1,4 +1,3 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 
@@ -7,6 +6,8 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Tree;
 public class DocumentTreeItemResponseModel : ContentTreeItemResponseModel
 {
     public bool IsProtected { get; set; }
+
+    public Guid[] AncestorIds { get; set; } = [];
 
     public DocumentTypeReferenceResponseModel DocumentType { get; set; } = new();
 

--- a/src/Umbraco.Core/Services/EntityService.cs
+++ b/src/Umbraco.Core/Services/EntityService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Events;
@@ -758,5 +759,19 @@ public class EntityService : RepositoryService, IEntityService
             return _entityRepository.GetPagedResultsByQuery(query, objectTypeGuids, pageNumber, pageSize, out totalRecords, filter, ordering);
         }
     }
-}
 
+    /// <inheritdoc/>>
+    public Guid[] GetPathKeys(IEntitySlim entity)
+    {
+        var ids = entity.Path.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => int.TryParse(x, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : -1)
+            .Where(x => x != -1)
+            .ToList();
+
+        return ids
+            .Select(x => _idKeyMap.GetKeyForId(x, UmbracoObjectTypes.Document))
+            .Where(x => x.Success)
+            .Select(x => x.Result)
+            .ToArray();
+    }
+}

--- a/src/Umbraco.Core/Services/EntityService.cs
+++ b/src/Umbraco.Core/Services/EntityService.cs
@@ -761,17 +761,24 @@ public class EntityService : RepositoryService, IEntityService
     }
 
     /// <inheritdoc/>>
-    public Guid[] GetPathKeys(IEntitySlim entity)
+    public Guid[] GetPathKeys(ITreeEntity entity, bool omitSelf = false)
     {
-        var ids = entity.Path.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
+        IEnumerable<int> ids = entity.Path.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
             .Select(x => int.TryParse(x, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : -1)
-            .Where(x => x != -1)
-            .ToList();
+            .Where(x => x != -1);
 
-        return ids
+        Guid[] keys = ids
             .Select(x => _idKeyMap.GetKeyForId(x, UmbracoObjectTypes.Document))
             .Where(x => x.Success)
             .Select(x => x.Result)
             .ToArray();
+
+        if (omitSelf)
+        {
+            // Omit the last path key as that will be for the item itself.
+            return keys.Take(keys.Length - 1).ToArray();
+        }
+
+        return keys;
     }
 }

--- a/src/Umbraco.Core/Services/IEntityService.cs
+++ b/src/Umbraco.Core/Services/IEntityService.cs
@@ -382,4 +382,11 @@ public interface IEntityService
     /// <returns>The identifier.</returns>
     /// <remarks>When a new content or a media is saved with the key, it will have the reserved identifier.</remarks>
     int ReserveId(Guid key);
+
+    /// <summary>
+    /// Gets the GUID keys for an entity's path (provided as a comma separated list of integer Ids).
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>The path with each ID converted to a GUID.</returns>
+    Guid[] GetPathKeys(IEntitySlim entity) => [];
 }

--- a/src/Umbraco.Core/Services/IEntityService.cs
+++ b/src/Umbraco.Core/Services/IEntityService.cs
@@ -387,6 +387,7 @@ public interface IEntityService
     /// Gets the GUID keys for an entity's path (provided as a comma separated list of integer Ids).
     /// </summary>
     /// <param name="entity">The entity.</param>
+    /// <param name="omitSelf">A value indicating whether to omit the entity's own key from the result.</param>
     /// <returns>The path with each ID converted to a GUID.</returns>
-    Guid[] GetPathKeys(IEntitySlim entity) => [];
+    Guid[] GetPathKeys(ITreeEntity entity, bool omitSelf = false) => [];
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
@@ -870,6 +870,26 @@ public class EntityServiceTests : UmbracoIntegrationTest
         Assert.IsFalse(EntityService.GetId(Guid.NewGuid(), UmbracoObjectTypes.DocumentType).Success);
     }
 
+    [Test]
+    public void EntityService_GetPathKeys_ReturnsExpectedKeys()
+    {
+        var contentType = ContentTypeService.Get("umbTextpage");
+
+        var root = ContentBuilder.CreateSimpleContent(contentType);
+        ContentService.Save(root);
+
+        var child = ContentBuilder.CreateSimpleContent(contentType, Guid.NewGuid().ToString(), root);
+        ContentService.Save(child);
+        var grandChild = ContentBuilder.CreateSimpleContent(contentType, Guid.NewGuid().ToString(), child);
+        ContentService.Save(grandChild);
+
+        var grandChildEntity = EntityService.Get(grandChild.Key);
+        Assert.IsNotNull(grandChildEntity);
+
+        var result = EntityService.GetPathKeys(grandChildEntity);
+        Assert.AreEqual($"{root.Key},{child.Key},{grandChild.Key}", string.Join(",", result));
+    }
+
     private static bool _isSetup;
 
     private int _folderId;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
@@ -883,11 +883,12 @@ public class EntityServiceTests : UmbracoIntegrationTest
         var grandChild = ContentBuilder.CreateSimpleContent(contentType, Guid.NewGuid().ToString(), child);
         ContentService.Save(grandChild);
 
-        var grandChildEntity = EntityService.Get(grandChild.Key);
-        Assert.IsNotNull(grandChildEntity);
-
-        var result = EntityService.GetPathKeys(grandChildEntity);
+        var result = EntityService.GetPathKeys(grandChild);
         Assert.AreEqual($"{root.Key},{child.Key},{grandChild.Key}", string.Join(",", result));
+
+        var result2 = EntityService.GetPathKeys(grandChild, omitSelf: true);
+        Assert.AreEqual($"{root.Key},{child.Key}", string.Join(",", result2));
+
     }
 
     private static bool _isSetup;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Relates to the fix necessary for  https://github.com/umbraco/Umbraco-CMS/issues/18517

### Description
When evaluating document permissions on the client, there's a need to know the ancestors of the current item.  This is because granular permissions can be assigned on an ancestor document, and they should apply to the current one.

From internal discussion:

> ... I think I have it working correctly for the workspace now. To check the inheritance path, we currently use the /tree/document/ancestors endpoint. It all works fine, but "unfortunately," we have made some updates to the UI which give me some challenges with this endpoint.
We now show the first available "Entity Action" on all tree items and collection items. This means that I would need to check for permissions already when rendering the tree and a collection, and can't wait and ask each individual item when opening the menu.
In the old back office, if I remember correctly, we had the path - a string array of ids available on each tree item: [-1, 12, 25, 48], etc. If we are able to bring something similar back, then I have all the information available that I need.

So this PR brings back this "path", but in the form of an array of GUIDs under a property named `ancestorIds`.  It's added on the document tree and collection item response models.

To populate I've created a new method in `IEntityService` that uses the `IIdKeyMap` to translate the entity's `Path` property - which is a comma delimited list of integer IDs - to the array of GUIDs.

### Testing

To test you can call the following management API endpoints, for documents at various levels in the tree and verify the `ancestorIds` property is correctly populated.


```
GET /umbraco/management/api/v1/collection/document/{id}?orderBy=updateDate&skip=0&take=100
GET /umbraco/management/api/v1/tree/document/children?parentId={id}&skip=0&take=100
```

E.g. you should get a response like the following:

```
{
  "total": 5,
  "items": [
    {
      "documentType": {
        "id": "752230cd-fc00-441e-85e5-a8efbcccdc84",
        "alias": "blogpost",
        "icon": "icon-calendar color-black"
      },
      "isTrashed": false,
      "isProtected": false,
      "ancestors": [
        {
          "id": "ca4249ed-2b23-4337-b522-63cabe5587d1"
        },
        {
          "id": "e8ad9b65-cff6-4952-ac5b-efe56a60db62"
        }
      ],
     ...
```
