### PR TITLE
additional context name for 'content property context' 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/index.ts
@@ -1,1 +1,3 @@
 export * from './property-type-based-property.element.js';
+export * from './property-type-based-property.context-token.js';
+export * from './property-type-based-property.context.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.context-token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.context-token.ts
@@ -1,0 +1,14 @@
+import type { UmbPropertyTypeBasedPropertyContext } from './property-type-based-property.context.js';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+
+export const UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT = new UmbContextToken<UmbPropertyTypeBasedPropertyContext>(
+	'UmbPropertyTypeBasedPropertyContext',
+);
+
+/**
+ * @deprecated Use `UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT` instead.
+ * This will be removed in v.18
+ */
+export const UMB_CONTENT_PROPERTY_CONTEXT = new UmbContextToken<UmbPropertyTypeBasedPropertyContext>(
+	'UmbContentPropertyContext',
+);

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.context.ts
@@ -1,18 +1,24 @@
-import { UMB_CONTENT_PROPERTY_CONTEXT } from './content-property.context-token.js';
+import { UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT } from './property-type-based-property.context-token.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbPropertyTypeModel } from '@umbraco-cms/backoffice/content-type';
 
-export class UmbContentPropertyContext extends UmbContextBase {
+export class UmbPropertyTypeBasedPropertyContext extends UmbContextBase {
 	#dataType = new UmbObjectState<UmbPropertyTypeModel['dataType'] | undefined>(undefined);
 	dataType = this.#dataType.asObservable();
 
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_CONTENT_PROPERTY_CONTEXT);
+		super(host, UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT);
 	}
 
 	setDataType(dataType: UmbPropertyTypeModel['dataType'] | undefined) {
 		this.#dataType.setValue(dataType);
 	}
 }
+
+/**
+ * @deprecated Use `UmbPropertyTypeBasedPropertyContext` instead.
+ * This will be removed in v.18
+ */
+export { UmbPropertyTypeBasedPropertyContext as UmbContentPropertyContext };

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.element.ts
@@ -1,4 +1,4 @@
-import { UmbContentPropertyContext } from '../../content-property.context.js';
+import { UmbPropertyTypeBasedPropertyContext } from './property-type-based-property.context.js';
 import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
 import { css, customElement, html, ifDefined, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbDataTypeDetailRepository } from '@umbraco-cms/backoffice/data-type';
@@ -57,17 +57,18 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 	private _isUnsupported?: boolean;
 
 	@state()
-	private _dataTypeData?: UmbPropertyEditorConfig;
+	private _dataTypeValues?: UmbPropertyEditorConfig;
 
 	private _dataTypeDetailRepository = new UmbDataTypeDetailRepository(this);
 	private _dataTypeObserver?: UmbObserverController<UmbDataTypeDetailModel | undefined>;
 
-	#contentPropertyContext = new UmbContentPropertyContext(this);
+	#context = new UmbPropertyTypeBasedPropertyContext(this);
 
 	private async _checkSchemaSupport() {
 		if (!this._ownerEntityType || !this._propertyEditorSchemaAlias) return;
 
 		if (this._ownerEntityType in UMB_UNSUPPORTED_EDITOR_SCHEMA_ALIASES) {
+			// TODO: We should get rid of this system, f your reading this please dont rely on this, we will get rid of it in the future. [NL]
 			this._isUnsupported = UMB_UNSUPPORTED_EDITOR_SCHEMA_ALIASES[this._ownerEntityType].includes(
 				this._propertyEditorSchemaAlias,
 			);
@@ -83,9 +84,9 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 				await this._dataTypeDetailRepository.byUnique(dataTypeUnique),
 				(dataType) => {
 					const contextValue = dataType ? { unique: dataType.unique } : undefined;
-					this.#contentPropertyContext.setDataType(contextValue);
+					this.#context.setDataType(contextValue);
 
-					this._dataTypeData = dataType?.values;
+					this._dataTypeValues = dataType?.values;
 					this._propertyEditorUiAlias = dataType?.editorUiAlias || undefined;
 					this._propertyEditorSchemaAlias = dataType?.editorAlias || undefined;
 					this._checkSchemaSupport();
@@ -127,7 +128,7 @@ export class UmbPropertyTypeBasedPropertyElement extends UmbLitElement {
 				.description=${this._property.description ?? undefined}
 				.appearance=${this._property.appearance}
 				property-editor-ui-alias=${ifDefined(this._propertyEditorUiAlias)}
-				.config=${this._dataTypeData}
+				.config=${this._dataTypeValues}
 				.validation=${this._property.validation}
 				?readonly=${this.readonly}>
 			</umb-property>

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/content-property.context-token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/content-property.context-token.ts
@@ -1,4 +1,0 @@
-import type { UmbContentPropertyContext } from './content-property.context.js';
-import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
-
-export const UMB_CONTENT_PROPERTY_CONTEXT = new UmbContextToken<UmbContentPropertyContext>('UmbContentPropertyContext');

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/index.ts
@@ -1,6 +1,3 @@
-export { UMB_CONTENT_PROPERTY_CONTEXT } from './content-property.context-token.js';
-export { UmbContentPropertyContext } from './content-property.context.js';
-
 export * from './collection/index.js';
 export * from './components/index.js';
 export * from './constants.js';


### PR DESCRIPTION
Providing 'content property context' under the name 'property type based property context'. keeping the old and marked that as deprecated, with removal in v.18.