### PR TITLE
V16: Remove circular dependency for icon-picker-modal

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -52,7 +52,7 @@ if (circular.length) {
 	*/
 
 	// TODO: Remove this check and set an exit with argument 1 when we have fixed all circular dependencies.
-	const MAX_CIRCULAR_DEPENDENCIES = 7;
+	const MAX_CIRCULAR_DEPENDENCIES = 6;
 	if (circular.length > MAX_CIRCULAR_DEPENDENCIES) {
 		process.exit(1);
 	} else if (circular.length < MAX_CIRCULAR_DEPENDENCIES) {

--- a/src/Umbraco.Web.UI.Client/devops/circular/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/circular/index.js
@@ -52,7 +52,12 @@ if (circular.length) {
 	*/
 
 	// TODO: Remove this check and set an exit with argument 1 when we have fixed all circular dependencies.
-	if (circular.length > 7) {
+	const MAX_CIRCULAR_DEPENDENCIES = 7;
+	if (circular.length > MAX_CIRCULAR_DEPENDENCIES) {
+		process.exit(1);
+	} else if (circular.length < MAX_CIRCULAR_DEPENDENCIES) {
+		console.error(`\nYou have fewer circular dependencies (${circular.length}) than anticipated (${MAX_CIRCULAR_DEPENDENCIES}). That is great!\n`);
+		console.error(`(Now please adjust the number in MAX_CIRCULAR_DEPENDENCIES to ${circular.length} in devops/circular/index.js).\n`);
 		process.exit(1);
 	} else {
 		process.exit(0);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icon-picker-modal/icon-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icon-picker-modal/icon-picker-modal.element.ts
@@ -1,10 +1,11 @@
+import { UMB_ICON_REGISTRY_CONTEXT } from '../icon-registry.context-token.js';
+import type { UmbIconDefinition } from '../types.js';
 import type { UmbIconPickerModalData, UmbIconPickerModalValue } from './icon-picker-modal.token.js';
 import { css, customElement, html, nothing, query, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { extractUmbColorVariable, umbracoColors } from '@umbraco-cms/backoffice/resources';
 import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UMB_ICON_REGISTRY_CONTEXT, type UmbIconDefinition } from '@umbraco-cms/backoffice/icon';
 import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-icon-picker-modal')


### PR DESCRIPTION
This pull request includes changes to improve the handling of circular dependencies and to correct import statements in the icon picker modal element.

Improvements to circular dependency handling:

* [`src/Umbraco.Web.UI.Client/devops/circular/index.js`](diffhunk://#diff-f88d4fba2df8b9c7edc7c1b10e590d32e1ade66d384dbd66cc1f09b633e559a9L55-R60): Introduced a constant `MAX_CIRCULAR_DEPENDENCIES` to limit the number of circular dependencies and added logging to inform the user when the number of circular dependencies is below the threshold.

Corrections to import statements:

* [`src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icon-picker-modal/icon-picker-modal.element.ts`](diffhunk://#diff-79cd0f1d64b23a081cd5861392218d06af8c6c844365a350e5fd2f591f31425eR1-L7): Corrected the import statements by importing `UMB_ICON_REGISTRY_CONTEXT` and `UmbIconDefinition` from their respective files instead of the incorrect path.