### PR TITLE
V13/bugfix/partial cache

### DIFF
--- a/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/IMemberPartialViewCacheInvalidator.cs
+++ b/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/IMemberPartialViewCacheInvalidator.cs
@@ -1,6 +1,16 @@
 namespace Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
 
+/// <summary>
+/// Defines behaviours for clearing of cached partials views that are configured to be cached individually by member.
+/// </summary>
 public interface IMemberPartialViewCacheInvalidator
 {
-    void ClearPartialViewCacheItems(IEnumerable<int> updatedMemberIds);
+    /// <summary>
+    /// Clears the partial view cache items for the specified member ids.
+    /// </summary>
+    /// <param name="memberIds">The member Ids to clear the cache for.</param>
+    /// <remarks>
+    /// Called from the <see cref="MemberCacheRefresher"/> when a member is saved or deleted.
+    /// </remarks>
+    void ClearPartialViewCacheItems(IEnumerable<int> memberIds);
 }

--- a/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/IMemberPartialViewCacheInvalidator.cs
+++ b/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/IMemberPartialViewCacheInvalidator.cs
@@ -1,0 +1,6 @@
+namespace Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
+
+public interface IMemberPartialViewCacheInvalidator
+{
+    void ClearPartialViewCacheItems(IEnumerable<int> updatedMemberIds);
+}

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -97,7 +97,9 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
 
     private void ClearCache(params JsonPayload[] payloads)
     {
+        // Clear the partial views cache for all partials that are cached by member, for the updates members.
         _memberPartialViewCacheInvalidator.ClearPartialViewCacheItems(payloads.Select(p => p.Id));
+
         Attempt<IAppPolicyCache?> memberCache = AppCaches.IsolatedCaches.Get<IMember>();
 
         foreach (JsonPayload p in payloads)

--- a/src/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidator.cs
+++ b/src/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidator.cs
@@ -4,25 +4,30 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Website.Cache.PartialViewCacheInvalidators;
 
+/// <summary>
+/// Implementation of <see cref="IMemberPartialViewCacheInvalidator"/> that only remove cached partial views
+/// that were cached for the specified member(s).
+/// </summary>
 public class MemberPartialViewCacheInvalidator : IMemberPartialViewCacheInvalidator
 {
     private readonly AppCaches _appCaches;
 
-    public MemberPartialViewCacheInvalidator(
-        AppCaches appCaches)
-    {
-        _appCaches = appCaches;
-    }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemberPartialViewCacheInvalidator"/> class.
+    /// </summary>
+    public MemberPartialViewCacheInvalidator(AppCaches appCaches) => _appCaches = appCaches;
 
-    /// by default, we only remove cached partial views that were cached for the specified member.
-    /// partial view cache keys follow the following format
-    /// [] is optional or only added if the information is available
-    /// {} is a parameter
-    /// "Umbraco.Web.PartialViewCacheKey{partialViewName}-[{currentThreadCultureName}-][m{memberId}-][c{contextualKey}-]"
-    /// see <see cref="HtmlHelperRenderExtensions.CachedPartialAsync"/> for more information
-    public void ClearPartialViewCacheItems(IEnumerable<int> updatedMemberIds)
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Partial view cache keys follow the following format:
+    ///   [] is optional or only added if the information is available
+    ///   {} is a parameter
+    ///   "Umbraco.Web.PartialViewCacheKey{partialViewName}-[{currentThreadCultureName}-][m{memberId}-][c{contextualKey}-]"
+    /// See <see cref="HtmlHelperRenderExtensions.CachedPartialAsync"/> for more information.
+    /// </remarks>
+    public void ClearPartialViewCacheItems(IEnumerable<int> memberIds)
     {
-        foreach (var memberId in updatedMemberIds)
+        foreach (var memberId in memberIds)
         {
             _appCaches.RuntimeCache.ClearByRegex($"{CoreCacheHelperExtensions.PartialViewCacheKey}.*-m{memberId}-*");
         }

--- a/src/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidator.cs
+++ b/src/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidator.cs
@@ -1,0 +1,30 @@
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Web.Website.Cache.PartialViewCacheInvalidators;
+
+public class MemberPartialViewCacheInvalidator : IMemberPartialViewCacheInvalidator
+{
+    private readonly AppCaches _appCaches;
+
+    public MemberPartialViewCacheInvalidator(
+        AppCaches appCaches)
+    {
+        _appCaches = appCaches;
+    }
+
+    /// by default, we only remove cached partial views that were cached for the specified member.
+    /// partial view cache keys follow the following format
+    /// [] is optional or only added if the information is available
+    /// {} is a parameter
+    /// "Umbraco.Web.PartialViewCacheKey{partialViewName}-[{currentThreadCultureName}-][m{memberId}-][c{contextualKey}-]"
+    /// see <see cref="HtmlHelperRenderExtensions.CachedPartialAsync"/> for more information
+    public void ClearPartialViewCacheItems(IEnumerable<int> updatedMemberIds)
+    {
+        foreach (var memberId in updatedMemberIds)
+        {
+            _appCaches.RuntimeCache.ClearByRegex($"{CoreCacheHelperExtensions.PartialViewCacheKey}.*-m{memberId}-*");
+        }
+    }
+}

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -76,7 +76,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IPublicAccessRequestHandler, PublicAccessRequestHandler>();
         builder.Services.AddSingleton<BasicAuthenticationMiddleware>();
 
-        // Partial cache invalidators
+        // Partial view cache invalidators
         builder.Services.AddUnique<IMemberPartialViewCacheInvalidator, MemberPartialViewCacheInvalidator>();
 
         builder

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Routing;
@@ -13,6 +14,7 @@ using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.DependencyInjection;
 using Umbraco.Cms.Web.Common.Middleware;
 using Umbraco.Cms.Web.Common.Routing;
+using Umbraco.Cms.Web.Website.Cache.PartialViewCacheInvalidators;
 using Umbraco.Cms.Web.Website.Collections;
 using Umbraco.Cms.Web.Website.Models;
 using Umbraco.Cms.Web.Website.Routing;
@@ -73,6 +75,9 @@ public static partial class UmbracoBuilderExtensions
 
         builder.Services.AddSingleton<IPublicAccessRequestHandler, PublicAccessRequestHandler>();
         builder.Services.AddSingleton<BasicAuthenticationMiddleware>();
+
+        // Partial cache invalidators
+        builder.Services.AddUnique<IMemberPartialViewCacheInvalidator, MemberPartialViewCacheInvalidator>();
 
         builder
             .AddDistributedCache()

--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -104,42 +104,18 @@ public static class HtmlHelperRenderExtensions
         ViewDataDictionary? viewData = null,
         Func<object, ViewDataDictionary?, string>? contextualKeyBuilder = null)
     {
-        var cacheKey = new StringBuilder(partialViewName + "-");
-
-        // let's always cache by the current culture to allow variants to have different cache results
-        var cultureName = Thread.CurrentThread.CurrentUICulture.Name;
-        if (!string.IsNullOrEmpty(cultureName))
-        {
-            cacheKey.AppendFormat("{0}-", cultureName);
-        }
-
         IUmbracoContextAccessor umbracoContextAccessor = GetRequiredService<IUmbracoContextAccessor>(htmlHelper);
         umbracoContextAccessor.TryGetUmbracoContext(out IUmbracoContext? umbracoContext);
 
-        if (cacheByPage)
-        {
-            if (umbracoContext == null)
-            {
-                throw new InvalidOperationException(
-                    "Cannot cache by page if the UmbracoContext has not been initialized, this parameter can only be used in the context of an Umbraco request");
-            }
-
-            cacheKey.AppendFormat("{0}-", umbracoContext.PublishedRequest?.PublishedContent?.Id ?? 0);
-        }
-
-        if (cacheByMember)
-        {
-            IMemberManager memberManager =
-                htmlHelper.ViewContext.HttpContext.RequestServices.GetRequiredService<IMemberManager>();
-            MemberIdentityUser? currentMember = await memberManager.GetCurrentMemberAsync();
-            cacheKey.AppendFormat("m{0}-", currentMember?.Id ?? "0");
-        }
-
-        if (contextualKeyBuilder != null)
-        {
-            var contextualKey = contextualKeyBuilder(model, viewData);
-            cacheKey.AppendFormat("c{0}-", contextualKey);
-        }
+        string cacheKey = await GenerateCacheKeyForCachedPartialViewAsync(
+            partialViewName,
+            cacheByPage,
+            umbracoContext,
+            cacheByMember,
+            cacheByMember ? GetRequiredService<IMemberManager>(htmlHelper) : null,
+            model,
+            viewData,
+            contextualKeyBuilder);
 
         AppCaches appCaches = GetRequiredService<AppCaches>(htmlHelper);
         IHostingEnvironment hostingEnvironment = GetRequiredService<IHostingEnvironment>(htmlHelper);
@@ -153,6 +129,58 @@ public static class HtmlHelperRenderExtensions
             cacheTimeout,
             cacheKey.ToString(),
             viewData);
+    }
+
+    // Internal for tests.
+    internal static async Task<string> GenerateCacheKeyForCachedPartialViewAsync(
+        string partialViewName,
+        bool cacheByPage,
+        IUmbracoContext? umbracoContext,
+        bool cacheByMember,
+        IMemberManager? memberManager,
+        object model,
+        ViewDataDictionary? viewData,
+        Func<object, ViewDataDictionary?, string>? contextualKeyBuilder)
+    {
+        var cacheKey = new StringBuilder(partialViewName + "-");
+
+        // let's always cache by the current culture to allow variants to have different cache results
+        var cultureName = Thread.CurrentThread.CurrentUICulture.Name;
+        if (!string.IsNullOrEmpty(cultureName))
+        {
+            cacheKey.AppendFormat("{0}-", cultureName);
+        }
+
+        if (cacheByPage)
+        {
+            if (umbracoContext == null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot cache by page if the UmbracoContext has not been initialized, this parameter can only be used in the context of an Umbraco request.");
+            }
+
+            cacheKey.AppendFormat("{0}-", umbracoContext.PublishedRequest?.PublishedContent?.Id ?? 0);
+        }
+
+        if (cacheByMember)
+        {
+            if (memberManager == null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot cache by member if the MemberManager is not available.");
+            }
+
+            MemberIdentityUser? currentMember = await memberManager.GetCurrentMemberAsync();
+            cacheKey.AppendFormat("m{0}-", currentMember?.Id ?? "0");
+        }
+
+        if (contextualKeyBuilder != null)
+        {
+            var contextualKey = contextualKeyBuilder(model, viewData);
+            cacheKey.AppendFormat("c{0}-", contextualKey);
+        }
+
+        return cacheKey.ToString();
     }
 
     // public static IHtmlContent EditorFor<T>(this IHtmlHelper htmlHelper, string templateName = "", string htmlFieldName = "", object additionalViewData = null)

--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -104,7 +104,7 @@ public static class HtmlHelperRenderExtensions
         ViewDataDictionary? viewData = null,
         Func<object, ViewDataDictionary?, string>? contextualKeyBuilder = null)
     {
-        var cacheKey = new StringBuilder(partialViewName);
+        var cacheKey = new StringBuilder(partialViewName + "-");
 
         // let's always cache by the current culture to allow variants to have different cache results
         var cultureName = Thread.CurrentThread.CurrentUICulture.Name;

--- a/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DistributedLocking;
@@ -43,6 +44,8 @@ public static class UmbracoBuilderExtensions
     public static IUmbracoBuilder AddTestServices(this IUmbracoBuilder builder, TestHelper testHelper)
     {
         builder.Services.AddUnique(AppCaches.NoCache);
+        builder.Services.AddUnique(Mock.Of<IMemberPartialViewCacheInvalidator>());
+
         builder.Services.AddUnique(Mock.Of<IUmbracoBootPermissionChecker>());
         builder.Services.AddUnique(testHelper.MainDom);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidatorTests.cs
@@ -59,9 +59,15 @@ public class MemberPartialViewCacheInvalidatorTests
             new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary()),
             null);
         cacheKey = CoreCacheHelperExtensions.PartialViewCacheKey + cacheKey;
