### PR TITLE
Filter out invariant properties when determining changed variants, fixing issue with editing language variants on blueprints

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/manager/content-data-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/manager/content-data-manager.ts
@@ -140,7 +140,7 @@ export class UmbContentWorkspaceDataManager<
 			};
 		});
 
-		const changedProperties = current?.values.map((value) => {
+		const changedProperties = current?.values.filter(v => v.culture || v.segment).map((value) => {
 			const persistedValues = persisted?.values.find((x) => UmbVariantId.Create(value).compare(x));
 			return {
 				culture: value.culture,


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/19312

### Description
This PR filters out the invariant properties that have changed when determining the changed variants, which ensures only true variants are handled.  Without this we get a null variant coming through which fails with the error `One or more selected variants have not been created` in `runMandatoryValidationForSaveData` in `UmbContentDetailWorkspaceContextBase`.

Testing suggests this does resolve the problem and doesn't affect similar editing on documents, but the code is quite complex here so it needs a check to make sure I haven't missed something. 

### Testing

- Set up a document with two languages, at least one shared property and at least one variant one.
- Create a blueprint for the document.
- Update making sure you change at least one shared property and at least one variant one.
- You should find the save of the blueprint completes without error.
