### PR TITLE
Output the correct error status code from the Management API

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
@@ -35,11 +35,17 @@ internal static class ApplicationBuilderExtensions
                         return;
                     }
 
+                    var statusCode = (exception as BadHttpRequestException)?.StatusCode;
+                    if (statusCode.HasValue)
+                    {
+                        context.Response.StatusCode = statusCode.Value;
+                    }
+
                     var response = new ProblemDetails
                     {
                         Title = exception.Message,
                         Detail = isDebug ? exception.StackTrace : null,
-                        Status = StatusCodes.Status500InternalServerError,
+                        Status = statusCode ?? StatusCodes.Status500InternalServerError,
                         Instance = isDebug ? exception.GetType().Name : null,
                         Type = "Error"
                     };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When uploading files that exceed the max request body size, we get a HTTP500 from the Management API. It would be preferable to get a HTTP413 instead.

This PR adds a little extra error checking to the generic error handling of the Management API, ensuring to return the actual status code if possible, instead of the currently hardcoded HTTP500.

### Testing this PR

Configure a low max request body size - something like this in `Program.cs`:

```cs
builder.Services.Configure<KestrelServerOptions>(options =>
{
    // 512 kb
    options.Limits.MaxRequestBodySize = 1024 * 512;
});
```

Then use Swagger to upload a temporary file larger than the configured max and verify that you'll get a HTTP413 instead of the HTTP500.

![image](https://github.com/user-attachments/assets/e2eeb842-1dea-4460-881c-37d33e40fea1)
