### PR TITLE
hotfix: Make sure only to prepend relative URLs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-field.element.ts
@@ -78,7 +78,12 @@ export class UmbInputImageCropperFieldElement extends UmbLitElement {
 
 	get source(): string {
 		if (this.src) {
-			return `${this._serverUrl}${this.src}`;
+			// Test that URL is relative:
+			if (this.src.startsWith('/')) {
+				return `${this._serverUrl}${this.src}`;
+			} else {
+				return this.src;
+			}
 		}
 
 		return this.fileDataUrl ?? '';


### PR DESCRIPTION
Fixes problem with Media Picker using Image Cropper.
Where image source gets double host prepended.