### PR TITLE
Use GetIdsFromPathReversed to avoid allocating the string values of the integers parsed

### DIFF
--- a/src/Umbraco.Core/Services/PublicAccessService.cs
+++ b/src/Umbraco.Core/Services/PublicAccessService.cs
@@ -1,5 +1,3 @@
-using System.Globalization;
-using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -88,19 +86,14 @@ internal sealed class PublicAccessService : RepositoryService, IPublicAccessServ
     {
         // Get all ids in the path for the content item and ensure they all
         // parse to ints that are not -1.
-        var ids = contentPath.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries)
-            .Select(x => int.TryParse(x, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : -1)
-            .Where(x => x != -1)
-            .ToList();
-
-        // start with the deepest id
-        ids.Reverse();
+        // Start with the deepest id.
+        IEnumerable<int> ids = contentPath.GetIdsFromPathReversed().Where(x => x != -1);
 
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             // This will retrieve from cache!
             var entries = _publicAccessRepository.GetMany().ToList();
-            foreach (var id in CollectionsMarshal.AsSpan(ids))
+            foreach (var id in ids)
             {
                 PublicAccessEntry? found = entries.Find(x => x.ProtectedNodeId == id);
                 if (found != null)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
This will avoid allocating strings when parsing the integers, using improvements in #18199 
Also reducing nearly duplicated code