### PR TITLE
V16 RC: Autocomplete should not be available on the main entity field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -299,6 +299,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 				data-mark="input:entity-name"
 				placeholder=${this.localize.term('placeholders_entername')}
 				label=${this.localize.term('placeholders_entername')}
+				autocomplete="off"
 				.value=${this.#getNameValue()}
 				@input=${this.#handleInput}
 				required


### PR DESCRIPTION
## Description

Fixes #19298

I could not reproduce the error exactly as listed, and this fix is a bit simplistic, as it just turns off **autocomplete**. It seems to be quite error prone to have autocomplete allowed for this field in the first place as any given page or entity needs a unique name.