### PR TITLE
Adds search to Document Type picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/manager/picker-search.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/manager/picker-search.manager.ts
@@ -175,10 +175,9 @@ export class UmbPickerSearchManager<
 	async #search() {
 		if (this.getSearchable() === false) throw new Error('Search is not enabled');
 		if (!this.#searchProvider) throw new Error('Search provider is not available');
-		const query = this.#query.getValue();
-		if (!query) throw new Error('No query provided');
 
-		if (!query.query) {
+		const query = this.#query.getValue();
+		if (!query?.query) {
 			this.clear();
 			return;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.context.ts
@@ -6,6 +6,10 @@ import type { UmbDocumentTypeTreeItemModel } from '../../tree/types.js';
 import { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
+interface UmbDocumentTypePickerInputContextOpenArgs {
+	elementTypesOnly?: boolean;
+}
+
 export class UmbDocumentTypePickerInputContext extends UmbPickerInputContext<
 	UmbDocumentTypeItemModel,
 	UmbDocumentTypeTreeItemModel,
@@ -30,6 +34,11 @@ export class UmbDocumentTypePickerInputContext extends UmbPickerInputContext<
 				...pickerData?.search,
 			};
 		}
+
+		combinedPickerData.search!.queryParams = {
+			elementTypesOnly: args?.elementTypesOnly,
+			...pickerData?.search?.queryParams,
+		};
 
 		await super.openPicker(combinedPickerData);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.context.ts
@@ -1,8 +1,8 @@
-import type { UmbDocumentTypePickerModalData, UmbDocumentTypePickerModalValue } from '../../modals/index.js';
+import { UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS, UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS } from '../../constants.js';
 import { UMB_DOCUMENT_TYPE_PICKER_MODAL } from '../../modals/index.js';
+import type { UmbDocumentTypePickerModalData, UmbDocumentTypePickerModalValue } from '../../modals/index.js';
 import type { UmbDocumentTypeItemModel } from '../../types.js';
 import type { UmbDocumentTypeTreeItemModel } from '../../tree/types.js';
-import { UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS } from '../../constants.js';
 import { UmbPickerInputContext } from '@umbraco-cms/backoffice/picker-input';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
@@ -14,5 +14,23 @@ export class UmbDocumentTypePickerInputContext extends UmbPickerInputContext<
 > {
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS, UMB_DOCUMENT_TYPE_PICKER_MODAL);
+	}
+
+	override async openPicker(
+		pickerData?: Partial<UmbDocumentTypePickerModalData>,
+		args?: UmbDocumentTypePickerInputContextOpenArgs,
+	): Promise<void> {
+		const combinedPickerData = {
+			...pickerData,
+		};
+
+		if (!pickerData?.search) {
+			combinedPickerData.search = {
+				providerAlias: UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS,
+				...pickerData?.search,
+			};
+		}
+
+		await super.openPicker(combinedPickerData);
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
@@ -156,10 +156,15 @@ export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | un
 	}
 
 	#openPicker() {
-		this.#pickerContext.openPicker({
-			hideTreeRoot: true,
-			pickableFilter: this.#getPickableFilter(),
-		});
+		this.#pickerContext.openPicker(
+			{
+				hideTreeRoot: true,
+				pickableFilter: this.#getPickableFilter(),
+			},
+			{
+				elementTypesOnly: this.elementTypesOnly ? true : undefined,
+			},
+		);
 	}
 
 	#removeItem(item: UmbDocumentTypeItemModel) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/manifests.ts
@@ -1,5 +1,6 @@
 import { manifests as entityActionsManifests } from './entity-actions/manifests.js';
 import { manifests as menuManifests } from './menu/manifests.js';
+import { manifests as pickerManifests } from './picker/manifests.js';
 import { manifests as propertyEditorManifests } from './property-editors/manifests.js';
 import { manifests as propertyTypeManifests } from './property-type/manifests.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
