### PR TITLE
Fixed JSDoc comment for ManifestBase.weight

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/types/manifest-base.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/types/manifest-base.interface.ts
@@ -21,7 +21,7 @@ export interface ManifestBase {
 	name: string;
 
 	/**
-	 * Extensions such as dashboards are ordered by weight with lower numbers being first in the list
+	 * Extensions such as dashboards are ordered by weight with higher numbers being first in the list
 	 */
 	weight?: number;
 }


### PR DESCRIPTION
### Description
The JSDoc comments for `ManifestBase.weight` in the extension API specified that lower values would be put first, but it is actually higher values first. The JSDoc specifically mentions dashboards but I tested this out with a `ManifestMenuItem` as well and it also checks out with what the dashboard documentation says.

| Property | Type   | Description                                                                |
|----------|--------|----------------------------------------------------------------------------|
| weight   | number | (Optional) The weight of the dashboard, higher numbers are displayed first |

https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/dashboard#properties


<!-- Thanks for contributing to Umbraco CMS! -->
