### PR TITLE
V16: Block selector is limited to 100 blocks

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-data-type-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-data-type-picker-modal.element.ts
@@ -35,7 +35,7 @@ export class UmbDataTypePickerFlowDataTypePickerModalElement extends UmbModalBas
 
 		const collection = await dataTypeCollectionRepository.requestCollection({
 			skip: 0,
-			take: 100,
+			take: 1000,
 			editorUiAlias: propertyEditorUiAlias,
 		});
 


### PR DESCRIPTION
Edit on - https://github.com/umbraco/Umbraco-CMS/pull/19208 due to changing the release to target 

Fixes ↓
https://github.com/umbraco/Umbraco-CMS/issues/19200

Description
Changed the Block List configuration item limit that is shown from 100