### PR TITLE
Add copy to clipboard success notification

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2457,6 +2457,7 @@ export default {
 		labelForCopyToClipboard: 'Copy to clipboard',
 		confirmDeleteHeadline: 'Delete from clipboard',
 		confirmDeleteDescription: 'Are you sure you want to delete <strong>{0}</strong> from the clipboard?',
+		copySuccessHeadline: 'Copied to clipboard',
 	},
 	propertyActions: {
 		tooltipForPropertyActionsMenu: 'Open Property Actions',

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/copy/copy-to-clipboard.property-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/copy/copy-to-clipboard.property-action.ts
@@ -62,7 +62,7 @@ export class UmbCopyToClipboardPropertyAction extends UmbPropertyActionBase<Meta
 
 		const propertyEditorUiIcon = this.#propertyContext.getEditorManifest()?.meta.icon;
 
-		this.#clipboardContext.write({
+		await this.#clipboardContext.write({
 			name: entryName,
 			icon: propertyEditorUiIcon,
 			propertyValue,

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/context/clipboard.property-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/context/clipboard.property-context.ts
@@ -121,7 +121,8 @@ export class UmbClipboardPropertyContext extends UmbContextBase {
 
 			return clipboardEntry;
 		} catch (error) {
-			notificationContext.peek('danger', { data: { message: error as string } });
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			notificationContext.peek('danger', { data: { message: errorMessage } });
 		}
 
 		return undefined;

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/context/clipboard.property-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/context/clipboard.property-context.ts
@@ -17,6 +17,8 @@ import { UMB_PROPERTY_CONTEXT, UmbPropertyValueCloneController } from '@umbraco-
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import type { ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 /**
  * Clipboard context for managing clipboard entries for property values
@@ -26,6 +28,7 @@ import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
  */
 export class UmbClipboardPropertyContext extends UmbContextBase {
 	#init?: Promise<unknown>;
+	#localize = new UmbLocalizationController(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_CLIPBOARD_PROPERTY_CONTEXT);
@@ -104,7 +107,24 @@ export class UmbClipboardPropertyContext extends UmbContextBase {
 			icon: args.icon,
 		};
 
-		return await clipboardContext.write(entryPreset);
+		const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+		if (!notificationContext) {
+			throw new Error('Notification context is required');
+		}
+
+		try {
+			const clipboardEntry = await clipboardContext.write(entryPreset);
+
+			notificationContext.peek('positive', {
+				data: { message: this.#localize.term('clipboard_copySuccessHeadline') },
+			});
+
+			return clipboardEntry;
+		} catch (error) {
+			notificationContext.peek('danger', { data: { message: error as string } });
+		}
+
+		return undefined;
 	}
 
 	/**


### PR DESCRIPTION
After PR https://github.com/umbraco/Umbraco-CMS/pull/19119, the user no longer gets a notification when using the clipboard feature.

The PR adds a success notification when a property value is copied to the clipboard. A notification is necessary here as no other UI indicates that the action has been successful.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/18516