### PR TITLE
Make it possible to disable Examine indexes by composition

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOffice.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/UmbracoBuilder.BackOffice.cs
@@ -35,9 +35,7 @@ public static partial class UmbracoBuilderExtensions
         .AddRecurringBackgroundJobs()
         .AddUmbracoHybridCache()
         .AddDistributedCache()
-        .AddCoreNotifications()
-        .AddExamine()
-        .AddExamineIndexes();
+        .AddCoreNotifications();
 
     public static IUmbracoBuilder AddBackOfficeCore(this IUmbracoBuilder builder)
     {

--- a/src/Umbraco.Examine.Lucene/AddExamineComposer.cs
+++ b/src/Umbraco.Examine.Lucene/AddExamineComposer.cs
@@ -1,0 +1,14 @@
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Examine.DependencyInjection;
+
+namespace Umbraco.Cms.Infrastructure.Examine;
+
+public sealed class AddExamineComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder
+            .AddExamine()
+            .AddExamineIndexes();
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -186,7 +186,8 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddTransient<IUserInviteSender, EmailUserInviteSender>();
         builder.Services.AddTransient<IUserForgotPasswordSender, EmailUserForgotPasswordSender>();
 
-        builder.Services.AddSingleton<IExamineManager, ExamineManager>();
+        builder.Services.AddSingleton<IExamineManager, NoopExamineManager>();
+        builder.Services.AddSingleton<IIndexRebuilder, NoopIndexRebuilder>();
 
         builder.Services.AddScoped<ITagQuery, TagQuery>();
 

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Examine.cs
@@ -1,3 +1,4 @@
+using Examine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.DeliveryApi;
@@ -21,6 +22,8 @@ public static partial class UmbracoBuilderExtensions
 {
     public static IUmbracoBuilder AddExamine(this IUmbracoBuilder builder)
     {
+        builder.Services.AddUnique<IExamineManager, ExamineManager>();
+
         // populators are not a collection: one cannot remove ours, and can only add more
         // the container can inject IEnumerable<IIndexPopulator> and get them all
         builder.Services.AddSingleton<IIndexPopulator, MemberIndexPopulator>();

--- a/src/Umbraco.Infrastructure/Examine/NoopExamineManager.cs
+++ b/src/Umbraco.Infrastructure/Examine/NoopExamineManager.cs
@@ -1,0 +1,24 @@
+using Examine;
+
+namespace Umbraco.Cms.Infrastructure.Examine;
+
+internal sealed class NoopExamineManager : IExamineManager
+{
+    public void Dispose() {}
+
+    public bool TryGetIndex(string indexName, out IIndex index)
+    {
+        index = null!;
+        return false;
+    }
+
+    public bool TryGetSearcher(string searcherName, out ISearcher searcher)
+    {
+        searcher = null!;
+        return false;
+    }
+
+    public IEnumerable<IIndex> Indexes => Array.Empty<IIndex>();
+
+    public IEnumerable<ISearcher> RegisteredSearchers => Array.Empty<ISearcher>();
+}

--- a/src/Umbraco.Infrastructure/Examine/NoopIndexRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/NoopIndexRebuilder.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Cms.Infrastructure.Examine;
+
+internal sealed class NoopIndexRebuilder : IIndexRebuilder
+{
+    public bool CanRebuild(string indexName) => false;
+
+    public void RebuildIndex(string indexName, TimeSpan? delay = null, bool useBackgroundThread = true) {}
+
+    public void RebuildIndexes(bool onlyEmptyIndexes, TimeSpan? delay = null, bool useBackgroundThread = true) {}
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The upcoming search abstraction layer will need to work as an add-on to V16. For this to happen, we need to be able to disable the current Examine indexes, to let the search abstraction take over.

This PR moves the Examine DI setup to a composer, because composers can be omitted by code 😄 

### Testing this PR

First and foremost, make sure Examine still works as per usual - that is, indexing and search still works.

Now add a new composer which disables the `AddExamineComposer` of this PR. Something along these lines:

```cs
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Infrastructure.Examine;

namespace Umbraco.Cms.Web.UI.Custom.Search;

[Disable(typeof(AddExamineComposer))]
public class DisableExamineComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
    }
}
```

Restart Umbraco. The Examine indexes should no longer appear in the Examine Management dashboard.