### PR TITLE
Adds `searchResultItem` element for Document Type items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type-search-result-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type-search-result-item.element.ts
@@ -1,0 +1,61 @@
+import type { UmbDocumentTypeItemModel } from '../repository/types.js';
+import { css, customElement, html, nothing, property, when } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UmbSearchResultItemModel } from '@umbraco-cms/backoffice/search';
+
+@customElement('umb-document-type-search-result-item')
+export class UmbDocumentTypeSearchResultItemElement extends UmbLitElement {
+	@property({ type: Object })
+	item?: UmbSearchResultItemModel & UmbDocumentTypeItemModel;
+
+	override render() {
+		if (!this.item) return nothing;
+
+		return html`
+			${when(
+				this.item.icon,
+				(icon) => html`<umb-icon name=${icon}></umb-icon>`,
+				() => html`<uui-icon name="icon-document"></uui-icon>`,
+			)}
+			<span>${this.item.name}</span>
+			<div class="extra">
+				${when(
+					this.item.isElement,
+					() => html`
+						<uui-tag look="secondary">
+							<umb-localize key="contentTypeEditor_elementType">Element Type</umb-localize>
+						</uui-tag>
+					`,
+				)}
+			</div>
+		`;
+	}
+
+	static override styles = [
+		css`
+			:host {
+				border-radius: var(--uui-border-radius);
+				outline-offset: -3px;
+				padding: var(--uui-size-space-3) var(--uui-size-space-5);
+
+				display: flex;
+				gap: var(--uui-size-space-3);
+				align-items: center;
+
+				width: 100%;
+
+				> span {
+					flex: 1;
+				}
+			}
+		`,
+	];
+}
+
+export { UmbDocumentTypeSearchResultItemElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-document-type-search-result-item': UmbDocumentTypeSearchResultItemElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/manifests.ts
@@ -13,9 +13,10 @@ export const manifests: Array<UmbExtensionManifest> = [
 		},
 	},
 	{
-		name: 'Document Type Search Result Item ',
+		name: 'Document Type Search Result Item',
 		alias: 'Umb.SearchResultItem.DocumentType',
 		type: 'searchResultItem',
+		element: () => import('./document-type-search-result-item.element.js'),
 		forEntityTypes: [UMB_DOCUMENT_TYPE_ENTITY_TYPE],
 	},
 ];


### PR DESCRIPTION
### Description

Adds a `searchResultItem` element for Document Type search result items. Includes a tag for "Element Type".

![Screenshot 2025-04-16 135015](https://github.com/user-attachments/assets/345e6962-b855-4d8e-9cf6-b0db588b2d95)

