### PR TITLE
Allow deselection of color picker property.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
@@ -17,8 +17,7 @@ export class UmbPropertyEditorUIColorPickerElement extends UmbLitElement impleme
 
 	@property({ type: Object })
 	public set value(value: UmbSwatchDetails | undefined) {
-		if (!value) return;
-		this.#value = this.#ensureHashPrefix(value);
+		this.#value = value ? this.#ensureHashPrefix(value) : undefined;
 	}
 	public get value(): UmbSwatchDetails | undefined {
 		return this.#value;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/19165

### Description
As the linked issue shows, you can't currently deselect a previously selected colour from a property.  This PR allows that.

### Testing

- Create a property on a document type based on the "Approved colour" data type, with one or more available colours.
- Create content based on the document type, set a value for the colour property and save.
- Click to unselect the value and save again.
- Verify that with the PR applied the empty value is persisted.  With the current code it will be restored to the previously selected value.

### Release

Can cherry-pick into `release/16.0` when approved and merged.