### PR TITLE
fix: json serialization and deserialization for NuCacheSerializerType

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonContentNestedDataSerializer.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonContentNestedDataSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Umbraco.Cms.Core.Models;
 
@@ -8,7 +8,11 @@ internal class JsonContentNestedDataSerializer : IContentCacheDataSerializer
 {
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters =
+        {
+            new JsonObjectConverter(),
+        },
     };
 
     /// <inheritdoc />

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonObjectConverter.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonObjectConverter.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Infrastructure.HybridCache.Serialization;
+
+internal class JsonObjectConverter : JsonConverter<object>
+{
+    public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.TokenType switch
+        {
+            JsonTokenType.String => reader.GetString(),
+            JsonTokenType.Number => reader.TryGetInt64(out var l) ? l : reader.GetDouble(),
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.Null => null,
+            _ => JsonDocument.ParseValue(ref reader).RootElement.Clone(), // fallback for complex types
+        };
+
+    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        => JsonSerializer.Serialize(writer, value, value.GetType(), options);
+}


### PR DESCRIPTION
### Prerequisites

This PR fixes https://github.com/umbraco/Umbraco-CMS/issues/19544

### Description
If NuCacheSerializerType is set to JSON, values in PropertyData are not deserialized correctly when the underlying store contains JSON strings.

What I did
Updated the JsonConverter logic to ensure proper deserialization of string values.

How to test
Create a content item that uses a Block Grid property.

Inspect the strongly typed property value.

Without the fix, the property is null; with the fix, it is correctly deserialized.

✅ No breaking changes introduced.
