### PR TITLE
Added more namespaces to _ViewImports.cshtml

### DIFF
--- a/src/Umbraco.Web.UI/Views/_ViewImports.cshtml
+++ b/src/Umbraco.Web.UI/Views/_ViewImports.cshtml
@@ -1,6 +1,8 @@
+@using System.IO
 @using Umbraco.Extensions
 @using Umbraco.Cms.Web.Common.PublishedModels
 @using Umbraco.Cms.Web.Common.Views
 @using Umbraco.Cms.Core.Models.PublishedContent
+@using Microsoft.AspNetCore.Hosting
 @using Microsoft.AspNetCore.Html
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Maybe I'm doing something wrong, but in new Umbraco projects, I have problems with referencen certain types from Razor views due to implicit usings, but without any errors shown in Visual Studio.

For instance, any type in the `System.IO` namespace will look fine in Visual Studio - e.g. as shown here:

![image](https://github.com/user-attachments/assets/be78ce8e-c26a-470d-bf3b-53715fb66fcb)

But accessing the view will result in a Razor compile error:

![image](https://github.com/user-attachments/assets/41d761d2-c093-41d6-84e6-c0df2eaf854b)

Adding a `@using System.IO` will fix the issue, but it's a bit frustrating, as Visual Studio won't show any errors, so I often end up forgetting this until I see the error when running the site.

The same happens for the `Microsoft.AspNetCore.Hosting` (I use injecting `IWebHostEnvironment` a lot directly in the view when debugging something), which why my PR is for these to namespaces in particular. I can't remember whether I have encountered similar issues for other namespaces, but here are probably some more as well 🤷‍♂️ 