### PR TITLE
Fix issue not display hidden tab name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
@@ -130,9 +130,9 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 							${this._hasRootGroups && this._tabs.length > 0
 								? html`
 										<uui-tab
-											.label=${this.localize.term('general_generic')}
+											label=${this.localize.term('general_generic')}
 											.active=${this._routerPath + '/root' === this._activePath}
-											.href=${this._routerPath + '/root'}></uui-tab>
+											href=${this._routerPath + '/root'}></uui-tab>
 									`
 								: ''}
 							${repeat(
@@ -141,9 +141,9 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 								(tab) => {
 									const path = this._routerPath + '/tab/' + encodeFolderName(tab.name || '');
 									return html`<uui-tab
-										.label=${this.localize.string(tab.name ?? '#general_unnamed')}
+										label=${this.localize.string(tab.name ?? '#general_unnamed')}
 										.active=${path === this._activePath}
-										.href=${path}></uui-tab>`;
+										href=${path}></uui-tab>`;
 								},
 							)}
 						</uui-tab-group>`


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

This PR fixes this https://github.com/umbraco/Umbraco-CMS/issues/19282
There are 2 bugs fixed here, which are showing the names of hidden tabs in the dropdown when the width is too long, and their href links working when clicked