### PR TITLE
V16 RC: Add more debug info to System Information

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -35,11 +35,16 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 			return;
 		}
 
-		const { data } = await this.#dataSource.getConfig();
+		const temporaryFileConfig = await this.requestTemporaryFileConfiguration();
 
-		if (data) {
-			this.#dataStore?.update(data);
+		if (temporaryFileConfig) {
+			this.#dataStore?.update(temporaryFileConfig);
 		}
+	}
+
+	async requestTemporaryFileConfiguration() {
+		const { data } = await this.#dataSource.getConfig();
+		return data;
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.server.data-source.ts
@@ -13,6 +13,6 @@ export class UmbTemporaryFileConfigServerDataSource {
 	 * Get the temporary file configuration.
 	 */
 	getConfig() {
-		return tryExecute(this.#host, TemporaryFileService.getTemporaryFileConfiguration());
+		return tryExecute(this.#host, TemporaryFileService.getTemporaryFileConfiguration(), { disableNotifications: true });
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
@@ -186,8 +186,9 @@ ${this._systemInformation}`;
 	static override readonly styles = [
 		UmbTextStyles,
 		css`
-			#code-block {
+			#codeblock {
 				max-height: 300px;
+				overflow: auto;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
@@ -5,10 +5,11 @@ import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import type { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import { UmbCurrentUserRepository } from '@umbraco-cms/backoffice/current-user';
+import { UmbTemporaryFileConfigRepository } from '@umbraco-cms/backoffice/temporary-file';
 
 type ServerKeyValue = {
-	name: string;
-	data: string;
+	name?: string;
+	data?: string;
 };
 
 @customElement('umb-sysinfo')
@@ -25,6 +26,7 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 	readonly #serverKeyValues: Array<ServerKeyValue> = [];
 	readonly #sysinfoRepository = new UmbSysinfoRepository(this);
 	readonly #currentUserRepository = new UmbCurrentUserRepository(this);
+	readonly #temporaryFileConfigRepository = new UmbTemporaryFileConfigRepository(this);
 
 	override connectedCallback(): void {
 		super.connectedCallback();
@@ -35,28 +37,38 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 		this._loading = true;
 		this.#serverKeyValues.length = 0;
 
-		const [serverTroubleshooting, serverInformation] = await Promise.all([
-			this.#sysinfoRepository.requestTroubleShooting(),
-			this.#sysinfoRepository.requestServerInformation(),
-		]);
+		const [serverTroubleshooting, serverInformation, clientInformation, { data: currentUser }, temporaryFileConfig] =
+			await Promise.all([
+				this.#sysinfoRepository.requestTroubleShooting(),
+				this.#sysinfoRepository.requestServerInformation(),
+				this.#sysinfoRepository.requestClientInformation(),
+				this.#currentUserRepository.requestCurrentUser(),
+				this.#temporaryFileConfigRepository.requestTemporaryFileConfiguration(),
+			]);
 
+		this.#serverKeyValues.push({ name: 'Server Troubleshooting' });
 		if (serverTroubleshooting) {
 			this.#serverKeyValues.push(...serverTroubleshooting.items);
 		}
 
+		this.#serverKeyValues.push({});
+		this.#serverKeyValues.push({ name: 'Server Information' });
 		if (serverInformation) {
 			this.#serverKeyValues.push({ name: 'Umbraco build version', data: serverInformation.version });
+			this.#serverKeyValues.push({ name: 'Umbraco assembly version', data: serverInformation.assemblyVersion });
 			this.#serverKeyValues.push({ name: 'Server time offset', data: serverInformation.baseUtcOffset });
 			this.#serverKeyValues.push({ name: 'Runtime mode', data: serverInformation.runtimeMode });
 		}
 
-		// Browser information
-		this.#serverKeyValues.push({ name: 'Browser (user agent)', data: navigator.userAgent });
-		this.#serverKeyValues.push({ name: 'Browser language', data: navigator.language });
-		this.#serverKeyValues.push({ name: 'Browser location', data: location.href });
+		this.#serverKeyValues.push({});
+		this.#serverKeyValues.push({ name: 'Client Information' });
+		if (clientInformation) {
+			this.#serverKeyValues.push({ name: 'Umbraco client version', data: clientInformation.version });
+		}
 
 		// User information
-		const { data: currentUser } = await this.#currentUserRepository.requestCurrentUser();
+		this.#serverKeyValues.push({});
+		this.#serverKeyValues.push({ name: 'Current user' });
 		if (currentUser) {
 			this.#serverKeyValues.push({ name: 'User is admin', data: currentUser.isAdmin ? 'Yes' : 'No' });
 			this.#serverKeyValues.push({ name: 'User sections', data: currentUser.allowedSections.join(', ') });
@@ -67,9 +79,38 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 			});
 			this.#serverKeyValues.push({
 				name: 'User document start nodes',
-				data: currentUser.documentStartNodeUniques.length ? currentUser.documentStartNodeUniques.join(', ') : 'None',
+				data: currentUser.documentStartNodeUniques.join(', '),
 			});
 		}
+
+		this.#serverKeyValues.push({});
+		this.#serverKeyValues.push({ name: 'Temporary file configuration' });
+		// Temporary file configuration
+		if (temporaryFileConfig) {
+			this.#serverKeyValues.push({
+				name: 'Max allowed file size',
+				data: temporaryFileConfig.maxFileSize?.toString() ?? 'Not set (unlimited)',
+			});
+			this.#serverKeyValues.push({
+				name: 'Allowed file types',
+				data: temporaryFileConfig.allowedUploadedFileExtensions.join(', '),
+			});
+			this.#serverKeyValues.push({
+				name: 'Disallowed file types',
+				data: temporaryFileConfig.disallowedUploadedFilesExtensions?.join(', '),
+			});
+			this.#serverKeyValues.push({
+				name: 'Image file types',
+				data: temporaryFileConfig.imageFileTypes?.join(', '),
+			});
+		}
+
+		// Browser information
+		this.#serverKeyValues.push({});
+		this.#serverKeyValues.push({ name: 'Browser Troubleshooting' });
+		this.#serverKeyValues.push({ name: 'Browser (user agent)', data: navigator.userAgent });
+		this.#serverKeyValues.push({ name: 'Browser language', data: navigator.language });
+		this.#serverKeyValues.push({ name: 'Browser location', data: location.href });
 
 		this._systemInformation = this.#renderServerKeyValues();
 		this._loading = false;
