### PR TITLE
Move database cache rebuild to a background task with polling (13)

### DIFF
--- a/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
+++ b/src/Umbraco.Core/PublishedCache/IPublishedSnapshotService.cs
@@ -32,6 +32,12 @@ public interface IPublishedSnapshotService : IDisposable
     IPublishedSnapshot CreatePublishedSnapshot(string? previewToken);
 
     /// <summary>
+    /// Indicates if the database cache is in the process of being rebuilt.
+    /// </summary>
+    /// <returns></returns>
+    bool IsRebuilding() => false;
+
+    /// <summary>
     ///     Rebuilds internal database caches (but does not reload).
     /// </summary>
     /// <param name="contentTypeIds">
@@ -61,6 +67,38 @@ public interface IPublishedSnapshotService : IDisposable
         IReadOnlyCollection<int>? mediaTypeIds = null,
         IReadOnlyCollection<int>? memberTypeIds = null);
 
+    /// <summary>
+    ///     Rebuilds internal database caches (but does not reload).
+    /// </summary>
+    /// <param name="contentTypeIds">
+    ///     If not null will process content for the matching content types, if empty will process all
+    ///     content
+    /// </param>
+    /// <param name="mediaTypeIds">
+    ///     If not null will process content for the matching media types, if empty will process all
+    ///     media
+    /// </param>
+    /// <param name="memberTypeIds">
+    ///     If not null will process content for the matching members types, if empty will process all
+    ///     members
+    /// </param>
+    /// <param name="useBackgroundThread">Flag indicating whether to use a background thread for the operation and immediately return to the caller.</param>
+    /// <remarks>
+    ///     <para>
+    ///         Forces the snapshot service to rebuild its internal database caches. For instance, some caches
+    ///         may rely on a database table to store pre-serialized version of documents.
+    ///     </para>
+    ///     <para>
+    ///         This does *not* reload the caches. Caches need to be reloaded, for instance via
+    ///         <see cref="DistributedCache" /> RefreshAllPublishedSnapshot method.
+    ///     </para>
+    /// </remarks>
+    void Rebuild(
+        bool useBackgroundThread,
+        IReadOnlyCollection<int>? contentTypeIds = null,
+        IReadOnlyCollection<int>? mediaTypeIds = null,
+        IReadOnlyCollection<int>? memberTypeIds = null) => Rebuild(contentTypeIds, mediaTypeIds, memberTypeIds);
+
 
     /// <summary>
     ///     Rebuilds all internal database caches (but does not reload).
@@ -76,6 +114,22 @@ public interface IPublishedSnapshotService : IDisposable
     ///     </para>
     /// </remarks>
     void RebuildAll() => Rebuild(Array.Empty<int>(), Array.Empty<int>(), Array.Empty<int>());
