### PR TITLE
Avoids unnecessary additional domain save notification publishing when sorting an already sorted collection of domains

### DIFF
--- a/src/Umbraco.Core/Services/DomainService.cs
+++ b/src/Umbraco.Core/Services/DomainService.cs
@@ -108,7 +108,7 @@ public class DomainService : RepositoryService, IDomainService
         EventMessages eventMessages = EventMessagesFactory.Get();
 
         IDomain[] domains = items.ToArray();
-        if (domains.Length == 0)
+        if (domains.Length == 0 || AreDomainsAlreadySorted(domains))
         {
             return OperationResult.Attempt.NoOperation(eventMessages);
         }
@@ -143,5 +143,19 @@ public class DomainService : RepositoryService, IDomainService
         }
 
         return OperationResult.Attempt.Succeed(eventMessages);
+    }
+
+    private static bool AreDomainsAlreadySorted(IDomain[] domains)
+    {
+        // Check if the domains are already sorted by comparing the current sort order with what we'll set to be the new sort order.
+        for (int i = 0; i < domains.Length; i++)
+        {
+            if (domains[i].SortOrder != i)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19104

### Description
The behaviour described in the linked issue occurs due to two operations being requested on the domains collection:

- A save for each domain
- A sort for each domain that's not already sorted

In most cases, we aren't sorting as well as saving, so we can short-circuit and not publish the second notification when we aren't making any changes to sort order.

When we are sorting, it's strictly correct to publish two notifications as we are making two separate saves.
