### PR TITLE
Added custom RichTextRegexValidator to validate markup instead of JSON

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/Validators/RegexValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validators/RegexValidator.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.Validators;
 /// <summary>
 ///     A validator that validates that the value against a regular expression.
 /// </summary>
-public sealed class RegexValidator : IValueFormatValidator, IManifestValueValidator
+public class RegexValidator : IValueFormatValidator, IManifestValueValidator
 {
     private const string ValueIsInvalid = "Value is invalid, it does not match the correct pattern";
     private readonly ILocalizedTextService _textService;
@@ -83,7 +83,7 @@ public sealed class RegexValidator : IValueFormatValidator, IManifestValueValida
     }
 
     /// <inheritdoc cref="IValueFormatValidator.ValidateFormat" />
-    public IEnumerable<ValidationResult> ValidateFormat(object? value, string? valueType, string format)
+    public virtual IEnumerable<ValidationResult> ValidateFormat(object? value, string? valueType, string format)
     {
         if (format == null)
         {

--- a/src/Umbraco.Core/PropertyEditors/Validators/RegexValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validators/RegexValidator.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.PropertyEditors.Validators;
 /// <summary>
 ///     A validator that validates that the value against a regular expression.
 /// </summary>
-public class RegexValidator : IValueFormatValidator, IManifestValueValidator
+public sealed class RegexValidator : IValueFormatValidator, IManifestValueValidator
 {
     private const string ValueIsInvalid = "Value is invalid, it does not match the correct pattern";
     private readonly ILocalizedTextService _textService;
@@ -83,7 +83,7 @@ public class RegexValidator : IValueFormatValidator, IManifestValueValidator
     }
 
     /// <inheritdoc cref="IValueFormatValidator.ValidateFormat" />
-    public virtual IEnumerable<ValidationResult> ValidateFormat(object? value, string? valueType, string format)
+    public IEnumerable<ValidationResult> ValidateFormat(object? value, string? valueType, string format)
     {
         if (format == null)
         {

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -240,6 +240,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IBlockEditorElementTypeCache, BlockEditorElementTypeCache>();
 
         builder.Services.AddSingleton<IRichTextRequiredValidator, RichTextRequiredValidator>();
+        builder.Services.AddSingleton<IRichTextRegexValidator, RichTextRegexValidator>();
 
         return builder;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -176,6 +176,7 @@ public class RichTextPropertyEditor : DataEditor
         private readonly IJsonSerializer _jsonSerializer;
         private readonly IBlockEditorElementTypeCache _elementTypeCache;
         private readonly IRichTextRequiredValidator _richTextRequiredValidator;
+        private readonly IRichTextRegexValidator _richTextRegexValidator;
         private readonly ILogger<RichTextPropertyValueEditor> _logger;
 
         [Obsolete("Use non-obsolete constructor. This is schedules for removal in v16.")]
@@ -215,7 +216,8 @@ public class RichTextPropertyEditor : DataEditor
                 elementTypeCache,
                 propertyValidationService,
                 dataValueReferenceFactoryCollection,
-                StaticServiceProvider.Instance.GetRequiredService<IRichTextRequiredValidator>())
+                StaticServiceProvider.Instance.GetRequiredService<IRichTextRequiredValidator>(),
+                StaticServiceProvider.Instance.GetRequiredService<IRichTextRegexValidator>())
         {
 
         }
@@ -237,7 +239,8 @@ public class RichTextPropertyEditor : DataEditor
             IBlockEditorElementTypeCache elementTypeCache,
             IPropertyValidationService propertyValidationService,
             DataValueReferenceFactoryCollection dataValueReferenceFactoryCollection,
-            IRichTextRequiredValidator richTextRequiredValidator)
+            IRichTextRequiredValidator richTextRequiredValidator,
+            IRichTextRegexValidator richTextRegexValidator)
             : base(attribute, propertyEditors, dataTypeReadCache, localizedTextService, logger, shortStringHelper, jsonSerializer, ioHelper, dataValueReferenceFactoryCollection)
         {
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
@@ -249,6 +252,7 @@ public class RichTextPropertyEditor : DataEditor
             _macroParameterParser = macroParameterParser;
             _elementTypeCache = elementTypeCache;
             _richTextRequiredValidator = richTextRequiredValidator;
+            _richTextRegexValidator = richTextRegexValidator;
             _jsonSerializer = jsonSerializer;
             _logger = logger;
 
@@ -256,6 +260,8 @@ public class RichTextPropertyEditor : DataEditor
         }
 
         public override IValueRequiredValidator RequiredValidator => _richTextRequiredValidator;
+
+        public override IValueFormatValidator FormatValidator => _richTextRegexValidator;
 
         /// <inheritdoc />
         public override object? Configuration

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -219,8 +219,50 @@ public class RichTextPropertyEditor : DataEditor
                 StaticServiceProvider.Instance.GetRequiredService<IRichTextRequiredValidator>(),
                 StaticServiceProvider.Instance.GetRequiredService<IRichTextRegexValidator>())
         {
-
         }
