### PR TITLE
Optimize the member save as part of the member login process, by-passing locking and audit steps and handling only the expected update properties

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IMemberRepository.cs
@@ -38,4 +38,11 @@ public interface IMemberRepository : IContentRepository<int, IMember>
     /// <param name="query"></param>
     /// <returns></returns>
     int GetCountByQuery(IQuery<IMember>? query);
+
+    /// <summary>
+    /// Saves only the properties related to login for the member, using an optimized, non-locking update.
+    /// </summary>
+    /// <param name="member">The member to update.</param>
+    /// <returns>Used to avoid the full save of the member object after a login operation.</returns>
+    Task UpdateLoginPropertiesAsync(IMember member) => Task.CompletedTask;
 }

--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -343,4 +343,11 @@ public interface IMemberService : IMembershipMemberService
     ///     <see cref="IEnumerable{IMember}" />
     /// </returns>
     IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, DateTime value, ValuePropertyMatchType matchType = ValuePropertyMatchType.Exact);
+
+    /// <summary>
+    /// Saves only the properties related to login for the member, using an optimized, non-locking update.
+    /// </summary>
+    /// <param name="member">The member to update.</param>
+    /// <returns>Used to avoid the full save of the member object after a login operation.</returns>
+    Task UpdateLoginPropertiesAsync(IMember member) => Task.CompletedTask;
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -848,5 +848,50 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
         entity.ResetDirtyProperties();
     }
 
+    /// <inheritdoc/>
+    public async Task UpdateLoginPropertiesAsync(IMember member)
+    {
+        var updatedLastLoginDate = member.IsPropertyDirty(nameof(member.LastLoginDate));
+        var updatedSecurityStamp = member.IsPropertyDirty(nameof(member.SecurityStamp));
+        if (updatedLastLoginDate is false && updatedSecurityStamp is false)
+        {
+            return;
+        }
+
+        NPocoSqlExtensions.SqlUpd<MemberDto> GetMemberSetExpression(IMember member, NPocoSqlExtensions.SqlUpd<MemberDto> m)
+        {
+            var setExpression = new NPocoSqlExtensions.SqlUpd<MemberDto>(SqlContext);
+            if (updatedLastLoginDate)
+            {
+                setExpression.Set(x => x.LastLoginDate, member.LastLoginDate);
+            }
+
+            if (updatedSecurityStamp)
+            {
+                setExpression.Set(x => x.SecurityStampToken, member.SecurityStamp);
+            }
+
+            return setExpression;
+        }
+
+        member.UpdatingEntity();
+
+        Sql<ISqlContext> updateMemberQuery = Sql()
+            .Update<MemberDto>(m => GetMemberSetExpression(member, m))
+            .Where<MemberDto>(m => m.NodeId == member.Id);
+        await Database.ExecuteAsync(updateMemberQuery);
+
+        Sql<ISqlContext> updateContentVersionQuery = Sql()
+            .Update<ContentVersionDto>(m => m.Set(x => x.VersionDate, member.UpdateDate))
+            .Where<ContentVersionDto>(m => m.NodeId == member.Id && m.Current == true);
+        await Database.ExecuteAsync(updateContentVersionQuery);
+
+        OnUowRefreshedEntity(new MemberRefreshNotification(member, new EventMessages()));
+
+        _memberByUsernameCachePolicy.DeleteByUserName(CacheKeys.MemberUserNameCachePrefix, member.Username);
+
+        member.ResetDirtyProperties();
+    }
+
     #endregion
 }

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -161,7 +161,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
     }
 
     /// <inheritdoc />
