### PR TITLE
V16-RC: Not all types are exported from 'documents'

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/types.ts
@@ -17,6 +17,7 @@ export type * from './modals/types.js';
 export type * from './publishing/types.js';
 export type * from './recycle-bin/types.js';
 export type * from './tree/types.js';
+export type * from './url/types.js';
 export type * from './user-permissions/types.js';
 export type * from './workspace/types.js';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/index.ts
@@ -1,4 +1,5 @@
 export { UmbDocumentUrlRepository, UMB_DOCUMENT_URL_REPOSITORY_ALIAS } from './repository/index.js';
 
+export * from './repository/index.js';
 export * from './constants.js';
 export * from './document-urls-data-resolver.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/types.ts
@@ -1,0 +1,1 @@
+export type * from './repository/types.js';


### PR DESCRIPTION
## Description

Exports new types from documents/documents/url

Fixes #19413