### PR TITLE
Replace UUIFormControlMixin with UmbFormControlMixin

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-color/input-color.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-color/input-color.element.ts
@@ -1,16 +1,16 @@
 import { html, customElement, property, map, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbSwatchDetails } from '@umbraco-cms/backoffice/models';
 import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 /*
  * This wraps the UUI library uui-color-swatches component
  * @element umb-input-color
  */
 @customElement('umb-input-color')
-export class UmbInputColorElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputColorElement extends UmbFormControlMixin(UmbLitElement) {
 	protected override getFormElement() {
 		return undefined;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-eye-dropper/input-eye-dropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-eye-dropper/input-eye-dropper.element.ts
@@ -1,11 +1,11 @@
 import { customElement, html, property, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UUIColorPickerChangeEvent } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-eye-dropper')
-export class UmbInputEyeDropperElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputEyeDropperElement extends UmbFormControlMixin(UmbLitElement, '') {
 	protected override getFormElement() {
 		return undefined;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-slider/input-slider.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-slider/input-slider.element.ts
@@ -1,11 +1,11 @@
 import { customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UUISliderEvent } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-slider')
-export class UmbInputSliderElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputSliderElement extends UmbFormControlMixin(UmbLitElement, '') {
 	@property()
 	label: string = '';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-input.element.ts
@@ -1,18 +1,18 @@
 import type { UmbMultipleColorPickerItemInputElement } from './multiple-color-picker-item-input.element.js';
 import { css, customElement, html, nothing, repeat, property, state } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import type { UmbInputEvent, UmbDeleteEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbSwatchDetails } from '@umbraco-cms/backoffice/models';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 /**
  * @element umb-multiple-color-picker-input
  */
 @customElement('umb-multiple-color-picker-input')
-export class UmbMultipleColorPickerInputElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbMultipleColorPickerInputElement extends UmbFormControlMixin(UmbLitElement, '') {
 	#sorter = new UmbSorterController(this, {
 		getUniqueOfElement: (element: UmbMultipleColorPickerItemInputElement) => {
 			return element.value.toString();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
@@ -12,14 +12,14 @@ import {
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent, UmbInputEvent, UmbDeleteEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UUIColorPickerElement, UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 /**
  * @element umb-multiple-color-picker-item-input
  */
 @customElement('umb-multiple-color-picker-item-input')
-export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbMultipleColorPickerItemInputElement extends UmbFormControlMixin(UmbLitElement, '') {
 	@property({ type: String })
 	public override set value(value: string) {
 		if (value.startsWith('#')) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-text-string-input/input-multiple-text-string-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-text-string-input/input-multiple-text-string-item.element.ts
@@ -2,14 +2,14 @@ import { css, customElement, html, nothing, property, query, when } from '@umbra
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent, UmbInputEvent, UmbDeleteEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 /**
  * @element umb-input-multiple-text-string-item
  */
 @customElement('umb-input-multiple-text-string-item')
-export class UmbInputMultipleTextStringItemElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputMultipleTextStringItemElement extends UmbFormControlMixin(UmbLitElement, '') {
 	/**
 	 * Disables the input
 	 * @type {boolean}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/culture/components/input-culture-select/input-culture-select.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/culture/components/input-culture-select/input-culture-select.element.ts
@@ -2,12 +2,12 @@ import { UmbCultureRepository } from '../../repository/culture.repository.js';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { html, repeat, ifDefined, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
 import type { UUIComboboxElement, UUIComboboxEvent } from '@umbraco-cms/backoffice/external/uui';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { CultureReponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-culture-select')
-export class UmbInputCultureSelectElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputCultureSelectElement extends UmbFormControlMixin(UmbLitElement, '') {
 	/**
 	 * Disables the input
 	 * @type {boolean}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/object-type/input-object-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/object-type/input-object-type.element.ts
@@ -1,11 +1,11 @@
 import { UmbObjectTypeRepository } from './object-type.repository.js';
 import { html, customElement, property, query, state } from '@umbraco-cms/backoffice/external/lit';
 import type { UUISelectElement } from '@umbraco-cms/backoffice/external/uui';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-object-type')
-export class UmbInputObjectTypeElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputObjectTypeElement extends UmbFormControlMixin(UmbLitElement, '') {
 	@query('uui-select')
 	private select!: UUISelectElement;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/components/data-type-input/data-type-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/components/data-type-input/data-type-input.element.ts
@@ -5,11 +5,11 @@ import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 // TODO: Rename to 'umb-input-data-type'. [LK]
 @customElement('umb-data-type-input')
-export class UmbDataTypeInputElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbDataTypeInputElement extends UmbFormControlMixin(UmbLitElement, '') {
 	#sorter = new UmbSorterController<string>(this, {
 		getUniqueOfElement: (element) => {
 			return element.id;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document-property-value/input-document-property-value-user-permission/input-document-property-value-user-permission.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document-property-value/input-document-property-value-user-permission/input-document-property-value-user-permission.element.ts
@@ -15,7 +15,6 @@ import {
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import {
 	UMB_ENTITY_USER_PERMISSION_MODAL,
 	type ManifestEntityUserPermission,
@@ -25,9 +24,10 @@ import {
 	type UmbDocumentTypeDetailModel,
 } from '@umbraco-cms/backoffice/document-type';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-document-property-value-user-permission')
-export class UmbInputDocumentPropertyValueUserPermissionElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputDocumentPropertyValueUserPermissionElement extends UmbFormControlMixin(UmbLitElement, '') {
 	_permissions: Array<UmbDocumentPropertyValueUserPermissionModel> = [];
 	public get permissions(): Array<UmbDocumentPropertyValueUserPermissionModel> {
 		return this._permissions;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/input-document-granular-user-permission/input-document-granular-user-permission.element.ts
@@ -9,14 +9,14 @@ import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import type { UmbDeselectedEvent } from '@umbraco-cms/backoffice/event';
 import { UmbChangeEvent, UmbSelectedEvent } from '@umbraco-cms/backoffice/event';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import {
 	UMB_ENTITY_USER_PERMISSION_MODAL,
 	type ManifestEntityUserPermission,
 } from '@umbraco-cms/backoffice/user-permission';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-document-granular-user-permission')
-export class UmbInputDocumentGranularUserPermissionElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputDocumentGranularUserPermissionElement extends UmbFormControlMixin(UmbLitElement, '') {
 	_permissions: Array<UmbDocumentUserPermissionModel> = [];
 	public get permissions(): Array<UmbDocumentUserPermissionModel> {
 		return this._permissions;

--- a/src/Umbraco.Web.UI.Client/src/packages/language/components/input-language/input-language.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/components/input-language/input-language.element.ts
@@ -5,10 +5,10 @@ import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-language')
-export class UmbInputLanguageElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputLanguageElement extends UmbFormControlMixin(UmbLitElement, '') {
 	#sorter = new UmbSorterController<string>(this, {
 		getUniqueOfElement: (element) => {
 			return element.id;

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -17,12 +17,12 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbModalRouteBuilder } from '@umbraco-cms/backoffice/router';
 import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UUIModalSidebarSize } from '@umbraco-cms/backoffice/external/uui';
 import { UmbDocumentUrlRepository, UmbDocumentUrlsDataResolver } from '@umbraco-cms/backoffice/document';
 import { UmbMediaUrlRepository } from '@umbraco-cms/backoffice/media';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 /**
  * @element umb-input-multi-url
@@ -32,7 +32,7 @@ import { UmbMediaUrlRepository } from '@umbraco-cms/backoffice/media';
  */
 const elementName = 'umb-input-multi-url';
 @customElement(elementName)
-export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputMultiUrlElement extends UmbFormControlMixin(UmbLitElement, '') {
 	#sorter = new UmbSorterController<UmbLinkPickerLink>(this, {
 		getUniqueOfElement: (element) => {
 			return element.id;

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/components/input-collection-content-type-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/components/input-collection-content-type-property.element.ts
@@ -1,5 +1,4 @@
 import { html, customElement, property, css } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbChangeEvent, UmbSelectionChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbMediaTypeDetailRepository, UMB_MEDIA_TYPE_PICKER_MODAL } from '@umbraco-cms/backoffice/media-type';
@@ -9,6 +8,7 @@ import { UMB_ITEM_PICKER_MODAL, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/b
 import type { UmbContentTypeModel } from '@umbraco-cms/backoffice/content-type';
 import type { UmbDetailRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbItemPickerModel, UmbModalToken, UmbPickerModalValue } from '@umbraco-cms/backoffice/modal';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 export type UmbContentTypePropertyValue = {
 	label: string;
@@ -32,7 +32,7 @@ type UmbInputContentTypePropertyConfiguration = {
 };
 
 @customElement('umb-input-collection-content-type-property')
-export class UmbInputCollectionContentTypePropertyElement extends UUIFormControlMixin(UmbLitElement, undefined) {
+export class UmbInputCollectionContentTypePropertyElement extends UmbFormControlMixin(UmbLitElement, undefined) {
 	#configuration: UmbInputContentTypePropertyConfiguration = {
 		documentTypes: {
 			item: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-content/input-content-picker-source.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-content/input-content-picker-source.element.ts
@@ -2,14 +2,14 @@ import type { UmbContentPickerDynamicRoot, UmbContentPickerSourceType } from '..
 import type { UmbInputContentPickerDocumentRootElement } from '../../dynamic-root/components/input-content-picker-document-root.element.js';
 import { html, customElement, property, css, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import type { UUISelectEvent } from '@umbraco-cms/backoffice/external/uui';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 import '../../dynamic-root/components/input-content-picker-document-root.element.js';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-content-picker-source')
-export class UmbInputContentPickerSourceElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputContentPickerSourceElement extends UmbFormControlMixin(UmbLitElement, '') {
 	protected override getFormElement() {
 		return undefined;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
@@ -11,12 +11,12 @@ import {
 	repeat,
 } from '@umbraco-cms/backoffice/external/lit';
 import type { UUIInputElement, UUIInputEvent, UUITagElement } from '@umbraco-cms/backoffice/external/uui';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { TagResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-tags-input')
-export class UmbTagsInputElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbTagsInputElement extends UmbFormControlMixin(UmbLitElement, '') {
 	@property({ type: String })
 	group?: string;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/global-components/stylesheet-input/stylesheet-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/global-components/stylesheet-input/stylesheet-input.element.ts
@@ -1,12 +1,12 @@
 import type { UmbStylesheetItemModel } from '../../types.js';
 import { UmbStylesheetPickerInputContext } from './stylesheet-input.context.js';
 import { css, html, customElement, property, state, repeat } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-stylesheet-input')
-export class UmbStylesheetInputElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbStylesheetInputElement extends UmbFormControlMixin(UmbLitElement, '') {
 	/**
 	 * This is a minimum amount of selected items in this input.
 	 * @type {number}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/global-components/input-template/input-template.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/global-components/input-template/input-template.element.ts
@@ -4,15 +4,15 @@ import type { UmbTemplateItemModel } from '../../repository/item/index.js';
 import { UmbTemplateItemRepository } from '../../repository/item/index.js';
 import { UMB_TEMPLATE_PICKER_MODAL } from '../../modals/index.js';
 import { css, html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/workspace';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-input-template')
-export class UmbInputTemplateElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbInputTemplateElement extends UmbFormControlMixin(UmbLitElement, '') {
 	/**
 	 * This is a minimum amount of selected items in this input.
 	 * @type {number}

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/global-components/template-card/template-card.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/global-components/template-card/template-card.element.ts
@@ -1,6 +1,6 @@
 import { css, html, customElement, property } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 /**
  * @element umb-template-card
@@ -11,9 +11,9 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 // TODO: This should extends the UUICardElement, and the visual look of this should be like the UserCard or similarly.
 // TOOD: Consider if this should be select in the 'persisted'-select style when it is selected as a default. (But its should not use the runtime-selection style)
 @customElement('umb-template-card')
-export class UmbTemplateCardElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbTemplateCardElement extends UmbFormControlMixin(UmbLitElement, '') {
 	@property({ type: String })
-	override name = '';
+	name = '';
 
 	@property({ type: Boolean, reflect: true })
 	default = false;

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/components/input-user-group/user-group-input.element.ts
@@ -2,14 +2,14 @@ import { UMB_USER_GROUP_ENTITY_TYPE } from '../../entity.js';
 import type { UmbUserGroupItemModel } from '../../repository/index.js';
 import { UmbUserGroupPickerInputContext } from './user-group-input.context.js';
 import { css, html, customElement, property, state, ifDefined, nothing } from '@umbraco-cms/backoffice/external/lit';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/workspace';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 @customElement('umb-user-group-input')
-export class UmbUserGroupInputElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbUserGroupInputElement extends UmbFormControlMixin(UmbLitElement, '') {
 	/**
 	 * This is a minimum amount of selected items in this input.
 	 * @type {number}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/components/user-input/user-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/components/user-input/user-input.element.ts
@@ -5,11 +5,11 @@ import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
-import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
 // TODO: Shall we rename to 'umb-input-user'? [LK]
 @customElement('umb-user-input')
-export class UmbUserInputElement extends UUIFormControlMixin(UmbLitElement, '') {
+export class UmbUserInputElement extends UmbFormControlMixin(UmbLitElement, '') {
 	#sorter = new UmbSorterController<string>(this, {
 		getUniqueOfElement: (element) => {
 			return element.id;


### PR DESCRIPTION
Refactors all relevant input and form control components to use the new UmbFormControlMixin from '@umbraco-cms/backoffice/validation' instead of the deprecated UUIFormControlMixin. This change improves consistency and aligns with updated validation handling in the codebase.
