### PR TITLE
V16: XHR requests do not report the underlying problem details object

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/resources/try-execute.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/resources/try-execute.controller.ts
@@ -1,3 +1,4 @@
+import { isProblemDetailsLike } from './apiTypeValidators.function.js';
 import { UmbResourceController } from './resource.controller.js';
 import type { UmbApiResponse, UmbTryExecuteOptions } from './types.js';
 import { UmbApiError, UmbCancelError } from './umb-error.js';
@@ -44,11 +45,17 @@ export class UmbTryExecuteController<T> extends UmbResourceController<T> {
 		let message = 'An error occurred while trying to execute the request.';
 		let details: Record<string, string[]> | undefined = undefined;
 
-		if (UmbApiError.isUmbApiError(error)) {
-			// UmbApiError, show notification
-			headline = error.problemDetails.title ?? error.name;
-			message = error.problemDetails.detail ?? error.message;
-			details = error.problemDetails.errors ?? undefined;
+		// Check if we can extract problem details from the error
+		const problemDetails = UmbApiError.isUmbApiError(error)
+			? error.problemDetails
+			: isProblemDetailsLike(error)
+				? error
+				: undefined;
+
+		if (problemDetails) {
+			// UmbProblemDetails, show notification
+			message = problemDetails.title;
+			details = problemDetails.errors ?? undefined;
 		} else {
 			// Unknown error, show notification
 			headline = '';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file.server.data-source.ts
@@ -40,6 +40,7 @@ export class UmbTemporaryFileServerDataSource {
 			url: '/umbraco/management/api/v1/temporary-file',
 			method: 'POST',
 			responseHeader: 'Umb-Generated-Resource',
+			disableNotifications: true,
 			body,
 			onProgress,
 			abortSignal,

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/avatar/user-avatar.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/avatar/user-avatar.repository.ts
@@ -1,19 +1,12 @@
 import { UmbUserRepositoryBase } from '../user-repository-base.js';
 import { UmbUserAvatarServerDataSource } from './user-avatar.server.data-source.js';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbId } from '@umbraco-cms/backoffice/id';
-import { UmbTemporaryFileRepository } from '@umbraco-cms/backoffice/temporary-file';
+import { TemporaryFileStatus, UmbTemporaryFileManager } from '@umbraco-cms/backoffice/temporary-file';
 
 export class UmbUserAvatarRepository extends UmbUserRepositoryBase {
-	#temporaryFileRepository: UmbTemporaryFileRepository;
-	#avatarSource: UmbUserAvatarServerDataSource;
-
-	constructor(host: UmbControllerHost) {
-		super(host);
-
-		this.#avatarSource = new UmbUserAvatarServerDataSource(host);
-		this.#temporaryFileRepository = new UmbTemporaryFileRepository(host);
-	}
+	#temporaryFileManager = new UmbTemporaryFileManager(this);
+	#avatarSource = new UmbUserAvatarServerDataSource(this);
+	#abortController = new AbortController();
 
 	/**
 	 * Uploads an avatar for the user with the given id
@@ -27,11 +20,19 @@ export class UmbUserAvatarRepository extends UmbUserRepositoryBase {
 		await this.init;
 
 		// upload temp file
-		const fileId = UmbId.new();
-		await this.#temporaryFileRepository.upload(fileId, file);
+		const temporaryUnique = UmbId.new();
+		const { status } = await this.#temporaryFileManager.uploadOne({
+			file,
+			temporaryUnique,
+			abortController: this.#abortController,
+		});
+
+		if (status === TemporaryFileStatus.ERROR) {
+			return { error: new Error('Avatar upload failed') };
+		}
 
 		// assign temp file to avatar
-		const { error } = await this.#avatarSource.createAvatar(userUnique, fileId);
+		const { error } = await this.#avatarSource.createAvatar(userUnique, temporaryUnique);
 
 		if (!error) {
 			// TODO: update store + current user


### PR DESCRIPTION
## Description

Two problems are solved here:

### XHR Requests and Problem Details
XHR requests created through the **UmbTryXhrRequestController** did not map back the underlying problem details object, resulting in details being lost, which then resulted in a blank error notification as outlined in #19154. This has been fixed in the controller.

This now means that error notifications are shown again:
![image](https://github.com/user-attachments/assets/2784a66d-a573-4cdb-8a90-e041b065b864)

And this fixes #19154 

### MaxFileSize is not being detected
If the developer fails to inform us of the intended max file size (also known as the max request length), we have no way of using this to validate the file size before attempting an upload. This results in a 413 error on the server, which is then wrapped into a problem details object. 

This Pull Request attempts to recognize these errors (at least when uploading temporary files) by disabling notifications and checking on the error itself in the **UmbTemporaryFileManager**.

This fixes #18994

## Additionally

I went through the dictionary import and user avatar to ensure that they, too, use the UmbTemporaryFileManager, which will now correctly validate temporary file uploads (and handle queueing, but that is negligible for singular file uploads).