### PR TITLE
hotfix: correct dark theme color for variant selector

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -596,8 +596,8 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 			}
 
 			.switch-button:hover {
-				background: var(--uui-palette-sand);
-				color: var(--uui-palette-space-cadet-light);
+				background: var(--uui-color-surface-emphasis);
+				color: var(--uui-color-interactive-emphasis);
 			}
 			.switch-button .variant-info {
 				flex-grow: 1;


### PR DESCRIPTION
fix the variant selector so hover uses themes colors (previously it was white in white, so not readable)

![image](https://github.com/user-attachments/assets/3571bf17-7c58-4192-a30b-c377ee693628)
