### PR TITLE
Allow segment access to editors with access to documents, not only settings

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Segment/AllSegmentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Segment/AllSegmentController.cs
@@ -14,7 +14,6 @@ using Umbraco.Cms.Web.Common.Authorization;
 namespace Umbraco.Cms.Api.Management.Controllers.Segment;
 
 [ApiVersion("1.0")]
-[Authorize(Policy = AuthorizationPolicies.SectionAccessSettings)]
 public class AllSegmentController : SegmentControllerBase
 {
     private readonly ISegmentService _segmentService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
@@ -9,7 +9,6 @@ namespace Umbraco.Cms.Api.Management.Controllers.Segment;
 
 [VersionedApiBackOfficeRoute("segment")]
 [ApiExplorerSettings(GroupName = "Segment")]
-[Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]
 public abstract class SegmentControllerBase : ManagementApiControllerBase
 {
     protected IActionResult MapFailure(SegmentOperationStatus status)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
@@ -1,12 +1,15 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Segment;
 
 [VersionedApiBackOfficeRoute("segment")]
 [ApiExplorerSettings(GroupName = "Segment")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocuments)]
 public abstract class SegmentControllerBase : ManagementApiControllerBase
 {
     protected IActionResult MapFailure(SegmentOperationStatus status)

--- a/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Segment/SegmentControllerBase.cs
@@ -1,9 +1,7 @@
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.Cms.Web.Common.Authorization;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Segment;
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
Noticed in a testing that with a user that didn't have access to "Settings" and with segments setup, you'd get a permissions error.  This resolves it by asking only for "Document" section permissions.

### Testing
Unless you already have segments set up for another reason, likely sufficient to visually inspect this one.

### Release
No harm if this goes into 16.0-rc2, since it's a fix to an 16 specific issue.