@@ -78,7 +119,7 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 	#renderServerKeyValues() {
 		return this.#serverKeyValues
 			.map((serverKeyValue) => {
-				return `${serverKeyValue.name}: ${serverKeyValue.data}`;
+				return serverKeyValue.name ? `${serverKeyValue.name}: ${serverKeyValue.data ?? ''}` : '';
 			})
 			.join('\n');
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/sysinfo/repository/sysinfo.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/sysinfo/repository/sysinfo.repository.ts
@@ -1,3 +1,4 @@
+import packageJson from '../../../../package.json';
 import type { UmbServerUpgradeCheck } from '../types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
@@ -18,6 +19,14 @@ export class UmbSysinfoRepository extends UmbRepositoryBase {
 	async requestServerInformation() {
 		const { data } = await tryExecute(this, ServerService.getServerInformation(), { disableNotifications: true });
 		return data;
+	}
+
+	async requestClientInformation() {
+		const { version } = packageJson;
+		const clientInformation = {
+			version,
+		};
+		return clientInformation;
 	}
 
 	/**


### PR DESCRIPTION
## Description

* Rearrange sysinfo debug for a better overview
* See if we can pull in the client version directly from the package.json to verify against the server version
* Adds information directly from the TemporaryFileConfiguration repository such as allowed/disallowed upload types and file max size
* Fixes a small UI issue where `#code-block` and `#codeblock` were used intermittently in the CSS

**Before:**
<img width="738" alt="image" src="https://github.com/user-attachments/assets/b518282e-5f1e-42f7-ab8a-5efa06fc325d" />


**After:**
<img width="695" alt="image" src="https://github.com/user-attachments/assets/16b00f18-4c01-4508-ba6a-77d1627de1b4" />

Example output:
```
Umbraco system information
--------------------------------
Server Troubleshooting: 
Server OS: Darwin 24.4.0 Darwin Kernel Version 24.4.0: Fri Apr 11 18:33:47 PDT 2025; root:xnu-11417.101.15~117/RELEASE_ARM64_T6000
Server Framework: .NET 9.0.2
Default Language: en-US
Umbraco Version: 16.1.0-rc.preview.21
Current Culture: en-US
Current UI Culture: en-US
Current Webserver: Kestrel
Models Builder Mode: InMemoryAuto
Runtime Mode: BackofficeDevelopment
Debug Mode: True
Database Provider: System.Data.SQLite
Current Server Role: Single

Server Information: 
Umbraco build version: 16.1.0-rc.preview.21+ceab77d
Umbraco assembly version: 16.1.0-rc.preview.21
Server time offset: 01:00:00
Runtime mode: BackofficeDevelopment

Client Information: 
Umbraco client version: 16.0.0-rc

Current user: 
User is admin: Yes
User sections: Umb.Section.Content, Umb.Section.Forms, Umb.Section.Media, Umb.Section.Members, Umb.Section.Packages, Umb.Section.Settings, Umb.Section.Translation, Umb.Section.Users
User culture: en-US
User languages: All
User document start nodes: 

Temporary file configuration: 
Max allowed file size: Not set (unlimited)
Allowed file types: 
Disallowed file types: ashx, aspx, ascx, config, cshtml, vbhtml, asmx, air, axd, xamlx, html
Image file types: png, apng, jpg, jpeg, jfif, gif, bm, bmp, dip, ppm, pbm, pgm, tga, vda, icb, vst, tiff, tif, webp, qoi

Browser Troubleshooting: 
Browser (user agent): Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36
Browser language: en-US
Browser location: http://localhost:5173/section/media/workspace/media/create/parent/media-root/null/4c52d8ab-54e6-40cd-999c-7a5f24903e4d/invariant/root
```
