### PR TITLE
Correct the display of pending package migrations

### DIFF
--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -326,8 +326,9 @@ public class PackagingService : IPackagingService
                     PackageName = group.Key.PackageName,
                 };
 
+                var packageKey = Constants.Conventions.Migrations.KeyValuePrefix + (group.Key.PackageId ?? group.Key.PackageName);
                 var currentState = keyValues?
-                    .GetValueOrDefault(Constants.Conventions.Migrations.KeyValuePrefix + group.Key.PackageId);
+                    .GetValueOrDefault(packageKey);
 
                 package.PackageMigrationPlans = group
                     .Select(plan => new InstalledPackageMigrationPlans

--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
@@ -131,7 +131,7 @@ export class UmbInstalledPackagesSectionViewItemElement extends UmbLitElement {
 										.state=${this._migrationButtonState}
 										color="warning"
 										look="primary"
-										label=${this.localize.term('packageMigrationsRun')}></uui-button>`
+										label=${this.localize.term('packager_packageMigrationsRun')}></uui-button>`
 								: nothing}
 						</div>
 					</uui-ref-node-package>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19275

### Description
When a package doesn't define a package Id, it's name is used to identify it's migration status in the `umbracoKeyValue` table.  But when looking for the status, we were only using the ID.

This PR corrects that and also resolves a small localization issue with the "Run pending package migrations" button.