### PR TITLE
Block Type Configuration: filter search to only include element types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
@@ -106,6 +106,12 @@ export class UmbInputBlockTypeElement<
 								presetAlias: 'element',
 							},
 						},
+						// TODO: hide the queryParams and filter config under a "elementTypesOnly" field. [MR]
+						search: {
+							queryParams: {
+								isElementType: true,
+							},
+						},
 						pickableFilter: (docType) =>
 							// Only pick elements:
 							docType.isElement &&


### PR DESCRIPTION
When setting up a block grid/list configuration, it is currently possible to search for a document type (not an element type). This PR ensures that only element types are returned in the search results.