### PR TITLE
Models builder generates different types for color picker value

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/ColorPickerValueConverter.cs
@@ -22,34 +22,29 @@ public class ColorPickerValueConverter : PropertyValueConverterBase
         => propertyType.EditorAlias.InvariantEquals(Constants.PropertyEditors.Aliases.ColorPicker);
 
     public override Type GetPropertyValueType(IPublishedPropertyType propertyType)
-        => UseLabel(propertyType) ? typeof(PickedColor) : typeof(string);
+        => typeof(PickedColor);
 
     public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
         => PropertyCacheLevel.Element;
 
     public override object? ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, object? source, bool preview)
     {
-        var useLabel = UseLabel(propertyType);
-
         if (source is null)
         {
-            return useLabel ? null : string.Empty;
+            return null;
         }
 
         var value = source.ToString()!;
         if (value.DetectIsJson())
         {
             PickedColor? convertedValue = _jsonSerializer.Deserialize<PickedColor>(value);
-            return useLabel ? convertedValue : convertedValue?.Color;
+            return convertedValue;
         }
-
-        // This seems to be something old old where it may not be json at all.
-        if (useLabel)
+        else
         {
+            // This seems to be something old old where it may not be json at all.
             return new PickedColor(value, value);
         }
-
-        return value;
     }
 
     private bool UseLabel(IPublishedPropertyType propertyType) => ConfigurationEditor


### PR DESCRIPTION
### Prerequisites

You find the steps for testing the PR in https://github.com/umbraco/Umbraco-CMS/issues/19341

The data type setting of "Include labels?" the returnd model is always of type `PickedColor`
![color-picker-datatype-setting](https://github.com/user-attachments/assets/29dbfeae-da72-40b5-af8f-bca7ecd2685d)

```
///<summary>
/// Color with Label
///</summary>
[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "17.0.0--rc.preview.3+135f0f6")]
[global::System.Diagnostics.CodeAnalysis.MaybeNull]
[ImplementPropertyType("colorWithLabel")]
public virtual global::Umbraco.Cms.Core.PropertyEditors.ValueConverters.ColorPickerValueConverter.PickedColor ColorWithLabel => this.Value<global::Umbraco.Cms.Core.PropertyEditors.ValueConverters.ColorPickerValueConverter.PickedColor>(_publishedValueFallback, "colorWithLabel");

///<summary>
/// Color without Label
///</summary>
[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "17.0.0--rc.preview.3+135f0f6")]
[global::System.Diagnostics.CodeAnalysis.MaybeNull]
[ImplementPropertyType("colorWithoutLabel")]
public virtual global::Umbraco.Cms.Core.PropertyEditors.ValueConverters.ColorPickerValueConverter.PickedColor ColorWithoutLabel => this.Value<global::Umbraco.Cms.Core.PropertyEditors.ValueConverters.ColorPickerValueConverter.PickedColor>(_publishedValueFallback, "colorWithoutLabel");
```

![ColorPicker](https://github.com/user-attachments/assets/b46f258c-0066-4e4f-9efb-94c4d6b33486)

You can use the following template for frontend:
```html
@using Umbraco.Cms.Web.Common.PublishedModels;
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Web.Common.PublishedModels.ColorPicker>
@{
	Layout = null;
    var colorWithLabel = Model?.ColorWithLabel?.Color ?? "#000000"; // Default to black if no color is set
    //var colorWithoutLabel = Model?.ColorWithoutLabel ?? "#000000";
    var colorWithoutLabel = Model?.ColorWithoutLabel?.Color ?? "#000000"; // Default to black if no color is set
}
<html>
    <head>
    <title>Color Picker Example</title>
    <style>
        body {
            font-family: Arial, sans-serif;
            margin: 20px;
            background-color: #aaa;
        }
        p {
            font-size: 16px;
        }
    </style>
</head>
<body>
    <p style="color: @colorWithLabel">
        colorWithLabel: @colorWithLabel
        </p>
    <p style="color: @colorWithoutLabel">
        colorWithoutLabel: @colorWithoutLabel
        </p>
    <p>
        <a href="/umbraco" target="_blank">backoffice</a>
    </p>
</body>
</html>
```