### PR TITLE
V16: Installer does not proceed from last step

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
@@ -10,7 +10,7 @@ import type {
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { InstallService } from '@umbraco-cms/backoffice/external/backend-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { tryExecute, UmbApiError, type UmbProblemDetails } from '@umbraco-cms/backoffice/resources';
+import { tryExecute, UmbApiError } from '@umbraco-cms/backoffice/resources';
 
 @customElement('umb-installer-database')
 export class UmbInstallerDatabaseElement extends UmbLitElement {
@@ -196,28 +196,8 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 
 		this._installerContext.nextStep();
 
-		const { error } = await tryExecute(
-			this,
-			InstallService.postInstallSetup({ requestBody: this._installerContext.getData() }),
-			{ disableNotifications: true },
-		);
-		if (error) {
-			if (UmbApiError.isUmbApiError(error)) this._handleRejected(error.problemDetails);
-		} else {
-			this._handleFulfilled();
-		}
+		this._installerContext.postInstallSetup();
 	};
-
-	private _handleFulfilled() {
-		// TODO: The post install will probably return a user in the future, so we have to set that context somewhere to let the client know that it is authenticated
-		console.warn('TODO: Set up real authentication');
-		sessionStorage.setItem('is-authenticated', 'true');
-		history.replaceState(null, '', 'section/content');
-	}
-
-	private _handleRejected(e: UmbProblemDetails) {
-		this._installerContext?.setInstallStatus(e);
-	}
 
 	private _onBack() {
 		this._installerContext?.prevStep();

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/installer.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/installer.context.ts
@@ -112,7 +112,6 @@ export class UmbInstallerContext extends UmbContextBase<UmbInstallerContext, typ
 		}
 
 		// TODO: The post install will probably return a user in the future, so we have to set that context somewhere to let the client know that it is authenticated
-		console.warn('TODO: Set up real authentication');
 		history.replaceState(null, '', 'section/content');
 
 		return true;

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/installer.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/installer.context.ts
@@ -84,7 +84,7 @@ export class UmbInstallerContext extends UmbContextBase<UmbInstallerContext, typ
 	/**
 	 * Set the data for the installation process
 	 * @public
-	 * @param {Partial<PostInstallRequest>} data
+	 * @param {Partial<InstallRequestModel>} data The data to set
 	 * @memberof UmbInstallerContext
 	 */
 	public appendData(data: Partial<InstallRequestModel>): void {
@@ -99,6 +99,23 @@ export class UmbInstallerContext extends UmbContextBase<UmbInstallerContext, typ
 	 */
 	public getData(): InstallRequestModel {
 		return this._data.getValue();
+	}
+
+	public async postInstallSetup(): Promise<boolean> {
+		const { error } = await tryExecute(this, InstallService.postInstallSetup({ requestBody: this.getData() }), {
+			disableNotifications: true,
+		});
+		if (error) {
+			if (UmbApiError.isUmbApiError(error)) this.setInstallStatus(error.problemDetails);
+			else this.setInstallStatus({ title: 'Unknown error', detail: error.message, status: 500, type: 'error' });
+			return false;
+		}
+
+		// TODO: The post install will probably return a user in the future, so we have to set that context somewhere to let the client know that it is authenticated
+		console.warn('TODO: Set up real authentication');
+		history.replaceState(null, '', 'section/content');
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Description

Moves logic from installation step to context in order not to destroy the host for the request.

The request is cancelled because the host is destroyed, which now happens because the UmbResourceController actually works again and calls its cancel() mechanism when a host goes away.