### PR TITLE
Make culture specific update dates work again

### DIFF
--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -301,7 +301,7 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
             }
 
             // set
-            else
+            else if (GetCultureName(culture) != name)
             {
                 this.SetCultureInfo(culture!, name, DateTime.Now);
             }
@@ -455,10 +455,12 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
                 $"No PropertyType exists with the supplied alias \"{propertyTypeAlias}\".");
         }
 
-        property?.SetValue(value, culture, segment);
-
-        // bump the culture to be flagged for updating
-        this.TouchCulture(culture);
+        var updated = property.SetValue(value, culture, segment);
+        if (updated)
+        {
+            // bump the culture to be flagged for updating
+            this.TouchCulture(culture);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Models/Entities/BeingDirtyBase.cs
+++ b/src/Umbraco.Core/Models/Entities/BeingDirtyBase.cs
@@ -162,7 +162,8 @@ public abstract class BeingDirtyBase : IRememberBeingDirty
     /// <param name="propertyName">The property name.</param>
     /// <param name="comparer">A comparer to compare property values.</param>
     /// <param name="changed">A value indicating whether we know values have changed and no comparison is required.</param>
-    protected void DetectChanges<T>(T value, T orig, string propertyName, IEqualityComparer<T> comparer, bool changed)
+    /// <returns>True if a change was detected, false otherwise.</returns>
+    protected bool DetectChanges<T>(T value, T orig, string propertyName, IEqualityComparer<T> comparer, bool changed)
     {
         // compare values
         changed = _withChanges && (changed || !comparer.Equals(orig, value));
@@ -172,6 +173,8 @@ public abstract class BeingDirtyBase : IRememberBeingDirty
         {
             OnPropertyChanged(propertyName);
         }
+
+        return changed;
     }
 
     #endregion

--- a/src/Umbraco.Core/Models/IProperty.cs
+++ b/src/Umbraco.Core/Models/IProperty.cs
@@ -32,7 +32,12 @@ public interface IProperty : IEntity, IRememberBeingDirty
     /// <summary>
     ///     Sets a value.
     /// </summary>
-    void SetValue(object? value, string? culture = null, string? segment = null);
+    /// <returns>true if the value was set (updated), false otherwise.</returns>
+    /// <remarks>
+    /// A false return value does not indicate failure, but rather that the property value was not changed
+    /// (i.e. the value passed in was equal to the current property value).
+    /// </remarks>
+    bool SetValue(object? value, string? culture = null, string? segment = null);
 
     void PublishValues(string? culture = "*", string segment = "*");
 

--- a/src/Umbraco.Core/Models/Property.cs
+++ b/src/Umbraco.Core/Models/Property.cs
@@ -257,10 +257,8 @@ public class Property : EntityBase, IProperty
         }
     }
 
-    /// <summary>
-    ///     Sets a value.
-    /// </summary>
-    public void SetValue(object? value, string? culture = null, string? segment = null)
+    /// <inheritdoc />
+    public bool SetValue(object? value, string? culture = null, string? segment = null)
     {
         culture = culture?.NullOrWhiteSpaceAsNull();
         segment = segment?.NullOrWhiteSpaceAsNull();
@@ -273,6 +271,7 @@ public class Property : EntityBase, IProperty
 
         (IPropertyValue? pvalue, var change) = GetPValue(culture, segment, true);
 
+        var changed = false;
         if (pvalue is not null)
         {
             var origValue = pvalue.EditedValue;
@@ -280,8 +279,10 @@ public class Property : EntityBase, IProperty
 
             pvalue.EditedValue = setValue;
 
-            DetectChanges(setValue, origValue, nameof(Values), PropertyValueComparer, change);
+            changed = DetectChanges(setValue, origValue, nameof(Values), PropertyValueComparer, change);
         }
+
+        return changed;
     }
 
     public object? ConvertAssignedValue(object? value) =>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTestsBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTestsBase.cs
@@ -74,7 +74,7 @@ public abstract class ContentEditingServiceTestsBase : UmbracoIntegrationTestWit
         return contentType;
     }
 
-    protected async Task<IContentType> CreateVariantContentType(ContentVariation variation = ContentVariation.Culture)
+    protected async Task<IContentType> CreateVariantContentType(ContentVariation variation = ContentVariation.Culture, bool variantTitleAsMandatory = true)
     {
         var language = new LanguageBuilder()
             .WithCultureInfo("da-DK")
@@ -88,7 +88,7 @@ public abstract class ContentEditingServiceTestsBase : UmbracoIntegrationTestWit
             .AddPropertyType()
             .WithAlias("variantTitle")
             .WithName("Variant Title")
-            .WithMandatory(true)
+            .WithMandatory(variantTitleAsMandatory)
             .WithVariations(variation)
             .Done()
             .AddPropertyType()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTests.cs
@@ -29,8 +29,9 @@ public class ContentTests
 
     private readonly PropertyEditorCollection _propertyEditorCollection = new (new DataEditorCollection(() => []));
 
-    [Test]
-    public void Variant_Culture_Names_Track_Dirty_Changes()
+    [TestCase("name-fr", false)]
+    [TestCase("name-fr-updated", true)]
+    public void Variant_Culture_Names_Track_Dirty_Changes(string newName, bool expectedDirty)
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias("contentType")
@@ -58,14 +59,17 @@ public class ContentTests
         Assert.IsTrue(frCultureName.IsPropertyDirty("Date"));
 
         content.ResetDirtyProperties();
+        frCultureName.ResetDirtyProperties();
 
         Assert.IsFalse(content.IsPropertyDirty("CultureInfos")); // it's been reset
         Assert.IsTrue(content.WasPropertyDirty("CultureInfos"));
 
         Thread.Sleep(500); // The "Date" wont be dirty if the test runs too fast since it will be the same date
-        content.SetCultureName("name-fr", langFr);
-        Assert.IsTrue(frCultureName.IsPropertyDirty("Date"));
-        Assert.IsTrue(content.IsPropertyDirty("CultureInfos")); // it's true now since we've updated a name
+        content.SetCultureName(newName, langFr);
+
+        // dirty is only true if we updated the name
+        Assert.AreEqual(expectedDirty, frCultureName.IsPropertyDirty("Date"));
+        Assert.AreEqual(expectedDirty, content.IsPropertyDirty("CultureInfos"));
     }
 
     [Test]
