### PR TITLE
Deprecate `AuditService.Write()` method

### DIFF
--- a/src/Umbraco.Core/Services/AuditService.cs
+++ b/src/Umbraco.Core/Services/AuditService.cs
@@ -264,6 +264,7 @@ public sealed class AuditService : RepositoryService, IAuditService
     }
 
     /// <inheritdoc />
+    [Obsolete("Will be moved to a new service and removed from this one in a future version.")]
     public IAuditEntry Write(int performingUserId, string perfomingDetails, string performingIp, DateTime eventDateUtc, int affectedUserId, string? affectedDetails, string eventType, string eventDetails)
     {
         if (performingUserId < 0 && performingUserId != Constants.Security.SuperUserId)

--- a/src/Umbraco.Core/Services/AuditService.cs
+++ b/src/Umbraco.Core/Services/AuditService.cs
@@ -264,8 +264,16 @@ public sealed class AuditService : RepositoryService, IAuditService
     }
 
     /// <inheritdoc />
-    [Obsolete("Will be moved to a new service and removed from this one in a future version.")]
-    public IAuditEntry Write(int performingUserId, string perfomingDetails, string performingIp, DateTime eventDateUtc, int affectedUserId, string? affectedDetails, string eventType, string eventDetails)
+    [Obsolete("Will be moved to a new service. Scheduled for removal in V18.")]
+    public IAuditEntry Write(
+        int performingUserId,
+        string perfomingDetails,
+        string performingIp,
+        DateTime eventDateUtc,
+        int affectedUserId,
+        string? affectedDetails,
+        string eventType,
+        string eventDetails)
     {
         if (performingUserId < 0 && performingUserId != Constants.Security.SuperUserId)
         {

--- a/src/Umbraco.Core/Services/IAuditService.cs
+++ b/src/Umbraco.Core/Services/IAuditService.cs
@@ -144,7 +144,7 @@ public interface IAuditService : IService
     ///     </example>
     /// </param>
     /// <param name="eventDetails">Free-form details about the audited event.</param>
-    [Obsolete("Will be moved to a new service and removed from this one in a future version.")]
+    [Obsolete("Will be moved to a new service. Scheduled for removal in V18.")]
     IAuditEntry Write(
         int performingUserId,
         string perfomingDetails,

--- a/src/Umbraco.Core/Services/IAuditService.cs
+++ b/src/Umbraco.Core/Services/IAuditService.cs
@@ -144,6 +144,7 @@ public interface IAuditService : IService
     ///     </example>
     /// </param>
     /// <param name="eventDetails">Free-form details about the audited event.</param>
+    [Obsolete("Will be moved to a new service and removed from this one in a future version.")]
     IAuditEntry Write(
         int performingUserId,
         string perfomingDetails,


### PR DESCRIPTION
### Description
At the moment the `AuditService` is handling two types of audits, `umbracoLog` and `umbracoAudit`.
To better separate concerns and avoid confusion, the public `umbracoAudit` methods (which in this case is just the `Write`) will be moved to their own service.
This will be done in the current AuditService rework.