### PR TITLE
Return 404 on delivery API requests for segments that are invalid or not created

### DIFF
--- a/src/Umbraco.Core/DeliveryApi/ApiContentBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentBuilder.cs
@@ -7,8 +7,6 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public sealed class ApiContentBuilder : ApiContentBuilderBase<IApiContent>, IApiContentBuilder
 {
-    private readonly IVariationContextAccessor _variationContextAccessor;
-
     [Obsolete("Please use the constructor that takes an IVariationContextAccessor instead. Scheduled for removal in V17.")]
     public ApiContentBuilder(
         IApiContentNameProvider apiContentNameProvider,
@@ -27,9 +25,10 @@ public sealed class ApiContentBuilder : ApiContentBuilderBase<IApiContent>, IApi
         IApiContentRouteBuilder apiContentRouteBuilder,
         IOutputExpansionStrategyAccessor outputExpansionStrategyAccessor,
         IVariationContextAccessor variationContextAccessor)
-        : base(apiContentNameProvider, apiContentRouteBuilder, outputExpansionStrategyAccessor)
-        => _variationContextAccessor = variationContextAccessor;
+        : base(apiContentNameProvider, apiContentRouteBuilder, outputExpansionStrategyAccessor, variationContextAccessor)
+    {
+    }
 
     protected override IApiContent Create(IPublishedContent content, string name, IApiContentRoute route, IDictionary<string, object?> properties)
-        => new ApiContent(content.Key, name, content.ContentType.Alias, content.CreateDate, content.CultureDate(_variationContextAccessor), route, properties);
+        => new ApiContent(content.Key, name, content.ContentType.Alias, content.CreateDate, content.CultureDate(VariationContextAccessor), route, properties);
 }

