### PR TITLE
Fix UI creation and updating of Document Blueprints

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -820,7 +820,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		} else {
 			/* If there are multiple variants but no modal token is set 
 			we will save the variants that would have been preselected in the modal. 
-			These are based on what variants have edited */
+			These are based on the variants that have been edited */
 			variantIds = selected.map((x) => UmbVariantId.FromString(x));
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -818,7 +818,10 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 
 			variantIds = result?.selection.map((x) => UmbVariantId.FromString(x)) ?? [];
 		} else {
-			throw new Error('No variant picker modal token is set. There are multiple variants to save. Cannot proceed.');
+			/* If there are multiple variants but no modal token is set 
+			we will save the variants that would have been preselected in the modal. 
+			These are based on what variants have edited */
+			variantIds = selected.map((x) => UmbVariantId.FromString(x));
 		}
 
 		const saveData = await this.constructSaveData(variantIds);


### PR DESCRIPTION
If a workspace that extends the content-detail workspace base doesn't include a save token, we currently show an error.

The save token is used to open a dialog that allows you to change a preselection of changed variants.

I have updated the code so that instead of throwing an error for the missing token, we will save what would have been the preselected variants directly. This way, the dialog can be seen as an additional UX improvement to change your selection. If the save token is not provided, we will save all variants with changes.

With these changes, the Document Blueprint workspace is able to create and save again. If we want to provide a similar experience as the Document Workspace, we can introduce a specific modal to handle the blueprint variants.