### PR TITLE
V16: Chore: Deprecate `getManifest()` methods

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/conditions/collection-alias.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/conditions/collection-alias.condition.ts
@@ -11,7 +11,7 @@ export class UmbCollectionAliasCondition
 	constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<CollectionAliasConditionConfig>) {
 		super(host, args);
 		this.consumeContext(UMB_COLLECTION_CONTEXT, (context) => {
-			this.permitted = context.getManifest()?.alias === this.config.match;
+			this.permitted = context.manifest?.alias === this.config.match;
 		});
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.context.ts
@@ -15,7 +15,7 @@ import { UmbArrayState, UmbBasicState, UmbNumberState, UmbObjectState } from '@u
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbExtensionApiInitializer } from '@umbraco-cms/backoffice/extension-api';
-import { UmbSelectionManager, UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
+import { UmbSelectionManager, UmbPaginationManager, UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 import type { ManifestRepository } from '@umbraco-cms/backoffice/extension-registry';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
@@ -336,6 +336,11 @@ export class UmbDefaultCollectionContext<
 	 * @deprecated Use get the `.manifest` property instead.
 	 */
 	public getManifest() {
+		new UmbDeprecation({
+			removeInVersion: '18.0.0',
+			deprecated: 'getManifest',
+			solution: 'Use .manifest property instead',
+		}).warn();
 		return this._manifest;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.context.ts
@@ -333,7 +333,7 @@ export class UmbDefaultCollectionContext<
 	 * Returns the manifest for the collection.
 	 * @returns {ManifestCollection}
 	 * @memberof UmbCollectionContext
-	 * @deprecated Use get the `.manifest` property instead.
+	 * @deprecated Use the `.manifest` property instead.
 	 */
 	public getManifest() {
 		new UmbDeprecation({

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/tree/tree-item/recycle-bin-tree-item.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/tree/tree-item/recycle-bin-tree-item.context.ts
@@ -32,7 +32,7 @@ export class UmbRecycleBinTreeItemContext<
 		const entityType = event.getEntityType();
 		if (!entityType) throw new Error('Entity type is required');
 
-		const supportedEntityTypes = this.getManifest()?.meta.supportedEntityTypes;
+		const supportedEntityTypes = this.manifest?.meta.supportedEntityTypes;
 
 		if (!supportedEntityTypes) {
 			throw new Error('Entity types are missing from the manifest (manifest.meta.supportedEntityTypes).');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
@@ -11,7 +11,7 @@ import { type ManifestRepository, umbExtensionsRegistry } from '@umbraco-cms/bac
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbExtensionApiInitializer } from '@umbraco-cms/backoffice/extension-api';
-import { UmbPaginationManager, UmbSelectionManager, debounce } from '@umbraco-cms/backoffice/utils';
+import { UmbDeprecation, UmbPaginationManager, UmbSelectionManager, debounce } from '@umbraco-cms/backoffice/utils';
 import {
 	UmbRequestReloadChildrenOfEntityEvent,
 	type UmbEntityActionEvent,
@@ -110,13 +110,18 @@ export class UmbDefaultTreeContext<
 		return this.#manifest;
 	}
 
-	// TODO: getManifest, could be refactored to use the getter method [NL]
 	/**
 	 * Returns the manifest.
 	 * @returns {ManifestTree}
 	 * @memberof UmbDefaultTreeContext
+	 * @deprecated Use get the `.manifest` property instead.
 	 */
 	public getManifest() {
+		new UmbDeprecation({
+			removeInVersion: '18.0.0',
+			deprecated: 'getManifest',
+			solution: 'Use .manifest property instead',
+		}).warn();
 		return this.#manifest;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
@@ -114,7 +114,7 @@ export class UmbDefaultTreeContext<
 	 * Returns the manifest.
 	 * @returns {ManifestTree}
 	 * @memberof UmbDefaultTreeContext
-	 * @deprecated Use get the `.manifest` property instead.
+	 * @deprecated Use the `.manifest` property instead.
 	 */
 	public getManifest() {
 		new UmbDeprecation({

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
@@ -116,7 +116,7 @@ export abstract class UmbTreeItemContextBase<
 	 * Returns the manifest.
 	 * @returns {ManifestCollection}
 	 * @memberof UmbCollectionContext
-	 * @deprecated Use get the `.manifest` property instead.
+	 * @deprecated Use the `.manifest` property instead.
 	 */
 	public getManifest() {
 		new UmbDeprecation({

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
@@ -17,7 +17,7 @@ import {
 	UmbRequestReloadStructureForEntityEvent,
 } from '@umbraco-cms/backoffice/entity-action';
 import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
-import { UmbPaginationManager, debounce } from '@umbraco-cms/backoffice/utils';
+import { UmbDeprecation, UmbPaginationManager, debounce } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
 
@@ -112,13 +112,18 @@ export abstract class UmbTreeItemContextBase<
 		return this.#manifest;
 	}
 
-	// TODO: Be aware that this method, could be removed and we can use the getter method instead [NL]
 	/**
 	 * Returns the manifest.
 	 * @returns {ManifestCollection}
 	 * @memberof UmbCollectionContext
+	 * @deprecated Use get the `.manifest` property instead.
 	 */
 	public getManifest() {
+		new UmbDeprecation({
+			removeInVersion: '18.0.0',
+			deprecated: 'getManifest',
+			solution: 'Use .manifest property instead',
+		}).warn();
 		return this.#manifest;
 	}
 


### PR DESCRIPTION
### Description

Marked various context's `.getManifest()` methods as deprecated, (for removal in v18).

Added `UmbDeprecation` warnings with a resolution of using the `.manifest` property instead.
