### PR TITLE
Allow configuring collection no-items text via manifest or attribute

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.element.ts
@@ -69,6 +69,15 @@ export class UmbCollectionDefaultElement extends UmbLitElement {
 		);
 	}
 
+	#generateEmptyStateLabel() {
+		const labelKey =
+			this.#collectionContext?.manifest?.meta.noItemsLabel ??
+			this.#collectionContext?.getConfig()?.noItemsLabel ??
+			'#collection_noItemsTitle';
+
+		return this.localize.string(labelKey);
+	}
+
 	override render() {
 		return this._routes
 			? html`
@@ -98,9 +107,10 @@ export class UmbCollectionDefaultElement extends UmbLitElement {
 
 	#renderEmptyState() {
 		if (!this._isDoneLoading) return nothing;
+
 		return html`
 			<div id="empty-state" class="uui-text">
-				<h4><umb-localize key="collection_noItemsTitle"></umb-localize></h4>
+				<h4>${this.#generateEmptyStateLabel()}</h4>
 			</div>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/extensions/collection.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/extensions/collection.extension.ts
@@ -9,6 +9,7 @@ export interface ManifestCollection
 
 export interface MetaCollection {
 	repositoryAlias: string;
+	noItemsLabel?: string;
 }
 
 declare global {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/types.ts
@@ -25,6 +25,7 @@ export interface UmbCollectionConfiguration {
 	orderBy?: string;
 	orderDirection?: string;
 	pageSize?: number;
+	noItemsLabel?: string;
 	userDefinedProperties?: Array<UmbCollectionColumnConfiguration>;
 }
 


### PR DESCRIPTION
This PR introduces the ability to provide custom text for the no-items message in a collection, either via the collection extension manifest or collection configuration object.

To test via manifest:
- edit `/src/packages/members/member-group/collection/manifests.ts`
  - add `noItemsLabel: 'Custom text'` to the `meta` property
- verify the member group collection displays 'Custom text' in the empty state,
- edit the manifest again
  - update `noItemsLabel` to `#general_delete`
- verify the member group collection displays the localized text in the empty state

To test via config:
- edit `/src/packages/dictionary/dashboard/dictionary-overview-dashboard-element.ts`
  - add a config attribute to the `umb-collection` element: `.config=${{ noItemsLabel: 'Custom text'}}`
- verify the dictionary/translation section dashboard displays 'Custom text' in the empty state
- edit the element again
  - update `noItemsLabel` to `#general_delete`
- verify the dictionary/translation section dashboard displays the localized text in the empty state   

If both the manifest and element config set the `noItemsLabel` property, the manifest value is prioritised. If neither is set, we fallback to the original `No items` text, via the `collection_noItemsTitle` localization key.