### PR TITLE
Ensure picker search config query params are always included in the server request

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/types.ts
@@ -10,9 +10,9 @@ export interface UmbPickerModalData<ItemType> {
 	search?: UmbPickerModalSearchConfig;
 }
 
-export interface UmbPickerModalSearchConfig {
+export interface UmbPickerModalSearchConfig<QueryParamsType = Record<string, unknown>> {
 	providerAlias: string;
-	queryParams?: object;
+	queryParams?: QueryParamsType;
 }
 
 export interface UmbPickerModalValue {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/manager/picker-search.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/manager/picker-search.manager.ts
@@ -183,8 +183,10 @@ export class UmbPickerSearchManager<
 		}
 
 		const args = {
-			searchFrom: this.#config?.searchFrom,
 			...query,
+			// ensure that config params are always included
+			...this.#config?.queryParams,
+			searchFrom: this.#config?.searchFrom,
 		};
 
 		const { data } = await this.#searchProvider.search(args);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/manager/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/manager/types.ts
@@ -1,6 +1,7 @@
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 
-export interface UmbPickerSearchManagerConfig {
+export interface UmbPickerSearchManagerConfig<QueryParamsType = Record<string, unknown>> {
 	providerAlias: string;
 	searchFrom?: UmbEntityModel;
+	queryParams?: QueryParamsType;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.element.ts
@@ -58,13 +58,6 @@ export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase
 					...this.data.search,
 					searchFrom: this.data.startNode,
 				});
-
-				const searchQueryParams = this.data.search.queryParams;
-				if (searchQueryParams) {
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					//@ts-ignore - TODO wire up types
-					this.#pickerContext.search.setQuery(searchQueryParams);
-				}
 			}
 
 			const multiple = this.data?.multiple ?? false;


### PR DESCRIPTION
This PR ensures that all query parameters set through the picker search config are always included in the server request.

Fixes the second part of this issue: https://github.com/umbraco/Umbraco-CMS/issues/19150 - see comment https://github.com/umbraco/Umbraco-CMS/issues/19150#issuecomment-2838055742

This PR will be ignored for the release as it resolves a bug found during the internal testing phase.