### PR TITLE
Allow selection of unpublished documents in link picker and align display of URLs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2799,7 +2799,7 @@ export default {
 		modalSource: 'Source',
 		modalManual: 'Manual',
 		modalAnchorValidationMessage:
-			'Please enter an anchor or querystring, or select a published document or media item, or manually configure the URL.',
+			'Please enter an anchor or querystring, select a document or media item, or manually configure the URL.',
 		resetUrlHeadline: 'Reset URL?',
 		resetUrlMessage: 'Are you sure you want to reset this URL?',
 		resetUrlLabel: 'Reset',

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -196,7 +196,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 	async #getUrlForDocument(unique: string) {
 		const documentUrlRepository = new UmbDocumentUrlRepository(this);
 		const { data: documentUrlData } = await documentUrlRepository.requestItems([unique]);
-		return documentUrlData?.[0].urls[0].url ?? '';
+		return documentUrlData && documentUrlData[0].urls.length > 0 ? (documentUrlData?.[0].urls[0].url ?? '') : '';
 	}
 
 	async #getUrlForMedia(unique: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -78,9 +78,9 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 	async populateLinkUrl() {
 		// Documents and media have URLs saved in the local link format. Display the actual URL to align with what
 		// the user sees when they selected it initially.
-		if (!this.value.link?.unique || this.value.link?.url?.indexOf("localLink") === -1) return;
+		if (!this.value.link?.unique || this.value.link?.url?.indexOf('localLink') === -1) return;
 
-		let url:string | undefined = undefined;
+		let url: string | undefined = undefined;
 		switch (this.value.link.type) {
 			case 'document': {
 				url = await this.#getUrlForDocument(this.value.link.unique);
@@ -196,9 +196,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 	async #getUrlForDocument(unique: string) {
 		const documentUrlRepository = new UmbDocumentUrlRepository(this);
 		const { data: documentUrlData } = await documentUrlRepository.requestItems([unique]);
-		return documentUrlData && documentUrlData[0].urls.length > 0
-			? documentUrlData?.[0].urls[0].url
-			: '';
+		return documentUrlData?.[0].urls[0].url ?? '';
 	}
 
 	async #getUrlForMedia(unique: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -56,13 +56,14 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		}
 
 		this.#getMediaTypes();
+		this.populateLinkUrl();
 	}
 
 	protected override firstUpdated() {
 		this._linkAnchorInput?.addValidator(
 			'valueMissing',
 			() => this.localize.term('linkPicker_modalAnchorValidationMessage'),
-			() => !this.value.link.url && !this.value.link.queryString,
+			() => !this.value.link.name && !this.value.link.queryString,
 		);
 	}
 
@@ -72,6 +73,30 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		const { data: mediaTypes } = await mediaTypeStructureRepository.requestAllowedChildrenOf(null, null);
 		this._allowedMediaTypeUniques =
 			(mediaTypes?.items.map((x) => x.unique).filter((x) => x && !isUmbracoFolder(x)) as Array<string>) ?? [];
+	}
+
+	async populateLinkUrl() {
+		// Documents and media have URLs saved in the local link format. Display the actual URL to align with what
+		// the user sees when they selected it initially.
+		if (!this.value.link?.unique || this.value.link?.url?.indexOf("localLink") === -1) return;
+
+		let url:string | undefined = undefined;
+		switch (this.value.link.type) {
+			case 'document': {
+				url = await this.#getUrlForDocument(this.value.link.unique);
+				break;
+			}
+			case 'media': {
+				url = await this.#getUrlForMedia(this.value.link.unique);
+				break;
+			}
+			default:
+				break;
+		}
+
+		if (url) {
+			this.#partialUpdateLink({ url });
+		}
 	}
 
 	#partialUpdateLink(linkObject: Partial<UmbLinkPickerLink>) {
@@ -136,10 +161,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 					if (documentData) {
 						icon = documentData.documentType.icon;
 						name = documentData.variants[0].name;
-
-						const documentUrlRepository = new UmbDocumentUrlRepository(this);
-						const { data: documentUrlData } = await documentUrlRepository.requestItems([unique]);
-						url = documentUrlData?.[0].urls[0].url ?? '';
+						url = await this.#getUrlForDocument(unique);
 					}
 					break;
 				}
@@ -149,10 +171,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 					if (mediaData) {
 						icon = mediaData.mediaType.icon;
 						name = mediaData.variants[0].name;
-
-						const mediaUrlRepository = new UmbMediaUrlRepository(this);
-						const { data: mediaUrlData } = await mediaUrlRepository.requestItems([unique]);
-						url = mediaUrlData?.[0].url ?? '';
+						url = await this.#getUrlForMedia(unique);
 					}
 					break;
 				}
@@ -163,7 +182,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 
 		const link = {
 			icon,
-			name: this.value.link.name || name,
+			name: name || this.value.link.name,
 			type: unique ? type : undefined,
 			unique,
 			url: url ?? this.value.link.url,
@@ -172,6 +191,20 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		this.#partialUpdateLink(link);
 
 		await this.#validationContext.validate();
+	}
+
+	async #getUrlForDocument(unique: string) {
+		const documentUrlRepository = new UmbDocumentUrlRepository(this);
+		const { data: documentUrlData } = await documentUrlRepository.requestItems([unique]);
+		return documentUrlData && documentUrlData[0].urls.length > 0
+			? documentUrlData?.[0].urls[0].url
+			: '';
+	}
+
+	async #getUrlForMedia(unique: string) {
+		const mediaUrlRepository = new UmbMediaUrlRepository(this);
+		const { data: mediaUrlData } = await mediaUrlRepository.requestItems([unique]);
+		return mediaUrlData?.[0].url ?? '';
 	}
 
 	async #onResetUrl() {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19294

### Description
The linked issue notes that that the validation we have in place currently prevents selection of an unpublished document in the link picker, and that we supported that in 13.

This PR allows that now, but moving the validation to look at the `name` for the selected URL, which we will always have, rather than the URL.  It also fixes an error that occurred when we didn't get a URL back from the request to retrieve it for the document.

I also noticed that when selecting a document or media URL, we see it's actual URL displayed in the picker.  But on the opening of the picker for a pre-selected link, we see the `localLink` syntax.  So I've also aligned this by requesting the actual URL for display when the picker is loaded.

### Testing

- Verify that unpublished documents can now be selected.
- General test of selecting, saving and reloading links of the different types.