### PR TITLE
Fix: append to frozen object fix for RTE Base

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -53,7 +53,11 @@ export abstract class UmbPropertyEditorUiRteElementBase
 
 		const buildUpValue: Partial<UmbPropertyEditorRteValueType> = value ? { ...value } : {};
 		buildUpValue.markup ??= '';
-		buildUpValue.blocks ??= { layout: {}, contentData: [], settingsData: [], expose: [] };
+		if (buildUpValue.blocks) {
+			buildUpValue.blocks = { ...buildUpValue.blocks };
+		} else {
+			buildUpValue.blocks ??= { layout: {}, contentData: [], settingsData: [], expose: [] };
+		}
 		buildUpValue.blocks.layout ??= {};
 		buildUpValue.blocks.contentData ??= [];
 		buildUpValue.blocks.settingsData ??= [];


### PR DESCRIPTION
Fixing when appending the layout or other missing properties to ´blocks´ that already is existing and therefor frozen.
So by expanding existing Blocks property it is unfrozen and can have properties appended.