### PR TITLE
Handle file paths as not found in delivery API by route requests

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
@@ -145,7 +145,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
         path = DecodePath(path);
         path = path.Length == 0 ? "/" : path;
 
-        if (_apiContentPathResolver.IsResolveablePath(path) is false)
+        if (_apiContentPathResolver.IsResolvablePath(path) is false)
         {
             return NotFound();
         }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
@@ -145,6 +145,11 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
         path = DecodePath(path);
         path = path.Length == 0 ? "/" : path;
 
+        if (_apiContentPathResolver.IsResolveablePath(path) is false)
+        {
+            return NotFound();
+        }
+
         IPublishedContent? contentItem = GetContent(path);
         if (contentItem is not null)
         {

--- a/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
@@ -15,7 +15,7 @@ public class ApiContentPathResolver : IApiContentPathResolver
         _apiPublishedContentCache = apiPublishedContentCache;
     }
 
-    public virtual bool IsResolveablePath(string path)
+    public virtual bool IsResolvablePath(string path)
     {
         // File requests will blow up with an downstream exception in GetRequiredPublishedSnapshot, which fails due to an UmbracoContext
         // not being available for what's considered a static file request.

--- a/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
@@ -19,8 +19,19 @@ public class ApiContentPathResolver : IApiContentPathResolver
     {
         path = path.EnsureStartsWith("/");
 
+        // File requests will blow up with an downstream exception in GetRequiredPublishedSnapshot, which fails due to an UmbracoContext
+        // not being available for what's considered a static file request.
+        // Given a URL segment and hence route can't contain a period, we can safely assume that if the last segment of the path contains
+        // a period, it's a file request and should return null here.
+        if (IsFileRequest(path))
+        {
+            return null;
+        }
+
         var contentRoute = _requestRoutingService.GetContentRoute(path);
         IPublishedContent? contentItem = _apiPublishedContentCache.GetByRoute(contentRoute);
         return contentItem;
     }
+
+    private static bool IsFileRequest(string path) => path.Split('/', StringSplitOptions.RemoveEmptyEntries).Last().Contains('.');
 }

--- a/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
@@ -4,5 +4,7 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public interface IApiContentPathResolver
 {
+    bool IsResolveablePath(string path) => true;
+
     IPublishedContent? ResolveContentPath(string path);
 }

--- a/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public interface IApiContentPathResolver
 {
-    bool IsResolveablePath(string path) => true;
+    bool IsResolvablePath(string path) => true;
 
     IPublishedContent? ResolveContentPath(string path);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
@@ -10,17 +10,18 @@ public class ApiContentPathResolverTests
 {
     private const string TestPath = "/test/page";
 
-    [TestCase("file.txt")]
-    [TestCase("test/file.txt")]
-    [TestCase("test/test2/file.txt")]
-    [TestCase("/file.txt")]
-    [TestCase("/test/file.txt")]
-    [TestCase("/test/test2/file.txt")]
-    public void Resolves_Null_For_File_Requests(string path)
+    [TestCase(TestPath, true)]
+    [TestCase("file.txt", false)]
+    [TestCase("test/file.txt", false)]
+    [TestCase("test/test2/file.txt", false)]
+    [TestCase("/file.txt", false)]
+    [TestCase("/test/file.txt", false)]
+    [TestCase("/test/test2/file.txt", false)]
+    public void Can_Verify_Resolveable_Paths(string path, bool expected)
     {
         var resolver = CreateResolver();
-        var result = resolver.ResolveContentPath(path);
-        Assert.IsNull(result);
+        var result = resolver.IsResolveablePath(path);
+        Assert.AreEqual(expected, result);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
@@ -20,7 +20,7 @@ public class ApiContentPathResolverTests
     public void Can_Verify_Resolveable_Paths(string path, bool expected)
     {
         var resolver = CreateResolver();
-        var result = resolver.IsResolveablePath(path);
+        var result = resolver.IsResolvablePath(path);
         Assert.AreEqual(expected, result);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
@@ -1,0 +1,46 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.DeliveryApi;
+
+[TestFixture]
+public class ApiContentPathResolverTests
+{
+    private const string TestPath = "/test/page";
+
+    [TestCase("file.txt")]
+    [TestCase("test/file.txt")]
+    [TestCase("test/test2/file.txt")]
+    [TestCase("/file.txt")]
+    [TestCase("/test/file.txt")]
+    [TestCase("/test/test2/file.txt")]
+    public void Resolves_Null_For_File_Requests(string path)
+    {
+        var resolver = CreateResolver();
+        var result = resolver.ResolveContentPath(path);
+        Assert.IsNull(result);
+    }
+
+    [Test]
+    public void Resolves_Content_For_Path()
+    {
+        var resolver = CreateResolver();
+        var result = resolver.ResolveContentPath(TestPath);
+        Assert.IsNotNull(result);
+    }
+
+    private static ApiContentPathResolver CreateResolver()
+    {
+        var mockRequestRoutingService = new Mock<IRequestRoutingService>();
+        mockRequestRoutingService
+            .Setup(x => x.GetContentRoute(It.IsAny<string>()))
+            .Returns((string path) => path);
+        var mockApiPublishedContentCache = new Mock<IApiPublishedContentCache>();
+        mockApiPublishedContentCache
+            .Setup(x => x.GetByRoute(It.Is<string>(y => y == TestPath)))
+            .Returns(new Mock<IPublishedContent>().Object);
+        return new ApiContentPathResolver(mockRequestRoutingService.Object, mockApiPublishedContentCache.Object);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19051

### Description
As the linked issue shows, a request to the delivery API to retrieve a content item by route will fail with a 500 rather than a 404 for a file path request.  This is because there's no Umbraco context available for these requests and an exception is thrown as one is expected to exist.

In this update I've checked for a file request and where found, immediately return null and hence 404 to the caller.

Note that this doesn't happen on 15 - due to the removal of the "published snapshot" - a 404 is returned already on this version.  So the fix is needed only for 15.

### Testing

- Make a delivery API request to an existing route, e.g. `/umbraco/delivery/api/v2/content/item/my-folder/my-page`, and verify the expected 200 response is returned.
- Make a delivery API request to a non-existing route, e.g. `/umbraco/delivery/api/v2/content/item/my-folder/my-missing-page`, and verify the expected 404 response is returned.
- Make a delivery API request to a file, e.g. `/umbraco/delivery/api/v2/content/item/my-folder/my-file.txt`, and verify that now a 404 response is returned.
