### PR TITLE
Make sure not to early return when verifying ancestor path is published without completing scope

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -115,12 +115,9 @@ internal sealed class DocumentCacheService : IDocumentCacheService
                 // When unpublishing a node, a payload with RefreshBranch is published, so we don't have to worry about this.
                 // Similarly, when a branch is published, next time the content is requested, the parent will be published,
                 // this works because we don't cache null values.
-                if (preview is false && contentCacheNode is not null)
+                if (preview is false && contentCacheNode is not null && HasPublishedAncestorPath(contentCacheNode.Key) is false)
                 {
-                    if (HasPublishedAncestorPath(contentCacheNode.Key) is false)
-                    {
-                        return null;
-                    }
+                    contentCacheNode = null;
                 }
 
                 scope.Complete();

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -117,6 +117,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
                 // this works because we don't cache null values.
                 if (preview is false && contentCacheNode is not null && HasPublishedAncestorPath(contentCacheNode.Key) is false)
                 {
+                    // Careful not to early return here. We need to complete the scope even if returning null.
                     contentCacheNode = null;
                 }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/18973

### Description
This was most of a day of debugging to end up with a tiny change!  The issue manifests itself when you try to publish a parent node that has an unpublished child and a published grandchild, i.e.

![Image](https://github.com/user-attachments/assets/f874fb8a-90e6-42a6-9718-0e24650bc155)

The publish would appear to succeed from the API and UI perspective, but if you check the database, the published page or the history, you can see it hasn't actually published.

When debugging I could see all the expected database updates were made, but they weren't being persisted.

After a bit of trial and error I found the cause to be in the redirect tracker, which is triggered on a `ContentPublishingNotification`.  This makes a call to `DescendantsOrSelf` which eventually gets to the method I've amended.  At this point we have retrieved a content item from the cache - the grandchild - but need to consider it unpublished and not in the list of descendants due to it's parent being unpublished.

We have this check - and an integration test for it - but there was an early return which meant the scope wasn't completed.  Not quite sure on the details after this, but it looks to mean the outer scope was also not completed in order to persist the changes.

### Testing

To test, set up a structure as shown above and verify that before the PR you wouldn't be able to publish the root node, but with the changes applied, you can.

I have considered an integration test to specifically verify this fix, but it doesn't feel that the effort is worthwhile.  It would likely have to be on `DescendantsOrSelf` itself, and we don't currently have tests for these extensions.  As noted, we do already have a test for the specific behaviour, but it didn't show the issue dealt with here due to not being within a nested scope.

### Release

Should consider for cherry-pick into the 15.4 release branch.