@@ -11,6 +12,7 @@ import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension
 export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [
 	...entityActionsManifests,
 	...menuManifests,
+	...pickerManifests,
 	...propertyEditorManifests,
 	...propertyTypeManifests,
 	...repositoryManifests,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/modals/document-type-picker-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/modals/document-type-picker-modal.token.ts
@@ -1,5 +1,6 @@
 import { UMB_DOCUMENT_TYPE_ENTITY_TYPE, UMB_DOCUMENT_TYPE_ROOT_ENTITY_TYPE } from '../entity.js';
 import { UMB_CREATE_DOCUMENT_TYPE_WORKSPACE_PATH_PATTERN } from '../paths.js';
+import { UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS } from '../search/index.js';
 import type { UmbDocumentTypeTreeItemModel } from '../tree/index.js';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 import {
@@ -38,6 +39,9 @@ export const UMB_DOCUMENT_TYPE_PICKER_MODAL = new UmbModalToken<
 				parentUnique: null,
 				presetAlias: null,
 			},
+		},
+		search: {
+			providerAlias: UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS,
 		},
 	},
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/picker/document-type-picker-search-result-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/picker/document-type-picker-search-result-item.element.ts
@@ -1,0 +1,39 @@
+import type { UmbDocumentTypeSearchItemModel } from '../search/types.js';
+import { customElement, html, nothing, when } from '@umbraco-cms/backoffice/external/lit';
+import { UmbPickerSearchResultItemElementBase } from '@umbraco-cms/backoffice/picker';
+
+@customElement('umb-document-type-picker-search-result-item')
+export class UmbDocumentTypePickerSearchResultItemElement extends UmbPickerSearchResultItemElementBase<UmbDocumentTypeSearchItemModel> {
+	override render() {
+		if (!this.item) return nothing;
+		const item = this.item;
+		return html`
+			<umb-ref-item
+				name=${item.name}
+				id=${item.unique}
+				icon=${item.icon ?? 'icon-document'}
+				select-only
+				selectable
+				?selected=${this._isSelected}
+				@deselected=${() => this.pickerContext?.selection.deselect(item.unique)}
+				@selected=${() => this.pickerContext?.selection.select(item.unique)}>
+				${when(
+					item.isElement,
+					() => html`
+						<uui-tag slot="tag" look="secondary">
+							<umb-localize key="contentTypeEditor_elementType">Element Type</umb-localize>
+						</uui-tag>
+					`,
+				)}
+			</umb-ref-item>
+		`;
+	}
+}
+
+export { UmbDocumentTypePickerSearchResultItemElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-document-type-picker-search-result-item': UmbDocumentTypePickerSearchResultItemElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/picker/manifests.ts
@@ -1,0 +1,12 @@
+import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '../entity.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'pickerSearchResultItem',
+		kind: 'default',
+		alias: 'Umb.PickerSearchResultItem.DocumentType',
+		name: 'Document Type Picker Search Result Item',
+		element: () => import('./document-type-picker-search-result-item.element.js'),
+		forEntityTypes: [UMB_DOCUMENT_TYPE_ENTITY_TYPE],
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type-search.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type-search.repository.ts
@@ -1,9 +1,10 @@
 import { UmbDocumentTypeSearchServerDataSource } from './document-type-search.server.data-source.js';
 import type { UmbDocumentTypeSearchItemModel } from './document-type.search-provider.js';
-import type { UmbSearchRepository, UmbSearchRequestArgs } from '@umbraco-cms/backoffice/search';
+import type { UmbDocumentTypeSearchRequestArgs } from './types.js';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbSearchRepository } from '@umbraco-cms/backoffice/search';
 
 export class UmbDocumentTypeSearchRepository
 	extends UmbControllerBase
@@ -17,7 +18,7 @@ export class UmbDocumentTypeSearchRepository
 		this.#dataSource = new UmbDocumentTypeSearchServerDataSource(this);
 	}
 
-	search(args: UmbSearchRequestArgs) {
+	search(args: UmbDocumentTypeSearchRequestArgs) {
 		return this.#dataSource.search(args);
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type-search.server.data-source.ts
@@ -1,9 +1,10 @@
 import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '../entity.js';
 import type { UmbDocumentTypeSearchItemModel } from './document-type.search-provider.js';
-import type { UmbSearchDataSource, UmbSearchRequestArgs } from '@umbraco-cms/backoffice/search';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { DocumentTypeService } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbDocumentTypeSearchRequestArgs } from './types.js';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
+import { DocumentTypeService } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbSearchDataSource } from '@umbraco-cms/backoffice/search';
 
 /**
  * A data source for the Rollback that fetches data from the server
@@ -24,15 +25,15 @@ export class UmbDocumentTypeSearchServerDataSource implements UmbSearchDataSourc
 
 	/**
 	 * Get a list of versions for a data
-	 * @param args
+	 * @param {UmbDocumentTypeSearchRequestArgs} args - The arguments for the search
 	 * @returns {*}
 	 * @memberof UmbDocumentTypeSearchServerDataSource
 	 */
-	async search(args: UmbSearchRequestArgs) {
+	async search(args: UmbDocumentTypeSearchRequestArgs) {
 		const { data, error } = await tryExecute(
 			this.#host,
 			DocumentTypeService.getItemDocumentTypeSearch({
-				query: { query: args.query },
+				query: { query: args.query, isElement: args.elementTypesOnly },
 			}),
 		);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type.search-provider.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/document-type.search-provider.ts
@@ -1,7 +1,8 @@
 import type { UmbDocumentTypeItemModel } from '../index.js';
+import type { UmbDocumentTypeSearchRequestArgs } from './types.js';
 import { UmbDocumentTypeSearchRepository } from './document-type-search.repository.js';
-import type { UmbSearchProvider, UmbSearchRequestArgs } from '@umbraco-cms/backoffice/search';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbSearchProvider } from '@umbraco-cms/backoffice/search';
 
 export interface UmbDocumentTypeSearchItemModel extends UmbDocumentTypeItemModel {
 	href: string;
@@ -13,7 +14,7 @@ export class UmbDocumentTypeSearchProvider
 {
 	#repository = new UmbDocumentTypeSearchRepository(this);
 
-	async search(args: UmbSearchRequestArgs) {
+	async search(args: UmbDocumentTypeSearchRequestArgs) {
 		return this.#repository.search(args);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/types.ts
@@ -1,0 +1,10 @@
+import type { UmbDocumentTypeItemModel } from '../repository/types.js';
+import type { UmbSearchRequestArgs } from '@umbraco-cms/backoffice/search';
+
+export interface UmbDocumentTypeSearchItemModel extends UmbDocumentTypeItemModel {
+	href: string;
+}
+
+export interface UmbDocumentTypeSearchRequestArgs extends UmbSearchRequestArgs {
+	elementTypesOnly?: boolean;
+}


### PR DESCRIPTION
### Description

Adds support for a search provider to the Document Type picker.

Adds a `pickerSearchResultItem` element to display the result items, including a tag for Element Types.

![Screenshot 2025-04-16 145402](https://github.com/user-attachments/assets/81ff9ebb-df58-4868-93df-64647918b79c)

### How to test?

Open a Document Type picker, (e.g. on a Document Type workspace > Structure > "Allowed child node types" field), try searching for a document type and/or element type.

