### PR TITLE
Add a warning to the `CreateContentFromBlueprint` method xml docs

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -3627,6 +3627,7 @@ public class ContentService : RepositoryService, IContentService
 
     private static readonly string?[] ArrayOfOneNullString = { null };
 
+    /// <inheritdoc />
     public IContent CreateContentFromBlueprint(IContent blueprint, string name, int userId = Constants.Security.SuperUserId)
     {
         if (blueprint == null)

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -56,6 +56,9 @@ public interface IContentService : IContentServiceBase<IContent>
     /// <summary>
     ///     Creates a new content item from a blueprint.
     /// </summary>
+    /// <remarks>Warning: If you intend to save the resulting <c>IContent</c> as a content node, you must trigger a
+    /// <see cref="Notifications.ContentScaffoldedNotification"/> notification to ensure that the block ids are regenerated.
+    /// Failing to do so could lead to caching issues.</remarks>
     IContent CreateContentFromBlueprint(IContent blueprint, string name, int userId = Constants.Security.SuperUserId);
 
     /// <summary>


### PR DESCRIPTION
Closes #19352

A proper fix was done for V16 in #19528, but for V13 it would be more tricky as we wouldn't want to introduce new methods or a behavioral change. Instead, a remark was added to the method's xml docs to warn users.