### PR TITLE
Tiptap RTE: Corrects invalidation border

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -242,7 +242,7 @@ export abstract class UmbPropertyEditorUiRteElementBase
 
 				context.setValue(super.value);
 			},
-			'motherObserver',
+			'blockManagerObserver',
 		);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -237,7 +237,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				justify-content: center;
 			}
 
-			:host(:not([pristine]):invalid),
+			:host(:invalid:not([pristine])),
 			/* polyfill support */
 			:host(:not([pristine])[internals-invalid]) {
 				--umb-tiptap-edge-border-color: var(--uui-color-invalid);
@@ -250,7 +250,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				display: flex;
 				overflow: auto;
 				border-radius: var(--uui-border-radius);
-				border: 1px solid var(--uui-color-border);
+				border: 1px solid var(--umb-tiptap-edge-border-color, var(--uui-color-border));
 				padding: 1rem;
 				box-sizing: border-box;
 				height: 100%;

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
@@ -1,6 +1,6 @@
 import type { UmbInputTiptapElement } from '../../components/input-tiptap/input-tiptap.element.js';
 import { UmbPropertyEditorUiRteElementBase } from '@umbraco-cms/backoffice/rte';
-import { customElement, html, type PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, type PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 
 import '../../components/input-tiptap/input-tiptap.element.js';
 
@@ -74,6 +74,12 @@ export class UmbPropertyEditorUiTiptapElement extends UmbPropertyEditorUiRteElem
 				@change=${this.#onChange}></umb-input-tiptap>
 		`;
 	}
+
+	static override styles = css`
+		:host(:invalid:not([pristine])) umb-input-tiptap {
+			--umb-tiptap-edge-border-color: var(--uui-color-invalid);
+		}
+	`;
 }
 
 export { UmbPropertyEditorUiTiptapElement as element };


### PR DESCRIPTION
Gives tiptap a invalid colored border when it is invalid from a validation perspective. Doing this to align with visuals for other editors.