### PR TITLE
Bugfixes/v17/19341 description update models builder generates different types for color picker value

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -1218,10 +1218,10 @@ export default {
 	},
 	colorPickerConfigurations: {
 		colorsTitle: 'Farver',
-		colorsDescription: 'Tilføj, fjern eller sorter farver',
+		colorsDescription: 'Tilføj, fjern eller sorter farver (og etiketter).',
 		showLabelTitle: 'Inkluder label?',
 		showLabelDescription:
-			'Gemmer farver som et Json-objekt, der både indeholder farvens hex streng og label, i stedet for kun at gemme hex strengen.',
+			'Viser et farvet felt og en etiket for hver farve i farvevælgeren i stedet for blot et farvet felt.',
 	},
 	contentPicker: {
 		allowedItemTypes: 'Du kan kun vælge følgende type(r) dokumenter: %0%',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -30,10 +30,10 @@ export default {
 		noColors: 'You have not configured any approved colors',
 	},
 	colorPickerConfigurations: {
-		colorsDescription: 'Add, remove or sort colors',
+		colorsDescription: 'Add, remove or sort colors (and labels).',
 		colorsTitle: 'Colors',
 		showLabelDescription:
-			'Stores colors as a JSON object containing both the color hex string and label, rather than just the hex string.',
+			'Displays colored field and a label for each color in the color picker, rather than just a colored field.',
 	},
 	create: {
 		folderDescription: 'Used to organize items and other folders. Keep items structured and easy to access.',
@@ -51,7 +51,7 @@ export default {
 		databaseNotFound:
 			'<p>Database not found! Please check that the information in the "connection string" of the "web.config" file is correct.</p><p>To proceed, please edit the "web.config" file (using Visual Studio or your favorite text editor), scroll to the bottom, add the connection string for your database in the key named "UmbracoDbDSN" and save the file.</p><p>Click the <strong>retry</strong> button when done.<br /><a href="https://our.umbraco.com/documentation/Reference/Config/webconfig/" target="_blank" rel="noopener">More information on editing web.config here</a>.</p>',
 		showLabelDescription:
-			'Stores colors as a JSON object containing both the color hex string and label, rather than just the hex string.',
+			'Displays colored field and a label for each color in the color picker, rather than just a colored field.',
 	},
 	openidErrors: {
 		unauthorizedClient: 'Unauthorized client',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1271,10 +1271,10 @@ export default {
 	},
 	colorPickerConfigurations: {
 		colorsTitle: 'Colours',
-		colorsDescription: 'Add, remove or sort colours',
+		colorsDescription: 'Add, remove or sort colours (and labels).',
 		showLabelTitle: 'Include labels?',
 		showLabelDescription:
-			'Stores colours as a JSON object containing both the colour hex string and label, rather than just the hex string.',
+			'Displays coloured field and a label for each colour in the colour picker, rather than just a coloured field.',
 	},
 	contentPicker: {
 		allowedItemTypes: 'You can only select items of type(s): %0%',


### PR DESCRIPTION
### Prerequisites
PR #19430 changes the behaviour of the Colour Picker data type. This PR changes the descriptions oft the data type settings accordingly in languages: en, en-US and da

I have decided to propose these changes in a second PR. Thus you can decide independently about the technical and the textual changes.

### Description
**English (UK)**:
![color-picker-datatype-setting-description](https://github.com/user-attachments/assets/885cffb2-c712-4d56-b51a-e848348b5874)

**English (US)**:
```
colorPickerConfigurations: {
	colorsDescription: 'Add, remove or sort colors', <!-- previous value -->
	colorsDescription: 'Add, remove or sort colors (and labels).',
	colorsTitle: 'Colors',
	showLabelDescription:
		'Stores colors as a JSON object containing both the color hex string and label, rather than just the hex string.', <!-- previous value -->
		'Displays colored field and a label for each color in the color picker, rather than just a colored field.',
},
```

**Danish**:
```
colorPickerConfigurations: {
	colorsTitle: 'Farver',
	colorsDescription: 'Tilføj, fjern eller sorter farver', <!-- previous value -->
	colorsDescription: 'Tilføj, fjern eller sorter farver (og etiketter).',
	showLabelTitle: 'Inkluder label?',
	showLabelDescription:
		'Gemmer farver som et Json-objekt, der både indeholder farvens hex streng og label, i stedet for kun at gemme hex strengen.', <!-- previous value -->
		'Viser et farvet felt og en etiket for hver farve i farvevælgeren i stedet for blot et farvet felt.',
},
```