### PR TITLE
Fix toast notification can not be closed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/backoffice-modal-container/backoffice-modal-container.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/backoffice-modal-container/backoffice-modal-container.element.ts
@@ -146,7 +146,7 @@ export class UmbBackofficeModalContainerElement extends UmbLitElement {
 		dialog.insertBefore(notificationContainer, dialog.firstChild);
 	}
 
-	override async updated(){
+	override async updated() {
 		await Promise.all([this.updateComplete, this.addNotificationContainer()]);
 	}
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR fixes https://github.com/umbraco/Umbraco-CMS/issues/16486

**Reason**: 
The showModal() method of the [HTMLDialogElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) interface displays the dialog as a modal, over the top of any other dialogs that might be present. That's why toast-notification (popover ) stays non-interactive despite appearing above the modal.
**Solution**:
When the dialog is opened, move the `umb-backoffice-notification-container` inside the dialog so that the notification can be interacted with, and when the dialog is closed, move the notification back out to the DOM.
<!-- Thanks for contributing to Umbraco CMS! -->
