### PR TITLE
Clear member cache by older user name when member user name is updated (16)

### DIFF
--- a/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
@@ -4,6 +4,7 @@
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services.Changes;
 
 namespace Umbraco.Extensions;
@@ -152,11 +153,49 @@ public static class DistributedCacheExtensions
 
     #region MemberCacheRefresher
 
+    [Obsolete("Please use the overload taking all parameters. Scheduled for removal in Umbraco 18.")]
     public static void RefreshMemberCache(this DistributedCache dc, IEnumerable<IMember> members)
-        => dc.RefreshByPayload(MemberCacheRefresher.UniqueId, members.DistinctBy(x => (x.Id, x.Username)).Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username, false)));
+        => dc.RefreshMemberCache(members, new Dictionary<string, object?>());
 
+    public static void RefreshMemberCache(this DistributedCache dc, IEnumerable<IMember> members, IDictionary<string, object?> state)
+        => dc.RefreshByPayload(
+            MemberCacheRefresher.UniqueId,
+            GetPayloads(members, state, false));
+
+    [Obsolete("Please use the overload taking all parameters. Scheduled for removal in Umbraco 18.")]
     public static void RemoveMemberCache(this DistributedCache dc, IEnumerable<IMember> members)
-        => dc.RefreshByPayload(MemberCacheRefresher.UniqueId, members.DistinctBy(x => (x.Id, x.Username)).Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username, true)));
+        => dc.RemoveMemberCache(members, new Dictionary<string, object?>());
+
+    public static void RemoveMemberCache(this DistributedCache dc, IEnumerable<IMember> members, IDictionary<string, object?> state)
+        => dc.RefreshByPayload(
+            MemberCacheRefresher.UniqueId,
+            GetPayloads(members, state, true));
+
+    // Internal for unit test.
+    internal static IEnumerable<MemberCacheRefresher.JsonPayload> GetPayloads(IEnumerable<IMember> members, IDictionary<string, object?> state, bool removed)
+        => members
+            .DistinctBy(x => (x.Id, x.Username))
+            .Select(x => new MemberCacheRefresher.JsonPayload(x.Id, x.Username, removed)
+            {
+                PreviousUsername = GetPreviousUsername(x, state)
+            });
+
+    private static string? GetPreviousUsername(IMember x, IDictionary<string, object?> state)
+    {
+        if (state.TryGetValue(MemberSavedNotification.PreviousUserNameStateKey, out object? previousUserNames) is false)
+        {
+            return null;
+        }
+
+        if (previousUserNames is not IDictionary<Guid, string> previousUserNamesDictionary)
+        {
+            return null;
+        }
+
+        return previousUserNamesDictionary.TryGetValue(x.Key, out string? previousUsername)
+            ? previousUsername
+            : null;
+    }
 
     #endregion
 

