### PR TITLE
V16.1: Fix broken content creation when using blueprints

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
@@ -56,7 +56,7 @@ export class UmbDocumentServerDataSource
 			variants: [],
 		};
 
-		const scaffold = umbDeepMerge(defaultData, preset) as UmbDocumentDetailModel;
+		const scaffold = umbDeepMerge(preset, defaultData);
 
 		return { data: scaffold };
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/media-detail.server.data-source.ts
@@ -57,7 +57,7 @@ export class UmbMediaServerDataSource extends UmbControllerBase implements UmbDe
 			],
 		};
 
-		const scaffold = umbDeepMerge(defaultData, preset) as UmbMediaDetailModel;
+		const scaffold = umbDeepMerge(preset, defaultData);
 
 		return { data: scaffold };
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/member-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/member-detail.server.data-source.ts
@@ -6,7 +6,7 @@ import type { UmbDetailDataSource } from '@umbraco-cms/backoffice/repository';
 import type { CreateMemberRequestModel, UpdateMemberRequestModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { MemberService } from '@umbraco-cms/backoffice/external/backend-api';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
-import { umbDeepMerge } from '@umbraco-cms/backoffice/utils';
+import {umbDeepMerge, type UmbDeepPartialObject} from '@umbraco-cms/backoffice/utils';
 import { UmbMemberTypeDetailServerDataSource } from '@umbraco-cms/backoffice/member-type';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 
@@ -22,7 +22,7 @@ export class UmbMemberServerDataSource extends UmbControllerBase implements UmbD
 	 * @returns { CreateMemberRequestModel }
 	 * @memberof UmbMemberServerDataSource
 	 */
-	async createScaffold(preset: Partial<UmbMemberDetailModel> = {}) {
+	async createScaffold(preset: UmbDeepPartialObject<UmbMemberDetailModel> = {}) {
 		let memberTypeIcon = '';
 
 		const memberTypeUnique = preset.memberType?.unique;
@@ -64,7 +64,7 @@ export class UmbMemberServerDataSource extends UmbControllerBase implements UmbD
 			],
 		};
 
-		const scaffold = umbDeepMerge(defaultData, preset) as UmbMemberDetailModel;
+		const scaffold = umbDeepMerge(preset, defaultData);
 
 		return { data: scaffold };
 	}


### PR DESCRIPTION
This issue was introduced in https://github.com/umbraco/Umbraco-CMS/pull/19292 (to be released in `16.1.0`) and was preventing the fields from being filled in (based on the blueprint) in the UI.

Due to the usage of `umbDeepMerge(defaultData, preset)`, since the `values` and `variants` were set to `[]`in `defaultData`, they wouldn't be `overridden` by the ones in `preset`.
By changing the order of the parameters to `umbDeepMerge(preset, defaultData)`, the `preset` values now take precedence.

With a blueprint:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/200c70ca-30c8-4990-b4b1-869400e956f7" />

Before the fix:
![Recording 2025-06-10 at 13 49 55](https://github.com/user-attachments/assets/5c7b9003-ad94-4400-847f-801639c41aee)

After the fix:
![Recording 2025-06-10 at 13 44 11](https://github.com/user-attachments/assets/fd31f56d-e7d3-4140-9a5c-5c6d15d57cad)
