### PR TITLE
Improve active state check for menu and tree item

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
@@ -1,5 +1,6 @@
 import { html, customElement, property, ifDefined, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { ensureSlash } from '@umbraco-cms/backoffice/router';
 import { debounce } from '@umbraco-cms/backoffice/utils';
 
 /**
@@ -62,8 +63,12 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 			return;
 		}
 
-		const location = window.location.pathname;
-		this._isActive = location.includes(this.href);
+		/* Check if the current location includes the href of this menu item
+		We ensure that the paths ends with a slash to avoid collisions with paths like /path-1 and /path-1-2 where /path is in both.
+		Instead we compare /path-1/ with /path-1-2/ which wont collide.*/
+		const location = ensureSlash(window.location.pathname);
+		const compareHref = ensureSlash(this.href);
+		this._isActive = location.includes(compareHref);
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
@@ -20,6 +20,7 @@ import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action
 import { UmbDeprecation, UmbPaginationManager, debounce } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
+import { ensureSlash } from '@umbraco-cms/backoffice/router';
 
 export abstract class UmbTreeItemContextBase<
 		TreeItemType extends UmbTreeItemModel,
@@ -441,9 +442,12 @@ export abstract class UmbTreeItemContextBase<
 			return;
 		}
 
-		const path = this.#path.getValue();
-		const location = window.location.pathname;
-		const isActive = location.includes(path);
+		/* Check if the current location includes the path of this tree item.
+		We ensure that the paths ends with a slash to avoid collisions with paths like /path-1 and /path-1-2 where /path-1 is in both.
+		Instead we compare /path-1/ with /path-1-2/ which wont collide.*/
+		const location = ensureSlash(window.location.pathname);
+		const comparePath = ensureSlash(this.#path.getValue());
+		const isActive = location.includes(comparePath);
 		this.#isActive.setValue(isActive);
 	}
 


### PR DESCRIPTION
This PR improves the active state check for menu and tree items to prevent highlighting multiple items when paths include the same part.

### Before
Currently, these items are both shown as active:
* `/test-1`
* `/test-1-2`

Because `/test-1` is part of both of them.

<img width="650" alt="Screenshot 2025-05-08 at 19 02 10" src="https://github.com/user-attachments/assets/4ae0b8b7-f714-43a9-8bb6-a65cda455636" />

<img width="629" alt="Screenshot 2025-05-08 at 19 02 47" src="https://github.com/user-attachments/assets/8e18eb14-0381-4698-b522-159b78285f83" />

### After
With the new solution, we add a slash at the end of the part we compare, so the check now looks like this:
* `/test-1/`
* `/test-1-2/`

`/test-1/` is not part of `/test-1-2/`.

<img width="617" alt="Screenshot 2025-05-08 at 19 03 21" src="https://github.com/user-attachments/assets/b24bb3d0-7d6e-47b2-8bcd-c47bbfdfb7bf" />

