### PR TITLE
Fix issues with removal of user logins on change to external login provider configuration (13)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -57,10 +57,17 @@ internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUser
         Database.Delete<ExternalLoginDto>("WHERE userOrMemberKey=@userOrMemberKey", new { userOrMemberKey });
 
     /// <inheritdoc />
-    public void DeleteUserLoginsForRemovedProviders(IEnumerable<string> currentLoginProviders) =>
-        Database.Execute(Sql()
-            .Delete<ExternalLoginDto>()
-            .WhereNotIn<ExternalLoginDto>(x => x.LoginProvider, currentLoginProviders));
+    public void DeleteUserLoginsForRemovedProviders(IEnumerable<string> currentLoginProviders)
+    {
+        Sql<ISqlContext> sql = Sql()
+            .Select<ExternalLoginDto>(x => x.Id)
+            .From<ExternalLoginDto>()
+            .Where<ExternalLoginDto>(x => x.LoginProvider.StartsWith(Constants.Security.MemberExternalAuthenticationTypePrefix) == false) // Only remove external logins relating to backoffice users, not members.
+            .WhereNotIn<ExternalLoginDto>(x => x.LoginProvider, currentLoginProviders);
+
+        var toDelete = Database.Query<ExternalLoginDto>(sql).Select(x => x.Id).ToList();
+        DeleteExternalLogins(toDelete);
+    }
 
     /// <inheritdoc />
     public void Save(Guid userOrMemberKey, IEnumerable<IExternalLogin> logins)
@@ -100,13 +107,7 @@ internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUser
         }
 
         // do the deletes, updates and inserts
-        if (toDelete.Count > 0)
-        {
-            // Before we can remove the external login, we must remove the external login tokens associated with that external login,
-            // otherwise we'll get foreign key constraint errors
-            Database.DeleteMany<ExternalLoginTokenDto>().Where(x => toDelete.Contains(x.ExternalLoginId)).Execute();
-            Database.DeleteMany<ExternalLoginDto>().Where(x => toDelete.Contains(x.Id)).Execute();
-        }
+        DeleteExternalLogins(toDelete);
 
         foreach (KeyValuePair<int, IExternalLogin> u in toUpdate)
         {
@@ -114,6 +115,19 @@ internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUser
         }
 
         Database.InsertBulk(toInsert.Select(i => ExternalLoginFactory.BuildDto(userOrMemberKey, i)));
