### PR TITLE
Removes full-width from toggle property editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-toggle/input-toggle.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-toggle/input-toggle.element.ts
@@ -71,14 +71,6 @@ export class UmbInputToggleElement extends UmbFormControlMixin(UmbLitElement, ''
 			><span>${label}</span>
 		</uui-toggle>`;
 	}
-
-	static override styles = [
-		css`
-			uui-toggle {
-				width: 100%;
-			}
-		`,
-	];
 }
 
 export default UmbInputToggleElement;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19625

### Description
Previously the "hitbox" for the toggle property editor was the full-width of the workspace, making inadvertent edits possible.  It's also inconsistent from where we use the raw `uui-toggle` - e.g. in the members section - where we don't allow the full width to be clickable.

### Testing

With a toggle property editor, verify that only the element itself is clickable, and not the full-width of the property editor.  See linked issue for illustration.
