### PR TITLE
Fix issue with requests to delivery API by path where URL segment contains special characters

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Services/RoutingServiceBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RoutingServiceBase.cs
@@ -36,7 +36,7 @@ internal abstract class RoutingServiceBase
     }
 
     protected static string GetContentRoute(DomainAndUri domainAndUri, Uri contentRoute)
-        => $"{domainAndUri.ContentId}{DomainUtilities.PathRelativeToDomain(domainAndUri.Uri, contentRoute.AbsolutePath)}";
+        => $"{domainAndUri.ContentId}{DomainUtilities.PathRelativeToDomain(domainAndUri.Uri, contentRoute.LocalPath)}"; // Use LocalPath over AbsolutePath to keep the path decoded.
 
     protected DomainAndUri? GetDomainAndUriForRoute(Uri contentUrl)
     {

--- a/src/Umbraco.Cms.Api.Delivery/Umbraco.Cms.Api.Delivery.csproj
+++ b/src/Umbraco.Cms.Api.Delivery/Umbraco.Cms.Api.Delivery.csproj
@@ -14,6 +14,9 @@
       <_Parameter1>Umbraco.Tests.UnitTests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Umbraco.Tests.Integration</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/RequestRoutingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/RequestRoutingServiceTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Delivery.Services;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.DeliveryApi;
+
+[TestFixture]
+[UmbracoTest(
+    Database = UmbracoTestOptions.Database.NewSchemaPerFixture,
+    WithApplication = true)]
+public class RequestRoutingServiceTests : UmbracoIntegrationTest
+{
+    private IRequestRoutingService RequestRoutingService => GetRequiredService<IRequestRoutingService>();
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.Services.AddUnique<IRequestRoutingService, RequestRoutingService>();
+
+        var elementCache = new FastDictionaryAppCache();
+        var snapshotCache = new FastDictionaryAppCache();
+
+        var domainCacheMock = new Mock<IDomainCache>();
+        domainCacheMock.Setup(x => x.GetAll(It.IsAny<bool>()))
+            .Returns(
+            [
+                new Domain(1, "localhost/en", 1000, "en-us", false, 0),
+                new Domain(2, "localhost/jp", 1000, "ja-jp", false, 1),
+            ]);
+        var publishedSnapshotMock = new Mock<IPublishedSnapshot>();
+        publishedSnapshotMock.SetupGet(p => p.ElementsCache).Returns(elementCache);
+        publishedSnapshotMock.SetupGet(p => p.SnapshotCache).Returns(snapshotCache);
+        publishedSnapshotMock.SetupGet(p => p.Domains).Returns(domainCacheMock.Object);
+
+        var publishedSnapshot = publishedSnapshotMock.Object;
+        var publishedSnapshotAccessor = new Mock<IPublishedSnapshotAccessor>();
+        publishedSnapshotAccessor.Setup(p => p.TryGetPublishedSnapshot(out publishedSnapshot)).Returns(true);
+        builder.Services.AddSingleton(provider => publishedSnapshotAccessor.Object);
+    }
+
+    [TestCase(null, "")]
+    [TestCase("", "")]
+    [TestCase("/", "/")]
+    [TestCase("/en/test/", "1000/test/")]       // Verifies matching a domain.
+    [TestCase("/da/test/", "/da/test/")]        // Verifies that with no matching domain, so route will be returned as is.
+    [TestCase("/jp/オフィス/", "1000/オフィス/")] // Verifies that with a URL segment containing special characters, the route remains decoded.
+    public void GetContentRoute_ReturnsExpectedRoute(string? requestedRoute, string expectedResult)
+    {
+        if (!string.IsNullOrEmpty(requestedRoute))
+        {
+            var httpContextAccessor = GetRequiredService<IHttpContextAccessor>();
+
+            httpContextAccessor.HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("localhost"),
+                    Path = requestedRoute,
+                },
+            };
+        }
+
+        var result = RequestRoutingService.GetContentRoute(requestedRoute);
+        Assert.AreEqual(expectedResult, result);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/18982

### Description
The linked issue presents an example where the delivery API isn't able to route by path due to the path containing special characters.  The issue seems to be related to the conversion of the requested route as a string to a `Uri`, and then using the `AbsolutePath` property.  This encodes the values which then doesn't match with the cached URL segment and routing fails.  Using `LocalPath` retains the decoded values.

### Testing
Replicate the scenario provided in the linked issue (there's a uSync export that can be imported to setup - I had a bit of trouble when trying to do so solely from the description).  I've done this though, so you may consider it's not necessary to repeat, particularly given some integration tests are provided, one of which covers this case and failed before the update in this PR.

### Release
Once approved this can be merged and made available in 13.9 or 13.10.  It then needs merging/re-applying for 16.
