### PR TITLE
Move cache instructions pruning to background job

### DIFF
--- a/src/Umbraco.Core/Services/ICacheInstructionService.cs
+++ b/src/Umbraco.Core/Services/ICacheInstructionService.cs
@@ -45,7 +45,14 @@ public interface ICacheInstructionService
         CacheRefresherCollection cacheRefreshers,
         CancellationToken cancellationToken,
         string localIdentity,
-        int lastId);
+        int lastId) =>
+        ProcessInstructions(
+            cacheRefreshers,
+            ServerRole.Unknown,
+            cancellationToken,
+            localIdentity,
+            lastPruned: DateTime.UtcNow,
+            lastId);
 
     /// <summary>
     ///     Processes and then prunes pending database cache instructions.

--- a/src/Umbraco.Core/Services/ICacheInstructionService.cs
+++ b/src/Umbraco.Core/Services/ICacheInstructionService.cs
@@ -37,11 +37,27 @@ public interface ICacheInstructionService
     ///     Processes and then prunes pending database cache instructions.
     /// </summary>
     /// <param name="cacheRefreshers">Cache refreshers.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="localIdentity">Local identity of the executing AppDomain.</param>
+    /// <param name="lastId">Id of the latest processed instruction.</param>
+    /// <returns>The processing result.</returns>
+    ProcessInstructionsResult ProcessInstructions(
+        CacheRefresherCollection cacheRefreshers,
+        CancellationToken cancellationToken,
+        string localIdentity,
+        int lastId);
+
+    /// <summary>
+    ///     Processes and then prunes pending database cache instructions.
+    /// </summary>
+    /// <param name="cacheRefreshers">Cache refreshers.</param>
     /// <param name="serverRole">Server role.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <param name="localIdentity">Local identity of the executing AppDomain.</param>
     /// <param name="lastPruned">Date of last prune operation.</param>
