### PR TITLE
Transparent Focal Point

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
@@ -304,7 +304,6 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 			border: solid 2px white;
 			border-radius: 50%;
 			pointer-events: none;
-			background-color: var(--uui-palette-white);
 			transition: 150ms transform;
 			box-sizing: inherit;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
@@ -298,11 +298,13 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 			width: calc(2 * var(--dot-radius));
 			height: calc(2 * var(--dot-radius));
 			top: 0;
-			box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+			box-shadow:
+				rgba(0, 0, 0, 0.25) 0px 0px 0px 1px,
+				inset rgba(0, 0, 0, 0.25) 0px 0px 0px 1px;
 			border: solid 2px white;
 			border-radius: 50%;
 			pointer-events: none;
-			background-color: var(--uui-palette-spanish-pink-light);
+			background-color: var(---uui-palette-white);
 			transition: 150ms transform;
 			box-sizing: inherit;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/image-cropper-focus-setter.element.ts
@@ -304,7 +304,7 @@ export class UmbImageCropperFocusSetterElement extends UmbLitElement {
 			border: solid 2px white;
 			border-radius: 50%;
 			pointer-events: none;
-			background-color: var(---uui-palette-white);
+			background-color: var(--uui-palette-white);
 			transition: 150ms transform;
 			box-sizing: inherit;
 		}


### PR DESCRIPTION
The focal point should not be pink. As the pink color is for the active location.

We could have used our blue selection color. But to have the highest contrast between the outer and inner borders, then black and white works best:

![image](https://github.com/user-attachments/assets/16fe27e7-018b-4b54-a4bb-725d6aeb7331)
![image](https://github.com/user-attachments/assets/b6ddce00-82b0-4f89-add2-d3b5faa86993)
![image](https://github.com/user-attachments/assets/a7380d7c-abf6-4d77-b524-47fc2a59ebe9)
