### PR TITLE
attempted fix for Save and Preview button #15360

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/edit.controller.js
@@ -1033,9 +1033,12 @@
                 $scope.content.variants.forEach(variant => variant.save = false);
                 //ensure the save flag is set for the active variant
                 selectedVariant.save = true;
+                $scope.page.previewButtonState = "busy";
                 performSave({ saveMethod: $scope.saveMethod(), action: "save" }).then(function (data) {
+                    $scope.page.previewButtonState = "success";
                     openPreviewWindow(url, urlTarget);
                 }, function (err) {
+                    $scope.page.previewButtonState = "error";
                     //validation issues ....
                 });
             }


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

- Create a new content node
- Publish the node
- Save and Preview the node (Adding throttling to the request would help test this easily) 
- Progress animation appears until the preview window is open


If there's an existing issue for this PR then this fixes #15360 

### Description

Added logic to update `page.previewButtonState` so the spinner is visible when the state is set to 'busy'.

**Bug:**
![umbracopreviewwithbug](https://github.com/user-attachments/assets/917d7384-a133-4a1e-9459-b40ecb00daff)

**Fix:**
![umbracopreviewbug](https://github.com/user-attachments/assets/b008151b-be96-4f5a-9b10-510d3574c127)
