### PR TITLE
Document URLs Data Resolver

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/info-app/global-components/workspace-info-app-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/info-app/global-components/workspace-info-app-layout.element.ts
@@ -22,10 +22,6 @@ export class UmbWorkspaceInfoAppLayoutElement extends UmbLitElement {
 			uui-box {
 				--uui-box-default-padding: 0;
 			}
-
-			#container {
-				padding-left: var(--uui-size-space-4);
-			}
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/document-item-data-resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/document-item-data-resolver.ts
@@ -45,6 +45,7 @@ export class UmbDocumentItemDataResolver<DataType extends UmbDocumentItemDataRes
 	constructor(host: UmbControllerHost) {
 		super(host);
 
+		// TODO: listen for UMB_VARIANT_CONTEXT when available
 		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (context) => {
 			this.#propertyDataSetCulture = context?.getVariantId();
 			this.#setVariantAwareValues();

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
@@ -1,10 +1,9 @@
 import type { UmbDocumentUrlModel } from './repository/types.js';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
-import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 /**
  * A controller for resolving data for document urls

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
@@ -1,0 +1,105 @@
+import type { UmbDocumentUrlModel } from './repository/types.js';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+
+/**
+ * A controller for resolving data for document urls
+ * @exports
+ * @class UmbDocumentUrlsDataResolver
+ * @augments {UmbControllerBase}
+ */
+export class UmbDocumentUrlsDataResolver extends UmbControllerBase {
+	#defaultCulture?: string;
+	#appCulture?: string;
+	#propertyDataSetCulture?: UmbVariantId;
+	#data?: Array<UmbDocumentUrlModel> | undefined;
+
+	#init: Promise<unknown>;
+
+	#urls = new UmbArrayState<UmbDocumentUrlModel>([], (url) => url.url);
+	/**
+	 * The urls for the current culture
+	 * @returns {ObservableArray<UmbDocumentUrlModel>} The urls for the current culture
+	 * @memberof UmbDocumentUrlsDataResolver
+	 */
+	public readonly urls = this.#urls.asObservable();
+
+	constructor(host: UmbControllerHost) {
+		super(host);
+
+		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (context) => {
+			this.#propertyDataSetCulture = context?.getVariantId();
+			this.#setCultureAwareValues();
+		});
+
+		// We do not depend on this context because we know is it only available in some cases
+		this.#init = this.consumeContext(UMB_APP_LANGUAGE_CONTEXT, (context) => {
+			this.observe(context?.appLanguageCulture, (culture) => {
+				this.#appCulture = culture;
+				this.#setCultureAwareValues();
+			});
+
+			this.observe(context?.appDefaultLanguage, (value) => {
+				this.#defaultCulture = value?.unique;
+				this.#setCultureAwareValues();
+			});
+		}).asPromise();
+	}
+
+	/**
+	 * Get the current data
+	 * @returns {Array<UmbDocumentUrlModel> | undefined} The current data
+	 * @memberof UmbDocumentUrlsDataResolver
+	 */
+	getData(): Array<UmbDocumentUrlModel> | undefined {
+		return this.#data;
+	}
+
+	/**
+	 * Set the current data
+	 * @param {Array<UmbDocumentUrlModel> | undefined} data The current data
+	 * @memberof UmbDocumentUrlsDataResolver
+	 */
+	setData(data: Array<UmbDocumentUrlModel> | undefined) {
+		this.#data = data;
+
+		if (!this.#data) {
+			this.#urls.setValue([]);
+			return;
+		}
+
+		this.#setCultureAwareValues();
+	}
+
+	/**
+	 * Get the urls for the current culture
+	 * @returns {(Promise<Array<UmbDocumentUrlModel> | []>)} The urls for the current culture
+	 * @memberof UmbDocumentUrlsDataResolver
+	 */
+	async getUrls(): Promise<Array<UmbDocumentUrlModel> | []> {
+		await this.#init;
+		return this.#urls.getValue();
+	}
+
+	#setCultureAwareValues() {
+		this.#setUrls();
+	}
+
+	#setUrls() {
+		const data = this.#getDataForCurrentCulture();
+		this.#urls.setValue(data ?? []);
+	}
+
+	#getCurrentCulture(): string | undefined {
+		return this.#propertyDataSetCulture?.culture || this.#appCulture || this.#defaultCulture;
+	}
+
+	#getDataForCurrentCulture(): Array<UmbDocumentUrlModel> | undefined {
+		const culture = this.#getCurrentCulture();
+		return this.#data?.filter((x) => x.culture === culture);
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/index.ts
@@ -1,3 +1,4 @@
 export { UmbDocumentUrlRepository, UMB_DOCUMENT_URL_REPOSITORY_ALIAS } from './repository/index.js';
 
 export * from './constants.js';
