### PR TITLE
Image Cropper + Tags style adjustments

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
@@ -275,6 +275,13 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 				inset: 0;
 				cursor: pointer;
 				border: 1px dashed var(--uui-color-divider-emphasis);
+				border-radius: var(--uui-border-radius);
+			}
+
+			:host([standalone]:not([disabled]):hover) {
+				border-color: var(--uui-color-default-emphasis);
+				--uui-color-default: var(--uui-color-default-emphasis);
+				color: var(--uui-color-default-emphasis);
 			}
 
 			#dropzone {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -186,6 +186,11 @@ export class UmbInputImageCropperElement extends UmbFormControlMixin<
 	static override readonly styles = [
 		UmbTextStyles,
 		css`
+			:host {
+				display: block;
+				max-width: 500px;
+				min-width: 300px;
+			}
 			#loader {
 				display: flex;
 				justify-content: center;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -186,8 +186,7 @@ export class UmbInputImageCropperElement extends UmbFormControlMixin<
 	static override readonly styles = [
 		UmbTextStyles,
 		css`
-			:host {
-				display: block;
+			umb-input-dropzone {
 				max-width: 500px;
 				min-width: 300px;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
@@ -278,6 +278,7 @@ export class UmbTagsInputElement extends UUIFormControlMixin(UmbLitElement, '') 
 				align-items: center;
 				padding: var(--uui-size-space-2);
 				border: 1px solid var(--uui-color-border);
+				border-radius: var(--uui-border-radius);
 				background-color: var(--uui-input-background-color, var(--uui-color-surface));
 				flex: 1;
 				min-height: 40px;


### PR DESCRIPTION
Minor style adjustments for Image Cropper and Tags inputs.

Includes Round borders and hover state.

Result:
![image](https://github.com/user-attachments/assets/203af3bb-fa5e-42ef-805f-229228e9868d)
