### PR TITLE
Fix observe property string name

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor-property.element.ts
@@ -33,7 +33,7 @@ export class UmbContentWorkspaceViewEditPropertyElement extends UmbLitElement {
 
 	override willUpdate(changedProperties: Map<string, any>) {
 		super.willUpdate(changedProperties);
-		if (changedProperties.has('type') || changedProperties.has('variantId') || changedProperties.has('_context')) {
+		if (changedProperties.has('property') || changedProperties.has('variantId') || changedProperties.has('_context')) {
 			if (this.variantId && this.property && this._context) {
 				const propertyVariantId = new UmbVariantId(
 					this.property.variesByCulture ? this.variantId.culture : null,


### PR DESCRIPTION
There was a naming mistake here, which does not affect anything currently, but should be corrected — cause I think that is just a coincidence.

(This code is new for 16)