### PR TITLE
V16 QA Updated the nightly test pipeline to run against the main branch

### DIFF
--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -10,7 +10,7 @@ schedules:
       include:
         - v14/dev
         - v15/dev
-        - v16/dev
+        - main
 
 variables:
   nodeVersion: 20


### PR DESCRIPTION
Since the v16/dev branch is deleted and the main branch is new default branch from now on,  I updated the nightly test pipeline to run against the main branch.