### PR TITLE
Table checkbox/icon alignment

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -277,7 +277,7 @@ export class UmbTableElement extends UmbLitElement {
 					this.config.allowSelection,
 					() => html`
 						<uui-checkbox
-							aria-label="Select all rows"
+							aria-label=${this.localize.term('general_selectAll')}
 							style="padding: var(--uui-size-4) var(--uui-size-5);"
 							@change="${this._handleAllRowsCheckboxChange}"
 							?checked=${this.selection.length === this.items.length}></uui-checkbox>
@@ -319,7 +319,7 @@ export class UmbTableElement extends UmbLitElement {
 					this.config.allowSelection,
 					() => html`
 						<uui-checkbox
-							aria-label="Select row"
+							aria-label=${this.localize.term('buttons_select')}
 							@click=${(e: PointerEvent) => e.stopPropagation()}
 							@change=${(event: Event) => this._handleRowCheckboxChange(event, item)}
 							?checked=${this._isSelected(item.id)}></uui-checkbox>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -279,13 +279,13 @@ export class UmbTableElement extends UmbLitElement {
 			<uui-table-head-cell style="--uui-table-cell-padding: 0; text-align: center;">
 				${when(
 					this.config.allowSelection,
-					() =>
-						html` <uui-checkbox
-							label="Select All"
+					() => html`
+						<uui-checkbox
+							aria-label="Select all rows"
 							style="padding: var(--uui-size-4) var(--uui-size-5);"
 							@change="${this._handleAllRowsCheckboxChange}"
-							?checked="${this.selection.length === this.items.length}">
-						</uui-checkbox>`,
+							?checked=${this.selection.length === this.items.length}></uui-checkbox>
+					`,
 				)}
 			</uui-table-head-cell>
 		`;
@@ -321,11 +321,10 @@ export class UmbTableElement extends UmbLitElement {
 					this.config.allowSelection,
 					() => html`
 						<uui-checkbox
-							label="Select Row"
+							aria-label="Select row"
 							@click=${(e: PointerEvent) => e.stopPropagation()}
 							@change=${(event: Event) => this._handleRowCheckboxChange(event, item)}
-							?checked="${this._isSelected(item.id)}">
-						</uui-checkbox>
+							?checked=${this._isSelected(item.id)}></uui-checkbox>
 					`,
 				)}
 			</uui-table-cell>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -235,13 +235,10 @@ export class UmbTableElement extends UmbLitElement {
 	}
 
 	override render() {
+		const style = !(this.config.allowSelection === false && this.config.hideIcon === true) ? 'width: 60px' : undefined;
 		return html`
 			<uui-table class="uui-text">
-				<uui-table-column
-					.style=${when(
-						!(this.config.allowSelection === false && this.config.hideIcon === true),
-						() => 'width: 60px',
-					)}></uui-table-column>
+				<uui-table-column style=${ifDefined(style)}></uui-table-column>
 				<uui-table-head>
 					${this._renderHeaderCheckboxCell()} ${this.columns.map((column) => this._renderHeaderCell(column))}
 				</uui-table-head>
@@ -274,7 +271,6 @@ export class UmbTableElement extends UmbLitElement {
 
 	private _renderHeaderCheckboxCell() {
 		if (this.config.hideIcon && !this.config.allowSelection) return;
-
 		return html`
 			<uui-table-head-cell style="--uui-table-cell-padding: 0; text-align: center;">
 				${when(
@@ -307,9 +303,11 @@ export class UmbTableElement extends UmbLitElement {
 
 	private _renderRowCheckboxCell(item: UmbTableItem) {
 		if (this.sortable === true) {
-			return html`<uui-table-cell style="text-align: center;">
-				<uui-icon name="icon-grip"></uui-icon>
-			</uui-table-cell>`;
+			return html`
+				<uui-table-cell style="text-align: center;">
+					<uui-icon name="icon-grip"></uui-icon>
+				</uui-table-cell>
+			`;
 		}
 
 		if (this.config.hideIcon && !this.config.allowSelection) return;


### PR DESCRIPTION
### Description

Fixes #19563.

The reason for the misalignment with the table row's icon and checkbox (on hover), is that the `<uui-checkbox>` component had whitespace (newline) within the slotted content, causing the component's `flex` layout to add a `gap` between the checkbox input and the whitespace. By removing the whitespace, the gap is removed, realigning the icon and checkbox.


