### PR TITLE
Close dropdown after executed action workaround

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/dropdown/dropdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/dropdown/dropdown.element.ts
@@ -40,10 +40,8 @@ export class UmbDropdownElement extends UmbLitElement {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('open') && this.popoverContainerElement) {
 			if (this.open) {
-				console.warn('open is currently not working, use .openDropdown() instead');
 				this.openDropdown();
 			} else {
-				console.warn('open is currently not working, use .closeDropdown() instead');
 				this.closeDropdown();
 			}
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/dropdown/dropdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/dropdown/dropdown.element.ts
@@ -12,8 +12,6 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 // TODO: maybe move this to UI Library.
 @customElement('umb-dropdown')
 export class UmbDropdownElement extends UmbLitElement {
-	@query('#dropdown-popover')
-	popoverContainerElement?: UUIPopoverContainerElement;
 	@property({ type: Boolean, reflect: true })
 	open = false;
 
@@ -35,19 +33,18 @@ export class UmbDropdownElement extends UmbLitElement {
 	@property({ type: Boolean, attribute: 'hide-expand' })
 	hideExpand = false;
 
+	@query('#dropdown-popover')
+	popoverContainerElement?: UUIPopoverContainerElement;
+
 	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('open') && this.popoverContainerElement) {
 			if (this.open) {
-				// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
-				this.popoverContainerElement.showPopover();
+				console.warn('open is currently not working, use .openDropdown() instead');
+				this.openDropdown();
 			} else {
-				// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
-				this.popoverContainerElement.hidePopover();
+				console.warn('open is currently not working, use .closeDropdown() instead');
+				this.closeDropdown();
 			}
 		}
 	}
@@ -57,6 +54,20 @@ export class UmbDropdownElement extends UmbLitElement {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		this.open = event.newState === 'open';
+	}
+
+	openDropdown() {
+		// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		this.popoverContainerElement?.showPopover();
+	}
+
+	closeDropdown() {
+		// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS jet.
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		this.popoverContainerElement?.hidePopover();
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
@@ -1,7 +1,17 @@
 import { UmbEntityContext } from '../../entity/entity.context.js';
+import type { UmbDropdownElement } from '../dropdown/index.js';
 import type { UmbEntityAction, ManifestEntityActionDefaultKind } from '@umbraco-cms/backoffice/entity-action';
 import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
-import { html, nothing, customElement, property, state, ifDefined, css } from '@umbraco-cms/backoffice/external/lit';
+import {
+	html,
+	nothing,
+	customElement,
+	property,
+	state,
+	ifDefined,
+	css,
+	query,
+} from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbExtensionsManifestInitializer, createExtensionApi } from '@umbraco-cms/backoffice/extension-api';
@@ -29,8 +39,8 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 	@state()
 	private _firstActionHref?: string;
 
-	@state()
-	_dropdownIsOpen = false;
+	@query('#action-modal')
+	private _dropdownElement?: UmbDropdownElement;
 
 	// TODO: provide the entity context on a higher level, like the root element of this entity, tree-item/workspace/... [NL]
 	#entityContext = new UmbEntityContext(this);
@@ -79,7 +89,7 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 	}
 
 	#onActionExecuted() {
-		this._dropdownIsOpen = false;
+		this._dropdownElement?.closeDropdown();
 	}
 
 	#onDropdownClick(event: Event) {
@@ -95,13 +105,7 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 		if (this._numberOfActions === 1) return nothing;
 
 		return html`
-			<umb-dropdown
-				id="action-modal"
-				.open=${this._dropdownIsOpen}
-				@click=${this.#onDropdownClick}
-				.label=${this.label}
-				compact
-				hide-expand>
+			<umb-dropdown id="action-modal" @click=${this.#onDropdownClick} .label=${this.label} compact hide-expand>
 				<uui-symbol-more slot="label" .label=${this.label}></uui-symbol-more>
 				<uui-scroll-container>
 					<umb-entity-action-list


### PR DESCRIPTION
This PR is a workaround for the bug and fixes #19295

For one reason or another, the 'umb-dropdown` doesn't toggle the popover when the `.open` property is set. I have added two methods to open and close the dropdown, which do the same thing but actually work.