--- a/src/Umbraco.Core/Cache/NotificationHandlers/DistributedCacheNotificationHandlerBase.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/DistributedCacheNotificationHandlerBase.cs
@@ -10,11 +10,20 @@ public abstract class DistributedCacheNotificationHandlerBase<TEntity, TNotifica
 {
     /// <inheritdoc />
     public void Handle(TNotification notification)
-        => Handle(GetEntities(notification));
+        => Handle(
+            GetEntities(notification),
+            notification is StatefulNotification statefulNotification
+                ? statefulNotification.State
+                : new Dictionary<string, object?>());
 
     /// <inheritdoc />
     public void Handle(IEnumerable<TNotification> notifications)
-        => Handle(notifications.SelectMany(GetEntities));
+    {
+        foreach (TNotification notification in notifications)
+        {
+            Handle(notification);
+        }
+    }
 
     /// <summary>
     /// Gets the entities from the specified notification.
@@ -29,5 +38,13 @@ public abstract class DistributedCacheNotificationHandlerBase<TEntity, TNotifica
     /// Handles the specified entities.
     /// </summary>
     /// <param name="entities">The entities.</param>
+    [Obsolete("Please use the overload taking all parameters. Scheduled for removal in Umbraco 18.")]
     protected abstract void Handle(IEnumerable<TEntity> entities);
+
+    /// <summary>
+    /// Handles the specified entities.
+    /// </summary>
+    /// <param name="entities">The entities.</param>
+    /// <param name="state">The notification state.</param>
+    protected abstract void Handle(IEnumerable<TEntity> entities, IDictionary<string, object?> state);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ContentTreeChangeDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ContentTreeChangeDistributedCacheNotificationHandler.cs
@@ -18,6 +18,11 @@ public sealed class ContentTreeChangeDistributedCacheNotificationHandler : TreeC
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<TreeChange<IContent>> entities)
+         => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<TreeChange<IContent>> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshContentCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ContentTypeChangedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ContentTypeChangedDistributedCacheNotificationHandler.cs
@@ -18,6 +18,11 @@ public sealed class ContentTypeChangedDistributedCacheNotificationHandler : Cont
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<ContentTypeChange<IContentType>> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<ContentTypeChange<IContentType>> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshContentTypeCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DataTypeDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DataTypeDeletedDistributedCacheNotificationHandler.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Cache;
@@ -17,7 +18,12 @@ public sealed class DataTypeDeletedDistributedCacheNotificationHandler : Deleted
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IDataType> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IDataType> entities, IDictionary<string, object?> state)
     {
         _distributedCache.RemoveDataTypeCache(entities);
         _distributedCache.RefreshValueEditorCache(entities);

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DataTypeSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DataTypeSavedDistributedCacheNotificationHandler.cs
@@ -17,9 +17,14 @@ public sealed class DataTypeSavedDistributedCacheNotificationHandler : SavedDist
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IDataType> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IDataType> entities, IDictionary<string, object?> state)
     {
-        _distributedCache.RefreshDataTypeCache(entities);
+        _distributedCache.RemoveDataTypeCache(entities);
         _distributedCache.RefreshValueEditorCache(entities);
     }
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DictionaryItemDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DictionaryItemDeletedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class DictionaryItemDeletedDistributedCacheNotificationHandler : D
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IDictionaryItem> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IDictionaryItem> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveDictionaryCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DictionaryItemSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DictionaryItemSavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class DictionaryItemSavedDistributedCacheNotificationHandler : Sav
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IDictionaryItem> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IDictionaryItem> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshDictionaryCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DomainDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DomainDeletedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class DomainDeletedDistributedCacheNotificationHandler : DeletedDi
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IDomain> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IDomain> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveDomainCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DomainSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/DomainSavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class DomainSavedDistributedCacheNotificationHandler : SavedDistri
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IDomain> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IDomain> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshDomainCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/LanguageDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/LanguageDeletedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class LanguageDeletedDistributedCacheNotificationHandler : Deleted
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<ILanguage> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<ILanguage> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveLanguageCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/LanguageSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/LanguageSavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class LanguageSavedDistributedCacheNotificationHandler : SavedDist
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<ILanguage> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<ILanguage> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshLanguageCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MediaTreeChangeDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MediaTreeChangeDistributedCacheNotificationHandler.cs
@@ -18,6 +18,11 @@ public sealed class MediaTreeChangeDistributedCacheNotificationHandler : TreeCha
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<TreeChange<IMedia>> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<TreeChange<IMedia>> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshMediaCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MediaTypeChangedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MediaTypeChangedDistributedCacheNotificationHandler.cs
@@ -18,6 +18,11 @@ public sealed class MediaTypeChangedDistributedCacheNotificationHandler : Conten
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<ContentTypeChange<IMediaType>> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<ContentTypeChange<IMediaType>> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshContentTypeCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberDeletedDistributedCacheNotificationHandler.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Cache;
@@ -17,6 +18,11 @@ public sealed class MemberDeletedDistributedCacheNotificationHandler : DeletedDi
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IMember> entities)
-        => _distributedCache.RemoveMemberCache(entities);
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IMember> entities, IDictionary<string, object?> state)
+        => _distributedCache.RemoveMemberCache(entities, state);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberGroupDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberGroupDeletedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class MemberGroupDeletedDistributedCacheNotificationHandler : Dele
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IMemberGroup> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IMemberGroup> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveMemberGroupCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberGroupSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberGroupSavedDistributedCacheNotificationHandler.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
 
