### PR TITLE
make repositories remember their stores

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/detail/detail-repository-base.ts
@@ -35,7 +35,9 @@ export abstract class UmbDetailRepositoryBase<
 		// TODO: ideally no preventTimeouts here.. [NL]
 		this.#init = Promise.all([
 			this.consumeContext(detailStoreContextAlias, (instance) => {
-				this.#detailStore = instance;
+				if (instance) {
+					this.#detailStore = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 		]);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/item/item-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/item/item-repository-base.ts
@@ -22,7 +22,9 @@ export class UmbItemRepositoryBase<ItemType extends { unique: string }>
 		this.#itemSource = new itemSource(host);
 
 		this._init = this.consumeContext(itemStoreContextAlias, (instance) => {
-			this._itemStore = instance as UmbItemStore<ItemType>;
+			if (instance) {
+				this._itemStore = instance as UmbItemStore<ItemType>;
+			}
 		}).asPromise({ preventTimeout: true });
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -20,9 +20,11 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 		super(host, UMB_TEMPORARY_FILE_REPOSITORY_ALIAS.toString());
 		this.initialized = new Promise<void>((resolve) => {
 			this.consumeContext(UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT, async (store) => {
-				this.#dataStore = store;
-				await this.#init();
-				resolve();
+				if (store) {
+					this.#dataStore = store;
+					await this.#init();
+					resolve();
+				}
 			});
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/data/tree-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/data/tree-repository-base.ts
@@ -61,7 +61,9 @@ export abstract class UmbTreeRepositoryBase<
 		this._treeSource = new treeSourceConstructor(this);
 
 		this._init = this.consumeContext(treeStoreContextAlias, (instance) => {
-			this._treeStore = instance;
+			if (instance) {
+				this._treeStore = instance;
+			}
 		}).asPromise({ preventTimeout: true });
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/collection/repository/data-type-collection.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/collection/repository/data-type-collection.repository.ts
@@ -16,7 +16,9 @@ export class UmbDataTypeCollectionRepository extends UmbRepositoryBase implement
 		super(host);
 
 		this.#init = this.consumeContext(UMB_DATA_TYPE_ITEM_STORE_CONTEXT, (instance) => {
-			this.#itemStore = instance;
+			if (instance) {
+				this.#itemStore = instance;
+			}
 		}).asPromise({ preventTimeout: true });
 
 		this.#collectionSource = new UmbDataTypeCollectionServerDataSource(host);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-bulk-actions/move-to/repository/move-to.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-bulk-actions/move-to/repository/move-to.repository.ts
@@ -3,21 +3,12 @@ import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import type { UmbBulkMoveToRepository, UmbBulkMoveToRequestArgs } from '@umbraco-cms/backoffice/entity-bulk-action';
 import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbBulkMoveToDocumentRepository extends UmbRepositoryBase implements UmbBulkMoveToRepository {
 	#moveSource = new UmbMoveDocumentServerDataSource(this);
-	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
-
-	constructor(host: UmbControllerHost) {
-		super(host);
-
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (notificationContext) => {
-			this.#notificationContext = notificationContext;
-		});
-	}
 
 	async requestBulkMoveTo(args: UmbBulkMoveToRequestArgs): Promise<UmbRepositoryErrorResponse> {
+		const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
 		let count = 0;
 
 		const destination = args.destination;
@@ -26,7 +17,7 @@ export class UmbBulkMoveToDocumentRepository extends UmbRepositoryBase implement
 
 			if (error) {
 				const notification = { data: { message: error.message } };
-				this.#notificationContext?.peek('danger', notification);
+				notificationContext?.peek('danger', notification);
 			} else {
 				count++;
 			}
@@ -34,7 +25,7 @@ export class UmbBulkMoveToDocumentRepository extends UmbRepositoryBase implement
 
 		if (count > 0) {
 			const notification = { data: { message: `Moved ${count} ${count === 1 ? 'document' : 'documents'}` } };
-			this.#notificationContext?.peek('positive', notification);
+			notificationContext?.peek('positive', notification);
 		}
 
 		return {};

--- a/src/Umbraco.Web.UI.Client/src/packages/media/imaging/imaging.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/imaging/imaging.repository.ts
@@ -15,7 +15,9 @@ export class UmbImagingRepository extends UmbRepositoryBase implements UmbApi {
 		this.#itemSource = new UmbImagingServerDataSource(host);
 
 		this.consumeContext(UMB_IMAGING_STORE_CONTEXT, (instance) => {
-			this.#dataStore = instance;
+			if (instance) {
+				this.#dataStore = instance;
+			}
 		});
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-bulk-actions/move-to/repository/move-to.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-bulk-actions/move-to/repository/move-to.repository.ts
@@ -3,21 +3,12 @@ import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import type { UmbBulkMoveToRepository, UmbBulkMoveToRequestArgs } from '@umbraco-cms/backoffice/entity-bulk-action';
 import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbBulkMoveToMediaRepository extends UmbRepositoryBase implements UmbBulkMoveToRepository {
 	#moveSource = new UmbMoveMediaServerDataSource(this);
-	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
-
-	constructor(host: UmbControllerHost) {
-		super(host);
-
-		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (notificationContext) => {
-			this.#notificationContext = notificationContext;
-		});
-	}
 
 	async requestBulkMoveTo(args: UmbBulkMoveToRequestArgs): Promise<UmbRepositoryErrorResponse> {
+		const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
 		let count = 0;
 
 		const destination = args.destination;
@@ -26,7 +17,7 @@ export class UmbBulkMoveToMediaRepository extends UmbRepositoryBase implements U
 
 			if (error) {
 				const notification = { data: { message: error.message } };
-				this.#notificationContext?.peek('danger', notification);
+				notificationContext?.peek('danger', notification);
 			} else {
 				count++;
 			}
@@ -34,7 +25,7 @@ export class UmbBulkMoveToMediaRepository extends UmbRepositoryBase implements U
 
 		if (count > 0) {
 			const notification = { data: { message: `Moved ${count} media ${count === 1 ? 'item' : 'items'}` } };
-			this.#notificationContext?.peek('positive', notification);
+			notificationContext?.peek('positive', notification);
 		}
 
 		return {};

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/member-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/member-repository-base.ts
@@ -18,15 +18,21 @@ export abstract class UmbMemberRepositoryBase extends UmbRepositoryBase {
 
 		this.init = Promise.all([
 			this.consumeContext(UMB_MEMBER_DETAIL_STORE_CONTEXT, (instance) => {
-				this.detailStore = instance;
+				if (instance) {
+					this.detailStore = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 
 			this.consumeContext(UMB_MEMBER_ITEM_STORE_CONTEXT, (instance) => {
-				this.itemStore = instance;
+				if (instance) {
+					this.itemStore = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 
 			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
-				this.notificationContext = instance;
+				if (instance) {
+					this.notificationContext = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 		]);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/detail/relation-type-detail.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/detail/relation-type-detail.repository.ts
@@ -19,7 +19,9 @@ export class UmbRelationTypeDetailRepository
 		super(host);
 
 		this.#init = this.consumeContext(UMB_RELATION_TYPE_DETAIL_STORE_CONTEXT, (instance) => {
-			this.#detailStore = instance;
+			if (instance) {
+				this.#detailStore = instance;
+			}
 		}).asPromise({ preventTimeout: true });
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user.repository.ts
@@ -21,11 +21,15 @@ export class UmbCurrentUserRepository extends UmbRepositoryBase {
 
 		this.#init = Promise.all([
 			this.consumeContext(UMB_CURRENT_USER_STORE_CONTEXT, (instance) => {
-				this.#currentUserStore = instance;
+				if (instance) {
+					this.#currentUserStore = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 
 			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
-				this.notificationContext = instance;
+				if (instance) {
+					this.notificationContext = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 		]);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/current-user-config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/current-user-config.repository.ts
@@ -20,9 +20,11 @@ export class UmbCurrentUserConfigRepository extends UmbRepositoryBase implements
 		super(host);
 		this.initialized = new Promise<void>((resolve) => {
 			this.consumeContext(UMB_CURRENT_USER_CONFIG_STORE_CONTEXT, async (store) => {
-				this.#dataStore = store;
-				await this.#init();
-				resolve();
+				if (store) {
+					this.#dataStore = store;
+					await this.#init();
+					resolve();
+				}
 			});
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.ts
@@ -20,9 +20,11 @@ export class UmbUserConfigRepository extends UmbRepositoryBase implements UmbApi
 		super(host);
 		this.initialized = new Promise<void>((resolve) => {
 			this.consumeContext(UMB_USER_CONFIG_STORE_CONTEXT, async (store) => {
-				this.#dataStore = store;
-				await this.#init();
-				resolve();
+				if (store) {
+					this.#dataStore = store;
+					await this.#init();
+					resolve();
+				}
 			});
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/user-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/user-repository-base.ts
@@ -18,15 +18,21 @@ export abstract class UmbUserRepositoryBase extends UmbRepositoryBase {
 
 		this.init = Promise.all([
 			this.consumeContext(UMB_USER_DETAIL_STORE_CONTEXT, (instance) => {
-				this.detailStore = instance;
+				if (instance) {
+					this.detailStore = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 
 			this.consumeContext(UMB_USER_ITEM_STORE_CONTEXT, (instance) => {
-				this.itemStore = instance;
+				if (instance) {
+					this.itemStore = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 
 			this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
-				this.notificationContext = instance;
+				if (instance) {
+					this.notificationContext = instance;
+				}
 			}).asPromise({ preventTimeout: true }),
 		]);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-event/repository/webhook-event.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-event/repository/webhook-event.repository.ts
@@ -17,7 +17,9 @@ export class UmbWebhookEventRepository extends UmbRepositoryBase implements UmbA
 		this.#source = new UmbWebhookEventServerDataSource(host);
 
 		this.#init = this.consumeContext(UMB_WEBHOOK_EVENT_STORE_CONTEXT, (instance) => {
-			this.#store = instance;
+			if (instance) {
+				this.#store = instance;
+			}
 		}).asPromise({ preventTimeout: true });
 	}
 


### PR DESCRIPTION
With latest update of Context API we do want the Repositories to work as previously, remembering the Stores so they still can update the stores despite being removed from the DOM.