### PR TITLE
Removes unnecessary newlines from rich text as JSON delivery API output

### DIFF
--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -1,13 +1,10 @@
 using HtmlAgilityPack;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.PublishedCache;
-using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Infrastructure.Extensions;
 using Umbraco.Extensions;
 
@@ -103,7 +100,7 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
         // - non-empty #text nodes
         // - empty #text between inline elements (see #17037) but not #text with only newlines (see #19388)
         HtmlNode[] childNodes = element.ChildNodes
-            .Where(c => c.Name != CommentNodeName && (c.Name != TextNodeName || (c.NextSibling is not null && c.PreviousSibling is not null) || IsNonEmptyElement(c)))
+            .Where(c => c.Name != CommentNodeName && (c.Name != TextNodeName || IsNonEmptyElement(c)))
             .ToArray();
 
         var tag = TagName(element);

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -1,4 +1,4 @@
-﻿using HtmlAgilityPack;
+using HtmlAgilityPack;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
@@ -101,9 +101,9 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
         // - non-#comment nodes
         // - non-#text nodes
         // - non-empty #text nodes
-        // - empty #text between inline elements (see #17037)
+        // - empty #text between inline elements (see #17037) but not #text with only newlines (see #19388)
         HtmlNode[] childNodes = element.ChildNodes
-            .Where(c => c.Name != CommentNodeName && (c.Name != TextNodeName || c.NextSibling is not null || string.IsNullOrWhiteSpace(c.InnerText) is false))
+            .Where(c => c.Name != CommentNodeName && (c.Name != TextNodeName || (c.NextSibling is not null && c.PreviousSibling is not null) || IsNonEmptyElement(c)))
             .ToArray();
 
         var tag = TagName(element);
@@ -123,6 +123,9 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
 
         return createElement(tag, attributes, childElements);
     }
+
+    private static bool IsNonEmptyElement(HtmlNode htmlNode) =>
+        string.IsNullOrWhiteSpace(htmlNode.InnerText) is false || htmlNode.InnerText.Any(c => c != '\n' && c != '\r');
 
     private string TagName(HtmlNode htmlNode) => htmlNode.Name;
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
@@ -372,12 +372,18 @@ public class RichTextParserTests : PropertyValueConverterTests
         AssertTestParagraph(paragraphElement);
     }
 
-    [Test]
-    public void ParseElement_RemovesNewLinesAroundHtmlElements()
+    [TestCase(1, "\n")]
+    [TestCase(2, "\n")]
+    [TestCase(1, "\r")]
+    [TestCase(2, "\r")]
+    [TestCase(1, "\r\n")]
+    [TestCase(2, "\r\n")]
+    public void ParseElement_RemovesNewLinesAroundHtmlStructuralElements(int numberOfNewLineCharacters, string newlineCharacter)
     {
         var parser = CreateRichTextElementParser();
 
-        var element = parser.Parse($"<table>\n<tr>\n<td>{TestParagraph}</td>\n</tr>\n</table>") as RichTextRootElement;
+        var newLineSeparator = string.Concat(Enumerable.Repeat(newlineCharacter, numberOfNewLineCharacters));
+        var element = parser.Parse($"<table>{newLineSeparator}<tr>{newLineSeparator}<td>{TestParagraph}</td>{newLineSeparator}</tr>{newLineSeparator}</table>") as RichTextRootElement;
         Assert.IsNotNull(element);
         var tableElement = element.Elements.Single() as RichTextGenericElement;
         Assert.IsNotNull(tableElement);
@@ -389,6 +395,29 @@ public class RichTextParserTests : PropertyValueConverterTests
         Assert.IsNotNull(cellElement);
 
         AssertTestParagraph(cellElement);
+    }
+
+    [TestCase(1, "\n")]
+    [TestCase(2, "\n")]
+    [TestCase(1, "\r")]
+    [TestCase(2, "\r")]
+    [TestCase(1, "\r\n")]
+    [TestCase(2, "\r\n")]
+    public void ParseElement_RemovesNewLinesAroundHtmlContentElements(int numberOfNewLineCharacters, string newlineCharacter)
+    {
+        var parser = CreateRichTextElementParser();
+
+        var newLineSeparator = string.Concat(Enumerable.Repeat(newlineCharacter, numberOfNewLineCharacters));
+        var element = parser.Parse($"<div><p>{TestParagraph}</p>{newLineSeparator}<p></p>{newLineSeparator}<p>&nbsp;</p>{newLineSeparator}<p>{TestParagraph}</p></div>") as RichTextRootElement;
+        Assert.IsNotNull(element);
+        var divElement = element.Elements.Single() as RichTextGenericElement;
+        Assert.IsNotNull(divElement);
+
+        var paragraphELements = divElement.Elements;
+        Assert.AreEqual(4, paragraphELements.Count());
+
+        AssertTestParagraph(paragraphELements.First() as RichTextGenericElement);
+        AssertTestParagraph(paragraphELements.Last() as RichTextGenericElement);
     }
 
     private static void AssertTestParagraph(RichTextGenericElement paragraphElement)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19388

### Description
This PR removes unnecessary newlines between HTML elements in the JSON output for rich text in the delivery API, retaining the spaces between inline elements applied via https://github.com/umbraco/Umbraco-CMS/pull/17983.

### Testing
Add mark-up to a rich text editor with line breaks.

Verify the output when requesting an the content item with the rich text property that unnecessary line breaks are removed, but spaces are retained between inline elements.  See the unit tests for samples.

The delivery API needs to be enabled with the following configuration:

```
  "DeliveryApi": {
    "Enabled": true,
    "RichTextOutputAsJson": true,
```