-    /// <param name="lastId">Id of the latest processed instruction</param>
+    /// <param name="lastId">Id of the latest processed instruction.</param>
+    /// <returns>The processing result.</returns>
+    [Obsolete("Use the non-obsolete overload. Scheduled for removal in V19.")]
     ProcessInstructionsResult ProcessInstructions(
         CacheRefresherCollection cacheRefreshers,
         ServerRole serverRole,

--- a/src/Umbraco.Core/Services/ICacheInstructionService.cs
+++ b/src/Umbraco.Core/Services/ICacheInstructionService.cs
@@ -64,7 +64,7 @@ public interface ICacheInstructionService
     /// <param name="lastPruned">Date of last prune operation.</param>
     /// <param name="lastId">Id of the latest processed instruction.</param>
     /// <returns>The processing result.</returns>
-    [Obsolete("Use the non-obsolete overload. Scheduled for removal in V19.")]
+    [Obsolete("Use the non-obsolete overload. Scheduled for removal in V17.")]
     ProcessInstructionsResult ProcessInstructions(
         CacheRefresherCollection cacheRefreshers,
         ServerRole serverRole,

--- a/src/Umbraco.Core/Services/ICacheInstructionService.cs
+++ b/src/Umbraco.Core/Services/ICacheInstructionService.cs
@@ -34,7 +34,7 @@ public interface ICacheInstructionService
     void DeliverInstructionsInBatches(IEnumerable<RefreshInstruction> instructions, string localIdentity);
 
     /// <summary>
-    ///     Processes and then prunes pending database cache instructions.
+    ///     Processes pending database cache instructions.
     /// </summary>
     /// <param name="cacheRefreshers">Cache refreshers.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -55,7 +55,7 @@ public interface ICacheInstructionService
             lastId);
 
     /// <summary>
-    ///     Processes and then prunes pending database cache instructions.
+    ///     Processes pending database cache instructions.
     /// </summary>
     /// <param name="cacheRefreshers">Cache refreshers.</param>
     /// <param name="serverRole">Server role.</param>

--- a/src/Umbraco.Core/Services/ProcessInstructionsResult.cs
+++ b/src/Umbraco.Core/Services/ProcessInstructionsResult.cs
@@ -14,11 +14,13 @@ public class ProcessInstructionsResult
 
     public int LastId { get; private set; }
 
+    [Obsolete("Instruction pruning has been moved to a separate background job. Scheduled for removal in V19.")]
     public bool InstructionsWerePruned { get; private set; }
 
     public static ProcessInstructionsResult AsCompleted(int numberOfInstructionsProcessed, int lastId) =>
         new() { NumberOfInstructionsProcessed = numberOfInstructionsProcessed, LastId = lastId };
 
+    [Obsolete("Instruction pruning has been moved to a separate background job. Scheduled for removal in V19.")]
     public static ProcessInstructionsResult AsCompletedAndPruned(int numberOfInstructionsProcessed, int lastId) =>
         new()
         {

--- a/src/Umbraco.Core/Services/ProcessInstructionsResult.cs
+++ b/src/Umbraco.Core/Services/ProcessInstructionsResult.cs
@@ -14,13 +14,13 @@ public class ProcessInstructionsResult
 
     public int LastId { get; private set; }
 
-    [Obsolete("Instruction pruning has been moved to a separate background job. Scheduled for removal in V19.")]
+    [Obsolete("Instruction pruning has been moved to a separate background job. Scheduled for removal in V18.")]
     public bool InstructionsWerePruned { get; private set; }
 
     public static ProcessInstructionsResult AsCompleted(int numberOfInstructionsProcessed, int lastId) =>
         new() { NumberOfInstructionsProcessed = numberOfInstructionsProcessed, LastId = lastId };
 
-    [Obsolete("Instruction pruning has been moved to a separate background job. Scheduled for removal in V19.")]
+    [Obsolete("Instruction pruning has been moved to a separate background job. Scheduled for removal in V18.")]
     public static ProcessInstructionsResult AsCompletedAndPruned(int numberOfInstructionsProcessed, int lastId) =>
         new()
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJob.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+
+namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
+
+/// <summary>
+/// A background job that prunes cache instructions from the database.
+/// </summary>
+public class CacheInstructionsPruningJob : IRecurringBackgroundJob
+{
+    private readonly IOptions<GlobalSettings> _globalSettings;
+    private readonly ICacheInstructionRepository _cacheInstructionRepository;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CacheInstructionsPruningJob"/> class.
+    /// </summary>
+    /// <param name="globalSettings">The global settings configuration.</param>
+    /// <param name="cacheInstructionRepository">The repository for cache instructions.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    public CacheInstructionsPruningJob(
+        IOptions<GlobalSettings> globalSettings,
+        ICacheInstructionRepository cacheInstructionRepository,
+        TimeProvider timeProvider)
+    {
+        _globalSettings = globalSettings;
+        _cacheInstructionRepository = cacheInstructionRepository;
+        _timeProvider = timeProvider;
+        Period = globalSettings.Value.DatabaseServerMessenger.TimeBetweenPruneOperations;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler PeriodChanged
+    {
+        add { }
+        remove { }
+    }
+
+    /// <inheritdoc />
+    public TimeSpan Period { get; }
+
+    /// <inheritdoc />
+    public Task RunJobAsync()
+    {
+        DateTimeOffset pruneDate = _timeProvider.GetUtcNow() - _globalSettings.Value.DatabaseServerMessenger.TimeToRetainInstructions;
+        _cacheInstructionRepository.DeleteInstructionsOlderThan(pruneDate.DateTime);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJob.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
 
@@ -11,21 +13,25 @@ public class CacheInstructionsPruningJob : IRecurringBackgroundJob
 {
     private readonly IOptions<GlobalSettings> _globalSettings;
     private readonly ICacheInstructionRepository _cacheInstructionRepository;
+    private readonly ICoreScopeProvider _scopeProvider;
     private readonly TimeProvider _timeProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CacheInstructionsPruningJob"/> class.
     /// </summary>
+    /// <param name="scopeProvider">Provides scopes for database operations.</param>
     /// <param name="globalSettings">The global settings configuration.</param>
     /// <param name="cacheInstructionRepository">The repository for cache instructions.</param>
     /// <param name="timeProvider">The time provider.</param>
     public CacheInstructionsPruningJob(
         IOptions<GlobalSettings> globalSettings,
         ICacheInstructionRepository cacheInstructionRepository,
+        ICoreScopeProvider scopeProvider,
         TimeProvider timeProvider)
     {
         _globalSettings = globalSettings;
         _cacheInstructionRepository = cacheInstructionRepository;
+        _scopeProvider = scopeProvider;
         _timeProvider = timeProvider;
         Period = globalSettings.Value.DatabaseServerMessenger.TimeBetweenPruneOperations;
     }
@@ -44,7 +50,12 @@ public class CacheInstructionsPruningJob : IRecurringBackgroundJob
     public Task RunJobAsync()
     {
         DateTimeOffset pruneDate = _timeProvider.GetUtcNow() - _globalSettings.Value.DatabaseServerMessenger.TimeToRetainInstructions;
-        _cacheInstructionRepository.DeleteInstructionsOlderThan(pruneDate.DateTime);
+        using (ICoreScope scope = _scopeProvider.CreateCoreScope())
+        {
+            _cacheInstructionRepository.DeleteInstructionsOlderThan(pruneDate.DateTime);
+            scope.Complete();
+        }
+
         return Task.CompletedTask;
     }
 }

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -136,7 +136,7 @@ namespace Umbraco.Cms
             }
 
             /// <inheritdoc />
-            [Obsolete("Use the non-obsolete overload. Scheduled for removal in V19.")]
+            [Obsolete("Use the non-obsolete overload. Scheduled for removal in V17.")]
             public ProcessInstructionsResult ProcessInstructions(
                 CacheRefresherCollection cacheRefreshers,
                 ServerRole serverRole,

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -122,42 +122,29 @@ namespace Umbraco.Cms
             /// <inheritdoc />
             public ProcessInstructionsResult ProcessInstructions(
                 CacheRefresherCollection cacheRefreshers,
-                ServerRole serverRole,
                 CancellationToken cancellationToken,
                 string localIdentity,
-                DateTime lastPruned,
                 int lastId)
             {
                 using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<CacheInstructionService>("Syncing from database..."))
                 using (ICoreScope scope = ScopeProvider.CreateCoreScope())
                 {
                     var numberOfInstructionsProcessed = ProcessDatabaseInstructions(cacheRefreshers, cancellationToken, localIdentity, ref lastId);
-
-                    // Check for pruning throttling.
-                    if (cancellationToken.IsCancellationRequested || DateTime.UtcNow - lastPruned <=
-                        _globalSettings.DatabaseServerMessenger.TimeBetweenPruneOperations)
-                    {
-                        scope.Complete();
-                        return ProcessInstructionsResult.AsCompleted(numberOfInstructionsProcessed, lastId);
-                    }
-
-                    var instructionsWerePruned = false;
-                    switch (serverRole)
-                    {
-                        case ServerRole.Single:
-                        case ServerRole.SchedulingPublisher:
-                            PruneOldInstructions();
-                            instructionsWerePruned = true;
-                            break;
-                    }
-
                     scope.Complete();
-
-                    return instructionsWerePruned
-                        ? ProcessInstructionsResult.AsCompletedAndPruned(numberOfInstructionsProcessed, lastId)
-                        : ProcessInstructionsResult.AsCompleted(numberOfInstructionsProcessed, lastId);
+                    return ProcessInstructionsResult.AsCompleted(numberOfInstructionsProcessed, lastId);
                 }
             }
+
+            /// <inheritdoc />
+            [Obsolete("Use the non-obsolete overload. Scheduled for removal in V19.")]
+            public ProcessInstructionsResult ProcessInstructions(
+                CacheRefresherCollection cacheRefreshers,
+                ServerRole serverRole,
+                CancellationToken cancellationToken,
+                string localIdentity,
+                DateTime lastPruned,
+                int lastId) =>
+                ProcessInstructions(cacheRefreshers, cancellationToken, localIdentity, lastId);
 
             private CacheInstruction CreateCacheInstruction(IEnumerable<RefreshInstruction> instructions, string localIdentity)
                 => new(
@@ -485,21 +472,6 @@ namespace Umbraco.Cms
                 }
 
                 return jsonRefresher;
-            }
-
-            /// <summary>
-            ///     Remove old instructions from the database
-            /// </summary>
-            /// <remarks>
-            ///     Always leave the last (most recent) record in the db table, this is so that not all instructions are removed which
-            ///     would cause
-            ///     the site to cold boot if there's been no instruction activity for more than TimeToRetainInstructions.
-            ///     See: http://issues.umbraco.org/issue/U4-7643#comment=67-25085
-            /// </remarks>
-            private void PruneOldInstructions()
-            {
-                DateTime pruneDate = DateTime.UtcNow - _globalSettings.DatabaseServerMessenger.TimeToRetainInstructions;
-                _cacheInstructionRepository.DeleteInstructionsOlderThan(pruneDate);
             }
         }
     }