--- a/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Models.DeliveryApi;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Core.DeliveryApi;
@@ -7,21 +9,42 @@ public abstract class ApiContentBuilderBase<T>
     where T : IApiContent
 {
     private readonly IApiContentNameProvider _apiContentNameProvider;
-    private readonly IApiContentRouteBuilder _apiContentRouteBuilder;
     private readonly IOutputExpansionStrategyAccessor _outputExpansionStrategyAccessor;
 
-    protected ApiContentBuilderBase(IApiContentNameProvider apiContentNameProvider, IApiContentRouteBuilder apiContentRouteBuilder, IOutputExpansionStrategyAccessor outputExpansionStrategyAccessor)
+    [Obsolete("Please use the constructor that takes all parameters. Scheduled for removal in Umbraco 17.")]
+    protected ApiContentBuilderBase(
+        IApiContentNameProvider apiContentNameProvider,
+        IApiContentRouteBuilder apiContentRouteBuilder,
+        IOutputExpansionStrategyAccessor outputExpansionStrategyAccessor)
+        : this(
+              apiContentNameProvider,
+              apiContentRouteBuilder,
+              outputExpansionStrategyAccessor,
+              StaticServiceProvider.Instance.GetRequiredService<IVariationContextAccessor>())
+    {
+    }
+
+    protected ApiContentBuilderBase(
+        IApiContentNameProvider apiContentNameProvider,
+        IApiContentRouteBuilder apiContentRouteBuilder,
+        IOutputExpansionStrategyAccessor outputExpansionStrategyAccessor,
+        IVariationContextAccessor variationContextAccessor)
     {
         _apiContentNameProvider = apiContentNameProvider;
-        _apiContentRouteBuilder = apiContentRouteBuilder;
+        ApiContentRouteBuilder = apiContentRouteBuilder;
         _outputExpansionStrategyAccessor = outputExpansionStrategyAccessor;
+        VariationContextAccessor = variationContextAccessor;
     }
+
+    protected IApiContentRouteBuilder ApiContentRouteBuilder { get; }
+
+    protected IVariationContextAccessor VariationContextAccessor { get; }
 
     protected abstract T Create(IPublishedContent content, string name, IApiContentRoute route, IDictionary<string, object?> properties);
 
     public virtual T? Build(IPublishedContent content)
     {
-        IApiContentRoute? route = _apiContentRouteBuilder.Build(content);
+        IApiContentRoute? route = ApiContentRouteBuilder.Build(content);
         if (route is null)
         {
             return default;
@@ -32,10 +55,32 @@ public abstract class ApiContentBuilderBase<T>
                 ? outputExpansionStrategy.MapContentProperties(content)
                 : new Dictionary<string, object?>();
 
+        // If a segment is requested and all segmented properties are null, we consider the segment as not created or non-existing and return null.
+        // This aligns the behaviour of the API when it comes to "Accept-Segment" and "Accept-Language" requests, so 404 is returned for both when
+        // the segment or language is not created or does not exist.
+        // It also aligns with what we show in the backoffice for whether a segment is "Published" or "Not created".
+        // Requested languages that aren't created or don't exist will already have exited early in the route builder.
+        if (IsSegmentRequested() && AreAllSegmentedPropertiesNull(content, properties))
+        {
+            return default;
+        }
+
         return Create(
             content,
             _apiContentNameProvider.GetName(content),
             route,
             properties);
+    }
+
+    private bool IsSegmentRequested() => string.IsNullOrWhiteSpace(VariationContextAccessor.VariationContext?.Segment) is false;
+
+    private static bool AreAllSegmentedPropertiesNull(
+        IPublishedContent content,
+        IDictionary<string, object?> properties)
+    {
+        IEnumerable<string> segmentedProperties = content.Properties
+            .Where(x => x.PropertyType.Variations.HasFlag(Models.ContentVariation.Segment))
+            .Select(x => x.Alias);
+        return segmentedProperties.All(x => properties.ContainsKey(x) is false || properties[x] is null);
     }
 }

--- a/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentResponseBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -7,9 +7,6 @@ namespace Umbraco.Cms.Core.DeliveryApi;
 
 public class ApiContentResponseBuilder : ApiContentBuilderBase<IApiContentResponse>, IApiContentResponseBuilder
 {
-    private readonly IApiContentRouteBuilder _apiContentRouteBuilder;
-    private readonly IVariationContextAccessor _variationContextAccessor;
-
     [Obsolete("Please use the constructor that takes an IVariationContextAccessor instead. Scheduled for removal in V17.")]
     public ApiContentResponseBuilder(
         IApiContentNameProvider apiContentNameProvider,
@@ -28,16 +25,14 @@ public class ApiContentResponseBuilder : ApiContentBuilderBase<IApiContentRespon
         IApiContentRouteBuilder apiContentRouteBuilder,
         IOutputExpansionStrategyAccessor outputExpansionStrategyAccessor,
         IVariationContextAccessor variationContextAccessor)
-        : base(apiContentNameProvider, apiContentRouteBuilder, outputExpansionStrategyAccessor)
+        : base(apiContentNameProvider, apiContentRouteBuilder, outputExpansionStrategyAccessor, variationContextAccessor)
     {
-        _apiContentRouteBuilder = apiContentRouteBuilder;
-        _variationContextAccessor = variationContextAccessor;
     }
 
     protected override IApiContentResponse Create(IPublishedContent content, string name, IApiContentRoute route, IDictionary<string, object?> properties)
     {
         IDictionary<string, IApiContentRoute> cultures = GetCultures(content);
-        return new ApiContentResponse(content.Key, name, content.ContentType.Alias, content.CreateDate, content.CultureDate(_variationContextAccessor), route, properties, cultures);
+        return new ApiContentResponse(content.Key, name, content.ContentType.Alias, content.CreateDate, content.CultureDate(VariationContextAccessor), route, properties, cultures);
     }
 
     protected virtual IDictionary<string, IApiContentRoute> GetCultures(IPublishedContent content)
@@ -52,7 +47,7 @@ public class ApiContentResponseBuilder : ApiContentBuilderBase<IApiContentRespon
                 continue;
             }
 
-            IApiContentRoute? cultureRoute = _apiContentRouteBuilder.Build(content, publishedCultureInfo.Culture);
+            IApiContentRoute? cultureRoute = ApiContentRouteBuilder.Build(content, publishedCultureInfo.Culture);
             if (cultureRoute == null)
             {
                 // content is un-routable in this culture

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
@@ -73,7 +73,12 @@ public class DeliveryApiTests
         PublishStatusQueryService = publishStatusQueryService.Object;
     }
 
-    protected IPublishedPropertyType SetupPublishedPropertyType(IPropertyValueConverter valueConverter, string propertyTypeAlias, string editorAlias, object? dataTypeConfiguration = null)
+    protected IPublishedPropertyType SetupPublishedPropertyType(
+        IPropertyValueConverter valueConverter,
+        string propertyTypeAlias,
+        string editorAlias,
+        object? dataTypeConfiguration = null,
+        ContentVariation contentVariation = ContentVariation.Nothing)
     {
         var mockPublishedContentTypeFactory = new Mock<IPublishedContentTypeFactory>();
         mockPublishedContentTypeFactory.Setup(x => x.GetDataType(It.IsAny<int>()))
@@ -83,7 +88,7 @@ public class DeliveryApiTests
             propertyTypeAlias,
             123,
             true,
-            ContentVariation.Nothing,
+            contentVariation,
             new PropertyValueConverterCollection(() => new[] { valueConverter }),
             Mock.Of<IPublishedModelFactory>(),
             mockPublishedContentTypeFactory.Object);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19580

### Description
The linked issue illustrates that when requesting segmented content for an existing document from the delivery API, and providing a segment that's either invalid or not completed, you don't get a 404 response.  Rather a response with null values for segmented properties is returned (with shared properties populated).

This isn't consistent with what you'd get for requesting a missing language - where you do get a 404.

I debated a bit whether we should fix this.  Under the hood segments and languages are quite different, with only the latter being independently publishable and routable.  But I think from the perspective of the delivery API you would have the expectation that when passing `Accept-Language` or `Accept-Segment` you would get the same behaviour.

From the delivery API perspective, when requesting a document by ID we find it and then verify it can be routed (basically, determining if it's published).  We have the concept of languages being published, hence if providing `Accept-Language` for an invalid or unpublished language, we won't route the content and from there will return a 404.

Segments aren't explicitly published so we are able to route when requesting published content by segment, even if the segment doesn't exist.  Seems like the only way to align this would be to check all segmented properties, and if all are null, return 404.  So that's what I've done here.

It has the benefit of aligning also with the backoffice, where we do indicate of a segment is "Published" or "Not created":

<img width="338" height="184" alt="image" src="https://github.com/user-attachments/assets/f8caa8ce-ff3a-45eb-a87d-edd9b7ab4dac" />

### Testing

- Setup segmented content using a composer like the following:

```
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Configuration.Models;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Services.OperationStatus;

public class MySegmentService : ISegmentService
{
    private readonly Segment[] _segments =
    [
        new Segment { Alias = "developers", Name = "Developers" },
        new Segment { Alias = "project-managers", Name = "Project Managers" }
    ];

    public Task<Attempt<PagedModel<Segment>?, SegmentOperationStatus>> GetPagedSegmentsAsync(int skip = 0, int take = 100)
        => Task.FromResult(Attempt.SucceedWithStatus<PagedModel<Segment>?, SegmentOperationStatus>(
            SegmentOperationStatus.Success,
            new PagedModel<Segment> { Total = _segments.Length, Items = _segments.Skip(skip).Take(take) }));
}

public class MySegmentServiceComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Services.Configure<SegmentSettings>(settings => settings.Enabled = true);
        builder.Services.AddUnique<ISegmentService, MySegmentService>();
    }
}
```

- Create some content that varies by segment.
- Populate the content for one segment but not the other/
- Request the segment from the delivery API using the `Accept-Segment` header.
- Verify that with the changes in place from the PR you'll get a 404 for a segment that's not yet populated.