### PR TITLE
Dynamic Root: Refactored to use `UmbAncestorsEntityContext`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/dynamic-root/repository/dynamic-root.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/dynamic-root/repository/dynamic-root.repository.ts
@@ -28,10 +28,10 @@ export class UmbContentPickerDynamicRootRepository extends UmbControllerBase {
 	 * @returns {*}
 	 * @memberof UmbContentPickerDynamicRootRepository
 	 */
-	async requestRoot(query: UmbContentPickerDynamicRoot, entityUnique: string, parentUnique?: string) {
+	async requestRoot(query: UmbContentPickerDynamicRoot, entityUnique: string | null, parentUnique?: string | null) {
 		const model: DynamicRootRequestModel = {
 			context: {
-				id: entityUnique,
+				id: entityUnique ?? null,
 				parent: { id: parentUnique ?? GUID_EMPTY },
 			},
 			query: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/property-editor-ui-content-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/property-editor-ui-content-picker.element.ts
@@ -6,6 +6,7 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UMB_ANCESTORS_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
 import { UMB_DOCUMENT_ENTITY_TYPE } from '@umbraco-cms/backoffice/document';
 import { UMB_MEDIA_ENTITY_TYPE } from '@umbraco-cms/backoffice/media';
 import { UMB_MEMBER_ENTITY_TYPE } from '@umbraco-cms/backoffice/member';
@@ -139,11 +140,9 @@ export class UmbPropertyEditorUIContentPickerElement
 		if (this._rootUnique) return;
 		if (!this.#dynamicRoot) return;
 
-		const menuStructureWorkspaceContext = (await this.getContext('UmbMenuStructureWorkspaceContext')) as any;
-		const structure = (await this.observe(menuStructureWorkspaceContext.structure, () => {})?.asPromise()) as any[];
-		const [parentUnique, unique] = structure?.slice(-2).map((x) => x.unique) ?? [];
-
-		if (!unique) return;
+		const ancestorsContext = await this.getContext(UMB_ANCESTORS_ENTITY_CONTEXT);
+		const ancestors = ancestorsContext?.getAncestors();
+		const [parentUnique, unique] = ancestors?.slice(-2).map((x) => x.unique) ?? [];
 
 		const result = await this.#dynamicRootRepository.requestRoot(this.#dynamicRoot, unique, parentUnique);
 		if (result && result.length > 0) {


### PR DESCRIPTION
### Description

Whilst investigating issue #18768 (_Content Picker's Dynamic Root on new documents_), I found that PR #18935 introduced the `UmbAncestorsEntityContext`.

For the Content Picker property-editor, we were using `UmbMenuStructureWorkspaceContext` to get the unique IDs for the current and parent documents, (at the time of development, there was no other approach). I've refactored the code to use `UmbAncestorsEntityContext` instead, making the intention of the code clearer.

### How to test?

Initial test is to check if a Content Picker property-editor that is configured to use Dynamic Root still works.

For a more comprehensive test, try the bug reproduction steps outlined in issue #18768.