### PR TITLE
V13: Clear Member Username Cache in Load Balanced Environments

### DIFF
--- a/src/Umbraco.Core/Cache/CacheKeys.cs
+++ b/src/Umbraco.Core/Cache/CacheKeys.cs
@@ -22,4 +22,6 @@ public static class CacheKeys
 
     public const string ContentRecycleBinCacheKey = "recycleBin_content";
     public const string MediaRecycleBinCacheKey = "recycleBin_media";
+
+    public const string MemberUserNameCachePrefix = "uRepo_userNameKey+";
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -12,6 +12,8 @@ namespace Umbraco.Cms.Core.Cache;
 
 public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCacheRefresherNotification, MemberCacheRefresher.JsonPayload>
 {
+    private static string UserNameCachePrefix = "uRepo_userNameKey+";
+
     public static readonly Guid UniqueId = Guid.Parse("E285DF34-ACDC-4226-AE32-C0CB5CF388DA");
 
     private readonly IIdKeyMap _idKeyMap;
@@ -73,11 +75,14 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
         foreach (JsonPayload p in payloads)
         {
             _idKeyMap.ClearCache(p.Id);
-            if (memberCache.Success)
+            if (memberCache.Success is false)
             {
-                memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, int>(p.Id));
-                memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(p.Username));
+                continue;
             }
+
+            memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, int>(p.Id));
+            memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(p.Username));
+            memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(UserNameCachePrefix + p.Username));
         }
     }
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -12,8 +12,6 @@ namespace Umbraco.Cms.Core.Cache;
 
 public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCacheRefresherNotification, MemberCacheRefresher.JsonPayload>
 {
-    private static readonly string UserNameCachePrefix = "uRepo_userNameKey+";
-
     public static readonly Guid UniqueId = Guid.Parse("E285DF34-ACDC-4226-AE32-C0CB5CF388DA");
 
     private readonly IIdKeyMap _idKeyMap;
@@ -83,14 +81,14 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
             memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, int>(p.Id));
             memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(p.Username));
 
-            // This specific cache key was introduce to fix an issue where the member username could not be the same as the member id, because the cache keys collided.
+            // This specific cache key was introduced to fix an issue where the member username could not be the same as the member id, because the cache keys collided.
             // This is done in a bit of a hacky way, because the cache key is created internally in the repository, but we need to clear it here.
-            // Ideally we want the use a shared way of generating the key between this, and the repository.
-            // Additionally, the RepositoryCacheKeys actually caches the string to avoid re-allocating memory, we would like to also use this in the repository
+            // Ideally, we want to use a shared way of generating the key between this and the repository.
+            // Additionally, the RepositoryCacheKeys actually caches the string to avoid re-allocating memory; we would like to also use this in the repository
             // See:
             // https://github.com/umbraco/Umbraco-CMS/pull/17350
             // https://github.com/umbraco/Umbraco-CMS/pull/17815
-            memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(UserNameCachePrefix + p.Username));
+            memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(CacheKeys.MemberUserNameCachePrefix + p.Username));
         }
     }
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.Cache;
 
 public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCacheRefresherNotification, MemberCacheRefresher.JsonPayload>
 {
-    private static string UserNameCachePrefix = "uRepo_userNameKey+";
+    private static readonly string UserNameCachePrefix = "uRepo_userNameKey+";
 
     public static readonly Guid UniqueId = Guid.Parse("E285DF34-ACDC-4226-AE32-C0CB5CF388DA");
 

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -82,6 +82,14 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
 
             memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, int>(p.Id));
             memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(p.Username));
+
+            // This specific cache key was introduce to fix an issue where the member username could not be the same as the member id, because the cache keys collided.
+            // This is done in a bit of a hacky way, because the cache key is created internally in the repository, but we need to clear it here.
+            // Ideally we want the use a shared way of generating the key between this, and the repository.
+            // Additionally, the RepositoryCacheKeys actually caches the string to avid re-allocating memory, we would like to also use this in the repository
+            // See:
+            // https://github.com/umbraco/Umbraco-CMS/pull/17350
+            // https://github.com/umbraco/Umbraco-CMS/pull/17815
             memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(UserNameCachePrefix + p.Username));
         }
     }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -86,7 +86,7 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
             // This specific cache key was introduce to fix an issue where the member username could not be the same as the member id, because the cache keys collided.
             // This is done in a bit of a hacky way, because the cache key is created internally in the repository, but we need to clear it here.
             // Ideally we want the use a shared way of generating the key between this, and the repository.
-            // Additionally, the RepositoryCacheKeys actually caches the string to avid re-allocating memory, we would like to also use this in the repository
+            // Additionally, the RepositoryCacheKeys actually caches the string to avoid re-allocating memory, we would like to also use this in the repository
             // See:
             // https://github.com/umbraco/Umbraco-CMS/pull/17350
             // https://github.com/umbraco/Umbraco-CMS/pull/17815

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -38,7 +38,6 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
     private readonly ITagRepository _tagRepository;
     private bool _passwordConfigInitialized;
     private string? _passwordConfigJson;
-    private const string UsernameCacheKey = "uRepo_userNameKey+";
 
     public MemberRepository(
         IScopeAccessor scopeAccessor,
@@ -229,7 +228,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
     }
 
     public IMember? GetByUsername(string? username) =>
-        _memberByUsernameCachePolicy.GetByUserName(UsernameCacheKey, username, PerformGetByUsername, PerformGetAllByUsername);
+        _memberByUsernameCachePolicy.GetByUserName(CacheKeys.MemberUserNameCachePrefix, username, PerformGetByUsername, PerformGetAllByUsername);
 
     public int[] GetMemberIds(string[] usernames)
     {
@@ -511,7 +510,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
 
     protected override void PersistDeletedItem(IMember entity)
     {
-        _memberByUsernameCachePolicy.DeleteByUserName(UsernameCacheKey, entity.Username);
+        _memberByUsernameCachePolicy.DeleteByUserName(CacheKeys.MemberUserNameCachePrefix, entity.Username);
         base.PersistDeletedItem(entity);
     }
 
@@ -844,7 +843,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
 
         OnUowRefreshedEntity(new MemberRefreshNotification(entity, new EventMessages()));
 
-        _memberByUsernameCachePolicy.DeleteByUserName(UsernameCacheKey, entity.Username);
+        _memberByUsernameCachePolicy.DeleteByUserName(CacheKeys.MemberUserNameCachePrefix, entity.Username);
 
         entity.ResetDirtyProperties();
     }


### PR DESCRIPTION
Fixes #18781

The issue was that after #17350 the member username key wasn't evicted from the cache. 

To fix this, I've for now added an extra line clearing this in the `MemberCacheRefresher`

I think a separate task is warranted to align how we generate these cache keys. Currently, each repository generates this cache key internally, which is why this "extension" of the member cache is added as `MemberRepositoryUsernameCachePolicy`; however, at the same time, we have `RepositoryCacheKeys`, which is used to generate the cache keys when clearing the cache in cache refreshers. `RepositoryCacheKeys` also has an optimization to avoid allocation of strings, however, we're missing out on this when populating the caches. I think we should use something like `RepositoryCacheKeys` both places, however, make this extendable on an pr. entity basis, remove the need for the  `MemberRepositoryUsernameCachePolicy` because it's kind of hacky :smile: I'll get a task made on the board :saluting_face: 

## Testing

See original issue, however I've already tested this on a load balanced setup, and the logic is quite straightforward.


This should be cherry picked up to 15+ 