### PR TITLE
Updated server-side dependencies to latest versions for Umbraco 16

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,19 +5,19 @@
   </PropertyGroup>
   <!-- Global packages (private, build-time packages for all projects) -->
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <GlobalPackageReference Include="Umbraco.Code" Version="2.2.0" />
     <GlobalPackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" />
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />  <!-- TODO: Update the hard-dependency that Umbraco.Code has on 4.10.0 to allow update of this to latest (4.13.0). -->
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
@@ -38,65 +38,64 @@
   <!-- Umbraco packages -->
   <ItemGroup>
     <PackageVersion Include="Umbraco.JsonSchema.Extensions" Version="0.3.0" />
-    <PackageVersion Include="Umbraco.CSharpTest.Net.Collections" Version="15.0.0" />
   </ItemGroup>
   <!-- Third-party packages -->
   <ItemGroup>
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageVersion Include="Examine" Version="3.7.0" />
-    <PackageVersion Include="Examine.Core" Version="3.7.0" />
-    <PackageVersion Include="HtmlAgilityPack" Version="1.11.74" />
-    <PackageVersion Include="JsonPatch.Net" Version="3.1.1" />
+    <PackageVersion Include="Examine" Version="3.7.1" />
+    <PackageVersion Include="Examine.Core" Version="3.7.1" />
+    <PackageVersion Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-    <PackageVersion Include="MailKit" Version="4.10.0" />
+    <PackageVersion Include="MailKit" Version="4.11.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
-    <PackageVersion Include="MessagePack" Version="2.5.192" />
+    <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     <PackageVersion Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageVersion Include="ncrontab" Version="3.3.3" />
     <PackageVersion Include="NPoco" Version="5.7.1" />
     <PackageVersion Include="NPoco.SqlServer" Version="5.7.1" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="6.1.1" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="6.1.1" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="6.1.1" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="6.2.1" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="6.2.1" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="6.2.1" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact.Reader" Version="4.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
-    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.3" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.1.0" />
+    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.1" />
   </ItemGroup>
   <!-- Transitive pinned versions (only required because our direct dependencies have vulnerable versions of transitive dependencies) -->
   <ItemGroup>
     <!-- Microsoft.EntityFrameworkCore.SqlServer and NPoco.SqlServer brings in a vulnerable version of Azure.Identity -->
     <!-- Take top-level depedendency on Azure.Identity, because Microsoft.EntityFrameworkCore.SqlServer depends on a vulnerable version -->
-    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <!-- Microsoft.EntityFrameworkCore.SqlServer brings in a vulnerable version of System.Runtime.Caching -->
-    <PackageVersion Include="System.Runtime.Caching" Version="9.0.0" />
+    <PackageVersion Include="System.Runtime.Caching" Version="9.0.4" />
     <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- Examine brings in a vulnerable version of System.Security.Cryptography.Xml -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.4" />
     <!-- Dazinator.Extensions.FileProviders and MiniProfiler.AspNetCore.Mvc brings in a vulnerable version of System.Text.RegularExpressions -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- OpenIddict.AspNetCore, Npoco.SqlServer and Microsoft.EntityFrameworkCore.SqlServer brings in a vulnerable version of Microsoft.IdentityModel.JsonWebTokens -->
     <!-- Take top-level depedendency on Microsoft.IdentityModel.JsonWebTokens, because OpenIddict.AspNetCore, Npoco.SqlServer and Microsoft.EntityFrameworkCore.SqlServer depends on a vulnerable version -->
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.8.0" />
     <!-- Azure.Identity, Microsoft.EntityFrameworkCore.SqlServer and Dazinator.Extensions.FileProviders brings in a legacy version of System.Text.Encodings.Web -->
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.4" />
     <!-- NPoco.SqlServer brings in a vulnerable version of Microsoft.Data.SqlClient  -->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <!-- Examine.Lucene brings in a vulnerable version of Lucene.Net.Replicator -->
     <PackageVersion Include="Lucene.Net.Replicator" Version="4.8.0-beta00017" />
   </ItemGroup>

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorPastedImages.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorPastedImages.cs
@@ -190,7 +190,7 @@ public sealed class RichTextEditorPastedImages
                 });
             }
 
-            img.SetAttributeValue("src", location);
+            img.SetAttributeValue("src", location ?? string.Empty);
 
             // Remove the data attribute (so we do not re-process this)
             img.Attributes.Remove(TemporaryImageDataAttribute);

--- a/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
+++ b/src/Umbraco.Web.Common/Mvc/HtmlStringUtilities.cs
@@ -30,13 +30,13 @@ public sealed class HtmlStringUtilities
 
     public HtmlString StripHtmlTags(string html, params string[]? tags)
     {
-        HtmlDocument doc = new HtmlDocument();
+        var doc = new HtmlDocument();
         doc.LoadHtml(html);
 
-        List<HtmlNode> targets = new List<HtmlNode>();
-        HtmlNodeCollection nodes = doc.DocumentNode.SelectNodes(".//*");
+        var targets = new List<HtmlNode>();
+        HtmlNodeCollection? nodes = doc.DocumentNode.SelectNodes(".//*");
 
-        if (nodes != null)
+        if (nodes is not null)
         {
             foreach (HtmlNode node in nodes)
             {

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,21 +5,21 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="9.0.0" />
-    <PackageVersion Include="System.Data.OleDb" Version="9.0.0" />
+    <PackageVersion Include="System.Data.Odbc" Version="9.0.4" />
+    <PackageVersion Include="System.Data.OleDb" Version="9.0.4" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Third-party packages -->
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.NUnit3" Version="4.18.1" />
-    <PackageVersion Include="Bogus" Version="35.6.1" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="NUnit" Version="3.14.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" PrivateAssets="all" />
+    <PackageVersion Include="Bogus" Version="35.6.3" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="AutoFixture.NUnit3" Version="4.18.1" />
     <PackageVersion Include="Bogus" Version="35.6.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" PrivateAssets="all" />
+    <PackageVersion Include="NUnit" Version="3.14.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/OpenApiContractTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/OpenApiContractTest.cs
@@ -39,7 +39,7 @@ internal sealed class OpenApiContractTest : UmbracoTestServerTestBase
     private const string ExpectedOpenApiContract =
     """
     {
-      "openapi": "3.0.1",
+      "openapi": "3.0.4",
       "info": {
         "title": "Umbraco Delivery API",
         "description": "You can find out more about the Umbraco Delivery API in [the documentation](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api).",


### PR DESCRIPTION
### Description
This PR updates Umbraco's server-side dependencies to their latest non-pre-release versions.

Note that I couldn't update `Microsoft.CodeAnalysis.CSharp` without a similar update in `Umbraco.Code`.  It's not too important though, so we can handle that another time - I've added a `TODO`.

I've removed `Umbraco.CSharpTest.Net.Collections` - as this doesn't look to be used any more.  IIRC it was a dependency of NuCache, which is now replaced with Microsoft's Hybrid Cache.

There are a few major version bumps here, but reading through release notes nothing jumped out as being of concern (e.g. license changes, data format changes).

There were a couple of minor breaking changes.

I've verified that Umbraco builds without any dependency warnings, runs, and unit tests all pass.  Will see on the pipeline for the other tests.