### PR TITLE
Remove workspace split view entity actions for new content

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view.context.ts
@@ -2,7 +2,7 @@ import { UMB_VARIANT_WORKSPACE_CONTEXT } from '../../contexts/index.js';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
-import { UmbNumberState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbBooleanState, UmbNumberState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
 import { UMB_MARK_ATTRIBUTE_NAME } from '@umbraco-cms/backoffice/const';
@@ -21,6 +21,9 @@ export class UmbWorkspaceSplitViewContext extends UmbContextBase {
 	#index = new UmbNumberState(undefined);
 	index = this.#index.asObservable();
 
+	#isNew = new UmbBooleanState(undefined);
+	isNew = this.#isNew.asObservable();
+
 	//#variantId = new UmbClassState<UmbVariantId | undefined>(undefined);
 	//variantId = this.#variantId.asObservable();
 
@@ -30,11 +33,22 @@ export class UmbWorkspaceSplitViewContext extends UmbContextBase {
 		this.consumeContext(UMB_VARIANT_WORKSPACE_CONTEXT, (context) => {
 			this.#workspaceContext = context;
 			this._observeVariant();
+			this.#observeIsNew();
 		});
 
 		this.observe(this.index, () => {
 			this._observeVariant();
 		});
+	}
+
+	#observeIsNew() {
+		this.observe(
+			this.#workspaceContext?.isNew,
+			(isNew) => {
+				this.#isNew.setValue(isNew ?? false);
+			},
+			'umbObserveIsNew',
+		);
 	}
 
 	private _observeVariant() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view.element.ts
@@ -1,5 +1,14 @@
 import { UmbWorkspaceSplitViewContext } from './workspace-split-view.context.js';
-import { css, html, customElement, property, ifDefined, state, when } from '@umbraco-cms/backoffice/external/lit';
+import {
+	css,
+	html,
+	customElement,
+	property,
+	ifDefined,
+	state,
+	when,
+	nothing,
+} from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
@@ -31,10 +40,25 @@ export class UmbWorkspaceSplitViewElement extends UmbLitElement {
 	@state()
 	private _variantSelectorSlotHasContent = false;
 
+	@state()
+	private _isNew = false;
+
 	splitViewContext = new UmbWorkspaceSplitViewContext(this);
 
 	#onVariantSelectorSlotChanged(e: Event) {
 		this._variantSelectorSlotHasContent = (e.target as HTMLSlotElement).assignedNodes({ flatten: true }).length > 0;
+	}
+
+	constructor() {
+		super();
+
+		this.observe(
+			this.splitViewContext.isNew,
+			(isNew) => {
+				this._isNew = isNew ?? false;
+			},
+			'umbObserveIsNew',
+		);
 	}
 
 	override render() {
@@ -49,16 +73,19 @@ export class UmbWorkspaceSplitViewElement extends UmbLitElement {
 						() => html`<umb-workspace-split-view-variant-selector></umb-workspace-split-view-variant-selector>`,
 					)}
 				</slot>
-				${when(
-					this.displayNavigation,
-					() =>
-						html`<umb-workspace-entity-action-menu
-							slot="action-menu"
-							data-mark="workspace:action-menu"></umb-workspace-entity-action-menu>`,
-				)}
+				${this.#renderEntityActions()}
 				<slot name="action-menu" slot="action-menu"></slot>
 			</umb-workspace-editor>
 		`;
+	}
+
+	#renderEntityActions() {
+		if (this._isNew) return nothing;
+		if (!this.displayNavigation) return nothing;
+
+		return html`<umb-workspace-entity-action-menu
+			slot="action-menu"
+			data-mark="workspace:action-menu"></umb-workspace-entity-action-menu>`;
 	}
 
 	static override readonly styles = [


### PR DESCRIPTION
This PR ensures that the workspace split view entity actions are not rendered for new content 

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19050