### PR TITLE
Fix for code scanning alert no. 1719: Client-side cross-site scripting

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
@@ -7,7 +7,7 @@ import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice
 import type { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { debounce } from '@umbraco-cms/backoffice/utils';
-
+import DOMPurify from 'dompurify';
 interface UmbMediaInfoViewLink {
 	url: string | undefined;
 }
@@ -111,12 +111,16 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 		const html = `<!doctype html>
 <body style="background-image: linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%); background-size:30px 30px; background-position:0 0, 15px 0, 15px -15px, 0px 15px;">
 	<img src="${imagePath}"/>
-	<script>history.pushState(null, null, "${window.location.href}");</script>
+	<script>history.pushState(null, null, "${this.#sanitizeUrl(window.location.href)}");</script>
 </body>`;
 
 		popup.document.open();
 		popup.document.write(html);
 		popup.document.close();
+	}
+
+	#sanitizeUrl(url: string): string {
+		return DOMPurify.sanitize(url);
 	}
 
 	#renderContent() {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/url/info-app/media-links-workspace-info-app.element.ts
@@ -6,8 +6,8 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import type { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
-import { debounce } from '@umbraco-cms/backoffice/utils';
-import DOMPurify from 'dompurify';
+import { debounce, sanitizeHTML } from '@umbraco-cms/backoffice/utils';
+
 interface UmbMediaInfoViewLink {
 	url: string | undefined;
 }
@@ -111,16 +111,12 @@ export class UmbMediaLinksWorkspaceInfoAppElement extends UmbLitElement {
 		const html = `<!doctype html>
 <body style="background-image: linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%); background-size:30px 30px; background-position:0 0, 15px 0, 15px -15px, 0px 15px;">
 	<img src="${imagePath}"/>
-	<script>history.pushState(null, null, "${this.#sanitizeUrl(window.location.href)}");</script>
+	<script>history.pushState(null, null, "${sanitizeHTML(window.location.href)}");</script>
 </body>`;
 
 		popup.document.open();
 		popup.document.write(html);
 		popup.document.close();
-	}
-
-	#sanitizeUrl(url: string): string {
-		return DOMPurify.sanitize(url);
 	}
 
 	#renderContent() {


### PR DESCRIPTION
Potential fix for [https://github.com/umbraco/Umbraco-CMS/security/code-scanning/1719](https://github.com/umbraco/Umbraco-CMS/security/code-scanning/1719)

To fix the issue, we need to sanitize or encode the `window.location.href` value before including it in the `html` string. The best approach is to use a library like `DOMPurify` to sanitize the value or encode it using a utility function to ensure it is safe for inclusion in HTML. This will prevent any malicious scripts from being executed.

Steps to fix:
1. Import a library like `DOMPurify` or use a built-in encoding function to sanitize or encode the `window.location.href` value.
2. Replace the direct usage of `window.location.href` in the `html` string with its sanitized or encoded version.
3. Ensure that the rest of the functionality remains unchanged.
