### PR TITLE
Sort available composition folders

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/modals/composition-picker/composition-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/modals/composition-picker/composition-picker-modal.element.ts
@@ -111,7 +111,7 @@ export class UmbCompositionPickerModalElement extends UmbModalBaseElement<
 
 		if (!data) return;
 
-		const folders = Array.from(new Set(data.map((c) => '/' + c.folderPath.join('/'))));
+		const folders = Array.from(new Set(data.map((c) => '/' + c.folderPath.join('/')))).sort();
 		this._compatibleCompositions = folders.map((path) => ({
 			path,
 			compositions: data.filter((c) => '/' + c.folderPath.join('/') === path),


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #19327 

### Description
The API returns the list of available compositions for a certain content type, ordered alphabetically, but individually (not grouped by folder). The grouping is done in the FE, by doing a distinct on the folder "path", and then getting all the compositions relating to that path.
As such, the folders were ordered by the placement in which they first appeared in the non-grouped results, which was not relevant.
As a fix, I added a `.sort()` to the folders.
This element is shared by content types, media types and member types.

#### Testing
1. Create a structure of document types and folders (not ordered alphabetically).
Example:
  ![image](https://github.com/user-attachments/assets/4949d867-6fc5-41e8-a020-accf901d93aa)
2. Create a new document type and open the Compositions modal

**Before the fix**
![image](https://github.com/user-attachments/assets/9841930c-1750-4c44-8eb5-2b902592ce56)

**After the fix**
![image](https://github.com/user-attachments/assets/ab1b31dd-99e7-4c30-a6bb-77c74509bc4a)