### PR TITLE
Fix pagination in Content Delivery API Index Helper

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexHelper.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexHelper.cs
@@ -33,7 +33,7 @@ internal sealed class DeliveryApiContentIndexHelper : IDeliveryApiContentIndexHe
 
     internal void EnumerateApplicableDescendantsForContentIndex(int rootContentId, Action<IContent[]> actionToPerform, int pageSize)
     {
-        var pageIndex = 0;
+        var itemIndex = 0;
         long total;
 
         IQuery<IContent> query = _umbracoDatabaseFactory.SqlContext.Query<IContent>().Where(content => content.Trashed == false);
@@ -42,14 +42,14 @@ internal sealed class DeliveryApiContentIndexHelper : IDeliveryApiContentIndexHe
         do
         {
             descendants = _contentService
-                .GetPagedDescendants(rootContentId, pageIndex / pageSize, pageSize, out total, query, Ordering.By("Path"))
+                .GetPagedDescendants(rootContentId, itemIndex / pageSize, pageSize, out total, query, Ordering.By("Path"))
                 .Where(descendant => _deliveryApiSettings.IsAllowedContentType(descendant.ContentType.Alias))
                 .ToArray();
 
             actionToPerform(descendants);
 
-            pageIndex += pageSize;
+            itemIndex += pageSize;
         }
-        while (descendants.Length > 0 && pageIndex < total);
+        while (descendants.Length > 0 && itemIndex < total);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexHelperTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexHelperTests.cs
@@ -21,7 +21,7 @@ public class DeliveryApiContentIndexHelperTests : UmbracoIntegrationTestWithCont
         base.CreateTestData();
 
         // Save an extra, published content item of a different type to those created via the base class,
-        // that we'll use to test filtering out.
+        // that we'll use to test filtering out disallowed content types.
         var template = TemplateBuilder.CreateTextPageTemplate("textPage2");
         FileService.SaveTemplate(template);
 


### PR DESCRIPTION
**Resolves**: https://github.com/umbraco/Umbraco-CMS/issues/18683

### Description
 When rebuilding the Content Delivery API Index it only fetches 10.000 descendants at maximum currently. The logic that was used was flawed and was always stopping at 10.000 items.
This fix updates the logic so that it can fetch all of the descendants and insert them into the index.
We tested this on our own website and this fix is currently working in production.