### PR TITLE
Custom validator example take2

### DIFF
--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/README.md
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/README.md
@@ -1,0 +1,5 @@
+# Custom Validation Workspace Context Example
+
+This example demonstrates how you can append extra validation messages to the Validation Context based on the value of a Property of a property Editor that this Customization is not interested in overriding/replacing.
+
+See this having an effect on the All RTEs page, where too long words are invalid.

--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
@@ -62,6 +62,12 @@ export class CustomValidationValidator extends UmbControllerBase implements UmbV
 				this.#isValid = false;
 			}
 		} else {
+			// Notice how we say the validation is valid if the value is empty.
+			// If you end up making a validation rule that requires the value to be present,
+			// then still make this Validator approve when empty,
+			// and then mark the property to be Mandatory so that Validation will enforce the value to be filled in,
+			// and then your Validator can be used to check the value it is present.
+			// — In this way you avoid overwhelming the user with validation messages before the user even entered a value.
 			this.#isValid = true;
 		}
 
@@ -81,7 +87,7 @@ export class CustomValidationValidator extends UmbControllerBase implements UmbV
 
 	async validate(): Promise<void> {
 		// Validate is called when the validation state of this validator is asked to be fully resolved. Like when user clicks Save & Publish.
-		// If you need to ask the server then it can be done here, instead of asking the server each time the value changes.
+		// If you need to ask the server then it could be done here, instead of asking the server each time the value changes.
 		// In this particular example we do not need to do anything, because our validation is represented via a message that we always set no matter the user interaction.
 		// If we did not like to only to check the Validation State when absolute needed then this method must be implemented.
 	}

