### PR TITLE
fix: check for NullRepresentationInCache in AppCacheExtensions

### DIFF
--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -7,8 +7,6 @@ namespace Umbraco.Extensions;
 /// </summary>
 public static class AppCacheExtensions
 {
-    public const string NullRepresentationInCache = "*NULL*";
-
     public static T? GetCacheItem<T>(
         this IAppPolicyCache provider,
         string cacheKey,
@@ -43,7 +41,7 @@ public static class AppCacheExtensions
     public static T? GetCacheItem<T>(this IAppCache provider, string cacheKey)
     {
         var result = provider.Get(cacheKey);
-        if (result is null or (object)NullRepresentationInCache)
+        if (IsRetrievedItemNull(result))
         {
             return default;
         }
@@ -54,13 +52,15 @@ public static class AppCacheExtensions
     public static T? GetCacheItem<T>(this IAppCache provider, string cacheKey, Func<T> getCacheItem)
     {
         var result = provider.Get(cacheKey, () => getCacheItem());
-        if (result is null or (object)NullRepresentationInCache)
+        if (IsRetrievedItemNull(result))
         {
             return default;
         }
 
         return result.TryConvertTo<T>().Result;
     }
+
+    private static bool IsRetrievedItemNull(object? result) => result is null or (object)Cms.Core.Constants.Cache.NullRepresentationInCache;
 
     public static async Task<T?> GetCacheItemAsync<T>(
         this IAppPolicyCache provider,

--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -7,6 +7,8 @@ namespace Umbraco.Extensions;
 /// </summary>
 public static class AppCacheExtensions
 {
+    public const string NullRepresentationInCache = "*NULL*";
+
     public static T? GetCacheItem<T>(
         this IAppPolicyCache provider,
         string cacheKey,
@@ -41,7 +43,7 @@ public static class AppCacheExtensions
     public static T? GetCacheItem<T>(this IAppCache provider, string cacheKey)
     {
         var result = provider.Get(cacheKey);
-        if (result == null)
+        if (result is null or (object)NullRepresentationInCache)
         {
             return default;
         }
@@ -52,7 +54,7 @@ public static class AppCacheExtensions
     public static T? GetCacheItem<T>(this IAppCache provider, string cacheKey, Func<T> getCacheItem)
     {
         var result = provider.Get(cacheKey, () => getCacheItem());
-        if (result == null)
+        if (result is null or (object)NullRepresentationInCache)
         {
             return default;
         }

--- a/src/Umbraco.Core/Constants-Cache.cs
+++ b/src/Umbraco.Core/Constants-Cache.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core;
+namespace Umbraco.Cms.Core;
 public static partial class Constants
 {
     public static class Cache
@@ -9,5 +9,13 @@ public static partial class Constants
 
             public const string Media = "media";
         }
+
+        /// <summary>
+        /// Defines the string used to represent a null value in the cache.
+        /// </summary>
+        /// <remarks>
+        /// Used in conjunction with the option to cache null values on the repository caches, so we
+        /// can distinguish a true null "not found" value and a cached null value.</remarks>
+        public const string NullRepresentationInCache = "*NULL*";
     }
 }

--- a/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
@@ -24,8 +24,6 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
     private static readonly TEntity[] _emptyEntities = new TEntity[0]; // const
     private readonly RepositoryCachePolicyOptions _options;
 
-    private const string NullRepresentationInCache = "*NULL*";
-
     public DefaultRepositoryCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, RepositoryCachePolicyOptions options)
         : base(cache, scopeAccessor) =>
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -142,7 +140,7 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
         // Because TEntity can never be a string, we will never be in a position where the proxy value collides withs a real value.
         // Therefore this point can only be reached if there is a proxy null value => becomes null when cast to TEntity above OR the item simply does not exist.
         // If we've cached a "null" value, return null.
-        if (_options.CacheNullValues && Cache.GetCacheItem<string>(cacheKey) == NullRepresentationInCache)
+        if (_options.CacheNullValues && Cache.GetCacheItem<string>(cacheKey) == AppCacheExtensions.NullRepresentationInCache)
         {
             return null;
         }
@@ -273,7 +271,7 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
         // a value that does exist but isn't yet cached, or a value that has been explicitly cached with a null value.
         // Both would return null when we retrieve from the cache and we couldn't distinguish between the two.
         // So we cache a special value that represents null, and then we can check for that value when we retrieve from the cache.
-        Cache.Insert(cacheKey, () => NullRepresentationInCache, TimeSpan.FromMinutes(5), true);
+        Cache.Insert(cacheKey, () => AppCacheExtensions.NullRepresentationInCache, TimeSpan.FromMinutes(5), true);
     }
 
     protected virtual void InsertEntities(TId[]? ids, TEntity[]? entities)

--- a/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
@@ -137,10 +137,8 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
             return fromCache;
         }
 
-        // Because TEntity can never be a string, we will never be in a position where the proxy value collides withs a real value.
-        // Therefore this point can only be reached if there is a proxy null value => becomes null when cast to TEntity above OR the item simply does not exist.
         // If we've cached a "null" value, return null.
-        if (_options.CacheNullValues && Cache.GetCacheItem<string>(cacheKey) == AppCacheExtensions.NullRepresentationInCache)
+        if (_options.CacheNullValues && Cache.GetCacheItem<string>(cacheKey) == Constants.Cache.NullRepresentationInCache)
         {
             return null;
         }
@@ -271,7 +269,7 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
         // a value that does exist but isn't yet cached, or a value that has been explicitly cached with a null value.
         // Both would return null when we retrieve from the cache and we couldn't distinguish between the two.
         // So we cache a special value that represents null, and then we can check for that value when we retrieve from the cache.
-        Cache.Insert(cacheKey, () => AppCacheExtensions.NullRepresentationInCache, TimeSpan.FromMinutes(5), true);
+        Cache.Insert(cacheKey, () => Constants.Cache.NullRepresentationInCache, TimeSpan.FromMinutes(5), true);
     }
 
     protected virtual void InsertEntities(TId[]? ids, TEntity[]? entities)


### PR DESCRIPTION
### Description

I have noticed the back-office being noticeably slow during development of some websites (V13). The console output is **flooded** with the following while navigating the CMS:

```
Exception thrown: 'System.InvalidCastException' in System.Private.CoreLib.dll
Exception thrown: 'System.InvalidCastException' in Umbraco.Core.dll
Exception thrown: 'System.InvalidCastException' in System.Private.CoreLib.dll
Exception thrown: 'System.InvalidCastException' in Umbraco.Core.dll
...(thousands of times)...
```

This PR updates `GetCacheItem` to check for `NullRepresentationInCache`. This prevents the above flood of exception handling and also improves performance. Umbraco was seemingly trying to cast the string `"*NULL*"` to `IDictionaryItem` thousands of times while doing basic operations such as opening a page in the CMS.

I moved `NullRepresentationInCache` to AppCacheExtensions.cs in this PR. I understand this may not be the best place for this constant.