### PR TITLE
Adds attribute to ensure management API requests are never cached in the browser or via a CDN

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Features;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Cms.Web.Common.Filters;
 
 namespace Umbraco.Cms.Api.Management.Controllers;
 
@@ -22,6 +23,7 @@ namespace Umbraco.Cms.Api.Management.Controllers;
 [MapToApi(ManagementApiConfiguration.ApiName)]
 [JsonOptionsName(Constants.JsonOptionsNames.BackOffice)]
 [AppendEventMessages]
+[DisableBrowserCache]
 [Produces("application/json")]
 public abstract class ManagementApiControllerBase : Controller, IUmbracoFeature
 {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Came up via an internal support request.

### Description
It's been identified that in Umbraco 13 we specifically disabled caching on any backoffice API requests, but we don't do the same on the management API.  Although there's no evidence this has caused issues with usage via the backoffice, this can lead to cached responses being returned when a CDN is in the mix.

As such I've added the existing attribute for disabling the browser cache to the base management API controller.

### Testing

Verify the headers you see on the response.

Before:
![image](https://github.com/user-attachments/assets/8f9a8f1d-90b5-4dda-a4e9-82428fa785c5)

After:
![image](https://github.com/user-attachments/assets/6fda85a3-0549-4bb9-bed0-8f11796e4792)

