### PR TITLE
Adds XML header docs indicating usage of options on NuCacheSerializerType

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/NuCacheSerializerType.cs
+++ b/src/Umbraco.Core/Configuration/Models/NuCacheSerializerType.cs
@@ -4,10 +4,23 @@
 namespace Umbraco.Cms.Core.Configuration.Models;
 
 /// <summary>
-///     The serializer type that nucache uses to persist documents in the database.
+///     The serializer type that the published content cache uses to persist documents in the database.
 /// </summary>
 public enum NuCacheSerializerType
 {
-    MessagePack = 1, // Default
+    /// <summary>
+    /// The default serializer type, which uses MessagePack for serialization.
+    /// </summary>
+    MessagePack = 1,
+
+    /// <summary>
+    /// The legacy JSON serializer type, which uses JSON for serialization.
+    /// </summary>
+    /// <remarks>
+    /// This option was provided for backward compatibility for the Umbraco cache implementation used from Umbraco 8 to 14 (NuCache).
+    /// It is no longer supported with the cache implementation from Umbraco 15 based on .NET's Hybrid cache.
+    /// Use the faster and more compact <see cref="MessagePack"/> instead.
+    /// The option is kept available only for a more readable format suitable for testing purposes.
+    /// </remarks>
     JSON = 2,
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Relates to https://github.com/umbraco/Umbraco-CMS/issues/19544

### Description
We currently offer a legacy configuration option for cache serialization that's no longer supported since the introduction of the hybrid cache implementation, and has some issues with particular property types such as integers.

To make it work changes would be needed to property type converters, e.g. 

```
public override object ConvertSourceToIntermediate(
    IPublishedElement owner,
    IPublishedPropertyType propertyType,
    object? source,
    bool preview)
{
    if (source is JsonElement jsonElementSource && jsonElementSource.ValueKind == JsonValueKind.Number)
    {
        return jsonElementSource.GetInt32();
    }

    return source.TryConvertTo<int>().Result;
}
```

I considered that as there's no reason to use this option over the faster and more compact `MessagePack`, we would obsolete the options and schedules the removal in 17. 

However we have some integration tests that rely on it for assertions.  Possibly we could make those work with `MessagePack`, but it didn't seem straightforward.  Also this got me thinking that the one benefit of this option is that it's more readable, so given that it's worth keeping around for these tests (and potentially others in future).

As such I've limited changes to just providing more information on appropriate usage.
