### PR TITLE
Route Redirect fixes

### DIFF
--- a/src/Umbraco.Web.UI.Client/examples/modal-routed/dashboard.element.ts
+++ b/src/Umbraco.Web.UI.Client/examples/modal-routed/dashboard.element.ts
@@ -17,6 +17,7 @@ export class UmbDashboardElement extends UmbElementMixin(LitElement) {
 		},
 		{
 			path: '',
+			pathMatch: 'full',
 			redirectTo: 'tab1',
 		},
 	];

--- a/src/Umbraco.Web.UI.Client/examples/modal-routed/modal/example-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/examples/modal-routed/modal/example-modal.element.ts
@@ -17,6 +17,7 @@ export class UmbExampleModal extends UmbModalBaseElement {
 		},
 		{
 			path: '',
+			pathMatch: 'full',
 			redirectTo: 'modalOverview',
 		},
 	];

--- a/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-main.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-main.element.ts
@@ -65,6 +65,7 @@ export class UmbBackofficeMainElement extends UmbLitElement {
 			newRoutes.push({
 				path: '',
 				pathMatch: 'full',
+				awaitStability: true,
 				redirectTo: newRoutes[0].path,
 			});
 

--- a/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-main.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-main.element.ts
@@ -63,8 +63,9 @@ export class UmbBackofficeMainElement extends UmbLitElement {
 
 		if (newRoutes.length > 0) {
 			newRoutes.push({
+				path: '',
+				pathMatch: 'full',
 				redirectTo: newRoutes[0].path,
-				path: ``,
 			});
 
 			newRoutes.push({

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit.element.ts
@@ -123,6 +123,7 @@ export class UmbBlockWorkspaceViewEditElement extends UmbLitElement implements U
 			if (!this._hasRootGroups) {
 				routes.push({
 					path: '',
+					pathMatch: 'full',
 					redirectTo: routes[0]?.path,
 				});
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -205,12 +205,14 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			});
 			routes.push({
 				path: '',
+				pathMatch: 'full',
 				redirectTo: 'root',
 				guards: [() => this.#processingTabId === undefined],
 			});
 		} else {
 			routes.push({
 				path: '',
+				pathMatch: 'full',
 				redirectTo: routes[0]?.path,
 				guards: [() => this.#processingTabId === undefined],
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
@@ -109,6 +109,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 		if (routes.length !== 0) {
 			routes.push({
 				path: '',
+				pathMatch: 'full',
 				redirectTo: routes[0].path,
 			});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/router-slot/model.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/router-slot/model.ts
@@ -75,6 +75,9 @@ export interface IRedirectRoute<D = any> extends IRouteBase<D> {
 	// The paths the route should redirect to. Can either be relative or absolute.
 	redirectTo: string;
 
+	// First redirect when the routes appears stable. Delaying the redirect so other routes get the change to resolve first.
+	awaitStability?: boolean;
+
 	// Whether the query should be preserved when redirecting.
 	preserveQuery?: boolean;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
@@ -79,6 +79,7 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 			// Using first single view as the default route for now (hence the math below):
 			routes.push({
 				path: '',
+				pathMatch: 'full',
 				redirectTo: routes[variants.length * variants.length]?.path,
 			});
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/dashboard/media-dashboard.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/dashboard/media-dashboard.element.ts
@@ -53,6 +53,7 @@ export class UmbMediaDashboardElement extends UmbLitElement {
 					},
 					{
 						path: '',
+						pathMatch: 'full',
 						redirectTo: 'collection',
 					},
 					{

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
@@ -79,6 +79,7 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 			// Using first single view as the default route for now (hence the math below):
 			routes.push({
 				path: '',
+				pathMatch: 'full',
 				redirectTo: routes[variants.length * variants.length]?.path,
 			});
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace-editor.element.ts
@@ -81,6 +81,7 @@ export class UmbMemberWorkspaceEditorElement extends UmbLitElement {
 			// Using first single view as the default route for now (hence the math below):
 			routes.push({
 				path: '',
+				pathMatch: 'full',
 				redirectTo: routes[options.length * options.length]?.path,
 			});
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/created-packages-section-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/created-packages-section-view.element.ts
@@ -54,6 +54,7 @@ export class UmbCreatedPackagesSectionViewElement extends UmbLitElement implemen
 
 		routes.push({
 			path: '',
+			pathMatch: 'full',
 			redirectTo: 'overview',
 		});
 		routes.push({


### PR DESCRIPTION
The cases described here fixes an issue that only appeared on an actual server. these can be seen on a local server by running with `disabled cache` and a network throttling like this:
![image](https://github.com/user-attachments/assets/7fccf34f-0404-4e3a-82b1-f5b0c83ad1cc)

This fixes two things:
A.
Fixes so a deep link does not just redirect to the root of a section, typically `section/settings` — this is resolved by using pathMatch 'full', a feature of the router slot we have not utilized previously.

B. 
Fixes so the initial empty path load does not go to section/settings, just because it loaded slightly before the content section. This is done by introducing a feature that makes redirects await a delay, the delay will be reset everytime a new route appears, making it able to extend the time as long as routes are getting registered within the given delay. And then the delay is calculated based on the browsers assumption on the internet speed. That's a guess but better than none.