### PR TITLE
V15/bugfix/fix route issue from 18859

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/router-slot/model.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/router-slot/model.ts
@@ -62,6 +62,9 @@ export interface IRouteBase<D = any> {
 	// - If "full" router-slot will try to match the entire path.
 	// - If "fuzzy" router-slot will try to match an arbitrary part of the path.
 	pathMatch?: PathMatch;
+
+	// A unique identifier for the route, used to identify the route so we can avoid re-rendering it.
+	unique?: string | Symbol;
 }
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/external/router-slot/router-slot.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/router-slot/router-slot.ts
@@ -208,10 +208,8 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 				// If navigate is not determined, then we will check if we have a route match, and if the new match is different from current. [NL]
 				const newMatch = this.getRouteMatch();
 				if (newMatch) {
-					if (this._routeMatch?.route.path !== newMatch.route.path) {
-						// Check if this match matches the current match (aka. If the path has changed), if so we should navigate. [NL]
-						navigate = shouldNavigate(this.match, newMatch);
-					}
+					// Check if this match matches the current match (aka. If the path has changed), if so we should navigate. [NL]
+					navigate = shouldNavigate(this.match, newMatch);
 				}
 			}
 		}

--- a/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
@@ -303,7 +303,8 @@ export function shouldNavigate<D>(currentMatch: IRouteMatch<D> | null, newMatch:
 
 	const isSameRoute = currentRoute == newRoute;
 	const isSameFragments = currentFragments.consumed == newFragments.consumed;
+	const isSameBasedOnUnique = currentRoute.unique === newRoute.unique;
 
 	// Only navigate if the URL consumption is new or if the two routes are no longer the same.
-	return !isSameFragments || !isSameRoute;
+	return !isSameFragments || !isSameRoute || !isSameBasedOnUnique;
 }

--- a/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
@@ -127,6 +127,7 @@ export function matchRoutes<D = any>(routes: IRoute<D>[], path: string | PathFra
  * @param info
  */
 export async function resolvePageComponent(route: IComponentRoute, info: IRoutingInfo): Promise<PageComponent> {
+	console.log('resolvePageComponent');
 	// Figure out if the component were given as an import or class.
 	let cmp = route.component;
 	if (cmp instanceof Function) {
@@ -301,7 +302,7 @@ export function shouldNavigate<D>(currentMatch: IRouteMatch<D> | null, newMatch:
 	const { route: currentRoute, fragments: currentFragments } = currentMatch;
 	const { route: newRoute, fragments: newFragments } = newMatch;
 
-	const isSameRoute = currentRoute == newRoute;
+	const isSameRoute = currentRoute.path == newRoute.path;
 	const isSameFragments = currentFragments.consumed == newFragments.consumed;
 	const isSameBasedOnUnique = currentRoute.unique === newRoute.unique;
 

--- a/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/router-slot/util/router.ts
@@ -127,7 +127,6 @@ export function matchRoutes<D = any>(routes: IRoute<D>[], path: string | PathFra
  * @param info
  */
 export async function resolvePageComponent(route: IComponentRoute, info: IRoutingInfo): Promise<PageComponent> {
-	console.log('resolvePageComponent');
 	// Figure out if the component were given as an import or class.
 	let cmp = route.component;
 	if (cmp instanceof Function) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/collection-view.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/collection-view.manager.ts
@@ -94,6 +94,7 @@ export class UmbCollectionViewManager extends UmbControllerBase {
 
 			if (routes.length > 0) {
 				routes.push({
+					unique: fallbackView.alias,
 					path: '',
 					component: () => createExtensionElement(fallbackView),
 					setup: () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/modal.element.ts
@@ -95,6 +95,7 @@ export class UmbModalElement extends UmbLitElement {
 			this.#modalRouterElement = document.createElement('umb-router-slot');
 			this.#modalRouterElement.routes = [
 				{
+					unique: '_umbEmptyRoute_',
 					path: '',
 					component: document.createElement('slot'),
 				},

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/components/router-slot/route.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/components/router-slot/route.context.ts
@@ -60,6 +60,7 @@ export class UmbRouteContext extends UmbContextBase<UmbRouteContext> {
 	#generateRoute(modalRegistration: UmbModalRouteRegistration): UmbRoutePlusModalKey {
 		return {
 			__modalKey: modalRegistration.key,
+			unique: 'umbModalKey_' + modalRegistration.key,
 			path: '/' + modalRegistration.generateModalPath(),
 			component: EmptyDiv,
 			setup: async (component, info) => {
@@ -112,6 +113,7 @@ export class UmbRouteContext extends UmbContextBase<UmbRouteContext> {
 		// Add an empty route, so there is a route for the router to react on when no modals are open.
 		this.#modalRoutes.push({
 			__modalKey: '_empty_',
+			unique: 'umbEmptyModal',
 			path: '',
 			component: EmptyDiv,
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.element.ts
@@ -70,11 +70,11 @@ export class UmbWorkspaceEditorElement extends UmbLitElement {
 							(component as any).manifest = manifest;
 						}
 					},
-				} as UmbRoute;
+				};
 			});
 
 			// Duplicate first workspace and use it for the empty path scenario. [NL]
-			newRoutes.push({ ...newRoutes[0], path: '' });
+			newRoutes.push({ ...newRoutes[0], unique: newRoutes[0].path, path: '' });
 
 			newRoutes.push({
 				path: `**`,


### PR DESCRIPTION
Fixes issue from https://github.com/umbraco/Umbraco-CMS/pull/18859

that takes the user to first appearing workspace view and then never navigates when the content view appears, resulting in this:
[info-app-active.webm](https://github.com/user-attachments/assets/c6c59e0f-b294-4795-bc47-31ce12d1f9cb)
