### PR TITLE
Tiptap cannot set the top position of the toolbar

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
@@ -108,7 +108,7 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 			flex-direction: column;
 
 			position: sticky;
-			top: -25px;
+			top: var(--umb-tiptap-top,-25px);
 			left: 0;
 			right: 0;
 			padding: var(--uui-size-3);

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
@@ -8,6 +8,12 @@ import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/
 
 import '../cascading-menu-popover/cascading-menu-popover.element.js';
 
+/**
+* Provides a sticky toolbar for the {@link UmbInputTiptapElement}
+* @element umb-tiptap-toolbar
+* @cssprop --umb-tiptap-edge-border-color - Defines the edge border color
+* @cssprop --umb-tiptap-top - Defines the top value for the sticky toolbar
+*/
 @customElement('umb-tiptap-toolbar')
 export class UmbTiptapToolbarElement extends UmbLitElement {
 	#attached = false;


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/19086 by adding a variable for `top`.