### PR TITLE
V16: Bumps core dependencies openapi-ts and uuid to latest

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -1053,15 +1053,16 @@
 			}
 		},
 		"node_modules/@hey-api/json-schema-ref-parser": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.0.4.tgz",
-			"integrity": "sha512-IaJ4yFgU5r63KZyeySHRKSM1bavFIda8KdwCFi5BxQCIklltzEByBksNOPms+yHXpWWfR+OopIusVZV8roycYg==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.0.5.tgz",
+			"integrity": "sha512-bWUV9ICwvU5I3YKVZqWIUXFC2SIXznUi/u+LqurJx6ILiyImfZD5+g/lj3w4EiyXxmjqyaxptzUz/1IgK3vVtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jsdevtools/ono": "^7.1.3",
 				"@types/json-schema": "^7.0.15",
-				"js-yaml": "^4.1.0"
+				"js-yaml": "^4.1.0",
+				"lodash": "^4.17.21"
 			},
 			"engines": {
 				"node": ">= 16"
@@ -1071,13 +1072,13 @@
 			}
 		},
 		"node_modules/@hey-api/openapi-ts": {
-			"version": "0.66.1",
-			"resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.66.1.tgz",
-			"integrity": "sha512-Mol3vuM76d8F7xLvcZi502UxM3taXy7TDZzZfFpUMT+VLMdPiGd9cTWfKfQde0kgi+SZPjejvqmad1zk4EIu7A==",
+			"version": "0.66.6",
+			"resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.66.6.tgz",
+			"integrity": "sha512-EmZHVqfHuGNoyBDPcL+3vGHLb/qEbjIix3dnQ/CzfZQ+xm4vnOecpR7JaaaR9u2W8Ldeyqnk7NwmEqOBgkgG4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@hey-api/json-schema-ref-parser": "1.0.4",
+				"@hey-api/json-schema-ref-parser": "1.0.5",
 				"c12": "2.0.1",
 				"commander": "13.0.0",
 				"handlebars": "4.7.8"
@@ -3354,9 +3355,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/diff": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.1.tgz",
-			"integrity": "sha512-R/BHQFripuhW6XPXy05hIvXJQdQ4540KnTvEFHSLjXfHYM41liOLKgIJEyYYiQe796xpaMHfe4Uj/p7Uvng2vA==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+			"integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
 			"license": "MIT"
 		},
 		"node_modules/@types/eslint": {
@@ -16675,9 +16676,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-			"integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
@@ -17479,13 +17480,13 @@
 		"src/packages/core": {
 			"name": "@umbraco-backoffice/core",
 			"dependencies": {
-				"@types/diff": "^7.0.1",
+				"@types/diff": "^7.0.2",
 				"diff": "^7.0.0",
-				"uuid": "^11.0.5"
+				"uuid": "^11.1.0"
 			},
 			"devDependencies": {
 				"@hey-api/client-fetch": "^0.10.0",
-				"@hey-api/openapi-ts": "^0.66.1"
+				"@hey-api/openapi-ts": "^0.66.6"
 			}
 		},
 		"src/packages/data-type": {

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -167,7 +167,6 @@
 		"example": "node ./devops/example-runner/index.js",
 		"format:fix": "npm run format -- --write",
 		"format": "prettier 'src/**/*.ts' --check",
-		"generate:server-api-dev": "npm run generate:server-api-dev -w @umbraco-backoffice/core",
 		"generate:server-api": "npm run generate:server-api -w @umbraco-backoffice/core",
 		"generate:icons": "node ./devops/icons/index.js",
 		"generate:overrides": "node ./devops/tsc/index.js",

--- a/src/Umbraco.Web.UI.Client/src/packages/core/openapi-ts.dev.config.js
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/openapi-ts.dev.config.js
@@ -1,8 +1,0 @@
-import { defineConfig } from '@hey-api/openapi-ts';
-
-import defaultConfig from './openapi-ts.config';
-
-export default defineConfig({
-	...defaultConfig,
-	input: 'http://localhost:11000/umbraco/swagger/management/swagger.json',
-});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/package.json
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/package.json
@@ -4,7 +4,6 @@
 	"type": "module",
 	"scripts": {
 		"build": "vite build",
-		"generate:server-api-dev": "openapi-ts --file openapi-ts.dev.config.js",
 		"generate:server-api": "openapi-ts --file openapi-ts.config.js"
 	},
 	"dependencies": {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/package.json
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/package.json
@@ -7,12 +7,12 @@
 		"generate:server-api": "openapi-ts --file openapi-ts.config.js"
 	},
 	"dependencies": {
-		"@types/diff": "^7.0.1",
+		"@types/diff": "^7.0.2",
 		"diff": "^7.0.0",
-		"uuid": "^11.0.5"
+		"uuid": "^11.1.0"
 	},
 	"devDependencies": {
 		"@hey-api/client-fetch": "^0.10.0",
-		"@hey-api/openapi-ts": "^0.66.1"
+		"@hey-api/openapi-ts": "^0.66.6"
 	}
 }


### PR DESCRIPTION
## Description

Updates the @umbraco-cms/core dependencies and removes the `server-api-dev` script that has started injecting its own baseUrl rendering it useless.