### PR TITLE
V16: Chore: Corrects `UmbLocalizationController` usage in comments/docs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/element-api/element.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/element-api/element.interface.ts
@@ -4,7 +4,7 @@ import type { UmbClassInterface } from '@umbraco-cms/backoffice/class-api';
 
 export interface UmbElement extends UmbClassInterface, UmbControllerHostElement {
 	/**
-	 * Use the UmbLocalizeController to localize your element.
+	 * Use the UmbLocalizationController to localize your element.
 	 * @see UmbLocalizationController
 	 */
 	localize: UmbLocalizationController;

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -78,7 +78,7 @@ const danishRegional: UmbLocalizationSet = {
 };
 //#endregion
 
-describe('UmbLocalizeController', () => {
+describe('UmbLocalizationController', () => {
 	let controller: UmbLocalizationController;
 
 	beforeEach(async () => {

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -23,15 +23,15 @@ import type { UmbController, UmbControllerHost } from '@umbraco-cms/backoffice/c
 
 const LocalizationControllerAlias = Symbol();
 /**
- * The UmbLocalizeController enables localization for your element.
+ * The UmbLocalizationController enables localization for your element.
  * @see UmbLocalizeElement
  * @example
  * ```ts
- * import { UmbLocalizeController } from '@umbraco-cms/backoffice/localization-api';
+ * import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
  *
  * \@customElement('my-element')
  * export class MyElement extends LitElement {
- *   private localize = new UmbLocalizeController(this);
+ *   private localize = new UmbLocalizationController(this);
  *
  *   render() {
  *     return html`<p>${this.localize.term('general_close')}</p>`;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/stories/localization.mdx
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/stories/localization.mdx
@@ -89,9 +89,9 @@ The `umb-localize` component is used to translate text in the UI. It is used lik
 
 Experiment with the component here: [Localize](/story/api-localization-umblocalizeelement--default)
 
-### UmbLocalizeController
+### UmbLocalizationController
 
-The `UmbLocalizeController` is used to translate text in the UI. It is used like this:
+The `UmbLocalizationController` is used to translate text in the UI. It is used like this:
 
 **UmbElementMixin**
 
@@ -110,11 +110,11 @@ export class MyElement extends UmbElementMixin(LitElement) {
 If you do not use the `UmbElementMixin` in your element, you can use the reactive controller like this:
 
 ```ts
-import { UmbLocalizeController } from '@umbraco-cms/backoffice/localization-api';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 export class MyElement extends LitElement {
 	// Create a new instance of the controller and attach it to the element
-	private localize = new UmbLocalizeController(this);
+	private localize = new UmbLocalizationController(this);
 
 	override render() {
 		return html` <uui-button .label=${this.localize.localize('general_close')}></uui-button> `;


### PR DESCRIPTION
### Description

I'd noticed that `UmbLocalizationController` was being references as `UmbLocalizeController` in the code comments/docs/tests.