--- a/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
@@ -50,7 +50,7 @@ public class BatchedDatabaseServerMessenger : DatabaseServerMessenger
     /// <summary>
     ///     Initializes a new instance of the <see cref="BatchedDatabaseServerMessenger" /> class.
     /// </summary>
-    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in V19.")]
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in V18.")]
     public BatchedDatabaseServerMessenger(
         IMainDom mainDom,
         CacheRefresherCollection cacheRefreshers,

--- a/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
@@ -16,12 +16,41 @@ namespace Umbraco.Cms.Infrastructure.Sync;
 /// </summary>
 public class BatchedDatabaseServerMessenger : DatabaseServerMessenger
 {
-    private readonly IRequestAccessor _requestAccessor;
     private readonly IRequestCache _requestCache;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="BatchedDatabaseServerMessenger" /> class.
     /// </summary>
+    public BatchedDatabaseServerMessenger(
+        IMainDom mainDom,
+        CacheRefresherCollection cacheRefreshers,
+        ILogger<BatchedDatabaseServerMessenger> logger,
+        ISyncBootStateAccessor syncBootStateAccessor,
+        IHostingEnvironment hostingEnvironment,
+        ICacheInstructionService cacheInstructionService,
+        IJsonSerializer jsonSerializer,
+        IRequestCache requestCache,
+        LastSyncedFileManager lastSyncedFileManager,
+        IOptionsMonitor<GlobalSettings> globalSettings)
+        : base(
+            mainDom,
+            cacheRefreshers,
+            logger,
+            true,
+            syncBootStateAccessor,
+            hostingEnvironment,
+            cacheInstructionService,
+            jsonSerializer,
+            lastSyncedFileManager,
+            globalSettings)
+    {
+        _requestCache = requestCache;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="BatchedDatabaseServerMessenger" /> class.
+    /// </summary>
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in V19.")]
     public BatchedDatabaseServerMessenger(
         IMainDom mainDom,
         CacheRefresherCollection cacheRefreshers,
@@ -35,11 +64,18 @@ public class BatchedDatabaseServerMessenger : DatabaseServerMessenger
         IRequestAccessor requestAccessor,
         LastSyncedFileManager lastSyncedFileManager,
         IOptionsMonitor<GlobalSettings> globalSettings)
-        : base(mainDom, cacheRefreshers, serverRoleAccessor, logger, true, syncBootStateAccessor, hostingEnvironment,
-            cacheInstructionService, jsonSerializer, lastSyncedFileManager, globalSettings)
+        : this(
+            mainDom,
+            cacheRefreshers,
+            logger,
+            syncBootStateAccessor,
+            hostingEnvironment,
+            cacheInstructionService,
+            jsonSerializer,
+            requestCache,
+            lastSyncedFileManager,
+            globalSettings)
     {
-        _requestCache = requestCache;
-        _requestAccessor = requestAccessor;
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -83,7 +83,7 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
     /// <summary>
     ///     Initializes a new instance of the <see cref="DatabaseServerMessenger" /> class.
     /// </summary>
-    [Obsolete("Use the non-obsolete constructor. Scheduled for removal in V19.")]
+    [Obsolete("Use the non-obsolete constructor. Scheduled for removal in V18.")]
     protected DatabaseServerMessenger(
         IMainDom mainDom,
         CacheRefresherCollection cacheRefreshers,

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -31,11 +31,9 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
      */
 
     private readonly IMainDom _mainDom;
-    private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly ISyncBootStateAccessor _syncBootStateAccessor;
     private readonly ManualResetEvent _syncIdle;
     private bool _disposedValue;
-    private DateTime _lastPruned;
     private DateTime _lastSync;
     private bool _syncing;
 
@@ -45,7 +43,6 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
     protected DatabaseServerMessenger(
         IMainDom mainDom,
         CacheRefresherCollection cacheRefreshers,
-        IServerRoleAccessor serverRoleAccessor,
         ILogger<DatabaseServerMessenger> logger,
         bool distributedEnabled,
         ISyncBootStateAccessor syncBootStateAccessor,
@@ -59,7 +56,6 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
         _cancellationToken = _cancellationTokenSource.Token;
         _mainDom = mainDom;
         _cacheRefreshers = cacheRefreshers;
-        _serverRoleAccessor = serverRoleAccessor;
         _hostingEnvironment = hostingEnvironment;
         Logger = logger;
         _syncBootStateAccessor = syncBootStateAccessor;
@@ -67,7 +63,7 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
         JsonSerializer = jsonSerializer;
         _lastSyncedFileManager = lastSyncedFileManager;
         GlobalSettings = globalSettings.CurrentValue;
-        _lastPruned = _lastSync = DateTime.UtcNow;
+        _lastSync = DateTime.UtcNow;
         _syncIdle = new ManualResetEvent(true);
 
         globalSettings.OnChange(x => GlobalSettings = x);
@@ -82,6 +78,36 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
         }
 
         _initialized = new Lazy<SyncBootState?>(InitializeWithMainDom);
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DatabaseServerMessenger" /> class.
+    /// </summary>
+    [Obsolete("Use the non-obsolete constructor. Scheduled for removal in V19.")]
+    protected DatabaseServerMessenger(
+        IMainDom mainDom,
+        CacheRefresherCollection cacheRefreshers,
+        IServerRoleAccessor serverRoleAccessor,
+        ILogger<DatabaseServerMessenger> logger,
+        bool distributedEnabled,
+        ISyncBootStateAccessor syncBootStateAccessor,
+        IHostingEnvironment hostingEnvironment,
+        ICacheInstructionService cacheInstructionService,
+        IJsonSerializer jsonSerializer,
+        LastSyncedFileManager lastSyncedFileManager,
+        IOptionsMonitor<GlobalSettings> globalSettings)
+        : this(
+            mainDom,
+            cacheRefreshers,
+            logger,
+            distributedEnabled,
+            syncBootStateAccessor,
+            hostingEnvironment,
+            cacheInstructionService,
+            jsonSerializer,
+            lastSyncedFileManager,
+            globalSettings)
+    {
     }
 
     public GlobalSettings GlobalSettings { get; private set; }
@@ -146,16 +172,9 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
         {
             ProcessInstructionsResult result = CacheInstructionService.ProcessInstructions(
                 _cacheRefreshers,
-                _serverRoleAccessor.CurrentServerRole,
                 _cancellationToken,
                 LocalIdentity,
-                _lastPruned,
                 _lastSyncedFileManager.LastSyncedId);
-
-            if (result.InstructionsWerePruned)
-            {
-                _lastPruned = _lastSync;
-            }
 
             if (result.LastId > 0)
             {

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -189,6 +189,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddRecurringBackgroundJob<WebhookFiring>();
         builder.Services.AddRecurringBackgroundJob<WebhookLoggingCleanup>();
         builder.Services.AddRecurringBackgroundJob<ReportSiteJob>();
+        builder.Services.AddRecurringBackgroundJob<CacheInstructionsPruningJob>();
 
 
         builder.Services.AddSingleton(RecurringBackgroundJobHostedService.CreateHostedServiceFactory);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/CacheInstructionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/CacheInstructionServiceTests.cs
@@ -20,8 +20,10 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
     private const string LocalIdentity = "localIdentity";
     private const string AlternateIdentity = "alternateIdentity";
 
-    private CancellationToken CancellationToken => new();
+    private CancellationToken CancellationToken => CancellationToken.None;
+
     private CacheRefresherCollection CacheRefreshers => GetRequiredService<CacheRefresherCollection>();
+
     private IServerRoleAccessor ServerRoleAccessor => GetRequiredService<IServerRoleAccessor>();
 
     [Test]
@@ -150,31 +152,14 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
         // Create three instruction records, each with two instructions.  First two records are for a different identity.
         CreateAndDeliveryMultipleInstructions(sut);
 
-        var result = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole, CancellationToken,
-            LocalIdentity, DateTime.UtcNow.AddSeconds(-1), -1);
+        var result = sut.ProcessInstructions(CacheRefreshers, CancellationToken, LocalIdentity, -1);
 
         Assert.Multiple(() =>
         {
             Assert.AreEqual(3, result.LastId); // 3 records found.
             Assert.AreEqual(2,
                 result.NumberOfInstructionsProcessed); // 2 records processed (as one is for the same identity).
-            Assert.IsFalse(result.InstructionsWerePruned);
         });
-    }
-
-    [Test]
-    public void Can_Process_And_Purge_Instructions()
-    {
-        // Purging of instructions only occurs on single or master servers, so we need to ensure this is set before running the test.
-        EnsureServerRegistered();
-        var sut = (CacheInstructionService)GetRequiredService<ICacheInstructionService>();
-
-        CreateAndDeliveryMultipleInstructions(sut);
-
-        var result = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole, CancellationToken,
-            LocalIdentity, DateTime.UtcNow.AddHours(-1), -1);
-
-        Assert.IsTrue(result.InstructionsWerePruned);
     }
 
     [Test]
@@ -187,14 +172,12 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
         var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.Cancel();
 
-        var result = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole,
-            cancellationTokenSource.Token, LocalIdentity, DateTime.UtcNow.AddSeconds(-1), -1);
+        var result = sut.ProcessInstructions(CacheRefreshers, cancellationTokenSource.Token, LocalIdentity, -1);
 
         Assert.Multiple(() =>
         {
             Assert.AreEqual(0, result.LastId);
             Assert.AreEqual(0, result.NumberOfInstructionsProcessed);
-            Assert.IsFalse(result.InstructionsWerePruned);
         });
     }
 
@@ -209,14 +192,12 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
 
         var lastId = -1;
         // Run once
-        var result = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole, CancellationToken,
-            LocalIdentity, DateTime.UtcNow.AddSeconds(-1), lastId);
+        var result = sut.ProcessInstructions(CacheRefreshers, CancellationToken, LocalIdentity, lastId);
 
         Assert.Multiple(() =>
         {
             Assert.AreEqual(3, result.LastId); // 3 records found.
             Assert.AreEqual(2, result.NumberOfInstructionsProcessed); // 2 records processed (as one is for the same identity).
-            Assert.IsFalse(result.InstructionsWerePruned);
         });
 
         // DatabaseServerMessenger stores the LastID after ProcessInstructions has been run.
@@ -224,13 +205,7 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
 
         // The instructions has now been processed and shouldn't be processed on the next call...
         // Run again.
-        var secondResult = sut.ProcessInstructions(
-            CacheRefreshers,
-            ServerRoleAccessor.CurrentServerRole,
-            CancellationToken,
-            LocalIdentity,
-            DateTime.UtcNow.AddSeconds(-1),
-            lastId);
+        var secondResult = sut.ProcessInstructions(CacheRefreshers, CancellationToken, LocalIdentity, lastId);
         Assert.Multiple(() =>
         {
             Assert.AreEqual(
@@ -238,7 +213,6 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
                 secondResult
                     .LastId); // No instructions was processed so LastId is 0, this is consistent with behavior from V8
             Assert.AreEqual(0, secondResult.NumberOfInstructionsProcessed); // Nothing was processed.
-            Assert.IsFalse(secondResult.InstructionsWerePruned);
         });
     }
 
