### PR TITLE
Fixed check for navigation to list after delete of member.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/member/member.delete.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/member/member.delete.controller.js
@@ -19,7 +19,7 @@ function MemberDeleteController($scope, memberResource, treeService, navigationS
             treeService.removeNode($scope.currentNode);
 
             //if the current edited item is the same one as we're deleting, we need to navigate elsewhere
-            if (editorState.current && editorState.current.key == $scope.currentNode.id) {
+            if (editorState.current && editorState.current.key.replace(/-/g, "") == $scope.currentNode.id) {
                 $location.path("/member/member/list/" + ($routeParams.listName ? $routeParams.listName : 'all-members'));
             }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19330

### Description
This PR corrects the check in place to see if we have deleted the member we are currently viewing in order to navigate to the list.

### Testing
Create and delete a member via the actions drop-down and confirm that you are returned to the list of members.

### Release
Can be cherry-picked into `release/13.9` for release in 13.9.
