### PR TITLE
set manifest on property editor uis

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/extensions/property-editor-ui-element.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/extensions/property-editor-ui-element.interface.ts
@@ -1,6 +1,8 @@
 import type { UmbPropertyEditorConfigCollection } from '../config/index.js';
+import type { ManifestPropertyEditorUi } from './property-editor.extension.js';
 
 export interface UmbPropertyEditorUiElement extends HTMLElement {
+	manifest?: ManifestPropertyEditorUi;
 	name?: string;
 	value?: unknown;
 	config?: UmbPropertyEditorConfigCollection;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.element.ts
@@ -334,6 +334,7 @@ export class UmbPropertyElement extends UmbLitElement {
 				this._element.addEventListener('change', this._onPropertyEditorChange as any as EventListener);
 				this._element.addEventListener('property-value-change', this._onPropertyEditorChange as any as EventListener);
 				// No need to observe mandatory or label, as we already do so and set it on the _element if present: [NL]
+				this._element.manifest = manifest;
 				this._element.mandatory = this._mandatory;
 				this._element.name = this._label;
 


### PR DESCRIPTION
For consistency, we should always set the `manifest` on elements of extensions. For some reason this was not done for Property Editor UIs. which this PR corrects.