### PR TITLE
GitHub: Only deploy to Azure on direct pull requests

### DIFF
--- a/.github/workflows/azure-backoffice.yml
+++ b/.github/workflows/azure-backoffice.yml
@@ -44,7 +44,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/backoffice')
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:

--- a/.github/workflows/azure-backoffice.yml
+++ b/.github/workflows/azure-backoffice.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && (contains(github.event.pull_request.labels.*.name, 'preview/backoffice')))
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/backoffice') && github.repository == github.event.pull_request.head.repo.full_name)
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -44,7 +44,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/backoffice')
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/backoffice') && github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:

--- a/.github/workflows/azure-storybook.yml
+++ b/.github/workflows/azure-storybook.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && (contains(github.event.pull_request.labels.*.name, 'preview/storybook')))
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/storybook') && github.repository == github.event.pull_request.head.repo.full_name)
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -45,7 +45,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/storybook')
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/storybook') && github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:

--- a/.github/workflows/azure-storybook.yml
+++ b/.github/workflows/azure-storybook.yml
@@ -45,7 +45,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview/storybook')
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:


### PR DESCRIPTION
This alleviates the problem that the deploymentToken for Azure only exists within the repository.

According to CoPilot, this is the correct way to check if you are on a fork or not: https://docs.github.com/?search-overlay-open=true&search-overlay-ask-ai=true&search-overlay-input=how%20can%20I%20determine%20through%20environment%20variables%20that%20a%20pull%20request%20runs%20in%20a%20fork%20of%20the%20repository%3F