### PR TITLE
Added content type endpoints for setting and clearing inheritance

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/InheritDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/InheritDocumentTypeController.cs
@@ -29,7 +29,7 @@ public class InheritDocumentTypeController : DocumentTypeControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Move(
+    public async Task<IActionResult> Inherit(
         CancellationToken cancellationToken,
         Guid id,
         InheritDocumentTypeRequestModel inheritDocumentTypeRequestModel)

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/InheritDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/InheritDocumentTypeController.cs
@@ -1,0 +1,47 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+public class InheritDocumentTypeController : DocumentTypeControllerBase
+{
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public InheritDocumentTypeController(IContentTypeService contentTypeService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _contentTypeService = contentTypeService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpPut("{id:guid}/inherit")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Move(
+        CancellationToken cancellationToken,
+        Guid id,
+        InheritDocumentTypeRequestModel inheritDocumentTypeRequestModel)
+    {
+        Attempt<ContentTypeOperationStatus> result =
+            await _contentTypeService.InheritAsync(
+                id,
+                inheritDocumentTypeRequestModel.Target?.Id,
+                CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result.Success
+            ? Ok()
+            : OperationStatusResult(result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/InheritMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/InheritMediaTypeController.cs
@@ -29,7 +29,7 @@ public class InheritMediaTypeController : MediaTypeControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Move(
+    public async Task<IActionResult> Inherit(
         CancellationToken cancellationToken,
         Guid id,
         InheritMediaTypeRequestModel inheritMediaTypeRequestModel)

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/InheritMediaTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/InheritMediaTypeController.cs
@@ -1,0 +1,47 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MediaType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessMediaTypes)]
+public class InheritMediaTypeController : MediaTypeControllerBase
+{
+    private readonly IMediaTypeService _mediaTypeService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public InheritMediaTypeController(IMediaTypeService mediaTypeService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _mediaTypeService = mediaTypeService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpPut("{id:guid}/inherit")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Move(
+        CancellationToken cancellationToken,
+        Guid id,
+        InheritMediaTypeRequestModel inheritMediaTypeRequestModel)
+    {
+        Attempt<ContentTypeOperationStatus> result =
+            await _mediaTypeService.InheritAsync(
+                id,
+                inheritMediaTypeRequestModel.Target?.Id,
+                CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result.Success
+            ? Ok()
+            : OperationStatusResult(result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/InheritMemberTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/InheritMemberTypeController.cs
@@ -1,0 +1,47 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.MemberType;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessMemberTypes)]
+public class InheritMemberTypeController : MemberTypeControllerBase
+{
+    private readonly IMemberTypeService _memberTypeService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public InheritMemberTypeController(IMemberTypeService memberTypeService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _memberTypeService = memberTypeService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    [HttpPut("{id:guid}/inherit")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Move(
+        CancellationToken cancellationToken,
+        Guid id,
+        InheritMemberTypeRequestModel inheritMemberTypeRequestModel)
+    {
+        Attempt<ContentTypeOperationStatus> result =
+            await _memberTypeService.InheritAsync(
+                id,
+                inheritMemberTypeRequestModel.Target?.Id,
+                CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result.Success
+            ? Ok()
+            : OperationStatusResult(result.Result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/InheritMemberTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/InheritMemberTypeController.cs
@@ -29,7 +29,7 @@ public class InheritMemberTypeController : MemberTypeControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Move(
+    public async Task<IActionResult> Inherit(
         CancellationToken cancellationToken,
         Guid id,
         InheritMemberTypeRequestModel inheritMemberTypeRequestModel)

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -5321,6 +5321,148 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document-type/{id}/inherit": {
+      "put": {
+        "tags": [
+          "Document Type"
+        ],
+        "operationId": "PutDocumentTypeByIdInherit",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritDocumentTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/document-type/{id}/move": {
       "put": {
         "tags": [
@@ -14702,6 +14844,148 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/media-type/{id}/inherit": {
+      "put": {
+        "tags": [
+          "Media Type"
+        ],
+        "operationId": "PutMediaTypeByIdInherit",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritMediaTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritMediaTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritMediaTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/media-type/{id}/move": {
       "put": {
         "tags": [
@@ -19493,6 +19777,148 @@
                   "format": "uri"
                 }
               },
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/member-type/{id}/inherit": {
+      "put": {
+        "tags": [
+          "Member Type"
+        ],
+        "operationId": "PutMemberTypeByIdInherit",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritMemberTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritMemberTypeRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/InheritMemberTypeRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
               "Umb-Notifications": {
                 "description": "The list of notifications produced during the request.",
                 "schema": {
@@ -37996,45 +38422,6 @@
         },
         "additionalProperties": false
       },
-      "DocumentTypePropertyReferenceResponseModel": {
-        "required": [
-          "$type",
-          "documentType",
-          "id"
-        ],
-        "type": "object",
-        "properties": {
-          "$type": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "alias": {
-            "type": "string",
-            "nullable": true
-          },
-          "documentType": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TrackedReferenceDocumentTypeModel"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false,
-        "discriminator": {
-          "propertyName": "$type",
-          "mapping": {
-            "DocumentTypePropertyReferenceResponseModel": "#/components/schemas/DocumentTypePropertyReferenceResponseModel"
-          }
-        }
-      },
       "DocumentTypePropertyTypeContainerResponseModel": {
         "required": [
           "id",
@@ -38069,6 +38456,45 @@
           }
         },
         "additionalProperties": false
+      },
+      "DocumentTypePropertyTypeReferenceResponseModel": {
+        "required": [
+          "$type",
+          "documentType",
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "$type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TrackedReferenceDocumentTypeModel"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "DocumentTypePropertyTypeReferenceResponseModel": "#/components/schemas/DocumentTypePropertyTypeReferenceResponseModel"
+          }
+        }
       },
       "DocumentTypePropertyTypeResponseModel": {
         "required": [
@@ -39314,6 +39740,48 @@
         },
         "additionalProperties": false
       },
+      "InheritDocumentTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "target": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InheritMediaTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "target": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InheritMemberTypeRequestModel": {
+        "type": "object",
+        "properties": {
+          "target": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "InstallRequestModel": {
         "required": [
           "database",
@@ -40099,45 +40567,6 @@
         },
         "additionalProperties": false
       },
-      "MediaTypePropertyReferenceResponseModel": {
-        "required": [
-          "$type",
-          "id",
-          "mediaType"
-        ],
-        "type": "object",
-        "properties": {
-          "$type": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "alias": {
-            "type": "string",
-            "nullable": true
-          },
-          "mediaType": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TrackedReferenceMediaTypeModel"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false,
-        "discriminator": {
-          "propertyName": "$type",
-          "mapping": {
-            "MediaTypePropertyReferenceResponseModel": "#/components/schemas/MediaTypePropertyReferenceResponseModel"
-          }
-        }
-      },
       "MediaTypePropertyTypeContainerResponseModel": {
         "required": [
           "id",
@@ -40172,6 +40601,45 @@
           }
         },
         "additionalProperties": false
+      },
+      "MediaTypePropertyTypeReferenceResponseModel": {
+        "required": [
+          "$type",
+          "id",
+          "mediaType"
+        ],
+        "type": "object",
+        "properties": {
+          "$type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "mediaType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TrackedReferenceMediaTypeModel"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "MediaTypePropertyTypeReferenceResponseModel": "#/components/schemas/MediaTypePropertyTypeReferenceResponseModel"
+          }
+        }
       },
       "MediaTypePropertyTypeResponseModel": {
         "required": [
@@ -40916,45 +41384,6 @@
         },
         "additionalProperties": false
       },
-      "MemberTypePropertyReferenceResponseModel": {
-        "required": [
-          "$type",
-          "id",
-          "memberType"
-        ],
-        "type": "object",
-        "properties": {
-          "$type": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "name": {
-            "type": "string",
-            "nullable": true
-          },
-          "alias": {
-            "type": "string",
-            "nullable": true
-          },
-          "memberType": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/TrackedReferenceMemberTypeModel"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false,
-        "discriminator": {
-          "propertyName": "$type",
-          "mapping": {
-            "MemberTypePropertyReferenceResponseModel": "#/components/schemas/MemberTypePropertyReferenceResponseModel"
-          }
-        }
-      },
       "MemberTypePropertyTypeContainerResponseModel": {
         "required": [
           "id",
@@ -40989,6 +41418,45 @@
           }
         },
         "additionalProperties": false
+      },
+      "MemberTypePropertyTypeReferenceResponseModel": {
+        "required": [
+          "$type",
+          "id",
+          "memberType"
+        ],
+        "type": "object",
+        "properties": {
+          "$type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "memberType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TrackedReferenceMemberTypeModel"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "MemberTypePropertyTypeReferenceResponseModel": "#/components/schemas/MemberTypePropertyTypeReferenceResponseModel"
+          }
+        }
       },
       "MemberTypePropertyTypeResponseModel": {
         "required": [
@@ -42163,19 +42631,19 @@
                   "$ref": "#/components/schemas/DocumentReferenceResponseModel"
                 },
                 {
-                  "$ref": "#/components/schemas/DocumentTypePropertyReferenceResponseModel"
+                  "$ref": "#/components/schemas/DocumentTypePropertyTypeReferenceResponseModel"
                 },
                 {
                   "$ref": "#/components/schemas/MediaReferenceResponseModel"
                 },
                 {
-                  "$ref": "#/components/schemas/MediaTypePropertyReferenceResponseModel"
+                  "$ref": "#/components/schemas/MediaTypePropertyTypeReferenceResponseModel"
                 },
                 {
                   "$ref": "#/components/schemas/MemberReferenceResponseModel"
                 },
                 {
-                  "$ref": "#/components/schemas/MemberTypePropertyReferenceResponseModel"
+                  "$ref": "#/components/schemas/MemberTypePropertyTypeReferenceResponseModel"
                 }
               ]
             }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/InheritDocumentTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/InheritDocumentTypeRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+
+public class InheritDocumentTypeRequestModel
+{
+    public ReferenceByIdModel? Target { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/InheritMediaTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/InheritMediaTypeRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.MediaType;
+
+public class InheritMediaTypeRequestModel
+{
+    public ReferenceByIdModel? Target { get; set; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MemberType/InheritMemberTypeRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MemberType/InheritMemberTypeRequestModel.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.MemberType;
+
+public class InheritMemberTypeRequestModel
+{
+    public ReferenceByIdModel? Target { get; set; }
+}

--- a/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBaseOfTRepositoryTItemTService.cs
@@ -1217,6 +1217,7 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
             }
         }
 
+        // Call update to save the changes to the parent.
         return await UpdateAsync(toUpdateInheritance, performingUserKey);
     }
 

--- a/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
+++ b/src/Umbraco.Core/Services/IContentTypeServiceBase.cs
@@ -157,6 +157,16 @@ public interface IContentTypeBaseService<TItem> : IContentTypeBaseService, IServ
     Task<Attempt<TItem?, ContentTypeStructureOperationStatus>> MoveAsync(Guid key, Guid? containerKey);
 
     /// <summary>
+    /// Applies inheritance to a content type.
+    /// </summary>
+    /// <param name="key">The content type key.</param>
+    /// <param name="parentKey">The intended parent to inherit from's key, or null if inheritance is being cleared.</param>
+    /// <param name="performingUserKey">The key of the performing user.</param>
+    /// <returns>Status of operation result.</returns>
+    Task<Attempt<ContentTypeOperationStatus>> InheritAsync(Guid key, Guid? parentKey, Guid performingUserKey)
+        => throw new NotSupportedException();
+
+    /// <summary>
     /// Returns all the content type allowed as root.
     /// </summary>
     Task<PagedModel<TItem>> GetAllAllowedAsRootAsync(int skip, int take);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Handles work item [50400 ](https://dev.azure.com/umbraco/D-Team%20Tracker/_workitems/edit/50400) (internal link).

### Description
This PR adds management API endpoints for setting and clearing inheritance relationships between document types.

The request model follows a similar one used for "Move" (as that's really what we are doing - moving the content type to another as it's parent).  Providing a reference to a content type sets the inheritance, providing null clears it and moves the content type to it's nearest container or the root.

### Testing

To test you can verify and run the provided integration tests and experiment with the new endpoints at:

```
PUT /umbraco/management/api/v1/document-type/{id}/inherit
PUT /umbraco/management/api/v1/media-type/{id}/inherit
PUT /umbraco/management/api/v1/member-type/{id}/inherit
```

That take a payload of the following to set an inheritance relationship:

```
{
  "target": {
    "id": "{parent-id}"
  }
}
```

And this to clear it:

```
{
  "target": null
}
```

### Further UI Work Needed

Although this sets the relationships correctly some more work is needed to display the relationship in the UI.

- The member type tree doesn't support children (for document and media types the parent/child relationship for inheritance is shown).
- There is no information of the inheritance displayed in the content type workspace (i.e. no greyed out properties that inherit from the parent are shown). 

