### PR TITLE
Validation Context destroys self destroy before clean up

### DIFF
--- a/src/Umbraco.Web.UI.Client/examples/validation-context/validation-context-dashboard.ts
+++ b/src/Umbraco.Web.UI.Client/examples/validation-context/validation-context-dashboard.ts
@@ -45,21 +45,21 @@ export class UmbExampleValidationContextDashboardElement extends UmbLitElement {
 				},
 				'observeValidationMessages',
 			);
+		});
 
-			// Observe all errors
-			this.validation.messages.messagesOfPathAndDescendant('$.form').subscribe((value) => {
-				this.totalErrorCount = [...new Set(value.map((x) => x.path))].length;
-			});
+		// Observe all errors
+		this.observe(this.validation.messages.messagesOfPathAndDescendant('$.form'), (value) => {
+			this.totalErrorCount = [...new Set(value.map((x) => x.path))].length;
+		});
 
-			// Observe errors for tab1, note that we only use part of the full JSONPath
-			this.validation.messages.messagesOfPathAndDescendant('$.form.tab1').subscribe((value) => {
-				this.tab1ErrorCount = [...new Set(value.map((x) => x.path))].length;
-			});
+		// Observe errors for tab1, note that we only use part of the full JSONPath
+		this.observe(this.validation.messages.messagesOfPathAndDescendant('$.form.tab1'), (value) => {
+			this.tab1ErrorCount = [...new Set(value.map((x) => x.path))].length;
+		});
 
-			// Observe errors for tab2, note that we only use part of the full JSONPath
-			this.validation.messages.messagesOfPathAndDescendant('$.form.tab2').subscribe((value) => {
-				this.tab2ErrorCount = [...new Set(value.map((x) => x.path))].length;
-			});
+		// Observe errors for tab2, note that we only use part of the full JSONPath
+		this.observe(this.validation.messages.messagesOfPathAndDescendant('$.form.tab2'), (value) => {
+			this.tab2ErrorCount = [...new Set(value.map((x) => x.path))].length;
 		});
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/libs/context-api/consume/context-consumer.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/context-api/consume/context-consumer.ts
@@ -219,8 +219,7 @@ export class UmbContextConsumer<
 			this.#raf = undefined;
 		}
 
-		this.#instance = undefined;
-		this.#callback?.(undefined);
+		this.#unprovide();
 		if (this.#promiseRejecter) {
 			const hostElement = this._retrieveHost();
 			this.#promiseRejecter(

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -454,6 +454,7 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 	}
 
 	override destroy(): void {
+		super.destroy();
 		this.#validationMode = false;
 		if (this.#inUnprovidingState === true) {
 			return;
@@ -468,6 +469,5 @@ export class UmbValidationController extends UmbControllerBase implements UmbVal
 		this.#localMessages = undefined;
 		this.#parentMessages = undefined;
 		this.#parent = undefined;
-		super.destroy();
 	}
 }

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithMultiURLPicker.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithMultiURLPicker.spec.ts
@@ -39,7 +39,7 @@ test('can create content with the document link', {tag: '@smoke'}, async ({umbra
   await umbracoUi.content.clickAddMultiURLPickerButton();
   await umbracoUi.content.clickDocumentLinkButton();
   await umbracoUi.content.selectLinkByName(linkedDocumentName);
-  await umbracoUi.content.clickButtonWithName('Choose');
+  await umbracoUi.content.clickChooseModalButton();
   await umbracoUi.content.clickAddButton();
   await umbracoUi.content.clickSaveButton();
 
@@ -87,7 +87,7 @@ test('can publish content with the document link', async ({umbracoApi, umbracoUi
   await umbracoUi.content.clickSaveAndPublishButton();
 
   // Assert
-  //await umbracoUi.content.doesSuccessNotificationsHaveCount(2);  
+  //await umbracoUi.content.doesSuccessNotificationsHaveCount(2);
   await umbracoUi.content.isErrorNotificationVisible(false);
   expect(await umbracoApi.document.doesNameExist(contentName)).toBeTruthy();
   const contentData = await umbracoApi.document.getByName(contentName);


### PR DESCRIPTION
Fix example and make sure super.destroy is handled first. And only trigger the callback with undefined once.