### PR TITLE
set ESLint working directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "unprovide"
     ],
     "eslint.workingDirectories": [
-    "./src/Umbraco.Web.UI.Client/"
+    "./src/Umbraco.Web.UI.Client/",
+    "./src/Umbraco.Web.UI.Login/"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "cSpell.words": [
         "unprovide"
-    ]
+    ],
+    "eslint.workingDirectories": [
+    "./src/Umbraco.Web.UI.Client/"
+  ]
 }


### PR DESCRIPTION
Makes ESLint able to work despite opening the whole repository in VSCode.