### PR TITLE
Title returns "Server Error" in non-debug mode

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
@@ -43,7 +43,7 @@ internal static class ApplicationBuilderExtensions
 
                     var response = new ProblemDetails
                     {
-                        Title = exception.Message,
+                        Title = isDebug ? exception.Message : null, // ui resolves title in case of null
                         Detail = isDebug ? exception.StackTrace : null,
                         Status = statusCode ?? StatusCodes.Status500InternalServerError,
                         Instance = isDebug ? exception.GetType().Name : null,

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/ApplicationBuilderExtensions.cs
@@ -43,7 +43,7 @@ internal static class ApplicationBuilderExtensions
 
                     var response = new ProblemDetails
                     {
-                        Title = isDebug ? exception.Message : null, // ui resolves title in case of null
+                        Title = isDebug ? exception.Message : "Server Error",
                         Detail = isDebug ? exception.StackTrace : null,
                         Status = statusCode ?? StatusCodes.Status500InternalServerError,
                         Instance = isDebug ? exception.GetType().Name : null,


### PR DESCRIPTION

If there's an existing issue for this PR then this fixes [19664](https://github.com/umbraco/Umbraco-CMS/issues/19664)

### Description
This fix adds a condition for the title.

I am not sure of the value of the title for non-debug mode. The value was copied from [here](https://github.com/umbraco/Umbraco-CMS/blob/9812630bb4664026150732d850d56672b178fa2e/src/Umbraco.Web.UI.Client/src/packages/core/resources/api-interceptor.controller.ts#L110)

How to test:

- Set in appsettings Umbraco:CMS:Hosting:Debug = false
- Add `throw new Exception("Example error message")` for any ManagementApiController
- Trigger this action from backoffice UI and look at the error notificaiton
For non-debug mode we must not see the exception details. But for debug mode we must see the exception details.

