### PR TITLE
Update community forum links

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/help/header-app/help-header-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/help/header-app/help-header-app.element.ts
@@ -1,5 +1,5 @@
 import { UMB_HELP_MENU_ALIAS } from '../menu/index.js';
-import { customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbExtensionsManifestInitializer } from '@umbraco-cms/backoffice/extension-api';
 import { UmbHeaderAppButtonElement } from '@umbraco-cms/backoffice/components';
@@ -54,7 +54,14 @@ export class UmbHelpHeaderAppElement extends UmbHeaderAppButtonElement {
 		`;
 	}
 
-	static override styles = UmbHeaderAppButtonElement.styles;
+	static override styles = [
+		...UmbHeaderAppButtonElement.styles,
+		css`
+			:host {
+				--uui-menu-item-flat-structure: 1;
+			}
+		`,
+	];
 }
 
 export { UmbHelpHeaderAppElement as element };

--- a/src/Umbraco.Web.UI.Client/src/packages/help/menu/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/help/menu/manifests.ts
@@ -35,7 +35,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			menus: [UMB_HELP_MENU_ALIAS],
 			label: 'Community Website',
 			icon: 'icon-hearts',
-			href: 'https://our.umbraco.com?utm_source=core&amp;utm_medium=help&amp;utm_content=link&amp;utm_campaign=our',
+			href: 'https://our.umbraco.com?utm_source=core&utm_medium=help&utm_content=link&utm_campaign=our',
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
@@ -54,7 +54,7 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 	private _searchMenuData: Array<{ label: string; href: () => string; icon: string; title: string }> = [
 		{
 			label: 'Search in Google',
-			title: '@logViewer_searchThisMessageWithGoogle',
+			title: '#logViewer_searchThisMessageWithGoogle',
 			href: () => `https://www.google.com/search?q=${this.renderedMessage}`,
 			icon: 'https://www.google.com/favicon.ico',
 		},
