### PR TITLE
Incorrect forum and security urls when raising issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,11 +4,11 @@ contact_links:
       url: https://github.com/umbraco/Umbraco-CMS/discussions/new?category=features-and-ideas
       about: Start a new discussion when you have ideas or feature requests, eventually discussions can turn into plans
     - name: ⁉️ Support Question
-      url: https://our.umbraco.com
+      url: https://forum.umbraco.com
       about: This issue tracker is NOT meant for support questions. If you have a question, please join us on the forum.
     - name: 📖 Documentation Issue
       url: https://github.com/umbraco/UmbracoDocs/issues
       about: Documentation issues should be reported on the Umbraco documentation repository.
     - name: 🔐 Security Issue
-      url: https://umbraco.com/about-us/trust-center/security-and-umbraco/how-to-report-a-vulnerability-in-umbraco/
+      url: https://umbraco.com/trust-center/security-and-umbraco/how-to-report-a-vulnerability-in-umbraco/
       about: Discovered a Security Issue in Umbraco?


### PR DESCRIPTION
The "create new issue" popup is still pointing at the Our forum, and the security url has changed on .com