### PR TITLE
Adds support for retrieval of data type references when data type is routed using a GUID

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
@@ -37,6 +37,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
     [PluginController(Constants.Web.Mvc.BackOfficeApiArea)]
     [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentsOrDocumentTypes)]
     [ParameterSwapControllerActionSelector(nameof(GetById), "id", typeof(int), typeof(Guid), typeof(Udi))]
+    [ParameterSwapControllerActionSelector(nameof(GetReferences), "id", typeof(int), typeof(Guid))]
     public class DataTypeController : BackOfficeNotificationsController
     {
         private readonly PropertyEditorCollection _propertyEditors;
@@ -421,10 +422,10 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         }
 
         /// <summary>
-        /// Returns the references (usages) for the data type
+        /// Returns the references (usages) for the data type.
         /// </summary>
-        /// <param name="id"></param>
-        /// <returns></returns>
+        /// <param name="id">Date type's integer Id.</param>
+        [HttpGet]
         public DataTypeReferences GetReferences(int id)
         {
             var result = new DataTypeReferences();
@@ -460,6 +461,22 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Returns the references (usages) for the data type.
+        /// </summary>
+        /// <param name="id">Date type's key.</param>
+        [HttpGet]
+        public DataTypeReferences GetReferences(Guid id)
+        {
+            IDataType? dataType = _dataTypeService.GetDataType(id);
+            if (dataType is null)
+            {
+                return new DataTypeReferences();
+            }
+
+            return GetReferences(dataType.Id);
         }
 
         [HttpGet]

--- a/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
@@ -1,14 +1,10 @@
-using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Net.Mime;
 using System.Text;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -424,7 +420,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <summary>
         /// Returns the references (usages) for the data type.
         /// </summary>
-        /// <param name="id">Date type's integer Id.</param>
+        /// <param name="id">Data type's integer Id.</param>
         [HttpGet]
         public DataTypeReferences GetReferences(int id)
         {
@@ -466,7 +462,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         /// <summary>
         /// Returns the references (usages) for the data type.
         /// </summary>
-        /// <param name="id">Date type's key.</param>
+        /// <param name="id">Data type's key.</param>
         [HttpGet]
         public DataTypeReferences GetReferences(Guid id)
         {

--- a/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/DataTypeController.cs
@@ -49,7 +49,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
         private readonly IConfigurationEditorJsonSerializer _serializer;
         private readonly IDataTypeUsageService _dataTypeUsageService;
-        private readonly IEntityService _entityService;
+        private readonly IIdKeyMap _idKeyMap;
 
         [Obsolete("Use constructor that takes IDataTypeUsageService, scheduled for removal in V12")]
         public DataTypeController(
@@ -77,7 +77,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             backOfficeSecurityAccessor,
             serializer,
             StaticServiceProvider.Instance.GetRequiredService<IDataTypeUsageService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IEntityService>())
+            StaticServiceProvider.Instance.GetRequiredService<IIdKeyMap>())
          {
          }
 
@@ -108,7 +108,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
                 backOfficeSecurityAccessor,
                 serializer,
                 dataTypeUsageService,
-                StaticServiceProvider.Instance.GetRequiredService<IEntityService>())
+                StaticServiceProvider.Instance.GetRequiredService<IIdKeyMap>())
         {
         }
 
@@ -126,7 +126,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
             IConfigurationEditorJsonSerializer serializer,
             IDataTypeUsageService dataTypeUsageService,
-            IEntityService entityService)
+            IIdKeyMap entityService)
         {
             _propertyEditors = propertyEditors ?? throw new ArgumentNullException(nameof(propertyEditors));
             _dataTypeService = dataTypeService ?? throw new ArgumentNullException(nameof(dataTypeService));
@@ -140,7 +140,7 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
             _backOfficeSecurityAccessor = backOfficeSecurityAccessor ?? throw new ArgumentNullException(nameof(backOfficeSecurityAccessor));
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _dataTypeUsageService = dataTypeUsageService ?? throw new ArgumentNullException(nameof(dataTypeUsageService));
-            _entityService = entityService ?? throw new ArgumentNullException(nameof(entityService));
+            _idKeyMap = entityService ?? throw new ArgumentNullException(nameof(entityService));
         }
 
         /// <summary>
@@ -502,10 +502,10 @@ namespace Umbraco.Cms.Web.BackOffice.Controllers
         [HttpGet]
         public DataTypeReferences GetReferences(Guid id)
         {
-            IEntitySlim? dataType = _entityService.Get(id, UmbracoObjectTypes.DataType);
-            return dataType is null
-                ? new DataTypeReferences()
-                : GetReferences(dataType.Id);
+            Attempt<int> dataType = _idKeyMap.GetIdForKey(id, UmbracoObjectTypes.DataType);
+            return dataType.Success
+                ? GetReferences(dataType.Result)
+                : new DataTypeReferences();
         }
 
         [HttpGet]


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19182

### Description
Although integer IDs are used for backoffice routes in Umbraco 13, we mostly support replacing the integer ID with it's GUID equivalent.  But not for data type references as shown in the linked issue.

This PR adds that support so that these requests are resolved.

### Testing
- Navigate to a data type that's used on a document type and verify you see the references shown on the "Info" panel.
- Look-up the data type's GUID and manually change the route so this is used in place of the integer ID.
- Verify the references are still shown.
