### PR TITLE
Parse update date before sorting in media list view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbmediagrid.directive.js
@@ -351,14 +351,17 @@ Use this directive to generate a thumbnail grid of media items.
             // sort function
             scope.sortBy = function (item) {
                 if (scope.sortColumn === "updateDate") {
-                    return [-item['isFolder'],item['updateDate']];
+                    return [-item['isFolder'],parseUpdateDate(item['updateDate'])];
                 }
                 else {
                     return [-item['isFolder'],item['name']];
                 }
             };
+        }
 
-
+        function parseUpdateDate(date) {
+            var parsedDate = Date.parse(date);
+            return isNaN(parsedDate) ? date : parsedDate;
         }
 
         var directive = {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19695

### Description
In the media picker list view, when sorting, date fields are sorted alphabetically.

This PR attempts to parse the date entry to a date before doing the sorting.

### Testing
To replicate the original issue you need some media or folders that when ordered alphabetically aren't ordered by date and time.

With the PR applied you should see them ordered by date and time as would be expected.