-        var regex = $"Umbraco.Web.PartialViewCacheKey.*-m{MemberId}-*";
-        var regexMatch = Regex.IsMatch(cacheKey, regex);
+        Assert.AreEqual("Umbraco.Web.PartialViewCacheKeyTestPartial.cshtml-en-US-0-m1234-", cacheKey);
+
+        var regexForMember = $"Umbraco.Web.PartialViewCacheKey.*-m{MemberId}-*";
+        var regexMatch = Regex.IsMatch(cacheKey, regexForMember);
         Assert.IsTrue(regexMatch);
+
+        var regexForAnotherMember = $"Umbraco.Web.PartialViewCacheKey.*-m{4321}-*";
+        regexMatch = Regex.IsMatch(cacheKey, regexForAnotherMember);
+        Assert.IsFalse(regexMatch);
     }
 
     private class TestViewModel

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Cache/PartialViewCacheInvalidators/MemberPartialViewCacheInvalidatorTests.cs
@@ -1,0 +1,70 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Website.Cache.PartialViewCacheInvalidators;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Routing;
+
+[TestFixture]
+public class MemberPartialViewCacheInvalidatorTests
+{
+    [Test]
+    public void ClearPartialViewCacheItems_Clears_ExpectedItems()
+    {
+        var runTimeCacheMock = new Mock<IAppPolicyCache>();
+        runTimeCacheMock
+            .Setup(x => x.ClearByRegex(It.IsAny<string>()))
+            .Verifiable();
+        var appCaches = new AppCaches(
+            runTimeCacheMock.Object,
+            NoAppCache.Instance,
+            new IsolatedCaches(type => new ObjectCacheAppCache()));
+        var memberPartialViewCacheInvalidator = new MemberPartialViewCacheInvalidator(appCaches);
+
+        var memberIds = new[] { 1, 2, 3 };
+
+        memberPartialViewCacheInvalidator.ClearPartialViewCacheItems(memberIds);
+
+        foreach (var memberId in memberIds)
+        {
+            var regex = $"Umbraco.Web.PartialViewCacheKey.*-m{memberId}-*";
+            runTimeCacheMock
+                .Verify(x => x.ClearByRegex(It.Is<string>(x => x == regex)), Times.Once);
+        }
+    }
+
+    [Test]
+    public async Task ClearPartialViewCacheItems_Regex_Matches_CachedKeys()
+    {
+        const int MemberId = 1234;
+
+        var memberManagerMock = new Mock<IMemberManager>();
+        memberManagerMock
+            .Setup(x => x.GetCurrentMemberAsync())
+            .ReturnsAsync(new MemberIdentityUser { Id = MemberId.ToString() });
+
+        var cacheKey = await HtmlHelperRenderExtensions.GenerateCacheKeyForCachedPartialViewAsync(
+            "TestPartial.cshtml",
+            true,
+            Mock.Of<IUmbracoContext>(),
+            true,
+            memberManagerMock.Object,
+            new TestViewModel(),
+            new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary()),
+            null);
+        cacheKey = CoreCacheHelperExtensions.PartialViewCacheKey + cacheKey;
+        var regex = $"Umbraco.Web.PartialViewCacheKey.*-m{MemberId}-*";
+        var regexMatch = Regex.IsMatch(cacheKey, regex);
+        Assert.IsTrue(regexMatch);
+    }
+
+    private class TestViewModel
+    {
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19098

### Description
When caching the execution of a partial view by using the `CachedPartialAsync` extension method on the `IHtmlHelper` and stating you want it cached by member or not, it seems logical to expect that when a member is updated, only the partials that are cached for that specific member are removed from the cache. 

Since an IMember gets updated every time it logs in, as the last login date is saved, the partial views cache was fully invalidated every time a user logs in resulting in a very ineffective caching strategy under heavy member load.

In future versions we will look into separating the last login date and similar Identity fields from the domain object to lower the amount of domain object persistence operations we need to do but since this would be to breaking for v13 and because being able to extend/replace only the code that deals with the partial view cache invalidation triggered from a member update is a friendly thing to supply we went with this approach for v13.

We have also made plans to look into similar enhancements for the other CacheRefreshers to split the logic to make it easier to extend in the future.

### Notes
I placed the implementation into the same project as the code that builds the cache key. As the core should not hold an implementation that is tightly bound to the workings of a web application. In an ideal scenario the core would define a more abstract interface to run extra cache invalidators but that will be looked at when we investigate the rework of the CacheRefreshers.

### Testing
- Setup a member login setup with multiple members
- Setup up at least 2 partial views that you render on an page, one of them cached by member and the other not. You can find some inspiration below
- Login with one member, the page should display both partials
- Login with another member in incognito, the page should display the same result for the non member cached partial and a different result for the member cached partial
- Reload the page for the first member, their result should not change
- Logout and login one of the members, the member specific partial should change, the other not
- Try to break the default implementation by supplying extra parameters to the `CachedPartialAsync` method or changing the stup
- Try to replace the default implementation trough composition


### Testing code examples
General.cshtml
```cshtml
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage

@{
    <p>Time of first render: @DateTime.Now.ToString("R")</p>
}
```
Member.cshtml
```cshtml
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
    <p>Time of first render after login: @DateTime.Now.ToString("R")</p>
}
```
Master.cshtml
```
...
@await Html.CachedPartialAsync("general",Model,TimeSpan.FromDays(1))
@if (MemberManager.IsLoggedIn())
{
    @await Html.CachedPartialAsync("member",Model,TimeSpan.FromDays(1), cacheByMember:true)
}
...
```