@@ -97,6 +101,7 @@ public class ContentTests
         Assert.IsTrue(frCultureName.IsPropertyDirty("Date"));
 
         content.ResetDirtyProperties();
+        frCultureName.ResetDirtyProperties();
 
         Assert.IsFalse(content.IsPropertyDirty("PublishCultureInfos")); // it's been reset
         Assert.IsTrue(content.WasPropertyDirty("PublishCultureInfos"));


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

While working on another task, I realized we have introduced a behavioural change for variant update dates in V14 (and beyond).

In V14, the [`CultureDate`](https://github.com/umbraco/Umbraco-CMS/blob/release/16.0/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs#L139) of a published culture variant updates when _any_ variant is published on the document.

In V13, the `CultureDate` of a specific published variant only updates when:

- The variant is explicitly published.
	- `CultureDate` becomes the datetime of the publish action.
- The variant is edited, and another variant is published.
	- `CultureDate` becomes the datetime of the name edit action.

While the latter kinda seems like a mistake, it really is the V13 behaviour, and we need to align with it for V16. So this PR ensures that.

The published `CultureDate` is tied to the update date of the draft variant (`IContent`). And this is where the reason for this change in behaviour is found:

- In V13 we only update the actively selected culture variants when saving a document (somewhat equivalent to a PATCH operation, although it's not _actually_ a PATCH).
- In V14 we update all culture variants explicitly, because the Management API does not support PATCH operations; it expects the "whole truth" when updating a document.

To get around this, I have changed the behaviour of updates at service layer level, so updates only register as changes if something actually changed (name or property values).

In effect, this means that [`GetUpdateDate`](https://github.com/umbraco/Umbraco-CMS/blob/release/16.0/src/Umbraco.Core/Models/IContentBase.cs#L113) for a draft variant only updates when

- An actual change has been made to the variant name or a property value, or
- The variant is published.

This is a slight behavioural change compared to V13, where the draft variant update date would _always_ change when the variant was saved, regardless of changes having been made or not.

I think we can live with this behavioural change in the grand scheme of things; effectively it won't matter to the editors, since the update date is still updated correctly when publishing. And comparatively, this behavioural change is much preferrable to the current difference between V13 and V14 (as described above).

### Breaking change

This _is_ a breaking change, in part due to the behavioural change described above, and in part due to the signature changes of `IProperty.SetValue()` and `BeingDirtyBase.DetectChanges()`.

Fortuantely, these are minimal changes and they're not behaviourally breaking on their own. In effect they will likely not incur any issues, since consumers don't _have_ to care about the changed return values.

Any consumers going through `IContent` for updates won't notice a difference.

### Testing this PR

Verify that the `CultureDate` of published content and `UpdateDate` of draft content works as described above - both for variant and invariant content.

The following template might help with the testing - at least it's the one I've used 😂

```cshtml
@using Umbraco.Cms.Core.Services
@inject IVariationContextAccessor VariationContextAccessor
@inject IContentService ContentService
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
	Layout = null;
    var culture = Context.Request.Query["culture"].ToString();
    if (culture.IsNullOrWhiteSpace() is false)
    {
        VariationContextAccessor.VariationContext = new VariationContext(culture, null);
    }

    culture = VariationContextAccessor.VariationContext!.Culture;
    var content = ContentService.GetById(Model.Key)!;
}
<html>
<body>
<h1>@Model.Name [@Model.ContentType.Alias]</h1>
<ul>
    @*
        The culture date should reflect the latest publish date of the variant,
        and should differ per variant.
    *@
    <li>CultureDate (variant): @Model.CultureDate(culture)</li>
    @*
        The update date should reflect the latest update/edit date of the variant,
        and should differ per variant.
        A publish of the variant should also trigger an update of the update date.
    *@
    <li>UpdateDate (variant): @content.GetUpdateDate(culture)</li>
    @*
        The invariant update date is considered a "global" update date for variant content,
        and should always reflect the latest update date of any vaiant.
    *@
    <li>UpdateDate (invariant/global): @content.UpdateDate</li>
</ul>
<ul>
    <li>Culture: @culture</li>
</ul>
</body>
</html>
```