+export * from './document-urls-data-resolver.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/info-app/document-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/info-app/document-links-workspace-info-app.element.ts
@@ -3,8 +3,16 @@ import type { UmbDocumentVariantOptionModel } from '../../types.js';
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '../../workspace/constants.js';
 import type { UmbDocumentUrlModel } from '../repository/types.js';
 import { UmbDocumentUrlsDataResolver } from '../document-urls-data-resolver.js';
-import { UmbDocumentItemDataResolver } from '../../item/document-item-data-resolver.js';
-import { css, customElement, html, nothing, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
+import {
+	css,
+	customElement,
+	html,
+	ifDefined,
+	nothing,
+	repeat,
+	state,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
@@ -206,7 +214,7 @@ export class UmbDocumentLinksWorkspaceInfoAppElement extends UmbLitElement {
 		}
 
 		return html`
-			<a class="link-item" href=${this.#getTargetUrl(link.url)} target="_blank">
+			<a class="link-item" href=${ifDefined(this.#getTargetUrl(link.url))} target="_blank">
 				<span>
 					${this.#renderLinkCulture(link.culture, links)}
 					<span>${link.url}</span>

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/info-app/document-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/info-app/document-links-workspace-info-app.element.ts
@@ -266,10 +266,6 @@ export class UmbDocumentLinksWorkspaceInfoAppElement extends UmbLitElement {
 
 	static override styles = [
 		css`
-			uui-box {
-				--uui-box-default-padding: 0;
-			}
-
 			#loader-container {
 				display: flex;
 				justify-content: center;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/repository/types.ts
@@ -4,6 +4,6 @@ export interface UmbDocumentUrlsModel {
 }
 
 export interface UmbDocumentUrlModel {
-	culture?: string | null;
-	url?: string;
+	culture: string | null;
+	url: string;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/repository/types.ts
@@ -5,5 +5,5 @@ export interface UmbDocumentUrlsModel {
 
 export interface UmbDocumentUrlModel {
 	culture: string | null;
-	url: string;
+	url?: string;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -11,7 +11,6 @@ import {
 	umbBindToValidation,
 	UmbObserveValidationStateController,
 	UmbValidationContext,
-	UmbValidationController,
 	type UmbValidator,
 } from '@umbraco-cms/backoffice/validation';
 import { umbConfirmModal, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
@@ -27,6 +26,7 @@ import type { UmbInputMediaElement } from '@umbraco-cms/backoffice/media';
 import type { UUIBooleanInputEvent, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 
 class UmbLinkPickerValueValidator extends UmbControllerBase implements UmbValidator {
 	#context?: typeof UMB_VALIDATION_CONTEXT.TYPE;
@@ -38,7 +38,7 @@ class UmbLinkPickerValueValidator extends UmbControllerBase implements UmbValida
 
 	#value: unknown;
 
-	#unique = 'Hej';
+	#unique = 'UmbLinkPickerValueValidator';
 
 	setValue(value: unknown) {
 		this.#value = value;
@@ -113,7 +113,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 	constructor() {
 		super();
 
-		new UmbObserveValidationStateController(this, '$.url', (invalid) => {
+		new UmbObserveValidationStateController(this, '$.type', (invalid) => {
 			this._missingLinkUrl = invalid;
 		});
 	}
@@ -136,10 +136,10 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		this.#getMediaTypes();
 		this.populateLinkUrl();
 
-		const validator = new UmbLinkPickerValueValidator(this, '$.url');
+		const validator = new UmbLinkPickerValueValidator(this, '$.type');
 
 		this.observe(this.modalContext?.value, (value) => {
-			validator.setValue(value?.link.url);
+			validator.setValue(value?.link.type);
 		});
 	}
 
@@ -417,9 +417,10 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 				placeholder=${this.localize.term('placeholders_enterUrl')}
 				.value=${this.value.link.url ?? ''}
 				?disabled=${!!this.value.link.unique}
-				?required=${this._config.hideAnchor}
-				@input=${this.#onLinkUrlInput}>
-				${umbBindToValidation(this)}>
+				required
+				@input=${this.#onLinkUrlInput}
+				${umbBindToValidation(this)}
+				${umbFocus()}>
 				${when(
 					!this.value.link.unique,
 					() => html`

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -83,7 +83,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 	async populateLinkUrl() {
 		// Documents and media have URLs saved in the local link format. Display the actual URL to align with what
 		// the user sees when they selected it initially.
-		if (!this.value.link?.unique || this.value.link?.url?.indexOf('localLink') === -1) return;
+		if (!this.value.link?.unique) return;
 
 		let url: string | undefined = undefined;
 		switch (this.value.link.type) {

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -9,7 +9,6 @@ import { isUmbracoFolder, UmbMediaTypeStructureRepository } from '@umbraco-cms/b
 import { umbBindToValidation, UmbValidationContext } from '@umbraco-cms/backoffice/validation';
 import { umbConfirmModal, UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import {
-	UmbDocumentDetailRepository,
 	UmbDocumentItemDataResolver,
 	UmbDocumentItemRepository,
 	UmbDocumentUrlRepository,

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -14,7 +14,7 @@ import {
 	UmbDocumentUrlRepository,
 	UmbDocumentUrlsDataResolver,
 } from '@umbraco-cms/backoffice/document';
-import { UmbMediaDetailRepository, UmbMediaUrlRepository } from '@umbraco-cms/backoffice/media';
+import { UmbMediaItemRepository, UmbMediaUrlRepository } from '@umbraco-cms/backoffice/media';
 import type { UmbInputDocumentElement } from '@umbraco-cms/backoffice/document';
 import type { UmbInputMediaElement } from '@umbraco-cms/backoffice/media';
 import type { UUIBooleanInputEvent, UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
@@ -174,11 +174,12 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 					break;
 				}
 				case 'media': {
-					const mediaRepository = new UmbMediaDetailRepository(this);
-					const { data: mediaData } = await mediaRepository.requestByUnique(unique);
-					if (mediaData) {
-						icon = mediaData.mediaType.icon;
-						name = mediaData.variants[0].name;
+					const mediaRepository = new UmbMediaItemRepository(this);
+					const { data: mediaData } = await mediaRepository.requestItems([unique]);
+					const mediaItem = mediaData?.[0];
+					if (mediaItem) {
+						icon = mediaItem.mediaType.icon;
+						name = mediaItem.variants[0].name;
 						url = await this.#getUrlForMedia(unique);
 					}
 					break;

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -187,6 +187,9 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 				default:
 					break;
 			}
+			// The selection was removed
+		} else {
+			this.#resetUrl();
 		}
 
 		const link = {
@@ -228,6 +231,10 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 			});
 		}
 
+		this.#resetUrl();
+	}
+
+	#resetUrl() {
 		this.#partialUpdateLink({ type: null, url: null });
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relations/reference/workspace-info-app/entity-references-workspace-view-info.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relations/reference/workspace-info-app/entity-references-workspace-view-info.element.ts
@@ -106,7 +106,7 @@ export class UmbEntityReferencesWorkspaceInfoAppElement extends UmbLitElement {
 		if (!this._items?.length) return nothing;
 		return html`
 			<umb-workspace-info-app-layout headline="#references_labelUsedByItems">
-				${this.#renderItems()} ${this.#renderReferencePagination()}
+				<div id="content">${this.#renderItems()} ${this.#renderReferencePagination()}</div>
 			</umb-workspace-info-app-layout>
 		`;
 	}
@@ -142,6 +142,11 @@ export class UmbEntityReferencesWorkspaceInfoAppElement extends UmbLitElement {
 		css`
 			:host {
 				display: contents;
+			}
+
+			#content {
+				display: block;
+				padding: var(--uui-size-space-3) var(--uui-size-space-4);
 			}
 
 			.pagination-container {


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/18317

This PR updates the Multi URL Picker UI to render variant-aware URLs and adds the variant name to the URL title field. It introduces a DocumentURLsDataResolver to obtain the variant-aware URLs. This resolver is now reused for both the workspace URLs in the info app and the Multi URL Picker.

The workspace URLs now display only the URLs for the active variant unless the document is invariant; in that case, it will show all URLs.

**Updates to the Multi URL Picker**
https://github.com/user-attachments/assets/f6f8a7b7-f747-4aad-8250-c2edfeb175ac

**Updates to the document URLs app**
https://github.com/user-attachments/assets/f3fc25ee-8ee4-42e8-8459-a6272dcd67fd