### PR TITLE
Fix issue with newly created template under an existing one

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -65,6 +65,10 @@ export class UmbTemplateWorkspaceContext
 	}
 
 	override async load(unique: string) {
+		// Reset state before load to ensure we don't short-circuit the load method.
+		// Without this on editing a newly created template we won't get the created data,
+		// rather the initial scaffold.
+		super.resetState();
 		const response = await super.load(unique);
 		if (response.data) {
 			this.setMasterTemplate(response.data.masterTemplate?.unique ?? null);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19632

### Description
The linked issue illustrates problems when creating a template under an existing one - the newly created template loses it's updates and appears to have changes when it doesn't.

The problem looks to occur when we attempt to load the newly created template and we don't get the data returned from the API, rather the originally scaffolded content.

Resetting the state before loading as I've done here does fix the problem - but it may be more something that illustrates the problem and a more competent front-end reviewer can find to do in a better way.

### Testing
Create a template under and existing one, and verify the master template is correctly identified for subsequent editing.
