### PR TITLE
Avoid async await Task.FromResult, plus some other minor tweaks

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/RebuildPublishedCacheController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PublishedCache/RebuildPublishedCacheController.cs
@@ -15,7 +15,7 @@ public class RebuildPublishedCacheController : PublishedCacheControllerBase
     [HttpPost("rebuild")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IActionResult> Rebuild(CancellationToken cancellationToken)
+    public Task<IActionResult> Rebuild(CancellationToken cancellationToken)
     {
         if (_databaseCacheRebuilder.IsRebuilding())
         {
@@ -27,10 +27,10 @@ public class RebuildPublishedCacheController : PublishedCacheControllerBase
                 Type = "Error",
             };
 
-            return await Task.FromResult(Conflict(problemDetails));
+            return Task.FromResult<IActionResult>(Conflict(problemDetails));
         }
 
         _databaseCacheRebuilder.Rebuild(true);
-        return await Task.FromResult(Ok());
+        return Task.FromResult<IActionResult>(Ok());
     }
 }

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
@@ -50,7 +50,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
 
         var currentCompositionAliases = currentCompositeKeys.Any()
             ? allContentTypes.Where(ct => currentCompositeKeys.Contains(ct.Key)).Select(ct => ct.Alias).ToArray()
-            : Array.Empty<string>();
+            : [];
 
         ContentTypeAvailableCompositionsResults availableCompositions = _contentTypeService.GetAvailableCompositeContentTypes(
             contentType,
@@ -142,9 +142,9 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return Attempt.SucceedWithStatus<TContentType?, ContentTypeOperationStatus>(ContentTypeOperationStatus.Success, contentType);
     }
 
