### PR TITLE
hotfix: close modals when url changes drastically

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/route/router-slot.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/route/router-slot.element.ts
@@ -95,12 +95,13 @@ export class UmbRouterSlotElement extends UmbLitElement {
 	}
 
 	override disconnectedCallback() {
+		window.removeEventListener('navigationsuccess', this._onNavigationChanged);
+		this.#listening = false;
+
 		// Close modals opened by this router slot.
 		this.#routeContext._internal_modalRouterChanged(undefined);
 
 		super.disconnectedCallback();
-		window.removeEventListener('navigationsuccess', this._onNavigationChanged);
-		this.#listening = false;
 	}
 
 	protected override firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {


### PR DESCRIPTION
If URL gets changed so more than one router-slot gets removed from the DOM, then modals of such stays. This will make sure that once a router slot is disconnected its modals follows.