### PR TITLE
V15: Ensure elements cache is cleared on subscribers in load balanced scenarios

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/DistributedCacheRefresherTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/DistributedCacheRefresherTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Cms.Infrastructure.HybridCache;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Cache;
+
+// We need to make sure that it's the distributed cache refreshers that refresh the elements cache
+// see: https://github.com/umbraco/Umbraco-CMS/issues/18467
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerFixture)]
+internal sealed class DistributedCacheRefresherTests : UmbracoIntegrationTest
+{
+    private IElementsCache ElementsCache => GetRequiredService<IElementsCache>();
+
+    private ContentCacheRefresher ContentCacheRefresher => GetRequiredService<ContentCacheRefresher>();
+
+    private MediaCacheRefresher MediaCacheRefresher => GetRequiredService<MediaCacheRefresher>();
+
+    [Test]
+    public void DistributedContentCacheRefresherClearsElementsCache()
+    {
+        var cacheKey = "test";
+        PopulateCache("test");
+
+        ContentCacheRefresher.Refresh([new ContentCacheRefresher.JsonPayload()]);
+
+        Assert.IsNull(ElementsCache.Get(cacheKey));
+    }
+
+    [Test]
+    public void DistributedMediaCacheRefresherClearsElementsCache()
+    {
+        var cacheKey = "test";
+        PopulateCache("test");
+
+        MediaCacheRefresher.Refresh([new MediaCacheRefresher.JsonPayload(1, Guid.NewGuid(), TreeChangeTypes.RefreshAll)]);
+
+        Assert.IsNull(ElementsCache.Get(cacheKey));
+    }
+
+    private void PopulateCache(string key)
+    {
+        ElementsCache.Get(key, () => new object());
+
+        // Just making sure something is in the cache now.
+        Assert.IsNotNull(ElementsCache.Get(key));
+    }
+}


### PR DESCRIPTION
Fixes #18467

Previously, the `CacheRefreshingNotificationHandler` was used to clear the `IElements` cache, this notification is only published on the publisher, meaning the elements cache wasn't cleared on subscribers. 

This PR changes this behaviour so the distributed cache refreshers are used instead.

## Testing
I've already tested this on a load balanced setup, and both servers are updated correctly now, maybe follow the steps in #18467 on a single server setup :smile: 

I've also added some super simple integration tests that ensure the elements cache is always cleared when the content or media cache is cleared. 