### PR TITLE
Tiptap RTE: Adds token for statusbar context

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/constants.ts
@@ -1,1 +1,2 @@
+export { UMB_TIPTAP_STATUSBAR_CONFIGURATION_CONTEXT } from './contexts/tiptap-statusbar-configuration.context-token.js';
 export { UMB_TIPTAP_TOOLBAR_CONFIGURATION_CONTEXT } from './contexts/tiptap-toolbar-configuration.context-token.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/contexts/tiptap-statusbar-configuration.context-token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/contexts/tiptap-statusbar-configuration.context-token.ts
@@ -1,0 +1,6 @@
+import type { UmbTiptapStatusbarConfigurationContext } from './tiptap-statusbar-configuration.context.js';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+
+export const UMB_TIPTAP_STATUSBAR_CONFIGURATION_CONTEXT = new UmbContextToken<UmbTiptapStatusbarConfigurationContext>(
+	'UmbTiptapStatusbarConfigurationContext',
+);

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/contexts/tiptap-statusbar-configuration.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/contexts/tiptap-statusbar-configuration.context.ts
@@ -1,5 +1,6 @@
 import type { UmbTiptapStatusbarExtension, UmbTiptapStatusbarViewModel } from '../types.js';
 import type { UmbTiptapStatusbarValue } from '../../../components/types.js';
+import { UMB_TIPTAP_STATUSBAR_CONFIGURATION_CONTEXT } from './tiptap-statusbar-configuration.context-token.js';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbArrayState, UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
@@ -24,7 +25,7 @@ export class UmbTiptapStatusbarConfigurationContext extends UmbContextBase {
 	public readonly statusbar = this.#statusbar.asObservable();
 
 	constructor(host: UmbControllerHost) {
-		super(host, 'UmbTiptapStatusbarConfigurationContext');
+		super(host, UMB_TIPTAP_STATUSBAR_CONFIGURATION_CONTEXT);
 
 		this.observe(umbExtensionsRegistry.byType('tiptapStatusbarExtension'), (extensions) => {
 			const _extensions = extensions


### PR DESCRIPTION
### Description

Adds and exports a `UMB_TIPTAP_STATUSBAR_CONFIGURATION_CONTEXT` token, for the Tiptap RTE statusbar context.

This has no impact on functionality, it is more from an API perspective and to feature match the toolbar's `UMB_TIPTAP_TOOLBAR_CONFIGURATION_CONTEXT` token.