@@ -249,8 +223,7 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
         CreateAndDeliveryMultipleInstructions(sut);
 
         var lastId = -1;
-        var result = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole, CancellationToken,
-            LocalIdentity, DateTime.UtcNow.AddSeconds(-1), lastId);
+        var result = sut.ProcessInstructions(CacheRefreshers, CancellationToken, LocalIdentity, lastId);
 
         Assert.AreEqual(3, result.LastId); // Make sure LastId is 3, the rest is tested in other test.
         lastId = result.LastId;
@@ -259,14 +232,12 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
         var instructions = CreateInstructions();
         sut.DeliverInstructions(instructions, AlternateIdentity);
 
-        var secondResult = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole,
-            CancellationToken, LocalIdentity, DateTime.UtcNow.AddSeconds(-1), lastId);
+        var secondResult = sut.ProcessInstructions(CacheRefreshers, CancellationToken, LocalIdentity, lastId);
 
         Assert.Multiple(() =>
         {
             Assert.AreEqual(4, secondResult.LastId);
             Assert.AreEqual(1, secondResult.NumberOfInstructionsProcessed);
-            Assert.IsFalse(secondResult.InstructionsWerePruned);
         });
     }
 
@@ -277,8 +248,7 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
         CreateAndDeliveryMultipleInstructions(sut);
 
         var lastId = -1;