@@ -17,6 +17,11 @@ public sealed class MemberGroupSavedDistributedCacheNotificationHandler : SavedD
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IMemberGroup> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IMemberGroup> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshMemberGroupCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberSavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class MemberSavedDistributedCacheNotificationHandler : SavedDistri
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IMember> entities)
-        => _distributedCache.RefreshMemberCache(entities);
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IMember> entities, IDictionary<string, object?> state)
+        => _distributedCache.RefreshMemberCache(entities, state);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberTypeChangedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/MemberTypeChangedDistributedCacheNotificationHandler.cs
@@ -19,6 +19,11 @@ public sealed class MemberTypeChangedDistributedCacheNotificationHandler : Conte
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<ContentTypeChange<IMemberType>> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<ContentTypeChange<IMemberType>> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshContentTypeCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/PublicAccessEntryDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/PublicAccessEntryDeletedDistributedCacheNotificationHandler.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Cache;
@@ -17,6 +18,11 @@ public sealed class PublicAccessEntryDeletedDistributedCacheNotificationHandler 
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<PublicAccessEntry> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<PublicAccessEntry> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshPublicAccess();
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/PublicAccessEntrySavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/PublicAccessEntrySavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class PublicAccessEntrySavedDistributedCacheNotificationHandler : 
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<PublicAccessEntry> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<PublicAccessEntry> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshPublicAccess();
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/RelationTypeDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/RelationTypeDeletedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class RelationTypeDeletedDistributedCacheNotificationHandler : Del
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IRelationType> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IRelationType> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveRelationTypeCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/RelationTypeSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/RelationTypeSavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class RelationTypeSavedDistributedCacheNotificationHandler : Saved
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IRelationType> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IRelationType> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshRelationTypeCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/TemplateDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/TemplateDeletedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class TemplateDeletedDistributedCacheNotificationHandler : Deleted
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<ITemplate> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<ITemplate> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveTemplateCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/TemplateSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/TemplateSavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class TemplateSavedDistributedCacheNotificationHandler : SavedDist
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<ITemplate> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<ITemplate> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshTemplateCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserDeletedDistributedCacheNotificationHandler.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Extensions;
@@ -17,6 +18,11 @@ public sealed class UserDeletedDistributedCacheNotificationHandler : DeletedDist
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IUser> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IUser> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveUserCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserGroupDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserGroupDeletedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class UserGroupDeletedDistributedCacheNotificationHandler : Delete
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IUserGroup> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IUserGroup> entities, IDictionary<string, object?> state)
         => _distributedCache.RemoveUserGroupCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserGroupWithUsersSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserGroupWithUsersSavedDistributedCacheNotificationHandler.cs
@@ -22,6 +22,11 @@ public sealed class UserGroupWithUsersSavedDistributedCacheNotificationHandler :
         => notification.SavedEntities.Select(x => x.UserGroup);
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IUserGroup> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IUserGroup> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshUserGroupCache(entities);
 }

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserSavedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/UserSavedDistributedCacheNotificationHandler.cs
@@ -17,6 +17,11 @@ public sealed class UserSavedDistributedCacheNotificationHandler : SavedDistribu
         => _distributedCache = distributedCache;
 
     /// <inheritdoc />
+    [Obsolete("Scheduled for removal in Umbraco 18.")]
     protected override void Handle(IEnumerable<IUser> entities)
+        => Handle(entities, new Dictionary<string, object?>());
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<IUser> entities, IDictionary<string, object?> state)
         => _distributedCache.RefreshUserCache(entities);
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -62,6 +62,8 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
 
         public string? Username { get; }
 
+        public string? PreviousUsername { get; set; }
+
         public bool Removed { get; }
     }
 
@@ -112,6 +114,13 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
             // https://github.com/umbraco/Umbraco-CMS/pull/17350
             // https://github.com/umbraco/Umbraco-CMS/pull/17815
             memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(CacheKeys.MemberUserNameCachePrefix + p.Username));
+
+            // If provided, clear the cache by the previous user name too.
+            if (string.IsNullOrEmpty(p.PreviousUsername) is false)
+            {
+                memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(p.PreviousUsername));
+                memberCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMember, string>(CacheKeys.MemberUserNameCachePrefix + p.PreviousUsername));
+            }
         }
     }
 }

