### PR TITLE
Fix: V16 Variant breadcrumb wrong after creating a nested document

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
@@ -58,10 +58,12 @@ export class UmbWorkspaceVariantMenuBreadcrumbElement extends UmbLitElement {
 
 	#observeStructure() {
 		if (!this.#structureContext || !this.#workspaceContext) return;
-		const isNew = this.#workspaceContext.getIsNew();
 
 		this.observe(this.#structureContext.structure, (value) => {
-			this._structure = isNew ? value : value.slice(0, -1);
+			if (!this.#workspaceContext) return;
+			const unique = this.#workspaceContext.getUnique();
+			// exclude the current unique from the structure. We append this with an observer of the name
+			this._structure = value.filter((structureItem) => structureItem.unique !== unique);
 		});
 	}
 


### PR DESCRIPTION
When creating a new nested document the breadcrumb is wrong after the document is created.

Before fix:

https://github.com/user-attachments/assets/b93f4e1e-bfeb-4e3c-8afb-dc4fdbaa58a5

After fix:

https://github.com/user-attachments/assets/bf131059-e047-4218-85a3-52d524f835f3



