### PR TITLE
Removed encoding of request to retrieve files and folders by path, to avoid double encoding via the typed client

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/repository/sources/log-viewer.server.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/repository/sources/log-viewer.server.data.ts
@@ -146,7 +146,15 @@ export class UmbLogMessagesServerDataSource implements LogMessagesDataSource {
 		return await tryExecute(
 			this.#host,
 			LogViewerService.getLogViewerLog({
-				query: { skip, take, orderDirection, filterExpression, logLevel, startDate, endDate },
+				query: {
+					skip,
+					take,
+					orderDirection,
+					filterExpression,
+					logLevel: logLevel?.length ? logLevel : undefined,
+					startDate,
+					endDate,
+				},
 			}),
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-message.element.ts
@@ -110,7 +110,7 @@ export class UmbLogViewerMessageElement extends UmbLitElement {
 
 		query = {
 			...query,
-			lq: encodeURIComponent(`${name}=${sanitizedValue}`),
+			lq: `${name}=${sanitizedValue}`,
 		};
 
 		const queryString = toQueryString(query);

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/entity-actions/rename/rename-partial-view.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/entity-actions/rename/rename-partial-view.server.data-source.ts
@@ -39,7 +39,7 @@ export class UmbRenamePartialViewServerDataSource {
 		const { data, error } = await tryExecute(
 			this.#host,
 			PartialViewService.putPartialViewByPathRename({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 				body,
 			}),
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/repository/partial-view-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/repository/partial-view-detail.server.data-source.ts
@@ -70,7 +70,7 @@ export class UmbPartialViewDetailServerDataSource implements UmbDetailDataSource
 
 		const { data, error } = await tryExecute(
 			this.#host,
-			PartialViewService.getPartialViewByPath({ path: { path: encodeURIComponent(path) } }),
+			PartialViewService.getPartialViewByPath({ path: { path } }),
 		);
 
 		if (error || !data) {
@@ -100,7 +100,7 @@ export class UmbPartialViewDetailServerDataSource implements UmbDetailDataSource
 		const { error } = await tryExecute(
 			this.#host,
 			PartialViewService.putPartialViewByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 				body,
 			}),
 		);
@@ -121,7 +121,7 @@ export class UmbPartialViewDetailServerDataSource implements UmbDetailDataSource
 		return tryExecute(
 			this.#host,
 			PartialViewService.deletePartialViewByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/repository/partial-view-folder.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/repository/partial-view-folder.server.data-source.ts
@@ -58,7 +58,7 @@ export class UmbPartialViewFolderServerDataSource implements UmbDetailDataSource
 		const { data, error } = await tryExecute(
 			this.#host,
 			PartialViewService.getPartialViewFolderByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 
@@ -125,7 +125,7 @@ export class UmbPartialViewFolderServerDataSource implements UmbDetailDataSource
 		return tryExecute(
 			this.#host,
 			PartialViewService.deletePartialViewFolderByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/entity-actions/rename/rename-script.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/entity-actions/rename/rename-script.server.data-source.ts
@@ -39,7 +39,7 @@ export class UmbRenameScriptServerDataSource {
 		const { data, error } = await tryExecute(
 			this.#host,
 			ScriptService.putScriptByPathRename({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 				body,
 			}),
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/repository/script-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/repository/script-detail.server.data-source.ts
@@ -67,7 +67,7 @@ export class UmbScriptDetailServerDataSource implements UmbDetailDataSource<UmbS
 
 		const { data, error } = await tryExecute(
 			this.#host,
-			ScriptService.getScriptByPath({ path: { path: encodeURIComponent(path) } }),
+			ScriptService.getScriptByPath({ path: { path } }),
 		);
 
 		if (error || !data) {
@@ -97,7 +97,7 @@ export class UmbScriptDetailServerDataSource implements UmbDetailDataSource<UmbS
 		const { error } = await tryExecute(
 			this.#host,
 			ScriptService.putScriptByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 				body,
 			}),
 		);
@@ -118,7 +118,7 @@ export class UmbScriptDetailServerDataSource implements UmbDetailDataSource<UmbS
 		return tryExecute(
 			this.#host,
 			ScriptService.deleteScriptByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/repository/script-folder.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/repository/script-folder.server.data-source.ts
@@ -58,7 +58,7 @@ export class UmbScriptFolderServerDataSource implements UmbDetailDataSource<UmbF
 		const { data, error } = await tryExecute(
 			this.#host,
 			ScriptService.getScriptFolderByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 
@@ -124,7 +124,7 @@ export class UmbScriptFolderServerDataSource implements UmbDetailDataSource<UmbF
 		return tryExecute(
 			this.#host,
 			ScriptService.deleteScriptFolderByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/entity-actions/rename/rename-stylesheet.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/entity-actions/rename/rename-stylesheet.server.data-source.ts
@@ -39,7 +39,7 @@ export class UmbRenameStylesheetServerDataSource {
 		const { data, error } = await tryExecute(
 			this.#host,
 			StylesheetService.putStylesheetByPathRename({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 				body,
 			}),
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/repository/stylesheet-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/repository/stylesheet-detail.server.data-source.ts
@@ -70,7 +70,7 @@ export class UmbStylesheetDetailServerDataSource implements UmbDetailDataSource<
 
 		const { data, error } = await tryExecute(
 			this.#host,
-			StylesheetService.getStylesheetByPath({ path: { path: encodeURIComponent(path) } }),
+			StylesheetService.getStylesheetByPath({ path: { path } }),
 		);
 
 		if (error || !data) {
@@ -100,7 +100,7 @@ export class UmbStylesheetDetailServerDataSource implements UmbDetailDataSource<
 		const { error } = await tryExecute(
 			this.#host,
 			StylesheetService.putStylesheetByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 				body,
 			}),
 		);
@@ -121,7 +121,7 @@ export class UmbStylesheetDetailServerDataSource implements UmbDetailDataSource<
 		return tryExecute(
 			this.#host,
 			StylesheetService.deleteStylesheetByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/repository/stylesheet-folder.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/repository/stylesheet-folder.server.data-source.ts
@@ -52,7 +52,7 @@ export class UmbStylesheetFolderServerDataSource implements UmbDetailDataSource<
 		const { data, error } = await tryExecute(
 			this.#host,
 			StylesheetService.getStylesheetFolderByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 
@@ -119,7 +119,7 @@ export class UmbStylesheetFolderServerDataSource implements UmbDetailDataSource<
 		return tryExecute(
 			this.#host,
 			StylesheetService.deleteStylesheetFolderByPath({
-				path: { path: encodeURIComponent(path) },
+				path: { path },
 			}),
 		);
 	}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/19446

### Description
In testing we found that when running under IIS errors were thrown when requesting script, stylesheet and partial view files.  Using Kestrel didn't show these issues.  The requested path string was being double encoded - once in our own code and once automatically via the typed HTTP client.  Seemingly the latter web server could handle this, but not the former.

Removing the double encoding by removing our initial encoding before the request is passed to the typed API client looks to resolve the issue.

### Testing
Verify script, stylesheet and partial view files and folders can be created, retrieved, updated and deleted (I've done this on Windows, using both IISExpress and Kestrel).