### PR TITLE
Populate name for content and media on URL picker if title is left empty

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/MultiUrlPickerValueConverter.cs
@@ -101,6 +101,11 @@ public class MultiUrlPickerValueConverter : PropertyValueConverterBase, IDeliver
                         continue;
                     }
 
+                    if (string.IsNullOrEmpty(dto.Name))
+                    {
+                        dto.Name = content.Name;
+                    }
+
                     url = content.Url(_publishedUrlProvider);
                 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -292,35 +292,27 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 	}
 
 	async #getUrlForDocument(unique: string) {
-		const { data: documentUrlData } = await this.#documentUrlRepository.requestItems([unique]);
-		const urlsItem = documentUrlData?.[0];
+		const { data: data } = await this.#documentUrlRepository.requestItems([unique]);
 
-		this.#documentUrlsDataResolver.setData(urlsItem?.urls);
+		this.#documentUrlsDataResolver.setData(data?.[0]?.urls);
+
 		const resolvedUrls = await this.#documentUrlsDataResolver.getUrls();
 		return resolvedUrls?.[0]?.url ?? '';
 	}
 
 	async #getUrlForMedia(unique: string) {
-		const { data: mediaUrlData } = await this.#mediaUrlRepository.requestItems([unique]);
-		return mediaUrlData?.[0].url ?? '';
+		const { data } = await this.#mediaUrlRepository.requestItems([unique]);
+		return data?.[0].url ?? '';
 	}
 
 	async #getNameForDocument(unique: string) {
 		const { data } = await this.#documentItemRepository.requestItems([unique]);
-		if (data && data.length > 0) {
-			return data[0].name;
-		}
-
-		return '';
+		return data?.[0]?.name ?? '';
 	}
 
 	async #getNameForMedia(unique: string) {
 		const { data } = await this.#mediaItemRepository.requestItems([unique]);
-		if (data && data.length > 0) {
-			return data[0].name;
-		}
-
-		return '';
+		return data?.[0]?.name ?? '';
 	}
 
 	async #requestRemoveItem(index: number) {

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -395,7 +395,7 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 		const unique = this.#getUnique(link);
 		const href = this.readonly ? undefined : (this._modalRoute?.({ index }) ?? undefined);
 		const resolvedName = this._resolvedLinkNames.find((name) => name.unique === link.unique)?.name ?? '';
-		const resolvedUrl = this._resolvedLinkUrls.find((url) => url.unique === link.unique)?.url ?? '';
+		const resolvedUrl = this._resolvedLinkUrls.find((url) => url.unique === link.unique)?.url ?? link.url ?? '';
 		return html`
 			<uui-ref-node
 				id=${unique}

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -12,17 +12,21 @@ import {
 	when,
 } from '@umbraco-cms/backoffice/external/lit';
 import { simpleHashCode } from '@umbraco-cms/backoffice/observable-api';
+import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
+import {
+	UmbDocumentItemRepository,
+	UmbDocumentUrlRepository,
+	UmbDocumentUrlsDataResolver,
+} from '@umbraco-cms/backoffice/document';
+import { UmbMediaItemRepository, UmbMediaUrlRepository } from '@umbraco-cms/backoffice/media';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 import { UUIFormControlMixin } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbModalRouteBuilder } from '@umbraco-cms/backoffice/router';
 import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UUIModalSidebarSize } from '@umbraco-cms/backoffice/external/uui';
-import { UmbDocumentItemRepository, UmbDocumentUrlRepository, UmbDocumentUrlsDataResolver } from '@umbraco-cms/backoffice/document';
-import { UmbMediaItemRepository, UmbMediaUrlRepository } from '@umbraco-cms/backoffice/media';
 
 /**
  * @element umb-input-multi-url

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -365,6 +365,17 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
+	#getResolvedItemName(link: UmbLinkPickerLink): string {
+		return (link.name || this._resolvedLinkNames.find((name) => name.unique === link.unique)?.name) ?? '';
+	}
+
+	#getResolvedItemUrl(link: UmbLinkPickerLink): string {
+		return (
+			(this._resolvedLinkUrls.find((url) => url.unique === link.unique)?.url ?? link.url ?? '') +
+			(link.queryString || '')
+		);
+	}
+
 	override render() {
 		return html`${this.#renderItems()} ${this.#renderAddButton()}`;
 	}
@@ -401,14 +412,15 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 	#renderItem(link: UmbLinkPickerLink, index: number) {
 		const unique = this.#getUnique(link);
 		const href = this.readonly ? undefined : (this._modalRoute?.({ index }) ?? undefined);
