### PR TITLE
Do not set icon color if the item is selected

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
@@ -71,7 +71,7 @@ export abstract class UmbTreeItemElementBase<
 	private _isSelectable = false;
 
 	@state()
-	private _isSelected = false;
+	protected _isSelected = false;
 
 	@state()
 	private _hasChildren = false;
@@ -168,7 +168,7 @@ export abstract class UmbTreeItemElementBase<
 		const iconWithoutColor = icon?.split(' ')[0];
 
 		if (icon && iconWithoutColor) {
-			return html`<umb-icon slot="icon" name="${this._isActive ? iconWithoutColor : icon}"></umb-icon>`;
+			return html`<umb-icon slot="icon" name="${this._isActive || this._isSelected ? iconWithoutColor : icon}"></umb-icon>`;
 		}
 
 		if (isFolder) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
@@ -43,7 +43,7 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<
 			<span id="icon-container" slot="icon" class=${classMap({ draft: this._isDraft })}>
 				${icon && iconWithoutColor
 					? html`
-							<umb-icon id="icon" slot="icon" name="${this._isActive ? iconWithoutColor : icon}"></umb-icon>
+							<umb-icon id="icon" slot="icon" name="${this._isActive || this._isSelected ? iconWithoutColor : icon}"></umb-icon>
 							${this.#renderStateIcon()}
 						`
 					: nothing}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/tree-item/media-tree-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/tree-item/media-tree-item.element.ts
@@ -14,7 +14,7 @@ export class UmbMediaTreeItemElement extends UmbTreeItemElementBase<UmbMediaTree
 			<span id="icon-container" slot="icon">
 				${icon && iconWithoutColor
 					? html`
-							<umb-icon id="icon" slot="icon" name="${this._isActive ? iconWithoutColor : icon}"></umb-icon>
+							<umb-icon id="icon" slot="icon" name="${this._isActive || this._isSelected ? iconWithoutColor : icon}"></umb-icon>
 							${this.#renderStateIcon()}
 						`
 					: nothing}


### PR DESCRIPTION
If there's an existing issue for this PR then this fixes #19400 

This is an addition to PR #17703, so the same behavior happens for the selected state.
This can be tested using the document picker, multi url picker or by selecting "Allowed child node types" in document or media types.