### PR TITLE
V16.1: Never reject a token response

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth-flow.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth-flow.ts
@@ -305,7 +305,7 @@ export class UmbAuthFlow {
 	/**
 	 * This method will check if the token needs to be refreshed and if so, it will refresh it and return the new access token.
 	 * If the token does not need to be refreshed, it will return the current access token.
-	 * @returns The access token for the user.
+	 * @returns {Promise<string>} The access token for the user.
 	 */
 	async performWithFreshTokens(): Promise<string> {
 		// if the access token is valid, return it
@@ -313,17 +313,16 @@ export class UmbAuthFlow {
 			return Promise.resolve(this.#tokenResponse.accessToken);
 		}
 
+		// if the access token is not valid, try to refresh it
 		const success = await this.makeRefreshTokenRequest();
 
 		if (!success) {
+			// if the refresh token request failed, we need to clear the token state
 			this.clearTokenStorage();
-			this.#timeoutSignal.next();
-			return Promise.reject('Missing tokenResponse.');
 		}
 
-		return this.#tokenResponse
-			? Promise.resolve(this.#tokenResponse.accessToken)
-			: Promise.reject('Missing tokenResponse.');
+		// if the refresh token request was successful, return the new access token
+		return Promise.resolve(this.#tokenResponse?.accessToken ?? '');
 	}
 
 	/**


### PR DESCRIPTION
## Description

If a token response is rejected, then the pipeline will also fail because it does not understand that error. Let the API interceptors do their job instead and simply return the old, now-invalid token which will prompt the API interceptors to store the request states and retry them afterwards.