### PR TITLE
Lock appropriate tree for media operations

### DIFF
--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -418,7 +418,7 @@ namespace Umbraco.Cms.Core.Services
             }
 
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
-            scope.ReadLock(Constants.Locks.ContentTree);
+            scope.ReadLock(Constants.Locks.MediaTree);
             return _mediaRepository.GetPage(Query<IMedia>()?.Where(x => x.ContentTypeId == contentTypeId), pageIndex, pageSize, out totalRecords, filter, ordering);
         }
 
@@ -441,7 +441,7 @@ namespace Umbraco.Cms.Core.Services
             }
 
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
-            scope.ReadLock(Constants.Locks.ContentTree);
+            scope.ReadLock(Constants.Locks.MediaTree);
             return _mediaRepository.GetPage(
                 Query<IMedia>()?.Where(x => contentTypeIds.Contains(x.ContentTypeId)), pageIndex, pageSize, out totalRecords, filter, ordering);
         }


### PR DESCRIPTION
The MediaService currently locks the ContentTree for GetPagedOfType(s) operations, but it's querying the MediaTree. This ensures we lock the correct tree.
