### PR TITLE
Clear member cache by older user name when member user name is updated.

### DIFF
--- a/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
@@ -172,7 +172,8 @@ public static class DistributedCacheExtensions
             MemberCacheRefresher.UniqueId,
             GetPayloads(members, true));
 
-    private static IEnumerable<MemberCacheRefresher.JsonPayload> GetPayloads(IEnumerable<IMember> members, bool removed)
+    // Internal for unit test.
+    internal static IEnumerable<MemberCacheRefresher.JsonPayload> GetPayloads(IEnumerable<IMember> members, bool removed)
         => members
             .DistinctBy(x => (x.Id, x.Username))
             .Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username, removed)

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -70,6 +70,8 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
 
         public string? Username { get; }
 
+        public string? PreviousUsername { get; set; }
+
         public bool Removed { get; }
     }
 
@@ -121,6 +123,13 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
             // https://github.com/umbraco/Umbraco-CMS/pull/17350
             // https://github.com/umbraco/Umbraco-CMS/pull/17815
             memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(CacheKeys.MemberUserNameCachePrefix + p.Username));
+
+            // If provided, clear the cache by the previous user name too.
+            if (string.IsNullOrEmpty(p.PreviousUsername) is false)
+            {
+                memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(p.PreviousUsername));
+                memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(CacheKeys.MemberUserNameCachePrefix + p.PreviousUsername));
+            }
         }
     }
 }

--- a/src/Umbraco.Core/Constants-Entities.cs
+++ b/src/Umbraco.Core/Constants-Entities.cs
@@ -1,0 +1,14 @@
+namespace Umbraco.Cms.Core;
+
+public static partial class Constants
+{
+    public static class Entities
+    {
+        public static class AdditionalDataKeys
+        {
+            public const string MemberPreviousUserName = "previousUsername";
+
+            public const string MemberGroupPreviousName = "previousName";
+        }
+    }
+}

--- a/src/Umbraco.Core/Handlers/PublicAccessHandler.cs
+++ b/src/Umbraco.Core/Handlers/PublicAccessHandler.cs
@@ -21,16 +21,17 @@ public sealed class PublicAccessHandler :
 
     private void Handle(IEnumerable<IMemberGroup> affectedEntities)
     {
+        var keyName = Constants.Entities.AdditionalDataKeys.MemberGroupPreviousName;
         foreach (IMemberGroup grp in affectedEntities)
         {
             // check if the name has changed
-            if ((grp.AdditionalData?.ContainsKey("previousName") ?? false)
-                && grp.AdditionalData["previousName"] != null
-                && grp.AdditionalData["previousName"]?.ToString().IsNullOrWhiteSpace() == false
-                && grp.AdditionalData["previousName"]?.ToString() != grp.Name)
+            if ((grp.AdditionalData?.ContainsKey(keyName) ?? false)
+                && grp.AdditionalData[keyName] != null
+                && grp.AdditionalData[keyName]?.ToString().IsNullOrWhiteSpace() == false
+                && grp.AdditionalData[keyName]?.ToString() != grp.Name)
             {
                 _publicAccessService.RenameMemberGroupRoleRules(
-                    grp.AdditionalData["previousName"]?.ToString(),
+                    grp.AdditionalData[keyName]?.ToString(),
                     grp.Name);
             }
         }

--- a/src/Umbraco.Core/Models/MemberGroup.cs
+++ b/src/Umbraco.Core/Models/MemberGroup.cs
@@ -35,7 +35,7 @@ _additionalData ??= new Dictionary<string, object?>();
                 // if the name has changed, add the value to the additional data,
                 // this is required purely for event handlers to know the previous name of the group
                 // so we can keep the public access up to date.
-                AdditionalData["previousName"] = _name;
+                AdditionalData[Constants.Entities.AdditionalDataKeys.MemberGroupPreviousName] = _name;
             }
 
             SetPropertyValueAndDetectChanges(value, ref _name, nameof(Name));

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -780,7 +780,8 @@ namespace Umbraco.Cms.Core.Services
             {
                 // If the user name has changed, populate the previous user name in the additional data, so the cache refreshers
                 // have it available to clear the cache by the old name as well as the new.
-                if (string.Equals(previousUsername, member.Username, StringComparison.OrdinalIgnoreCase) is false)
+                if (string.IsNullOrWhiteSpace(previousUsername) is false &&
+                    string.Equals(previousUsername, member.Username, StringComparison.OrdinalIgnoreCase) is false)
                 {
                     member.AdditionalData![Constants.Entities.AdditionalDataKeys.MemberPreviousUserName] = previousUsername;
                 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DistributedCacheExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DistributedCacheExtensionsTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Cache;
+
+[TestFixture]
+public class DistributedCacheExtensionsTests
+{
+    [Test]
+    public void Member_GetPayloads_CorrectlyCreatesPayloads()
+    {
+        var members = new List<IMember>()
+        {
+            CreateMember(1, "Fred", "fred", "fred@test.com"),
+            CreateMember(1, "Fred", "fred", "fred@test.com"),
+            CreateMember(2, "Sally", "sally", "sally@test.com"),
+            CreateMember(3, "Jane", "jane", "jane@test.com", "janeold"),
+        };
+
+        var payloads = DistributedCacheExtensions.GetPayloads(members, false);
+        Assert.AreEqual(3, payloads.Count());
+
+        var payloadForFred = payloads.First();
+        Assert.AreEqual("fred", payloadForFred.Username);
+        Assert.AreEqual(1, payloadForFred.Id);
+        Assert.IsNull(payloadForFred.PreviousUsername);
+
+        var payloadForSally = payloads.Skip(1).First();
+        Assert.AreEqual("sally", payloadForSally.Username);
+        Assert.AreEqual(2, payloadForSally.Id);
+        Assert.IsNull(payloadForSally.PreviousUsername);
+
+        var payloadForJane = payloads.Skip(2).First();
+        Assert.AreEqual("jane", payloadForJane.Username);
+        Assert.AreEqual(3, payloadForJane.Id);
+        Assert.AreEqual("janeold", payloadForJane.PreviousUsername);
+    }
+
+    private static IMember CreateMember(int id, string name, string username, string email, string? previousUserName = null)
+    {
+        var memberBuilder = new MemberBuilder()
+            .AddMemberType()
+                .Done()
+            .WithId(id)
+            .WithName(name)
+            .WithLogin(username, "password")
+            .WithEmail(email);
+
+        if (previousUserName != null)
+        {
+            memberBuilder.AddAdditionalData()
+                .WithKeyValue(global::Umbraco.Cms.Core.Constants.Entities.AdditionalDataKeys.MemberPreviousUserName, previousUserName)
+                .Done();
+        }
+
+        return memberBuilder.Build();
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19618

### Description
The linked issue discusses the problem where updating a user in the backoffice to change the user name still leaves the member cached and retrievable by the old user name.

This PR uses the `AdditionalData` collection available on entities to provide the previous user name to the cache refresher, so it can clear by the old user name as well as the new.

I've also added a constant for the `AdditionalData` key and used it for one other instance.

### Testing
With code like the following, retrieve a member by the user name:

```
@inject IMemberService MemberService;
@{
    var fred = MemberService.GetByUsername("fred@test.com");
    @if (fred is null)
    {
        <div>Fred not found</div>
    }
    else
    {
        <div>Found Fred: @fred.Email</div>
    }
}
```

Update the member's user name in the backoffice.  Before the PR you will see the member is still found, but after these changes are applied, it should not be.

