### PR TITLE
Hide the content files that come from the Microsoft.CodeAnalysis.Workspaces.Common package in the web.ui project.

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -32,6 +32,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Hide the content files that come from the Microsoft.CodeAnalysis.Workspaces.Common package. -->
+    <Content Update="$(NuGetPackageRoot)\microsoft.codeanalysis.workspaces.msbuild\**\**" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Ensure the AppLocalIcu setting is the same as the referenced ICU package version and changes are also done to the template project! -->
     <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" VersionOverride="72.1.0.3" />


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Relates to this [internal discussion at HQ](https://umbraco.slack.com/archives/C027U315T54/p1746520423722969).

### Description
https://github.com/umbraco/Umbraco-CMS/pull/19202 resolved restore warnings on the `Web.UI` project, but due to the upgrade of `Microsoft.CodeAnalysis.Workspaces.Common` introduced some "folders" that pollute the solution view.

Adding this update to the `.csproj` file hides them.

### Testing

Verify that you no longer see these content files in the solution view:

![image](https://github.com/user-attachments/assets/bed197bd-5493-46ba-a6c4-3c69e57faaf1)