-    protected virtual async Task<ContentTypeOperationStatus> AdditionalCreateValidationAsync(
+    protected virtual Task<ContentTypeOperationStatus> AdditionalCreateValidationAsync(
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
-        => await Task.FromResult(ContentTypeOperationStatus.Success);
+        => Task.FromResult(ContentTypeOperationStatus.Success);
 
     #region Sanitization
 
@@ -346,7 +346,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return ContentTypeOperationStatus.Success;
     }
 
-    private ContentTypeOperationStatus ValidateProperties(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
+    private static ContentTypeOperationStatus ValidateProperties(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
     {
         // grab all content types used for composition and/or inheritance
         Guid[] allCompositionKeys = KeysForCompositionTypes(model, CompositionType.Composition, CompositionType.Inheritance);
@@ -365,7 +365,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return ContentTypeOperationStatus.Success;
     }
 
-    private ContentTypeOperationStatus ValidateContainers(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
+    private static ContentTypeOperationStatus ValidateContainers(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, IContentTypeComposition[] allContentTypeCompositions)
     {
         if (model.Containers.Any(container => Enum.TryParse<PropertyGroupType>(container.Type, out _) is false))
         {
@@ -420,7 +420,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return ContentTypeAliasIsInUse(alias) is false;
     }
 
-    private bool IsReservedContentTypeAlias(string alias)
+    private static bool IsReservedContentTypeAlias(string alias)
     {
         var reservedAliases = new[] { "system" };
         return reservedAliases.InvariantContains(alias);
@@ -474,7 +474,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return contentType;
     }
 
-    private void UpdateAllowedContentTypes(
+    private static void UpdateAllowedContentTypes(
         TContentType contentType,
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model,
         IContentTypeComposition[] allContentTypeCompositions)
@@ -573,7 +573,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         }
     }
 
-    private string PropertyGroupAlias(string? containerName)
+    private static string PropertyGroupAlias(string? containerName)
     {
         if (containerName.IsNullOrWhiteSpace())
         {
@@ -625,7 +625,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return propertyType;
     }
 
-    private void UpdateCompositions(
+    private static void UpdateCompositions(
         TContentType contentType,
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model,
         IContentTypeComposition[] allContentTypeCompositions)
@@ -658,7 +658,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         }
     }
 
-    private void UpdateParentContentType(
+    private static void UpdateParentContentType(
         TContentType contentType,
         ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model,
         IContentTypeComposition[] allContentTypeCompositions)
@@ -677,7 +677,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
 
     #region Shared between model validation and model update
 
-    private Guid[] GetDataTypeKeys(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
+    private static Guid[] GetDataTypeKeys(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
         => model.Properties.Select(property => property.DataTypeKey).Distinct().ToArray();
 
     private async Task<IDataType[]> GetDataTypesAsync(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model)
@@ -685,7 +685,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         Guid[] dataTypeKeys = GetDataTypeKeys(model);
         return dataTypeKeys.Any()
             ? (await _dataTypeService.GetAllAsync(GetDataTypeKeys(model))).ToArray()
-            : Array.Empty<IDataType>();
+            : [];
     }
 
     private int? GetParentId(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, Guid? containerKey)
@@ -711,7 +711,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
         return Constants.System.Root;
     }
 
-    private Guid[] KeysForCompositionTypes(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, params CompositionType[] compositionTypes)
+    private static Guid[] KeysForCompositionTypes(ContentTypeEditingModelBase<TPropertyTypeModel, TPropertyTypeContainer> model, params CompositionType[] compositionTypes)
         => model.Compositions
             .Where(c => compositionTypes.Contains(c.CompositionType))
             .Select(c => c.Key)

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
@@ -20,27 +20,27 @@ public class ElementSwitchValidator : IElementSwitchValidator
         _dataTypeService = dataTypeService;
     }
 
-    public async Task<bool> AncestorsAreAlignedAsync(IContentType contentType)
+    public Task<bool> AncestorsAreAlignedAsync(IContentType contentType)
     {
         // this call does not return the system roots
         var ancestorIds = contentType.AncestorIds();
         if (ancestorIds.Length == 0)
         {
             // if there are no ancestors, validation passes
-            return true;
+            return Task.FromResult(true);
         }
 
         // if there are any ancestors where IsElement is different from the contentType, the validation fails
-        return await Task.FromResult(_contentTypeService.GetMany(ancestorIds)
+        return Task.FromResult(_contentTypeService.GetMany(ancestorIds)
             .Any(ancestor => ancestor.IsElement != contentType.IsElement) is false);
     }
 
-    public async Task<bool> DescendantsAreAlignedAsync(IContentType contentType)
+    public Task<bool> DescendantsAreAlignedAsync(IContentType contentType)
     {
         IEnumerable<IContentType> descendants = _contentTypeService.GetDescendants(contentType.Id, false);
 
         // if there are any descendants where IsElement is different from the contentType, the validation fails
-        return await Task.FromResult(descendants.Any(descendant => descendant.IsElement != contentType.IsElement) is false);
+        return Task.FromResult(descendants.Any(descendant => descendant.IsElement != contentType.IsElement) is false);
     }
 
     public async Task<bool> ElementToDocumentNotUsedInBlockStructuresAsync(IContentTypeBase contentType)
@@ -59,8 +59,8 @@ public class ElementSwitchValidator : IElementSwitchValidator
                 .ConfiguredElementTypeKeys().Contains(contentType.Key)) is false;
     }
 
-    public async Task<bool> DocumentToElementHasNoContentAsync(IContentTypeBase contentType) =>
+    public Task<bool> DocumentToElementHasNoContentAsync(IContentTypeBase contentType) =>
 
         // if any content for the content type exists, the validation fails.
-        await Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
+        Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
 }

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -355,13 +355,13 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<IDataType>> GetByEditorAliasAsync(string[] propertyEditorAlias)
+        public Task<IEnumerable<IDataType>> GetByEditorAliasAsync(string[] propertyEditorAlias)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
             IQuery<IDataType> query = Query<IDataType>().Where(x => propertyEditorAlias.Contains(x.EditorAlias));
             IEnumerable<IDataType> dataTypes = _dataTypeRepository.Get(query).ToArray();
             ConvertMissingEditorsOfDataTypesToLabels(dataTypes);
-            return await Task.FromResult(dataTypes);
+            return Task.FromResult(dataTypes);
         }
 
         /// <inheritdoc />
@@ -396,7 +396,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                 return;
             }
 
-            ConvertMissingEditorsOfDataTypesToLabels(new[] { dataType });
+            ConvertMissingEditorsOfDataTypesToLabels([dataType]);
         }
 
         private void ConvertMissingEditorsOfDataTypesToLabels(IEnumerable<IDataType> dataTypes)
@@ -763,7 +763,7 @@ namespace Umbraco.Cms.Core.Services.Implement
             var totalItems = combinedUsages.Count;
 
             // Create the page of items.
-            IList<(string PropertyAlias, Udi Udi)> pagedUsages = combinedUsages
+            List<(string PropertyAlias, Udi Udi)> pagedUsages = combinedUsages
                 .OrderBy(x => x.Udi.EntityType) // Document types first, then media types, then member types.
                 .ThenBy(x => x.PropertyAlias)
                 .Skip(skip)
