### PR TITLE
Fixes save of empty, invariant block list on variant content

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -296,6 +296,10 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
 
         TValue? mergedBlockValue =
             MergeVariantInvariantPropertyValueTyped(source, target, canUpdateInvariantData, allowedCultures);
+        if (mergedBlockValue is null)
+        {
+            return null;
+        }
 
         return _jsonSerializer.Serialize(mergedBlockValue);
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListEditorPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListEditorPropertyValueEditorTests.cs
@@ -75,6 +75,14 @@ public class BlockListEditorPropertyValueEditorTests
         }
     }
 
+    [Test]
+    public void MergeVariantInvariantPropertyValue_Can_Merge_Null_Values()
+    {
+        var editor = CreateValueEditor();
+        var result = editor.MergeVariantInvariantPropertyValue(null, null, true, ["en-US"]);
+        Assert.IsNull(result);
+    }
+
     private static JsonObject CreateBlocksJson(int numberOfBlocks)
     {
         var layoutItems = new JsonArray();


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
This fix came from a support issue - [internal link](https://umbraco.slack.com/archives/C02JJQU9B/p1743580444937869) - which noted that with an invariant block list on variant content leads to "Published (pending changes)" being displayed on the info panel - even with no changes pending.  After a fair bit of debugging I found the problem isn't actually with the display, rather it comes from the initial save of the data, which leads to a value of `"null"` being stored as the value in `umbracoPropertyData`.

We then have a comparison of `"null"` v `null` which is detected as a change, hence the display.

It happens in the block value property editor, where we end up serializing `null` - which comes out as `"null"`.  So I've put a check in for that, so we return actual `null`, along with a unit test that previously failed verifying it.

### Testing

- Set up two languages.
- Create a document type that varies by culture and add an invariant block list property to it.
- Create an item of content based on that document type, don't set any blocks and save the default language.
- Note that before this PR is applied:
    - The info tab for the content item will show "Published (pending changes)",
    - `select * from umbracoPropertyData` will show the value `"null"` in the `textValue` column,
- Repeating with the PR applied shows:
    - The info tab for the content item will show "Published",
    - `select * from umbracoPropertyData` will show no records,

