### PR TITLE
V16-RC: Workspaces do not have correct path in distributed package.json file

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/publish/cleanse-pkg.js
+++ b/src/Umbraco.Web.UI.Client/devops/publish/cleanse-pkg.js
@@ -12,5 +12,11 @@ delete packageJson.devDependencies;
 packageJson.peerDependencies = { ...packageJson.dependencies };
 delete packageJson.dependencies;
 
+// Update workspaces path
+packageJson.workspaces = packageJson.workspaces.map((workspace) => {
+	// Rename the 'src/' prefix to 'dist-cms/' from each workspace path
+	return workspace.replace('./src', './dist-cms');
+});
+
 // Write the package.json back to disk
 writeFileSync(packageFile, JSON.stringify(packageJson, null, 2), 'utf8');


### PR DESCRIPTION
## Description

This renames `./src` to `./dist-cms` in the distributed package.json file so that consumers can install all peer dependencies.

Fixes #19407