### PR TITLE
Removes tree actions from tree selection in duplicate document dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
@@ -48,7 +48,10 @@ export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 				<uui-box id="tree-box" headline="Duplicate to">
 					<umb-tree
 						alias=${UMB_DOCUMENT_TREE_ALIAS}
-						.props=${{ expandTreeRoot: true }}
+						.props=${{
+							expandTreeRoot: true,
+							hideTreeItemActions: true,
+						}}
 						@selection-change=${this.#onTreeSelectionChange}></umb-tree>
 				</uui-box>
 				<uui-box headline="Options">


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/19025

### Description
Removes the actions from the tree shown in the duplicate document dialog (which aren't required, and can't be used).

### Testing
Launch the duplicate content dialog from the entity action and verify that the actions aren't displayed.

### Release
When approved and merged, consider whether to include in 15.4 or 16.0, and label the issue accordingly.  If 15.4, it needs cherry-picking into `release/15.4`.  If 16, it can be merged as is to `v15/dev` and that branch merged up to `v16/dev`.