### PR TITLE
Webhook log authorization and file system path checks

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/WebhookItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/WebhookItemControllerBase.cs
@@ -1,14 +1,11 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Webhook.Item;
 
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Webhook}")]
 [ApiExplorerSettings(GroupName = "Webhook")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessWebhooks)]
 public class WebhookItemControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/WebhookItemControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Item/WebhookItemControllerBase.cs
@@ -1,11 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Webhook.Item;
 
 [VersionedApiBackOfficeRoute($"{Constants.Web.RoutePath.Item}/{Constants.UdiEntityType.Webhook}")]
 [ApiExplorerSettings(GroupName = "Webhook")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessWebhooks)]
 public class WebhookItemControllerBase : ManagementApiControllerBase
 {
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Logs/WebhookLogControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Logs/WebhookLogControllerBase.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Factories;
@@ -5,6 +6,7 @@ using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Api.Management.ViewModels.Webhook.Logs;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Webhook.Logs;
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Logs/WebhookLogControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Webhook/Logs/WebhookLogControllerBase.cs
@@ -10,6 +10,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.Webhook.Logs;
 
 [VersionedApiBackOfficeRoute($"{Constants.UdiEntityType.Webhook}")]
 [ApiExplorerSettings(GroupName = "Webhook")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessWebhooks)]
 public class WebhookLogControllerBase : ManagementApiControllerBase
 {
     protected PagedViewModel<WebhookLogResponseModel> CreatePagedWebhookLogResponseModel(PagedModel<WebhookLog> logs, IWebhookPresentationFactory webhookPresentationFactory)

--- a/src/Umbraco.Core/IO/PhysicalFileSystem.cs
+++ b/src/Umbraco.Core/IO/PhysicalFileSystem.cs
@@ -358,7 +358,7 @@ namespace Umbraco.Cms.Core.IO
 
             // nothing prevents us to reach the file, security-wise, yet it is outside
             // this filesystem's root - throw
-            throw new UnauthorizedAccessException($"File original: [{originalPath}] full: [{path}] is outside this filesystem's root.");
+            throw new UnauthorizedAccessException($"Requested path {originalPath} is outside this filesystem's root.");
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
This PR handles a couple of low severity security concerns:

- Webhook logs are readable by backoffice users without access to the webhooks feature.
- The validation for reading from the file system outside of the root exposes the resolved path.

### Testing

For the first issue, verify that the webhook logs are still displayed when logged into the backoffice with a user that has access to webhooks.

Verify that this request to the management API fails with a 403 response when signed in as a user without access to webhooks.

```
GET /umbraco/management/api/v1/webhook/{id}/logs?skip=0&take=100
```

For the second, verify this request to the management API fails but only reveals the originally requested relative path.

```
GET /umbraco/management/api/v1/tree/partial-view/children?parentPath=..%2F&skip=0&take=100
```