### PR TITLE
Fix check for pending package migration to use the package not the plan name

### DIFF
--- a/src/Umbraco.Infrastructure/Install/PackageMigrationRunner.cs
+++ b/src/Umbraco.Infrastructure/Install/PackageMigrationRunner.cs
@@ -77,8 +77,9 @@ public class PackageMigrationRunner
     /// </summary>
     public async Task<Attempt<bool, PackageMigrationOperationStatus>> RunPendingPackageMigrations(string packageName)
     {
-        // Check if there are any migrations
-        if (_packageMigrationPlans.ContainsKey(packageName) == false)
+        // Check if there are any migrations (note that the key for _packageMigrationPlans is the migration plan name, not the package name).
+        if (_packageMigrationPlans.Values
+            .Any(x => x.PackageName.InvariantEquals(packageName)) is false)
         {
             return Attempt.FailWithStatus(PackageMigrationOperationStatus.NotFound, false);
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19503

### Description
When running attending package migrations from the backoffice, there's a check for the requested package to ensure we have a plan for it.  However, as the linked issue describes, we are comparing the package with the plan name, and they can be different.  This fixes by comparing to the package name.

### Testing
- Configure `Umbraco:Cms:Unattended:PackageMigrationsUnattended` to be `false`.
- Create an example migration plan for a package with a different plan and package name
- Run the pending package migrations from the `Packages > Installed` dashboard.
- Before this PR you should see an error that no package migrations were found, after this PR you should find it succeeds and see the expected state value in the `umbracoKeyValue` table.

Example package migration and plan:

```
using Umbraco.Cms.Core.Packaging;

public class MigrationPlan() : PackageMigrationPlan("Example migration", "Example migration plan")
{
    protected override void DefinePlan()
    {
        To<MigrationExample>(MigrationExample.MigrationIdentifier);
    }
}
```

```
using Umbraco.Cms.Infrastructure.Migrations;

public class MigrationExample(IMigrationContext context, ILogger<MigrationExample> logger) : MigrationBase(context)
{
    public static Guid MigrationIdentifier = new("ed57c617-20c2-4e2a-9433-4f7bdcbf39b6");

    protected override void Migrate()
    {
        logger.LogInformation("Running migration step 1");
    }
}
```

