### PR TITLE
V16: Main language dropdown does not scroll

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
@@ -138,7 +138,8 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 			id="dropdown-popover"
 			data-mark="app-language-menu"
 			@beforetoggle=${this.#onPopoverToggle}>
-			<umb-popover-layout>
+						<umb-popover-layout>
+			<uui-scroll-container style="max-height:calc(100vh - (var(--umb-header-layout-height) + 60px));">
 				${repeat(
 					this._languages,
 					(language) => language.unique,
@@ -152,7 +153,9 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 						</uui-menu-item>
 					`,
 				)}
-			</umb-popover-layout>
+				</uui-scroll-container>
+							</umb-popover-layout>
+
 		</uui-popover-container>`;
 	}
 
@@ -197,6 +200,8 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 
 			uui-menu-item {
 				color: var(--uui-color-text);
+				
+				width: auto;
 			}
 		`,
 	];


### PR DESCRIPTION
Edit on - https://github.com/umbraco/Umbraco-CMS/pull/19209 due to changing the release to target v16.0.0

Fixes ↓
[Issue - 19197](https://github.com/umbraco/Umbraco-CMS/issues/19197)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->

The Language popover in the content tree did not support scrolling, so if you had more languages than the view height, you'd not be able to choose the languages lower down, see below GIF

![chrome_zoLWHE0jfN](https://github.com/user-attachments/assets/8db66310-8e01-49af-ade3-b4586aec582d)


The language popover does not support scrolling,g and you are able to pick the language you need 

![chrome_8WLl6IjHF0](https://github.com/user-attachments/assets/3603e5d9-a5ac-494f-98c8-3252fdc9f6c8)


---
_This item has been added to our backlog AB#52593_