### PR TITLE
Update version of MiniProfiler.AspNetCore.Mvc to align with MiniProfiler.Shared

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="MailKit" Version="4.10.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
     <PackageVersion Include="MessagePack" Version="2.5.192" />
-    <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />
+    <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     <PackageVersion Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageVersion Include="ncrontab" Version="3.3.3" />
     <PackageVersion Include="NPoco" Version="5.7.1" />


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19100

### Description
The problem shown in the linked issue indicates that we have a mismatched set of dependencies for MiniProfiler.  I've updated them so they align which resolves the linked issue.

### Testing
Verify using the reproduction steps on the linked issue.