### PR TITLE
Removed duplicate/obsolete code fixing issue with document move permission checks

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/MoveDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/MoveDocumentController.cs
@@ -53,16 +53,6 @@ public class MoveDocumentController : DocumentControllerBase
             return Forbidden();
         }
 
-        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
-            User,
-            ContentPermissionResource.WithKeys(ActionMove.ActionLetter, new[] { moveDocumentRequestModel.Target?.Id, id }),
-            AuthorizationPolicies.ContentPermissionByResource);
-
-        if (!authorizationResult.Succeeded)
-        {
-            return Forbidden();
-        }
-
         Attempt<IContent?, ContentEditingOperationStatus> result = await _contentEditingService.MoveAsync(
             id,
             moveDocumentRequestModel.Target?.Id,


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19547

### Description
Looks like this was a bad merge at some point, as we have the correct permission checks in place but then also were calling the old, incorrect ones.

### Testing

See linked issue - with a setup like this for a user, previously the move operation would be denied.  With these changes in place, it succeeds.

Permissions: Read, UI Read, UI Write
Granular Permissions:

![image](https://github.com/user-attachments/assets/7d24afa5-5802-4899-8acc-3c032220174c)
