### PR TITLE
Register no-op implementation of IMemberPartialViewCacheInvalidator in headless setups

### DIFF
--- a/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/NoopMemberPartialViewCacheInvalidator.cs
+++ b/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/NoopMemberPartialViewCacheInvalidator.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
+
+internal class NoopMemberPartialViewCacheInvalidator : IMemberPartialViewCacheInvalidator
+{
+    public void ClearPartialViewCacheItems(IEnumerable<int> memberIds)
+    {
+        // No operation performed, this is a no-op implementation.
+    }
+}

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -41,6 +41,7 @@ using Umbraco.Cms.Core.Telemetry;
 using Umbraco.Cms.Core.Templates;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
+using Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
 
 namespace Umbraco.Cms.Core.DependencyInjection
 {
@@ -341,6 +342,11 @@ namespace Umbraco.Cms.Core.DependencyInjection
             // Data type configuration cache
             Services.AddUnique<IDataTypeConfigurationCache, DataTypeConfigurationCache>();
             Services.AddNotificationHandler<DataTypeCacheRefresherNotification, DataTypeConfigurationCacheRefresher>();
+
+            // Partial view cache invalidators (no-op, shipped implementation is added in Umbraco.Web.Website, but we
+            // need this to ensure we have a service registered for this interface even in headless setups).
+            // See: https://github.com/umbraco/Umbraco-CMS/issues/19661
+            Services.AddUnique<IMemberPartialViewCacheInvalidator, NoopMemberPartialViewCacheInvalidator>();
         }
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -8,12 +8,14 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Grid;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Diagnostics;
 using Umbraco.Cms.Core.Dictionary;
+using Umbraco.Cms.Core.DynamicRoot;
 using Umbraco.Cms.Core.Editors;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Features;
@@ -35,13 +37,11 @@ using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.DynamicRoot;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Telemetry;
 using Umbraco.Cms.Core.Templates;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
-using Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
 
 namespace Umbraco.Cms.Core.DependencyInjection
 {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19661

### Description
As the linked issue discusses, when we don't have a call to `.AddWebsite()` in `Program.cs`, the `IMemberPartialViewCacheInvalidator` has no registered implementation, which causes an error when logging in.

This PR registers a no-op implementation of this interface that'll be overridden by the primary implementation if `.AddWebsite()` is used.

### Testing

Setup `Program.cs` like the following, so there's no front-end website but you should be able log into the backoffice.

Verify that you can't before this PR is applied but you can after.

Revert to the standard setup for Umbraco with the front-end rendering, put a breaking point in `MemberPartialViewCacheInvalidator.ClearPartialViewCacheItems` and verify that the primary implementation is called when saving a member in the backoffice.