### PR TITLE
Build: Avoids rebuilding Backoffice unless it is required

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
+++ b/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj
@@ -26,23 +26,36 @@
     <ProjectReference Include="..\Umbraco.Web.Website\Umbraco.Web.Website.csproj" />
   </ItemGroup>
 
-  <!-- Restore and build backoffice project -->
+  <!-- General ignored files -->
+  <ItemGroup>
+    <Content Remove="wwwroot\umbraco\assets\README.md" />
+  </ItemGroup>
+
+
+
+  <!-- BEGIN: Restore and build backoffice project -->
   <PropertyGroup>
     <BackofficeProjectDirectory Condition="'$(BackofficeProjectDirectory)' == ''">..\Umbraco.Web.UI.Client\</BackofficeProjectDirectory>
-    <BackofficeAssetsPath>wwwroot\umbraco\backoffice</BackofficeAssetsPath>
+    <BackofficeAssetsPath>$(ProjectDir)wwwroot\umbraco\backoffice</BackofficeAssetsPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <BackofficeAssetsInputs Include="$(BackofficeProjectDirectory)package.json;$(BackofficeProjectDirectory)package-lock.json;$(BackofficeProjectDirectory)src\**" Exclude="$(DefaultItemExcludes)" />
     <Content Remove="$(BackofficeAssetsPath)\**" />
   </ItemGroup>
 
-  <Target Name="RestoreBackoffice" Inputs="$(BackofficeProjectDirectory)package-lock.json" Outputs="$(BackofficeProjectDirectory)node_modules\.package-lock.json">
-    <Message Importance="high" Text="Restoring Backoffice NPM packages..." />
-    <Exec Command="npm ci --no-fund --no-audit --prefer-offline" WorkingDirectory="$(BackofficeProjectDirectory)" />
+  <Target Name="BuildStaticAssetsPreconditions" BeforeTargets="AssignTargetPaths">
+    <Message Text="Skip BuildBackoffice target because UmbracoBuild is '$(UmbracoBuild)' (this is not Visual Studio)" Importance="high" Condition="'$(UmbracoBuild)' != ''" />
+    <Message Text="Skip BuildBackoffice target because '$(BackofficeAssetsPath)' already exists" Importance="high" Condition="Exists('$(BackofficeAssetsPath)')" />
+    <Message Text="Call BuildBackoffice target because UmbracoBuild is empty (this is Visual Studio) and '$(BackofficeAssetsPath)' doesn't exist" Importance="high" Condition="'$(UmbracoBuild)' == '' and !Exists('$(BackofficeAssetsPath)')" />
+    <CallTarget Targets="BuildBackoffice" Condition="'$(UmbracoBuild)' == '' and !Exists('$(BackofficeAssetsPath)')" />
   </Target>
 
-  <Target Name="BuildBackoffice" DependsOnTargets="RestoreBackoffice" BeforeTargets="AssignTargetPaths" Inputs="@(BackofficeAssetsInputs)" Outputs="$(IntermediateOutputPath)backoffice.complete.txt">
+  <Target Name="RestoreBackoffice" Inputs="$(BackofficeProjectDirectory)package-lock.json" Outputs="$(BackofficeProjectDirectory)node_modules\.package-lock.json">
+    <Message Importance="high" Text="Restoring Backoffice NPM packages..." />
+    <Exec Command="npm i --no-fund --no-audit" WorkingDirectory="$(BackofficeProjectDirectory)" />
+  </Target>
+
+  <Target Name="BuildBackoffice" DependsOnTargets="RestoreBackoffice">
     <Message Importance="high" Text="Executing Backoffice NPM build script..." />
     <Exec Command="npm run build:for:cms" WorkingDirectory="$(BackofficeProjectDirectory)" />
     <ItemGroup>
@@ -61,27 +74,46 @@
     </DefineStaticWebAssets>
   </Target>
 
-  <!-- Restore and build login project -->
+  <Target Name="CleanStaticAssetsPreconditions" AfterTargets="Clean" Condition="'$(UmbracoBuild)' == ''">
+    <Message Text="Skip CleanBackoffice target because '$(BackofficeAssetsPath)' doesn't exist" Importance="high" Condition="!Exists('$(BackofficeAssetsPath)')" />
+    <Message Text="Skip CleanBackoffice target because preserve.backoffice marker file exists" Importance="high" Condition="Exists('$(BackofficeAssetsPath)') and Exists('$(SolutionDir)preserve.backoffice')" />
+    <Message Text="Call CleanBackoffice target because '$(BackofficeAssetsPath)' exists and preserve.backoffice marker file doesn't exist" Importance="high" Condition="Exists('$(BackofficeAssetsPath)') and !Exists('$(SolutionDir)preserve.backoffice')" />
+    <CallTarget Targets="CleanBackoffice" Condition="Exists('$(BackofficeAssetsPath)') and !Exists('$(SolutionDir)preserve.backoffice')" />
+  </Target>
+
+  <Target Name="CleanBackoffice">
+    <ItemGroup>
+      <BackofficeDirectories Include="$(BackofficeAssetsPath)" />
+    </ItemGroup>
+    <RemoveDir Directories="@(BackofficeDirectories)" />
+  </Target>
+  <!-- END: Restore and build backoffice project -->
+
+
+
+  <!-- BEGIN: Restore and build login project -->
   <PropertyGroup>
     <LoginProjectDirectory Condition="'$(LoginProjectDirectory)' == ''">..\Umbraco.Web.UI.Login\</LoginProjectDirectory>
