### PR TITLE
Ensures that null values aren't used to create a CompositeStringStringKey

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/Property.cs
+++ b/src/Umbraco.PublishedCache.NuCache/Property.cs
@@ -240,7 +240,7 @@ internal class Property : PublishedPropertyBase
 
         EnsureSourceValuesInitialized();
 
-        var k = new CompositeStringStringKey(culture, segment);
+        var k = new CompositeStringStringKey(culture ?? string.Empty, segment ?? string.Empty); // Null values are not valid when creating a CompositeStringStringKey.
 
         SourceInterValue vvalue = _sourceValues!.GetOrAdd(k, _ =>
             new SourceInterValue


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19609

### Description
I haven't been able to replicate the problem, which looks from the reported issue that it bubbles up from Commerce.  But it does look to be similar to the fix applied for https://github.com/umbraco/Umbraco-CMS/issues/16753 in https://github.com/umbraco/Umbraco-CMS/pull/17024, and this is a further case.

The problem is that the constructor of `CompositeStringStringKey` accepts null values but throws if they are passed.  So we ned to make sure we use `string.Empty` as we did in the other case.

### Testing
Visual inspection will need to suffice here I believe.
