### PR TITLE
Allow save of empty translations for dictionary items

### DIFF
--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -37181,7 +37181,6 @@
             "type": "string"
           },
           "translation": {
-            "minLength": 1,
             "type": "string"
           }
         },

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/DictionaryItemTranslationModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Dictionary/DictionaryItemTranslationModel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Dictionary;
 
@@ -7,6 +7,5 @@ public class DictionaryItemTranslationModel
     [Required]
     public string IsoCode { get; set; } = string.Empty;
 
-    [Required]
     public string Translation { get; set; } = string.Empty;
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/18970

### Description
As the linked issue shows, you can't remove a specific language translation for a dictionary item, but the backoffice does allow you to create one with not all languages completed.

The reason this works as it does currently is that the backoffice will only send populated translations on create, but on update it sends all.  And in the latter case, we have a `[Required]` attribute which prevents the incoming model from being considered valid.

It's possible to argue that the API is correct and the UI is inconsistent.  But even if on update we only send populated languages, the API endpoint wouldn't remove any not provided (and it's arguably correct that it doesn't).  So given the dictionary entry is updated as one item - the key, along with all the language translations, I think it's consistent that we just accept empty strings as valid translations.  Hence to resolve I've just removed the `[Required]` attribute.

### Testing

Try creating and updating dictionary items with some or all languages populated.  Empty entries for translations for specific languages should be accepted.
