### PR TITLE
References correct starter kit version for Umbraco 16

### DIFF
--- a/templates/UmbracoProject/.template.config/starterkits.template.json
+++ b/templates/UmbracoProject/.template.config/starterkits.template.json
@@ -34,7 +34,7 @@
         "cases": [
           {
             "condition": "(StarterKit == 'Umbraco.TheStarterKit' && (UmbracoRelease == 'Latest' || UmbracoRelease == 'Custom'))",
-            "value": "14.0.0"
+            "value": "16.0.0-rc"
           },
           {
             "condition": "(StarterKit == 'Umbraco.TheStarterKit' && UmbracoRelease == 'LTS')",

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "16.0.0-rc4",
+  "version": "16.0.0-rc4", // TODO: When bumping this to 16.0.0, also remove the -rc suffix in the starterkits.template.json file. The starter kit final version for 16 will be released at the same time as the CMS.
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19389

### Description
This PR updates the starter kit reference to align with Umbraco 16 and adds a `TODO` to remember to remove the RC suffix with 16 final is prepared.

### Testing
See linked issue.
