### PR TITLE
Chore: Update the list of allowed tags for jsdocs

### DIFF
--- a/src/Umbraco.Web.UI.Client/eslint.config.js
+++ b/src/Umbraco.Web.UI.Client/eslint.config.js
@@ -80,6 +80,14 @@ export default [
 			'@typescript-eslint/consistent-type-exports': 'error',
 			'@typescript-eslint/consistent-type-imports': 'error',
 			'@typescript-eslint/no-import-type-side-effects': 'warn',
+			'@typescript-eslint/no-deprecated': 'warn',
+			'jsdoc/check-tag-names': [
+				'warn',
+				{
+					// allow all tags from https://github.com/runem/web-component-analyzer
+					definedTags: ['element', 'attr', 'fires', 'prop', 'slot', 'cssprop', 'csspart'],
+				},
+			],
 		},
 	},
 


### PR DESCRIPTION
This PR updates the list of allowed tags for our jsDocs to support the tags from https://github.com/runem/web-component-analyzer.

It also lowers the number of warnings a bit.