### PR TITLE
V16 RC: HtmlImageSourceParser should not care for order of attributes

### DIFF
--- a/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
@@ -115,7 +115,7 @@ public sealed class HtmlImageSourceParser
             // Find the src attribute
             Match src = SrcAttributeRegex.Match(match.Value);
 
-            return src.Success == false ?
+            return src.Success == false || string.IsNullOrWhiteSpace(src.Groups[1].Value) ?
                 match.Value : match.Value.Replace(src.Groups[1].Value, string.Empty);
         });
 }

--- a/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
@@ -11,7 +11,7 @@ public sealed class HtmlImageSourceParser
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex SrcAttributeRegex = new(
-        @"src=""([^""\?]*)(\?[^""]*)?""[^>]",
+        @"src=""([^""\?]*)(\?[^""]*)?""",
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
     private static readonly Regex DataUdiAttributeRegex = new(

--- a/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
@@ -75,8 +75,8 @@ public sealed class HtmlImageSourceParser
 
             // Find the src attribute
             // src match groups:
-            // - 1 = the src attribute value
-            // - 2 = the src attribute query string
+            // - 1 = the src attribute value until the query string
+            // - 2 = the src attribute query string including the '?'
             Match src = SrcAttributeRegex.Match(match.Value);
 
             if (src.Success == false)
@@ -116,6 +116,6 @@ public sealed class HtmlImageSourceParser
             Match src = SrcAttributeRegex.Match(match.Value);
 
             return src.Success == false ?
-                match.Value : match.Value.Replace(src.Value, "src=\"\"");
+                match.Value : match.Value.Replace(src.Groups[1].Value, string.Empty);
         });
 }

--- a/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlImageSourceParser.cs
@@ -106,6 +106,16 @@ public sealed class HtmlImageSourceParser
     /// <returns></returns>
     public string RemoveImageSources(string text)
 
-        // see comment in ResolveMediaFromTextString for group reference
-        => ResolveImgPattern.Replace(text, "$1$3$4$5");
+        // find each ResolveImgPattern match in the text, then find each
+        // SrcAttributeRegex match in the match value, then replace the src
+        // attribute value with an empty string
+        // (see comment in ResolveMediaFromTextString for group reference)
+        => ResolveImgPattern.Replace(text, match =>
+        {
+            // Find the src attribute
+            Match src = SrcAttributeRegex.Match(match.Value);
+
+            return src.Success == false ?
+                match.Value : match.Value.Replace(src.Value, "src=\"\"");
+        });
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -56,9 +56,17 @@ public class HtmlImageSourceParserTests
 </p>",
         TestName = "Remove image source with data-udi set")]
     [TestCase(
-        @"<img src=""/media/12354/test.jpg?width=400&height=400&hmac=test"" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
-        ExpectedResult = @"<img src=""?width=400&height=400&hmac=test"" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
+        @"<img alt title=""Title"" src=""/media/12354/test.jpg?width=400&height=400&hmac=test"" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
+        ExpectedResult = @"<img alt title=""Title"" src=""?width=400&height=400&hmac=test"" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
         TestName = "Remove image source but keep querystring")]
+    [TestCase(
+        @"<img alt title=""Title"" src="""" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
+        ExpectedResult = @"<img alt title=""Title"" src="""" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
+        TestName = "Remove image source with empty src")]
+    [TestCase(
+        @"<img src=""/media/12345/test.jpg"" />",
+        ExpectedResult = @"<img src=""/media/12345/test.jpg"" />",
+        TestName = "Do not remove image source without data-udi set")]
     [Category("Remove image sources")]
     public string Remove_Image_Sources(string sourceHtml)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -39,28 +39,34 @@ public class HtmlImageSourceParserTests
         Assert.AreEqual(UdiParser.Parse("umb://media-type/B726D735E4C446D58F703F3FBCFC97A5"), result[1]);
     }
 
-    [Test]
-    public void Remove_Image_Sources()
-    {
-        var imageSourceParser = new HtmlImageSourceParser(Mock.Of<IPublishedUrlProvider>());
-
-        var result = imageSourceParser.RemoveImageSources(@"<p>
+    [TestCase(
+        @"<p>
 <div>
     <img src=""/media/12354/test.jpg"" />
 </div></p>
 <p>
     <div><img src=""/media/987645/test.jpg"" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" /></div>
-</p>");
-
-        Assert.AreEqual(
-            @"<p>
+</p>",
+        ExpectedResult = @"<p>
 <div>
     <img src=""/media/12354/test.jpg"" />
 </div></p>
 <p>
     <div><img src="""" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" /></div>
 </p>",
-            result);
+        TestName = "Remove image source with data-udi set")]
+    [TestCase(
+        @"<img src=""/media/12354/test.jpg?width=400&height=400&hmac=test"" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
+        ExpectedResult = @"<img src=""?width=400&height=400&hmac=test"" data-udi=""umb://media/81BB2036-034F-418B-B61F-C7160D68DCD4"" />",
+        TestName = "Remove image source but keep querystring")]
+    [Category("Remove image sources")]
+    public string Remove_Image_Sources(string sourceHtml)
+    {
+        var imageSourceParser = new HtmlImageSourceParser(Mock.Of<IPublishedUrlProvider>());
+
+        var actual = imageSourceParser.RemoveImageSources(sourceHtml);
+
+        return actual;
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -147,6 +147,10 @@ public class HtmlImageSourceParserTests
         ExpectedResult = @"<div><img src=""/media/1001/image.jpg"" data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4""/></div>",
         TestName = "Filled source is overwritten with data-udi set")]
     [TestCase(
+        @"<div><img alt title=""Test"" data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4"" src=""non empty src"" /></div>",
+        ExpectedResult = @"<div><img alt title=""Test"" data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4"" src=""/media/1001/image.jpg"" /></div>",
+        TestName = "Order of attributes does not matter")]
+    [TestCase(
         @"<div><img src=""some src"" some-attribute data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4"" another-attribute/></div>",
         ExpectedResult = @"<div><img src=""/media/1001/image.jpg"" some-attribute data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4"" another-attribute/></div>",
         TestName = "Attributes are persisted")]
@@ -158,6 +162,10 @@ public class HtmlImageSourceParserTests
         @"<div><img src=""?width=100&height=500"" data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4""/></div>",
         ExpectedResult = @"<div><img src=""/media/1001/image.jpg?width=100&height=500"" data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4""/></div>",
         TestName = "Parameters are prefixed")]
+    [TestCase(
+        @"<div><img data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4"" src=""?width=100&height=500"" /></div>",
+        ExpectedResult = @"<div><img data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4"" src=""/media/1001/image.jpg?width=100&height=500"" /></div>",
+        TestName = "Parameters are prefixed (order of attributes reversed)")]
     [TestCase(
         @"<div>
                 <img src="""" data-udi=""umb://media/81BB2036034F418BB61FC7160D68DCD4""/>


### PR DESCRIPTION
## Description

Similar to the fix we did for the local link parser in #17288, the `HtmlImageSourceParser` should not care for the order of attributes. This fixes an up until now unknown bug with Tiptap, which switches the attributes `src` and `data-udi` around and is hard to control.

## How to test

1. Insert an image in a Tiptap editor
2. Edit the image path to something like `/media/test`
3. Verify that the original path is still set and works on the website frontend