### PR TITLE
Aligned jsdoc and inferred function type on UmbCurrentUserContext

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
@@ -196,9 +196,9 @@ export class UmbCurrentUserContext extends UmbContextBase {
 
 	/**
 	 * Get the permissions for the current user
-	 * @returns {Array<DocumentPermissionPresentationModel | UnknownTypePermissionPresentationModel> | undefined} The permissions for the current user
+	 * @returns {unknown[] | undefined} The permissions for the current user
 	 */
-	getPermissions() {
+	getPermissions(): unknown[] | undefined {
 		return this.#currentUser.getValue()?.permissions;
 	}
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19638

### Description
Just a small fix in the exposed client-side API type details.  This now aligned with what is defined in `UmbCurrentUserModel`:

```
export interface UmbCurrentUserModel {
        ...
	permissions: Array<unknown>;
        ...
}
```

