### PR TITLE
Content Picker Search: Option to exclude trashed items

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.context.ts
@@ -9,6 +9,7 @@ import type { UmbDocumentTypeEntityType } from '@umbraco-cms/backoffice/document
 
 interface UmbDocumentPickerInputContextOpenArgs {
 	allowedContentTypes?: Array<{ unique: string; entityType: UmbDocumentTypeEntityType }>;
+	includeTrashed?: boolean;
 }
 
 export class UmbDocumentPickerInputContext extends UmbPickerInputContext<
@@ -43,6 +44,7 @@ export class UmbDocumentPickerInputContext extends UmbPickerInputContext<
 		// pass allowedContentTypes to the search request args
 		combinedPickerData.search!.queryParams = {
 			allowedContentTypes: args?.allowedContentTypes,
+			includeTrashed: args?.includeTrashed,
 			...pickerData?.search?.queryParams,
 		};
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -89,6 +89,9 @@ export class UmbInputDocumentElement extends UmbFormControlMixin<string | undefi
 	@property({ type: Array })
 	allowedContentTypeIds?: string[] | undefined;
 
+	@property({ type: Boolean, attribute: 'include-trashed' })
+	includeTrashed = false;
+
 	@property({ type: String })
 	public override set value(selectionString: string | undefined) {
 		this.selection = splitStringToArray(selectionString);
@@ -153,6 +156,7 @@ export class UmbInputDocumentElement extends UmbFormControlMixin<string | undefi
 					unique: id,
 					entityType: UMB_DOCUMENT_TYPE_ENTITY_TYPE,
 				})),
+				includeTrashed: this.includeTrashed,
 			},
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
@@ -38,6 +38,7 @@ export class UmbDocumentSearchServerDataSource
 					query: args.query,
 					parentId: args.searchFrom?.unique ?? undefined,
 					allowedDocumentTypes: args.allowedContentTypes?.map((contentType) => contentType.unique),
+					trashed: args.includeTrashed,
 				},
 			}),
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/types.ts
@@ -8,4 +8,5 @@ export interface UmbDocumentSearchItemModel extends UmbDocumentItemModel {
 
 export interface UmbDocumentSearchRequestArgs extends UmbSearchRequestArgs {
 	allowedContentTypes?: Array<{ unique: string; entityType: UmbDocumentTypeEntityType }>;
+	includeTrashed?: boolean;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.context.ts
@@ -10,6 +10,7 @@ import type { UmbMediaTypeEntityType } from '@umbraco-cms/backoffice/media-type'
 
 interface UmbMediaPickerInputContextOpenArgs {
 	allowedContentTypes?: Array<{ unique: string; entityType: UmbMediaTypeEntityType }>;
+	includeTrashed?: boolean;
 }
 
 export class UmbMediaPickerInputContext extends UmbPickerInputContext<
@@ -41,6 +42,7 @@ export class UmbMediaPickerInputContext extends UmbPickerInputContext<
 		// pass allowedContentTypes to the search request args
 		combinedPickerData.search!.queryParams = {
 			allowedContentTypes: args?.allowedContentTypes,
+			includeTrashed: args?.includeTrashed,
 			...pickerData?.search?.queryParams,
 		};
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
@@ -110,6 +110,9 @@ export class UmbInputMediaElement extends UmbFormControlMixin<string | undefined
 	@property({ type: Array })
 	allowedContentTypeIds?: Array<string> | undefined;
 
+	@property({ type: Boolean, attribute: 'include-trashed' })
+	includeTrashed = false;
+
 	@property({ type: Object, attribute: false })
 	startNode?: UmbTreeStartNode;
 
@@ -194,6 +197,7 @@ export class UmbInputMediaElement extends UmbFormControlMixin<string | undefined
 					unique: id,
 					entityType: UMB_MEDIA_TYPE_ENTITY_TYPE,
 				})),
+				includeTrashed: this.includeTrashed,
 			},
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
@@ -38,6 +38,7 @@ export class UmbMediaSearchServerDataSource
 					query: args.query,
 					parentId: args.searchFrom?.unique || undefined,
 					allowedMediaTypes: args.allowedContentTypes?.map((mediaReference) => mediaReference.unique),
+					trashed: args.includeTrashed,
 				},
 			}),
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/types.ts
@@ -8,4 +8,5 @@ export interface UmbMediaSearchItemModel extends UmbMediaItemModel {
 
 export interface UmbMediaSearchRequestArgs extends UmbSearchRequestArgs {
 	allowedContentTypes?: Array<{ unique: string; entityType: UmbMediaTypeEntityType }>;
+	includeTrashed?: boolean;
 }


### PR DESCRIPTION
### Description

Adds an option to include/exclude trashed items in the Content Picker Search (for Documents `<umb-input-document>` and Media `<umb-input-media>` configurations).

_Please note, Content Picker is the artist formerly known as MNTP._
_...and this option has not yet been added to the Media Picker property-editor Picker Search, e.g. `<umb-input-rich-media>`._

### How to test?

With a Content Picker property-editor, configured with either Documents or Media, use the Search feature in the picker modal. Try to search for Documents or Media that are in the trash.

