### PR TITLE
`TimedScope` improvements and login duration clean-up

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -139,7 +139,7 @@ public class SecuritySettings
     /// The user login endpoint ensures that failed login attempts take at least as long as the average successful login.
     /// However, if no successful logins have occurred, this value is used as the default duration.
     /// </remarks>
-    [Range(0, long.MaxValue)]
+    [Range(0, int.MaxValue)] // TODO (V17): Change property type to short and update maximum range to short.MaxValue
     [DefaultValue(StaticUserDefaultFailedLoginDurationInMilliseconds)]
     public long UserDefaultFailedLoginDurationInMilliseconds { get; set; } = StaticUserDefaultFailedLoginDurationInMilliseconds;
 
@@ -149,7 +149,7 @@ public class SecuritySettings
     /// <value>
     /// The minimum duration (in milliseconds) of failed login attempts.
     /// </value>
-    [Range(0, long.MaxValue)]
+    [Range(0, int.MaxValue)] // TODO (V17): Change property type to short and update maximum range to short.MaxValue
     [DefaultValue(StaticUserMinimumFailedLoginDurationInMilliseconds)]
     public long UserMinimumFailedLoginDurationInMilliseconds { get; set; } = StaticUserMinimumFailedLoginDurationInMilliseconds;
 }

--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -139,6 +139,7 @@ public class SecuritySettings
     /// The user login endpoint ensures that failed login attempts take at least as long as the average successful login.
     /// However, if no successful logins have occurred, this value is used as the default duration.
     /// </remarks>
+    [Range(0, long.MaxValue)]
     [DefaultValue(StaticUserDefaultFailedLoginDurationInMilliseconds)]
     public long UserDefaultFailedLoginDurationInMilliseconds { get; set; } = StaticUserDefaultFailedLoginDurationInMilliseconds;
 
@@ -148,6 +149,7 @@ public class SecuritySettings
     /// <value>
     /// The minimum duration (in milliseconds) of failed login attempts.
     /// </value>
+    [Range(0, long.MaxValue)]
     [DefaultValue(StaticUserMinimumFailedLoginDurationInMilliseconds)]
     public long UserMinimumFailedLoginDurationInMilliseconds { get; set; } = StaticUserMinimumFailedLoginDurationInMilliseconds;
 }

--- a/src/Umbraco.Core/TimedScope.cs
+++ b/src/Umbraco.Core/TimedScope.cs
@@ -133,6 +133,8 @@ public sealed class TimedScope : IDisposable, IAsyncDisposable
         {
             Thread.Sleep(remaining);
         }
+
+        _cancellationTokenSource.Dispose();
     }
 
     /// <summary>
@@ -151,6 +153,8 @@ public sealed class TimedScope : IDisposable, IAsyncDisposable
         {
             await Task.Delay(remaining, _timeProvider, _cancellationTokenSource.Token).ConfigureAwait(false);
         }
+
+        _cancellationTokenSource.Dispose();
     }
 
     private bool TryGetRemaining(out TimeSpan remaining)

--- a/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/AuthenticationController.cs
@@ -419,7 +419,7 @@ public class AuthenticationController : UmbracoApiControllerBase
     public async Task<ActionResult<UserDetail?>> PostLogin(LoginModel loginModel)
     {
         // Start a timed scope to ensure failed responses return is a consistent time
-        await using var timedScope = new TimedScope(GetLoginDuration(), CancellationToken.None);
+        await using var timedScope = new TimedScope(GetLoginDuration(), HttpContext.RequestAborted);
 
         // Sign the user in with username/password, this also gives a chance for developers to
         // custom verify the credentials and auto-link user accounts with a custom IBackOfficePasswordChecker


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Although the changes in the latest (security) patches do fix the issue, I noticed `TimedScope` (backported from https://github.com/umbraco/Umbraco-CMS/commit/65bb2801b0d7bf9eb5099dd56ec306050bf7897c or https://github.com/umbraco/Umbraco-CMS/commit/839b6816f2ae3e5f54459a0f09dad6b17e2d1e07) doesn't dispose the `CancellationTokenSource` that's created in the constructors. Also, `CancellationToken.None` was used in the login method, instead of using `HttpContext.RequestAborted` (which would be the same as adding a new action parameter, see [Model Binding in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?view=aspnetcore-9.0#cancellationtoken)): this ensures the server stops waiting as soon as the request is aborted.

The `UserDefaultFailedLoginDurationInMilliseconds` and `UserMinimumFailedLoginDurationInMilliseconds` settings are now also validated to ensure they aren't set to negative values and I've removed the randomization of the average login duration. Although the idea of adding 'noise' to the timings would make it harder to correlate successful and failed responses, the fact that a fixed minimum and calculated average of successful logins is used for failed logins already ensures there's no difference between a non-existent user and failed password check on an existing user...

These changes should be easy to merge up to the latest versions as well (or update the PR base branch to the latest version, if we don't want to release this for v13).