### PR TITLE
V16: Localization extensions load unordered

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/rxjs/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/rxjs/index.ts
@@ -7,6 +7,7 @@ export {
 	map,
 	distinctUntilChanged,
 	combineLatest,
+	concatMap,
 	shareReplay,
 	takeUntil,
 	debounceTime,
@@ -19,4 +20,5 @@ export {
 	startWith,
 	skip,
 	first,
+	from,
 } from 'rxjs';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/localize.element.test.ts
@@ -3,11 +3,13 @@ import { aTimeout, elementUpdated, expect, fixture, html } from '@open-wc/testin
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 import { umbLocalizationRegistry } from './registry/localization.registry.js';
+import type { ManifestLocalization } from './extensions/localization.extension.js';
 
-const english = {
+const english: ManifestLocalization = {
 	type: 'localization',
 	alias: 'test.en',
 	name: 'Test English',
+	weight: 100,
 	meta: {
 		culture: 'en',
 		localizations: {
@@ -27,7 +29,75 @@ const english = {
 	},
 };
 
-const danish = {
+const englishUs: ManifestLocalization = {
+	type: 'localization',
+	alias: 'test.en-us',
+	name: 'Test English (US)',
+	weight: 100,
+	meta: {
+		culture: 'en-us',
+		localizations: {
+			general: {
+				close: 'Close US',
+				overridden: 'Overridden',
+			},
+		},
+	},
+};
+
+// This is a factory function that returns the localization object.
+const asyncFactory = async (localizations: Record<string, any>, delay: number) => {
+	await aTimeout(delay); // Simulate async loading
+	return {
+		// Simulate a JS module that exports a localization object.
+		default: localizations,
+	};
+};
+
+// This is an async localization that overrides the previous one.
+const englishAsyncOverride: ManifestLocalization = {
+	type: 'localization',
+	alias: 'test.en.async-override',
+	name: 'Test English Async Override',
+	weight: -100,
+	meta: {
+		culture: 'en-us',
+	},
+	js: () =>
+		asyncFactory(
+			{
+				general: {
+					close: 'Close Async',
+					overridden: 'Overridden Async',
+				},
+			},
+			100,
+		),
+};
+
+// This is another async localization that loads later than the previous one and overrides it because of a lower weight.
+const english2AsyncOverride: ManifestLocalization = {
+	type: 'localization',
+	alias: 'test.en.async-override-2',
+	name: 'Test English Async Override 2',
+	weight: -200,
+	meta: {
+		culture: 'en-us',
+	},
+	js: () =>
+		asyncFactory(
+			{
+				general: {
+					close: 'Another Async Close',
+				},
+			},
+			200, // This will load after the first async override
+			// so it should override the close translation.
+			// The overridden translation should not be overridden.
+		),
+};
+
+const danish: ManifestLocalization = {
 	type: 'localization',
 	alias: 'test.da',
 	name: 'Test Danish',
@@ -53,8 +123,7 @@ describe('umb-localize', () => {
 	});
 
 	describe('localization', () => {
-		umbExtensionsRegistry.register(english);
-		umbExtensionsRegistry.register(danish);
+		umbExtensionsRegistry.registerMany([english, englishUs, danish]);
 
 		beforeEach(async () => {
 			umbLocalizationRegistry.loadLanguage(english.meta.culture);
@@ -123,11 +192,48 @@ describe('umb-localize', () => {
 		it('should change the value if the language is changed', async () => {
 			expect(element.shadowRoot?.innerHTML).to.contain('Close');
 
+			// Change to Danish
 			umbLocalizationRegistry.loadLanguage(danish.meta.culture);
 			await aTimeout(0);
 			await elementUpdated(element);
-
 			expect(element.shadowRoot?.innerHTML).to.contain('Luk');
+		});
+
+		it('should fall back to the fallback language if the key is not found', async () => {
+			expect(element.shadowRoot?.innerHTML).to.contain('Close');
+
+			// Change to US English
+			umbLocalizationRegistry.loadLanguage(englishUs.meta.culture);
+			await aTimeout(0);
+			await elementUpdated(element);
+			expect(element.shadowRoot?.innerHTML).to.contain('Close US');
+
+			element.key = 'general_overridden';
+			await elementUpdated(element);
+			expect(element.shadowRoot?.innerHTML).to.contain('Overridden');
+
+			element.key = 'general_logout';
+			await elementUpdated(element);
+			expect(element.shadowRoot?.innerHTML).to.contain('Log out');
+		});
+
+		it('should accept a lazy loaded localization', async () => {
+			umbExtensionsRegistry.registerMany([englishAsyncOverride, english2AsyncOverride]);
+			umbLocalizationRegistry.loadLanguage(englishAsyncOverride.meta.culture);
+			await aTimeout(200); // Wait for the async override to load
+
+			await elementUpdated(element);
+			expect(element.shadowRoot?.innerHTML).to.contain(
+				'Another Async Close',
+				'(async) Should have overridden the close (from first language)',
+			);
+
+			element.key = 'general_overridden';
+			await elementUpdated(element);
+			expect(element.shadowRoot?.innerHTML).to.contain(
+				'Overridden Async',
+				'(async) Should not have overridden the overridden (from first language)',
+			);
 		});
 
 		it('should use the slot if translation is not found', async () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -9,14 +9,15 @@ import { umbLocalizationManager } from '@umbraco-cms/backoffice/localization-api
 import type { UmbBackofficeExtensionRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
-import { combineLatest } from '@umbraco-cms/backoffice/external/rxjs';
+import { distinctUntilChanged, filter, from, map, switchMap } from '@umbraco-cms/backoffice/external/rxjs';
+import type { Subscription } from '@umbraco-cms/backoffice/external/rxjs';
 import { hasDefaultExport, loadManifestPlainJs } from '@umbraco-cms/backoffice/extension-api';
 
 /**
- *
- * @param innerDictionary
- * @param dictionaryName
- * @param dictionary
+ * Adds or updates a dictionary in the inner dictionary.
+ * @param {UmbLocalizationFlatDictionary} innerDictionary The inner dictionary to add or update the dictionary in.
+ * @param {string} dictionaryName The name of the dictionary to add or update.
+ * @param {UmbLocalizationDictionary['value']} dictionary The dictionary to add or update.
  */
 function addOrUpdateDictionary(
 	innerDictionary: UmbLocalizationFlatDictionary,
@@ -34,63 +35,82 @@ export class UmbLocalizationRegistry {
 	);
 	readonly currentLanguage = this.#currentLanguage.asObservable();
 
-	#loadedExtAliases: Array<string> = [];
-
 	/**
 	 * Get the current registered translations.
 	 * @returns {Map<string, UmbLocalizationSetBase>} Returns the registered translations
 	 */
-	get localizations() {
+	get localizations(): Map<string, UmbLocalizationSetBase> {
 		return umbLocalizationManager.localizations;
 	}
 
+	#subscription: Subscription;
+
 	constructor(extensionRegistry: UmbBackofficeExtensionRegistry) {
-		combineLatest([this.currentLanguage, extensionRegistry.byType('localization')]).subscribe(
-			async ([currentLanguage, extensions]) => {
-				const locale = new Intl.Locale(currentLanguage);
-				const currentLanguageExtensions = extensions.filter(
-					(ext) =>
-						ext.meta.culture.toLowerCase() === locale.baseName.toLowerCase() ||
-						ext.meta.culture.toLowerCase() === locale.language.toLowerCase(),
-				);
+		// Store the locale in a variable to use when setting the document language and direction
+		let locale: Intl.Locale | undefined = undefined;
 
-				// If there are no extensions for the current language, return early
-				if (!currentLanguageExtensions.length) return;
-
-				// Register the new translations only if they have not been registered before
-				const diff = currentLanguageExtensions.filter((ext) => !this.#loadedExtAliases.includes(ext.alias));
-
-				// Load all localizations
-				const translations = await Promise.all(currentLanguageExtensions.map(this.#loadExtension));
-
-				// If there are no translations, return early
-				if (!translations.length) return;
-
-				if (diff.length) {
-					const filteredTranslations = translations.filter((t) =>
-						diff.some((ext) => ext.meta.culture.toLowerCase() === t.$code),
+		this.#subscription = this.currentLanguage
+			.pipe(
+				// Ensure the current language is not empty
+				filter((currentLanguage) => !!currentLanguage),
+				// Use distinctUntilChanged to avoid unnecessary re-renders when the language hasn't changed
+				distinctUntilChanged(),
+				// Switch to the extensions registry to get the current language and the extensions for that language
+				// Note: This also cancels the previous subscription if the language changes
+				switchMap((currentLanguage) => {
+					return extensionRegistry.byType('localization').pipe(
+						// Filter the extensions to only those that match the current language
+						map((extensions) => {
+							locale = new Intl.Locale(currentLanguage);
+							return extensions.filter(
+								(ext) =>
+									ext.meta.culture.toLowerCase() === locale!.baseName.toLowerCase() ||
+									ext.meta.culture.toLowerCase() === locale!.language.toLowerCase(),
+							);
+						}),
 					);
-					umbLocalizationManager.registerManyLocalizations(filteredTranslations);
-				}
+				}),
+				// Ensure we only process extensions that are registered
+				filter((extensions) => extensions.length > 0),
+				// Ensure we only process extensions that have not been loaded before
+				distinctUntilChanged((prev, curr) => {
+					const prevAliases = prev.map((ext) => ext.alias).sort();
+					const currAliases = curr.map((ext) => ext.alias).sort();
+					return JSON.stringify(prevAliases) === JSON.stringify(currAliases);
+				}),
+				// With switchMap, if a new language is selected before the previous translations finish loading,
+				// the previous promise is canceled (unsubscribed), and only the latest one is processed.
+				// This prevents race conditions and stale state.
+				switchMap((extensions) =>
+					from(
+						(async () => {
+							// Load all localizations
+							const translations = await Promise.all(extensions.map(this.#loadExtension));
 
-				// Set the document language
-				const newLang = locale.baseName.toLowerCase();
-				if (document.documentElement.lang.toLowerCase() !== newLang) {
-					document.documentElement.lang = newLang;
-				}
+							// If there are no translations, return early
+							if (!translations.length) return;
 
-				// Set the document direction to the direction of the primary language
-				const newDir = translations[0].$dir ?? 'ltr';
-				if (document.documentElement.dir !== newDir) {
-					document.documentElement.dir = newDir;
-				}
-			},
-		);
+							// Sort translations by their original extension weight (highest-to-lowest)
+							// This ensures that the translations with the lowest weight override the others
+							translations.sort((a, b) => {
+								if (a.$weight === b.$weight) return 0;
+								return a.$weight < b.$weight ? 1 : -1;
+							});
+
+							// Load the translations into the localization manager
+							umbLocalizationManager.registerManyLocalizations(translations);
+
+							// Set the browser language and direction based on the translations
+							this.#setBrowserLanguage(locale!, translations);
+						})(),
+					),
+				),
+			)
+			// Subscribe to the observable to trigger the loading of translations
+			.subscribe();
 	}
 
 	#loadExtension = async (extension: ManifestLocalization) => {
-		this.#loadedExtAliases.push(extension.alias);
-
 		const innerDictionary: UmbLocalizationFlatDictionary = {};
 
 		// If extension contains a dictionary, add it to the inner dictionary.
@@ -115,16 +135,55 @@ export class UmbLocalizationRegistry {
 		return {
 			$code: extension.meta.culture.toLowerCase(),
 			$dir: extension.meta.direction ?? 'ltr',
+			$weight: extension.weight ?? 100,
 			...innerDictionary,
-		} satisfies UmbLocalizationSetBase;
+		} satisfies UmbLocalizationSetBase & { $weight: number };
 	};
+
+	#setBrowserLanguage(locale: Intl.Locale, translations: UmbLocalizationSetBase[]) {
+		// Set the document language
+		const newLang = locale!.baseName.toLowerCase();
+		if (document.documentElement.lang.toLowerCase() !== newLang) {
+			document.documentElement.lang = newLang;
+		}
+
+		// We need to find the direction of the new language, so we look for the best match
+		// If the new language is not found, we default to 'ltr'
+		const reverseTranslations = translations.slice().reverse();
+
+		// Look for a direct match first
+		const directMatch = reverseTranslations.find((t) => t.$code.toLowerCase() === newLang);
+		if (directMatch) {
+			document.documentElement.dir = directMatch.$dir;
+			return;
+		}
+
+		// If no direct match, look for a match with the language code only
+		const langOnlyDirectMatch = reverseTranslations.find(
+			(t) => t.$code.toLowerCase() === locale!.language.toLowerCase(),
+		);
+		if (langOnlyDirectMatch) {
+			document.documentElement.dir = langOnlyDirectMatch.$dir;
+			return;
+		}
+
+		// If no match is found, default to 'ltr'
+		if (document.documentElement.dir !== 'ltr') {
+			document.documentElement.dir = 'ltr';
+		}
+	}
 
 	/**
 	 * Load a language from the extension registry.
 	 * @param {string} locale The locale to load.
 	 */
 	loadLanguage(locale: string) {
-		this.#currentLanguage.setValue(locale.toLowerCase());
+		const canonicalLocale = Intl.getCanonicalLocales(locale)[0];
+		this.#currentLanguage.setValue(canonicalLocale);
+	}
+
+	destroy() {
+		this.#subscription.unsubscribe();
 	}
 }
 


### PR DESCRIPTION
## Description

This pull request is difficult to explain, but in summary it fixes #19464.

It makes two changes to the `UmbLocalizationRegistry`:

**First change:** Do not check if localizations are already loaded; load them always when something changes

Old Logic (with alias/diff check): Risk of Stale/Un-overridden Translations
```mermaid
flowchart TD
    A[Language Change or Extension Registered] --> B[Check extension alias against loaded list]
    B -- Alias already loaded --> C[Skip registration]
    B -- Alias not loaded --> D[Register translations]
    D --> E[Translations in localization manager]
    C --> E
    E --> F[Result: Some keys may NOT be overridden if new extension has lower weight]
```

New Logic (Always Register All, Sorted by Weight): Reliable Overrides
```mermaid
flowchart TD
    A[Language Change or Extension Registered] --> B[Collect all matching extensions]
    B --> C[Sort all by weight, lowest weight = highest priority]
    C --> D[Register ALL translations in order]
    D --> E[Translations in localization manager]
    E --> F[Result: Lower weight always overrides higher, keys are reliably overridden]
```

----

**Second change:** Use the power of rxjs with `switchMap` to ensure that localizations are loaded in the order they are received

For example, if we imagined a user would register the extensions like `en` -> `en-us` -> `en-us` -> `en-us`, we would want all of them to finish, e.g. they could register their own keys each and override previous keys as well:

Old Logic (with `combineLatest`)

```mermaid
sequenceDiagram
    participant User
    participant Registry
    participant Loader

    User->>Registry: Registers "en"
    Registry->>Loader: Start loading "en"
    User->>Registry: Quickly registers "en-us"
    Registry->>Loader: Start loading "en, en-us" (queued)
    User->>Registry: Quickly registers "en-us" again
    Registry->>Loader: Start loading "en, en-us, en-us" (queued)
    User->>Registry: Quickly registers "en-us" a third time
    Registry->>Loader: Start loading "en, en-us, en-us, en-us" (queued)
    Loader-->>Registry: "en" finishes (may override)
    Loader-->>Registry: "en, en-us" finishes (may override)
    Loader-->>Registry: "en, en-us, en-us" finishes (may override)
    Loader-->>Registry: "en, en-us, en-us, en-us" finishes (final state)
    Note right of Registry: All loads run in order, but slow loads may override newer ones if not careful, so that the "en, en-us" could be final state.
```

New Logic (with switchMap, cancellation of previous loads)
```mermaid
sequenceDiagram
    participant User
    participant Registry
    participant Loader

    User->>Registry: Registers "en"
    Registry->>Loader: Start loading "en"
    User->>Registry: Quickly registers "en-us"
    Registry--xLoader: Cancel loading "en"
    Registry->>Loader: Start loading "en, en-us"
    User->>Registry: Quickly registers "en-us" again
    Registry--xLoader: Cancel loading "en, en-us"
    Registry->>Loader: Start loading "en, en-us, en-us"
    User->>Registry: Quickly registers "en-us" a third time
    Registry--xLoader: Cancel loading "en, en-us, en-us"
    Registry->>Loader: Start loading "en, en-us, en-us, en-us"
    Loader-->>Registry: "en, en-us, en-us, en-us" is allowed to finish (final state)
    Note right of Registry: Only the latest language set ("en, en-us, en-us, en-us") is loaded and applied and in that weighted order.
```