### PR TITLE
Handle null for retrieval of content section in unit tests

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -96,7 +96,10 @@ public static partial class UmbracoBuilderExtensions
 
         WebhookPayloadType webhookPayloadType = Constants.Webhooks.DefaultPayloadType;
 
-        // Intellisense indicates that GetSection cannot return null, but it will be null in some of our unit tests.
+        // IntelliSense indicates that GetSection cannot return null. However, in certain unit test setups,
+        // the configuration may not be fully initialized, leading to GetSection returning null. This null
+        // check ensures that the code behaves correctly in such scenarios and prevents potential null
+        // reference exceptions during testing.
         if (builder.Config.GetSection(Constants.Configuration.ConfigWebhookPayloadType)?.Value is not null)
         {
             webhookPayloadType = builder.Config.GetValue<WebhookPayloadType>(Constants.Configuration.ConfigWebhookPayloadType);

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -95,7 +95,9 @@ public static partial class UmbracoBuilderExtensions
         builder.ContentIndexHandlers().Add(() => builder.TypeLoader.GetTypes<IContentIndexHandler>());
 
         WebhookPayloadType webhookPayloadType = Constants.Webhooks.DefaultPayloadType;
-        if (builder.Config.GetSection(Constants.Configuration.ConfigWebhookPayloadType).Value is not null)
+
+        // Intellisense indicates that GetSection cannot return null, but it will be null in some of our unit tests.
+        if (builder.Config.GetSection(Constants.Configuration.ConfigWebhookPayloadType)?.Value is not null)
         {
             webhookPayloadType = builder.Config.GetValue<WebhookPayloadType>(Constants.Configuration.ConfigWebhookPayloadType);
         }


### PR DESCRIPTION
I thought I'd resolved this in reviewing and testing https://github.com/umbraco/Umbraco-CMS/pull/19110, but seems something got missed.

I've added a null check that is necessary for some of the unit tests that call into this code, even though in production we will never have a null here.