### PR TITLE
Adds checkbox for card selection (in document and media collections)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/grid/document-grid-collection-view.element.ts
@@ -73,6 +73,12 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 		this.#collectionContext?.selection.deselect(item.unique);
 	}
 
+	#onToggleSelect(item: UmbDocumentCollectionItemModel) {
+		if (item.unique) {
+			this.#collectionContext?.selection.toggleSelect(item.unique);
+		}
+	}
+
 	#isSelected(item: UmbDocumentCollectionItemModel) {
 		return this.#collectionContext?.selection.isSelected(item.unique);
 	}
@@ -100,17 +106,20 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 
 	#renderItem(item: UmbDocumentCollectionItemModel) {
 		return html`
-			<uui-card-content-node
-				.name=${item.name ?? 'Unnamed Document'}
-				selectable
-				?select-only=${this._selection.length > 0}
-				?selected=${this.#isSelected(item)}
-				href=${this.#getEditUrl(item)}
-				@selected=${() => this.#onSelect(item)}
-				@deselected=${() => this.#onDeselect(item)}>
-				<umb-icon slot="icon" name=${item.icon}></umb-icon>
-				${this.#renderState(item)} ${this.#renderProperties(item)}
-			</uui-card-content-node>
+			<div class="document-card">
+				<uui-checkbox ?checked=${this.#isSelected(item)} @change=${() => this.#onToggleSelect(item)}></uui-checkbox>
+				<uui-card-content-node
+					.name=${item.name ?? 'Unnamed Document'}
+					selectable
+					?select-only=${this._selection.length > 0}
+					?selected=${this.#isSelected(item)}
+					href=${this.#getEditUrl(item)}
+					@selected=${() => this.#onSelect(item)}
+					@deselected=${() => this.#onDeselect(item)}>
+					<umb-icon slot="icon" name=${item.documentType.icon}></umb-icon>
+					${this.#renderState(item)} ${this.#renderProperties(item)}
+				</uui-card-content-node>
+			</div>
 		`;
 	}
 
@@ -179,11 +188,30 @@ export class UmbDocumentGridCollectionViewElement extends UmbLitElement {
 				display: grid;
 				grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 				gap: var(--uui-size-space-4);
+
+				.document-card {
+					display: flex;
+					position: relative;
+
+					> uui-checkbox {
+						position: absolute;
+						top: calc(var(--uui-size-space-4) + var(--uui-size-1));
+						left: var(--uui-size-space-5);
+						opacity: 0;
+						transition: opacity 120ms;
+						z-index: 2;
+					}
+
+					&:has(:focus, :focus-within, :hover) > uui-checkbox,
+					> uui-checkbox[checked] {
+						opacity: 1;
+					}
+				}
 			}
 
 			uui-card-content-node {
 				width: 100%;
-				height: 180px;
+				min-height: 180px;
 			}
 
 			ul {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -1,13 +1,12 @@
 import { UmbMediaItemRepository } from '../../repository/index.js';
+import { UmbMediaSearchProvider } from '../../search/index.js';
 import { UmbMediaTreeRepository } from '../../tree/media-tree.repository.js';
 import { UMB_MEDIA_ROOT_ENTITY_TYPE } from '../../entity.js';
-import type { UmbMediaTreeItemModel, UmbMediaSearchItemModel, UmbMediaItemModel } from '../../types.js';
-import { UmbMediaSearchProvider } from '../../search/index.js';
 import type { UmbDropzoneMediaElement } from '../../dropzone/index.js';
+import type { UmbMediaTreeItemModel, UmbMediaSearchItemModel, UmbMediaItemModel } from '../../types.js';
 import type { UmbMediaPathModel } from './types.js';
 import type { UmbMediaPickerFolderPathElement } from './components/media-picker-folder-path.element.js';
 import type { UmbMediaPickerModalData, UmbMediaPickerModalValue } from './media-picker-modal.token.js';
-import type { UmbDropzoneChangeEvent, UmbUploadableItem } from '@umbraco-cms/backoffice/dropzone';
 import {
 	css,
 	html,
@@ -16,16 +15,18 @@ import {
 	repeat,
 	ifDefined,
 	query,
-	type PropertyValues,
 	nothing,
+	when,
 } from '@umbraco-cms/backoffice/external/lit';
 import { debounce, UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
+import { isUmbracoFolder } from '@umbraco-cms/backoffice/media-type';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UMB_PROPERTY_TYPE_BASED_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/content';
-import type { UUIInputEvent, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
-import { isUmbracoFolder } from '@umbraco-cms/backoffice/media-type';
-import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import { UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
+import type { PropertyValues } from '@umbraco-cms/backoffice/external/lit';
+import type { UmbDropzoneChangeEvent, UmbUploadableItem } from '@umbraco-cms/backoffice/dropzone';
+import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import type { UUIInputEvent, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 
 import '@umbraco-cms/backoffice/imaging';
 
@@ -411,7 +412,13 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<UmbMediaPick
 		const disabled = !(selectable || canNavigate);
 		return html`
 			<div class="media-card">
-				<uui-checkbox ?checked=${this.#isSelected(item)} @change=${() => this.#onToggleSelect(item)}></uui-checkbox>
+				${when(
+					selectable && (this._isSelectionMode || canNavigate === false),
+					() =>
+						html`<uui-checkbox
+							?checked=${this.#isSelected(item)}
+							@change=${() => this.#onToggleSelect(item)}></uui-checkbox>`,
+				)}
 				<uui-card-media
 					class=${ifDefined(disabled ? 'not-allowed' : undefined)}
 					.name=${item.name}


### PR DESCRIPTION
### Description

As a UX enhancement, a checkbox has been added to selectable cards in the Document and Media collection grid view. This gives a visual indicator that the card can be selected, (rather than attempting to click the border), this also aligns with how multiple rows are selected in the collection table view.

#### How to test?

Go the Media section/root, hover over a media item, notice that a checkbox appears, click the checkbox to select the card.
Try using keyboard navigation (tabbing + space to check the input) to select multiple cards.