### PR TITLE
Fix root path regression for the Delivery API

### DIFF
--- a/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentPathResolver.cs
@@ -15,6 +15,7 @@ public class ApiContentPathResolver : IApiContentPathResolver
         _apiPublishedContentCache = apiPublishedContentCache;
     }
 
+    [Obsolete("No longer used in V15. Scheduled for removal in V15.")]
     public virtual bool IsResolvablePath(string path)
     {
         // File requests will blow up with an downstream exception in GetRequiredPublishedSnapshot, which fails due to an UmbracoContext
@@ -30,7 +31,10 @@ public class ApiContentPathResolver : IApiContentPathResolver
         return true;
     }
 
-    private static bool IsFileRequest(string path) => path.Split('/', StringSplitOptions.RemoveEmptyEntries).Last().Contains('.');
+    private static bool IsFileRequest(string path) => path
+        .Split('/', StringSplitOptions.RemoveEmptyEntries)
+        .LastOrDefault()?
+        .Contains('.') is true;
 
     public virtual IPublishedContent? ResolveContentPath(string path)
     {

--- a/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiContentPathResolver.cs
@@ -4,6 +4,7 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public interface IApiContentPathResolver
 {
+    [Obsolete("No longer used in V15. Scheduled for removal in V15.")]
     bool IsResolvablePath(string path) => true;
 
     IPublishedContent? ResolveContentPath(string path);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ApiContentPathResolverTests.cs
@@ -11,6 +11,7 @@ public class ApiContentPathResolverTests
     private const string TestPath = "/test/page";
 
     [TestCase(TestPath, true)]
+    [TestCase("/", true)]
     [TestCase("file.txt", false)]
     [TestCase("test/file.txt", false)]
     [TestCase("test/test2/file.txt", false)]
@@ -24,11 +25,12 @@ public class ApiContentPathResolverTests
         Assert.AreEqual(expected, result);
     }
 
-    [Test]
-    public void Resolves_Content_For_Path()
+    [TestCase(TestPath)]
+    [TestCase("/")]
+    public void Resolves_Content_For_Path(string path)
     {
         var resolver = CreateResolver();
-        var result = resolver.ResolveContentPath(TestPath);
+        var result = resolver.ResolveContentPath(path);
         Assert.IsNotNull(result);
     }
 
@@ -40,7 +42,10 @@ public class ApiContentPathResolverTests
             .Returns((string path) => path);
         var mockApiPublishedContentCache = new Mock<IApiPublishedContentCache>();
         mockApiPublishedContentCache
-            .Setup(x => x.GetByRoute(It.Is<string>(y => y == TestPath)))
+            .Setup(x => x.GetByRoute(TestPath))
+            .Returns(new Mock<IPublishedContent>().Object);
+        mockApiPublishedContentCache
+            .Setup(x => x.GetByRoute("/"))
             .Returns(new Mock<IPublishedContent>().Object);
         return new ApiContentPathResolver(mockRequestRoutingService.Object, mockApiPublishedContentCache.Object);
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

#19063 has introduced a regression the Delivery API: It is no longer possible to fetch the route item by path (`/`). 

![image](https://github.com/user-attachments/assets/6b2331b3-79f8-4751-9b20-807c2d552359)

This PR fixes it.

Additionally, #19063 introduced the new method `IsResolvablePath(string path)` on `IApiContentPathResolver`, as part a fix for handling file requests correctly. But since this handling is not necessary for V15+ due to the changes in caching, the fix has not been forward merged - nor should it. For good measure I've added an obsoletion message to the method in this PR 👍 