### PR TITLE
Ensures cultures set on content are correctly cased

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -1575,4 +1575,22 @@ public static class StringExtensions
     // this is by far the fastest way to find string needles in a string haystack
     public static int CountOccurrences(this string haystack, string needle)
         => haystack.Length - haystack.Replace(needle, string.Empty).Length;
+
+    /// <summary>
+    /// Verifies the provided string is a valid culture code and returns it in a consistent casing.
+    /// </summary>
+    /// <param name="culture">Culture code.</param>
+    /// <returns>Culture code in standard casing.</returns>
+    public static string? EnsureCultureCode(this string? culture)
+    {
+        if (string.IsNullOrEmpty(culture) || culture == "*")
+        {
+            return culture;
+        }
+
+        // Create as CultureInfo instance from provided name so we can ensure consistent casing of culture code when persisting.
+        // This will accept mixed case but once created have a `Name` property that is consistently and correctly cased.
+        // Will throw in an invalid culture code is provided.
+        return new CultureInfo(culture).Name;
+    }
 }

--- a/src/Umbraco.Core/Models/ContentBase.cs
+++ b/src/Umbraco.Core/Models/ContentBase.cs
@@ -290,7 +290,7 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
         // set on variant content type
         if (ContentType.VariesByCulture())
         {
-            culture = EnsureConsistentCultureCode(culture);
+            culture = culture.EnsureCultureCode();
 
             // invariant is ok
             if (culture.IsNullOrWhiteSpace())
@@ -341,18 +341,6 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
         {
             _cultureInfos = null;
         }
-    }
-
-    private static string? EnsureConsistentCultureCode(string? culture)
-    {
-        if (culture.IsNullOrWhiteSpace())
-        {
-            return null;
-        }
-
-        // Create as CultureInfo instance from provided name so we can ensure consistent casing of culture code when persisting.
-        // This will accept mixed case but once created have a `Name` property that is consistently and correctly cased.
-        return new CultureInfo(culture).Name;
     }
 
     /// <summary>
@@ -466,7 +454,7 @@ public abstract class ContentBase : TreeEntityBase, IContentBase
                 $"No PropertyType exists with the supplied alias \"{propertyTypeAlias}\".");
         }
 
-        culture = EnsureConsistentCultureCode(culture);
+        culture = culture.EnsureCultureCode();
         var updated = property.SetValue(value, culture, segment);
         if (updated)
         {

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1184,6 +1184,8 @@ public class ContentService : RepositoryService, IContentService
             throw new ArgumentException("Cultures cannot be null or whitespace", nameof(cultures));
         }
 
+        cultures = cultures.Select(x => x.EnsureCultureCode()!).ToArray();
+
         EventMessages evtMsgs = EventMessagesFactory.Get();
 
         // we need to guard against unsaved changes before proceeding; the content will be saved, but we're not firing any saved notifications
@@ -1263,7 +1265,7 @@ public class ContentService : RepositoryService, IContentService
 
         EventMessages evtMsgs = EventMessagesFactory.Get();
 
-        culture = culture?.NullOrWhiteSpaceAsNull();
+        culture = culture?.NullOrWhiteSpaceAsNull().EnsureCultureCode();
 
         PublishedState publishedState = content.PublishedState;
         if (publishedState != PublishedState.Published && publishedState != PublishedState.Unpublished)
@@ -2063,7 +2065,7 @@ public class ContentService : RepositoryService, IContentService
             cultures = ["*"];
         }
 
-        return cultures;
+        return cultures.Select(x => x.EnsureCultureCode()!).ToArray();
     }
 
     private static bool ProvidedCulturesIndicatePublishAll(string[] cultures) => cultures.Length == 0 || (cultures.Length == 1 && cultures[0] == "invariant");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
@@ -51,7 +51,7 @@ internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
     /// codes are provided with inconsistent casing.
     /// </summary>
     [Test]
