### PR TITLE
Fix for invalid state in JsonBlockValueConverter when an unused layout has a nested array

### DIFF
--- a/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
@@ -189,9 +189,31 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
                 else
                 {
                     // ignore this layout - forward the reader to the end of the array and look for the next one
-                    while (reader.TokenType is not JsonTokenType.EndArray)
+
+                    // Read past the current StartArray token before we start counting
+                    reader.Read();
+
+                    var openCount = 0;
+                    while (true)
                     {
-                        reader.Read();
+                        if (reader.TokenType is JsonTokenType.EndArray && openCount == 0)
+                        {
+                            break;
+                        }
+
+                        if (reader.TokenType is JsonTokenType.StartArray)
+                        {
+                            openCount++;
+                        }
+                        else if (reader.TokenType is JsonTokenType.EndArray)
+                        {
+                            openCount--;
+                        }
+
+                        if(!reader.Read())
+                        {
+                            throw new JsonException($"Unexpected end of JSON while looking for the end of the layout items array for block editor alias: {blockEditorAlias}.");
+                        }
                     }
                 }
             }

--- a/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
@@ -209,6 +209,10 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
                         else if (reader.TokenType is JsonTokenType.EndArray)
                         {
                             openCount--;
+                            if (openCount < 0)
+                            {
+                                throw new JsonException($"Malformed JSON: Encountered more closing array tokens than opening ones while processing block editor alias: {blockEditorAlias}.");
+                            }
                         }
 
                         if (!reader.Read())

--- a/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
@@ -191,8 +191,9 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
                     // ignore this layout - forward the reader to the end of the array and look for the next one
 
                     // Read past the current StartArray token before we start counting
-                    reader.Read();
+                    _ = reader.Read();
 
+                    // Keep track of the number of open arrays to ensure we find the correct EndArray token
                     var openCount = 0;
                     while (true)
                     {
@@ -210,7 +211,7 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
                             openCount--;
                         }
 
-                        if(!reader.Read())
+                        if (!reader.Read())
                         {
                             throw new JsonException($"Unexpected end of JSON while looking for the end of the layout items array for block editor alias: {blockEditorAlias}.");
                         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
@@ -441,4 +441,33 @@ public class JsonBlockValueConverterTests
             Assert.AreEqual(settingsElementKey1, layoutItems.First().SettingsKey);
         });
     }
+
+    [Test]
+    public void Try_Deserialize_Unknown_Block_Layout_With_Nested_Array()
+    {
+        var json = """
+        {
+            "layout": {
+                "Umbraco.BlockGrid": [{
+                        "contentUdi": "umb://element/1304E1DDAC87439684FE8A399231CB3D",
+                        "rowSpan": 1,
+                        "areas": [],
+                        "columnSpan": 12
+                    }
+                ],
+                "Umbraco.BlockList": [{
+                        "contentUdi": "umb://element/1304E1DDAC87439684FE8A399231CB3D"
+                    }
+                ],
+                "Some.Custom.BlockEditor": [{
+                        "contentUdi": "umb://element/1304E1DDAC87439684FE8A399231CB3D"
+                    }
+                ]
+            }
+        }
+""";
+
+        var serializer = new SystemTextJsonSerializer();
+        Assert.DoesNotThrow(() => serializer.Deserialize<BlockListValue>(json));
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #19332

### Description

When JsonBlockValueConverter.cs encounters an unsupported block alias and its children contains an array the reader will end up in an invalid position to continue reading due to reading to the next `JsonTokenType.EndArray` even if it ends on a nested array.

Not sure how to recreate this by hand since we encountered it with existing content during an upgrade from Umbraco 13 to 15.