### PR TITLE
Add explicit Global Search extension point

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/constants.ts
@@ -5,8 +5,10 @@ export * from './modals/constants.js';
 export * from './paths.js';
 export * from './reference/constants.js';
 export * from './repository/constants.js';
+export * from './search/constants.js';
 export * from './tree/constants.js';
 export * from './workspace/constants.js';
+
 export {
 	UMB_DATA_TYPE_ENTITY_TYPE,
 	UMB_DATA_TYPE_ROOT_ENTITY_TYPE,

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_DATA_TYPE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.DataType';

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_DATA_TYPE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.DataType';

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_DATA_TYPE_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.DataType';

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_DATA_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_DATA_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Data Type Global Search',
+		alias: UMB_DATA_TYPE_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 400,
+		meta: {
+			label: 'Data Types',
+			searchProviderAlias: UMB_DATA_TYPE_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
 import { UMB_DATA_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_DATA_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_SETTINGS_SECTION_ALIAS } from '@umbraco-cms/backoffice/settings';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Data Types',
 			searchProviderAlias: UMB_DATA_TYPE_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_SETTINGS_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/search/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DATA_TYPE_ENTITY_TYPE } from '../entity.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -17,4 +18,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'searchResultItem',
 		forEntityTypes: [UMB_DATA_TYPE_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_DICTIONARY_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.Dictionary';

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_DICTIONARY_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.Dictionary';

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
 import { UMB_DICTIONARY_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_DICTIONARY_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_TRANSLATION_SECTION_ALIAS } from '@umbraco-cms/backoffice/translation';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Dictionary',
 			searchProviderAlias: UMB_DICTIONARY_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_TRANSLATION_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_DICTIONARY_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_DICTIONARY_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Dictionary Global Search',
+		alias: UMB_DICTIONARY_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 600,
+		meta: {
+			label: 'Dictionary',
+			searchProviderAlias: UMB_DICTIONARY_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_DICTIONARY_ENTITY_TYPE } from '../entity.js';
 import { UMB_DICTIONARY_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -18,4 +19,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'searchResultItem',
 		forEntityTypes: [UMB_DICTIONARY_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.DocumentType';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_DOCUMENT_TYPE_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.DocumentType';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_DOCUMENT_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Document Type Global Search',
+		alias: UMB_DOCUMENT_TYPE_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 600,
+		meta: {
+			label: 'Document Types',
+			searchProviderAlias: UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
 import { UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_DOCUMENT_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_SETTINGS_SECTION_ALIAS } from '@umbraco-cms/backoffice/settings';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Document Types',
 			searchProviderAlias: UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_SETTINGS_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '../entity.js';
 import { UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -19,4 +20,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./document-type-search-result-item.element.js'),
 		forEntityTypes: [UMB_DOCUMENT_TYPE_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.Document';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_DOCUMENT_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.Document';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
 import { UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_DOCUMENT_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_CONTENT_SECTION_ALIAS } from '@umbraco-cms/backoffice/content';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Documents',
 			searchProviderAlias: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_CONTENT_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_DOCUMENT_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Document Global Search',
+		alias: UMB_DOCUMENT_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 800,
+		meta: {
+			label: 'Documents',
+			searchProvider: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 800,
 		meta: {
 			label: 'Documents',
-			searchProvider: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
+			searchProviderAlias: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_DOCUMENT_ENTITY_TYPE } from '../entity.js';
 import { UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -19,4 +20,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./document-search-result-item.element.js'),
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/constants.ts
@@ -5,6 +5,7 @@ export * from './property-type/constants.js';
 export * from './repository/constants.js';
 export * from './tree/constants.js';
 export * from './workspace/constants.js';
+export * from './search/constants.js';
 
 export {
 	UMB_MEDIA_TYPE_ENTITY_TYPE,

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.MediaType';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.MediaType';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_MEDIA_TYPE_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.MediaType';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
 import { UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_MEDIA_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_SETTINGS_SECTION_ALIAS } from '@umbraco-cms/backoffice/settings';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Media Types',
 			searchProviderAlias: UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_SETTINGS_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_MEDIA_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Media Type Global Search',
+		alias: UMB_MEDIA_TYPE_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 500,
+		meta: {
+			label: 'Media Types',
+			searchProviderAlias: UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/manifests.ts
@@ -1,9 +1,11 @@
 import { UMB_MEDIA_TYPE_ENTITY_TYPE } from '../entity.js';
+import { UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		name: 'Media Type Search Provider',
-		alias: 'Umb.SearchProvider.MediaType',
+		alias: UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS,
 		type: 'searchProvider',
 		api: () => import('./media-type.search-provider.js'),
 		weight: 500,
@@ -17,4 +19,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'searchResultItem',
 		forEntityTypes: [UMB_MEDIA_TYPE_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/constants.ts
@@ -3,6 +3,7 @@ export * from './entity-actions/constants.js';
 export * from './entity-bulk-actions/constants.js';
 export * from './menu/constants.js';
 export * from './modals/constants.js';
+export * from './paths.js';
 export * from './recycle-bin/constants.js';
 export * from './reference/constants.js';
 export * from './repository/constants.js';
@@ -10,7 +11,6 @@ export * from './search/constants.js';
 export * from './tree/constants.js';
 export * from './url/constants.js';
 export * from './workspace/constants.js';
-export * from './paths.js';
 
 export { UMB_MEDIA_VARIANT_CONTEXT } from './property-dataset-context/media-property-dataset-context.token.js';
 export {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_MEDIA_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.Media';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_MEDIA_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.Media';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 700,
 		meta: {
 			label: 'Media',
-			searchProvider: UMB_MEDIA_SEARCH_PROVIDER_ALIAS,
+			searchProviderAlias: UMB_MEDIA_SEARCH_PROVIDER_ALIAS,
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_MEDIA_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_MEDIA_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Media Global Search',
+		alias: UMB_MEDIA_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 700,
+		meta: {
+			label: 'Media',
+			searchProvider: UMB_MEDIA_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
+import { UMB_MEDIA_SECTION_ALIAS } from '../../../media-section/constants.js';
 import { UMB_MEDIA_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_MEDIA_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Media',
 			searchProviderAlias: UMB_MEDIA_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_MEDIA_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_MEDIA_ENTITY_TYPE } from '../entity.js';
 import { UMB_MEDIA_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -19,4 +20,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./media-search-result-item.element.js'),
 		forEntityTypes: [UMB_MEDIA_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/constants.ts
@@ -2,6 +2,7 @@ export * from './entity-actions/constants.js';
 export * from './paths.js';
 export * from './property-type/constants.js';
 export * from './repository/constants.js';
+export * from './search/constants.js';
 export * from './tree/constants.js';
 export * from './workspace/constants.js';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.MemberType';

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.MemberType';

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_MEMBER_TYPE_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.MemberType';

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
 import { UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_MEMBER_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_SETTINGS_SECTION_ALIAS } from '@umbraco-cms/backoffice/settings';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Member Types',
 			searchProviderAlias: UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_SETTINGS_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_MEMBER_TYPE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Member Type Global Search',
+		alias: UMB_MEMBER_TYPE_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 200,
+		meta: {
+			label: 'Member Types',
+			searchProviderAlias: UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/manifests.ts
@@ -1,9 +1,11 @@
 import { UMB_MEMBER_TYPE_ENTITY_TYPE } from '../entity.js';
+import { UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		name: 'Member Type Search Provider',
-		alias: 'Umb.SearchProvider.MemberType',
+		alias: UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS,
 		type: 'searchProvider',
 		api: () => import('./member-type.search-provider.js'),
 		weight: 200,
@@ -17,4 +19,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'searchResultItem',
 		forEntityTypes: [UMB_MEMBER_TYPE_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_MEMBER_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.Member';

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_MEMBER_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.Member';

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_MEMBER_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_MEMBER_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Member Global Search',
+		alias: UMB_MEMBER_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 300,
+		meta: {
+			label: 'Members',
+			searchProviderAlias: UMB_MEMBER_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
+import { UMB_MEMBER_MANAGEMENT_SECTION_ALIAS } from '../../../section/constants.js';
 import { UMB_MEMBER_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_MEMBER_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Members',
 			searchProviderAlias: UMB_MEMBER_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_MEMBER_MANAGEMENT_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/search/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_MEMBER_ENTITY_TYPE } from '../entity.js';
 import { UMB_MEMBER_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -18,4 +19,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'searchResultItem',
 		forEntityTypes: [UMB_MEMBER_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/search/global-search/global-search.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/search/global-search/global-search.extension.ts
@@ -10,7 +10,7 @@ export interface ManifestGlobalSearch
 
 export interface MetaGlobalSearch {
 	label: string;
-	searchProvider: string;
+	searchProviderAlias: string;
 }
 
 declare global {

--- a/src/Umbraco.Web.UI.Client/src/packages/search/global-search/global-search.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/search/global-search/global-search.extension.ts
@@ -1,0 +1,20 @@
+import type { UmbGlobalSearchApi } from './types.js';
+import type { ManifestWithDynamicConditions, ManifestApi } from '@umbraco-cms/backoffice/extension-api';
+
+export interface ManifestGlobalSearch
+	extends ManifestApi<UmbGlobalSearchApi>,
+		ManifestWithDynamicConditions<UmbExtensionConditionConfig> {
+	type: 'globalSearch';
+	meta: MetaGlobalSearch;
+}
+
+export interface MetaGlobalSearch {
+	label: string;
+	searchProvider: string;
+}
+
+declare global {
+	interface UmbExtensionManifestMap {
+		umbGlobalSearch: ManifestGlobalSearch;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/search/global-search/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/search/global-search/types.ts
@@ -1,0 +1,4 @@
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbGlobalSearchApi extends UmbApi {}

--- a/src/Umbraco.Web.UI.Client/src/packages/search/search-modal/search-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/search/search-modal/search-modal.element.ts
@@ -96,7 +96,7 @@ export class UmbSearchModalElement extends UmbLitElement {
 				const globalSearchApi = await createExtensionApi<UmbGlobalSearchApi>(this, controller.manifest);
 				const searchProviderApi = await createExtensionApiByAlias<UmbSearchProvider<UmbSearchResultItemModel>>(
 					this,
-					controller.manifest.meta?.searchProvider,
+					controller.manifest.meta?.searchProviderAlias,
 				);
 
 				const searcher: GlobalSearchers = {

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/constants.ts
@@ -1,3 +1,4 @@
 export * from './conditions/constants.js';
 export * from './repository/constants.js';
+export * from './search/constants.js';
 export * from './workspace/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.Template';

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/constants.ts
@@ -1,1 +1,2 @@
+export * from './global-search/constants.js';
 export const UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS = 'Umb.SearchProvider.Template';

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_TEMPLATE_GLOBAL_SEARCH_ALIAS = 'Umb.GlobalSearch.Template';

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/manifests.ts
@@ -1,0 +1,15 @@
+import { UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
+import { UMB_TEMPLATE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		name: 'Template Global Search',
+		alias: UMB_TEMPLATE_GLOBAL_SEARCH_ALIAS,
+		type: 'globalSearch',
+		weight: 200,
+		meta: {
+			label: 'Templates',
+			searchProviderAlias: UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS,
+		},
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/manifests.ts
@@ -1,5 +1,7 @@
 import { UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS } from '../constants.js';
 import { UMB_TEMPLATE_GLOBAL_SEARCH_ALIAS } from './constants.js';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_SETTINGS_SECTION_ALIAS } from '@umbraco-cms/backoffice/settings';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,5 +13,11 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Templates',
 			searchProviderAlias: UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS,
 		},
+		conditions: [
+			{
+				alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
+				match: UMB_SETTINGS_SECTION_ALIAS,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/manifests.ts
@@ -1,9 +1,11 @@
 import { UMB_TEMPLATE_ENTITY_TYPE } from '../entity.js';
+import { UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS } from './constants.js';
+import { manifests as globalSearchManifests } from './global-search/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		name: 'Template Search Provider',
-		alias: 'Umb.SearchProvider.Template',
+		alias: UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS,
 		type: 'searchProvider',
 		api: () => import('./template.search-provider.js'),
 		weight: 100,
@@ -17,4 +19,5 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'searchResultItem',
 		forEntityTypes: [UMB_TEMPLATE_ENTITY_TYPE],
 	},
+	...globalSearchManifests,
 ];


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/17998

Make an explicit extension point to add to the "Global Search" modal.

We currently list all "search providers" in the "Global Search" modal. We need to conditionally render some search options in global search while still making them available in all pickers.

With this new extension point, we can use the condition system on global search registrations.

**Breaking Change**

Search providers will no longer automatically appear in the "Global Search" modal. An additional registration is now required to add this. Manifest:

```ts
{
  name: 'Document Global Search',
  alias: UMB_DOCUMENT_GLOBAL_SEARCH_ALIAS,
  type: 'globalSearch',
  weight: 800,
  meta: {
    label: 'Documents',
    searchProviderAlias: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
  },
 conditions: [
    {
      alias: UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS,
      match: UMB_SETTINGS_SECTION_ALIAS,
    },
  ]
},
```