### PR TITLE
readme shield for forum instead of discord-chats

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,8 +4,8 @@
 [![NuGet Version](https://img.shields.io/nuget/v/Umbraco.Cms)](https://www.nuget.org/packages/Umbraco.Cms)
 [![Build status](https://img.shields.io/azure-devops/build/umbraco/Umbraco%2520Cms/301?logo=azurepipelines&label=Azure%20Pipelines)](https://umbraco.visualstudio.com/Umbraco%20Cms/_build?definitionId=301) 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md) 
+[![Forum](https://img.shields.io/badge/help-forum-blue)](https://forum.umbraco.com) 
 [![Chat about Umbraco on Discord](https://img.shields.io/discord/869656431308189746?logo=discord&logoColor=fff)](https://discord.gg/umbraco) 
-[![Read what's going on in the Umbraco Discord chat now](https://img.shields.io/badge/read-discord-blue)](https://discord-chats.umbraco.com)
 ![Mastodon Follow](https://img.shields.io/mastodon/follow/110661369750014952?domain=https%3A%2F%2Fumbracocommunity.social)
 
 


### PR DESCRIPTION
The current readme has the following shields, which includes "read | discord" that takes you to discord-chats
![image](https://github.com/user-attachments/assets/5d449a87-8f05-40cd-ac96-a3662ce4bc4a)

We surely don't want this link any more as there is no more Q&A on Discord. Instead we should have a link to the forum (and perhaps prioritise this over discord now)?

This PR updates the readme to use a static badge that links to https://forum.umbraco.com that looks like this:

![image](https://github.com/user-attachments/assets/b9f18b03-0dba-4f78-914a-7d6fe621700d)

Another option would be to use the dynamic shield that lists the number of users on Discourse. This could look like this:

![image](https://github.com/user-attachments/assets/d42659cd-450e-4f63-a221-c12c3a31aff7)

Not sure if we want the user count. If we think this is preferable to the static badge then I can update this PR accordingly