### PR TITLE
V16 Variant breadcrumbs: the parent entity-type and unique were being mixed up

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -54,10 +54,10 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	async #requestStructure() {
 		const isNew = this.#workspaceContext?.getIsNew();
 		const uniqueObservable = isNew
-			? this.#workspaceContext?._internal_createUnderParentEntityType
+			? this.#workspaceContext?._internal_createUnderParentEntityUnique
 			: this.#workspaceContext?.unique;
 		const entityTypeObservable = isNew
-			? this.#workspaceContext?._internal_createUnderParentEntityUnique
+			? this.#workspaceContext?._internal_createUnderParentEntityType
 			: this.#workspaceContext?.entityType;
 
 		let structureItems: Array<UmbVariantStructureItemModel> = [];
@@ -112,7 +112,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	}
 
 	#setParentData(structureItems: Array<UmbVariantStructureItemModel>) {
-		/* If the item is not new, the current item is the last item in the array. 
+		/* If the item is not new, the current item is the last item in the array.
 			We filter out the current item unique to handle any case where it could show up */
 		const parent = structureItems.filter((item) => item.unique !== this.#workspaceContext?.getUnique()).pop();
 
@@ -142,7 +142,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 
 				return entity;
 			})
-			/* If the item is not new, the current item is the last item in the array. 
+			/* If the item is not new, the current item is the last item in the array.
 			We filter out the current item unique to handle any case where it could show up */
 			.filter((item) => item.unique !== this.#workspaceContext?.getUnique());
 


### PR DESCRIPTION
### Description

In 16-rc5 (build), when creating a new child document/media item (e.g. level deeper than root), then the Tree Repository would throw an error as the parent's entity-type and unique values were being mixed up.