### PR TITLE
Make the entity search service async

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -24,7 +24,7 @@ public class SearchDocumentItemController : DocumentItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
-    public Task<IActionResult> SearchWithTrashed(
+    public async Task<IActionResult> SearchWithTrashed(
         CancellationToken cancellationToken,
         string query,
         bool? trashed = null,
@@ -33,13 +33,13 @@ public class SearchDocumentItemController : DocumentItemControllerBase
         Guid? parentId = null,
         [FromQuery] IEnumerable<Guid>? allowedDocumentTypes = null)
     {
-        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Document, query, parentId, allowedDocumentTypes, trashed, skip, take);
+        PagedModel<IEntitySlim> searchResult = await _indexedEntitySearchService.SearchAsync(UmbracoObjectTypes.Document, query, parentId, allowedDocumentTypes, trashed, skip, take);
         var result = new PagedModel<DocumentItemResponseModel>
         {
             Items = searchResult.Items.OfType<IDocumentEntitySlim>().Select(_documentPresentationFactory.CreateItemResponseModel),
             Total = searchResult.Total,
         };
 
-        return Task.FromResult<IActionResult>(Ok(result));
+        return Ok(result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -29,15 +29,15 @@ public class SearchMediaItemController : MediaItemControllerBase
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
-    public Task<IActionResult> SearchFromParentWithAllowedTypes(CancellationToken cancellationToken, string query, bool? trashed = null, int skip = 0, int take = 100, Guid? parentId = null, [FromQuery]IEnumerable<Guid>? allowedMediaTypes = null)
+    public async Task<IActionResult> SearchFromParentWithAllowedTypes(CancellationToken cancellationToken, string query, bool? trashed = null, int skip = 0, int take = 100, Guid? parentId = null, [FromQuery]IEnumerable<Guid>? allowedMediaTypes = null)
     {
-        PagedModel<IEntitySlim> searchResult = _indexedEntitySearchService.Search(UmbracoObjectTypes.Media, query, parentId, allowedMediaTypes, trashed, skip, take);
+        PagedModel<IEntitySlim> searchResult = await _indexedEntitySearchService.SearchAsync(UmbracoObjectTypes.Media, query, parentId, allowedMediaTypes, trashed, skip, take);
         var result = new PagedModel<MediaItemResponseModel>
         {
             Items = searchResult.Items.OfType<IMediaEntitySlim>().Select(_mediaPresentationFactory.CreateItemResponseModel),
             Total = searchResult.Total,
         };
 
-        return Task.FromResult<IActionResult>(Ok(result));
+        return Ok(result);
     }
 }

--- a/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
@@ -25,6 +25,7 @@ public interface IIndexedEntitySearchService
         => Search(objectType,query, skip, take, ignoreUserStartNodes);
 
     // default implementation to avoid breaking changes falls back to old behaviour
+    [Obsolete("Please use async version of this method. Will be removed in V17.")]
     PagedModel<IEntitySlim> Search(
         UmbracoObjectTypes objectType,
         string query,
@@ -35,4 +36,14 @@ public interface IIndexedEntitySearchService
         int take = 100,
         bool ignoreUserStartNodes = false)
         => Search(objectType,query, skip, take, ignoreUserStartNodes);
+
+    Task<PagedModel<IEntitySlim>> SearchAsync(
+        UmbracoObjectTypes objectType,
+        string query,
+        Guid? parentId,
+        IEnumerable<Guid>? contentTypeIds,
+        bool? trashed,
+        int skip = 0,
+        int take = 100,
+        bool ignoreUserStartNodes = false);
 }

--- a/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
+++ b/src/Umbraco.Core/Services/IIndexedEntitySearchService.cs
@@ -25,7 +25,7 @@ public interface IIndexedEntitySearchService
         => Search(objectType,query, skip, take, ignoreUserStartNodes);
 
     // default implementation to avoid breaking changes falls back to old behaviour
-    [Obsolete("Please use async version of this method. Will be removed in V17.")]
+    [Obsolete("Please use the async version of this method, SearchAsync. Scheduled for removal in V17.")]
     PagedModel<IEntitySlim> Search(
         UmbracoObjectTypes objectType,
         string query,

--- a/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
@@ -73,6 +73,17 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
         int skip = 0,
         int take = 100,
         bool ignoreUserStartNodes = false)
+        => SearchAsync(objectType, query, parentId, contentTypeIds, trashed, skip, take, ignoreUserStartNodes).GetAwaiter().GetResult();
+
+    public Task<PagedModel<IEntitySlim>> SearchAsync(
+        UmbracoObjectTypes objectType,
+        string query,
+        Guid? parentId,
+        IEnumerable<Guid>? contentTypeIds,
+        bool? trashed,
+        int skip = 0,
+        int take = 100,
+        bool ignoreUserStartNodes = false)
     {
         UmbracoEntityTypes entityType = objectType switch
         {
@@ -115,12 +126,12 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
             .Where(key => key != Guid.Empty)
             .ToArray();
 
-        return new PagedModel<IEntitySlim>
+        return Task.FromResult(new PagedModel<IEntitySlim>
         {
             Items = keys.Any()
                 ? _entityService.GetAll(objectType, keys)
                 : Enumerable.Empty<IEntitySlim>(),
             Total = totalFound
-        };
+        });
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds async overloads to the search methods of `IIndexedEntitySearchService`, thus preparing it for any out-of-process search providers that might be built after introducing the ["future of search"](https://github.com/umbraco/rfcs/blob/0027-the-future-of-search/cms/0027-the-future-of-search.md).

### Testing this PR

Test that global search still works for documents and media.