### PR TITLE
Prevent Culture and Hostnames modal close on error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/culture-and-hostnames/modal/culture-and-hostnames-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/culture-and-hostnames/modal/culture-and-hostnames-modal.element.ts
@@ -56,16 +56,17 @@ export class UmbCultureAndHostnamesModalElement extends UmbModalBaseElement<
 		this._languageModel = data.items;
 	}
 
-	// Modal
-
 	async #handleSave() {
 		this.value = { defaultIsoCode: this._defaultIsoCode, domains: this._domains };
-		await this.#documentRepository.updateCultureAndHostnames(this.#unique!, this.value);
-		this.modalContext?.submit();
+		const { error } = await this.#documentRepository.updateCultureAndHostnames(this.#unique!, this.value);
+
+		if (!error) {
+			this._submitModal();
+		}
 	}
 
 	#handleCancel() {
-		this.modalContext?.reject();
+		this._rejectModal();
 	}
 
 	// Events

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/culture-and-hostnames/repository/culture-and-hostnames.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/culture-and-hostnames/repository/culture-and-hostnames.repository.ts
@@ -1,43 +1,20 @@
 import { UmbDocumentCultureAndHostnamesServerDataSource } from './culture-and-hostnames.server.data.js';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
-import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UpdateDomainsRequestModel } from '@umbraco-cms/backoffice/external/backend-api';
 
 export class UmbDocumentCultureAndHostnamesRepository extends UmbControllerBase implements UmbApi {
 	#dataSource = new UmbDocumentCultureAndHostnamesServerDataSource(this);
 
-	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
-
-	constructor(host: UmbControllerHost) {
-		super(host);
-
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
-			this.#notificationContext = instance;
-		});
-	}
-
 	async readCultureAndHostnames(unique: string) {
 		if (!unique) throw new Error('Unique is missing');
-
-		const { data, error } = await this.#dataSource.read(unique);
-		if (!error) {
-			return { data };
-		}
-		return { error };
+		return this.#dataSource.read(unique);
 	}
 
 	async updateCultureAndHostnames(unique: string, data: UpdateDomainsRequestModel) {
 		if (!unique) throw new Error('Unique is missing');
 		if (!data) throw new Error('Data is missing');
-
-		const { error } = await this.#dataSource.update(unique, data);
-		if (!error) {
-			const notification = { data: { message: `Cultures and hostnames saved` } };
-			this.#notificationContext?.peek('positive', notification);
-		}
-		return { error };
+		return this.#dataSource.update(unique, data);
 	}
 }
 


### PR DESCRIPTION
This PR fixes an issue in the "Cultures and hostnames" modal, where the modal would close even if an update failed. This also resulted in the error notification never appearing since the host had disappeared, meaning the user wouldn't know the update didn't happen.

The PR adds a check to close the modal only if the update is successful. Additionally, I have removed the success notification to align with the new notification UX - when the modal closes, the action has been successful.

How to test:
- Insert two identical domains in the list
- Expect an error notification to show

Example
![Screenshot 2025-04-24 at 13 54 34](https://github.com/user-attachments/assets/f9c6fad0-9433-46b0-a2ea-80026c2378ad)
