### PR TITLE
Change image picker to tree picker for selecting media start node for user or user group

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.context.ts
@@ -1,5 +1,4 @@
-import { UMB_MEDIA_ITEM_REPOSITORY_ALIAS } from '../../constants.js';
-import { UMB_MEDIA_PICKER_MODAL } from '../../modals/index.js';
+import { UMB_MEDIA_ITEM_REPOSITORY_ALIAS, UMB_MEDIA_TREE_PICKER_MODAL } from '../../constants.js';
 import type { UmbMediaItemModel } from '../../repository/item/types.js';
 import type { UmbMediaPickerModalData, UmbMediaPickerModalValue } from '../../modals/index.js';
 import { UMB_MEDIA_SEARCH_PROVIDER_ALIAS } from '../../search/constants.js';
@@ -19,7 +18,7 @@ export class UmbMediaPickerInputContext extends UmbPickerInputContext<
 	UmbMediaPickerModalValue
 > {
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_MEDIA_ITEM_REPOSITORY_ALIAS, UMB_MEDIA_PICKER_MODAL);
+		super(host, UMB_MEDIA_ITEM_REPOSITORY_ALIAS, UMB_MEDIA_TREE_PICKER_MODAL);
 	}
 
 	override async openPicker(pickerData?: Partial<UmbMediaPickerModalData>, args?: UmbMediaPickerInputContextOpenArgs) {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
@@ -186,7 +186,7 @@ export class UmbInputMediaElement extends UmbFormControlMixin<string | undefined
 	#openPicker() {
 		this.#pickerContext.openPicker(
 			{
-				multiple: this.max > 1,
+				hideTreeRoot: true,
 				startNode: this.startNode,
 			},
 			{


### PR DESCRIPTION
This PR fixes for the issue https://github.com/umbraco/Umbraco-CMS/issues/17785
Change the image picker to tree picker for selecting media start node for user or user group

### After fixing:
<img width="881" alt="image" src="https://github.com/user-attachments/assets/9483b5fe-d766-48b5-9873-44202ccfac4e" />


<!-- Thanks for contributing to Umbraco CMS! -->
