### PR TITLE
Add Conditions to ManifestHeaderApp

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/extensions/header-app.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/extension-registry/extensions/header-app.extension.ts
@@ -1,10 +1,10 @@
-import type { ManifestElement } from '@umbraco-cms/backoffice/extension-api';
+import type { ManifestElement, ManifestWithDynamicConditions } from '@umbraco-cms/backoffice/extension-api';
 
 /**
  * Header apps are displayed in the top right corner of the backoffice
  * The two provided header apps are the search and the user menu
  */
-export interface ManifestHeaderApp extends ManifestElement {
+export interface ManifestHeaderApp extends ManifestElement, ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
 	type: 'headerApp';
 	//meta: MetaHeaderApp;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes: #18979 

### Description
Adds `ManifestWithDynamicConditions` to `ManifestHeaderApp` so Header Apps can be conditionally shown/loaded like other Manifest/Extension types.

#### Test Notes
* Checkout PR
* Verify it builds
* Update or create a new Header App manifest
* Verify Conditions can be added
* Ensure conditions run and load/unload Header App as needed

Add a  simple condition such as this to verify that should make a header app only show if in the Settings section
```json
{
  ...
  "conditions": [
    {
      "alias": "Umb.Condition.SectionAlias",
      "match": "Umb.Section.Settings",
    },
  ]
}
```
