### PR TITLE
Fix issue forceHideContentEditorInOverlay not available in RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/workspace/views/block-rte-type-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/workspace/views/block-rte-type-workspace-view.element.ts
@@ -75,6 +75,13 @@ export class UmbBlockRteTypeWorkspaceViewSettingsElement extends UmbLitElement i
 						},
 					]}></umb-property>
 			</uui-box>
+			<uui-box headline=${this.localize.term('blockEditor_headlineAdvanced')}>
+				<umb-property
+					label=${this.localize.term('blockEditor_forceHideContentEditor')}
+					alias="forceHideContentEditorInOverlay"
+					description=${this.localize.term('blockEditor_forceHideContentEditorHelp')}
+					property-editor-ui-alias="Umb.PropertyEditorUi.Toggle"></umb-property>
+			</uui-box>
 		`;
 	}
 


### PR DESCRIPTION

### Description

This PR fixes for the issue https://github.com/umbraco/Umbraco-CMS/issues/19519.

I added the Hide content editor advanced setting for RTE.