--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
@@ -1,0 +1,110 @@
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
+import {
+	UMB_VALIDATION_CONTEXT,
+	UmbDataPathPropertyValueQuery,
+	type UmbValidator,
+} from '@umbraco-cms/backoffice/validation';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import type { UmbPropertyEditorRteValueType } from '@umbraco-cms/backoffice/rte';
+
+// The Example Workspace Context Controller:
+export class CustomValidationValidator extends UmbControllerBase implements UmbValidator {
+	//
+	#validationContext?: typeof UMB_VALIDATION_CONTEXT.TYPE;
+	#workspaceContext?: typeof UMB_CONTENT_WORKSPACE_CONTEXT.TYPE;
+
+	#propertyAlias: string;
+	#variantId?: UmbVariantId;
+	#dataPath: string;
+	#isValid: boolean = false;
+	#value?: UmbPropertyEditorRteValueType;
+
+	constructor(host: UmbControllerHost, propertyAlias: string, variantId?: UmbVariantId) {
+		super(host);
+		this.#propertyAlias = propertyAlias;
+		this.#variantId = variantId;
+		this.#dataPath = `$.values[${UmbDataPathPropertyValueQuery({
+			alias: this.#propertyAlias,
+			culture: this.#variantId?.culture ?? null,
+			segment: this.#variantId?.segment ?? null,
+		})}].value`;
+
+		this.consumeContext(UMB_VALIDATION_CONTEXT, (context) => {
+			this.#validationContext = context;
+			this.#checkValidation();
+		});
+
+		this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, async (context) => {
+			this.#workspaceContext = context;
+			this.observe(
+				await context.propertyValueByAlias<UmbPropertyEditorRteValueType>(propertyAlias, this.#variantId),
+				(value) => {
+					this.#value = value;
+					this.#checkValidation();
+				},
+			);
+		});
+	}
+
+	#checkValidation() {
+		// Check validation:
+		if (this.#value?.markup) {
+			const cleanedMarkup = this.#value.markup?.replace(/<\/?[^>]+(>|$)/g, '');
+			// Check if markup contains words longer than 6 characters:
+			const words = cleanedMarkup.split(/\s+/);
+			const invalidWords = words.filter((word) => word.length > 10);
+			if (invalidWords.length === 0) {
+				this.#isValid = true;
+			} else {
+				this.#isValid = false;
+			}
+		} else {
+			this.#isValid = true;
+		}
+
+		// Update validation message:
+		if (this.#validationContext && this.#workspaceContext) {
+			if (this.#isValid) {
+				this.#validationContext.messages.removeMessagesByTypeAndPath('custom', this.#dataPath);
+			} else {
+				this.#validationContext.messages.addMessage(
+					'custom',
+					this.#dataPath,
+					'Custom validation says this contains too long words',
+				);
+			}
+		}
+	}
+
+	async validate(): Promise<void> {
+		// validate is called when the validation state has to be fully resolved. Like when user clicks Save & Publish.
+		// If you need to ask the server then it can be done here, instead of asking the server each time the value changes.
+	}
+
+	get isValid(): boolean {
+		return this.#isValid;
+	}
+
+	reset(): void {
+		this.#isValid = false;
+	}
+
+	/**
+	 * Focus the first invalid element.
+	 */
+	focusFirstInvalidElement(): void {
+		alert('custom validation is invalid, you should implement a feature to focus the problematic element');
+	}
+}
+
+// Declare a api export, so Extension Registry can initialize this class:
+export const api = CustomValidationValidator;
+
+// Declare a Context Token, to other can request the context and to ensure typings.
+export const EXAMPLE_CUSTOM_VALIDATION_CONTEXT = new UmbContextToken<CustomValidationValidator>(
+	'UmbWorkspaceContext',
+	'example.workspaceContext.counter',
+);

--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
@@ -80,8 +80,10 @@ export class CustomValidationValidator extends UmbControllerBase implements UmbV
 	}
 
 	async validate(): Promise<void> {
-		// validate is called when the validation state has to be fully resolved. Like when user clicks Save & Publish.
+		// Validate is called when the validation state of this validator is asked to be fully resolved. Like when user clicks Save & Publish.
 		// If you need to ask the server then it can be done here, instead of asking the server each time the value changes.
+		// In this particular example we do not need to do anything, because our validation is represented via a message that we always set no matter the user interaction.
+		// If we did not like to only to check the Validation State when absolute needed then this method must be implemented.
 	}
 
 	get isValid(): boolean {
@@ -97,6 +99,13 @@ export class CustomValidationValidator extends UmbControllerBase implements UmbV
 	 */
 	focusFirstInvalidElement(): void {
 		alert('custom validation is invalid, you should implement a feature to focus the problematic element');
+	}
+
+	override destroy(): void {
+		this.#validationContext = undefined;
+		this.#workspaceContext = undefined;
+		this.#value = undefined;
+		super.destroy();
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-validator.ts
@@ -55,7 +55,7 @@ export class CustomValidationValidator extends UmbControllerBase implements UmbV
 			const cleanedMarkup = this.#value.markup?.replace(/<\/?[^>]+(>|$)/g, '');
 			// Check if markup contains words longer than 6 characters:
 			const words = cleanedMarkup.split(/\s+/);
-			const invalidWords = words.filter((word) => word.length > 10);
+			const invalidWords = words.filter((word) => word.length > 8);
 			if (invalidWords.length === 0) {
 				this.#isValid = true;
 			} else {

--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/custom-validation-workspace-context.ts
@@ -1,0 +1,68 @@
+import { CustomValidationValidator } from './custom-validation-validator.js';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+
+const EXAMPLE_CUSTOM_VALIDATION_PROPERTY_ALIAS = 'tiptap';
+
+// The Example Workspace Context Controller:
+export class CustomValidationWorkspaceContext extends UmbContextBase<
+	CustomValidationWorkspaceContext,
+	typeof EXAMPLE_CUSTOM_VALIDATION_CONTEXT
+> {
+	#validators?: Array<CustomValidationValidator>;
+
+	constructor(host: UmbControllerHost) {
+		super(host, EXAMPLE_CUSTOM_VALIDATION_CONTEXT);
+
+		this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, async (context) => {
+			// Observe the property type to see if it varies by culture:
+			this.observe(
+				await context?.structure.propertyStructureByAlias(EXAMPLE_CUSTOM_VALIDATION_PROPERTY_ALIAS),
+				(propertyType) => {
+					if (!propertyType) {
+						this.removeUmbControllerByAlias('observeVariantOptions');
+						this.#validators?.forEach((x) => x.destroy());
+						return;
+					}
+					if (propertyType.variesByCulture) {
+						// Because this property exists in multiple cultures we should observe cultures an create a custom validator for each culture value:
+						this.observe(
+							context.variantOptions,
+							(variantOptions) => {
+								// clean up old validators:
+								this.#validators?.forEach((x) => x.destroy());
+
+								this.#validators = variantOptions.map((option) => {
+									return new CustomValidationValidator(
+										this,
+										EXAMPLE_CUSTOM_VALIDATION_PROPERTY_ALIAS,
+										UmbVariantId.Create(option),
+									);
+								});
+							},
+							'observeVariantOptions',
+						);
+					} else {
+						// Not varying by culture, so we can just create a single validator for the invariant value:
+						this.removeUmbControllerByAlias('observeVariantOptions');
+						this.#validators?.forEach((x) => x.destroy());
+						this.#validators = [new CustomValidationValidator(this, EXAMPLE_CUSTOM_VALIDATION_PROPERTY_ALIAS)];
+					}
+				},
+				'observePropertyType',
+			);
+		});
+	}
+}
+
+// Declare a api export, so Extension Registry can initialize this class:
+export const api = CustomValidationWorkspaceContext;
+
+// Declare a Context Token, to other can request the context and to ensure typings.
+export const EXAMPLE_CUSTOM_VALIDATION_CONTEXT = new UmbContextToken<CustomValidationWorkspaceContext>(
+	'UmbWorkspaceContext',
+	'example.workspaceContext.counter',
+);

--- a/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/index.ts
+++ b/src/Umbraco.Web.UI.Client/examples/custom-validation-workspace-context/index.ts
@@ -1,0 +1,16 @@
+import { UMB_WORKSPACE_CONTENT_TYPE_ALIAS_CONDITION_ALIAS } from '@umbraco-cms/backoffice/content-type';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'workspaceContext',
+		name: 'Example Custom Validation Workspace Context',
+		alias: 'example.workspaceCounter.customValidation',
+		api: () => import('./custom-validation-workspace-context.js'),
+		conditions: [
+			{
+				alias: UMB_WORKSPACE_CONTENT_TYPE_ALIAS_CONDITION_ALIAS,
+				match: 'allRtesDocumentType',
+			},
+		],
+	},
+];

--- a/src/Umbraco.Web.UI.Client/examples/entity-content-type-condition/index.ts
+++ b/src/Umbraco.Web.UI.Client/examples/entity-content-type-condition/index.ts
@@ -1,3 +1,5 @@
+import { UMB_WORKSPACE_CONTENT_TYPE_ALIAS_CONDITION_ALIAS } from '@umbraco-cms/backoffice/content-type';
+
 const workspace: UmbExtensionManifest = {
 	type: 'workspaceView',
 	alias: 'Example.WorkspaceView.EntityContentTypeCondition',
@@ -10,7 +12,7 @@ const workspace: UmbExtensionManifest = {
 	},
 	conditions: [
 		{
-			alias: 'Umb.Condition.WorkspaceContentTypeAlias',
+			alias: UMB_WORKSPACE_CONTENT_TYPE_ALIAS_CONDITION_ALIAS,
 			//match : 'blogPost'
 			oneOf: ['blogPost', 'mediaType1'],
 		},

--- a/src/Umbraco.Web.UI.Client/src/libs/class-api/class.mixin.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/class-api/class.mixin.ts
@@ -33,7 +33,7 @@ export const UmbClassMixin = <T extends ClassConstructor<EventTarget>>(superClas
 		}
 
 		getHostElement(): Element {
-			return this._host.getHostElement();
+			return this._host?.getHostElement();
 		}
 
 		get controllerAlias(): UmbControllerAlias {

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document-type/document-type.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document-type/document-type.data.ts
@@ -1750,7 +1750,7 @@ export const data: Array<UmbMockDocumentTypeModel> = [
 		description: null,
 		icon: 'icon-document',
 		allowedAsRoot: true,
-		variesByCulture: false,
+		variesByCulture: true,
 		variesBySegment: false,
 		isElement: false,
 		hasChildren: false,

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
@@ -74,7 +74,7 @@ export const data: Array<UmbMockDocumentModel> = [
 			{
 				editorAlias: 'Umbraco.RichText',
 				alias: 'richTextEditor',
-				culture: null,
+				culture: 'en-US',
 				segment: null,
 				value: {
 					blocks: {},
@@ -125,28 +125,28 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'email',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.ColorPicker',
 				alias: 'colorPicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.MultiNodeTreePicker',
 				alias: 'contentPicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.ColorPicker.EyeDropper',
 				alias: 'eyeDropper',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.MultiUrlPicker',
@@ -170,7 +170,7 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'multiUrlPicker',
 				culture: 'da-dk',
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.MultiNodeTreePicker',
@@ -206,77 +206,77 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'email',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.TextBox',
 				alias: 'textBox',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.DropDown.Flexible',
 				alias: 'dropdown',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.DropDown.Flexible',
 				alias: 'dropdownMultiple',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.TextArea',
 				alias: 'textArea',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.Slider',
 				alias: 'slider',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.TrueFalse',
 				alias: 'toggle',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.Tags',
 				alias: 'tags',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.MarkdownEditor',
 				alias: 'markdownEditor',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.RadioButtonList',
 				alias: 'radioButtonList',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.CheckBoxList',
 				alias: 'checkboxList',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.BlockList',
@@ -296,39 +296,84 @@ export const data: Array<UmbMockDocumentModel> = [
 						{
 							key: '1234',
 							contentTypeKey: '4f68ba66-6fb2-4778-83b8-6ab4ca3a7c5c',
-							elementProperty: 'Hello world',
+							values: [
+								{
+									editorAlias: 'Umbraco.TextBox',
+									alias: 'elementProperty',
+									culture: null,
+									segment: null,
+									value: 'Hello world 123',
+								},
+							],
 						},
 					],
 					settingsData: [
 						{
 							key: '5678',
 							contentTypeKey: 'all-property-editors-document-type-id',
-							elementProperty: 'Hello world',
-							textBox: 'Hello world 123',
-							blockList: {
-								layout: {
-									'Umbraco.BlockList': [
-										{
-											contentKey: '1234b',
-											settingsKey: '5678b',
-										},
-									],
+							values: [
+								{
+									editorAlias: 'Umbraco.TextBox',
+									alias: 'elementProperty',
+									culture: null,
+									segment: null,
+									value: 'Hello world 123',
 								},
-								contentData: [
-									{
-										key: '1234b',
-										contentTypeKey: '4f68ba66-6fb2-4778-83b8-6ab4ca3a7c5c',
-										elementProperty: 'Hello world',
+								{
+									editorAlias: 'Umbraco.TextBox',
+									alias: 'textBox',
+									culture: null,
+									segment: null,
+									value: 'Hello world 123',
+								},
+								{
+									editorAlias: 'Umbraco.BlockList',
+									alias: 'blockList',
+									culture: null,
+									segment: null,
+									value: {
+										layout: {
+											'Umbraco.BlockList': [
+												{
+													contentKey: '1234b',
+													settingsKey: '5678b',
+												},
+											],
+										},
+										contentData: [
+											{
+												key: '1234b',
+												contentTypeKey: '4f68ba66-6fb2-4778-83b8-6ab4ca3a7c5c',
+												values: [
+													{
+														editorAlias: 'Umbraco.TextBox',
+														alias: 'elementProperty',
+														culture: null,
+														segment: null,
+														value: 'Hello world 123',
+													},
+												],
+											},
+										],
+										settingsData: [
+											{
+												key: '5678b',
+												contentTypeKey: 'all-property-editors-document-type-id',
+												elementProperty: 'Hello world',
+												values: [
+													{
+														editorAlias: 'Umbraco.TextBox',
+														alias: 'elementProperty',
+														culture: null,
+														segment: null,
+														value: 'Hello world 123',
+													},
+												],
+											},
+										],
 									},
-								],
-								settingsData: [
-									{
-										key: '5678b',
-										contentTypeKey: 'all-property-editors-document-type-id',
-										elementProperty: 'Hello world',
-									},
-								],
-							},
+								},
+							],
 						},
 					],
 				},
@@ -338,7 +383,7 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'mediaPicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.ImageCropper',
@@ -426,7 +471,7 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'uploadField',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.BlockGrid',
@@ -475,7 +520,15 @@ export const data: Array<UmbMockDocumentModel> = [
 						{
 							key: '1234',
 							contentTypeKey: '4f68ba66-6fb2-4778-83b8-6ab4ca3a7c5c',
-							elementProperty: 'Hello world',
+							values: [
+								{
+									editorAlias: 'Umbraco.TextBox',
+									alias: 'elementProperty',
+									culture: null,
+									segment: null,
+									value: 'Hello world 123',
+								},
+							],
 						},
 						{
 							key: 'a1234',
@@ -497,7 +550,15 @@ export const data: Array<UmbMockDocumentModel> = [
 						{
 							key: '5678',
 							contentTypeKey: 'all-property-editors-document-type-id',
-							elementProperty: 'Hello world',
+							values: [
+								{
+									editorAlias: 'Umbraco.TextBox',
+									alias: 'elementProperty',
+									culture: null,
+									segment: null,
+									value: 'Hello world 123',
+								},
+							],
 						},
 						{
 							key: 'a5678',
@@ -517,70 +578,49 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'blockGrid',
 				culture: null,
 				segment: null,
-				value: null,
-			},
-			{
-				editorAlias: '',
-				alias: 'numberRange',
-				culture: null,
-				segment: null,
-				value: null,
-			},
-			{
-				editorAlias: '',
-				alias: 'orderDirection',
-				culture: null,
-				segment: null,
-				value: null,
-			},
-			{
-				editorAlias: '',
-				alias: 'overlaySize',
-				culture: null,
-				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.Label',
 				alias: 'label',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.Integer',
 				alias: 'integer',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.Decimal',
 				alias: 'decimal',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.MemberPicker',
 				alias: 'memberPicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.MemberGroupPicker',
 				alias: 'memberGroupPicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.UserPicker',
 				alias: 'userPicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 		],
 		variants: [
@@ -867,14 +907,14 @@ export const data: Array<UmbMockDocumentModel> = [
 				alias: 'multiNodeTreePicker',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 			{
 				editorAlias: 'Umbraco.ListView',
 				alias: 'listView',
 				culture: null,
 				segment: null,
-				value: null,
+				value: undefined,
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
@@ -942,7 +942,7 @@ export const data: Array<UmbMockDocumentModel> = [
 			{
 				state: DocumentVariantStateModel.PUBLISHED,
 				publishDate: '2023-02-06T15:32:24.957009',
-				culture: null,
+				culture: 'en-US',
 				segment: null,
 				name: 'All RTEs',
 				createDate: '2023-02-06T15:32:05.350038',
@@ -956,42 +956,13 @@ export const data: Array<UmbMockDocumentModel> = [
 				culture: null,
 				segment: null,
 				value: {
-					markup: `
-						<p><a id="anchor"></a> Here is a link for <a href="https://gist.github.com/leekelleher/9490718" target="_blank">all HTML tags</a>.</p>
-						<p>
-							<span id="foo">Some</span> value for the RTE with an <a href="https://google.com">external link</a> and an <a type="document" href="/{localLink:c05da24d-7740-447b-9cdc-bd8ce2172e38}">internal link</a>.
-						</p>
-						<div data-foo-bar="123">
-							<span>This is a plain old span tag.</span>
-							<span style="color:red;">Hello <span style="color:blue;">world</span>.</span>
-						</div>
-						<table>
-							<thead>
-								<tr>
-									<th>Version</th>
-									<th>Date</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>15.3</td>
-									<td>2025-03-20</td>
-								</tr>
-								<tr>
-									<td>16.0</td>
-									<td>2025-06-12</td>
-								</tr>
-								<tr>
-									<td>17.0</td>
-									<td>2025-11-27</td>
-								</tr>
-							</tbody>
-						</table>
-						<p>
-							<img width="384" height="228" loading="lazy" alt="Installer illustration" src="/umbraco/backoffice/assets/installer-illustration.svg" />
-						</p>
-						<p>End of test content</p>
-					`,
+					blocks: {
+						layout: {},
+						contentData: [],
+						settingsData: [],
+						expose: [],
+					},
+					markup: `<p><a id="anchor"></a> Here is a link for <a target="_blank" data-router-slot="disabled" href="https://gist.github.com/leekelleher/9490718" type="external">all HTML tags</a>.</p><p><span id="foo">Some</span> value for the RTE with an <a target="" data-router-slot="disabled" href="https://google.com" type="external">external link</a> and an <a target="" data-router-slot="disabled" href="/{localLink:c05da24d-7740-447b-9cdc-bd8ce2172e38}" type="document">internal link</a>.</p><div data-foo-bar="123"><span>This is a plain old span tag.</span> <span style="color: red;">Hello </span><span style="color: blue;">world</span><span style="color: red;">.</span></div><table style="min-width: 50px"><colgroup><col style="min-width: 25px"><col style="min-width: 25px"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p> Version</p></th><th colspan="1" rowspan="1"><p>Date</p></th></tr><tr><td colspan="1" rowspan="1"><p>15.3</p></td><td colspan="1" rowspan="1"><p>2025-03-20</p></td></tr><tr><td colspan="1" rowspan="1"><p>16.0</p></td><td colspan="1" rowspan="1"><p>2025-06-12</p></td></tr><tr><td colspan="1" rowspan="1"><p>17.0</p></td><td colspan="1" rowspan="1"><p>2025-11-27</p></td></tr></tbody></table><p><img src="/umbraco/backoffice/assets/installer-illustration.svg" alt="Installer illustration" width="384" height="228" loading="lazy"></p><p>End of test content</p>`,
 				},
 			},
 		],

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/document/document.data.ts
@@ -956,7 +956,6 @@ export const data: Array<UmbMockDocumentModel> = [
 				culture: null,
 				segment: null,
 				value: {
-					blocks: undefined,
 					markup: `
 						<p><a id="anchor"></a> Here is a link for <a href="https://gist.github.com/leekelleher/9490718" target="_blank">all HTML tags</a>.</p>
 						<p>

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-value-cloner/property-value-cloner-block-rte.cloner.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-value-cloner/property-value-cloner-block-rte.cloner.test.ts
@@ -71,8 +71,8 @@ describe('UmbBlockRtePropertyValueCloner', () => {
 
 			const result = (await ctrl.clone(value)) as { value: UmbPropertyEditorRteValueType | undefined };
 
-			const newContentKey = result.value?.blocks.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].contentKey;
-			const newSettingsKey = result.value?.blocks.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].settingsKey;
+			const newContentKey = result.value?.blocks?.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].contentKey;
+			const newSettingsKey = result.value?.blocks?.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].settingsKey;
 
 			if (newContentKey === undefined) {
 				throw new Error('newContentKey is undefined');
@@ -80,20 +80,20 @@ describe('UmbBlockRtePropertyValueCloner', () => {
 
 			expect(result.value?.markup.indexOf(newContentKey) !== 0).to.be.true;
 
-			expect(result.value?.blocks.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].contentKey).to.not.be.equal(
+			expect(result.value?.blocks?.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].contentKey).to.not.be.equal(
 				'content-1',
 			);
-			expect(result.value?.blocks.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].settingsKey).to.not.be.equal(
+			expect(result.value?.blocks?.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].settingsKey).to.not.be.equal(
 				'settings-1',
 			);
-			expect(result.value?.blocks.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].contentKey).to.be.equal(
+			expect(result.value?.blocks?.layout[UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS]?.[0].contentKey).to.be.equal(
 				newContentKey,
 			);
 
-			expect(result.value?.blocks.contentData[0].key).to.not.be.equal('content-1');
-			expect(result.value?.blocks.contentData[0].key).to.be.equal(newContentKey);
-			expect(result.value?.blocks.settingsData[0].key).to.not.be.equal('settings-1');
-			expect(result.value?.blocks.settingsData[0].key).to.be.equal(newSettingsKey);
+			expect(result.value?.blocks?.contentData[0].key).to.not.be.equal('content-1');
+			expect(result.value?.blocks?.contentData[0].key).to.be.equal(newContentKey);
+			expect(result.value?.blocks?.settingsData[0].key).to.not.be.equal('settings-1');
+			expect(result.value?.blocks?.settingsData[0].key).to.be.equal(newSettingsKey);
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-value-cloner/property-value-cloner-block-rte.cloner.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-value-cloner/property-value-cloner-block-rte.cloner.ts
@@ -20,7 +20,9 @@ export class UmbBlockRTEPropertyValueCloner implements UmbPropertyValueCloner<Um
 				contentIdUpdatedCallback: this.#replaceContentKeyInMarkup,
 			});
 			const result = {} as UmbPropertyEditorRteValueType;