+
+    /// <summary>
+    ///     Rebuilds all internal database caches (but does not reload).
+    /// </summary>
+    /// <param name="useBackgroundThread">Flag indicating whether to use a background thread for the operation and immediately return to the caller.</param>
+    /// <remarks>
+    ///     <para>
+    ///         Forces the snapshot service to rebuild its internal database caches. For instance, some caches
+    ///         may rely on a database table to store pre-serialized version of documents.
+    ///     </para>
+    ///     <para>
+    ///         This does *not* reload the caches. Caches need to be reloaded, for instance via
+    ///         <see cref="DistributedCache" /> RefreshAllPublishedSnapshot method.
+    ///     </para>
+    /// </remarks>
+    void RebuildAll(bool useBackgroundThread) => Rebuild(useBackgroundThread, Array.Empty<int>(), Array.Empty<int>(), Array.Empty<int>());
 
     /* An IPublishedCachesService implementation can rely on transaction-level events to update
      * its internal, database-level data, as these events are purely internal. However, it cannot

--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotStatus.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotStatus.cs
@@ -29,6 +29,11 @@ internal class PublishedSnapshotStatus : IPublishedSnapshotStatus
                 $"The current {typeof(IPublishedSnapshotService)} is not the default type. A status cannot be determined.";
         }
 
+        if (_service.IsRebuilding())
+        {
+            return "Rebuild in progress. Please wait.";
+        }
+
         // TODO: This should be private
         _service.EnsureCaches();
 

--- a/src/Umbraco.Web.BackOffice/Controllers/PublishedSnapshotCacheStatusController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PublishedSnapshotCacheStatusController.cs
@@ -37,13 +37,32 @@ public class PublishedSnapshotCacheStatusController : UmbracoAuthorizedApiContro
     [HttpPost]
     public string RebuildDbCache()
     {
-        //Rebuild All
+        if (_publishedSnapshotService.IsRebuilding())
+        {
+            return "Rebuild already in progress.";
+        }
+
         _publishedSnapshotService.RebuildAll();
         return _publishedSnapshotStatus.GetStatus();
     }
 
     /// <summary>
-    ///     Gets a status report
+    ///     Rebuilds the Database cache on a background thread.
+    /// </summary>
+    [HttpPost]
+    public IActionResult RebuildDbCacheInBackground()
+    {
+        if (_publishedSnapshotService.IsRebuilding())
+        {
+            return BadRequest("Rebuild already in progress.");
+        }
+
+        _publishedSnapshotService.RebuildAll(true);
+        return Ok();
+    }
+
+    /// <summary>
+    ///     Gets a status report.
     /// </summary>
     [HttpGet]
     public string GetStatus() => _publishedSnapshotStatus.GetStatus();

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/publishedsnapshotcache.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/publishedsnapshotcache.controller.js
@@ -104,7 +104,10 @@ function publishedSnapshotCacheController($scope, $http, umbRequestHelper, local
                                     vm.status = result.data;
                                     clearInterval(interval);
                                 }
-                          });
+                            }, function () {
+                                vm.working = false;
+                                vm.status = "Could not retrieve rebuild cache status";
+                            });
 
                         }, 2000);
                 });

--- a/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/publishedsnapshotcache.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/dashboard/settings/publishedsnapshotcache.controller.js
@@ -1,4 +1,4 @@
-﻿function publishedSnapshotCacheController($scope, $http, umbRequestHelper, localizationService, overlayService) {
+function publishedSnapshotCacheController($scope, $http, umbRequestHelper, localizationService, overlayService) {
 
     var vm = this;
 
@@ -94,12 +94,20 @@
         vm.working = true;
 
         umbRequestHelper.resourcePromise(
-            $http.post(umbRequestHelper.getApiUrl("publishedSnapshotCacheStatusBaseUrl", "RebuildDbCache")),
-            'Failed to rebuild the cache.')
-            .then(function (result) {
-                vm.working = false;
-                vm.status = result;
-            });
+            $http.post(umbRequestHelper.getApiUrl("publishedSnapshotCacheStatusBaseUrl", "RebuildDbCacheInBackground")), "Failed to rebuild the cache.")
+                .then(function () {
+                    const interval = setInterval(function () {
+                        $http.get(umbRequestHelper.getApiUrl("publishedSnapshotCacheStatusBaseUrl", "GetStatus"))
+                            .then(function (result) {
+                                if (!result.data.toString().startsWith("Rebuild in progress")) {
+                                    vm.working = false;
+                                    vm.status = result.data;
+                                    clearInterval(interval);
+                                }
+                          });
+
+                        }, 2000);
+                });
     }
 
     function init() {

--- a/tests/Umbraco.Tests.UnitTests/TestHelpers/PublishedSnapshotServiceTestBase.cs
+++ b/tests/Umbraco.Tests.UnitTests/TestHelpers/PublishedSnapshotServiceTestBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Hosting;
@@ -22,6 +23,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Infrastructure.HostedServices;
 using Umbraco.Cms.Infrastructure.PublishedCache;
 using Umbraco.Cms.Infrastructure.PublishedCache.DataSource;
 using Umbraco.Cms.Infrastructure.Serialization;
@@ -280,7 +282,9 @@ public class PublishedSnapshotServiceTestBase
             PublishedModelFactory,
             TestHelper.GetHostingEnvironment(),
             Options.Create(nuCacheSettings),
-            new ContentDataSerializer(new DictionaryOfPropertyDataSerializer()));
+            new ContentDataSerializer(new DictionaryOfPropertyDataSerializer()),
+            Mock.Of<IBackgroundTaskQueue>(),
+            AppCaches.NoCache);
 
         // invariant is the current default
         VariationContextAccessor.VariationContext = new VariationContext();


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

This was raised as an issue in Umbraco Cloud for large sites where the time to rebuild the database cache is quite long. It may go over the hard limit imposed by Cloudflare and although the work continues, the user has no indication that it's completed.

We already implemented this for 15 in https://github.com/umbraco/Umbraco-CMS/pull/18496 but it was felt useful to backport to 13 to support customers on that version.

### Description
This PR updates the database cache rebuild operation to move it from a single request/response to a pattern where we submit the task, run in in the background and poll for completion.

It is based on what we are already doing for Examine index rebuilds, so it's a pattern and technique already in use in the CMS that I've just applied to this operation.

### Testing
To test you can use the UI under Settings > Published Status and click the Rebuild Database Cache button. If you delete all records from `cmsContentNu` first you can see that they are recreated when the operation is completed.

To simulate a long running rebuild operation, you can add a `Thread.Sleep(20000);` into `PublishedSnapshotService.PerformRebuild()`.