+    }
+
+    private void DeleteExternalLogins(List<int> ids)
+    {
+        if (ids.Count <= 0)
+        {
+            return;
+        }
+
+        // Before we can remove the external login, we must remove the external login tokens associated with that external login,
+        // otherwise we'll get foreign key constraint errors
+        Database.DeleteMany<ExternalLoginTokenDto>().Where(x => ids.Contains(x.ExternalLoginId)).Execute();
+        Database.DeleteMany<ExternalLoginDto>().Where(x => ids.Contains(x.Id)).Execute();
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -119,7 +119,7 @@ internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUser
 
     private void DeleteExternalLogins(List<int> externalLoginIds)
     {
-        if (externalLoginIds.Count <= 0)
+        if (externalLoginIds.Count == 0)
         {
             return;
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19499

### Description
The linked issue describes an error that occurs with the implementation provided in https://github.com/umbraco/Umbraco-CMS/pull/19273, which is intended to ensure logins relating to backoffice users associated with external login providers are removed when the provider is removed from configuration.  This was added to improve security with the [Umbraco Cloud external login provider feature](https://docs.umbraco.com/umbraco-cloud/set-up/external-login-providers), but provides the same benefit to other setups where external login providers are used.

Investigating revealed two issues, both of which are resolved in this PR:

- Some external login provider setups will store tokens as well as user logins.  These need to be deleted first to avoid the foreign key constraint exception.
- We shouldn't remove logins or tokens relating to login providers for members, that are stored in the same table.

### Testing
To test this setup I've configured a Google backoffice and member login provider based on the [documentation](https://docs.umbraco.com/umbraco-cms/13.latest/reference/security/external-login-providers).  For reference:

<details>
<summary>GoogleAuthenticationExtensions</summary>

```
public static class GoogleAuthenticationExtensions
{
    public static IUmbracoBuilder AddGoogleAuthentication(this IUmbracoBuilder builder)
    {
        builder.Services.ConfigureOptions<GoogleBackOfficeExternalLoginProviderOptions>();
        builder.Services.ConfigureOptions<GoogleMemberLoginProviderOptions>();

        builder.AddMemberExternalLogins(logins =>
        {
            logins.AddMemberLogin(
                membersAuthenticationBuilder =>
                {
                    membersAuthenticationBuilder.AddGoogle(
                        membersAuthenticationBuilder.SchemeForMembers(GoogleMemberLoginProviderOptions.SchemeName),
                        options =>
                        {
                            // Callback path: Represents the URL to which the browser should be redirected to.
                            // The default value is '/signin-google'.
                            // The value here should match what you have configured in you external login provider.
                            // The value needs to be unique.
                            options.CallbackPath = "/umbraco-google-signin";
                            options.ClientId = "<client id>";
                            options.ClientSecret = "<client secret>";
                        });


                });
        });

        builder.AddBackOfficeExternalLogins(logins =>
        {
            logins.AddBackOfficeLogin(
                backOfficeAuthenticationBuilder =>
                {
                    // The scheme must be set with this method to work for the back office
                    var schemeName =
                        backOfficeAuthenticationBuilder.SchemeForBackOffice(GoogleBackOfficeExternalLoginProviderOptions
                            .SchemeName);

                    ArgumentNullException.ThrowIfNull(schemeName);

                    backOfficeAuthenticationBuilder.AddGoogle(
                        schemeName,
                        options =>
                        {
                            // Callback path: Represents the URL to which the browser should be redirected to.
                            // The default value is '/signin-google'.
                            // The value here should match what you have configured in you external login provider.
                            // The value needs to be unique.
                            options.CallbackPath = "/umbraco-backoffice-google-signin";
                            options.ClientId = "<client id>";
                            options.ClientSecret = "<client secret>";
                        });
                });
        });
        return builder;
    }

}
```
</details>

<details>
<summary>GoogleMemberLoginProviderOptions </summary>

```
using Microsoft.Extensions.Options;
using Umbraco.Cms.Core;
using Umbraco.Cms.Web.Common.Security;

public class GoogleMemberLoginProviderOptions : IConfigureNamedOptions<MemberExternalLoginProviderOptions>
{
    public const string SchemeName = "Google";

    public void Configure(string? name, MemberExternalLoginProviderOptions options)
    {
        if (name != Constants.Security.MemberExternalAuthenticationTypePrefix + SchemeName)
        {
            return;
        }

        Configure(options);
    }

    public void Configure(MemberExternalLoginProviderOptions options)
    {
        options.AutoLinkOptions = new MemberExternalSignInAutoLinkOptions(
            autoLinkExternalAccount: true,
            defaultCulture: null,
            defaultIsApproved: true,
            defaultMemberTypeAlias: Constants.Security.DefaultMemberTypeAlias)
        {
            OnAutoLinking = (autoLinkUser, loginInfo) =>
            {
            },
            OnExternalLogin = (user, loginInfo) =>
            {
                return true;
            }
        };
    }
}
```
</details>

<details>
<summary>GoogleBackOfficeExternalLoginProviderOptions </summary>

```
using Microsoft.Extensions.Options;
using Umbraco.Cms.Core;
using Umbraco.Cms.Web.BackOffice.Security;

public class GoogleBackOfficeExternalLoginProviderOptions : IConfigureNamedOptions<BackOfficeExternalLoginProviderOptions>
{
    public const string SchemeName = "Google";

    public void Configure(string? name, BackOfficeExternalLoginProviderOptions options)
    {
        ArgumentNullException.ThrowIfNull(name);

        if (name != Constants.Security.BackOfficeExternalAuthenticationTypePrefix + SchemeName)
        {
            return;
        }

        Configure(options);
    }

    public void Configure(BackOfficeExternalLoginProviderOptions options)
    {
        options.Icon = "icon-google-fill";

        options.AutoLinkOptions = new ExternalSignInAutoLinkOptions(
            autoLinkExternalAccount: true,
            defaultUserGroups: new[] { Constants.Security.EditorGroupAlias },
            defaultCulture: null,
            allowManualLinking: true
        )
        {
            OnAutoLinking = (autoLinkUser, loginInfo) =>
            {
            },
            OnExternalLogin = (user, loginInfo) =>
            {
                return true;
            },
        };

        options.DenyLocalLogin = false;

        options.AutoRedirectLoginToExternalProvider = false;
    }
}
```
</details>

I've then logged in as both backoffice and members using Google accounts, and verified when I add and remove the Google authentication in `Program.cs` the expected database updates are made:

```
builder.CreateUmbracoBuilder()
    .AddBackOffice()
    .AddWebsite()
    .AddDeliveryApi()
    .AddComposers()
    //.AddGoogleAuthentication()
    .Build();
```

Note that the main feature has already been tested via the original PR, so focus here can just be on behaviour with members.