-    public async Task Can_Publish_With_Inconsistent_Provision_Of_Culture_Codes()
+    public async Task Can_Publish_With_Inconsistent_Provision_Of_Culture_Codes_When_Setting_Properties()
     {
         var (langEn, langDa, contentType) = await SetupVariantTest();
 
@@ -64,6 +64,49 @@ internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
         ContentService.Save(content);
         var publishResult = ContentService.Publish(content, ["en-US"]);
         Assert.IsTrue(publishResult.Success);
+    }
+
+    [Test]
+    public async Task Can_Publish_With_Inconsistent_Provision_Of_Culture_Codes_When_Publishing()
+    {
+        var (langEn, langDa, contentType) = await SetupVariantTest();
+
+        IContent content = ContentService.Create("Test Item", Constants.System.Root, contentType);
+        content.SetCultureName("Test item", "en-US");
+        content.SetValue("title", "Title", "en-US");
+        ContentService.Save(content);
+
+        var publishResult = ContentService.Publish(content, ["en-us"]);
+        Assert.IsTrue(publishResult.Success);
+    }
+
+    [Test]
+    public async Task Can_Unpublish_With_Inconsistent_Provision_Of_Culture_Codes()
+    {
+        var (langEn, langDa, contentType) = await SetupVariantTest();
+
+        IContent content = ContentService.Create("Test Item", Constants.System.Root, contentType);
+        content.SetCultureName("Test item", "en-US");
+        content.SetValue("title", "Title", "en-US");
+        ContentService.Save(content);
+
+        var unpublishResult = ContentService.Unpublish(content, "en-us");
+        Assert.IsTrue(unpublishResult.Success);
+    }
+
+    [Test]
+    public async Task Can_Publish_Branch_With_Inconsistent_Provision_Of_Culture_Codes()
+    {
+        var (langEn, langDa, contentType) = await SetupVariantTest();
+
+        IContent content = ContentService.Create("Test Item", Constants.System.Root, contentType);
+        content.SetCultureName("Test item", "en-US");
+        content.SetValue("title", "Title", "en-US");
+        ContentService.Save(content);
+
+        var publishResult = ContentService.PublishBranch(content, PublishBranchFilter.All, ["en-us"]);
+        Assert.AreEqual(1, publishResult.Count());
+        Assert.IsTrue(publishResult.First().Success);
     }
 
     private async Task<(ILanguage LangEn, ILanguage LangDa, IContentType contentType)> SetupVariantTest()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
@@ -28,7 +28,7 @@ internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
     private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
 
     /// <summary>
-    /// Provides an happy path test case where culture codes are provided exactly matching the language ISO codes.
+    /// Provides a happy path test case where culture codes are provided exactly matching the language ISO codes.
     /// </summary>
     [Test]
     public async Task Can_Publish_With_Consistent_Provision_Of_Culture_Codes()
@@ -47,7 +47,8 @@ internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
     }
 
     /// <summary>
-    /// Provides an originally failing test case for https://github.com/umbraco/Umbraco-CMS/issues/19287.
+    /// Provides an originally failing test case for https://github.com/umbraco/Umbraco-CMS/issues/19287, where the culture
+    /// codes are provided with inconsistent casing.
     /// </summary>
     [Test]
     public async Task Can_Publish_With_Inconsistent_Provision_Of_Culture_Codes()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+// ReSharper disable CommentTypo