@@ -772,7 +772,7 @@ namespace Umbraco.Cms.Core.Services.Implement
 
             // Get the content types for the UDIs referenced in the page of items to construct the response from.
             // They could be document, media or member types.
-            IList<IContentTypeComposition> contentTypes = GetReferencedContentTypes(pagedUsages);
+            List<IContentTypeComposition> contentTypes = GetReferencedContentTypes(pagedUsages);
 
             IEnumerable<RelationItemModel> relations = pagedUsages
                 .Select(x =>
@@ -807,7 +807,7 @@ namespace Umbraco.Cms.Core.Services.Implement
             return Task.FromResult(pagedModel);
         }
 
-        private IList<IContentTypeComposition> GetReferencedContentTypes(IList<(string PropertyAlias, Udi Udi)> pagedUsages)
+        private List<IContentTypeComposition> GetReferencedContentTypes(List<(string PropertyAlias, Udi Udi)> pagedUsages)
         {
             IEnumerable<IContentTypeComposition> documentTypes = GetContentTypes(
                 pagedUsages,
@@ -845,10 +845,10 @@ namespace Umbraco.Cms.Core.Services.Implement
         {
             IConfigurationEditor? configurationEditor = dataType.Editor?.GetConfigurationEditor();
             return configurationEditor == null
-                ? new[]
-                {
+                ?
+                [
                     new ValidationResult($"Data type with editor alias {dataType.EditorAlias} does not have a configuration editor")
-                }
+                ]
                 : configurationEditor.Validate(dataType.ConfigurationData);
         }
 

--- a/src/Umbraco.Core/Services/EntityTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/EntityTypeContainerService.cs
@@ -52,18 +52,18 @@ internal abstract class EntityTypeContainerService<TTreeEntity, TEntityContainer
 
 
     /// <inheritdoc />
-    public async Task<IEnumerable<EntityContainer>> GetAsync(string name, int level)
+    public Task<IEnumerable<EntityContainer>> GetAsync(string name, int level)
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         ReadLock(scope);
-        return await Task.FromResult(_entityContainerRepository.Get(name, level));
+        return Task.FromResult(_entityContainerRepository.Get(name, level));
     }
     /// <inheritdoc />
-    public async Task<IEnumerable<EntityContainer>> GetAllAsync()
+    public Task<IEnumerable<EntityContainer>> GetAllAsync()
     {
         using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
         ReadLock(scope);
-        return await Task.FromResult(_entityContainerRepository.GetMany());
+        return Task.FromResult(_entityContainerRepository.GetMany());
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Services/Querying/ContentQueryService.cs
+++ b/src/Umbraco.Core/Services/Querying/ContentQueryService.cs
@@ -23,23 +23,23 @@ public class ContentQueryService : IContentQueryService
         _coreScopeProvider = coreScopeProvider;
     }
 
-    public async Task<Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>> GetWithSchedulesAsync(Guid id)
+    public Task<Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>> GetWithSchedulesAsync(Guid id)
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
 
-        IContent? content = await Task.FromResult(_contentService.GetById(id));
+        IContent? content = _contentService.GetById(id);
 
         if (content == null)
         {
-            return Attempt<ContentScheduleQueryResult, ContentQueryOperationStatus>.Fail(ContentQueryOperationStatus
-                .ContentNotFound);
+            return Task.FromResult(Attempt<ContentScheduleQueryResult, ContentQueryOperationStatus>.Fail(ContentQueryOperationStatus
+                .ContentNotFound));
         }
 
         ContentScheduleCollection schedules = _contentService.GetContentScheduleByContentId(id);
 
-        return Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>
+        return Task.FromResult(Attempt<ContentScheduleQueryResult?, ContentQueryOperationStatus>
             .Succeed(
                 ContentQueryOperationStatus.Success,
-                new ContentScheduleQueryResult(content, schedules));
+                new ContentScheduleQueryResult(content, schedules)));
     }
 }

--- a/src/Umbraco.Core/Strings/Diff.cs
+++ b/src/Umbraco.Core/Strings/Diff.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Strings;
 ///     Copyright (c) by Matthias Hertel, http://www.mathertel.de
 ///     This work is licensed under a BSD style license. See http://www.mathertel.de/License.aspx
 /// </summary>
-internal class Diff
+internal sealed class Diff
 {
     /// <summary>
     ///     Find the difference in 2 texts, comparing by text lines.


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

There are still some unneeded awaits left from the cleanup in #16535 (was maybe in  #18901)

I have also added some minor tweaks on private methods like static, use the actual type instead of interfaces to avoid looking for implementations and use async overloads when possible.