### PR TITLE
v16 QA Remove smoke tag from flaky test 

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithImageCropper.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithImageCropper.spec.ts
@@ -22,7 +22,7 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
 });
 
-// Flaky only on the pipeline, look into why. Can't reproduce on the pipeline, Add smoke tag after fixed
+// TODO: Investigate pipeline flakiness for this test. Reapply '@smoke' tag once the issue is resolved.
 test('can create content with the image cropper data type', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const expectedState = 'Draft';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithImageCropper.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentWithImageCropper.spec.ts
@@ -22,7 +22,8 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
 });
 
-test('can create content with the image cropper data type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+// Flaky only on the pipeline, look into why. Can't reproduce on the pipeline, Add smoke tag after fixed
+test('can create content with the image cropper data type', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const expectedState = 'Draft';
   const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);


### PR DESCRIPTION
Removed flaky test from running on each PR until we have fixed the test, currently the test only fails occasionally on the pipeline. I cannot recreate the issue locally 