### PR TITLE
Fix issue with preview in delivery API for MNTP property editor

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -205,7 +205,7 @@ public class MultiNodeTreePickerValueConverter : PropertyValueConverterBase, IDe
         {
             Constants.UdiEntityType.Document => entityTypeUdis.Select(udi =>
             {
-                IPublishedContent? content = _contentCache.GetById(udi.Guid);
+                IPublishedContent? content = _contentCache.GetById(preview, udi.Guid);
                 return content != null
                     ? _apiContentBuilder.Build(content)
                     : null;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -73,7 +73,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
 
         var otherContentKey = Guid.NewGuid();
         var otherContent = SetupPublishedContent("The other page", otherContentKey, PublishedItemType.Content, PublishedContentType);
-        RegisterContentWithProviders(otherContent.Object);
+        RegisterContentWithProviders(otherContent.Object, false);
 
         var valueConverter = MultiNodeTreePickerValueConverter();
 
@@ -95,6 +95,28 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
     }
 
     [Test]
+    public void MultiNodeTreePickerValueConverter_InSingleMode_WithPreview_ConvertsValueToListOfContent()
+    {
+        var publishedDataType = MultiNodePickerPublishedDataType(false, Constants.UdiEntityType.Document);
+        var publishedPropertyType = new Mock<IPublishedPropertyType>();
+        publishedPropertyType.SetupGet(p => p.DataType).Returns(publishedDataType);
+
+        var valueConverter = MultiNodeTreePickerValueConverter();
+
+        Assert.AreEqual(typeof(IEnumerable<IApiContent>), valueConverter.GetDeliveryApiPropertyValueType(publishedPropertyType.Object));
+
+        var inter = new Udi[] { new GuidUdi(Constants.UdiEntityType.Document, DraftContent.Key) };
+        var result = valueConverter.ConvertIntermediateToDeliveryApiObject(Mock.Of<IPublishedElement>(), publishedPropertyType.Object, PropertyCacheLevel.Element, inter, true, false) as IEnumerable<IApiContent>;
+        Assert.NotNull(result);
+        Assert.AreEqual(1, result.Count());
+        Assert.AreEqual(DraftContent.Name, result.First().Name);
+        Assert.AreEqual(DraftContent.Key, result.First().Id);
+        Assert.AreEqual("/the-draft-page-url/", result.First().Route.Path);
+        Assert.AreEqual("TheContentType", result.First().ContentType);
+        Assert.IsEmpty(result.First().Properties);
+    }
+
+    [Test]
     [TestCase(Constants.UdiEntityType.Document)]
     [TestCase("content")]
     public void MultiNodeTreePickerValueConverter_RendersContentProperties(string entityType)
@@ -113,7 +135,7 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
             .Setup(p => p.GetUrl(content.Object, It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
             .Returns(content.Object.UrlSegment);
         PublishedContentCacheMock
-            .Setup(pcc => pcc.GetById(key))
+            .Setup(pcc => pcc.GetById(false, key))
             .Returns(content.Object);
 
         var publishedDataType = MultiNodePickerPublishedDataType(false, entityType);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTestBase.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTestBase.cs
@@ -327,7 +327,7 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
         var urlSegment = "url-segment";
         ConfigurePublishedContentMock(content, key, name, urlSegment, _contentType, properties);
 
-        RegisterContentWithProviders(content.Object);
+        RegisterContentWithProviders(content.Object, false);
     }
 
     protected void SetupMediaMock(Mock<IPublishedContent> media, params IPublishedProperty[] properties)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/PropertyValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/PropertyValueConverterTests.cs
@@ -23,6 +23,8 @@ public class PropertyValueConverterTests : DeliveryApiTests
 
     protected IPublishedContent PublishedMedia { get; private set; }
 
+    protected IPublishedContent DraftContent { get; private set; }
+
     protected IPublishedContentType PublishedContentType { get; private set; }
 
     protected IPublishedContentType PublishedMediaType { get; private set; }
@@ -59,10 +61,21 @@ public class PropertyValueConverterTests : DeliveryApiTests
         var publishedMedia = SetupPublishedContent("The media", mediaKey, PublishedItemType.Media, publishedMediaType.Object);
         PublishedMedia = publishedMedia.Object;
 
+        var draftContentKey = Guid.NewGuid();
+        var draftContent = SetupPublishedContent("The page (draft)", draftContentKey, PublishedItemType.Content, publishedContentType.Object);
+        DraftContent = draftContent.Object;
+
         PublishedContentCacheMock = new Mock<IPublishedContentCache>();
         PublishedContentCacheMock
             .Setup(pcc => pcc.GetById(contentKey))
             .Returns(publishedContent.Object);
+        PublishedContentCacheMock
+            .Setup(pcc => pcc.GetById(false, contentKey))
+            .Returns(publishedContent.Object);
+        PublishedContentCacheMock
+            .Setup(pcc => pcc.GetById(true, draftContentKey))
+            .Returns(draftContent.Object);
+
         PublishedMediaCacheMock = new Mock<IPublishedMediaCache>();
         PublishedMediaCacheMock
             .Setup(pcc => pcc.GetById(mediaKey))
@@ -77,6 +90,9 @@ public class PropertyValueConverterTests : DeliveryApiTests
         PublishedUrlProviderMock
             .Setup(p => p.GetUrl(publishedContent.Object, It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
             .Returns("the-page-url");
+        PublishedUrlProviderMock
+            .Setup(p => p.GetUrl(draftContent.Object, It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
+            .Returns("the-draft-page-url");
         PublishedUrlProviderMock
             .Setup(p => p.GetMediaUrl(publishedMedia.Object, It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
             .Returns("the-media-url");
@@ -97,14 +113,20 @@ public class PropertyValueConverterTests : DeliveryApiTests
         return content;
     }
 
-    protected void RegisterContentWithProviders(IPublishedContent content)
+    protected void RegisterContentWithProviders(IPublishedContent content, bool preview)
     {
         PublishedUrlProviderMock
             .Setup(p => p.GetUrl(content, It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
             .Returns(content.UrlSegment);
         PublishedContentCacheMock
-            .Setup(pcc => pcc.GetById(content.Key))
+            .Setup(pcc => pcc.GetById(preview, content.Key))
             .Returns(content);
+        if (preview is false)
+        {
+            PublishedContentCacheMock
+                .Setup(pcc => pcc.GetById(content.Key))
+                .Returns(content);
+        }
     }
 
     protected void RegisterMediaWithProviders(IPublishedContent media)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19630

### Description
The linked issue shows that when requesting a document in preview via the delivery API, documents picked via a MNTP that aren't published aren't included in the output.

It looks like we just aren't passing on the `preview` flag in the property value converter, so I've done that, added a unit test and adjusted the mocks to accommodate the changes so the other unit tests continue to pass.

### Testing

See linked issue and create a setup like the following.

![image](https://github.com/user-attachments/assets/ec4d7132-18e2-40ab-af50-b8fcda799cdd)

Request the first page via the delivery API:

```
GET /umbraco/delivery/api/v2/content/item/{id}
Preview: true
Api-Key: {api key}

Note that after this PR the property details include the second page.