### PR TITLE
Ensure tag operations are case insensitive on insert across database types

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -248,13 +248,13 @@ WHERE r.tagId IS NULL";
     {
         public bool Equals(ITag? x, ITag? y) =>
             ReferenceEquals(x, y) // takes care of both being null
-            || (x != null && y != null && x.Text == y.Text && x.Group == y.Group && x.LanguageId == y.LanguageId);
+            || (x != null && y != null && x.Text.ToLowerInvariant() == y.Text.ToLowerInvariant() && x.Group == y.Group && x.LanguageId == y.LanguageId);
 
         public int GetHashCode(ITag obj)
         {
             unchecked
             {
-                var h = obj.Text.GetHashCode();
+                var h = obj.Text.ToLowerInvariant().GetHashCode();
                 h = (h * 397) ^ obj.Group.GetHashCode();
                 h = (h * 397) ^ (obj.LanguageId?.GetHashCode() ?? 0);
                 return h;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -128,10 +128,13 @@ internal class TagRepository : EntityRepositoryBase<int, ITag>, ITagRepository
         var group = SqlSyntax.GetQuotedColumnName("group");
 
         // insert tags
+        // - Note we are checking in the subquery for the existence of the tag, so we don't insert duplicates, using a case-insensitive comparison (the
+        //   LOWER keyword is consistent across SQLite and SQLServer). This ensures consistent behavior across databases as by default, SQLServer will
+        //   perform a case-insensitive comparison, while SQLite will not.
         var sql1 = $@"INSERT INTO cmsTags (tag, {group}, languageId)
 SELECT tagSet.tag, tagSet.{group}, tagSet.languageId
 FROM {tagSetSql}
-LEFT OUTER JOIN cmsTags ON (tagSet.tag = cmsTags.tag AND tagSet.{group} = cmsTags.{group} AND COALESCE(tagSet.languageId, -1) = COALESCE(cmsTags.languageId, -1))
+LEFT OUTER JOIN cmsTags ON (LOWER(tagSet.tag) = LOWER(cmsTags.tag) AND tagSet.{group} = cmsTags.{group} AND COALESCE(tagSet.languageId, -1) = COALESCE(cmsTags.languageId, -1))
 WHERE cmsTags.id IS NULL";
 
         Database.Execute(sql1);
@@ -142,7 +145,7 @@ SELECT {contentId}, {propertyTypeId}, tagSet2.Id
 FROM (
     SELECT t.Id
     FROM {tagSetSql}
-    INNER JOIN cmsTags as t ON (tagSet.tag = t.tag AND tagSet.{group} = t.{group} AND COALESCE(tagSet.languageId, -1) = COALESCE(t.languageId, -1))
+    INNER JOIN cmsTags as t ON (LOWER(tagSet.tag) = LOWER(t.tag) AND tagSet.{group} = t.{group} AND COALESCE(tagSet.languageId, -1) = COALESCE(t.languageId, -1))
 ) AS tagSet2
 LEFT OUTER JOIN cmsTagRelationship r ON (tagSet2.id = r.tagId AND r.nodeId = {contentId} AND r.propertyTypeID = {propertyTypeId})
 WHERE r.tagId IS NULL";

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
@@ -1066,7 +1065,8 @@ public class TagRepositoryTest : UmbracoIntegrationTest
             DocumentRepository.Save(content2);
 
             var repository = CreateRepository(provider);
-            Tag[] tags1 = { new() { Text = "tag1", Group = "test" } };
+            // Note two tags are applied, but they differ only in case.
+            Tag[] tags1 = { new() { Text = "tag1", Group = "test" }, new() { Text = "Tag1", Group = "test" } };
             repository.Assign(
                 content1.Id,
                 contentType.PropertyTypes.First().Id,


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/13981

### Description
This PR provides an update from https://github.com/umbraco/Umbraco-CMS/pull/14012, which was reverted, and addresses the issues identified in that.

Also fixes an issue where if the same tag is provided twice in a property, differing only by case, it would cause an exception on SQLite.

The integration test added would fail on SQLite (but not LocalDb) before the changes applied in `TagRepository`.  After the changes it passes with both database types.

### Testing
For manual testing enter the same tag twice with different casing (you may find you can only do this via the UI within a single property, as the UI will "correct" the casing for tags is already knows about).  You should find only one tag written to the `cmsTags` table when using both SQLite and SQL Server.
