### PR TITLE
Fix: filter input styling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/components/collection-filter-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/components/collection-filter-field.element.ts
@@ -34,7 +34,7 @@ export class UmbCollectionFilterFieldElement extends UmbLitElement {
 	static override readonly styles = [
 		css`
 			uui-input {
-				display: block;
+				width: 100%;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create-blueprint/modal/create-blueprint-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create-blueprint/modal/create-blueprint-modal.element.ts
@@ -79,7 +79,7 @@ export class UmbCreateBlueprintModalElement extends UmbModalBaseElement<
 			strong,
 			uui-label,
 			uui-input {
-				display: block;
+				width: 100%;
 			}
 
 			uui-label {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/collection/user-group-collection.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/collection/user-group-collection.element.ts
@@ -39,7 +39,7 @@ export class UmbUserGroupCollectionElement extends UmbCollectionDefaultElement {
 	static override styles = [
 		css`
 			uui-input {
-				display: block;
+				width: 100%;
 			}
 		`,
 	];


### PR DESCRIPTION
Fixes the styling of the uui-input in various locations, mainly when used as a filtering input on collections and extensions insights:
![image](https://github.com/user-attachments/assets/f7f052cc-413c-416c-a1a8-b82931bead67)
