### PR TITLE
V16/hotfix/input with alias and input range style problems

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
@@ -16,7 +16,7 @@ import type {
 	UmbBlockEditorCustomViewProperties,
 } from '@umbraco-cms/backoffice/block-custom-view';
 import type { UmbExtensionElementInitializer } from '@umbraco-cms/backoffice/extension-api';
-import { UUIBlinkAnimationValue } from '@umbraco-cms/backoffice/external/uui';
+import { UUIBlinkAnimationValue, UUIBlinkKeyframes } from '@umbraco-cms/backoffice/external/uui';
 import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UMB_CLIPBOARD_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/clipboard';
 
@@ -481,6 +481,7 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 	}
 
 	static override styles = [
+		UUIBlinkKeyframes,
 		css`
 			:host {
 				position: relative;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.element.ts
@@ -47,7 +47,21 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 	}
 
 	@property({ type: Object })
-	validationRange?: UmbNumberRangeValueType;
+	private _validationRange?: UmbNumberRangeValueType | undefined;
+	public get validationRange(): UmbNumberRangeValueType | undefined {
+		return this._validationRange;
+	}
+	public set validationRange(value: UmbNumberRangeValueType | undefined) {
+		this._validationRange = value;
+		this._minPlaceholder = value?.min !== undefined ? String(value?.min) : '';
+		this._maxPlaceholder = value?.max !== undefined && value.max !== Infinity ? String(value.max) : '∞';
+	}
+
+	@state()
+	private _minPlaceholder: string = '';
+
+	@state()
+	private _maxPlaceholder: string = '';
 
 	private updateValue() {
 		const newValue =
@@ -114,7 +128,7 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 				label=${this.minLabel}
 				min=${ifDefined(this.validationRange?.min)}
 				max=${ifDefined(this.validationRange?.max)}
-				placeholder=${this.validationRange?.min ?? ''}
+				placeholder=${this._minPlaceholder}
 				.value=${this._minValue}
 				@input=${this.#onMinInput}></uui-input>
 			<b>–</b>
@@ -123,13 +137,20 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 				label=${this.maxLabel}
 				min=${ifDefined(this.validationRange?.min)}
 				max=${ifDefined(this.validationRange?.max)}
-				placeholder=${this.validationRange?.max ?? '∞'}
+				placeholder=${this._maxPlaceholder}
 				.value=${this._maxValue}
 				@input=${this.#onMaxInput}></uui-input>
 		`;
 	}
 
 	static override styles = css`
+		:host {
+			display: flex;
+			align-items: center;
+		}
+		b {
+			margin: 0 var(--uui-size-space-1);
+		}
 		:host(:invalid:not([pristine])) {
 			color: var(--uui-color-invalid);
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -138,8 +138,6 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 		}
 
 		#alias {
-			max-width: 50%;
-
 			&.muted {
 				opacity: 0.55;
 				padding: var(--uui-size-1, 3px) var(--uui-size-space-3, 9px);


### PR DESCRIPTION
Fixes input with alias and number range style issue:

But reliease on a new RC of UI Library before the result is as desired:

![image](https://github.com/user-attachments/assets/7704b715-0046-40fa-808a-df12933760dc)

![image](https://github.com/user-attachments/assets/b3a8547d-5356-47d9-8d9a-bdc107d8b513)
