### PR TITLE
V16 RC: getOpenApiConfiguration().token does not work

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -250,7 +250,7 @@ export class UmbAuthContext extends UmbContextBase {
 		return {
 			base: config.baseUrl,
 			credentials: config.credentials,
-			token: this.getLatestToken,
+			token: () => this.getLatestToken(),
 		};
 	}
 

--- a/templates/UmbracoExtension/Client/package.json
+++ b/templates/UmbracoExtension/Client/package.json
@@ -9,13 +9,13 @@
     "generate-client": "node scripts/generate-openapi.js https://localhost:44339/umbraco/swagger/umbracoextension/swagger.json"
   },
   "devDependencies": {
-    "@hey-api/client-fetch": "^0.8.3",
-    "@hey-api/openapi-ts": "^0.64.10",
+    "@hey-api/client-fetch": "^0.10.0",
+    "@hey-api/openapi-ts": "^0.66.7",
     "@umbraco-cms/backoffice": "^UMBRACO_VERSION_FROM_TEMPLATE",
     "chalk": "^5.4.1",
     "cross-env": "^7.0.3",
     "node-fetch": "^3.3.2",
-    "typescript": "^5.8.2",
-    "vite": "^6.2.0"
+    "typescript": "^5.8.3",
+    "vite": "^6.3.4"
   }
 }

--- a/templates/UmbracoExtension/Client/src/dashboards/dashboard.element.ts
+++ b/templates/UmbracoExtension/Client/src/dashboards/dashboard.element.ts
@@ -7,29 +7,25 @@ import {
 } from "@umbraco-cms/backoffice/external/lit";
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
 import { UUIButtonElement } from "@umbraco-cms/backoffice/external/uui";
-import {
-  UMB_NOTIFICATION_CONTEXT,
-  UmbNotificationContext,
-} from "@umbraco-cms/backoffice/notification";
-import {
-  UMB_CURRENT_USER_CONTEXT,
-  UmbCurrentUserModel,
-} from "@umbraco-cms/backoffice/current-user";
+import { UMB_NOTIFICATION_CONTEXT } from "@umbraco-cms/backoffice/notification";
+import { UMB_CURRENT_USER_CONTEXT } from "@umbraco-cms/backoffice/current-user";
 import { UmbracoExtensionService, UserModel } from "../api/index.js";
 
 @customElement("example-dashboard")
 export class ExampleDashboardElement extends UmbElementMixin(LitElement) {
   @state()
-  private _yourName: string | undefined = "Press the button!";
+  private _yourName?: string = "Press the button!";
 
   @state()
-  private _timeFromMrWolf: Date | undefined;
+  private _timeFromMrWolf?: Date;
 
   @state()
-  private _serverUserData: UserModel | undefined = undefined;
+  private _serverUserData?: UserModel;
 
   @state()
-  private _contextCurrentUser: UmbCurrentUserModel | undefined = undefined;
+  private _contextCurrentUser?: typeof UMB_CURRENT_USER_CONTEXT.TYPE;
+
+  #notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
 
   constructor() {
     super();
@@ -42,13 +38,15 @@ export class ExampleDashboardElement extends UmbElementMixin(LitElement) {
       // When we have the current user context
       // We can observe properties from it, such as the current user or perhaps just individual properties
       // When the currentUser object changes we will get notified and can reset the @state properrty
-      this.observe(currentUserContext.currentUser, (currentUser) => {
-        this._contextCurrentUser = currentUser;
-      });
+      this.observe(
+        currentUserContext.currentUser,
+        (currentUser) => {
+          this._contextCurrentUser = currentUser;
+        },
+        "_contextCurrentUser"
+      );
     });
   }
-
-  #notificationContext: UmbNotificationContext | undefined = undefined;
 
   #onClickWhoAmI = async (ev: Event) => {
     const buttonElement = ev.target as UUIButtonElement;

--- a/templates/UmbracoExtension/Client/src/entrypoints/entrypoint.ts
+++ b/templates/UmbracoExtension/Client/src/entrypoints/entrypoint.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   UmbEntryPointOnInit,
   UmbEntryPointOnUnload,
 } from "@umbraco-cms/backoffice/extension-api";
@@ -15,12 +15,12 @@ export const onInit: UmbEntryPointOnInit = (_host, _extensionRegistry) => {
   // Do the OAuth token handshake stuff
   _host.consumeContext(UMB_AUTH_CONTEXT, async (authContext) => {
     // Get the token info from Umbraco
-    const config = authContext.getOpenApiConfiguration();
+    const config = authContext?.getOpenApiConfiguration();
 
     client.setConfig({
-      auth: config.token,
-      baseUrl: config.base,
-      credentials: config.credentials,
+      auth: config?.token ?? undefined,
+      baseUrl: config?.base ?? "",
+      credentials: config?.credentials ?? "same-origin",
     });
   });
   //#endif


### PR DESCRIPTION
## Description

One line accidentally got changed compared to V15, so getting the latest token through the helpful "openApiConfiguration" object was no longer possible.

This pull request reverts the line to V15, where the token is proxied through the AuthContext, so we don't accidentally call a private member of AuthFlow.

Additionally, I have updated the **umbraco-extension** template to reflect that all contexts are now potentially undefined, because they can be revoked.

This fixes #19207 

## How to test

Go to a random element like the umbraco-news-dashboard.element.ts and test that you can get the token through the two officially supported methods:

```js
	override firstUpdated() {
		this.consumeContext(UMB_AUTH_CONTEXT, async (auth) => {
			console.log('token 1', await auth?.getLatestToken());
			console.log('token 2', await auth?.getOpenApiConfiguration().token());
		});
	}
```

You should see **token 1** and **token 2** logged to the console.