### PR TITLE
Fixes label of enable/prevent clean up button after update

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/entity-action/rollback.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/entity-action/rollback.action.ts
@@ -11,16 +11,13 @@ export class UmbRollbackDocumentEntityAction extends UmbEntityActionBase<never> 
 		const modalManagerContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
 		const modalContext = modalManagerContext.open(this, UMB_ROLLBACK_MODAL, {});
 
-		await modalContext.onSubmit().then(
-			async () => {
-				const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-				notificationContext.peek('positive', {
-					data: { message: this.#localize.term('rollback_documentRolledBack') },
-				});
-			},
-			() => undefined,
-		);
+		const data = await modalContext.onSubmit().catch(() => undefined);
+		if (!data) return;
 
+		const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+		notificationContext.peek('positive', {
+			data: { message: this.#localize.term('rollback_documentRolledBack') },
+		});
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/entity-action/rollback.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/entity-action/rollback.action.ts
@@ -11,11 +11,16 @@ export class UmbRollbackDocumentEntityAction extends UmbEntityActionBase<never> 
 		const modalManagerContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
 		const modalContext = modalManagerContext.open(this, UMB_ROLLBACK_MODAL, {});
 
-		await modalContext.onSubmit();
-		const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-		notificationContext.peek('positive', {
-			data: { message: this.#localize.term('rollback_documentRolledBack') },
-		});
+		await modalContext.onSubmit().then(
+			async () => {
+				const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+				notificationContext.peek('positive', {
+					data: { message: this.#localize.term('rollback_documentRolledBack') },
+				});
+			},
+			() => undefined,
+		);
+
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
@@ -243,7 +243,7 @@ export class UmbRollbackModalElement extends UmbModalBaseElement<UmbRollbackModa
 		if (!version) return;
 
 		version.preventCleanup = preventCleanup;
-		this.requestUpdate('versions');
+		this.requestUpdate('_versions');
 	}
 
 	#onChangeCulture(event: UUISelectEvent) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/rollback/modal/rollback-modal.element.ts
@@ -223,6 +223,8 @@ export class UmbRollbackModalElement extends UmbModalBaseElement<UmbRollbackModa
 		const entityUpdatedEvent = new UmbEntityUpdatedEvent({ unique, entityType });
 		actionEventContext.dispatchEvent(entityUpdatedEvent);
 
+		this.value = {};
+
 		this.modalContext?.submit();
 	}
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/18945

### Description
Issue was a misnamed property in the request update after the change was triggered.

I also notice a console error in passing after cancelling the dialog, so resolved that too.

### Testing

- Make and publish a few updates for a document.
- Click through to the "Rollback" feature from the "Info" workspace view for the document.
- Click "Prevent cleanup" for one of the version and verify that the button label immediately updates.
- Cancel the dialog and verify that there's no console error.
