### PR TITLE
Handle existing RichTextEditorValue when parsing from markup or JSON structure

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditorHelper.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditorHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Extensions;
@@ -18,12 +18,20 @@ public static class RichTextPropertyEditorHelper
     /// <returns>True if the parsing succeeds, false otherwise</returns>
     /// <remarks>
     /// The passed value can be:
+    /// - a <see cref="RichTextEditorValue"/> instance (which will be the case if the rich text property is hidden from the editor).
     /// - a JSON string.
     /// - a JSON object.
     /// - a raw markup string (for backwards compatability).
     /// </remarks>
     public static bool TryParseRichTextEditorValue(object? value, IJsonSerializer jsonSerializer, ILogger logger, [NotNullWhen(true)] out RichTextEditorValue? richTextEditorValue)
     {
+        if (value is not null && value is RichTextEditorValue existingRichTextEditorValue)
+        {
+            // already a RichTextEditorValue instance
+            richTextEditorValue = existingRichTextEditorValue;
+            return true;
+        }
+
         var stringValue = value as string ?? value?.ToString();
         if (stringValue is null)
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
We had this issue come in through Umbraco support where the customer was using a `SendingContentNotification` to hide certain properties from certain editors.

They found when doing this with a rich text editor, any existing value would get lost on save (replaced with "Umbraco.Cms.Core.RichTextEditorValue".

I found it was happening as the existing value is provided to the `FromEditor` method of the property value converter, but the parsing doesn't expect to get the actual object here and only handles a JSON structure or the raw markup.  So I've just added an initial check to the parsing, to see if we have the object of the right type already, and if so, return it.

### Testing

- Set up a document with a rich text editor, add some text and save the document.
- Apply a notification handler like the following:

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

public class EditorSendingContentNotificationHandler : INotificationHandler<SendingContentNotification>
{
    public void Handle(SendingContentNotification notification)
    {
        var contentItemDisplay = notification.Content;
        var contentTypeAlias = "homePage";
        var propertyAlias = "bodyTextx";
        if (contentItemDisplay.ContentTypeAlias.InvariantEquals(contentTypeAlias))
        {
            foreach (var variant in contentItemDisplay.Variants)
            {
                foreach (var tab in variant.Tabs)
                {
                    tab.Properties = tab.Properties?.Where(x => !x.Alias.InvariantEquals(propertyAlias));
                }
            }
        }
    }
}

public class TestComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<SendingContentNotification, EditorSendingContentNotificationHandler>();
    }
}

```

- Verify the rich text field no longer displays.
- Save the document.
- Remove the notification handler and verify that the original value is still in place.