### PR TITLE
Ensure the default segment is always included in API responses

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Content/ContentMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Content/ContentMapDefinition.cs
@@ -56,7 +56,8 @@ public abstract class ContentMapDefinition<TContent, TValueViewModel, TVariantVi
     {
         IPropertyValue[] propertyValues = source.Properties.SelectMany(propertyCollection => propertyCollection.Values).ToArray();
         var cultures = source.AvailableCultures.DefaultIfEmpty(null).ToArray();
-        var segments = propertyValues.Select(property => property.Segment).Distinct().DefaultIfEmpty(null).ToArray();
+        // the default segment (null) must always be included in the view model - both for variant and invariant documents
+        var segments = propertyValues.Select(property => property.Segment).Union([null]).Distinct().ToArray();
 
         return cultures
             .SelectMany(culture => segments.Select(segment =>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The server fails to return the default segment for a document when:

- No property values have been defined for the default segment, and
- Other segments have been defined with values.

Kinda hard to explain, so here's a screencast:

[default-variant-with-no-property-values.webm](https://github.com/user-attachments/assets/2c97d6d7-5e8a-4efc-afc4-a9b50d2c9502)

### Testing this PR

All documents no matter their variance should _always_ yield the default segment from the Management API.
