### PR TITLE
Fixed error with reflection on integration test configure builder attributes, so integration tests can be created outside of the Umbraco integration test project

### DIFF
--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -205,7 +205,7 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
         }
     }
 
-    private static Type GetTestClassType()
+    private static Type? GetTestClassType()
     {
         string testClassName = TestContext.CurrentContext.Test.ClassName;
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/19076

### Description
The integration test update introducing the "configure builder" attributes in https://github.com/umbraco/Umbraco-CMS/pull/17707 have caused a regression for integration test projects that use our base classes.

It occurs as the `GetType` reflection used for handling "configure builder" attributes only works for types defined within the Umbraco integration test project itself.

I've extended it in this PR to look in other assemblies if not found in the current one.

### Testing
To verify this I created a new integration test project in the Umbraco solution, using the [documented instructions](https://docs.umbraco.com/umbraco-cms/implementation/integration-testing) but then taking project rather than a package reference on `Umbraco.Tests.IntegrationTests`.

![image](https://github.com/user-attachments/assets/bc56b670-0be4-4ff0-bab1-52d43002ec8a)

A simple test like the following would throw an exception before this fix, but passes once it is in place:

```
using Umbraco.Cms.Tests.Common.Testing;
using Umbraco.Cms.Tests.Integration.Testing;

namespace MyTestProject;

[TestFixture]
[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
public class IntegrationTests : UmbracoIntegrationTest
{
    [Test]
    public void Test1()
    {
        Assert.Pass("Test runs successfully");
    }
}
```

Otherwise testing is verifying existing integration tests also pass.

### Release
Given this affects only integration tests, we should cherry-pick this into the `release/15.4` branch and include in the 15.4.0 release.