-        var result = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole, CancellationToken,
-            LocalIdentity, DateTime.UtcNow.AddSeconds(-1), lastId);
+        var result = sut.ProcessInstructions(CacheRefreshers, CancellationToken, LocalIdentity, lastId);
 
         Assert.AreEqual(3, result.LastId); // Make sure LastId is 3, the rest is tested in other test.
         lastId = result.LastId;
@@ -287,14 +257,12 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
         var instructions = CreateInstructions();
         sut.DeliverInstructions(instructions, LocalIdentity);
 
-        var secondResult = sut.ProcessInstructions(CacheRefreshers, ServerRoleAccessor.CurrentServerRole,
-            CancellationToken, LocalIdentity, DateTime.UtcNow.AddSeconds(-1), lastId);
+        var secondResult = sut.ProcessInstructions(CacheRefreshers, CancellationToken, LocalIdentity, lastId);
 
         Assert.Multiple(() =>
         {
             Assert.AreEqual(4, secondResult.LastId);
             Assert.AreEqual(0, secondResult.NumberOfInstructionsProcessed);
-            Assert.IsFalse(secondResult.InstructionsWerePruned);
         });
     }
 
@@ -305,11 +273,5 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
             var instructions = CreateInstructions();
             sut.DeliverInstructions(instructions, i == 2 ? LocalIdentity : AlternateIdentity);
         }