+
+        public RichTextPropertyValueEditor(
+            DataEditorAttribute attribute,
+            PropertyEditorCollection propertyEditors,
+            IDataTypeConfigurationCache dataTypeReadCache,
+            ILogger<RichTextPropertyValueEditor> logger,
+            IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+            ILocalizedTextService localizedTextService,
+            IShortStringHelper shortStringHelper,
+            HtmlImageSourceParser imageSourceParser,
+            HtmlLocalLinkParser localLinkParser,
+            RichTextEditorPastedImages pastedImages,
+            IJsonSerializer jsonSerializer,
+            IIOHelper ioHelper,
+            IHtmlSanitizer htmlSanitizer,
+            IHtmlMacroParameterParser macroParameterParser,
+            IBlockEditorElementTypeCache elementTypeCache,
+            IPropertyValidationService propertyValidationService,
+            DataValueReferenceFactoryCollection dataValueReferenceFactoryCollection,
+            IRichTextRequiredValidator richTextRequiredValidator)
+            : this(
+                attribute,
+                propertyEditors,
+                dataTypeReadCache,
+                logger,
+                backOfficeSecurityAccessor,
+                localizedTextService,
+                shortStringHelper,
+                imageSourceParser,
+                localLinkParser,
+                pastedImages,
+                jsonSerializer,
+                ioHelper,
+                htmlSanitizer,
+                macroParameterParser,
+                elementTypeCache,
+                propertyValidationService,
+                dataValueReferenceFactoryCollection,
+                richTextRequiredValidator,
+                StaticServiceProvider.Instance.GetRequiredService<IRichTextRegexValidator>())
+            {
+            }
+
         public RichTextPropertyValueEditor(
             DataEditorAttribute attribute,
             PropertyEditorCollection propertyEditors,

--- a/src/Umbraco.Infrastructure/PropertyEditors/Validators/IRichTextRegexValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/Validators/IRichTextRegexValidator.cs
@@ -1,0 +1,5 @@
+namespace Umbraco.Cms.Core.PropertyEditors.Validators;
+
+internal interface IRichTextRegexValidator : IValueFormatValidator
+{
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRegexValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRegexValidator.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.PropertyEditors.Validators;
+
+internal class RichTextRegexValidator : RegexValidator, IRichTextRegexValidator
+{
+    private readonly IJsonSerializer _jsonSerializer;
+    private readonly ILogger<RichTextRegexValidator> _logger;
+
+    public RichTextRegexValidator(ILocalizedTextService textService, IJsonSerializer jsonSerializer, ILogger<RichTextRegexValidator> logger)
+        : this(textService, string.Empty, jsonSerializer, logger)
+    {
+    }
+
+    public RichTextRegexValidator(ILocalizedTextService textService, string regex, IJsonSerializer jsonSerializer, ILogger<RichTextRegexValidator> logger) : base(textService, regex)
+    {
+        _jsonSerializer = jsonSerializer;
+        _logger = logger;
+    }
+
+    public override IEnumerable<ValidationResult> ValidateFormat(object? value, string? valueType, string format) => base.ValidateFormat(GetValue(value), valueType, format);
+
+    private object? GetValue(object? value)
+    {
+        if (RichTextPropertyEditorHelper.TryParseRichTextEditorValue(value, _jsonSerializer, _logger, out RichTextEditorValue? richTextEditorValue))
+        {
+            return richTextEditorValue?.Markup;
+        }
+
+        return value;
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRegexValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRegexValidator.cs
@@ -5,31 +5,26 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Core.PropertyEditors.Validators;
 
-internal class RichTextRegexValidator : RegexValidator, IRichTextRegexValidator
+internal class RichTextRegexValidator : IRichTextRegexValidator
 {
+    private readonly RegexValidator _regexValidator;
     private readonly IJsonSerializer _jsonSerializer;
     private readonly ILogger<RichTextRegexValidator> _logger;
 
-    public RichTextRegexValidator(ILocalizedTextService textService, IJsonSerializer jsonSerializer, ILogger<RichTextRegexValidator> logger)
-        : this(textService, string.Empty, jsonSerializer, logger)
-    {
-    }
-
-    public RichTextRegexValidator(ILocalizedTextService textService, string regex, IJsonSerializer jsonSerializer, ILogger<RichTextRegexValidator> logger) : base(textService, regex)
+    public RichTextRegexValidator(
+        IJsonSerializer jsonSerializer,
+        ILogger<RichTextRegexValidator> logger,
+        RegexValidator regexValidator)
     {
         _jsonSerializer = jsonSerializer;
         _logger = logger;
+        _regexValidator = regexValidator;
     }
 
-    public override IEnumerable<ValidationResult> ValidateFormat(object? value, string? valueType, string format) => base.ValidateFormat(GetValue(value), valueType, format);
+    public IEnumerable<ValidationResult> ValidateFormat(object? value, string? valueType, string format) => _regexValidator.ValidateFormat(GetValue(value), valueType, format);
 
-    private object? GetValue(object? value)
-    {
-        if (RichTextPropertyEditorHelper.TryParseRichTextEditorValue(value, _jsonSerializer, _logger, out RichTextEditorValue? richTextEditorValue))
-        {
-            return richTextEditorValue?.Markup;
-        }
-
-        return value;
-    }
+    private object? GetValue(object? value) =>
+        RichTextPropertyEditorHelper.TryParseRichTextEditorValue(value, _jsonSerializer, _logger, out RichTextEditorValue? richTextEditorValue)
+            ? richTextEditorValue?.Markup
+            : value;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/19044

### Description
I've taken inspiration from a previous change where a custom required validator was added for RTE fields: https://github.com/umbraco/Umbraco-CMS/pull/16962

In the same style I added `RichTextRegexValidator` which inherits the default `RegexValidator` and ensures that it gets the RTE's Markup value before passing it to the base `ValidateFormat` method.

In the `RichTextPropertyEditor` class I have overridden the default `FormatValidator` with the new custom one.

To test this, please follow the same reproduction steps as mentioned in the issue and confirm that the node containing the RTE with a custom regular expression now can be saved & published successfully.

![image](https://github.com/user-attachments/assets/9fc4c01c-cb7b-4704-bba0-92d7093e8767)



---
_This item has been added to our backlog AB#52413_