### PR TITLE
Handle user id 0 (Unknown/System) when building content version response

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
@@ -19,17 +20,26 @@ internal sealed class DocumentVersionPresentationFactory : IDocumentVersionPrese
         _userIdKeyResolver = userIdKeyResolver;
     }
 
-    public async Task<DocumentVersionItemResponseModel> CreateAsync(ContentVersionMeta contentVersion) =>
-        new(
+    public async Task<DocumentVersionItemResponseModel> CreateAsync(ContentVersionMeta contentVersion)
+    {
+        ReferenceByIdModel userReference = contentVersion.UserId switch
+        {
+            Constants.Security.UnknownUserId => new ReferenceByIdModel(),
+            _ => new ReferenceByIdModel(await _userIdKeyResolver.GetAsync(contentVersion.UserId)),
+        };
+
+        return new DocumentVersionItemResponseModel(
             contentVersion.VersionId.ToGuid(), // this is a magic guid since versions do not have keys in the DB
             new ReferenceByIdModel(_entityService.GetKey(contentVersion.ContentId, UmbracoObjectTypes.Document).Result),
-            new ReferenceByIdModel(_entityService.GetKey(contentVersion.ContentTypeId, UmbracoObjectTypes.DocumentType)
-                .Result),
-            new ReferenceByIdModel(await _userIdKeyResolver.GetAsync(contentVersion.UserId)),
+            new ReferenceByIdModel(
+                _entityService.GetKey(contentVersion.ContentTypeId, UmbracoObjectTypes.DocumentType)
+                    .Result),
+            userReference,
             new DateTimeOffset(contentVersion.VersionDate),
             contentVersion.CurrentPublishedVersion,
             contentVersion.CurrentDraftVersion,
             contentVersion.PreventCleanup);
+    }
 
     public async Task<IEnumerable<DocumentVersionItemResponseModel>> CreateMultipleAsync(IEnumerable<ContentVersionMeta> contentVersions)
         => await CreateMultipleImplAsync(contentVersions).ToArrayAsync();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This relates to issue #17149, as it was also being caused by having entries with user id 0.

### Description
Details regarding the initial issue and how to test can be found in PR #19263.
In this case, instead of just opening the info tab, you will need to open the Rollback section.

The following code can be used to perform a publish with user id 0.
```cs
[Route("api/test")]
public class TestController : ControllerBase
{
    private readonly IContentService _contentService;

    public TestController(IContentService contentService)
    {
        _contentService = contentService;
    }

    [HttpGet("")]
    public IActionResult Get()
    {
        // Replace the GUID with the id of the content you created to test
        IContent content = _contentService.GetById(Guid.Parse("efd8a078-14d8-47f7-b22c-52d34944b6b0")) ?? throw new InvalidOperationException();
        _contentService.Save(content, 0);
        _contentService.Publish(content, ["*"], 0);

        return Ok();
    }
}

```

**Before the fix**

![Recording 2025-05-19 at 15 27 03](https://github.com/user-attachments/assets/540a8fc2-917e-4513-92f5-70e808610a46)

**After the fix**

![Recording 2025-05-19 at 15 23 56](https://github.com/user-attachments/assets/b4b31356-533c-461e-a7ba-660b6840eca7)