-    }
-
-    private void EnsureServerRegistered()
-    {
-        var serverRegistrationService = GetRequiredService<IServerRegistrationService>();
-        serverRegistrationService.TouchServer("http://localhost", TimeSpan.FromMinutes(10));
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJobTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.BackgroundJobs.Jobs;
+
+public class CacheInstructionsPruningJobTests
+{
+    private readonly Mock<IOptions<GlobalSettings>> _globalSettings = new(MockBehavior.Strict);
+    private readonly Mock<ICacheInstructionRepository> _cacheInstructionRepository = new(MockBehavior.Strict);
+    private readonly Mock<TimeProvider> _timeProvider = new(MockBehavior.Strict);
+
+    [Test]
+    public void Run_Period_Is_Retrieved_From_GlobalSettings()
+    {
+        var timeBetweenPruneOperations = TimeSpan.FromMinutes(2);
+        var job = CreateCacheInstructionsPruningJob(timeBetweenPruneOperations);
+        Assert.AreEqual(timeBetweenPruneOperations, job.Period, "The run period should be the same as 'TimeBetweenPruneOperations'.");
+    }
+
+    [Test]
+    public async Task RunJobAsync_Calls_DeleteInstructionsOlderThan_With_Expected_Date()
+    {
+        var timeToRetainInstructions = TimeSpan.FromMinutes(30);
+        var now = DateTime.UtcNow;
+        var expectedPruneDate = now - timeToRetainInstructions;
+
+        _timeProvider.Setup(tp => tp.GetUtcNow()).Returns(now);
+        _cacheInstructionRepository.Setup(repo => repo
+                .DeleteInstructionsOlderThan(expectedPruneDate));
+
+        var job = CreateCacheInstructionsPruningJob(timeToRetainInstructions: timeToRetainInstructions);
+
+        await job.RunJobAsync();
+
+        _cacheInstructionRepository.Verify(repo => repo.DeleteInstructionsOlderThan(expectedPruneDate), Times.Once);
+    }
+
+    private CacheInstructionsPruningJob CreateCacheInstructionsPruningJob(
+        TimeSpan? timeBetweenPruneOperations = null,
+        TimeSpan? timeToRetainInstructions = null)
+    {
+        timeBetweenPruneOperations ??= TimeSpan.FromMinutes(5);
+        timeToRetainInstructions ??= TimeSpan.FromMinutes(20);
+
+        var globalSettings = new GlobalSettings
+        {
+            DatabaseServerMessenger = new DatabaseServerMessengerSettings
+            {
+                TimeBetweenPruneOperations = timeBetweenPruneOperations.Value,
+                TimeToRetainInstructions = timeToRetainInstructions.Value,
+            },
+        };
+
+        _globalSettings
+            .Setup(g => g.Value)
+            .Returns(globalSettings);
+
+        return new CacheInstructionsPruningJob(_globalSettings.Object, _cacheInstructionRepository.Object, _timeProvider.Object);
+    }
+}


### PR DESCRIPTION
### Description
Moves the cache instructions pruning from the `CacheInstructionService.ProcessInstructions()` method to a new `CacheInstructionsPruningJob` background job.

### Testing
Make sure that the instructions are still pruned as expected, by checking the `umbracoCacheInstruction` database table.
To help with testing, adjust the following app settings to lower values:
```json
"Umbraco": {
  "CMS": {
    ..
    "Global": {
      ...
      "DatabaseServerMessenger": {
        "TimeBetweenPruneOperations": "0:00:30",
        "TimeToRetainInstructions": "0:05:00"
      }
    },
  }
}
```
This should make it so that the job will run every 30 seconds, and will delete all instructions older than 5 minutes (always leaving at least 1).
Be aware that there is a default delay of 3 minutes (default) from startup to when the background job actually starts running.