### PR TITLE
#16772 partial fix backoffice redirect after login

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -99,7 +99,7 @@ export default class UmbAuthElement extends LitElement {
 
   @property({attribute: 'return-url'})
   set returnPath(value: string) {
-    umbAuthContext.returnPath = value;
+    umbAuthContext.returnPath = `${value}${encodeURIComponent(window.location.hash)}`;
   }
   get returnPath() {
     return umbAuthContext.returnPath;

--- a/src/Umbraco.Web.UI.Login/src/components/external-login-provider.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/external-login-provider.element.ts
@@ -74,7 +74,12 @@ export class UmbExternalLoginProviderElement extends LitElement {
   set externalLoginUrl(value: string) {
     const tempUrl = new URL(value, window.location.origin);
     const searchParams = new URLSearchParams(window.location.search);
-    tempUrl.searchParams.append('redirectUrl', decodeURIComponent(searchParams.get('returnPath') ?? ''));
+    let returnUrl = decodeURIComponent(searchParams.get('returnPath') ?? '');
+    if(!returnUrl && window.location.hash) {
+      returnUrl = `/umbraco${window.location.hash}`;
+    }
+
+    tempUrl.searchParams.append('redirectUrl', returnUrl);
     this.#externalLoginUrl = tempUrl.pathname + tempUrl.search;
   }
 


### PR DESCRIPTION
With the mindset of better anything than nothing: partial fix for https://github.com/umbraco/Umbraco-CMS/issues/16772
Seems to enable login screen for local (hash needed) and OpenId login (reason for encoding).
This does not fix the flow when `AutoRedirectLoginToExternalProvider` is enabled since I have no idea yet how I would get the anchor value serverside or work around that issue.
