### PR TITLE
Fixes the Checkbox, Dropdown and Select list when the models change the UI updates.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/checkbox-list/property-editor-ui-checkbox-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/checkbox-list/property-editor-ui-checkbox-list.element.ts
@@ -29,6 +29,8 @@ export class UmbPropertyEditorUICheckboxListElement
 	@property({ type: Array })
 	public override set value(value: Array<string> | string | undefined) {
 		this.#selection = Array.isArray(value) ? value : value ? [value] : [];
+		// Update the checked state of existing list items when value changes
+		this.#updateCheckedState();
 	}
 	public override get value(): Array<string> | undefined {
 		return this.#selection;
@@ -87,6 +89,21 @@ export class UmbPropertyEditorUICheckboxListElement
 	#onChange(event: CustomEvent & { target: UmbInputCheckboxListElement }) {
 		this.value = event.target.selection;
 		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	/**
+	 * Updates the checked state of all list items based on current selection.
+	 * This fixes the issue where UI doesn't update when values are set programmatically.
+	 */
+	#updateCheckedState() {
+		if (this._list.length > 0) {
+			this._list = this._list.map(item => ({
+				...item,
+				checked: this.#selection.includes(item.value)
+			}));
+			// Trigger a re-render
+			this.requestUpdate();
+		}
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/property-editor-ui-dropdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/property-editor-ui-dropdown.element.ts
@@ -31,6 +31,8 @@ export class UmbPropertyEditorUIDropdownElement
 	@property({ type: Array })
 	public override set value(value: Array<string> | string | undefined) {
 		this.#selection = this.#ensureValueIsArray(value);
+		// Update the selected state of existing options when value changes
+		this.#updateSelectedState();
 	}
 	public override get value(): Array<string> | undefined {
 		return this.#selection;
@@ -57,6 +59,10 @@ export class UmbPropertyEditorUIDropdownElement
 
 	@property({ type: String })
 	name?: string;
+
+	constructor() {
+		super();
+	}
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
@@ -118,6 +124,23 @@ export class UmbPropertyEditorUIDropdownElement
 		this._options.forEach((item) => (item.selected = selection.includes(item.value)));
 		this.value = value;
 		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	/**
+	 * Updates the selected state of all options based on current selection.
+	 * This fixes the issue where UI doesn't update when values are set programmatically.
+	 */
+	#updateSelectedState() {
+		// Only update if we have options loaded and a valid selection
+		if (this._options.length > 0 && this.#selection) {
+			// Create a new array to trigger state change detection
+			this._options = this._options.map((item) => ({
+				...item,
+				selected: this.#selection.includes(item.value)
+			}));
+			// Trigger a re-render
+			this.requestUpdate();
+		}
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/select/property-editor-ui-select.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/select/property-editor-ui-select.element.ts
@@ -12,8 +12,21 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
  */
 @customElement('umb-property-editor-ui-select')
 export class UmbPropertyEditorUISelectElement extends UmbLitElement implements UmbPropertyEditorUiElement {
+	private _value: string = '';
+
+	constructor() {
+		super();
+	}
+
+	// Update the selected state of existing options when value changes
 	@property()
-	value?: string = '';
+	public set value(newValue: string | undefined) {
+		this._value = newValue || '';
+		this.#updateSelectedState();
+	}
+	public get value(): string {
+		return this._value;
+	}
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;
@@ -23,8 +36,8 @@ export class UmbPropertyEditorUISelectElement extends UmbLitElement implements U
 		if (Array.isArray(items) && items.length > 0) {
 			this._options =
 				typeof items[0] === 'string'
-					? items.map((item) => ({ name: item, value: item, selected: item === this.value }))
-					: items.map((item) => ({ name: item.name, value: item.value, selected: item.value === this.value }));
+					? items.map((item) => ({ name: item, value: item, selected: item === this._value }))
+					: items.map((item) => ({ name: item.name, value: item.value, selected: item.value === this._value }));
 		}
 	}
 
@@ -34,6 +47,22 @@ export class UmbPropertyEditorUISelectElement extends UmbLitElement implements U
 	#onChange(event: UUISelectEvent) {
 		this.value = event.target.value as string;
 		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	/**
+	 * Updates the selected state of all options based on current value.
+	 * This fixes the issue where UI doesn't update when values are set programmatically.
+	 */
+	#updateSelectedState() {
+		// Only update if we have options loaded
+		if (this._options.length > 0) {
+			this._options = this._options.map((option) => ({
+				...option,
+				selected: option.value === this._value,
+			}));
+			// Trigger a re-render
+			this.requestUpdate();
+		}
 	}
 
 	override render() {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

[Issue 19437](https://github.com/umbraco/Umbraco-CMS/issues/19437)

### Description

#### How to replicate the issue and test that the PR fixes it.

You can easily test this in a browser.

- Add a check box list to a document type
- Open up a content page using Chrome with the check box list
- Open Chrome Dev Tools
- Select the check box list then right click it in the Elements code view
- Click "Store as global variable"
- Use this variable to try and set the values, e.g. in my example: `temp2.value = ['Pork']`

What we expect is this will select the box, but nothing seems to happen, even though you have set the correct variable.

Note: In our plugin code we would be using setValue to do the same thing.

**Example that is not working**
![Example that is not working](https://github.com/user-attachments/assets/1f1e7931-08cf-4092-acc4-f306bff3bd44)

Now if you use my PR and try the same thing, you will see it does select the boxes.

**After the PR has been applied**
![image](https://github.com/user-attachments/assets/ef8150cf-08eb-4b5e-ad24-61a6b21b72ca)

You can test the dropdown and select lists in the same way :)