### PR TITLE
Upgrade examine to 3.7.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,8 +45,8 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="7.1.1" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.1.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageVersion Include="Examine" Version="3.7.0" />
-    <PackageVersion Include="Examine.Core" Version="3.7.0" />
+    <PackageVersion Include="Examine" Version="3.7.1" />
+    <PackageVersion Include="Examine.Core" Version="3.7.1" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="MailKit" Version="4.8.0" />


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description
We have a Umbraco 13.8.0 website running on Azure WebApps and configured as recommended in the documentation.

On a regular basis Examine indexes are corrupted. The only option is to manually delete them and restart the application to fix the problem.

See the following issues for more details :
https://github.com/Shazwazza/Examine/issues/402
https://github.com/umbraco/Umbraco-CMS/issues/16163

Last week we updated to Examine 3.7.1 and we have not seen the issue anymore.

This PR updates Examine for V13. Hopefully this can be taken into the next minor release.


