### PR TITLE
Remove success notification after document type export

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/entity-actions/export/repository/document-type-export.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/entity-actions/export/repository/document-type-export.repository.ts
@@ -1,23 +1,11 @@
 import { UmbExportDocumentTypeServerDataSource } from './document-type-export.server.data-source.js';
-import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 
 export class UmbExportDocumentTypeRepository extends UmbRepositoryBase {
 	#exportSource = new UmbExportDocumentTypeServerDataSource(this);
 
 	async requestExport(unique: string) {
-		const { data, error } = await this.#exportSource.export(unique);
-
-		if (!error) {
-			const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
-			if (!notificationContext) {
-				throw new Error('Notification context not found');
-			}
-			const notification = { data: { message: `Exported` } };
-			notificationContext.peek('positive', notification);
-		}
-
-		return { data, error };
+		return this.#exportSource.export(unique);
 	}
 }
 


### PR DESCRIPTION
Remove the success notification after exporting a document type, as the browser already shows the new file download