### PR TITLE
Include "Accept-Segment" in the "vary" response header

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Filters/AddVaryHeaderAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/AddVaryHeaderAttribute.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Api.Delivery.Filters;
 
 public sealed class AddVaryHeaderAttribute : ActionFilterAttribute
 {
-    private const string Vary = "Accept-Language, Preview, Start-Item";
+    private const string Vary = "Accept-Language, Accept-Segment, Preview, Start-Item";
 
     public override void OnResultExecuting(ResultExecutingContext context)
         => context.HttpContext.Response.Headers.Vary = context.HttpContext.Response.Headers.Vary.Count > 0


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This fixed as oversight in #19082 - I forgot to add the new "Accept-Segment" to the "vary" response header 🤦 

### Testing this PR

Request anything from the Delivery API. The "vary" response header should contain "Accept-Segment":

![image](https://github.com/user-attachments/assets/818d4e5b-09a1-47a2-ae8f-c227a31bfdc1)