-    <LoginAssetsPath>wwwroot\umbraco\login</LoginAssetsPath>
+    <LoginAssetsPath>$(ProjectDir)wwwroot\umbraco\login</LoginAssetsPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <LoginAssetsInputs Include="$(LoginProjectDirectory)**" Exclude="$(DefaultItemExcludes)" />
     <Content Remove="$(LoginAssetsPath)\**" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Remove="wwwroot\umbraco\assets\README.md" />
-  </ItemGroup>
+  <Target Name="BuildLoginStaticAssetsPreconditions" BeforeTargets="AssignTargetPaths">
+    <Message Text="Skip BuildLogin target because UmbracoBuild is '$(UmbracoBuild)' (this is not Visual Studio)" Importance="high" Condition="'$(UmbracoBuild)' != ''" />
+    <Message Text="Skip BuildLogin target because '$(LoginAssetsPath)' already exists" Importance="high" Condition="Exists('$(LoginAssetsPath)')" />
+    <Message Text="Call BuildLogin target because UmbracoBuild is empty (this is Visual Studio) and '$(LoginAssetsPath)' doesn't exist" Importance="high" Condition="'$(UmbracoBuild)' == '' and !Exists('$(LoginAssetsPath)')" />
+    <CallTarget Targets="BuildLogin" Condition="'$(UmbracoBuild)' == '' and !Exists('$(LoginAssetsPath)')" />
+  </Target>
 
   <Target Name="RestoreLogin" Inputs="$(LoginProjectDirectory)package-lock.json" Outputs="$(LoginProjectDirectory)node_modules/.package-lock.json">
     <Message Importance="high" Text="Restoring Login NPM packages..." />
-    <Exec Command="npm ci --no-fund --no-audit --prefer-offline" WorkingDirectory="$(LoginProjectDirectory)" />
+    <Exec Command="npm i --no-fund --no-audit" WorkingDirectory="$(LoginProjectDirectory)" />
   </Target>
 
-  <Target Name="BuildLogin" DependsOnTargets="RestoreLogin" BeforeTargets="AssignTargetPaths" Inputs="@(LoginAssetsInputs)" Outputs="$(IntermediateOutputPath)login.complete.txt">
+  <Target Name="BuildLogin" DependsOnTargets="RestoreLogin">
     <Message Importance="high" Text="Executing Login NPM build script..." />
     <Exec Command="npm run build" WorkingDirectory="$(LoginProjectDirectory)" />
     <ItemGroup>
@@ -99,4 +131,19 @@
       <Output TaskParameter="Assets" ItemName="StaticWebAsset" />
     </DefineStaticWebAssets>
   </Target>
+
+  <Target Name="CleanLoginStaticAssetsPreconditions" AfterTargets="Clean" Condition="'$(UmbracoBuild)' == ''">
+    <Message Text="Skip CleanLogin target because '$(LoginAssetsPath)' doesn't exist" Importance="high" Condition="!Exists('$(LoginAssetsPath)')" />
+    <Message Text="Skip CleanLogin target because preserve.login marker file exists" Importance="high" Condition="Exists('$(LoginAssetsPath)') and Exists('$(SolutionDir)preserve.login')" />
+    <Message Text="Call CleanLogin target because '$(LoginAssetsPath)' exists and preserve.login marker file doesn't exist" Importance="high" Condition="Exists('$(LoginAssetsPath)') and !Exists('$(SolutionDir)preserve.login')" />
+    <CallTarget Targets="CleanLogin" Condition="Exists('$(LoginAssetsPath)') and !Exists('$(SolutionDir)preserve.login')" />
+  </Target>
+
+  <Target Name="CleanLogin">
+    <ItemGroup>
+      <LoginDirectories Include="$(LoginAssetsPath)" />
+    </ItemGroup>
+    <RemoveDir Directories="@(LoginDirectories)" />
+  </Target>
+  <!-- END: Restore and build login project -->
 </Project>


### PR DESCRIPTION
## Description
Some people have noticed how the Backoffice seems to build even though no files are changed. Our theory is that this happens simply because there are too many input files to consider for the MSBuild target.

In v13, the StaticAssets build was only triggered by the existence of either the output folder or a preserve.* marker file. Here, we also check for the node_modules/.package-lock.json file before reinstalling npm dependencies. Additionally, we now only run `npm install` rather than `npm ci` to optimise the build.

As an aide, you can check how it was done in V13 here: https://github.com/umbraco/Umbraco-CMS/blob/v13/dev/src/Umbraco.Cms.StaticAssets/Umbraco.Cms.StaticAssets.csproj

## How to test
1. Check out this branch
2. Run `dotnet clean` or Clean Solution
3. Run `dotnet run`
4. Check that both the Login as well as the Backoffice UI are shown and working
5. Shut down the server and run it again
6. Verify that none of the client builds are running (e.g., it will be fast to start up again)
7. Run `dotnet clean` again
8. Verify that the output folders disappear (staticassets/wwwroot/backoffice and login)
9. Run `dotnet run` again
10. Verify that the output folders once again are built and work

**Hint:** You can CD into the **Umbraco.Cms.StaticAssets** directory and run `dotnet build -v diag --no-dependencies` and check the logged messages. It should say that the builds were skipped:

![image](https://github.com/user-attachments/assets/37f475d0-d9f4-47c0-97c2-35dda3c93429)