+// ReSharper disable StringLiteralTypo
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+[TestFixture]
+[UmbracoTest(
+    Database = UmbracoTestOptions.Database.NewSchemaPerTest,
+    PublishedRepositoryEvents = true,
+    WithApplication = true)]
+internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
+{
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    /// <summary>
+    /// Provides an happy path test case where culture codes are provided exactly matching the language ISO codes.
+    /// </summary>
+    [Test]
+    public async Task Can_Publish_With_Consistent_Provision_Of_Culture_Codes()
+    {
+        var (langEn, langDa, contentType) = await SetupVariantTest();
+
+        IContent content = ContentService.Create("Test Item", Constants.System.Root, contentType);
+        content.SetCultureName("Test item", "en-US");
+        content.SetValue("title", "Title", "en-US");
+
+        Assert.AreEqual("en-US", content.AvailableCultures.FirstOrDefault());
+
+        ContentService.Save(content);
+        var publishResult = ContentService.Publish(content, ["en-US"]);
+        Assert.IsTrue(publishResult.Success);
+    }
+
+    /// <summary>
+    /// Provides an originally failing test case for https://github.com/umbraco/Umbraco-CMS/issues/19287.
+    /// </summary>
+    [Test]
+    public async Task Can_Publish_With_Inconsistent_Provision_Of_Culture_Codes()
+    {
+        var (langEn, langDa, contentType) = await SetupVariantTest();
+
+        IContent content = ContentService.Create("Test Item", Constants.System.Root, contentType);
+        content.SetCultureName("Test item", "en-us");
+        content.SetValue("title", "Title", "en-us");
+
+        Assert.AreEqual("en-US", content.AvailableCultures.FirstOrDefault());
+
+        ContentService.Save(content);
+        var publishResult = ContentService.Publish(content, ["en-US"]);
+        Assert.IsTrue(publishResult.Success);
+    }
+
+    private async Task<(ILanguage LangEn, ILanguage LangDa, IContentType contentType)> SetupVariantTest()
+    {
+        var langEn = await LanguageService.GetAsync("en-US");
+
+        var langDa = new LanguageBuilder()
+            .WithCultureInfo("da-DK")
+            .Build();
+        await LanguageService.CreateAsync(langDa, Constants.Security.SuperUserKey);
+
+        var key = Guid.NewGuid();
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("variantContent")
+            .WithName("Variant Content")
+            .WithKey(key)
+            .WithContentVariation(ContentVariation.Culture)
+            .AddPropertyGroup()
+                .WithAlias("content")
+                .WithName("Content")
+                .WithSupportsPublishing(true)
+                .AddPropertyType()
+                    .WithAlias("title")
+                    .WithName("Title")
+                    .WithVariations(ContentVariation.Culture)
+                .Done()
+            .Done()
+            .Build();
+
+        contentType.AllowedAsRoot = true;
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        return (langEn, langDa, contentType);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -407,5 +407,6 @@ public class StringExtensionsTests
     public void EnsureCultureCode_ReturnsExpectedResult(string? culture, string? expected) => Assert.AreEqual(expected, culture.EnsureCultureCode());
 
     [Test]
+    [Platform(Include = "Win")]
     public void EnsureCultureCode_ThrowsOnUnrecognisedCode() => Assert.Throws<CultureNotFoundException>(() => "xxx-xxx".EnsureCultureCode());
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -395,4 +396,16 @@ public class StringExtensionsTests
         var ids = input.GetIdsFromPathReversed();
         Assert.AreEqual(expected, string.Join(",", ids));
     }
+
+    [TestCase(null, null)]
+    [TestCase("", "")]
+    [TestCase("*", "*")]
+    [TestCase("en", "en")]
+    [TestCase("EN", "en")]
+    [TestCase("en-US", "en-US")]
+    [TestCase("en-gb", "en-GB")]
+    public void EnsureCultureCode_ReturnsExpectedResult(string? culture, string? expected) => Assert.AreEqual(expected, culture.EnsureCultureCode());
+
+    [Test]
+    public void EnsureCultureCode_ThrowsOnUnrecognisedCode() => Assert.Throws<CultureNotFoundException>(() => "xxx-xxx".EnsureCultureCode());
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19287

### Description
The linked issue shows that Umbraco was previously a little more accepting of mixed case cultures, presenting a case that will blow up with invalid content if programatically created in the way demonstrated.

As is noted, the problem can be avoided by the developer ensuring to provide correctly cased culture codes.  But it seems we can correct for this ourselves by ensuring to create a `CultureInfo` from the code, which will accept mixed case but once created have a `Name` property that is consistently and correctly cased.

### Testing
See the linked issue or review the integration tests that I've created based on the provided case.  The second test that accepts mixed case was verified to fail before the amends in this PR were made.
