### PR TITLE
Fixed issue with syntax highlighting in code editor.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
@@ -38,7 +38,8 @@ export class UmbPropertyEditorUICodeEditorElement extends UmbLitElement implemen
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
 
-		this._language = config?.getValueByAlias<CodeEditorLanguage>('language') ?? this.#defaultLanguage;
+		const configuredLanguage = config?.getValueByAlias<CodeEditorLanguage>('language') ?? this.#defaultLanguage;
+		this._language = Array.isArray(configuredLanguage) ? configuredLanguage[0] : configuredLanguage;
 		this._height = Number(config?.getValueByAlias('height')) || 400;
 		this._lineNumbers = config?.getValueByAlias('lineNumbers') ?? false;
 		this._minimap = config?.getValueByAlias('minimap') ?? false;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19387

### Description
This PR handles the fact that we as use a drop-down list for selection of the language, we have an array rather than the single value we need.  See the linked issue for the diagnosis of this.

### Testing
- Create a property on a document using the code editor and configure a language.
- Verify that in use the appropriate syntax highlighting is show. 