### PR TITLE
Fix missing tag suggestions when no culture available.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
@@ -72,8 +72,8 @@ export class UmbTagsInputElement extends UUIFormControlMixin(UmbLitElement, '') 
 	}
 
 	async #getExistingTags(query: string) {
-		if (!this.group || this.culture === undefined || !query) return;
-		const { data } = await this.#repository.queryTags(this.group, this.culture, query);
+		if (!this.group || !query) return;
+		const { data } = await this.#repository.queryTags(this.group, this.culture ?? null, query);
 		if (!data) return;
 		this._matches = data.items;
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes: #19693 

### Description
As per issue description, when the Tags property editor is used inside an `umb-property-dataset` element the culture provided to the property editor is null.

I found that culture is not required by the Tag's Repository, Data Source, or Management API.  So, the check for undefined value is not needed.  I've modified the code to replace undefined values with null which can be handled by the subsequent call chain.

I've tested this by modifying the `dashboard-with-property-dataset` example with the following additions (not committed)

Added additional property to data set.
```
data: UmbPropertyValueData[] = [
    {
        alias: 'textProperty',
        value: 'Hello',
    },
    {
        alias: 'tagsProperty',
        value: [],
    }];
```
Added the tags property editor to the dashboard with configuration
```
<umb-property
    label="Tags"
    description="Tags editor for testing"
    alias="tagsProperty"
    property-editor-ui-alias="Umb.PropertyEditorUi.Tags"
    .config=${
	[{
	    "alias": "group",
	    "value": "Fruits"
	}]
    }></umb-property>
```