-    public override Task<IdentityResult> UpdateAsync(
+    public override async Task<IdentityResult> UpdateAsync(
         MemberIdentityUser user,
         CancellationToken cancellationToken = default)
     {
@@ -189,9 +189,21 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
                 var isLoginsPropertyDirty = user.IsPropertyDirty(nameof(MemberIdentityUser.Logins));
                 var isTokensPropertyDirty = user.IsPropertyDirty(nameof(MemberIdentityUser.LoginTokens));
 
-                if (UpdateMemberProperties(found, user, out var updateRoles))
+                IReadOnlyList<string> propertiesUpdated = UpdateMemberProperties(found, user, out var updateRoles);
+
+                if (propertiesUpdated.Count > 0)
                 {
-                    _memberService.Save(found);
+                    // As part of logging in members we update the last login date, and, if concurrent logins are disabled, the security stamp.
+                    // If and only if we are updating these properties, we can avoid the overhead of a full save of the member with the associated
+                    // locking, property updates, tag handline etc., and make a more efficient update.
+                    if (UpdatingOnlyLoginProperties(propertiesUpdated))
+                    {
+                        await _memberService.UpdateLoginPropertiesAsync(found);
+                    }
+                    else
+                    {
+                        _memberService.Save(found);
+                    }
 
                     if (updateRoles)
                     {
@@ -222,13 +234,19 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             }
 
             scope.Complete();
-            return Task.FromResult(IdentityResult.Success);
+            return IdentityResult.Success;
         }
         catch (Exception ex)
         {
-            return Task.FromResult(
-                IdentityResult.Failed(new IdentityError { Code = GenericIdentityErrorCode, Description = ex.Message }));
+            return IdentityResult.Failed(new IdentityError { Code = GenericIdentityErrorCode, Description = ex.Message });
         }
+    }
+
+    private static bool UpdatingOnlyLoginProperties(IReadOnlyList<string> propertiesUpdated)
+    {
+        string[] loginPropertyUpdates = [nameof(MemberIdentityUser.LastLoginDateUtc), nameof(MemberIdentityUser.SecurityStamp)];
+        return (propertiesUpdated.Count == 2 && propertiesUpdated.ContainsAll(loginPropertyUpdates)) ||
+               (propertiesUpdated.Count == 1 && propertiesUpdated.ContainsAny(loginPropertyUpdates));
     }
 
     /// <inheritdoc />
@@ -681,9 +699,9 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
         return user;
     }
 
-    private bool UpdateMemberProperties(IMember member, MemberIdentityUser identityUser, out bool updateRoles)
+    private IReadOnlyList<string> UpdateMemberProperties(IMember member, MemberIdentityUser identityUser, out bool updateRoles)
     {
-        var anythingChanged = false;
+        var updatedProperties = new List<string>();
         updateRoles = false;
 
         // don't assign anything if nothing has changed as this will trigger the track changes of the model
@@ -692,7 +710,7 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             || (identityUser.LastLoginDateUtc.HasValue &&
                 member.LastLoginDate?.ToUniversalTime() != identityUser.LastLoginDateUtc.Value))
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.LastLoginDateUtc));
 
             // if the LastLoginDate is being set to MinValue, don't convert it ToLocalTime
             DateTime dt = identityUser.LastLoginDateUtc == DateTime.MinValue
@@ -706,14 +724,14 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             || (identityUser.LastPasswordChangeDateUtc.HasValue && member.LastPasswordChangeDate?.ToUniversalTime() !=
                 identityUser.LastPasswordChangeDateUtc.Value))
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.LastPasswordChangeDateUtc));
             member.LastPasswordChangeDate = identityUser.LastPasswordChangeDateUtc?.ToLocalTime() ?? DateTime.Now;
         }
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Comments))
             && member.Comments != identityUser.Comments && identityUser.Comments.IsNullOrWhiteSpace() == false)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.Comments));
             member.Comments = identityUser.Comments;
         }
 
@@ -723,34 +741,34 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             || ((member.EmailConfirmedDate.HasValue == false || member.EmailConfirmedDate.Value == default) &&
                 identityUser.EmailConfirmed))
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.EmailConfirmed));
             member.EmailConfirmedDate = identityUser.EmailConfirmed ? DateTime.Now : null;
         }
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Name))
             && member.Name != identityUser.Name && identityUser.Name.IsNullOrWhiteSpace() == false)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.Name));
             member.Name = identityUser.Name ?? string.Empty;
         }
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Email))
             && member.Email != identityUser.Email && identityUser.Email.IsNullOrWhiteSpace() == false)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.Email));
             member.Email = identityUser.Email!;
         }
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.AccessFailedCount))
             && member.FailedPasswordAttempts != identityUser.AccessFailedCount)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.AccessFailedCount));
             member.FailedPasswordAttempts = identityUser.AccessFailedCount;
         }
 
         if (member.IsLockedOut != identityUser.IsLockedOut)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.IsLockedOut));
             member.IsLockedOut = identityUser.IsLockedOut;
 
             if (member.IsLockedOut)