--- a/src/Umbraco.Core/Notifications/MemberSavedNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberSavedNotification.cs
@@ -10,6 +10,14 @@ namespace Umbraco.Cms.Core.Notifications;
 /// </summary>
 public sealed class MemberSavedNotification : SavedNotification<IMember>
 {
+    /// <summary>
+    /// Defines the notification state key for tracking the previous username of a saved member.
+    /// </summary>
+    internal const string PreviousUserNameStateKey = "PreviousUsername";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemberSavedNotification"/> class.
+    /// </summary>
     public MemberSavedNotification(IMember target, EventMessages messages)
         : base(target, messages)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DistributedCacheExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DistributedCacheExtensionsTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Cache;
+
+[TestFixture]
+public class DistributedCacheExtensionsTests
+{
+    [Test]
+    public void Member_GetPayloads_CorrectlyCreatesPayloads()
+    {
+        var member1Key = Guid.NewGuid();
+        var member2Key = Guid.NewGuid();
+        var member3Key = Guid.NewGuid();
+        var members = new List<IMember>()
+        {
+            CreateMember(1, member1Key, "Fred", "fred", "fred@test.com"),
+            CreateMember(1, member1Key, "Fred", "fred", "fred@test.com"),
+            CreateMember(2, member2Key, "Sally", "sally", "sally@test.com"),
+            CreateMember(3, member3Key, "Jane", "jane", "jane@test.com"),
+        };
+
+        var state = new Dictionary<string, object>
+        {
+            {
+                MemberSavedNotification.PreviousUserNameStateKey,
+                new Dictionary<Guid, string> { { member3Key, "janeold" } }
+            },
+        };
+
+        var payloads = DistributedCacheExtensions.GetPayloads(members, state, false);
+        Assert.AreEqual(3, payloads.Count());
+
+        var payloadForFred = payloads.First();
+        Assert.AreEqual("fred", payloadForFred.Username);
+        Assert.AreEqual(1, payloadForFred.Id);
+        Assert.IsNull(payloadForFred.PreviousUsername);
+
+        var payloadForSally = payloads.Skip(1).First();
+        Assert.AreEqual("sally", payloadForSally.Username);
+        Assert.AreEqual(2, payloadForSally.Id);
+        Assert.IsNull(payloadForSally.PreviousUsername);
+
+        var payloadForJane = payloads.Skip(2).First();
+        Assert.AreEqual("jane", payloadForJane.Username);
+        Assert.AreEqual(3, payloadForJane.Id);
+        Assert.AreEqual("janeold", payloadForJane.PreviousUsername);
+    }
+
+    private static IMember CreateMember(int id, Guid key, string name, string username, string email)
+        => new MemberBuilder()
+            .AddMemberType()
+                .Done()
+            .WithId(id)
+            .WithKey(key)
+            .WithName(name)
+            .WithLogin(username, "password")
+            .WithEmail(email)
+            .Build();
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19618 for Umbraco 16

### Description
This is a port of https://github.com/umbraco/Umbraco-CMS/pull/19672 for Umbraco 16.  It needed a bit more work than just a cherry-pick, as we no longer have the `AdditionalData` available on entities that could be used to attach extra information via the entities and use it in the cache refreshers.

Rather it looks like this has been removed and state is now passed only via notifications.

The problem was that with the inheritance structure we had set up for distributed cache notifications, this wasn't made available at the point where we needed to act on it.  So I've had to add an additional parameter to the base distributed cache notification handler abstract class, obsolete the old one and provide it in all the handler implementations.  But having done that we can pass the details of the member's previous user name to the `MemberCacheRefresher` and act on it as we did in 13.

### Testing
With code like the following, retrieve a member by the user name:

```
@inject IMemberService MemberService;
@{
    var fred = MemberService.GetByUsername("fred@test.com");
    @if (fred is null)
    {
        <div>Fred not found</div>
    }
    else
    {
        <div>Found Fred: @fred.Email</div>
    }
}
```

Update the member's user name in the backoffice.  Before the PR you will see the member is still found, but after these changes are applied, it should not be.