-		const resolvedName = this._resolvedLinkNames.find((name) => name.unique === link.unique)?.name ?? '';
-		const resolvedUrl = this._resolvedLinkUrls.find((url) => url.unique === link.unique)?.url ?? link.url ?? '';
+		const name = this.#getResolvedItemName(link);
+		const url = this.#getResolvedItemUrl(link);
+
 		return html`
 			<uui-ref-node
 				id=${unique}
 				href=${ifDefined(href)}
-				name=${link.name || resolvedName}
-				detail=${resolvedUrl + (link.queryString || '')}
+				name=${name || url}
+				detail=${ifDefined(name ? url : undefined)}
 				?readonly=${this.readonly}>
 				<umb-icon slot="icon" name=${link.icon || 'icon-link'}></umb-icon>
 				${when(

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -248,6 +248,8 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 	#populateLinksNameAndUrl() {
 		// Documents and media have URLs saved in the local link format. Display the actual URL to align with what
 		// the user sees when they selected it initially.
+		this._resolvedLinkNames = [];
+		this._resolvedLinkUrls = []
 		this.#urls.forEach(async (link) => {
 			if (!link.unique) return;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -142,12 +142,12 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 
 	#urls: Array<UmbLinkPickerLink> = [];
 
-	#documentUrlRepository = new UmbDocumentUrlRepository(this);
-	#mediaUrlRepository = new UmbMediaUrlRepository(this);
 	#documentItemRepository = new UmbDocumentItemRepository(this);
-	#mediaItemRepository = new UmbMediaItemRepository(this);
-
+	#documentUrlRepository = new UmbDocumentUrlRepository(this);
 	#documentUrlsDataResolver = new UmbDocumentUrlsDataResolver(this);
+
+	#mediaItemRepository = new UmbMediaItemRepository(this);
+	#mediaUrlRepository = new UmbMediaUrlRepository(this);
 
 	/**
 	 * Sets the input to readonly mode, meaning value cannot be changed but still able to read and select its content.
@@ -249,15 +249,17 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 	}
 
 	#populateLinksNameAndUrl() {
-		// Documents and media have URLs saved in the local link format. Display the actual URL to align with what
-		// the user sees when they selected it initially.
 		this._resolvedLinkNames = [];
-		this._resolvedLinkUrls = []
+		this._resolvedLinkUrls = [];
+
+		// Documents and media have URLs saved in the local link format.
+		// Display the actual URL to align with what the user sees when they selected it initially.
 		this.#urls.forEach(async (link) => {
 			if (!link.unique) return;
 
 			let name: string | undefined = undefined;
 			let url: string | undefined = undefined;
+
 			switch (link.type) {
 				case 'document': {
 					if (!link.name || link.name.length === 0) {

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -30,8 +30,7 @@ import { UmbMediaItemRepository, UmbMediaUrlRepository } from '@umbraco-cms/back
  * @fires blur - when the input loses focus
  * @fires focus - when the input gains focus
  */
-const elementName = 'umb-input-multi-url';
-@customElement(elementName)
+@customElement('umb-input-multi-url')
 export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, '') {
 	#sorter = new UmbSorterController<UmbLinkPickerLink>(this, {
 		getUniqueOfElement: (element) => {
@@ -431,6 +430,6 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbInputMultiUrlElement;
+		'umb-input-multi-url': UmbInputMultiUrlElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -315,15 +315,15 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 		return data?.[0]?.name ?? '';
 	}
 
-	async #requestRemoveItem(index: number) {
+	async #requestRemoveItem(index: number, name?: string) {
 		const item = this.#urls[index];
 		if (!item) throw new Error('Could not find item at index: ' + index);
 
 		await umbConfirmModal(this, {
 			color: 'danger',
-			headline: `Remove ${item.name}?`,
-			content: 'Are you sure you want to remove this item',
-			confirmLabel: 'Remove',
+			headline: `Remove ${name || item.name || 'item'}?`,
+			content: 'Are you sure you want to remove this item?',
+			confirmLabel: '#general_remove',
 		});
 
 		this.#removeItem(index);
@@ -421,7 +421,7 @@ export class UmbInputMultiUrlElement extends UUIFormControlMixin(UmbLitElement, 
 						<uui-action-bar slot="actions">
 							<uui-button
 								label=${this.localize.term('general_remove')}
-								@click=${() => this.#requestRemoveItem(index)}></uui-button>
+								@click=${() => this.#requestRemoveItem(index, name)}></uui-button>
 						</uui-action-bar>
 					`,
 				)}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19674

### Description
The linked issue highlights some discrepancies with how the link picker works in 16 compared to 13.  Although the title field is optional - i.e. whilst it's pre-populated on selecting content or media, you can remove it and leave it blank - with 16 the blank title comes through to the front-end when rendering.  In 13 it would be populated with the content or media name if it was empty.

Also in the backoffice, the name isn't displayed if the title is empty.  Again in 13, the name of the content or media name would be shown (aligning with what would render on the front-end.

This PR addresses both of those issues.

In testing I also noted and fixed the display of the manually entered URLs in the backoffice link listing.

### Testing

- With a Multi URL picker, add links for content and media, and delete the pre-populated title before saving.
- Note that when rendering in the backoffice, the name of the content or media item will be shown where the title would normally be.
- Note that when rendering on the front-end, the `Name` of the `Link` object is populated by the name of the content or media item.
- Verify that manually entered URLs display the URL in the backoffice list of links.