@@ -762,14 +780,14 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
 
         if (member.IsApproved != identityUser.IsApproved)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.IsApproved));
             member.IsApproved = identityUser.IsApproved;
         }
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.UserName))
             && member.Username != identityUser.UserName && identityUser.UserName.IsNullOrWhiteSpace() == false)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.UserName));
             member.Username = identityUser.UserName!;
         }
 
@@ -777,33 +795,33 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
             && member.RawPasswordValue != identityUser.PasswordHash &&
             identityUser.PasswordHash.IsNullOrWhiteSpace() == false)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.PasswordHash));
             member.RawPasswordValue = identityUser.PasswordHash;
             member.PasswordConfiguration = identityUser.PasswordConfig;
         }
 
         if (member.PasswordConfiguration != identityUser.PasswordConfig)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.PasswordConfig));
             member.PasswordConfiguration = identityUser.PasswordConfig;
         }
 
         if (member.SecurityStamp != identityUser.SecurityStamp)
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.SecurityStamp));
             member.SecurityStamp = identityUser.SecurityStamp;
         }
 
         if (identityUser.IsPropertyDirty(nameof(MemberIdentityUser.Roles)))
         {
-            anythingChanged = true;
+            updatedProperties.Add(nameof(MemberIdentityUser.Roles));
             updateRoles = true;
         }
 
         // reset all changes
         identityUser.ResetDirtyProperties(false);
 
-        return anythingChanged;
+        return updatedProperties.AsReadOnly();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Attempts to resolve: https://github.com/umbraco/Umbraco-CMS/issues/13768

### Description
This PR is looking to handle reports of database locking when logging members in under load.  I haven't been able to replicate it myself, but those in the linked issue have (along with a few forum posts).

It's clear though there's a lot going on post login for a member, so I thought to go straight to trying to optimize.

The main issue is that we save the member after login - specifically to update:

- The last login date.
- The security stamp (if concurrent logins are disabled, which is the default).
- The update date on the member.

We do this though via a full save operation (the same as if saved via the backoffice) where we have to consider quite a few things that aren't going to be amended in this scenario: all other system properties, all the "content" properties, tags, audit, and, in particular, locking of the whole member tree.

It doesn't seem we need any of these in this situation.  In particular - though I'd like reviewers to consider and verify this - we don't need the locking of the member tree here.  If we were updating content properties, that could have relations between each other - we should following what we do for documents and lock.  But here we are just updating these system fields, and it's fine if they work in a "last one wins" fashion without locking.

So when merged this PR will:

- Add a check in the `MemberUserStore.UpdateAsync` method, and if we are only updating the last login date and/or the security stamp, no longer call `Save` on `IMemberService` but a new optimized, asynchronous method `UpdateLoginPropertiesAsync`.
- This will call up to the repository and save the member, but with:
    - No locking.
    - Only handling these two properties and the update date.
    - Not handling tags.
    - Not writing an audit record for content updates (though keeping the writes to the log table).
    - Also keeping the publishing of notifications)

### Testing

To test you'll need to create a method of logging in as a member - either using a controller as described in the linked issue or setting up the necessary partials and view components as per the handy gist [here](https://gist.github.com/AaronSadlerUK/7b1163a508b11bed9ae92fd87f4ca9a2) or the [docs](https://docs.umbraco.com/umbraco-cms/tutorials/members-registration-and-login).

Check the member login works as before.

Verify updates to the specific fields in the database via:

```
select lastLoginDate, securityStampToken from cmsMember where nodeId = 2060
select versionDate from umbracoContentVersion where nodeid = 2060
```



