### PR TITLE
Removed population of Urls on media response model and obsoleted property

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/MediaPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MediaPresentationFactory.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Api.Management.ViewModels.Media.Item;
@@ -14,56 +14,42 @@ namespace Umbraco.Cms.Api.Management.Factories;
 internal sealed class MediaPresentationFactory : IMediaPresentationFactory
 {
     private readonly IUmbracoMapper _umbracoMapper;
-    private readonly IMediaUrlFactory _mediaUrlFactory;
     private readonly IIdKeyMap _idKeyMap;
 
     public MediaPresentationFactory(
         IUmbracoMapper umbracoMapper,
-        IMediaUrlFactory mediaUrlFactory,
         IIdKeyMap idKeyMap)
     {
         _umbracoMapper = umbracoMapper;
-        _mediaUrlFactory = mediaUrlFactory;
         _idKeyMap = idKeyMap;
     }
 
-    public MediaResponseModel CreateResponseModel(IMedia media)
-    {
-        MediaResponseModel responseModel = _umbracoMapper.Map<MediaResponseModel>(media)!;
-
-        responseModel.Urls = _mediaUrlFactory.CreateUrls(media);
-
-        return responseModel;
-    }
+    public MediaResponseModel CreateResponseModel(IMedia media) => _umbracoMapper.Map<MediaResponseModel>(media)!;
 
     public MediaItemResponseModel CreateItemResponseModel(IMediaEntitySlim entity)
     {
         Attempt<Guid> parentKeyAttempt = _idKeyMap.GetKeyForId(entity.ParentId, UmbracoObjectTypes.Media);
 
-        var responseModel = new MediaItemResponseModel
+        return new MediaItemResponseModel
         {
             Id = entity.Key,
             IsTrashed = entity.Trashed,
             Parent = parentKeyAttempt.Success ? new ReferenceByIdModel { Id = parentKeyAttempt.Result } : null,
             HasChildren = entity.HasChildren,
+            MediaType = _umbracoMapper.Map<MediaTypeReferenceResponseModel>(entity)!,
+            Variants = CreateVariantsItemResponseModels(entity)
         };
-
-        responseModel.MediaType = _umbracoMapper.Map<MediaTypeReferenceResponseModel>(entity)!;
-
-        responseModel.Variants = CreateVariantsItemResponseModels(entity);
-
-        return responseModel;
     }
 
     public IEnumerable<VariantItemResponseModel> CreateVariantsItemResponseModels(IMediaEntitySlim entity)
-        => new[]
-        {
+        =>
+        [
             new VariantItemResponseModel
             {
                 Name = entity.Name ?? string.Empty,
                 Culture = null
             }
-        };
+        ];
 
     public MediaTypeReferenceResponseModel CreateMediaTypeReferenceResponseModel(IMediaEntitySlim entity)
         => _umbracoMapper.Map<MediaTypeReferenceResponseModel>(entity)!;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -39787,7 +39787,8 @@
                   "$ref": "#/components/schemas/MediaUrlInfoModel"
                 }
               ]
