### PR TITLE
Throw if attempting to use the default unique media path scheme with version 7 GUIDs

### DIFF
--- a/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
@@ -20,7 +20,7 @@ public class UniqueMediaPathScheme : IMediaPathScheme
         // We should detect that, throw, and recommend creation of standard GUIDs or the use of a custom IMediaPathScheme instead.
         if (itemGuid.Version == 7 || propertyGuid.Version == 7)
         {
-            throw new InvalidOperationException(
+            throw new ArgumentException(
                 "The UniqueMediaPathScheme cannot be used with version 7 GUIDs due to an increased risk of collisions in the generated file paths. " +
                 "Please use version 4 GUIDs created via Guid.NewGuid() or implement and register a different IMediaPathScheme.");
         }

--- a/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
+++ b/src/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathScheme.cs
@@ -13,6 +13,18 @@ public class UniqueMediaPathScheme : IMediaPathScheme
     /// <inheritdoc />
     public string GetFilePath(MediaFileManager fileManager, Guid itemGuid, Guid propertyGuid, string filename)
     {
+        // Shortening of the Guid to 8 chars risks collisions with GUIDs, which are expected to be very rare.
+        // However with GUID 7, the chance is much higher, as those created in a short period of time could have
+        // the same first 8 characters.
+        // Such GUIDs would have been created via Guid.CreateVersion7() rather than Guid.NewGuid().
+        // We should detect that, throw, and recommend creation of standard GUIDs or the use of a custom IMediaPathScheme instead.
+        if (itemGuid.Version == 7 || propertyGuid.Version == 7)
+        {
+            throw new InvalidOperationException(
+                "The UniqueMediaPathScheme cannot be used with version 7 GUIDs due to an increased risk of collisions in the generated file paths. " +
+                "Please use version 4 GUIDs created via Guid.NewGuid() or implement and register a different IMediaPathScheme.");
+        }
+
         Guid combinedGuid = GuidUtils.Combine(itemGuid, propertyGuid);
         var directory = GuidUtils.ToBase32String(combinedGuid, DirectoryLength);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathSchemeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathSchemeTests.cs
@@ -10,7 +10,12 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.IO.MediaPathSchemes;
 [TestFixture]
 public class UniqueMediaPathSchemeTests
 {
-    public static MediaFileManager MediaFileManager => new MediaFileManager(Mock.Of<IFileSystem>(), Mock.Of<IMediaPathScheme>(), Mock.Of<ILogger<MediaFileManager>>(), Mock.Of<IShortStringHelper>(), Mock.Of<IServiceProvider>());
+    private static MediaFileManager MediaFileManager => new(
+        Mock.Of<IFileSystem>(),
+        Mock.Of<IMediaPathScheme>(),
+        Mock.Of<ILogger<MediaFileManager>>(),
+        Mock.Of<IShortStringHelper>(),
+        Mock.Of<IServiceProvider>());
 
     [Test]
     public void GetFilePath_Creates_ExpectedPath()
@@ -29,8 +34,8 @@ public class UniqueMediaPathSchemeTests
     public void GetFilePath_ShouldThrow_WhenUsingVersion7Guids(bool userVersion7ForItemGuid, bool userVersion7ForPropertyGuid)
     {
         var scheme = new UniqueMediaPathScheme();
-        var itemGuid = new Guid("00000000-0000-7000-0000-000000000001");
-        var propertyGuid = new Guid("00000000-0000-4000-0000-000000000002");
+        var itemGuid = new Guid($"00000000-0000-{(userVersion7ForItemGuid ? "7" : "4")}000-0000-000000000001");
+        var propertyGuid = new Guid($"00000000-0000-{(userVersion7ForPropertyGuid ? "7" : "4")}000-0000-000000000002");
         var filename = "test.txt";
 
         Assert.Throws<ArgumentException>(() => scheme.GetFilePath(MediaFileManager, itemGuid, propertyGuid, filename));

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathSchemeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathSchemeTests.cs
@@ -1,11 +1,17 @@
+using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.IO.MediaPathSchemes;
+using Umbraco.Cms.Core.Strings;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.IO.MediaPathSchemes;
 
 [TestFixture]
 public class UniqueMediaPathSchemeTests
 {
+    public static MediaFileManager MediaFileManager => new MediaFileManager(Mock.Of<IFileSystem>(), Mock.Of<IMediaPathScheme>(), Mock.Of<ILogger<MediaFileManager>>(), Mock.Of<IShortStringHelper>(), Mock.Of<IServiceProvider>());
+
     [Test]
     public void GetFilePath_Creates_ExpectedPath()
     {
@@ -13,18 +19,20 @@ public class UniqueMediaPathSchemeTests
         var itemGuid = new Guid("00000000-0000-4000-0000-000000000001");
         var propertyGuid = new Guid("00000000-0000-4000-0000-000000000002");
         var filename = "test.txt";
-        string actualPath = scheme.GetFilePath(null, itemGuid, propertyGuid, filename);
+        string actualPath = scheme.GetFilePath(MediaFileManager, itemGuid, propertyGuid, filename);
         Assert.AreEqual("aaaaaaaa/test.txt", actualPath);
     }
 
-    [Test]
-    public void GetFilePath_ShouldThrow_WhenUsingVersion7Guids()
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(true, true)]
+    public void GetFilePath_ShouldThrow_WhenUsingVersion7Guids(bool userVersion7ForItemGuid, bool userVersion7ForPropertyGuid)
     {
         var scheme = new UniqueMediaPathScheme();
         var itemGuid = new Guid("00000000-0000-7000-0000-000000000001");
         var propertyGuid = new Guid("00000000-0000-4000-0000-000000000002");
         var filename = "test.txt";
 
-        Assert.Throws<InvalidOperationException>(() => scheme.GetFilePath(null, itemGuid, propertyGuid, filename));
+        Assert.Throws<ArgumentException>(() => scheme.GetFilePath(MediaFileManager, itemGuid, propertyGuid, filename));
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathSchemeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/MediaPathSchemes/UniqueMediaPathSchemeTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core.IO.MediaPathSchemes;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.IO.MediaPathSchemes;
+
+[TestFixture]
+public class UniqueMediaPathSchemeTests
+{
+    [Test]
+    public void GetFilePath_Creates_ExpectedPath()
+    {
+        var scheme = new UniqueMediaPathScheme();
+        var itemGuid = new Guid("00000000-0000-4000-0000-000000000001");
+        var propertyGuid = new Guid("00000000-0000-4000-0000-000000000002");
+        var filename = "test.txt";
+        string actualPath = scheme.GetFilePath(null, itemGuid, propertyGuid, filename);
+        Assert.AreEqual("aaaaaaaa/test.txt", actualPath);
+    }
+
+    [Test]
+    public void GetFilePath_ShouldThrow_WhenUsingVersion7Guids()
+    {
+        var scheme = new UniqueMediaPathScheme();
+        var itemGuid = new Guid("00000000-0000-7000-0000-000000000001");
+        var propertyGuid = new Guid("00000000-0000-4000-0000-000000000002");
+        var filename = "test.txt";
+
+        Assert.Throws<InvalidOperationException>(() => scheme.GetFilePath(null, itemGuid, propertyGuid, filename));
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19377

### Description
The linked issue raises the concern that it's possible to create overlapping media file paths with certain pairs of unique GUIDs.  This is known, but the historical consideration has been that the chance is very low and it's better not to chase 100% uniqueness at the cost of very long folder paths.  It's always possible to register a custom `IMediaPathScheme` - either the `TwoGuidsMediaPathScheme` we ship with or a custom implementation as provided in the linked issue.

What's new is version 7 of GUIDs, that contain timestamps, and as such if raised in very quick succession could have the same first eight characters and hence generate colliding paths.  Umbraco doesn't use these, so there's no problem with backoffice operations.  But programatically someone could generate media in quick succession and choose to use `Guid.CreateVersion7()` to do so.

As such this PR will throw on use of version 7 GUIDs to indicate the problem and advise use of either version 4 GUIDs (created from `Guid.NewGuid()`), or a custom `IMediaPathScheme`.

It's not possible to change the implementation of `UniqueMediaPathScheme` in a non-breaking way for existing installations that have already created media, so that seems the best we can do here.

### Testing
Visual inspection and verification that media can be created.
