### PR TITLE
Restored interface methods on obsolete IBackgroundTaskQueue

### DIFF
--- a/src/Umbraco.Core/HostedServices/IBackgroundTaskQueue.cs
+++ b/src/Umbraco.Core/HostedServices/IBackgroundTaskQueue.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Core.HostedServices;
 public interface IBackgroundTaskQueue
 {
     /// <summary>
-    ///     Enqueue a work item to be executed on in the background.
+    ///     Enqueue a work item to be executed in the background.
     /// </summary>
     void QueueBackgroundWorkItem(Func<CancellationToken, Task> workItem);
 

--- a/src/Umbraco.Infrastructure/HostedServices/IBackgroundTaskQueue.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/IBackgroundTaskQueue.cs
@@ -9,4 +9,13 @@ namespace Umbraco.Cms.Infrastructure.HostedServices;
 [Obsolete("This has been relocated into Umbraco.Cms.Core. This definition in Umbraco.Cms.Infrastructure is scheduled for removal in Umbraco 17.")]
 public interface IBackgroundTaskQueue : Core.HostedServices.IBackgroundTaskQueue
 {
+    /// <summary>
+    ///     Enqueue a work item to be executed on in the background.
+    /// </summary>
+    void QueueBackgroundWorkItem(Func<CancellationToken, Task> workItem);
+
+    /// <summary>
+    ///     Dequeue the first item on the queue.
+    /// </summary>
+    Task<Func<CancellationToken, Task>?> DequeueAsync(CancellationToken cancellationToken);
 }

--- a/src/Umbraco.Infrastructure/HostedServices/IBackgroundTaskQueue.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/IBackgroundTaskQueue.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Infrastructure.HostedServices;
 public interface IBackgroundTaskQueue : Core.HostedServices.IBackgroundTaskQueue
 {
     /// <summary>
-    ///     Enqueue a work item to be executed on in the background.
+    ///     Enqueue a work item to be executed in the background.
     /// </summary>
     void QueueBackgroundWorkItem(Func<CancellationToken, Task> workItem);
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco.Forms.Issues/issues/1393

### Description
This PR addresses the inadvertent breaking change introduced in 15.4 (see discussion in comment on [linked issue](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1393#issuecomment-2848621699)).

Although this didn't get picked up by the usual static package validation checks, it wasn't sufficient to inherit from the newly introduced interface in the core project and expect the methods defined on the obsolete one to be found.  Rather we need to keep the methods on the obsoleted interface too.

### Testing

I've verified the following using a standalone install of the CMS with Forms, comparing before and after using the packages generated from the build pipeline for this PR.

Install CMS 15.4 and Forms 15.1.1 and after submitting a form a missing method exception will be thrown.

With this PR in place, you should find that it no longer will be and the Form's Examine index will be populated as expected with the form submission information.

Also verify that the publish with descendants works without error (as this uses the introduced interface in core).