-			result.blocks = await cloner.cloneValue(value.blocks);
+			if (value.blocks) {
+				result.blocks = await cloner.cloneValue(value.blocks);
+			}
 			result.markup = this.#markup;
 			return result;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/property-value-resolver/block-value-resolver.api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/property-value-resolver/block-value-resolver.api.ts
@@ -38,7 +38,7 @@ export abstract class UmbBlockValueResolver<ValueType>
 		value: ValueType,
 		variantsCallback: (values: Array<UmbBlockExposeModel>) => Promise<Array<UmbBlockExposeModel> | undefined>,
 	) {
-		const expose = (await variantsCallback(value.expose)) ?? [];
+		const expose = (await variantsCallback(value.expose ?? [])) ?? [];
 		return { ...value, expose };
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/conditions/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/conditions/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Workspace Content Type Alias condition alias
+ */
+export const UMB_WORKSPACE_CONTENT_TYPE_ALIAS_CONDITION_ALIAS = 'Umb.Condition.WorkspaceContentTypeAlias';

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/conditions/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/conditions/types.ts
@@ -1,20 +1,22 @@
+import type { UMB_WORKSPACE_CONTENT_TYPE_ALIAS_CONDITION_ALIAS } from './constants.js';
 import type { UmbConditionConfigBase } from '@umbraco-cms/backoffice/extension-api';
 
-export type UmbWorkspaceContentTypeAliasConditionConfig =
-	UmbConditionConfigBase<'Umb.Condition.WorkspaceContentTypeAlias'> & {
-		/**
-		 * Define a content type alias in which workspace this extension should be available
-		 * @example
-		 * Depends on implementation, but i.e. "article", "image", "blockPage"
-		 */
-		match?: string;
-		/**
-		 * Define one or more content type aliases in which workspace this extension should be available
-		 * @example
-		 * ["article", "image", "blockPage"]
-		 */
-		oneOf?: Array<string>;
-	};
+export type UmbWorkspaceContentTypeAliasConditionConfig = UmbConditionConfigBase<
+	typeof UMB_WORKSPACE_CONTENT_TYPE_ALIAS_CONDITION_ALIAS
+> & {
+	/**
+	 * Define a content type alias in which workspace this extension should be available
+	 * @example
+	 * Depends on implementation, but i.e. "article", "image", "blockPage"
+	 */
+	match?: string;
+	/**
+	 * Define one or more content type aliases in which workspace this extension should be available
+	 * @example
+	 * ["article", "image", "blockPage"]
+	 */
+	oneOf?: Array<string>;
+};
 /**
  * @deprecated Use `UmbWorkspaceContentTypeAliasConditionConfig` instead. This will be removed in Umbraco 17.
  */

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/constants.ts
@@ -1,2 +1,3 @@
 export * from './modals/constants.js';
 export * from './workspace/constants.js';
+export * from './conditions/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/types.ts
@@ -2,6 +2,7 @@ import type { CompositionTypeModel } from '@umbraco-cms/backoffice/external/back
 import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 
 export type * from './composition/types.js';
+export type * from './conditions/types.js';
 
 export type UmbPropertyContainerTypes = 'Group' | 'Tab';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/sorter.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/sorter.controller.ts
@@ -72,7 +72,6 @@ function destroyIgnorerElements(element: HTMLElement, ignorerSelectors: string) 
  * @param element
  */
 function setupPreventEvent(element: Element) {
-	console.log('prevent on', element);
 	(element as HTMLElement).draggable = false;
 	//(element as HTMLElement).setAttribute('draggable', 'false');
 }
@@ -230,7 +229,7 @@ export type UmbSorterConfig<T, ElementType extends HTMLElement = HTMLElement> = 
 	Partial<Pick<INTERNAL_UmbSorterConfig<T, ElementType>, 'ignorerSelector' | 'containerSelector' | 'identifier'>>;
 
 /**
- 
+
  * @class UmbSorterController
  * @implements {UmbControllerInterface}
  * @description This controller can make user able to sort items.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/context/validation-messages.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/context/validation-messages.manager.ts
@@ -80,6 +80,10 @@ export class UmbValidationMessagesManager {
 		return this.getMessages().filter((x) => MatchPathOrDescendantPath(x.path, path));
 	}
 
+	getHasMessageOfPathAndBody(path: string, body: string): boolean {
+		return this.getMessages().some((x) => x.path === path && x.body === body);
+	}
+
 	messagesOfPathAndDescendant(path: string): Observable<Array<UmbValidationMessage>> {
 		//path = path.toLowerCase();
 		return createObservablePart(this.filteredMessages, (msgs) =>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/form-control-validator.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/form-control-validator.controller.ts
@@ -48,7 +48,10 @@ export class UmbFormControlValidator extends UmbControllerBase implements UmbVal
 			if (newVal) {
 				this.#context?.messages.removeMessagesByTypeAndPath('client', this.#dataPath);
 			} else {
-				this.#context?.messages.addMessages('client', this.#dataPath, [this.#control.validationMessage]);
+				// We only want to add the message if it is not already there. (this could be a custom or server message that got binded to the control, we do not want that double.)
+				if (!this.#context?.messages.getHasMessageOfPathAndBody(this.#dataPath, this.#control.validationMessage)) {
+					this.#context?.messages.addMessage('client', this.#dataPath, this.#control.validationMessage);
+				}
 			}
 		}
 		//this.dispatchEvent(new CustomEvent('change')); // To let the ValidationContext know that the validation state has changed.

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/property-value-resolver/rte-block-value-resolver.api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/property-value-resolver/rte-block-value-resolver.api.ts
@@ -16,7 +16,9 @@ export class UmbRteBlockValueResolver extends UmbBlockValueResolver<UmbPropertyE
 				...property,
 				value: {
 					...property.value,
-					blocks: await this._processValueBlockData(property.value.blocks, valuesCallback),
+					blocks: property.value?.blocks
+						? await this._processValueBlockData(property.value.blocks, valuesCallback)
+						: undefined,
 				},
 			};
 		}
@@ -32,7 +34,9 @@ export class UmbRteBlockValueResolver extends UmbBlockValueResolver<UmbPropertyE
 				...property,
 				value: {
 					...property.value,
-					blocks: await this._processVariantBlockData(property.value.blocks, variantsCallback),
+					blocks: property.value?.blocks
+						? await this._processVariantBlockData(property.value.blocks, variantsCallback)
+						: undefined,
 				},
 			};
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/types.ts
@@ -3,7 +3,7 @@ import type { UmbBlockRteLayoutModel } from '@umbraco-cms/backoffice/block-rte';
 
 export interface UmbPropertyEditorRteValueType {
 	markup: string;
-	blocks: UmbBlockValueType<UmbBlockRteLayoutModel>;
+	blocks?: UmbBlockValueType<UmbBlockRteLayoutModel>;
 }
 
 /**


### PR DESCRIPTION
Example demonstrating how you can build a custom validator that will always have an effect despite the UI not being rendered.

As well, this includes a few updates to make this happen properly.

Watch this intro to get a better idea about how it works:
https://github.com/user-attachments/assets/bc3b658c-1ec3-448f-9f5c-95276c3bdcfc