@@ -81,7 +81,7 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 		},
 		{
 			label: 'Search Umbraco Source',
-			title: 'Search within Umbraco source code on Github',
+			title: 'Search within Umbraco source code on GitHub',
 			href: () =>
 				`https://github.com/umbraco/Umbraco-CMS/search?q=${
 					this.properties.find((property) => property.name === 'SourceContext')?.value
@@ -90,7 +90,7 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 		},
 		{
 			label: 'Search Umbraco Issues',
-			title: 'Search Umbraco Issues on Github',
+			title: 'Search Umbraco Issues on GitHub',
 			href: () =>
 				`https://github.com/umbraco/Umbraco-CMS/issues?q=${
 					this.properties.find((property) => property.name === 'SourceContext')?.value

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
@@ -1,9 +1,9 @@
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
-import { css, html, customElement, property, query, state } from '@umbraco-cms/backoffice/external/lit';
-import type { LogLevelModel, LogMessagePropertyPresentationModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { css, customElement, html, property, query, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { query as getQuery, toQueryString } from '@umbraco-cms/backoffice/router';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import type { LogLevelModel, LogMessagePropertyPresentationModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 
 //TODO: check how to display EventId field in the message properties
 @customElement('umb-log-viewer-message')
@@ -53,40 +53,38 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 
 	private _searchMenuData: Array<{ label: string; href: () => string; icon: string; title: string }> = [
 		{
-			label: 'Search in Google',
+			label: 'Search with Google',
 			title: '#logViewer_searchThisMessageWithGoogle',
 			href: () => `https://www.google.com/search?q=${this.renderedMessage}`,
-			icon: 'https://www.google.com/favicon.ico',
+			icon: 'icon-google',
 		},
 		{
-			label: 'Search in Bing',
-			title: 'Search this message with Bing',
+			label: 'Search with Bing',
+			title: 'Search this message with Microsoft Bing',
 			href: () => `https://www.bing.com/search?q=${this.renderedMessage}`,
-			icon: 'https://www.bing.com/favicon.ico',
+			icon: 'icon-search',
 		},
 		{
 			label: 'Search in Umbraco Forum',
 			title: 'Search this message on the Umbraco forum',
 			href: () => `https://forum.umbraco.com/search?q=${this.renderedMessage}`,
-			icon: 'https://our.umbraco.com/assets/images/app-icons/favicon.png',
+			icon: 'icon-umbraco',
 		},
 		{
 			label: 'Search in Umbraco Forum with Google',
 			title: 'Search Umbraco Forum using Google',
 			href: () =>
-				`https://www.google.co.uk/?q=site:forum.umbraco.com ${this.renderedMessage}&safe=off#q=site:forum.umbraco.com ${
-					this.renderedMessage
-				} ${this.properties.find((property) => property.name === 'SourceContext')?.value}&safe=off"`,
-			icon: 'https://www.google.com/favicon.ico',
+				`https://www.google.co.uk/?q=site:forum.umbraco.com ${this.renderedMessage}&safe=off#q=site:forum.umbraco.com ${this.renderedMessage} ${this.properties.find((property) => property.name === 'SourceContext')?.value}&safe=off"`,
+			icon: 'icon-google',
 		},
 		{
-			label: 'Search Umbraco Source',
-			title: 'Search within Umbraco source code on GitHub',
+			label: 'Search Umbraco source code',
+			title: 'Search the Umbraco source code on GitHub',
 			href: () =>
 				`https://github.com/umbraco/Umbraco-CMS/search?q=${
 					this.properties.find((property) => property.name === 'SourceContext')?.value
 				}`,
-			icon: 'https://github.githubassets.com/favicon.ico',
+			icon: 'icon-github',
 		},
 		{
 			label: 'Search Umbraco Issues',
@@ -95,7 +93,7 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 				`https://github.com/umbraco/Umbraco-CMS/issues?q=${
 					this.properties.find((property) => property.name === 'SourceContext')?.value
 				}`,
-			icon: 'https://github.githubassets.com/favicon.ico',
+			icon: 'icon-github',
 		},
 	];
 
@@ -174,11 +172,15 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 						(menuItem) => html`
 							<uui-menu-item
 								class="search-item"
-								href="${menuItem.href()}"
+								href=${menuItem.href()}
 								target="_blank"
-								label="${menuItem.label}"
-								title="${menuItem.title}">
-								<img slot="icon" src="${menuItem.icon}" width="16" height="16" alt="" />
+								label=${menuItem.label}
+								title=${menuItem.title}>
+								${when(
+									menuItem.icon,
+									(icon) => html`<uui-icon slot="icon" name=${icon}></uui-icon>`,
+									() => html`<uui-icon slot="icon" name="icon-search"></uui-icon>`,
+								)}
 							</uui-menu-item>
 						`,
 					)}
@@ -187,7 +189,7 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 		`;
 	}
 
-	static override styles = [
+	static override readonly styles = [
 		UmbTextStyles,
 		css`
 			:host > details {

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
@@ -65,16 +65,16 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 			icon: 'https://www.bing.com/favicon.ico',
 		},
 		{
-			label: 'Search in OurUmbraco',
-			title: 'Search this message on Our Umbraco forums and docs',
-			href: () => `https://our.umbraco.com/search?q=${this.renderedMessage}&content=wiki,forum,documentation`,
+			label: 'Search in Umbraco Forum',
+			title: 'Search this message on the Umbraco forum',
+			href: () => `https://forum.umbraco.com/search?q=${this.renderedMessage}`,
 			icon: 'https://our.umbraco.com/assets/images/app-icons/favicon.png',
 		},
 		{
-			label: 'Search in OurUmbraco with Google',
-			title: 'Search Our Umbraco forums using Google',
+			label: 'Search in Umbraco Forum with Google',
+			title: 'Search Umbraco Forum using Google',
 			href: () =>
-				`https://www.google.co.uk/?q=site:our.umbraco.com ${this.renderedMessage}&safe=off#q=site:our.umbraco.com ${
+				`https://www.google.co.uk/?q=site:forum.umbraco.com ${this.renderedMessage}&safe=off#q=site:forum.umbraco.com ${
 					this.renderedMessage
 				} ${this.properties.find((property) => property.name === 'SourceContext')?.value}&safe=off"`,
 			icon: 'https://www.google.com/favicon.ico',

--- a/src/Umbraco.Web.UI.Client/src/packages/settings/welcome/settings-welcome-dashboard.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/settings/welcome/settings-welcome-dashboard.element.ts
@@ -29,7 +29,7 @@ export class UmbSettingsWelcomeDashboardElement extends UmbLitElement {
 					<div class="button-group">
 						<uui-button
 							look="outline"
-							href="https://our.umbraco.com/forum/"
+							href="https://forum.umbraco.com/"
 							label=${this.localize.term('settingsDashboard_goForum')}
 							target="_blank"></uui-button>
 						<uui-button


### PR DESCRIPTION
### Description

This PR started off as updating the community forum links from [Our Umbraco](https://our.umbraco.com/) to the [new forum website](https://forum.umbraco.com/), then I ended up making tweaks to the Help menu and Log Viewer Message component.

I'd noticed on the Log Viewer Message component that it was hot-linking to the favicons of Google, Bing, GitHub and Our Umbraco. _(Which may or may not be a privacy concern?)_ I have replaced these with our built-in icons, although we do not have an icon for Microsoft Bing _(and Simple Icons removed all Microsoft brand icons),_ so I used our usual `icon-search`.