### PR TITLE
Resolved exception thrown from NuCache locking mechanism on near-simultaneous content publish requests

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
+++ b/src/Umbraco.PublishedCache.NuCache/ContentStore.cs
@@ -408,16 +408,7 @@ public class ContentStore
         {
             if (lockInfo.Taken)
             {
-                if (_writeLock.CurrentCount == 0)
-                {
-                    _writeLock.Release();
-                }
-                else
-                {
-                    _logger.LogWarning(
-                        "On releasing the content store lock the current count was found unexpectedly to be non-zero with a value of {CurrentCount}.",
-                        _writeLock.CurrentCount);
-                }
+                _writeLock.Release();
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19338

### Description
The linked issue reports a regression after https://github.com/umbraco/Umbraco-CMS/pull/17246, which was introduced to avoid locking exceptions in asynchronous code.

It seems that after this, near-simultaneous requests to save and publish content results in one or more of the requests failing due to NuCache being unable to acquire a lock (the `SemaphoneSlim` that's it's based on not being released from the previous operation).  You would then find the content created and published, but the failed ones wouldn't be in the cache, which is manifested in the backoffice by the message of "published but not in the cache" shown where the URLs are displayed on the "Info" panel.

To resolve I've removed the "fast-fail" check we had before waiting for the `SemaphoneSlim`, and allowed the wait to pick up the lock when released from the previous operation.

Some advice from @ronaldbarendse:

> The recursive lock check was probably added as a defence to fail-fast, because a `Monitor` is shared on the current thread and could therefore take more than 1 write lock. However, I don't believe the `SemaphoreSlim` is susceptible to the same problem.

### Testing
The original issue can be replicated as shown in the linked issue from the browser console when logged into the backoffice.

You should find with this PR in place multiple requests to create, save and publish content will succeed.