### PR TITLE
V16 Ensures backwards compatibility of deprecated `UMB_CONTENT_PROPERTY_CONTEXT`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.context-token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/components/property-type-based-property/property-type-based-property.context-token.ts
@@ -10,5 +10,5 @@ export const UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT = new UmbContextToken<UmbP
  * This will be removed in v.18
  */
 export const UMB_CONTENT_PROPERTY_CONTEXT = new UmbContextToken<UmbPropertyTypeBasedPropertyContext>(
-	'UmbContentPropertyContext',
+	'UmbPropertyTypeBasedPropertyContext',
 );

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/document-tree.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/document-tree.context.ts
@@ -3,7 +3,7 @@ import type {
 	UmbDocumentTreeRootItemsRequestArgs,
 	UmbDocumentTreeRootModel,
 } from './types.js';
-import { UMB_CONTENT_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';
+import { UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';
 import { UmbDefaultTreeContext } from '@umbraco-cms/backoffice/tree';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
@@ -15,7 +15,7 @@ export class UmbDocumentTreeContext extends UmbDefaultTreeContext<
 	constructor(host: UmbControllerHost) {
 		super(host);
 
-		this.consumeContext(UMB_CONTENT_PROPERTY_CONTEXT, (context) => {
+		this.consumeContext(UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT, (context) => {
 			this.observe(context?.dataType, (value) => {
 				this.updateAdditionalRequestArgs({ dataType: value });
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -21,7 +21,7 @@ import {
 } from '@umbraco-cms/backoffice/external/lit';
 import { debounce, UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
-import { UMB_CONTENT_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';
+import { UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';
 import type { UUIInputEvent, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 import { isUmbracoFolder } from '@umbraco-cms/backoffice/media-type';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
@@ -82,7 +82,7 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<UmbMediaPick
 	constructor() {
 		super();
 
-		this.consumeContext(UMB_CONTENT_PROPERTY_CONTEXT, (context) => {
+		this.consumeContext(UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT, (context) => {
 			this.observe(context?.dataType, (dataType) => {
 				this.#dataType = dataType;
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.context.ts
@@ -1,5 +1,5 @@
 import type { UmbMediaTreeItemModel, UmbMediaTreeRootItemsRequestArgs, UmbMediaTreeRootModel } from './types.js';
-import { UMB_CONTENT_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';
+import { UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';
 import { UmbDefaultTreeContext } from '@umbraco-cms/backoffice/tree';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
@@ -11,7 +11,7 @@ export class UmbMediaTreeContext extends UmbDefaultTreeContext<
 	constructor(host: UmbControllerHost) {
 		super(host);
 
-		this.consumeContext(UMB_CONTENT_PROPERTY_CONTEXT, (context) => {
+		this.consumeContext(UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT, (context) => {
 			this.observe(context?.dataType, (value) => {
 				this.updateAdditionalRequestArgs({ dataType: value });
 			});


### PR DESCRIPTION
### Description

Fixes #19449.

Due to a name change in #19375, the `UMB_CONTENT_PROPERTY_CONTEXT` token no longer resolved.
This hot-fix updates the context alias (with `UmbPropertyTypeBasedPropertyContext`) so that the context can be resolved.

I have also updated the references of deprecated `UMB_CONTENT_PROPERTY_CONTEXT` to use `UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT` instead.