### PR TITLE
Deprecate hey-red/Markdown #19500

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="MailKit" Version="4.11.0" />
-    <PackageVersion Include="Markdown" Version="2.2.1" />
+    <PackageVersion Include="Markdig" Version="0.41.2" />
     <PackageVersion Include="MessagePack" Version="3.1.3" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     <PackageVersion Include="MiniProfiler.Shared" Version="4.5.4" />

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -202,11 +202,11 @@ Copyright: 2013-2024 .NET Foundation and Contributors
 
 ---
 
-Markdown: A library for parsing and compiling Markdown
+Markdig: A fast, powerful, CommonMark compliant, extensible Markdown processor for .NET
 
-URL: https://github.com/hey-red/Markdown
-License: MIT License
-Copyright: 2018 red
+URL: https://github.com/xoofx/markdig
+License: BSD-2-Clause license
+Copyright: 2018+, Alexandre Mutel. All rights reserved.
 
 ---
 

--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -29,7 +29,7 @@ public class TypeFinder : ITypeFinder
         "DataAnnotationsExtensions,", "DataAnnotationsExtensions.", "Dynamic,", "Examine,", "Examine.",
         "HtmlAgilityPack,", "HtmlAgilityPack.", "HtmlDiff,", "ICSharpCode.", "Iesi.Collections,", // used by NHibernate
         "JetBrains.Annotations,", "LightInject.", // DI
-        "LightInject,", "Lucene.", "Markdown,", "Microsoft.", "MiniProfiler,", "Moq,", "MySql.", "NHibernate,",
+        "LightInject,", "Lucene.", "Markdig,", "Microsoft.", "MiniProfiler,", "Moq,", "MySql.", "NHibernate,",
         "NHibernate.", "Newtonsoft.", "NPoco,", "NuGet.", "RouteDebugger,", "Semver.", "Serilog.", "Serilog,",
         "ServiceStack.", "SqlCE4Umbraco,", "Superpower,", // used by Serilog
         "System.", "TidyNet,", "TidyNet.", "WebDriver,", "itextsharp,", "mscorlib,", "NUnit,", "NUnit.", "NUnit3.",

--- a/src/Umbraco.Infrastructure/HealthChecks/MarkdownToHtmlConverter.cs
+++ b/src/Umbraco.Infrastructure/HealthChecks/MarkdownToHtmlConverter.cs
@@ -1,4 +1,4 @@
-using HeyRed.MarkdownSharp;
+using Markdig;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 
@@ -6,10 +6,11 @@ namespace Umbraco.Cms.Infrastructure.HealthChecks;
 
 public class MarkdownToHtmlConverter : IMarkdownToHtmlConverter
 {
+    private static readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
     public string ToHtml(HealthCheckResults results, HealthCheckNotificationVerbosity verbosity)
     {
-        var mark = new Markdown();
-        var html = mark.Transform(results.ResultsAsMarkDown(verbosity));
+        var html = Markdown.ToHtml(results.ResultsAsMarkDown(verbosity), _markdownPipeline);
         html = ApplyHtmlHighlighting(html);
         return html;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MarkdownEditorValueConverter.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using HeyRed.MarkdownSharp;
+using Markdig;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors.DeliveryApi;
 using Umbraco.Cms.Core.Strings;
@@ -15,6 +15,7 @@ public class MarkdownEditorValueConverter : PropertyValueConverterBase, IDeliver
 {
     private readonly HtmlLocalLinkParser _localLinkParser;
     private readonly HtmlUrlParser _urlParser;
+    private static readonly MarkdownPipeline _markdownPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
     public MarkdownEditorValueConverter(HtmlLocalLinkParser localLinkParser, HtmlUrlParser urlParser)
     {
@@ -51,8 +52,7 @@ public class MarkdownEditorValueConverter : PropertyValueConverterBase, IDeliver
     {
         // convert markup to HTML for frontend rendering.
         // source should come from ConvertSource and be a string (or null) already
-        var mark = new Markdown();
-        return new HtmlEncodedString(inter == null ? string.Empty : mark.Transform((string)inter));
+        return new HtmlEncodedString(inter == null ? string.Empty : Markdown.ToHtml((string)inter, _markdownPipeline));
     }
 
     public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;

--- a/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
+++ b/src/Umbraco.Infrastructure/Umbraco.Infrastructure.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Examine.Core" />
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="MailKit" />
-    <PackageReference Include="Markdown" />
+    <PackageReference Include="Markdig" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />


### PR DESCRIPTION
  - Replace with xoofx/markdig
  - Update package version in Directory.Packages.props
  - Update license entry in NOTICES.txt
  - Update package reference in src\Umbraco.Infrastructure\Umbraco.Infrastructure.csproj
  - Update src\Umbraco.Core\Composing\TypeFinder.cs
  - Update src\Umbraco.Infrastructure\HealthChecks\MarkdownToHtmlConverter.cs
  - Update src\Umbraco.Infrastructure\PropertyEditors\ValueConverters\MarkdownEditorValueConverter.cs

### Prerequisites

- [ x ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #19500

### Description

- Ran all Markdown Unit Tests - ✅ 
- Ran all the tests - ✅ 

![Back Office and Render](https://github.com/user-attachments/assets/f1fdb8d3-d2b0-4d3a-9cee-ce44b05a4e61)