-            }
+            },
+            "deprecated": true
           },
           "isTrashed": {
             "type": "boolean"

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/MediaResponseModel.cs
@@ -1,10 +1,11 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels.Content;
+using Umbraco.Cms.Api.Management.ViewModels.Content;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Media;
 
 public class MediaResponseModel : ContentResponseModelBase<MediaValueResponseModel, MediaVariantResponseModel>
 {
+    [Obsolete("This property is no longer populated. Please use /media/{id}/urls instead to retrieve the URLs for a document. Scheduled for removal in Umbraco 17.")]
     public IEnumerable<MediaUrlInfo> Urls { get; set; } = Enumerable.Empty<MediaUrlInfo>();
 
     public bool IsTrashed { get; set; }

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/media/media.data.ts
@@ -42,12 +42,7 @@ export const data: Array<UmbMockMediaModel> = [
 				updateDate: '2023-02-06T15:31:51.354764',
 			},
 		],
-		urls: [
-			{
-				culture: null,
-				url: '/umbraco/backoffice/assets/installer-illustration.svg',
-			},
-		],
+		urls: [],
 	},
 	{
 		hasChildren: false,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
@@ -1238,6 +1238,9 @@ export type MediaResponseModel = {
     values: Array<MediaValueResponseModel>;
     variants: Array<MediaVariantResponseModel>;
     id: string;
+    /**
+     * @deprecated
+     */
     urls: Array<MediaUrlInfoModel>;
     isTrashed: boolean;
     mediaType: MediaTypeReferenceResponseModel;
@@ -16140,5 +16143,5 @@ export type GetWebhookLogsResponses = {
 export type GetWebhookLogsResponse = GetWebhookLogsResponses[keyof GetWebhookLogsResponses];
 
 export type ClientOptions = {
-    baseUrl: `${string}://${string}` | (string & {});
+    baseUrl: 'http://localhost:11000' | (string & {});
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
@@ -16143,5 +16143,5 @@ export type GetWebhookLogsResponses = {
 export type GetWebhookLogsResponse = GetWebhookLogsResponses[keyof GetWebhookLogsResponses];
 
 export type ClientOptions = {
-    baseUrl: 'http://localhost:11000' | (string & {});
+    baseUrl: `${string}://${string}` | (string & {});
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-caption-alt-text/media-caption-alt-text-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-caption-alt-text/media-caption-alt-text-modal.element.ts
@@ -6,6 +6,7 @@ import type {
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import { UmbMediaUrlRepository } from '../../url/index.js';
 
 @customElement('umb-media-caption-alt-text-modal')
 export class UmbMediaCaptionAltTextModalElement extends UmbModalBaseElement<
@@ -14,6 +15,7 @@ export class UmbMediaCaptionAltTextModalElement extends UmbModalBaseElement<
 > {
 	#mediaUnique?: string;
 	readonly #mediaDetailRepository = new UmbMediaDetailRepository(this);
+	readonly #mediaUrlRepository = new UmbMediaUrlRepository(this);
 
 	override connectedCallback() {
 		super.connectedCallback();
@@ -23,10 +25,16 @@ export class UmbMediaCaptionAltTextModalElement extends UmbModalBaseElement<
 
 	async #getMediaDetail() {
 		if (!this.#mediaUnique) return;
-		const { data } = await this.#mediaDetailRepository.requestByUnique(this.#mediaUnique);
-		if (!data) return;
+		const { data: mediaData } = await this.#mediaDetailRepository.requestByUnique(this.#mediaUnique);
+		if (!mediaData) return;
 
-		this.value = { ...this.value, altText: this.value?.altText ?? data.variants[0].name, url: data.urls[0]?.url ?? '' };
+		const { data: mediaUrlData } = await this.#mediaUrlRepository.requestItems([this.#mediaUnique]);
+
+		this.value = {
+			...this.value,
+			altText: this.value?.altText ?? mediaData.variants[0].name,
+			url: mediaUrlData?.[0].url ?? ''
+		};
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
@@ -34,7 +34,6 @@ export class UmbMediaServerDataSource implements UmbDetailDataSource<UmbMediaDet
 		const data: UmbMediaDetailModel = {
 			entityType: UMB_MEDIA_ENTITY_TYPE,
 			unique: UmbId.new(),
-			urls: [],
 			mediaType: {
 				unique: '',
 				collection: null,
@@ -87,7 +86,6 @@ export class UmbMediaServerDataSource implements UmbDetailDataSource<UmbMediaDet
 					updateDate: variant.updateDate,
 				};
 			}),
-			urls: data.urls as UmbMediaDetailModel['urls'],
 			mediaType: {
 				unique: data.mediaType.id,
 				collection: data.mediaType.collection ? { unique: data.mediaType.collection.id } : null,

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/types.ts
@@ -21,7 +21,6 @@ export interface UmbMediaDetailModel extends UmbContentDetailModel {
 	entityType: UmbMediaEntityType;
 	isTrashed: boolean;
 	unique: string;
-	urls: Array<UmbMediaUrlInfoModel>;
 	values: Array<UmbMediaValueModel>;
 	variants: Array<UmbEntityVariantModel>;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
@@ -3,7 +3,6 @@ import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../../workspace/constants.js';
 import type { UmbMediaUrlModel } from '../repository/types.js';
 import { css, customElement, html, nothing, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
@@ -1,40 +1,125 @@
+import { UmbMediaUrlRepository } from '../repository/index.js';
 import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../../workspace/constants.js';
-import type { MediaUrlInfoModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { css, customElement, html, repeat, state } from '@umbraco-cms/backoffice/external/lit';
+import type { UmbMediaUrlModel } from '../repository/types.js';
+import { css, customElement, html, nothing, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
+import { debounce } from '@umbraco-cms/backoffice/utils';
+
+interface UmbMediaInfoViewLink {
+	url: string | undefined;
+}
 
 @customElement('umb-media-links-workspace-info-app')
 export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
-	@state()
-	private _urls?: Array<MediaUrlInfoModel>;
+	#mediaUrlRepository = new UmbMediaUrlRepository(this);
 
-	#workspaceContext?: typeof UMB_MEDIA_WORKSPACE_CONTEXT.TYPE;
+	@state()
+	private _isNew = false;
+
+	@state()
+	private _unique?: string;
+
+	@state()
+	private _loading = false;
+
+	@state()
+	private _links: Array<UmbMediaInfoViewLink> = [];
+
+	@state()
+	private _defaultCulture?: string;
+
+	#urls: Array<UmbMediaUrlModel> = [];
+
+	#mediaWorkspaceContext?: typeof UMB_MEDIA_WORKSPACE_CONTEXT.TYPE;
+	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 
 	constructor() {
 		super();
 
 		this.consumeContext(UMB_MEDIA_WORKSPACE_CONTEXT, (context) => {
-			this.#workspaceContext = context;
-			this.#observeUrls();
+			this.#mediaWorkspaceContext = context;
+			if (context) {
+				this.observe(
+					observeMultiple([context.isNew, context.unique]),
+					([isNew, unique]) => {
+						if (!unique) return;
+						this._isNew = isNew === true;
+
+						if (unique !== this._unique) {
+							this._unique = unique;
+							this.#requestUrls();
+						}
+					},
+					'observeWorkspaceState',
+				);
+			} else {
+				this.removeUmbControllerByAlias('observeWorkspaceState');
+			}
 		});
 	}
 
-	#observeUrls() {
-		if (!this.#workspaceContext) return;
+	#setLinks() {
+		const links: Array<UmbMediaInfoViewLink> = this.#urls.map((u) => {
+			const url = u.url;
+			return { url };
+		});
 
-		this.observe(
-			this.#workspaceContext.urls,
-			(urls) => {
-				this._urls = urls;
-			},
-			'__urls',
-		);
+		this._links = links;
 	}
 
-	protected override render() {
-		return html`<umb-workspace-info-app-layout headline="#general_links">
-			${this.#renderLinksSection()}
-		</umb-workspace-info-app-layout> `;
+	#getTargetUrl(url: string | undefined) {
+		if (!url || url.length === 0) {
+			return url;
+		}
+
+		if (url.includes('.') && !url.includes('//')) {
+			return '//' + url;
+		}
+
+		return url;
+	}
+
+	async #requestUrls() {
+		if (this._isNew) return;
+		if (!this._unique) return;
+
+		this._loading = true;
+		this.#urls = [];
+
+		const { data } = await this.#mediaUrlRepository.requestItems([this._unique]);
+
+		if (data?.length) {
+			this.#urls = data;
+			this.#setLinks();
+		}
+
+		this._loading = false;
+	}
+
+	#debounceRequestUrls = debounce(() => this.#requestUrls(), 50);
+
+	#onReloadRequest = (event: UmbEntityActionEvent) => {
+		this.#debounceRequestUrls();
+	};
+
+	override render() {
+		return html`
+			<umb-workspace-info-app-layout headline="#general_links">
+				${when(
+					this._loading,
+					() => this.#renderLoading(),
+					() => this.#renderContent(),
+				)}
+			</umb-workspace-info-app-layout>
+		`;
+	}
+
+	#renderLoading() {
+		return html`<div id="loader-container"><uui-loader></uui-loader></div>`;
 	}
 
 	#openSvg(imagePath: string) {
@@ -52,11 +137,11 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 		popup.document.close();
 	}
 
-	#renderLinksSection() {
-		if (this._urls && this._urls.length) {
+	#renderContent() {
+		if (this._links.length) {
 			return html`
 				${repeat(
-					this._urls,
+					this._links,
 					(item) => item.url,
 					(item) => this.#renderLinkItem(item),
 				)}
@@ -70,11 +155,12 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 		}
 	}
 
-	#renderLinkItem(item: MediaUrlInfoModel) {
+	#renderLinkItem(item: UmbMediaInfoViewLink) {
+		if (!item.url) return nothing;
 		const ext = item.url.split(/[#?]/)[0].split('.').pop()?.trim();
 		if (ext === 'svg') {
 			return html`
-				<a href="#" target="_blank" class="link-item with-href" @click=${() => this.#openSvg(item.url)}>
+				<a href="#" target="_blank" class="link-item with-href" @click=${() => this.#openSvg(item.url!)}>
 					<span class="link-content">${item.url}</span>
 					<uui-icon name="icon-out"></uui-icon>
 				</a>
@@ -87,6 +173,15 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 				</a>
 			`;
 		}
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+
+		this.#eventContext?.removeEventListener(
+			UmbRequestReloadStructureForEntityEvent.TYPE,
+			this.#onReloadRequest as unknown as EventListener,
+		);
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
@@ -29,19 +29,14 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 	@state()
 	private _links: Array<UmbMediaInfoViewLink> = [];
 
-	@state()
-	private _defaultCulture?: string;
-
 	#urls: Array<UmbMediaUrlModel> = [];
 
-	#mediaWorkspaceContext?: typeof UMB_MEDIA_WORKSPACE_CONTEXT.TYPE;
 	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 
 	constructor() {
 		super();
 
 		this.consumeContext(UMB_MEDIA_WORKSPACE_CONTEXT, (context) => {
-			this.#mediaWorkspaceContext = context;
 			if (context) {
 				this.observe(
 					observeMultiple([context.isNew, context.unique]),
@@ -71,18 +66,6 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 		this._links = links;
 	}
 
-	#getTargetUrl(url: string | undefined) {
-		if (!url || url.length === 0) {
-			return url;
-		}
-
-		if (url.includes('.') && !url.includes('//')) {
-			return '//' + url;
-		}
-
-		return url;
-	}
-
 	async #requestUrls() {
 		if (this._isNew) return;
 		if (!this._unique) return;
@@ -102,7 +85,7 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 
 	#debounceRequestUrls = debounce(() => this.#requestUrls(), 50);
 
-	#onReloadRequest = (event: UmbEntityActionEvent) => {
+	#onReloadRequest = () => {
 		this.#debounceRequestUrls();
 	};
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
@@ -4,7 +4,7 @@ import type { UmbMediaUrlModel } from '../repository/types.js';
 import { css, customElement, html, nothing, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
-import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import type { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { debounce } from '@umbraco-cms/backoffice/utils';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
@@ -39,8 +39,6 @@ export class UmbMediaWorkspaceContext
 	readonly contentTypeUnique = this._data.createObservablePartOfCurrent((data) => data?.mediaType.unique);
 	readonly contentTypeHasCollection = this._data.createObservablePartOfCurrent((data) => !!data?.mediaType.collection);
 
-	readonly urls = this._data.createObservablePartOfCurrent((data) => data?.urls || []);
-
 	#isTrashedContext = new UmbIsTrashedEntityContext(this);
 
 	constructor(host: UmbControllerHost) {

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -9,7 +9,7 @@ import { isUmbracoFolder, UmbMediaTypeStructureRepository } from '@umbraco-cms/b
 import { umbBindToValidation, UmbValidationContext } from '@umbraco-cms/backoffice/validation';
 import { umbConfirmModal, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbDocumentDetailRepository, UmbDocumentUrlRepository } from '@umbraco-cms/backoffice/document';
-import { UmbMediaDetailRepository } from '@umbraco-cms/backoffice/media';
+import { UmbMediaDetailRepository, UmbMediaUrlRepository } from '@umbraco-cms/backoffice/media';
 import type { UmbInputDocumentElement } from '@umbraco-cms/backoffice/document';
 import type { UmbInputMediaElement } from '@umbraco-cms/backoffice/media';
 import type { UUIBooleanInputEvent, UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
@@ -136,6 +136,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 					if (documentData) {
 						icon = documentData.documentType.icon;
 						name = documentData.variants[0].name;
+
 						const documentUrlRepository = new UmbDocumentUrlRepository(this);
 						const { data: documentUrlData } = await documentUrlRepository.requestItems([unique]);
 						url = documentUrlData?.[0].urls[0].url ?? '';
@@ -148,7 +149,10 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 					if (mediaData) {
 						icon = mediaData.mediaType.icon;
 						name = mediaData.variants[0].name;
-						url = mediaData.urls[0].url;
+
+						const mediaUrlRepository = new UmbMediaUrlRepository(this);
+						const { data: mediaUrlData } = await mediaUrlRepository.requestItems([unique]);
+						url = mediaUrlData?.[0].url ?? '';
 					}
 					break;
 				}


### PR DESCRIPTION
### Description
Following https://github.com/umbraco/Umbraco-CMS/pull/19030 it was raised that we hadn't made the analogous update for media URLs.  These are less critical to remove from the media response model, as there is only one no matter what languages, variants and URL providers that are in place, but for consistency it makes sense to align media and documents here.  Especially as there is already an API endpoint for retrieving media URLs.

So server-side I've obsoleted the `Urls` property on the media response model and am no longer populating it.

Client-side I've reworked the link picker and the media URLs display on the "Info" workspace view to use the dedicated `/urls/` endpoint for retrieving the URL information.

### Testing
Verify that media and in particular the links on the "Info" workspace view are rendered as expected.

Check also that the Link picker works as expected for media.

_Note I'm waiting the results of the build pipeline for acceptance tests failures, as it's possible we get some as we did with the document updates._