### PR TITLE
Further fix to configuration classes using ISet, resolving regression with custom 404 pages

### DIFF
--- a/src/Umbraco.Core/CompatibilitySuppressions.xml
+++ b/src/Umbraco.Core/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Umbraco.Cms.Core.Configuration.Models.ContentSettings.get_Error404Collection</Target>
+    <Left>lib/net9.0/Umbraco.Core.dll</Left>
+    <Right>lib/net9.0/Umbraco.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -50,7 +50,7 @@ public class ContentSettings
     /// <summary>
     ///     Gets or sets a value for the collection of error pages.
     /// </summary>
-    public ISet<ContentErrorPage> Error404Collection { get; set; } = new HashSet<ContentErrorPage>();
+    public IEnumerable<ContentErrorPage> Error404Collection { get; set; } = [];
 
     /// <summary>
     ///     Gets or sets a value for the preview badge mark-up.

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/ContentSettingsValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/ContentSettingsValidatorTests.cs
@@ -42,9 +42,9 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Configuration.Models.Validati
             new ContentSettings
             {
                 Error404Collection =
-                {
+                [
                     new() { Culture = culture, ContentId = 1 },
-                },
+                ],
                 Imaging =
                 {
                     AutoFillImageProperties =


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19567

### Description
The cause of this issue was another cases of issues involved in the fix https://github.com/umbraco/Umbraco-CMS/pull/19229, where `ISet` in configuration classes aren't bound.

Note that I've added a compatibility suppression for the breaking change, which I don't see how we can otherwise avoid.

### Testing
Prepare a custom 404 page as per the [instructions in the documentation](https://docs.umbraco.com/umbraco-cms/tutorials/custom-error-page#create-a-404-page-in-the-backoffice) (though note that I found this didn't work when using the name "404" for the document type and template, and instead used "File Not Found").  With this PR in place, the custom 404 should be displayed as expected.

To check via debugging, put a breaking point at the start of `NotFoundHandlerHelper.GetCurrentNotFoundPageId` and verify the `error404Collection` parameter matches the configured value.

### Release

Can consider for a 16.0.1, otherwise 16.1.0.

