### PR TITLE
hotfix: remove current user action look and color

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/action/current-user-app-button.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/action/current-user-app-button.element.ts
@@ -4,7 +4,7 @@ import type {
 	UmbCurrentUserAction,
 } from '../current-user-action.extension.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { html, customElement, ifDefined, state, property } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, ifDefined, state, property, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbActionExecutedEvent } from '@umbraco-cms/backoffice/event';
 
@@ -16,7 +16,7 @@ export class UmbCurrentUserAppButtonElement<
 	#api?: ApiType;
 
 	@state()
-	_href?: string;
+	private _href?: string;
 
 	@property({ attribute: false })
 	public manifest?: ManifestCurrentUserActionDefaultKind<MetaType>;
@@ -43,13 +43,9 @@ export class UmbCurrentUserAppButtonElement<
 
 	override render() {
 		return html`
-			<uui-button
-				@click=${this.#onClick}
-				look="${this.manifest?.meta.look ?? 'primary'}"
-				color="${this.manifest?.meta.color ?? 'default'}"
-				label="${ifDefined(this.label)}"
-				href="${ifDefined(this._href)}">
-				${this.manifest?.meta.icon ? html`<uui-icon name="${this.manifest.meta.icon}"></uui-icon>` : ''} ${this.label}
+			<uui-button @click=${this.#onClick} look="secondary" label=${ifDefined(this.label)} href=${ifDefined(this._href)}>
+				${this.manifest?.meta.icon ? html`<uui-icon name=${this.manifest.meta.icon}></uui-icon>` : nothing}
+				${this.label}
 			</uui-button>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user-action.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user-action.extension.ts
@@ -56,18 +56,6 @@ export interface MetaCurrentUserActionDefaultKind extends MetaCurrentUserAction 
 	 * ]
 	 */
 	label: string;
-
-	/**
-	 * The look of the button
-	 * @default primary
-	 */
-	look?: UUIInterfaceLook;
-
-	/**
-	 * The color of the button
-	 * @default default
-	 */
-	color?: UUIInterfaceColor;
 }
 
 declare global {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/external-login/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/external-login/manifests.ts
@@ -15,7 +15,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: '#defaultdialogs_externalLoginProviders',
 			icon: 'icon-lock',
-			look: 'secondary',
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/mfa-login/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/mfa-login/manifests.ts
@@ -11,7 +11,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: '#user_configureTwoFactor',
 			icon: 'icon-rectangle-ellipsis',
-			look: 'secondary',
 		},
 		conditions: [
 			{


### PR DESCRIPTION
Removes the option to set a `look` and `color` for the current user actions — we are not interested in this type of customization, as it pollutes the visuals, by taking unnecessary attention or unnecessary inconsistency. As well this is making it hard for us to move ahead with the future plans of this dialogue, where these buttons might have to be relocated to a more proper place. Therefore, these buttons will stay normal buttons with equal visual attention.

<img width="349" alt="image" src="https://github.com/user-attachments/assets/55f33081-3a1b-443a-a1c3-78986c2c0a41" />