### PR TITLE
Fix issue preventing blueprint derived values from being scaffolded

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -283,7 +283,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		await this.structure.loadType((data as any)[this.#contentTypePropertyName].unique);
 
 		// Set culture and segment for all values:
-		const cutlures = this.#languages.getValue().map((x) => x.unique);
+		const cultures = this.#languages.getValue().map((x) => x.unique);
 
 		if (this.structure.variesBySegment) {
 			console.warn('Segments are not yet implemented for preset');
@@ -319,11 +319,27 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		);
 
 		const controller = new UmbPropertyValuePresetVariantBuilderController(this);
-		controller.setCultures(cutlures);
+		controller.setCultures(cultures);
 		if (segments) {
 			controller.setSegments(segments);
 		}
-		data.values = await controller.create(valueDefinitions);
+
+		const presetValues = await controller.create(valueDefinitions);
+
+		// Don't just set the values, as we could have some already populated from a blueprint.
+		// If we have a value from both a blueprint and a preset, use the latter as priority.
+		const dataValues = data.values;
+		for (let index = 0; index < presetValues.length; index++) {
+			const presetValue = presetValues[index];
+			const matchingDataValueIndex = dataValues.findIndex(v => v.alias === presetValue.alias);
+			if (matchingDataValueIndex > -1) {
+				dataValues[matchingDataValueIndex] = presetValue;
+			} else {
+				dataValues.push(presetValue);
+			}
+		}
+
+		data.values = dataValues;
 
 		return data;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -331,7 +331,8 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		const dataValues = [...data.values];
 		for (let index = 0; index < presetValues.length; index++) {
 			const presetValue = presetValues[index];
-			const matchingDataValueIndex = dataValues.findIndex(v => v.alias === presetValue.alias);
+			const variantId = UmbVariantId.Create(presetValue);
+			const matchingDataValueIndex = dataValues.findIndex((v) => v.alias === presetValue.alias && variantId.compare(v));
 			if (matchingDataValueIndex > -1) {
 				dataValues[matchingDataValueIndex] = presetValue;
 			} else {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/content/workspace/content-detail-workspace-base.ts
@@ -328,7 +328,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 
 		// Don't just set the values, as we could have some already populated from a blueprint.
 		// If we have a value from both a blueprint and a preset, use the latter as priority.
-		const dataValues = data.values;
+		const dataValues = [...data.values];
 		for (let index = 0; index < presetValues.length; index++) {
 			const presetValue = presetValues[index];
 			const matchingDataValueIndex = dataValues.findIndex(v => v.alias === presetValue.alias);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18912

### Description
It appears that the introduction of the property value presets had an inadvertent effect of preventing the scaffolded values to come from content blueprints.  This PR resolves that by ensuring we don't overwrite the values that have been scaffolded from blueprints with and empty set of presets.

### Testing

- Create a content blueprint for a document with one or more properties filled out
- Create a document based on the blueprint.
- Verify that before the update in this PR the values from the blueprint are not pre-filled, but with this update in place they are.
