### PR TITLE
Make internal & private classes sealed where possible, to avoid code for virtual dispatch

### DIFF
--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureOpenIddict.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureOpenIddict.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Cms.Api.Common.Configuration;
 
-internal class ConfigureOpenIddict : IConfigureOptions<OpenIddictServerAspNetCoreOptions>
+internal sealed class ConfigureOpenIddict : IConfigureOptions<OpenIddictServerAspNetCoreOptions>
 {
     private readonly IOptions<GlobalSettings> _globalSettings;
 

--- a/src/Umbraco.Cms.Api.Common/Json/NamedSystemTextJsonInputFormatter.cs
+++ b/src/Umbraco.Cms.Api.Common/Json/NamedSystemTextJsonInputFormatter.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Umbraco.Cms.Api.Common.Json;
 
-internal class NamedSystemTextJsonInputFormatter : SystemTextJsonInputFormatter
+internal sealed class NamedSystemTextJsonInputFormatter : SystemTextJsonInputFormatter
 {
     private readonly string _jsonOptionsName;
 

--- a/src/Umbraco.Cms.Api.Common/Json/NamedSystemTextJsonOutputFormatter.cs
+++ b/src/Umbraco.Cms.Api.Common/Json/NamedSystemTextJsonOutputFormatter.cs
@@ -3,8 +3,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Umbraco.Cms.Api.Common.Json;
 
-
-internal class NamedSystemTextJsonOutputFormatter : SystemTextJsonOutputFormatter
+internal sealed class NamedSystemTextJsonOutputFormatter : SystemTextJsonOutputFormatter
 {
     private readonly string _jsonOptionsName;
 

--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions.cs
@@ -26,7 +26,7 @@ public class ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions : 
         options.OperationFilter<DeliveryApiSecurityFilter>();
     }
 
-    private class DeliveryApiSecurityFilter : SwaggerFilterBase<ContentApiControllerBase>, IOperationFilter, IDocumentFilter
+    private sealed class DeliveryApiSecurityFilter : SwaggerFilterBase<ContentApiControllerBase>, IOperationFilter, IDocumentFilter
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {

--- a/src/Umbraco.Cms.Api.Delivery/Filters/ContextualizeFromAcceptHeadersAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/ContextualizeFromAcceptHeadersAttribute.cs
@@ -13,7 +13,7 @@ internal sealed class ContextualizeFromAcceptHeadersAttribute : TypeFilterAttrib
     {
     }
 
-    private class LocalizeFromAcceptLanguageHeaderAttributeFilter : IActionFilter
+    private sealed class LocalizeFromAcceptLanguageHeaderAttributeFilter : IActionFilter
     {
         private readonly IRequestCultureService _requestCultureService;
         private readonly IRequestSegmmentService _requestSegmentService;

--- a/src/Umbraco.Cms.Api.Delivery/Filters/DeliveryApiAccessAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/DeliveryApiAccessAttribute.cs
@@ -11,7 +11,7 @@ internal sealed class DeliveryApiAccessAttribute : TypeFilterAttribute
     {
     }
 
-    private class DeliveryApiAccessFilter : IActionFilter
+    private sealed class DeliveryApiAccessFilter : IActionFilter
     {
         private readonly IApiAccessService _apiAccessService;
         private readonly IRequestPreviewService _requestPreviewService;

--- a/src/Umbraco.Cms.Api.Delivery/Filters/DeliveryApiMediaAccessAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/DeliveryApiMediaAccessAttribute.cs
@@ -11,7 +11,7 @@ internal sealed class DeliveryApiMediaAccessAttribute : TypeFilterAttribute
     {
     }
 
-    private class DeliveryApiMediaAccessFilter : IActionFilter
+    private sealed class DeliveryApiMediaAccessFilter : IActionFilter
     {
         private readonly IApiAccessService _apiAccessService;
 

--- a/src/Umbraco.Cms.Api.Delivery/Filters/ValidateStartItemAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/ValidateStartItemAttribute.cs
@@ -12,7 +12,7 @@ internal sealed class ValidateStartItemAttribute : TypeFilterAttribute
     {
     }
 
-    private class ValidateStartItemFilter : IActionFilter
+    private sealed class ValidateStartItemFilter : IActionFilter
     {
         private readonly IRequestStartItemProviderAccessor _requestStartItemProviderAccessor;
 

--- a/src/Umbraco.Cms.Api.Delivery/Rendering/RequestContextOutputExpansionStrategyV2.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Rendering/RequestContextOutputExpansionStrategyV2.cs
@@ -124,7 +124,7 @@ internal sealed class RequestContextOutputExpansionStrategyV2 : IOutputExpansion
     private object? GetPropertyValue(IPublishedProperty property)
         => _propertyRenderer.GetPropertyValue(property, _expandProperties.Peek() is not null);
 
-    private class Node
+    private sealed class Node
     {
         public string Key { get; private set; } = string.Empty;
 

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthBuilderExtensions.cs
@@ -79,7 +79,7 @@ public static class BackOfficeAuthBuilderExtensions
     }
 }
 
-internal class BackofficePipelineFilter : UmbracoPipelineFilter
+internal sealed class BackofficePipelineFilter : UmbracoPipelineFilter
 {
     public BackofficePipelineFilter(string name)
         : base(name)

--- a/src/Umbraco.Cms.Api.Management/Factories/PackagePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PackagePresentationFactory.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
-internal class PackagePresentationFactory : IPackagePresentationFactory
+internal sealed class PackagePresentationFactory : IPackagePresentationFactory
 {
     private readonly IUmbracoMapper _umbracoMapper;
     private readonly IRuntimeState _runtimeState;

--- a/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
@@ -8,7 +8,7 @@ using Umbraco.Cms.Core.Webhooks;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
-internal class WebhookPresentationFactory : IWebhookPresentationFactory
+internal sealed class WebhookPresentationFactory : IWebhookPresentationFactory
 {
     private readonly WebhookEventCollection _webhookEventCollection;
     private readonly IHostingEnvironment _hostingEnvironment;

--- a/src/Umbraco.Cms.Api.Management/Filters/AppendEventMessagesAttribute.cs
+++ b/src/Umbraco.Cms.Api.Management/Filters/AppendEventMessagesAttribute.cs
@@ -21,7 +21,7 @@ public sealed class AppendEventMessagesAttribute : TypeFilterAttribute
     {
     }
 
-    private class AppendEventMessagesFilter : IActionFilter
+    private sealed class AppendEventMessagesFilter : IActionFilter
     {
         private readonly IEventMessagesFactory _eventMessagesFactory;
         private readonly IJsonSerializer _jsonSerializer;

--- a/src/Umbraco.Cms.Api.Management/Filters/UserPasswordEnsureMinimumResponseTimeAttribute.cs
+++ b/src/Umbraco.Cms.Api.Management/Filters/UserPasswordEnsureMinimumResponseTimeAttribute.cs
@@ -4,14 +4,14 @@ using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Cms.Api.Management.Filters;
 
-internal class UserPasswordEnsureMinimumResponseTimeAttribute : TypeFilterAttribute
+internal sealed class UserPasswordEnsureMinimumResponseTimeAttribute : TypeFilterAttribute
 {
     public UserPasswordEnsureMinimumResponseTimeAttribute()
         : base(typeof(UserPasswordEnsureMinimumResponseTimeFilter))
     {
     }
 
-    private class UserPasswordEnsureMinimumResponseTimeFilter : EnsureMinimumResponseTimeFilter
+    private sealed class UserPasswordEnsureMinimumResponseTimeFilter : EnsureMinimumResponseTimeFilter
     {
         public UserPasswordEnsureMinimumResponseTimeFilter(IOptions<UserPasswordConfigurationSettings> options)
             : base(options.Value.MinimumResponseTime)

--- a/src/Umbraco.Cms.Api.Management/Mapping/SectionMapper.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/SectionMapper.cs
@@ -45,7 +45,7 @@ public static class SectionMapper
         return name;
     }
 
-    private class SectionMapping
+    private sealed class SectionMapping
     {
         public required string Alias { get; init; }
 

--- a/src/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsOperationFilter.cs
+++ b/src/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsOperationFilter.cs
@@ -2,7 +2,7 @@ using Umbraco.Cms.Api.Management.DependencyInjection;
 
 namespace Umbraco.Cms.Api.Management.OpenApi;
 
-internal class BackOfficeSecurityRequirementsOperationFilter : BackOfficeSecurityRequirementsOperationFilterBase
+internal sealed class BackOfficeSecurityRequirementsOperationFilter : BackOfficeSecurityRequirementsOperationFilterBase
 {
     protected override string ApiName => ManagementApiConfiguration.ApiName;
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi/NotificationHeaderFilter.cs
+++ b/src/Umbraco.Cms.Api.Management/OpenApi/NotificationHeaderFilter.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.OpenApi;
 
-internal class NotificationHeaderFilter : IOperationFilter
+internal sealed class NotificationHeaderFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {

--- a/src/Umbraco.Cms.Api.Management/OpenApi/ReponseHeaderOperationFilter.cs
+++ b/src/Umbraco.Cms.Api.Management/OpenApi/ReponseHeaderOperationFilter.cs
@@ -7,7 +7,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.OpenApi;
 
-internal class ResponseHeaderOperationFilter : IOperationFilter
+internal sealed class ResponseHeaderOperationFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
@@ -29,7 +29,7 @@ internal class ResponseHeaderOperationFilter : IOperationFilter
         }
     }
 
-    private void SetHeader(OpenApiResponse value, string headerName, string description, string type, string? format = null)
+    private static void SetHeader(OpenApiResponse value, string headerName, string description, string type, string? format = null)
     {
 
         if (value.Headers is null)

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
@@ -61,7 +61,7 @@ public class BackOfficeAuthenticationBuilder : AuthenticationBuilder
     // TODO: We could override and throw NotImplementedException for other methods?
 
     // Ensures that the sign in scheme is always the Umbraco back office external type
-    internal class EnsureBackOfficeScheme<TOptions> : IPostConfigureOptions<TOptions>
+    internal sealed class EnsureBackOfficeScheme<TOptions> : IPostConfigureOptions<TOptions>
         where TOptions : RemoteAuthenticationOptions
     {
         public void PostConfigure(string? name, TOptions options)

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecureDataFormat.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeSecureDataFormat.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Api.Management.Security;
 /// <summary>
 ///     Custom secure format that ensures the Identity in the ticket is verified <see cref="ClaimsIdentity" />
 /// </summary>
-internal class BackOfficeSecureDataFormat : ISecureDataFormat<AuthenticationTicket>
+internal sealed class BackOfficeSecureDataFormat : ISecureDataFormat<AuthenticationTicket>
 {
     private readonly TimeSpan _loginTimeout;
     private readonly ISecureDataFormat<AuthenticationTicket> _ticketDataFormat;

--- a/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/NoopMemberPartialViewCacheInvalidator.cs
+++ b/src/Umbraco.Core/Cache/PartialViewCacheInvalidators/NoopMemberPartialViewCacheInvalidator.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.Cache.PartialViewCacheInvalidators;
 /// The default implementation is added in Umbraco.Web.Website, but we need this to ensure we have a service
 /// registered for this interface even in headless setups).
 /// </remarks>
-internal class NoopMemberPartialViewCacheInvalidator : IMemberPartialViewCacheInvalidator
+internal sealed class NoopMemberPartialViewCacheInvalidator : IMemberPartialViewCacheInvalidator
 {
     /// <inheritdoc/>
     public void ClearPartialViewCacheItems(IEnumerable<int> memberIds)

--- a/src/Umbraco.Core/Composing/ComposerGraph.cs
+++ b/src/Umbraco.Core/Composing/ComposerGraph.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.Composing;
 /// <summary>
 ///     Handles the composers.
 /// </summary>
-internal class ComposerGraph
+internal sealed class ComposerGraph
 {
     private readonly IUmbracoBuilder _builder;
     private readonly IEnumerable<Type> _composerTypes;
@@ -415,7 +415,7 @@ internal class ComposerGraph
         }
     }
 
-    private class EnableInfo
+    private sealed class EnableInfo
     {
         public bool Enabled { get; set; }
 

--- a/src/Umbraco.Core/Composing/FindAssembliesWithReferencesTo.cs
+++ b/src/Umbraco.Core/Composing/FindAssembliesWithReferencesTo.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Core.Composing;
 ///     borrowed and modified from here
 ///     https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/src/Microsoft.NET.Sdk.Razor/FindAssembliesWithReferencesTo.cs
 /// </remarkes>
-internal class FindAssembliesWithReferencesTo
+internal sealed class FindAssembliesWithReferencesTo
 {
     private readonly bool _includeTargets;
     private readonly ILogger<FindAssembliesWithReferencesTo> _logger;

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -408,7 +408,7 @@ public sealed class TypeLoader
     /// </summary>
     /// <seealso cref="System.Exception" />
     [Serializable]
-    internal class CachedTypeNotFoundInFileException : Exception
+    internal sealed class CachedTypeNotFoundInFileException : Exception
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="CachedTypeNotFoundInFileException" /> class.

--- a/src/Umbraco.Core/Configuration/EntryAssemblyMetadata.cs
+++ b/src/Umbraco.Core/Configuration/EntryAssemblyMetadata.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 
 namespace Umbraco.Cms.Core.Configuration;
 
-internal class EntryAssemblyMetadata : IEntryAssemblyMetadata
+internal sealed class EntryAssemblyMetadata : IEntryAssemblyMetadata
 {
     public EntryAssemblyMetadata()
     {

--- a/src/Umbraco.Core/Configuration/Models/ContentErrorPage.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentErrorPage.cs
@@ -37,7 +37,7 @@ public class ContentErrorPage : ValidatableEntryBase
     [Required]
     public string Culture { get; set; } = null!;
 
-    internal override bool IsValid() =>
+    internal sealed override bool IsValid() =>
         base.IsValid() &&
         (HasContentId ^ HasContentKey);
 }

--- a/src/Umbraco.Core/Diagnostics/NoopMarchal.cs
+++ b/src/Umbraco.Core/Diagnostics/NoopMarchal.cs
@@ -1,6 +1,6 @@
 namespace Umbraco.Cms.Core.Diagnostics;
 
-internal class NoopMarchal : IMarchal
+internal sealed class NoopMarchal : IMarchal
 {
     public IntPtr GetExceptionPointers() => IntPtr.Zero;
 }

--- a/src/Umbraco.Core/Dictionary/UmbracoCultureDictionary.cs
+++ b/src/Umbraco.Core/Dictionary/UmbracoCultureDictionary.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Core.Dictionary;
 ///     fast
 ///     (even though there is caching involved, if there's lots of dictionary items the caching is not great)
 /// </remarks>
-internal class DefaultCultureDictionary : ICultureDictionary
+internal sealed class DefaultCultureDictionary : ICultureDictionary
 {
     private readonly ILocalizationService _localizationService;
     private readonly IAppCache _requestCache;

--- a/src/Umbraco.Core/EnvironmentHelper.cs
+++ b/src/Umbraco.Core/EnvironmentHelper.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Core;
 /// <summary>
 ///     Currently just used to get the machine name for use with file names
 /// </summary>
-internal class EnvironmentHelper
+internal static class EnvironmentHelper
 {
     /// <summary>
     ///     Returns the machine name that is safe to use in file paths.

--- a/src/Umbraco.Core/Events/EventAggregator.Notifications.cs
+++ b/src/Umbraco.Core/Events/EventAggregator.Notifications.cs
@@ -102,7 +102,7 @@ public partial class EventAggregator : IEventAggregator
         }
     }
 
-    private void PublishCore<TNotification>(IEnumerable<Action<IEnumerable<TNotification>>> allHandlers, IEnumerable<TNotification> notifications)
+    private static void PublishCore<TNotification>(IEnumerable<Action<IEnumerable<TNotification>>> allHandlers, IEnumerable<TNotification> notifications)
     {
         foreach (Action<IEnumerable<TNotification>> handler in allHandlers)
         {
@@ -110,7 +110,7 @@ public partial class EventAggregator : IEventAggregator
         }
     }
 
-    private async Task PublishCoreAsync<TNotification>(IEnumerable<Func<IEnumerable<TNotification>, CancellationToken, Task>> allHandlers, IEnumerable<TNotification> notifications, CancellationToken cancellationToken)
+    private static async Task PublishCoreAsync<TNotification>(IEnumerable<Func<IEnumerable<TNotification>, CancellationToken, Task>> allHandlers, IEnumerable<TNotification> notifications, CancellationToken cancellationToken)
     {
         foreach (Func<IEnumerable<TNotification>, CancellationToken, Task> handler in allHandlers)
         {
@@ -192,7 +192,7 @@ internal abstract class NotificationAsyncHandlerWrapper
         where TNotificationHandler : INotificationHandler;
 }
 
-internal class NotificationAsyncHandlerWrapperImpl<TNotificationType> : NotificationAsyncHandlerWrapper
+internal sealed class NotificationAsyncHandlerWrapperImpl<TNotificationType> : NotificationAsyncHandlerWrapper
     where TNotificationType : INotification
 {
     /// <remarks>
@@ -260,7 +260,7 @@ internal class NotificationAsyncHandlerWrapperImpl<TNotificationType> : Notifica
     }
 }
 
-internal class NotificationHandlerWrapperImpl<TNotificationType> : NotificationHandlerWrapper
+internal sealed class NotificationHandlerWrapperImpl<TNotificationType> : NotificationHandlerWrapper
     where TNotificationType : INotification
 {
     /// <remarks>

--- a/src/Umbraco.Core/Events/EventNameExtractor.cs
+++ b/src/Umbraco.Core/Events/EventNameExtractor.cs
@@ -169,7 +169,7 @@ public class EventNameExtractor
         return words[0].EndsWith("ing") == false;
     }
 
-    private class EventInfoArgs
+    private sealed class EventInfoArgs
     {
         public EventInfoArgs(EventInfo eventInfo, Type[] genericArgs)
         {

--- a/src/Umbraco.Core/Events/PassThroughEventDispatcher.cs
+++ b/src/Umbraco.Core/Events/PassThroughEventDispatcher.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.Events;
 ///     This means that events will be raised during the scope transaction,
 ///     whatever happens, and the transaction could roll back in the end.
 /// </remarks>
-internal class PassThroughEventDispatcher : IEventDispatcher
+internal sealed class PassThroughEventDispatcher : IEventDispatcher
 {
     public bool DispatchCancelable(EventHandler? eventHandler, object sender, CancellableEventArgs args, string? eventName = null)
     {

--- a/src/Umbraco.Core/Events/QueuingEventDispatcherBase.cs
+++ b/src/Umbraco.Core/Events/QueuingEventDispatcherBase.cs
@@ -414,7 +414,7 @@ public abstract class QueuingEventDispatcherBase : IEventDispatcher
         }
     }
 
-    private class EventDefinitionInfos
+    private sealed class EventDefinitionInfos
     {
         public IEventDefinition? EventDefinition { get; set; }
 

--- a/src/Umbraco.Core/Events/ScopedNotificationPublisher.cs
+++ b/src/Umbraco.Core/Events/ScopedNotificationPublisher.cs
@@ -116,7 +116,7 @@ public class ScopedNotificationPublisher<TNotificationHandler> : IScopedNotifica
     protected virtual void PublishScopedNotifications(IList<INotification> notifications)
         => _eventAggregator.Publish<INotification, TNotificationHandler>(notifications);
 
-    private class Suppressor : IDisposable
+    private sealed class Suppressor : IDisposable
     {
         private readonly ScopedNotificationPublisher<TNotificationHandler> _scopedNotificationPublisher;
         private bool _disposedValue;
@@ -129,7 +129,7 @@ public class ScopedNotificationPublisher<TNotificationHandler> : IScopedNotifica
 
         public void Dispose() => Dispose(true);
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!_disposedValue)
             {

--- a/src/Umbraco.Core/Handlers/WarnDocumentTypeElementSwitchNotificationHandler.cs
+++ b/src/Umbraco.Core/Handlers/WarnDocumentTypeElementSwitchNotificationHandler.cs
@@ -96,7 +96,7 @@ public class WarnDocumentTypeElementSwitchNotificationHandler :
         }
     }
 
-    private class DocumentTypeElementSwitchInformation
+    private sealed class DocumentTypeElementSwitchInformation
     {
         public bool WasElement { get; set; }
     }

--- a/src/Umbraco.Core/Hosting/NoopApplicationShutdownRegistry.cs
+++ b/src/Umbraco.Core/Hosting/NoopApplicationShutdownRegistry.cs
@@ -1,6 +1,6 @@
 namespace Umbraco.Cms.Core.Hosting;
 
-internal class NoopApplicationShutdownRegistry : IApplicationShutdownRegistry
+internal sealed class NoopApplicationShutdownRegistry : IApplicationShutdownRegistry
 {
     public void RegisterObject(IRegisteredObject registeredObject)
     {

--- a/src/Umbraco.Core/IO/ShadowFileSystem.cs
+++ b/src/Umbraco.Core/IO/ShadowFileSystem.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 namespace Umbraco.Cms.Core.IO;
 
-internal class ShadowFileSystem : IFileSystem
+internal sealed class ShadowFileSystem : IFileSystem
 {
     private readonly IFileSystem _sfs;
 
@@ -392,7 +392,7 @@ internal class ShadowFileSystem : IFileSystem
     }
 
     // copied from System.Web.Util.Wildcard internal
-    internal class WildcardExpression
+    internal sealed class WildcardExpression
     {
         private static readonly Regex MetaRegex = new("[\\+\\{\\\\\\[\\|\\(\\)\\.\\^\\$]");
         private static readonly Regex QuestRegex = new("\\?");
@@ -454,7 +454,7 @@ internal class ShadowFileSystem : IFileSystem
         }
     }
 
-    private class ShadowNode
+    private sealed class ShadowNode
     {
         public ShadowNode(bool isDelete, bool isdir)
         {

--- a/src/Umbraco.Core/IO/ShadowFileSystems.cs
+++ b/src/Umbraco.Core/IO/ShadowFileSystems.cs
@@ -1,7 +1,7 @@
 namespace Umbraco.Cms.Core.IO;
 
 // shadow filesystems is definitively ... too convoluted
-internal class ShadowFileSystems : ICompletable
+internal sealed class ShadowFileSystems : ICompletable
 {
     private readonly FileSystems _fileSystems;
     private bool _completed;

--- a/src/Umbraco.Core/IO/ShadowWrapper.cs
+++ b/src/Umbraco.Core/IO/ShadowWrapper.cs
@@ -5,7 +5,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.IO;
 
-internal class ShadowWrapper : IFileSystem, IFileProviderFactory
+internal sealed class ShadowWrapper : IFileSystem, IFileProviderFactory
 {
     private const string ShadowFsPath = "ShadowFs";
 

--- a/src/Umbraco.Core/Logging/LogProfiler.cs
+++ b/src/Umbraco.Core/Logging/LogProfiler.cs
@@ -39,7 +39,7 @@ public class LogProfiler : IProfiler
     public bool IsEnabled => _logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug);
 
     // a lightweight disposable timer
-    private class LightDisposableTimer : DisposableObjectSlim
+    private sealed class LightDisposableTimer : DisposableObjectSlim
     {
         private readonly Action<long> _callback;
         private readonly Stopwatch _stopwatch = Stopwatch.StartNew();

--- a/src/Umbraco.Core/Logging/NoopProfiler.cs
+++ b/src/Umbraco.Core/Logging/NoopProfiler.cs
@@ -17,7 +17,7 @@ public class NoopProfiler : IProfiler
     /// <inheritdoc/>
     public bool IsEnabled => false;
 
-    private class VoidDisposable : DisposableObjectSlim
+    private sealed class VoidDisposable : DisposableObjectSlim
     {
         protected override void DisposeResources()
         {

--- a/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
+++ b/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
@@ -2,7 +2,7 @@ using Umbraco.Cms.Core.Models.Email;
 
 namespace Umbraco.Cms.Core.Mail;
 
-internal class NotImplementedEmailSender : IEmailSender
+internal sealed class NotImplementedEmailSender : IEmailSender
 {
     public Task SendAsync(EmailMessage message, string emailType)
         => throw new NotImplementedException(

--- a/src/Umbraco.Core/Mail/NotImplementedSmsSender.cs
+++ b/src/Umbraco.Core/Mail/NotImplementedSmsSender.cs
@@ -3,7 +3,7 @@ namespace Umbraco.Cms.Core.Mail;
 /// <summary>
 ///     An <see cref="ISmsSender" /> that throws <see cref="NotImplementedException" />
 /// </summary>
-internal class NotImplementedSmsSender : ISmsSender
+internal sealed class NotImplementedSmsSender : ISmsSender
 {
     public Task SendSmsAsync(string number, string message)
         => throw new NotImplementedException(

--- a/src/Umbraco.Core/Models/DefaultPayloadModel.cs
+++ b/src/Umbraco.Core/Models/DefaultPayloadModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Core.Models;
 
-internal class DefaultPayloadModel
+internal sealed class DefaultPayloadModel
 {
     public Guid Id { get; set; }
 }

--- a/src/Umbraco.Core/Models/Membership/User.cs
+++ b/src/Umbraco.Core/Models/Membership/User.cs
@@ -426,7 +426,7 @@ public class User : EntityBase, IUser, IProfile
     /// <summary>
     ///     Internal class used to wrap the user in a profile
     /// </summary>
-    private class WrappedUserProfile : IProfile
+    private sealed class WrappedUserProfile : IProfile
     {
         private readonly IUser _user;
 

--- a/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
@@ -373,7 +373,7 @@ public class ModelType : Type
 }
 
 /// <inheritdoc />
-internal class ModelTypeArrayType : Type
+internal sealed class ModelTypeArrayType : Type
 {
     private readonly Type _elementType;
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeConverter.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeConverter.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace Umbraco.Cms.Core.Models.PublishedContent;
 
-internal class PublishedContentTypeConverter : TypeConverter
+internal sealed class PublishedContentTypeConverter : TypeConverter
 {
     private static readonly Type[] ConvertingTypes = { typeof(int) };
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedModelFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedModelFactory.cs
@@ -151,7 +151,7 @@ public class PublishedModelFactory : IPublishedModelFactory
     public Type MapModelType(Type type)
         => ModelType.Map(type, _modelTypeMap);
 
-    private class ModelInfo
+    private sealed class ModelInfo
     {
         public Type? ParameterType { get; set; }
 

--- a/src/Umbraco.Core/Persistence/Repositories/UpgradeCheckRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/UpgradeCheckRepository.cs
@@ -33,7 +33,7 @@ public class UpgradeCheckRepository : IUpgradeCheckRepository
         }
     }
 
-    private class CheckUpgradeDto
+    private sealed class CheckUpgradeDto
     {
         public CheckUpgradeDto(SemVersion version)
         {

--- a/src/Umbraco.Core/PropertyEditors/ContentPickerConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ContentPickerConfigurationEditor.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class ContentPickerConfigurationEditor : ConfigurationEditor<ContentPickerConfiguration>
+internal sealed class ContentPickerConfigurationEditor : ConfigurationEditor<ContentPickerConfiguration>
 {
     public ContentPickerConfigurationEditor(IIOHelper ioHelper)
         : base(ioHelper)

--- a/src/Umbraco.Core/PropertyEditors/ContentPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ContentPickerPropertyEditor.cs
@@ -37,7 +37,7 @@ public class ContentPickerPropertyEditor : DataEditor
     protected override IDataValueEditor CreateValueEditor() =>
         DataValueEditorFactory.Create<ContentPickerPropertyValueEditor>(Attribute!);
 
-    internal class ContentPickerPropertyValueEditor : DataValueEditor, IDataValueReference
+    internal sealed class ContentPickerPropertyValueEditor : DataValueEditor, IDataValueReference
     {
 
         public ContentPickerPropertyValueEditor(

--- a/src/Umbraco.Core/PropertyEditors/DateValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DateValueEditor.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 ///     CUstom value editor so we can serialize with the correct date format (excluding time)
 ///     and includes the date validator
 /// </summary>
-internal class DateValueEditor : DataValueEditor
+internal sealed class DateValueEditor : DataValueEditor
 {
     public DateValueEditor(
         IShortStringHelper shortStringHelper,

--- a/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
@@ -41,7 +41,7 @@ public class DecimalPropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the decimal property editor.
     /// </summary>
-    internal class DecimalPropertyValueEditor : DataValueEditor
+    internal sealed class DecimalPropertyValueEditor : DataValueEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DecimalPropertyValueEditor"/> class.
@@ -63,7 +63,7 @@ public class DecimalPropertyEditor : DataEditor
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
             => TryParsePropertyValue(editorValue.Value);
 
-        private decimal? TryParsePropertyValue(object? value)
+        private static decimal? TryParsePropertyValue(object? value)
             => value is decimal decimalValue
                 ? decimalValue
                 : decimal.TryParse(value?.ToString(), CultureInfo.InvariantCulture, out var parsedDecimalValue)
@@ -108,7 +108,7 @@ public class DecimalPropertyEditor : DataEditor
         /// <summary>
         /// Validates the min/max configuration for the decimal property editor.
         /// </summary>
-        internal class MinMaxValidator : DecimalPropertyConfigurationValidatorBase, IValueValidator
+        internal sealed class MinMaxValidator : DecimalPropertyConfigurationValidatorBase, IValueValidator
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="MinMaxValidator"/> class.
@@ -145,7 +145,7 @@ public class DecimalPropertyEditor : DataEditor
         /// <summary>
         /// Validates the step configuration for the decimal property editor.
         /// </summary>
-        internal class StepValidator : DecimalPropertyConfigurationValidatorBase, IValueValidator
+        internal sealed class StepValidator : DecimalPropertyConfigurationValidatorBase, IValueValidator
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="StepValidator"/> class.

--- a/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IntegerPropertyEditor.cs
@@ -39,7 +39,7 @@ public class IntegerPropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the integer property editor.
     /// </summary>
-    internal class IntegerPropertyValueEditor : DataValueEditor
+    internal sealed class IntegerPropertyValueEditor : DataValueEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IntegerPropertyValueEditor"/> class.
@@ -106,7 +106,7 @@ public class IntegerPropertyEditor : DataEditor
         /// <summary>
         /// Validates the min/max configuration for the integer property editor.
         /// </summary>
-        internal class MinMaxValidator : IntegerPropertyConfigurationValidatorBase, IValueValidator
+        internal sealed class MinMaxValidator : IntegerPropertyConfigurationValidatorBase, IValueValidator
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="MinMaxValidator"/> class.
@@ -143,7 +143,7 @@ public class IntegerPropertyEditor : DataEditor
         /// <summary>
         /// Validates the step configuration for the integer property editor.
         /// </summary>
-        internal class StepValidator : IntegerPropertyConfigurationValidatorBase, IValueValidator
+        internal sealed class StepValidator : IntegerPropertyConfigurationValidatorBase, IValueValidator
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="StepValidator"/> class.

--- a/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/LabelPropertyEditor.cs
@@ -37,7 +37,7 @@ public class LabelPropertyEditor : DataEditor
         new LabelConfigurationEditor(_ioHelper);
 
     // provides the property value editor
-    internal class LabelPropertyValueEditor : DataValueEditor
+    internal sealed class LabelPropertyValueEditor : DataValueEditor
     {
         public LabelPropertyValueEditor(
             IShortStringHelper shortStringHelper,

--- a/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MarkDownPropertyValueEditor.cs
@@ -2,13 +2,12 @@ using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Serialization;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class MarkDownPropertyValueEditor : DataValueEditor
+internal sealed class MarkDownPropertyValueEditor : DataValueEditor
 {
     private readonly IMarkdownSanitizer _markdownSanitizer;
 

--- a/src/Umbraco.Core/PropertyEditors/MemberGroupPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MemberGroupPickerPropertyEditor.cs
@@ -21,7 +21,7 @@ public class MemberGroupPickerPropertyEditor : DataEditor
     protected override IDataValueEditor CreateValueEditor() =>
         DataValueEditorFactory.Create<MemberGroupPickerPropertyValueEditor>(Attribute!);
 
-    private class MemberGroupPickerPropertyValueEditor : DataValueEditor
+    private sealed class MemberGroupPickerPropertyValueEditor : DataValueEditor
     {
         private readonly IMemberGroupService _memberGroupService;
 

--- a/src/Umbraco.Core/PropertyEditors/MemberPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/MemberPickerPropertyEditor.cs
@@ -21,7 +21,7 @@ public class MemberPickerPropertyEditor : DataEditor
     protected override IDataValueEditor CreateValueEditor() =>
         DataValueEditorFactory.Create<MemberPickerPropertyValueEditor>(Attribute!);
 
-    private class MemberPickerPropertyValueEditor : DataValueEditor, IDataValueReference
+    private sealed class MemberPickerPropertyValueEditor : DataValueEditor, IDataValueReference
     {
         private readonly IMemberService _memberService;
 

--- a/src/Umbraco.Core/PropertyEditors/TextOnlyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/TextOnlyValueEditor.cs
@@ -63,7 +63,7 @@ public class TextOnlyValueEditor : DataValueEditor
     /// <summary>
     /// A common length validator for both textbox and text area.
     /// </summary>
-    internal class LengthValidator : IValueValidator
+    internal sealed class LengthValidator : IValueValidator
     {
         private readonly ILocalizedTextService _localizedTextService;
 

--- a/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/UserPickerPropertyEditor.cs
@@ -21,7 +21,7 @@ public class UserPickerPropertyEditor : DataEditor
     protected override IDataValueEditor CreateValueEditor() =>
         DataValueEditorFactory.Create<UserPickerPropertyValueEditor>(Attribute!);
 
-    private class UserPickerPropertyValueEditor : DataValueEditor
+    private sealed class UserPickerPropertyValueEditor : DataValueEditor
     {
         private readonly IUserService _userService;
 

--- a/src/Umbraco.Core/PropertyEditors/Validation/JsonPathValidationError.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validation/JsonPathValidationError.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Core.PropertyEditors.Validation;
 
-internal class JsonPathValidationError
+internal sealed class JsonPathValidationError
 {
     public required string JsonPath { get; init; }
 

--- a/src/Umbraco.Core/PropertyEditors/Validation/JsonPathValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/Validation/JsonPathValidator.cs
@@ -55,7 +55,7 @@ internal static class JsonPathValidator
         return errors;
     }
 
-    private class JsonPathValidationTreeItem
+    private sealed class JsonPathValidationTreeItem
     {
         public required string JsonPath { get; init; }
 

--- a/src/Umbraco.Core/PublishedCache/PublishedElementPropertyBase.cs
+++ b/src/Umbraco.Core/PublishedCache/PublishedElementPropertyBase.cs
@@ -4,7 +4,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PublishedCache;
 
-internal class PublishedElementPropertyBase : PublishedPropertyBase
+internal sealed class PublishedElementPropertyBase : PublishedPropertyBase
 {
     protected readonly IPublishedElement Element;
 

--- a/src/Umbraco.Core/Security/Authorization/DictionaryPermissionAuthorizer.cs
+++ b/src/Umbraco.Core/Security/Authorization/DictionaryPermissionAuthorizer.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Services.AuthorizationStatus;
 
 namespace Umbraco.Cms.Core.Security.Authorization;
 
-internal class DictionaryPermissionAuthorizer : IDictionaryPermissionAuthorizer
+internal sealed class DictionaryPermissionAuthorizer : IDictionaryPermissionAuthorizer
 {
     private readonly IDictionaryPermissionService _dictionaryPermissionService;
 

--- a/src/Umbraco.Core/Services/ConsentService.cs
+++ b/src/Umbraco.Core/Services/ConsentService.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Core.Services;
 /// <summary>
 ///     Implements <see cref="IConsentService" />.
 /// </summary>
-internal class ConsentService : RepositoryService, IConsentService
+internal sealed class ConsentService : RepositoryService, IConsentService
 {
     private readonly IConsentRepository _consentRepository;
 

--- a/src/Umbraco.Core/Services/ContentVersionService.cs
+++ b/src/Umbraco.Core/Services/ContentVersionService.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 // ReSharper disable once CheckNamespace
 namespace Umbraco.Cms.Core.Services;
 
-internal class ContentVersionService : IContentVersionService
+internal sealed class ContentVersionService : IContentVersionService
 {
     private readonly IAuditRepository _auditRepository;
     private readonly IContentVersionCleanupPolicy _contentVersionCleanupPolicy;

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -45,7 +45,7 @@ public class DocumentUrlService : IDocumentUrlService
     /// Model used to cache a single published document along with all it's URL segments.
     /// </summary>
     /// <remarks>Internal for the purpose of unit and benchmark testing.</remarks>
-    internal class PublishedDocumentUrlSegments
+    internal sealed class PublishedDocumentUrlSegments
     {
         /// <summary>
         /// Gets or sets the document key.
@@ -456,7 +456,7 @@ public class DocumentUrlService : IDocumentUrlService
     private static bool IsVariantAndPublishedForCulture(IContent document, string? culture) =>
         document.PublishCultureInfos?.Values.Any(x => x.Culture == culture) ?? false;
 
-    private IEnumerable<PublishedDocumentUrlSegment> ConvertToPersistedModel(PublishedDocumentUrlSegments model)
+    private static IEnumerable<PublishedDocumentUrlSegment> ConvertToPersistedModel(PublishedDocumentUrlSegments model)
     {
         foreach (PublishedDocumentUrlSegments.UrlSegment urlSegment in model.UrlSegments)
         {
@@ -816,7 +816,7 @@ public class DocumentUrlService : IDocumentUrlService
         return '/' + string.Join('/', urlSegments);
     }
 
-    private bool HideTopLevel(bool hideTopLevelNodeFromPath, bool isRootFirstItem, List<string> urlSegments)
+    private static bool HideTopLevel(bool hideTopLevelNodeFromPath, bool isRootFirstItem, List<string> urlSegments)
     {
         if (hideTopLevelNodeFromPath is false)
         {

--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Core.Services;
 /// <summary>
 ///     Serializes entities to XML
 /// </summary>
-internal class EntityXmlSerializer : IEntityXmlSerializer
+internal sealed class EntityXmlSerializer : IEntityXmlSerializer
 {
     private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
     private readonly IContentService _contentService;

--- a/src/Umbraco.Core/Services/FileSystem/PartialViewFolderService.cs
+++ b/src/Umbraco.Core/Services/FileSystem/PartialViewFolderService.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Core.Services.FileSystem;
 
-internal class PartialViewFolderService : FolderServiceOperationBase<IPartialViewRepository, PartialViewFolderModel, PartialViewFolderOperationStatus>, IPartialViewFolderService
+internal sealed class PartialViewFolderService : FolderServiceOperationBase<IPartialViewRepository, PartialViewFolderModel, PartialViewFolderOperationStatus>, IPartialViewFolderService
 {
     public PartialViewFolderService(IPartialViewRepository repository, ICoreScopeProvider scopeProvider)
         : base(repository, scopeProvider)

--- a/src/Umbraco.Core/Services/FileSystem/ScriptFolderService.cs
+++ b/src/Umbraco.Core/Services/FileSystem/ScriptFolderService.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Core.Services.FileSystem;
 
-internal class ScriptFolderService : FolderServiceOperationBase<IScriptRepository, ScriptFolderModel, ScriptFolderOperationStatus>, IScriptFolderService
+internal sealed class ScriptFolderService : FolderServiceOperationBase<IScriptRepository, ScriptFolderModel, ScriptFolderOperationStatus>, IScriptFolderService
 {
     public ScriptFolderService(IScriptRepository repository, ICoreScopeProvider scopeProvider)
         : base(repository, scopeProvider)

--- a/src/Umbraco.Core/Services/FileSystem/StylesheetFolderService.cs
+++ b/src/Umbraco.Core/Services/FileSystem/StylesheetFolderService.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Core.Services.FileSystem;
 
-internal class StylesheetFolderService : FolderServiceOperationBase<IStylesheetRepository, StylesheetFolderModel, StylesheetFolderOperationStatus>, IStylesheetFolderService
+internal sealed class StylesheetFolderService : FolderServiceOperationBase<IStylesheetRepository, StylesheetFolderModel, StylesheetFolderOperationStatus>, IStylesheetFolderService
 {
     public StylesheetFolderService(IStylesheetRepository repository, ICoreScopeProvider scopeProvider)
         : base(repository, scopeProvider)

--- a/src/Umbraco.Core/Services/IdKeyMap.cs
+++ b/src/Umbraco.Core/Services/IdKeyMap.cs
@@ -418,7 +418,7 @@ public class IdKeyMap : IIdKeyMap, IDisposable
 
     // ReSharper disable ClassNeverInstantiated.Local
     // ReSharper disable UnusedAutoPropertyAccessor.Local
-    private class TypedIdDto
+    private sealed class TypedIdDto
     {
         public int Id { get; set; }
 

--- a/src/Umbraco.Core/Services/KeyValueService.cs
+++ b/src/Umbraco.Core/Services/KeyValueService.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Scoping;
 
 namespace Umbraco.Cms.Core.Services;
 
-internal class KeyValueService : IKeyValueService
+internal sealed class KeyValueService : IKeyValueService
 {
     private readonly IKeyValueRepository _repository;
     private readonly ICoreScopeProvider _scopeProvider;

--- a/src/Umbraco.Core/Services/MemberGroupService.cs
+++ b/src/Umbraco.Core/Services/MemberGroupService.cs
@@ -8,7 +8,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Core.Services;
 
-internal class MemberGroupService : RepositoryService, IMemberGroupService
+internal sealed class MemberGroupService : RepositoryService, IMemberGroupService
 {
     private readonly IMemberGroupRepository _memberGroupRepository;
 

--- a/src/Umbraco.Core/Services/MemberTwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/MemberTwoFactorLoginService.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 namespace Umbraco.Cms.Core.Services;
 
 /// <inheritdoc cref="Umbraco.Cms.Core.Services.IMemberTwoFactorLoginService" />
-internal class MemberTwoFactorLoginService : TwoFactorLoginServiceBase, IMemberTwoFactorLoginService
+internal sealed class MemberTwoFactorLoginService : TwoFactorLoginServiceBase, IMemberTwoFactorLoginService
 {
     private readonly IMemberService _memberService;
 

--- a/src/Umbraco.Core/Services/NotificationService.cs
+++ b/src/Umbraco.Core/Services/NotificationService.cs
@@ -607,7 +607,7 @@ public class NotificationService : INotificationService
         }
     }
 
-    private class NotificationRequest
+    private sealed class NotificationRequest
     {
         public NotificationRequest(EmailMessage mail, string? action, string? userName, string? email)
         {

--- a/src/Umbraco.Core/Services/RedirectUrlService.cs
+++ b/src/Umbraco.Core/Services/RedirectUrlService.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Scoping;
 
 namespace Umbraco.Cms.Core.Services;
 
-internal class RedirectUrlService : RepositoryService, IRedirectUrlService
+internal sealed class RedirectUrlService : RepositoryService, IRedirectUrlService
 {
     private readonly IRedirectUrlRepository _redirectUrlRepository;
 

--- a/src/Umbraco.Core/Services/UserTwoFactorLoginService.cs
+++ b/src/Umbraco.Core/Services/UserTwoFactorLoginService.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 namespace Umbraco.Cms.Core.Services;
 
 /// <inheritdoc cref="Umbraco.Cms.Core.Services.IUserTwoFactorLoginService" />
-internal class UserTwoFactorLoginService : TwoFactorLoginServiceBase, IUserTwoFactorLoginService
+internal sealed class UserTwoFactorLoginService : TwoFactorLoginServiceBase, IUserTwoFactorLoginService
 {
     private readonly IUserService _userService;
 

--- a/src/Umbraco.Core/Strings/Diff.cs
+++ b/src/Umbraco.Core/Strings/Diff.cs
@@ -500,7 +500,7 @@ internal sealed class Diff
     /// <summary>
     ///     Data on one input file being compared.
     /// </summary>
-    internal class DiffData
+    internal sealed class DiffData
     {
         /// <summary>Buffer of numbers that will be compared.</summary>
         internal int[] Data;

--- a/src/Umbraco.Core/SystemLock.cs
+++ b/src/Umbraco.Core/SystemLock.cs
@@ -89,7 +89,7 @@ public class SystemLock
 
     // note - before making those classes some structs, read
     // about "impure methods" and mutating readonly structs...
-    private class NamedSemaphoreReleaser : CriticalFinalizerObject, IDisposable
+    private sealed class NamedSemaphoreReleaser : CriticalFinalizerObject, IDisposable
     {
         private readonly Semaphore? _semaphore;
 
@@ -156,7 +156,7 @@ public class SystemLock
         }
     }
 
-    private class SemaphoreSlimReleaser : IDisposable
+    private sealed class SemaphoreSlimReleaser : IDisposable
     {
         private readonly SemaphoreSlim _semaphore;
 

--- a/src/Umbraco.Core/Telemetry/SiteIdentifierService.cs
+++ b/src/Umbraco.Core/Telemetry/SiteIdentifierService.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 namespace Umbraco.Cms.Core.Telemetry;
 
 /// <inheritdoc />
-internal class SiteIdentifierService : ISiteIdentifierService
+internal sealed class SiteIdentifierService : ISiteIdentifierService
 {
     private readonly IConfigManipulator _configManipulator;
     private readonly ILogger<SiteIdentifierService> _logger;

--- a/src/Umbraco.Core/Telemetry/TelemetryService.cs
+++ b/src/Umbraco.Core/Telemetry/TelemetryService.cs
@@ -11,7 +11,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Telemetry;
 
 /// <inheritdoc />
-internal class TelemetryService : ITelemetryService
+internal sealed class TelemetryService : ITelemetryService
 {
     private readonly IPackagingService _packagingService;
     private readonly IMetricsConsentService _metricsConsentService;

--- a/src/Umbraco.Core/UdiTypeConverter.cs
+++ b/src/Umbraco.Core/UdiTypeConverter.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Core;
 /// <remarks>
 ///     Primarily this is used so that WebApi can auto-bind a string parameter to a UDI instance
 /// </remarks>
-internal class UdiTypeConverter : TypeConverter
+internal sealed class UdiTypeConverter : TypeConverter
 {
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
     {

--- a/src/Umbraco.Core/Xml/XmlNodeListFactory.cs
+++ b/src/Umbraco.Core/Xml/XmlNodeListFactory.cs
@@ -13,7 +13,7 @@ public class XmlNodeListFactory
 
     #region XmlNodeListIterator
 
-    private class XmlNodeListIterator : XmlNodeList
+    private sealed class XmlNodeListIterator : XmlNodeList
     {
         private readonly XPathNodeIterator? _iterator;
         private readonly IList<XmlNode> _nodes = new List<XmlNode>();
@@ -108,7 +108,7 @@ public class XmlNodeListFactory
 
         #region XmlNodeListEnumerator
 
-        private class XmlNodeListEnumerator : IEnumerator
+        private sealed class XmlNodeListEnumerator : IEnumerator
         {
             private readonly XmlNodeListIterator _iterator;
             private int _position = -1;

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
@@ -71,7 +71,7 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
         _logger.LogInformation("Completed stopping recurring background jobs hosted services");
     }
 
-    private class NamedServiceJob
+    private sealed class NamedServiceJob
     {
         public NamedServiceJob(string name, IHostedService hostedService)
         {

--- a/src/Umbraco.Infrastructure/Cache/FullDataSetRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/FullDataSetRepositoryCachePolicy.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Core.Cache;
 ///         keep as a whole in memory.
 ///     </para>
 /// </remarks>
-internal class FullDataSetRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyBase<TEntity, TId>
+internal sealed class FullDataSetRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyBase<TEntity, TId>
     where TEntity : class, IEntity
 {
     protected static readonly TId[] EmptyIds = new TId[0]; // const

--- a/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Core.Cache;
 ///     </para>
 ///     <para>Used by DictionaryRepository.</para>
 /// </remarks>
-internal class SingleItemsOnlyRepositoryCachePolicy<TEntity, TId> : DefaultRepositoryCachePolicy<TEntity, TId>
+internal sealed class SingleItemsOnlyRepositoryCachePolicy<TEntity, TId> : DefaultRepositoryCachePolicy<TEntity, TId>
     where TEntity : class, IEntity
 {
     public SingleItemsOnlyRepositoryCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, RepositoryCachePolicyOptions options)

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -10,7 +10,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Umbraco.Cms.Infrastructure.Configuration;
 
-internal class JsonConfigManipulator : IConfigManipulator
+internal sealed class JsonConfigManipulator : IConfigManipulator
 {
     private const string ConnectionStringObjectName = "ConnectionStrings";
     private const string UmbracoConnectionStringPath = $"{ConnectionStringObjectName}:{Constants.System.UmbracoConnectionName}";

--- a/src/Umbraco.Infrastructure/Examine/Deferred/DeliveryApiContentIndexHandleContentChanges.cs
+++ b/src/Umbraco.Infrastructure/Examine/Deferred/DeliveryApiContentIndexHandleContentChanges.cs
@@ -136,7 +136,7 @@ internal sealed class DeliveryApiContentIndexHandleContentChanges : DeliveryApiC
                 }
             });
 
-    private class CulturePublishStatus : IEquatable<CulturePublishStatus>
+    private sealed class CulturePublishStatus : IEquatable<CulturePublishStatus>
     {
         public required string Culture { get; set; }
 

--- a/src/Umbraco.Infrastructure/Examine/DeferredActions.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeferredActions.cs
@@ -2,7 +2,7 @@ using Umbraco.Cms.Core.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
 
-internal class DeferredActions
+internal sealed class DeferredActions
 {
     // the default enlist priority is 100
     // enlist with a lower priority to ensure that anything "default" runs after us

--- a/src/Umbraco.Infrastructure/Examine/ExamineIndexingMainDomHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineIndexingMainDomHandler.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Runtime;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
 
-internal class ExamineIndexingMainDomHandler
+internal sealed class ExamineIndexingMainDomHandler
 {
     private readonly IMainDom _mainDom;
     private readonly IProfilingLogger _profilingLogger;

--- a/src/Umbraco.Infrastructure/Examine/ExamineUmbracoIndexingHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineUmbracoIndexingHandler.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Infrastructure.Examine;
 /// <summary>
 ///     Indexing handler for Examine indexes
 /// </summary>
-internal class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
+internal sealed class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
 {
     private readonly IBackgroundTaskQueue _backgroundTaskQueue;
     private readonly IContentValueSetBuilder _contentValueSetBuilder;
@@ -208,7 +208,7 @@ internal class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
     /// <summary>
     ///     Re-indexes an <see cref="IContent" /> item on a background thread
     /// </summary>
-    private class DeferredReIndexForContent : IDeferredAction
+    private sealed class DeferredReIndexForContent : IDeferredAction
     {
         private readonly IBackgroundTaskQueue _backgroundTaskQueue;
         private readonly IContent _content;
@@ -271,7 +271,7 @@ internal class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
     /// <summary>
     ///     Re-indexes an <see cref="IMedia" /> item on a background thread
     /// </summary>
-    private class DeferredReIndexForMedia : IDeferredAction
+    private sealed class DeferredReIndexForMedia : IDeferredAction
     {
         private readonly IBackgroundTaskQueue _backgroundTaskQueue;
         private readonly ExamineUmbracoIndexingHandler _examineUmbracoIndexingHandler;
@@ -323,7 +323,7 @@ internal class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
     /// <summary>
     ///     Re-indexes an <see cref="IMember" /> item on a background thread
     /// </summary>
-    private class DeferredReIndexForMember : IDeferredAction
+    private sealed class DeferredReIndexForMember : IDeferredAction
     {
         private readonly IBackgroundTaskQueue _backgroundTaskQueue;
         private readonly ExamineUmbracoIndexingHandler _examineUmbracoIndexingHandler;
@@ -366,7 +366,7 @@ internal class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
             });
     }
 
-    private class DeferredDeleteIndex : IDeferredAction
+    private sealed class DeferredDeleteIndex : IDeferredAction
     {
         private readonly ExamineUmbracoIndexingHandler _examineUmbracoIndexingHandler;
         private readonly int _id;
@@ -435,7 +435,7 @@ internal class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
     /// <summary>
     ///     Removes all protected content from applicable indexes on a background thread
     /// </summary>
-    private class DeferredRemoveProtectedContent : IDeferredAction
+    private sealed class DeferredRemoveProtectedContent : IDeferredAction
     {
         private readonly IBackgroundTaskQueue _backgroundTaskQueue;
         private readonly ExamineUmbracoIndexingHandler _examineUmbracoIndexingHandler;

--- a/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/Log4NetLevelMapperEnricher.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Core.Logging.Serilog.Enrichers;
 ///     This is used to create a new property in Logs called 'Log4NetLevel'
 ///     So that we can map Serilog levels to Log4Net levels - so log files stay consistent
 /// </summary>
-internal class Log4NetLevelMapperEnricher : ILogEventEnricher
+internal sealed class Log4NetLevelMapperEnricher : ILogEventEnricher
 {
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {

--- a/src/Umbraco.Infrastructure/Logging/Viewer/CountingFilter.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/CountingFilter.cs
@@ -2,7 +2,7 @@ using Serilog.Events;
 
 namespace Umbraco.Cms.Core.Logging.Viewer;
 
-internal class CountingFilter : ILogFilter
+internal sealed class CountingFilter : ILogFilter
 {
     public CountingFilter() => Counts = new LogLevelCounts();
 

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ErrorCounterFilter.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ErrorCounterFilter.cs
@@ -2,7 +2,7 @@ using Serilog.Events;
 
 namespace Umbraco.Cms.Core.Logging.Viewer;
 
-internal class ErrorCounterFilter : ILogFilter
+internal sealed class ErrorCounterFilter : ILogFilter
 {
     public int Count { get; private set; }
 

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ExpressionFilter.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ExpressionFilter.cs
@@ -6,7 +6,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Logging.Viewer;
 
 // Log Expression Filters (pass in filter exp string)
-internal class ExpressionFilter : ILogFilter
+internal sealed class ExpressionFilter : ILogFilter
 {
     private const string ExpressionOperators = "()+=*<>%-";
     private readonly Func<LogEvent, bool>? _filter;
@@ -57,7 +57,7 @@ internal class ExpressionFilter : ILogFilter
 
     public bool TakeLogEvent(LogEvent e) => _filter == null || _filter(e);
 
-    private Func<LogEvent, bool>? PerformMessageLikeFilter(string filterExpression, SerilogLegacyNameResolver serilogLegacyNameResolver)
+    private static Func<LogEvent, bool>? PerformMessageLikeFilter(string filterExpression, SerilogLegacyNameResolver serilogLegacyNameResolver)
     {
         var filterSearch = $"@Message like '%{SerilogExpression.EscapeLikeExpressionContent(filterExpression)}%'";
         if (SerilogExpression.TryCompile(filterSearch, null, serilogLegacyNameResolver, out CompiledExpression? compiled, out var error))

--- a/src/Umbraco.Infrastructure/Logging/Viewer/MessageTemplateFilter.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/MessageTemplateFilter.cs
@@ -2,7 +2,7 @@ using Serilog.Events;
 
 namespace Umbraco.Cms.Core.Logging.Viewer;
 
-internal class MessageTemplateFilter : ILogFilter
+internal sealed class MessageTemplateFilter : ILogFilter
 {
     public readonly Dictionary<string, int> Counts = new();
 

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogJsonLogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogJsonLogViewer.cs
@@ -5,7 +5,7 @@ using ILogger = Serilog.ILogger;
 
 namespace Umbraco.Cms.Core.Logging.Viewer;
 
-internal class SerilogJsonLogViewer : SerilogLogViewerSourceBase
+internal sealed class SerilogJsonLogViewer : SerilogLogViewerSourceBase
 {
     private const int FileSizeCap = 100;
     private readonly ILogger<SerilogJsonLogViewer> _logger;
@@ -112,7 +112,7 @@ internal class SerilogJsonLogViewer : SerilogLogViewerSourceBase
         return logs;
     }
 
-    private string GetSearchPattern(DateTime day) => $"*{day:yyyyMMdd}*.json";
+    private static string GetSearchPattern(DateTime day) => $"*{day:yyyyMMdd}*.json";
 
     private bool TryRead(LogEventReader reader, out LogEvent? evt)
     {

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install;
 /// <summary>
 ///     Creates the initial database data during install.
 /// </summary>
-internal class DatabaseDataCreator
+internal sealed class DatabaseDataCreator
 {
 
     internal const string EditorGroupAlias = "editor";

--- a/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationContext.cs
@@ -8,10 +8,9 @@ namespace Umbraco.Cms.Infrastructure.Migrations;
 /// <summary>
 ///     Implements <see cref="IMigrationContext" />.
 /// </summary>
-internal class MigrationContext : IMigrationContext
+internal sealed class MigrationContext : IMigrationContext
 {
     private readonly Action? _onCompleteAction;
-    private readonly List<Type> _postMigrations = new();
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="MigrationContext" /> class.

--- a/src/Umbraco.Infrastructure/Migrations/Notifications/DatabaseSchemaCreatedNotification.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Notifications/DatabaseSchemaCreatedNotification.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Notifications;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Notifications;
 
-internal class DatabaseSchemaCreatedNotification : StatefulNotification
+internal sealed class DatabaseSchemaCreatedNotification : StatefulNotification
 {
     public DatabaseSchemaCreatedNotification(EventMessages eventMessages) => EventMessages = eventMessages;
 

--- a/src/Umbraco.Infrastructure/Migrations/Notifications/DatabaseSchemaCreatingNotification.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Notifications/DatabaseSchemaCreatingNotification.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Notifications;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Notifications;
 
-internal class DatabaseSchemaCreatingNotification : CancelableNotification
+internal sealed class DatabaseSchemaCreatingNotification : CancelableNotification
 {
     public DatabaseSchemaCreatingNotification(EventMessages messages)
         : base(messages)

--- a/src/Umbraco.Infrastructure/Packaging/ImportPackageBuilder.cs
+++ b/src/Umbraco.Infrastructure/Packaging/ImportPackageBuilder.cs
@@ -11,7 +11,7 @@ using Umbraco.Cms.Infrastructure.Migrations.Expressions.Common;
 
 namespace Umbraco.Cms.Infrastructure.Packaging;
 
-internal class ImportPackageBuilder : ExpressionBuilderBase<ImportPackageBuilderExpression>, IImportPackageBuilder,
+internal sealed class ImportPackageBuilder : ExpressionBuilderBase<ImportPackageBuilderExpression>, IImportPackageBuilder,
     IExecutableBuilder
 {
     public ImportPackageBuilder(

--- a/src/Umbraco.Infrastructure/Packaging/ImportPackageBuilderExpression.cs
+++ b/src/Umbraco.Infrastructure/Packaging/ImportPackageBuilderExpression.cs
@@ -16,7 +16,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Packaging;
 
-internal class ImportPackageBuilderExpression : MigrationExpressionBase
+internal sealed class ImportPackageBuilderExpression : MigrationExpressionBase
 {
     private readonly IContentTypeBaseServiceProvider _contentTypeBaseServiceProvider;
     private readonly MediaFileManager _mediaFileManager;

--- a/src/Umbraco.Infrastructure/Persistence/DatabaseModelDefinitions/DbIndexDefinition.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DatabaseModelDefinitions/DbIndexDefinition.cs
@@ -3,7 +3,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.DatabaseModelDefinitions;
 /// <summary>
 ///     Represents a database index definition retrieved by querying the database
 /// </summary>
-internal class DbIndexDefinition
+internal sealed class DbIndexDefinition
 {
     public DbIndexDefinition(Tuple<string, string, string, bool> data)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/AccessDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/AccessDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Access)]
 [PrimaryKey("id", AutoIncrement = false)]
 [ExplicitColumns]
-internal class AccessDto
+internal sealed class AccessDto
 {
     [Column("id")]
     [PrimaryKeyColumn(Name = "PK_umbracoAccess", AutoIncrement = false)]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/AccessRuleDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/AccessRuleDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.AccessRule)]
 [PrimaryKey("id", AutoIncrement = false)]
 [ExplicitColumns]
-internal class AccessRuleDto
+internal sealed class AccessRuleDto
 {
     [Column("id")]
     [PrimaryKeyColumn(Name = "PK_umbracoAccessRule", AutoIncrement = false)]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/AuditEntryDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/AuditEntryDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.AuditEntry)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class AuditEntryDto
+internal sealed class AuditEntryDto
 {
     [Column("id")]
     [PrimaryKeyColumn]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/AxisDefintionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/AxisDefintionDto.cs
@@ -2,7 +2,7 @@ using NPoco;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
-internal class AxisDefintionDto
+internal sealed class AxisDefintionDto
 {
     [Column("nodeId")]
     public int NodeId { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentScheduleDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentScheduleDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id", AutoIncrement = false)]
 [ExplicitColumns]
-internal class ContentScheduleDto
+internal sealed class ContentScheduleDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.ContentSchedule;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentType2ContentTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentType2ContentTypeDto.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(Constants.DatabaseSchema.Tables.ElementTypeTree)]
 [ExplicitColumns]
-internal class ContentType2ContentTypeDto
+internal sealed class ContentType2ContentTypeDto
 {
     [Column("parentContentTypeId")]
     [PrimaryKeyColumn(AutoIncrement = false, Clustered = true, Name = "PK_cmsContentType2ContentType", OnColumns = "parentContentTypeId, childContentTypeId")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentTypeAllowedContentTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentTypeAllowedContentTypeDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.ContentChildType)]
 [PrimaryKey("Id", AutoIncrement = false)]
 [ExplicitColumns]
-internal class ContentTypeAllowedContentTypeDto
+internal sealed class ContentTypeAllowedContentTypeDto
 {
     [Column("Id")]
     [ForeignKey(typeof(ContentTypeDto), Name = "FK_cmsContentTypeAllowedContentType_cmsContentType", Column = "nodeId")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentTypeTemplateDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentTypeTemplateDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.DocumentType)]
 [PrimaryKey("contentTypeNodeId", AutoIncrement = false)]
 [ExplicitColumns]
-internal class ContentTypeTemplateDto
+internal sealed class ContentTypeTemplateDto
 {
     [Column("contentTypeNodeId")]
     [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_cmsDocumentType", OnColumns = "contentTypeNodeId, templateNodeId")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCleanupPolicyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCleanupPolicyDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("contentTypeId", AutoIncrement = false)]
 [ExplicitColumns]
-internal class ContentVersionCleanupPolicyDto
+internal sealed class ContentVersionCleanupPolicyDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.ContentVersionCleanupPolicy;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCultureVariationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionCultureVariationDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class ContentVersionCultureVariationDto
+internal sealed class ContentVersionCultureVariationDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.ContentVersionCultureVariation;
     private int? _updateUserId;

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/DocumentCultureVariationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/DocumentCultureVariationDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class DocumentCultureVariationDto
+internal sealed class DocumentCultureVariationDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.DocumentCultureVariation;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/DocumentPublishedReadOnlyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/DocumentPublishedReadOnlyDto.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Document)]
 [PrimaryKey("versionId", AutoIncrement = false)]
 [ExplicitColumns]
-internal class DocumentPublishedReadOnlyDto
+internal sealed class DocumentPublishedReadOnlyDto
 {
     [Column("nodeId")]
     public int NodeId { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/DomainDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/DomainDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class DomainDto
+internal sealed class DomainDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.Domain;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [ExplicitColumns]
 [PrimaryKey("Id")]
-internal class ExternalLoginDto
+internal sealed class ExternalLoginDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.ExternalLogin;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginTokenDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ExternalLoginTokenDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [ExplicitColumns]
 [PrimaryKey("Id")]
-internal class ExternalLoginTokenDto
+internal sealed class ExternalLoginTokenDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.ExternalLoginToken;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/KeyValueDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/KeyValueDto.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.KeyValue)]
 [PrimaryKey("key", AutoIncrement = false)]
 [ExplicitColumns]
-internal class KeyValueDto
+internal sealed class KeyValueDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.KeyValue;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/LanguageDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/LanguageDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class LanguageDto
+internal sealed class LanguageDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.Language;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/LockDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/LockDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Lock)]
 [PrimaryKey("id", AutoIncrement = false)]
 [ExplicitColumns]
-internal class LockDto
+internal sealed class LockDto
 {
     [Column("id")]
     [PrimaryKeyColumn(Name = "PK_umbracoLock", AutoIncrement = false)]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/LogDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/LogDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class LogDto
+internal sealed class LogDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.Log;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/LogViewerQueryDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/LogViewerQueryDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.LogViewerQuery)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class LogViewerQueryDto
+internal sealed class LogViewerQueryDto
 {
     [Column("id")]
     [PrimaryKeyColumn]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/MediaDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/MediaDto.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 // this is a special Dto that does not have a corresponding table
 // and is only used in our code to represent a media item, similar
 // to document items.
-internal class MediaDto
+internal sealed class MediaDto
 {
     public int NodeId { get; set; }
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/MediaVersionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/MediaVersionDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id", AutoIncrement = false)]
 [ExplicitColumns]
-internal class MediaVersionDto
+internal sealed class MediaVersionDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.MediaVersion;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/Member2MemberGroupDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/Member2MemberGroupDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Member2MemberGroup)]
 [PrimaryKey("Member", AutoIncrement = false)]
 [ExplicitColumns]
-internal class Member2MemberGroupDto
+internal sealed class Member2MemberGroupDto
 {
     [Column("Member")]
     [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_cmsMember2MemberGroup", OnColumns = "Member, MemberGroup")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/MemberDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/MemberDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("nodeId", AutoIncrement = false)]
 [ExplicitColumns]
-internal class MemberDto
+internal sealed class MemberDto
 {
     private const string TableName = Constants.DatabaseSchema.Tables.Member;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/MemberPropertyTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/MemberPropertyTypeDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.MemberPropertyType)]
 [PrimaryKey("pk")]
 [ExplicitColumns]
-internal class MemberPropertyTypeDto
+internal sealed class MemberPropertyTypeDto
 {
     [Column("pk")]
     [PrimaryKeyColumn]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/NavigationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/NavigationDto.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 // Used internally for representing the data needed for constructing the in-memory navigation structure.
 [TableName(NodeDto.TableName)]
-internal class NavigationDto : INavigationModel
+internal sealed class NavigationDto : INavigationModel
 {
     // Public constants to bind properties between DTOs
     public const string ContentTypeKeyColumnName = "contentTypeKey";

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyDataDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyDataDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class PropertyDataDto
+internal sealed class PropertyDataDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.PropertyData;
     public const int VarcharLength = 512;

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeCommonDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeCommonDto.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 // this is PropertyTypeDto + the special property type fields for members
 // it is used for querying everything needed for a property type, at once
-internal class PropertyTypeCommonDto : PropertyTypeDto
+internal sealed class PropertyTypeCommonDto : PropertyTypeDto
 {
     [Column("memberCanEdit")]
     public bool CanEdit { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeGroupDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeGroupDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id", AutoIncrement = true)]
 [ExplicitColumns]
-internal class PropertyTypeGroupDto
+internal sealed class PropertyTypeGroupDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.PropertyTypeGroup;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeGroupReadOnlyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeGroupReadOnlyDto.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.PropertyTypeGroup)]
 [PrimaryKey("id", AutoIncrement = true)]
 [ExplicitColumns]
-internal class PropertyTypeGroupReadOnlyDto
+internal sealed class PropertyTypeGroupReadOnlyDto
 {
     [Column("PropertyTypeGroupId")]
     public int? Id { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeReadOnlyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeReadOnlyDto.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.PropertyType)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class PropertyTypeReadOnlyDto
+internal sealed class PropertyTypeReadOnlyDto
 {
     [Column("PropertyTypeId")]
     public int? Id { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RedirectUrlDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RedirectUrlDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.RedirectUrl)]
 [PrimaryKey("id", AutoIncrement = false)]
 [ExplicitColumns]
-internal class RedirectUrlDto
+internal sealed class RedirectUrlDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.RedirectUrl;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RelationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RelationDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Relation)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class RelationDto
+internal sealed class RelationDto
 {
     [Column("id")]
     [PrimaryKeyColumn]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RelationTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RelationTypeDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.RelationType)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class RelationTypeDto
+internal sealed class RelationTypeDto
 {
     public const int NodeIdSeed = 10;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ServerRegistrationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ServerRegistrationDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Server)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class ServerRegistrationDto
+internal sealed class ServerRegistrationDto
 {
     [Column("id")]
     [PrimaryKeyColumn(AutoIncrement = true)]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/TagDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/TagDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class TagDto
+internal sealed class TagDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.Tag;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/TagRelationshipDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/TagRelationshipDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("nodeId", AutoIncrement = false)]
 [ExplicitColumns]
-internal class TagRelationshipDto
+internal sealed class TagRelationshipDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.TagRelationship;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/TemplateDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/TemplateDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Template)]
 [PrimaryKey("pk")]
 [ExplicitColumns]
-internal class TemplateDto
+internal sealed class TemplateDto
 {
     [Column("pk")]
     [PrimaryKeyColumn]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/TwoFactorLoginDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/TwoFactorLoginDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [ExplicitColumns]
 [PrimaryKey("Id")]
-internal class TwoFactorLoginDto
+internal sealed class TwoFactorLoginDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.TwoFactorLogin;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/User2NodeNotifyDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/User2NodeNotifyDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.User2NodeNotify)]
 [PrimaryKey("userId", AutoIncrement = false)]
 [ExplicitColumns]
-internal class User2NodeNotifyDto
+internal sealed class User2NodeNotifyDto
 {
     [Column("userId")]
     [PrimaryKeyColumn(AutoIncrement = false, Name = "PK_umbracoUser2NodeNotify", OnColumns = "userId, nodeId, action")]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2GranularPermissionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2GranularPermissionDto.cs
@@ -35,7 +35,7 @@ public class UserGroup2GranularPermissionDto
 
 // this is UserGroup2GranularPermissionDto + int ids
 // it is used for handling legacy cases where we use int Ids
-internal class UserGroup2GranularPermissionWithIdsDto : UserGroup2GranularPermissionDto
+internal sealed class UserGroup2GranularPermissionWithIdsDto : UserGroup2GranularPermissionDto
 {
     [Column("entityId")]
     public int EntityId { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2NodeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserGroup2NodeDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [Obsolete("Will be removed in Umbraco 18.")]
 [TableName(TableName)]
 [ExplicitColumns]
-internal class UserGroup2NodeDto
+internal sealed class UserGroup2NodeDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.UserGroup2Node;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserLoginDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserLoginDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(TableName)]
 [PrimaryKey("sessionId", AutoIncrement = false)]
 [ExplicitColumns]
-internal class UserLoginDto
+internal sealed class UserLoginDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.UserLogin;
 

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/UserNotificationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/UserNotificationDto.cs
@@ -2,7 +2,7 @@ using NPoco;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
-internal class UserNotificationDto
+internal sealed class UserNotificationDto
 {
     [Column("nodeId")]
     public int NodeId { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookDto.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.Webhook)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class WebhookDto
+internal sealed class WebhookDto
 {
     [Column("id")]
     [PrimaryKeyColumn(AutoIncrement = true)]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookLogDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookLogDto.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 [TableName(Constants.DatabaseSchema.Tables.WebhookLog)]
 [PrimaryKey("id")]
 [ExplicitColumns]
-internal class WebhookLogDto
+internal sealed class WebhookLogDto
 {
     [Column("id")]
     [PrimaryKeyColumn(AutoIncrement = true)]

--- a/src/Umbraco.Infrastructure/Persistence/Factories/ContentBaseFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/ContentBaseFactory.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Factories;
 
-internal class ContentBaseFactory
+internal sealed class ContentBaseFactory
 {
     /// <summary>
     ///     Builds an IContent item from a dto and content type.

--- a/src/Umbraco.Infrastructure/Persistence/FaultHandling/RetryDbConnection.cs
+++ b/src/Umbraco.Infrastructure/Persistence/FaultHandling/RetryDbConnection.cs
@@ -87,7 +87,7 @@ public class RetryDbConnection : DbConnection
         OnStateChange(stateChangeEventArguments);
 }
 
-internal class FaultHandlingDbCommand : DbCommand
+internal sealed class FaultHandlingDbCommand : DbCommand
 {
     private readonly RetryPolicy _cmdRetryPolicy;
     private RetryDbConnection _connection;

--- a/src/Umbraco.Infrastructure/Persistence/Querying/CachedExpression.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Querying/CachedExpression.cs
@@ -5,7 +5,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Querying;
 /// <summary>
 ///     Represents an expression which caches the visitor's result.
 /// </summary>
-internal class CachedExpression : Expression
+internal sealed class CachedExpression : Expression
 {
     private string _visitResult = null!;
 

--- a/src/Umbraco.Infrastructure/Persistence/Querying/ModelToSqlExpressionVisitor.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Querying/ModelToSqlExpressionVisitor.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Querying;
 ///     based on Umbraco's business logic models.
 /// </summary>
 /// <remarks>This object is stateful and cannot be re-used to parse an expression.</remarks>
-internal class ModelToSqlExpressionVisitor<T> : ExpressionVisitorBase
+internal sealed class ModelToSqlExpressionVisitor<T> : ExpressionVisitorBase
 {
     private readonly BaseMapper? _mapper;
     private readonly IMapperCollection? _mappers;

--- a/src/Umbraco.Infrastructure/Persistence/Querying/PocoToSqlExpressionVisitor.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Querying/PocoToSqlExpressionVisitor.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Querying;
 /// </summary>
 /// <typeparam name="TDto">The type of the DTO.</typeparam>
 /// <remarks>This visitor is stateful and cannot be reused.</remarks>
-internal class PocoToSqlExpressionVisitor<TDto> : ExpressionVisitorBase
+internal sealed class PocoToSqlExpressionVisitor<TDto> : ExpressionVisitorBase
 {
     private readonly string? _alias;
     private readonly PocoData _pd;
@@ -96,7 +96,7 @@ internal class PocoToSqlExpressionVisitor<TDto> : ExpressionVisitorBase
         return Visited ? string.Empty : "@" + (SqlParameters.Count - 1);
     }
 
-    protected virtual string GetFieldName(PocoData pocoData, string name, string? alias)
+    private string GetFieldName(PocoData pocoData, string name, string? alias)
     {
         KeyValuePair<string, PocoColumn> column =
             pocoData.Columns.FirstOrDefault(x => x.Value.MemberInfoData.Name == name);
@@ -113,7 +113,7 @@ internal class PocoToSqlExpressionVisitor<TDto> : ExpressionVisitorBase
 /// <typeparam name="TDto1">The type of DTO 1.</typeparam>
 /// <typeparam name="TDto2">The type of DTO 2.</typeparam>
 /// <remarks>This visitor is stateful and cannot be reused.</remarks>
-internal class PocoToSqlExpressionVisitor<TDto1, TDto2> : ExpressionVisitorBase
+internal sealed class PocoToSqlExpressionVisitor<TDto1, TDto2> : ExpressionVisitorBase
 {
     private readonly string? _alias1;
     private readonly string? _alias2;
@@ -194,7 +194,7 @@ internal class PocoToSqlExpressionVisitor<TDto1, TDto2> : ExpressionVisitorBase
         return Visited ? string.Empty : "@" + (SqlParameters.Count - 1);
     }
 
-    protected virtual string GetFieldName(PocoData pocoData, string name, string? alias)
+    private string GetFieldName(PocoData pocoData, string name, string? alias)
     {
         KeyValuePair<string, PocoColumn> column =
             pocoData.Columns.FirstOrDefault(x => x.Value.MemberInfoData.Name == name);
@@ -212,7 +212,7 @@ internal class PocoToSqlExpressionVisitor<TDto1, TDto2> : ExpressionVisitorBase
 /// <typeparam name="TDto2">The type of DTO 2.</typeparam>
 /// <typeparam name="TDto3">The type of DTO 3.</typeparam>
 /// <remarks>This visitor is stateful and cannot be reused.</remarks>
-internal class PocoToSqlExpressionVisitor<TDto1, TDto2, TDto3> : ExpressionVisitorBase
+internal sealed class PocoToSqlExpressionVisitor<TDto1, TDto2, TDto3> : ExpressionVisitorBase
 {
     private readonly string? _alias1;
     private readonly string? _alias2;
@@ -309,7 +309,7 @@ internal class PocoToSqlExpressionVisitor<TDto1, TDto2, TDto3> : ExpressionVisit
         return Visited ? string.Empty : "@" + (SqlParameters.Count - 1);
     }
 
-    protected virtual string GetFieldName(PocoData pocoData, string name, string? alias)
+    private string GetFieldName(PocoData pocoData, string name, string? alias)
     {
         KeyValuePair<string, PocoColumn> column =
             pocoData.Columns.FirstOrDefault(x => x.Value.MemberInfoData.Name == name);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents the NPoco implementation of <see cref="IAuditEntryRepository" />.
 /// </summary>
-internal class AuditEntryRepository : EntityRepositoryBase<int, IAuditEntry>, IAuditEntryRepository
+internal sealed class AuditEntryRepository : EntityRepositoryBase<int, IAuditEntry>, IAuditEntryRepository
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="AuditEntryRepository" /> class.

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
@@ -12,7 +12,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRepository
+internal sealed class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRepository
 {
     public AuditRepository(IScopeAccessor scopeAccessor, ILogger<AuditRepository> logger)
         : base(scopeAccessor, AppCaches.NoCache, logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CacheInstructionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/CacheInstructionRepository.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents the NPoco implementation of <see cref="ICacheInstructionRepository" />.
 /// </summary>
-internal class CacheInstructionRepository : ICacheInstructionRepository
+internal sealed class CacheInstructionRepository : ICacheInstructionRepository
 {
     private readonly IScopeAccessor _scopeAccessor;
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ConsentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ConsentRepository.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents the NPoco implementation of <see cref="IConsentRepository" />.
 /// </summary>
-internal class ConsentRepository : EntityRepositoryBase<int, IConsent>, IConsentRepository
+internal sealed class ConsentRepository : EntityRepositoryBase<int, IConsent>, IConsentRepository
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="ConsentRepository" /> class.

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1231,7 +1231,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             }
         }
 
-        private class NodeIdKey
+        private sealed class NodeIdKey
         {
             [Column("id")]
             public int NodeId { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Implements <see cref="IContentTypeCommonRepository" />.
 /// </summary>
-internal class ContentTypeCommonRepository : IContentTypeCommonRepository
+internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
 {
     private const string CacheKey =
         "Umbraco.Core.Persistence.Repositories.Implement.ContentTypeCommonRepository::AllTypes";
@@ -369,7 +369,7 @@ internal class ContentTypeCommonRepository : IContentTypeCommonRepository
         }
     }
 
-    private PropertyGroup MapPropertyGroup(PropertyTypeGroupDto dto, bool isPublishing) =>
+    private static PropertyGroup MapPropertyGroup(PropertyTypeGroupDto dto, bool isPublishing) =>
         new(new PropertyTypeCollection(isPublishing))
         {
             Id = dto.Id,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="IContentType" />
 /// </summary>
-internal class ContentTypeRepository : ContentTypeRepositoryBase<IContentType>, IContentTypeRepository
+internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContentType>, IContentTypeRepository
 {
     public ContentTypeRepository(
         IScopeAccessor scopeAccessor,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -1564,7 +1564,7 @@ WHERE {Constants.DatabaseSchema.Tables.Content}.nodeId IN (@ids) AND cmsContentT
             ?? Array.Empty<(TEntity, int)>();
     }
 
-    private class NameCompareDto
+    private sealed class NameCompareDto
     {
         public int NodeId { get; set; }
 
@@ -1583,7 +1583,7 @@ WHERE {Constants.DatabaseSchema.Tables.Content}.nodeId IN (@ids) AND cmsContentT
         public bool Edited { get; set; }
     }
 
-    private class PropertyValueVersionDto
+    private sealed class PropertyValueVersionDto
     {
         private decimal? _decimalValue;
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeContainerRepository.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class DataTypeContainerRepository : EntityContainerRepository, IDataTypeContainerRepository
+internal sealed class DataTypeContainerRepository : EntityContainerRepository, IDataTypeContainerRepository
 {
     public DataTypeContainerRepository(
         IScopeAccessor scopeAccessor,
@@ -15,5 +15,4 @@ internal class DataTypeContainerRepository : EntityContainerRepository, IDataTyp
         : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DataTypeContainer)
     {
     }
-
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -1,7 +1,5 @@
 using System.Data;
 using System.Globalization;
-using System.Linq.Expressions;
-using System.Reflection;
 using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Core;
@@ -16,7 +14,6 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Infrastructure.Persistence.Factories;
-using Umbraco.Cms.Infrastructure.Persistence.Mappers;
 using Umbraco.Cms.Infrastructure.Persistence.Querying;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
@@ -27,7 +24,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="DataType" />
 /// </summary>
-internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataTypeRepository
+internal sealed class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataTypeRepository
 {
     private readonly ILogger<IDataType> _dataTypeLogger;
     private readonly PropertyEditorCollection _editors;
@@ -234,7 +231,7 @@ internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataT
     }
 
     [TableName(Constants.DatabaseSchema.Tables.ContentType)]
-    private class ContentTypeReferenceDto : ContentTypeDto
+    private sealed class ContentTypeReferenceDto : ContentTypeDto
     {
         [ResultColumn]
         [Reference(ReferenceType.Many)]
@@ -242,7 +239,7 @@ internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataT
     }
 
     [TableName(Constants.DatabaseSchema.Tables.PropertyType)]
-    private class PropertyTypeReferenceDto
+    private sealed class PropertyTypeReferenceDto
     {
         [Column("ptAlias")]
         public string? Alias { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="DictionaryItem" />
 /// </summary>
-internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>, IDictionaryRepository
+internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>, IDictionaryRepository
 {
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILanguageRepository _languageRepository;
@@ -128,7 +128,7 @@ internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>
         return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, int>(GlobalIsolatedCache, ScopeAccessor, options);
     }
 
-    private IDictionaryItem ConvertFromDto(DictionaryDto dto, IDictionary<int, ILanguage> languagesById)
+    private static IDictionaryItem ConvertFromDto(DictionaryDto dto, IDictionary<int, ILanguage> languagesById)
     {
         IDictionaryItem entity = DictionaryItemFactory.BuildEntity(dto);
 
@@ -174,14 +174,14 @@ internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>
         return Get(query);
     }
 
-    private class DictionaryItemKeyIdDto
+    private sealed class DictionaryItemKeyIdDto
     {
         public string Key { get; } = null!;
 
         public Guid Id { get; set; }
     }
 
-    private class DictionaryByUniqueIdRepository : SimpleGetRepository<Guid, IDictionaryItem, DictionaryDto>
+    private sealed class DictionaryByUniqueIdRepository : SimpleGetRepository<Guid, IDictionaryItem, DictionaryDto>
     {
         private readonly DictionaryRepository _dictionaryRepository;
         private readonly IDictionary<int, ILanguage> _languagesById;
@@ -204,7 +204,7 @@ internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>
             "cmsDictionary." + SqlSyntax.GetQuotedColumnName("id") + " = @id";
 
         protected override IDictionaryItem ConvertToEntity(DictionaryDto dto) =>
-            _dictionaryRepository.ConvertFromDto(dto, _languagesById);
+            ConvertFromDto(dto, _languagesById);
 
         protected override object GetBaseWhereClauseArguments(Guid id) => new { id };
 
@@ -236,7 +236,7 @@ internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>
         }
     }
 
-    private class DictionaryByKeyRepository : SimpleGetRepository<string, IDictionaryItem, DictionaryDto>
+    private sealed class DictionaryByKeyRepository : SimpleGetRepository<string, IDictionaryItem, DictionaryDto>
     {
         private readonly DictionaryRepository _dictionaryRepository;
         private readonly IDictionary<int, ILanguage> _languagesById;
@@ -259,7 +259,7 @@ internal class DictionaryRepository : EntityRepositoryBase<int, IDictionaryItem>
             "cmsDictionary." + SqlSyntax.GetQuotedColumnName("key") + " = @id";
 
         protected override IDictionaryItem ConvertToEntity(DictionaryDto dto) =>
-            _dictionaryRepository.ConvertFromDto(dto, _languagesById);
+            ConvertFromDto(dto, _languagesById);
 
         protected override object GetBaseWhereClauseArguments(string? id) => new { id };
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintContainerRepository.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class DocumentBlueprintContainerRepository : EntityContainerRepository, IDocumentBlueprintContainerRepository
+internal sealed class DocumentBlueprintContainerRepository : EntityContainerRepository, IDocumentBlueprintContainerRepository
 {
     public DocumentBlueprintContainerRepository(
         IScopeAccessor scopeAccessor,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintRepository.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 ///     perform a lot of the underlying logic.
 ///     TODO: Create a helper method to contain most of the underlying logic for the ContentRepository
 /// </remarks>
-internal class DocumentBlueprintRepository : DocumentRepository, IDocumentBlueprintRepository
+internal sealed class DocumentBlueprintRepository : DocumentRepository, IDocumentBlueprintRepository
 {
     public DocumentBlueprintRepository(
         IScopeAccessor scopeAccessor,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -576,14 +576,14 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
         }
     }
 
-    private class ContentVariation
+    private sealed class ContentVariation
     {
         public string? Culture { get; set; }
         public string? Name { get; set; }
         public DateTime Date { get; set; }
     }
 
-    private class DocumentVariation
+    private sealed class DocumentVariation
     {
         public string? Culture { get; set; }
         public bool Edited { get; set; }
@@ -1553,7 +1553,7 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
     // reading repository purely for looking up by GUID
     // TODO: ugly and to fix we need to decouple the IRepositoryQueryable -> IRepository -> IReadRepository which should all be separate things!
     // This sub-repository pattern is super old and totally unecessary anymore, caching can be handled in much nicer ways without this
-    private class ContentByGuidReadRepository : EntityRepositoryBase<Guid, IContent>
+    private sealed class ContentByGuidReadRepository : EntityRepositoryBase<Guid, IContent>
     {
         private readonly DocumentRepository _outerRepo;
 
@@ -1821,7 +1821,7 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local
-    private class CultureNodeName
+    private sealed class CultureNodeName
     {
         public int Id { get; set; }
         public string? Name { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentTypeContainerRepository.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class DocumentTypeContainerRepository : EntityContainerRepository, IDocumentTypeContainerRepository
+internal sealed class DocumentTypeContainerRepository : EntityContainerRepository, IDocumentTypeContainerRepository
 {
     public DocumentTypeContainerRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<DocumentTypeContainerRepository> logger)
         : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DocumentTypeContainer)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentVersionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentVersionRepository.cs
@@ -9,7 +9,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class DocumentVersionRepository : IDocumentVersionRepository
+internal sealed class DocumentVersionRepository : IDocumentVersionRepository
 {
     private readonly IScopeAccessor _scopeAccessor;
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class DomainRepository : EntityRepositoryBase<int, IDomain>, IDomainRepository
+internal sealed class DomainRepository : EntityRepositoryBase<int, IDomain>, IDomainRepository
 {
     public DomainRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<DomainRepository> logger)
         : base(scopeAccessor, cache, logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 ///     <para>Limited to objects that have a corresponding node (in umbracoNode table).</para>
 ///     <para>Returns <see cref="IEntitySlim" /> objects, i.e. lightweight representation of entities.</para>
 /// </remarks>
-internal class EntityRepository : RepositoryBase, IEntityRepositoryExtended
+internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtended
 {
     public EntityRepository(IScopeAccessor scopeAccessor, AppCaches appCaches)
         : base(scopeAccessor, appCaches)
@@ -782,7 +782,7 @@ internal class EntityRepository : RepositoryBase, IEntityRepositoryExtended
     /// <summary>
     ///     The DTO used to fetch results for a generic content item which could be either a document, media or a member
     /// </summary>
-    private class GenericContentEntityDto : DocumentEntityDto
+    private sealed class GenericContentEntityDto : DocumentEntityDto
     {
         public string? MediaPath { get; set; }
     }
@@ -801,7 +801,7 @@ internal class EntityRepository : RepositoryBase, IEntityRepositoryExtended
     /// <summary>
     ///     The DTO used to fetch results for a media item with its media path info
     /// </summary>
-    private class MediaEntityDto : BaseDto
+    private sealed class MediaEntityDto : BaseDto
     {
         public string? MediaPath { get; set; }
     }
@@ -809,7 +809,7 @@ internal class EntityRepository : RepositoryBase, IEntityRepositoryExtended
     /// <summary>
     ///     The DTO used to fetch results for a member item
     /// </summary>
-    private class MemberEntityDto : BaseDto
+    private sealed class MemberEntityDto : BaseDto
     {
     }
 
@@ -917,7 +917,7 @@ internal class EntityRepository : RepositoryBase, IEntityRepositoryExtended
         entity.ListViewKey = dto.ListView;
     }
 
-    private MediaEntitySlim BuildMediaEntity(BaseDto dto)
+    private static MediaEntitySlim BuildMediaEntity(BaseDto dto)
     {
         // EntitySlim does not track changes
         var entity = new MediaEntitySlim();
@@ -936,7 +936,7 @@ internal class EntityRepository : RepositoryBase, IEntityRepositoryExtended
         return entity;
     }
 
-    private DocumentEntitySlim BuildDocumentEntity(BaseDto dto)
+    private static DocumentEntitySlim BuildDocumentEntity(BaseDto dto)
     {
         // EntitySlim does not track changes
         var entity = new DocumentEntitySlim();
@@ -953,7 +953,7 @@ internal class EntityRepository : RepositoryBase, IEntityRepositoryExtended
         return entity;
     }
 
-    private MemberEntitySlim BuildMemberEntity(BaseDto dto)
+    private static MemberEntitySlim BuildMemberEntity(BaseDto dto)
     {
         // EntitySlim does not track changes
         var entity = new MemberEntitySlim();

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -14,7 +14,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUserLogin>, IExternalLoginWithKeyRepository
+internal sealed class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUserLogin>, IExternalLoginWithKeyRepository
 {
     public ExternalLoginRepository(IScopeAccessor scopeAccessor, AppCaches cache,
         ILogger<ExternalLoginRepository> logger)
@@ -263,7 +263,7 @@ internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUser
         }
     }
 
-    private IEnumerable<IIdentityUserLogin> ConvertFromDtos(IEnumerable<ExternalLoginDto> dtos)
+    private static IEnumerable<IIdentityUserLogin> ConvertFromDtos(IEnumerable<ExternalLoginDto> dtos)
     {
         foreach (IIdentityUserLogin entity in dtos.Select(ExternalLoginFactory.BuildEntity))
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/KeyValueRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/KeyValueRepository.cs
@@ -12,7 +12,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class KeyValueRepository : EntityRepositoryBase<string, IKeyValue>, IKeyValueRepository
+internal sealed class KeyValueRepository : EntityRepositoryBase<string, IKeyValue>, IKeyValueRepository
 {
     public KeyValueRepository(IScopeAccessor scopeAccessor, ILogger<KeyValueRepository> logger)
         : base(scopeAccessor, AppCaches.NoCache, logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="Language" />
 /// </summary>
-internal class LanguageRepository : EntityRepositoryBase<int, ILanguage>, ILanguageRepository
+internal sealed class LanguageRepository : EntityRepositoryBase<int, ILanguage>, ILanguageRepository
 {
     // We need to lock this dictionary every time we do an operation on it as the languageRepository is registered as a unique implementation
     // It is used to quickly get isoCodes by Id, or the reverse by avoiding (deep)cloning dtos

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LocalFileSystemTemporaryFileRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LocalFileSystemTemporaryFileRepository.cs
@@ -158,7 +158,7 @@ internal sealed class LocalFileSystemTemporaryFileRepository : ITemporaryFileRep
         throw new InvalidOperationException("Unexpected content");
     }
 
-    private class FileMetaData
+    private sealed class FileMetaData
     {
         public DateTime AvailableUntil { get; init; }
     }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
@@ -12,7 +12,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class LogViewerQueryRepository : EntityRepositoryBase<int, ILogViewerQuery>, ILogViewerQueryRepository
+internal sealed class LogViewerQueryRepository : EntityRepositoryBase<int, ILogViewerQuery>, ILogViewerQueryRepository
 {
     public LogViewerQueryRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<LogViewerQueryRepository> logger)
         : base(scopeAccessor, cache, logger)
@@ -101,14 +101,14 @@ internal class LogViewerQueryRepository : EntityRepositoryBase<int, ILogViewerQu
         // use the underlying GetAll which will force cache all log queries
         GetMany().FirstOrDefault(x => x.Id == id);
 
-    private ILogViewerQuery ConvertFromDto(LogViewerQueryDto dto)
+    private static ILogViewerQuery ConvertFromDto(LogViewerQueryDto dto)
     {
         var factory = new LogViewerQueryModelFactory();
         ILogViewerQuery entity = factory.BuildEntity(dto);
         return entity;
     }
 
-    internal class LogViewerQueryModelFactory
+    internal sealed class LogViewerQueryModelFactory
     {
         public ILogViewerQuery BuildEntity(LogViewerQueryDto dto)
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -522,7 +522,7 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
     // A reading repository purely for looking up by GUID
     // TODO: This is ugly and to fix we need to decouple the IRepositoryQueryable -> IRepository -> IReadRepository which should all be separate things!
     // This sub-repository pattern is super old and totally unecessary anymore, caching can be handled in much nicer ways without this
-    private class MediaByGuidReadRepository : EntityRepositoryBase<Guid, IMedia>
+    private sealed class MediaByGuidReadRepository : EntityRepositoryBase<Guid, IMedia>
     {
         private readonly MediaRepository _outerRepo;
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeContainerRepository.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class MediaTypeContainerRepository : EntityContainerRepository, IMediaTypeContainerRepository
+internal sealed class MediaTypeContainerRepository : EntityContainerRepository, IMediaTypeContainerRepository
 {
     public MediaTypeContainerRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<MediaTypeContainerRepository> logger)
         : base(scopeAccessor, cache, logger, Constants.ObjectTypes.MediaTypeContainer)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -16,7 +16,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="IMediaType" />
 /// </summary>
-internal class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType>, IMediaTypeRepository
+internal sealed class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType>, IMediaTypeRepository
 {
     public MediaTypeRepository(
         IScopeAccessor scopeAccessor,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -15,7 +15,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class MemberGroupRepository : EntityRepositoryBase<int, IMemberGroup>, IMemberGroupRepository
+internal sealed class MemberGroupRepository : EntityRepositoryBase<int, IMemberGroup>, IMemberGroupRepository
 {
     private readonly IEventMessagesFactory _eventMessagesFactory;
 
@@ -302,7 +302,7 @@ internal class MemberGroupRepository : EntityRepositoryBase<int, IMemberGroup>, 
             });
     }
 
-    private class AssignedRolesDto
+    private sealed class AssignedRolesDto
     {
         [Column("text")]
         public string? RoleName { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeContainerRepository.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
     /// <remarks>
     /// Introduced to avoid inconsistencies with nullability of dependencies for type repositories for content, media and members.
     /// </remarks>
-    internal class MemberTypeContainerRepository : IMemberTypeContainerRepository
+    internal sealed class MemberTypeContainerRepository : IMemberTypeContainerRepository
     {
         public void Delete(EntityContainer entity)
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="IMemberType" />
 /// </summary>
-internal class MemberTypeRepository : ContentTypeRepositoryBase<IMemberType>, IMemberTypeRepository
+internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberType>, IMemberTypeRepository
 {
     private readonly IShortStringHelper _shortStringHelper;
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PartialViewRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PartialViewRepository.cs
@@ -6,7 +6,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class PartialViewRepository : FileRepository<string, IPartialView>, IPartialViewRepository
+internal sealed class PartialViewRepository : FileRepository<string, IPartialView>, IPartialViewRepository
 {
     public PartialViewRepository(FileSystems fileSystems)
         : base(fileSystems.PartialViewsFileSystem)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PermissionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PermissionRepository.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 ///     like the normal repository pattern but the standard repository Get commands don't apply and will throw
 ///     <see cref="NotImplementedException" />
 /// </remarks>
-internal class PermissionRepository<TEntity> : EntityRepositoryBase<int, ContentPermissionSet>
+internal sealed class PermissionRepository<TEntity> : EntityRepositoryBase<int, ContentPermissionSet>
     where TEntity : class, IEntity
 {
     public PermissionRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<PermissionRepository<TEntity>> logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PropertyTypeUsageRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PropertyTypeUsageRepository.cs
@@ -8,7 +8,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class PropertyTypeUsageRepository : IPropertyTypeUsageRepository
+internal sealed class PropertyTypeUsageRepository : IPropertyTypeUsageRepository
 {
     private static readonly Guid?[] NodeObjectTypes = new Guid?[]
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class PublicAccessRepository : EntityRepositoryBase<Guid, PublicAccessEntry>, IPublicAccessRepository
+internal sealed class PublicAccessRepository : EntityRepositoryBase<Guid, PublicAccessEntry>, IPublicAccessRepository
 {
     public PublicAccessRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<PublicAccessRepository> logger)
         : base(scopeAccessor, cache, logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -12,7 +12,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedirectUrl>, IRedirectUrlRepository
+internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedirectUrl>, IRedirectUrlRepository
 {
     public RedirectUrlRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<RedirectUrlRepository> logger)
         : base(scopeAccessor, cache, logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents a repository for doing CRUD operations for <see cref="Relation" />
 /// </summary>
-internal class RelationRepository : EntityRepositoryBase<int, IRelation>, IRelationRepository
+internal sealed class RelationRepository : EntityRepositoryBase<int, IRelation>, IRelationRepository
 {
     private readonly IEntityRepositoryExtended _entityRepository;
     private readonly IRelationTypeRepository _relationTypeRepository;
@@ -227,7 +227,7 @@ internal class RelationRepository : EntityRepositoryBase<int, IRelation>, IRelat
     ///     Used for joining the entity query with relations for the paging methods
     /// </summary>
     /// <param name="sql"></param>
-    private void SqlJoinRelations(Sql<ISqlContext> sql)
+    private static void SqlJoinRelations(Sql<ISqlContext> sql)
     {
         // add left joins for relation tables (this joins on both child or parent, so beware that this will normally return entities for
         // both sides of the relation type unless the IUmbracoEntity query passed in filters one side out).
@@ -304,7 +304,7 @@ internal class RelationRepository : EntityRepositoryBase<int, IRelation>, IRelat
         }
     }
 
-    private void ApplyOrdering(ref Sql<ISqlContext> sql, Ordering ordering)
+    private static void ApplyOrdering(ref Sql<ISqlContext> sql, Ordering ordering)
     {
         if (sql == null)
         {
@@ -458,7 +458,7 @@ internal class RelationRepository : EntityRepositoryBase<int, IRelation>, IRelat
     #endregion
 }
 
-internal class RelationItemDto
+internal sealed class RelationItemDto
 {
     [Column(Name = "nodeId")]
     public int ChildNodeId { get; set; }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ScriptRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ScriptRepository.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents the Script Repository
 /// </summary>
-internal class ScriptRepository : FileRepository<string, IScript>, IScriptRepository
+internal sealed class ScriptRepository : FileRepository<string, IScript>, IScriptRepository
 {
     public ScriptRepository(FileSystems fileSystems)
         : base(fileSystems.ScriptsFileSystem)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
@@ -11,7 +11,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class ServerRegistrationRepository : EntityRepositoryBase<int, IServerRegistration>,
+internal sealed class ServerRegistrationRepository : EntityRepositoryBase<int, IServerRegistration>,
     IServerRegistrationRepository
 {
     public ServerRegistrationRepository(IScopeAccessor scopeAccessor, ILogger<ServerRegistrationRepository> logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimilarNodeName.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimilarNodeName.cs
@@ -17,7 +17,7 @@ internal static class ListExtensions
         items.Any(x => x.Suffix.HasValue);
 }
 
-internal class SimilarNodeName
+internal sealed class SimilarNodeName
 {
     public int Id { get; set; }
 
@@ -181,7 +181,7 @@ internal class SimilarNodeName
         return current;
     }
 
-    internal class StructuredName
+    internal sealed class StructuredName
     {
         internal const uint Initialsuffix = 1;
         private const string Spacecharacter = " ";

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/StylesheetRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/StylesheetRepository.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents the Stylesheet Repository
 /// </summary>
-internal class StylesheetRepository : FileRepository<string, IStylesheet>, IStylesheetRepository
+internal sealed class StylesheetRepository : FileRepository<string, IStylesheet>, IStylesheetRepository
 {
     public StylesheetRepository(FileSystems fileSystems)
         : base(fileSystems.StylesheetsFileSystem)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -15,7 +15,7 @@ using static Umbraco.Cms.Core.Persistence.SqlExtensionsStatics;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class TagRepository : EntityRepositoryBase<int, ITag>, ITagRepository
+internal sealed class TagRepository : EntityRepositoryBase<int, ITag>, ITagRepository
 {
     public TagRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<TagRepository> logger)
         : base(scopeAccessor, cache, logger)
@@ -245,7 +245,7 @@ WHERE r.tagId IS NULL";
     }
 
     // used to run Distinct() on tags
-    private class TagComparer : IEqualityComparer<ITag>
+    private sealed class TagComparer : IEqualityComparer<ITag>
     {
         public bool Equals(ITag? x, ITag? y) =>
             ReferenceEquals(x, y) // takes care of both being null
@@ -276,7 +276,7 @@ WHERE r.tagId IS NULL";
 
     // ReSharper disable once ClassNeverInstantiated.Local
     // ReSharper disable UnusedAutoPropertyAccessor.Local
-    private class TaggedEntityDto
+    private sealed class TaggedEntityDto
     {
         public int NodeId { get; set; }
         public string? PropertyTypeAlias { get; set; }
@@ -538,7 +538,7 @@ WHERE r.tagId IS NULL";
         return sql;
     }
 
-    private Sql<ISqlContext> AddTagsSqlWhere(Sql<ISqlContext> sql, string? culture)
+    private static Sql<ISqlContext> AddTagsSqlWhere(Sql<ISqlContext> sql, string? culture)
     {
         if (culture == null)
         {
@@ -557,7 +557,7 @@ WHERE r.tagId IS NULL";
     private IEnumerable<ITag> ExecuteTagsQuery(Sql sql) =>
         Database.Fetch<TagDto>(sql).Select(TagFactory.BuildEntity);
 
-    private Guid GetNodeObjectType(TaggableObjectTypes type)
+    private static Guid GetNodeObjectType(TaggableObjectTypes type)
     {
         switch (type)
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -22,9 +22,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 ///     Represents the Template Repository
 /// </summary>
-internal class TemplateRepository : EntityRepositoryBase<int, ITemplate>, ITemplateRepository
+internal sealed class TemplateRepository : EntityRepositoryBase<int, ITemplate>, ITemplateRepository
 {
-    private readonly IIOHelper _ioHelper;
     private readonly IShortStringHelper _shortStringHelper;
     private readonly IFileSystem? _viewsFileSystem;
     private readonly IViewHelper _viewHelper;
@@ -35,13 +34,11 @@ internal class TemplateRepository : EntityRepositoryBase<int, ITemplate>, ITempl
         AppCaches cache,
         ILogger<TemplateRepository> logger,
         FileSystems fileSystems,
-        IIOHelper ioHelper,
         IShortStringHelper shortStringHelper,
         IViewHelper viewHelper,
         IOptionsMonitor<RuntimeSettings> runtimeSettings)
         : base(scopeAccessor, cache, logger)
     {
-        _ioHelper = ioHelper;
         _shortStringHelper = shortStringHelper;
         _viewsFileSystem = fileSystems.MvcViewsFileSystem;
         _viewHelper = viewHelper;
@@ -208,7 +205,7 @@ internal class TemplateRepository : EntityRepositoryBase<int, ITemplate>, ITempl
         return string.Empty;
     }
 
-    private string? GetFileContent(ITemplate template, IFileSystem? fs, string filename, bool init)
+    private static string? GetFileContent(ITemplate template, IFileSystem? fs, string filename, bool init)
     {
         // do not update .UpdateDate as that would make it dirty (side-effect)
         // unless initializing, because we have to do it once
@@ -229,7 +226,7 @@ internal class TemplateRepository : EntityRepositoryBase<int, ITemplate>, ITempl
         return init ? null : GetFileContent(fs, filename);
     }
 
-    private string? GetFileContent(IFileSystem? fs, string filename)
+    private static string? GetFileContent(IFileSystem? fs, string filename)
     {
         if (fs is null)
         {
@@ -627,7 +624,7 @@ internal class TemplateRepository : EntityRepositoryBase<int, ITemplate>, ITempl
         return descendants;
     }
 
-    private void AddChildren(ITemplate[]? all, List<ITemplate> descendants, string masterAlias)
+    private static void AddChildren(ITemplate[]? all, List<ITemplate> descendants, string masterAlias)
     {
         ITemplate[]? c = all?.Where(x => x.MasterTemplateAlias.InvariantEquals(masterAlias)).ToArray();
         if (c is null || c.Any() == false)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
     /// <summary>
     /// Implements <see cref="ITrackedReferencesRepository"/> to provide database access for tracked references."
     /// </summary>
-    internal class TrackedReferencesRepository : ITrackedReferencesRepository
+    internal sealed class TrackedReferencesRepository : ITrackedReferencesRepository
     {
         private readonly IScopeAccessor _scopeAccessor;
         private readonly IUmbracoMapper _umbracoMapper;
@@ -402,7 +402,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             return innerUnionSql;
         }
 
-        private class UnionHelperDto
+        private sealed class UnionHelperDto
         {
             [Column("id")] public int Id { get; set; }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TwoFactorLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TwoFactorLoginRepository.cs
@@ -12,7 +12,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class TwoFactorLoginRepository : EntityRepositoryBase<int, ITwoFactorLogin>, ITwoFactorLoginRepository
+internal sealed class TwoFactorLoginRepository : EntityRepositoryBase<int, ITwoFactorLogin>, ITwoFactorLoginRepository
 {
     public TwoFactorLoginRepository(IScopeAccessor scopeAccessor, AppCaches cache,
         ILogger<TwoFactorLoginRepository> logger)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserDataRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserDataRepository.cs
@@ -9,7 +9,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
-internal class UserDataRepository : IUserDataRepository
+internal sealed class UserDataRepository : IUserDataRepository
 {
     private readonly IScopeAccessor _scopeAccessor;
 
@@ -75,7 +75,7 @@ internal class UserDataRepository : IUserDataRepository
         await _scopeAccessor.AmbientScope?.Database.ExecuteAsync(sql)!;
     }
 
-    private Sql<ISqlContext> ApplyFilter(Sql<ISqlContext> sql, IUserDataFilter filter)
+    private static Sql<ISqlContext> ApplyFilter(Sql<ISqlContext> sql, IUserDataFilter filter)
     {
         if (filter.Groups?.Count > 0)
         {
@@ -95,10 +95,10 @@ internal class UserDataRepository : IUserDataRepository
         return sql;
     }
 
-    private IEnumerable<IUserData> DtosToModels(IEnumerable<UserDataDto> dtos)
+    private static IEnumerable<IUserData> DtosToModels(IEnumerable<UserDataDto> dtos)
         => dtos.Select(Map);
 
-    private IUserData Map(UserDataDto dto)
+    private static IUserData Map(UserDataDto dto)
         => new UserData
         {
             Key = dto.Key,
@@ -108,7 +108,7 @@ internal class UserDataRepository : IUserDataRepository
             UserKey = dto.UserKey,
         };
 
-    private UserDataDto Map(IUserData userData)
+    private static UserDataDto Map(IUserData userData)
         => new()
         {
             Key = userData.Key,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserGroupRepository.cs
@@ -183,7 +183,7 @@ public class UserGroupRepository : EntityRepositoryBase<int, IUserGroup>, IUserG
     /// <summary>
     ///     used to persist a user group with associated users at once
     /// </summary>
-    private class UserGroupWithUsers : EntityBase
+    private sealed class UserGroupWithUsers : EntityBase
     {
         public UserGroupWithUsers(IUserGroup userGroup, int[]? userIds)
         {
@@ -201,7 +201,7 @@ public class UserGroupRepository : EntityRepositoryBase<int, IUserGroup>, IUserG
     /// <summary>
     ///     used to persist a user group with associated users at once
     /// </summary>
-    private class UserGroupWithUsersRepository : EntityRepositoryBase<int, UserGroupWithUsers>
+    private sealed class UserGroupWithUsersRepository : EntityRepositoryBase<int, UserGroupWithUsers>
     {
         private readonly UserGroupRepository _userGroupRepo;
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 /// Represents the UserRepository for doing CRUD operations for <see cref="IUser"/>
 /// </summary>
-internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserRepository
+internal sealed class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserRepository
 {
     private readonly IMapperCollection _mapperCollection;
     private readonly GlobalSettings _globalSettings;
@@ -36,8 +36,6 @@ internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserReposito
     private bool _passwordConfigInitialized;
     private readonly Lock _sqliteValidateSessionLock = new();
     private readonly IDictionary<string, IPermissionMapper> _permissionMappers;
-    private readonly IAppPolicyCache _globalCache;
-    private readonly IScopeAccessor _scopeAccessor;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="UserRepository" /> class.
@@ -54,7 +52,6 @@ internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserReposito
     /// <param name="jsonSerializer">The JSON serializer.</param>
     /// <param name="runtimeState">State of the runtime.</param>
     /// <param name="permissionMappers">The permission mappers.</param>
-    /// <param name="globalCache">The app policy cache.</param>
     /// <exception cref="System.ArgumentNullException">
     ///     mapperCollection
     ///     or
@@ -71,18 +68,15 @@ internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserReposito
         IOptions<UserPasswordConfigurationSettings> passwordConfiguration,
         IJsonSerializer jsonSerializer,
         IRuntimeState runtimeState,
-        IEnumerable<IPermissionMapper> permissionMappers,
-        IAppPolicyCache globalCache)
+        IEnumerable<IPermissionMapper> permissionMappers)
         : base(scopeAccessor, appCaches, logger)
     {
-        _scopeAccessor = scopeAccessor;
         _mapperCollection = mapperCollection ?? throw new ArgumentNullException(nameof(mapperCollection));
         _globalSettings = globalSettings.Value ?? throw new ArgumentNullException(nameof(globalSettings));
         _passwordConfiguration =
             passwordConfiguration.Value ?? throw new ArgumentNullException(nameof(passwordConfiguration));
         _jsonSerializer = jsonSerializer;
         _runtimeState = runtimeState;
-        _globalCache = globalCache;
         _permissionMappers = permissionMappers.ToDictionary(x => x.Context);
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/DbTypesFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/DbTypesFactory.cs
@@ -2,7 +2,7 @@ using System.Data;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
 
-internal class DbTypesFactory
+internal sealed class DbTypesFactory
 {
     private readonly Dictionary<Type, DbType> _columnDbTypeMap = new();
     private readonly Dictionary<Type, string> _columnTypeMap = new();

--- a/src/Umbraco.Infrastructure/Persistence/UmbracoPocoDataBuilder.cs
+++ b/src/Umbraco.Infrastructure/Persistence/UmbracoPocoDataBuilder.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence;
 ///     <para>Beware, the application MUST restart when this class behavior changes.</para>
 ///     <para>You can override the GetColmunnInfo method to control which columns this includes</para>
 /// </remarks>
-internal class UmbracoPocoDataBuilder : PocoDataBuilder
+internal sealed class UmbracoPocoDataBuilder : PocoDataBuilder
 {
     private readonly bool _upgrading;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridConfigurationEditor.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.IO;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class BlockGridConfigurationEditor : ConfigurationEditor<BlockGridConfiguration>
+internal sealed class BlockGridConfigurationEditor : ConfigurationEditor<BlockGridConfiguration>
 {
     public BlockGridConfigurationEditor(IIOHelper ioHelper) : base(ioHelper)
     {

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockGridPropertyEditorBase.cs
@@ -40,7 +40,7 @@ public abstract class BlockGridPropertyEditorBase : DataEditor
     protected override IDataValueEditor CreateValueEditor() =>
         DataValueEditorFactory.Create<BlockGridEditorPropertyValueEditor>(Attribute!);
 
-    internal class BlockGridEditorPropertyValueEditor : BlockEditorPropertyValueEditor<BlockGridValue, BlockGridLayoutItem>
+    internal sealed class BlockGridEditorPropertyValueEditor : BlockEditorPropertyValueEditor<BlockGridValue, BlockGridLayoutItem>
     {
         public BlockGridEditorPropertyValueEditor(
             DataEditorAttribute attribute,
@@ -65,7 +65,7 @@ public abstract class BlockGridPropertyEditorBase : DataEditor
 
         protected override BlockGridValue CreateWithLayout(IEnumerable<BlockGridLayoutItem> layout) => new(layout);
 
-        private class MinMaxValidator : BlockEditorMinMaxValidatorBase<BlockGridValue, BlockGridLayoutItem>
+        private sealed class MinMaxValidator : BlockEditorMinMaxValidatorBase<BlockGridValue, BlockGridLayoutItem>
         {
             private readonly BlockEditorValues<BlockGridValue, BlockGridLayoutItem> _blockEditorValues;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListConfigurationEditor.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class BlockListConfigurationEditor : ConfigurationEditor<BlockListConfiguration>
+internal sealed class BlockListConfigurationEditor : ConfigurationEditor<BlockListConfiguration>
 {
     public BlockListConfigurationEditor(IIOHelper ioHelper)
         : base(ioHelper)

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockListPropertyEditorBase.cs
@@ -49,7 +49,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
     /// <summary>
     /// Defines the value editor for the block list property editors.
     /// </summary>
-    internal class BlockListEditorPropertyValueEditor : BlockEditorPropertyValueEditor<BlockListValue, BlockListLayoutItem>
+    internal sealed class BlockListEditorPropertyValueEditor : BlockEditorPropertyValueEditor<BlockListValue, BlockListLayoutItem>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockListEditorPropertyValueEditor"/> class.
@@ -85,7 +85,7 @@ public abstract class BlockListPropertyEditorBase : DataEditor
         /// <summary>
         /// Validates the min/max configuration for block list property editors.
         /// </summary>
-        private class MinMaxValidator : BlockEditorMinMaxValidatorBase<BlockListValue, BlockListLayoutItem>
+        private sealed class MinMaxValidator : BlockEditorMinMaxValidatorBase<BlockListValue, BlockListLayoutItem>
         {
             private readonly BlockEditorValues<BlockListValue, BlockListLayoutItem> _blockEditorValues;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactory.cs
@@ -8,7 +8,7 @@ using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class BlockValuePropertyIndexValueFactory :
+internal sealed class BlockValuePropertyIndexValueFactory :
     BlockValuePropertyIndexValueFactoryBase<BlockValuePropertyIndexValueFactory.IndexValueFactoryBlockValue>,
     IBlockValuePropertyIndexValueFactory
 {
@@ -24,7 +24,7 @@ internal class BlockValuePropertyIndexValueFactory :
         => GetDataItems(input.ContentData, input.Expose, published);
 
     // we only care about the content data when extracting values for indexing - not the layouts nor the settings
-    internal class IndexValueFactoryBlockValue
+    internal sealed class IndexValueFactoryBlockValue
     {
         public List<BlockItemData> ContentData { get; set; } = new();
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
@@ -10,7 +10,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class ColorPickerConfigurationEditor : ConfigurationEditor<ColorPickerConfiguration>
+internal sealed class ColorPickerConfigurationEditor : ConfigurationEditor<ColorPickerConfiguration>
 {
     public ColorPickerConfigurationEditor(IIOHelper ioHelper, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
         : base(ioHelper)
@@ -19,7 +19,7 @@ internal class ColorPickerConfigurationEditor : ConfigurationEditor<ColorPickerC
         items.Validators.Add(new ColorListValidator(configurationEditorJsonSerializer));
     }
 
-    internal class ColorListValidator : IValueValidator
+    internal sealed class ColorListValidator : IValueValidator
     {
         private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerPropertyEditor.cs
@@ -49,7 +49,7 @@ public class ColorPickerPropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the color picker property editor.
     /// </summary>
-    internal class ColorPickerPropertyValueEditor : DataValueEditor
+    internal sealed class ColorPickerPropertyValueEditor : DataValueEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ColorPickerPropertyValueEditor"/> class.
@@ -68,7 +68,7 @@ public class ColorPickerPropertyEditor : DataEditor
         /// <summary>
         /// Validates the color selection for the color picker property editor.
         /// </summary>
-        internal class ConfiguredColorValidator : IValueValidator
+        internal sealed class ConfiguredColorValidator : IValueValidator
         {
             private readonly ILocalizedTextService _localizedTextService;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/DropDownFlexibleConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/DropDownFlexibleConfigurationEditor.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class DropDownFlexibleConfigurationEditor : ConfigurationEditor<DropDownFlexibleConfiguration>
+internal sealed class DropDownFlexibleConfigurationEditor : ConfigurationEditor<DropDownFlexibleConfiguration>
 {
     public DropDownFlexibleConfigurationEditor(IIOHelper ioHelper, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
         : base(ioHelper)

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
@@ -21,7 +21,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// <summary>
 ///     The value editor for the file upload property editor.
 /// </summary>
-internal class FileUploadPropertyValueEditor : DataValueEditor
+internal sealed class FileUploadPropertyValueEditor : DataValueEditor
 {
     private readonly MediaFileManager _mediaFileManager;
     private readonly ITemporaryFileService _temporaryFileService;
@@ -159,7 +159,7 @@ internal class FileUploadPropertyValueEditor : DataValueEditor
     private TemporaryFileModel? TryGetTemporaryFile(Guid temporaryFileKey)
         => _temporaryFileService.GetAsync(temporaryFileKey).GetAwaiter().GetResult();
 
-    private bool IsAllowedInDataTypeConfiguration(string extension, object? dataTypeConfiguration)
+    private static bool IsAllowedInDataTypeConfiguration(string extension, object? dataTypeConfiguration)
     {
         if (dataTypeConfiguration is FileUploadConfiguration fileUploadConfiguration)
         {
@@ -207,7 +207,7 @@ internal class FileUploadPropertyValueEditor : DataValueEditor
     /// Provides media path.
     /// </summary>
     /// <returns>File system relative path</returns>
-    protected virtual string GetMediaPath(TemporaryFileModel file, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
+    private string GetMediaPath(TemporaryFileModel file, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
     {
         // in case we are using the old path scheme, try to re-use numbers (bah...)
         return _mediaFileManager.GetMediaPath(file.FileName, contentKey, propertyTypeKey);

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperConfigurationEditor.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// <summary>
 ///     Represents the configuration editor for the image cropper value editor.
 /// </summary>
-internal class ImageCropperConfigurationEditor : ConfigurationEditor<ImageCropperConfiguration>
+internal sealed class ImageCropperConfigurationEditor : ConfigurationEditor<ImageCropperConfiguration>
 {
     public ImageCropperConfigurationEditor(IIOHelper ioHelper)
         : base(ioHelper)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -290,7 +290,7 @@ public class ImageCropperPropertyEditor : DataEditor, IMediaUrlGenerator,
     }
 
     // for efficient value deserialization, we don't want to deserialize more than we need to (we don't need crops, focal point etc.)
-    private class LightWeightImageCropperValue
+    private sealed class LightWeightImageCropperValue
     {
         public string? Src { get; set; } = string.Empty;
     }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// <summary>
 ///     The value editor for the image cropper property editor.
 /// </summary>
-internal class ImageCropperPropertyValueEditor : DataValueEditor // TODO: core vs web?
+internal sealed class ImageCropperPropertyValueEditor : DataValueEditor // TODO: core vs web?
 {
     private readonly IDataTypeConfigurationCache _dataTypeConfigurationCache;
     private readonly IFileStreamSecurityValidator _fileStreamSecurityValidator;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -52,7 +52,7 @@ public class MediaPicker3PropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the media picker property editor.
     /// </summary>
-    internal class MediaPicker3PropertyValueEditor : DataValueEditor, IDataValueReference
+    internal sealed class MediaPicker3PropertyValueEditor : DataValueEditor, IDataValueReference
     {
         private readonly IDataTypeConfigurationCache _dataTypeReadCache;
         private readonly IJsonSerializer _jsonSerializer;
@@ -257,7 +257,7 @@ public class MediaPicker3PropertyEditor : DataEditor
         /// <summary>
         ///     Model/DTO that represents the JSON that the MediaPicker3 stores.
         /// </summary>
-        internal class MediaWithCropsDto
+        internal sealed class MediaWithCropsDto
         {
             /// <summary>
             /// Gets or sets the key.
@@ -338,7 +338,7 @@ public class MediaPicker3PropertyEditor : DataEditor
         /// <summary>
         /// Validates the min/max configuration for the media picker property editor.
         /// </summary>
-        internal class MinMaxValidator : ITypedJsonValidator<List<MediaWithCropsDto>, MediaPicker3Configuration>
+        internal sealed class MinMaxValidator : ITypedJsonValidator<List<MediaWithCropsDto>, MediaPicker3Configuration>
         {
             private readonly ILocalizedTextService _localizedTextService;
 
@@ -399,7 +399,7 @@ public class MediaPicker3PropertyEditor : DataEditor
         /// <summary>
         /// Validates the allowed type configuration for the media picker property editor.
         /// </summary>
-        internal class AllowedTypeValidator : ITypedJsonValidator<List<MediaWithCropsDto>, MediaPicker3Configuration>
+        internal sealed class AllowedTypeValidator : ITypedJsonValidator<List<MediaWithCropsDto>, MediaPicker3Configuration>
         {
             private readonly ILocalizedTextService _localizedTextService;
             private readonly IMediaTypeService _mediaTypeService;
@@ -472,7 +472,7 @@ public class MediaPicker3PropertyEditor : DataEditor
         /// <summary>
         /// Validates the start node configuration for the media picker property editor.
         /// </summary>
-        internal class StartNodeValidator : ITypedJsonValidator<List<MediaWithCropsDto>, MediaPicker3Configuration>
+        internal sealed class StartNodeValidator : ITypedJsonValidator<List<MediaWithCropsDto>, MediaPicker3Configuration>
         {
             private readonly ILocalizedTextService _localizedTextService;
             private readonly IMediaNavigationQueryService _mediaNavigationQueryService;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -189,7 +189,7 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor
         /// <summary>
         /// Validates the min/max configuration for the multi-node tree picker property editor.
         /// </summary>
-        internal class MinMaxValidator : ITypedJsonValidator<EditorEntityReference[], MultiNodePickerConfiguration>
+        internal sealed class MinMaxValidator : ITypedJsonValidator<EditorEntityReference[], MultiNodePickerConfiguration>
         {
             private readonly ILocalizedTextService _localizedTextService;
 
@@ -247,7 +247,7 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor
         /// <summary>
         /// Validates the selected object type for the multi-node tree picker property editor.
         /// </summary>
-        internal class ObjectTypeValidator : ITypedJsonValidator<EditorEntityReference[], MultiNodePickerConfiguration>
+        internal sealed class ObjectTypeValidator : ITypedJsonValidator<EditorEntityReference[], MultiNodePickerConfiguration>
         {
             private readonly ILocalizedTextService _localizedTextService;
             private readonly ICoreScopeProvider _coreScopeProvider;
@@ -335,7 +335,7 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor
         /// <summary>
         /// Validates the selected content type for the multi-node tree picker property editor.
         /// </summary>
-        internal class ContentTypeValidator : ITypedJsonValidator<EditorEntityReference[], MultiNodePickerConfiguration>
+        internal sealed class ContentTypeValidator : ITypedJsonValidator<EditorEntityReference[], MultiNodePickerConfiguration>
         {
             private readonly ILocalizedTextService _localizedTextService;
             private readonly ICoreScopeProvider _coreScopeProvider;

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -217,7 +217,7 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference
         public string? QueryString { get; set; }
     }
 
-    internal class MinMaxValidator : ITypedJsonValidator<LinkDisplay[], MultiUrlPickerConfiguration>
+    internal sealed class MinMaxValidator : ITypedJsonValidator<LinkDisplay[], MultiUrlPickerConfiguration>
     {
         private readonly ILocalizedTextService _localizedTextService;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringConfigurationEditor.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// <summary>
 ///     Represents the configuration editor for a multiple textstring value editor.
 /// </summary>
-internal class MultipleTextStringConfigurationEditor : ConfigurationEditor<MultipleTextStringConfiguration>
+internal sealed class MultipleTextStringConfigurationEditor : ConfigurationEditor<MultipleTextStringConfiguration>
 {
     public MultipleTextStringConfigurationEditor(IIOHelper ioHelper)
         : base(ioHelper)

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultipleTextStringPropertyEditor.cs
@@ -47,7 +47,7 @@ public class MultipleTextStringPropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the multiple text string property editor.
     /// </summary>
-    internal class MultipleTextStringPropertyValueEditor : DataValueEditor
+    internal sealed class MultipleTextStringPropertyValueEditor : DataValueEditor
     {
         private static readonly string _newLine = "\n";
         private static readonly string[] _newLineDelimiters = { "\r\n", "\r", "\n" };
@@ -110,7 +110,7 @@ public class MultipleTextStringPropertyEditor : DataEditor
     /// <summary>
     /// A custom <see href="IValueFormatValidator" /> to check each string against the configured format.
     /// </summary>
-    internal class MultipleTextStringFormatValidator : IValueFormatValidator
+    internal sealed class MultipleTextStringFormatValidator : IValueFormatValidator
     {
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> ValidateFormat(object? value, string valueType, string format)
@@ -137,7 +137,7 @@ public class MultipleTextStringPropertyEditor : DataEditor
     /// <summary>
     /// Validates the min/max configuration for the multiple text strings property editor.
     /// </summary>
-    internal class MinMaxValidator : IValueValidator
+    internal sealed class MinMaxValidator : IValueValidator
     {
         private readonly ILocalizedTextService _localizedTextService;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/RadioButtonsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RadioButtonsPropertyEditor.cs
@@ -48,7 +48,7 @@ public class RadioButtonsPropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the radio buttons property editor.
     /// </summary>
-    internal class RadioButtonsPropertyValueEditor : DataValueEditor
+    internal sealed class RadioButtonsPropertyValueEditor : DataValueEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RadioButtonsPropertyValueEditor"/> class.
@@ -66,7 +66,7 @@ public class RadioButtonsPropertyEditor : DataEditor
     /// <summary>
     /// Validates the prevalue configuration for the radio buttons property editor.
     /// </summary>
-    internal class RadioButtonValueValidator : IValueValidator
+    internal sealed class RadioButtonValueValidator : IValueValidator
     {
         private readonly ILocalizedTextService _localizedTextService;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorBlockValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextEditorBlockValidator.cs
@@ -8,7 +8,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class RichTextEditorBlockValidator: BlockEditorValidatorBase<RichTextBlockValue, RichTextBlockLayoutItem>
+internal sealed class RichTextEditorBlockValidator: BlockEditorValidatorBase<RichTextBlockValue, RichTextBlockLayoutItem>
 {
     private readonly BlockEditorValues<RichTextBlockValue, RichTextBlockLayoutItem> _blockEditorValues;
     private readonly IJsonSerializer _jsonSerializer;

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyEditor.cs
@@ -89,7 +89,7 @@ public class RichTextPropertyEditor : DataEditor
     ///     A custom value editor to ensure that images and blocks are parsed when being persisted and formatted correctly for
     ///     display in the editor
     /// </summary>
-    internal class RichTextPropertyValueEditor : BlockValuePropertyValueEditorBase<RichTextBlockValue, RichTextBlockLayoutItem>
+    internal sealed class RichTextPropertyValueEditor : BlockValuePropertyValueEditorBase<RichTextBlockValue, RichTextBlockLayoutItem>
     {
         private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
         private readonly IHtmlSanitizer _htmlSanitizer;
@@ -320,7 +320,7 @@ public class RichTextPropertyEditor : DataEditor
             return RichTextPropertyEditorHelper.SerializeRichTextEditorValue(mergedEditorValue, _jsonSerializer);
         }
 
-        private string MergeMarkupValue(
+        private static string MergeMarkupValue(
             string source,
             string target,
             RichTextBlockValue? mergedBlockValue,

--- a/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/RichTextPropertyIndexValueFactory.cs
@@ -9,7 +9,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
-internal class RichTextPropertyIndexValueFactory : BlockValuePropertyIndexValueFactoryBase<RichTextEditorValue>, IRichTextPropertyIndexValueFactory
+internal sealed class RichTextPropertyIndexValueFactory : BlockValuePropertyIndexValueFactoryBase<RichTextEditorValue>, IRichTextPropertyIndexValueFactory
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly ILogger<RichTextPropertyIndexValueFactory> _logger;

--- a/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/SliderPropertyEditor.cs
@@ -48,7 +48,7 @@ public class SliderPropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the slider property editor.
     /// </summary>
-    internal class SliderPropertyValueEditor : DataValueEditor
+    internal sealed class SliderPropertyValueEditor : DataValueEditor
     {
         private readonly IJsonSerializer _jsonSerializer;
 
@@ -99,7 +99,7 @@ public class SliderPropertyEditor : DataEditor
         /// <summary>
         /// Represents a slider value.
         /// </summary>
-        internal class SliderRange
+        internal sealed class SliderRange
         {
             /// <summary>
             /// Gets or sets the slider range from value.
@@ -156,7 +156,7 @@ public class SliderPropertyEditor : DataEditor
             /// <summary>
             /// Parses a <see cref="SliderRange"/> from the provided value.
             /// </summary>
-            protected bool TryParsePropertyValue(object? value, [NotNullWhen(true)] out SliderRange? parsedValue)
+            protected static bool TryParsePropertyValue(object? value, [NotNullWhen(true)] out SliderRange? parsedValue)
             {
                 if (value is null || value is not JsonObject valueAsJsonObject)
                 {
@@ -188,7 +188,7 @@ public class SliderPropertyEditor : DataEditor
         /// <summary>
         /// Validates the range configuration for the slider property editor.
         /// </summary>
-        internal class RangeValidator : SliderPropertyConfigurationValidatorBase, IValueValidator
+        internal sealed class RangeValidator : SliderPropertyConfigurationValidatorBase, IValueValidator
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="MinMaxValidator"/> class.
@@ -230,7 +230,7 @@ public class SliderPropertyEditor : DataEditor
         /// <summary>
         /// Validates the min/max configuration for the slider property editor.
         /// </summary>
-        internal class MinMaxValidator : SliderPropertyConfigurationValidatorBase, IValueValidator
+        internal sealed class MinMaxValidator : SliderPropertyConfigurationValidatorBase, IValueValidator
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="MinMaxValidator"/> class.
@@ -272,7 +272,7 @@ public class SliderPropertyEditor : DataEditor
         /// <summary>
         /// Validates the step configuration for the slider property editor.
         /// </summary>
-        internal class StepValidator : SliderPropertyConfigurationValidatorBase, IValueValidator
+        internal sealed class StepValidator : SliderPropertyConfigurationValidatorBase, IValueValidator
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="StepValidator"/> class.

--- a/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TagsPropertyEditor.cs
@@ -46,7 +46,7 @@ public class TagsPropertyEditor : DataEditor
     protected override IConfigurationEditor CreateConfigurationEditor() =>
         new TagConfigurationEditor(_ioHelper);
 
-    internal class TagPropertyValueEditor : DataValueEditor, IDataValueTags
+    internal sealed class TagPropertyValueEditor : DataValueEditor, IDataValueTags
     {
         private readonly IJsonSerializer _jsonSerializer;
         private readonly IDataTypeService _dataTypeService;
@@ -183,7 +183,7 @@ public class TagsPropertyEditor : DataEditor
         ///         the underlying data is JSON. Yes, this makes little sense.
         ///     </para>
         /// </remarks>
-        private class RequiredJsonValueValidator : IValueRequiredValidator
+        private sealed class RequiredJsonValueValidator : IValueRequiredValidator
         {
             /// <inheritdoc />
             public IEnumerable<ValidationResult> ValidateRequired(object? value, string valueType)

--- a/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/TrueFalsePropertyEditor.cs
@@ -33,7 +33,7 @@ public class TrueFalsePropertyEditor : DataEditor
     /// <summary>
     /// Defines the value editor for the true/false (toggle) property editor.
     /// </summary>
-    internal class TrueFalsePropertyValueEditor : DataValueEditor
+    internal sealed class TrueFalsePropertyValueEditor : DataValueEditor
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TrueFalsePropertyValueEditor"/> class.
@@ -61,7 +61,7 @@ public class TrueFalsePropertyEditor : DataEditor
         public override object? FromEditor(ContentPropertyData editorValue, object? currentValue)
             => ParsePropertyValue(editorValue.Value) ? 1 : 0;
 
-        private bool ParsePropertyValue(object? value)
+        private static bool ParsePropertyValue(object? value)
             => value switch
             {
                 bool booleanValue => booleanValue,

--- a/src/Umbraco.Infrastructure/PropertyEditors/Validators/BlockListValueRequiredValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/Validators/BlockListValueRequiredValidator.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Infrastructure.PropertyEditors.Validators;
 /// <summary>
 /// Custom validator for block value required validation.
 /// </summary>
-internal class BlockListValueRequiredValidator : RequiredValidator
+internal sealed class BlockListValueRequiredValidator : RequiredValidator
 {
     private readonly IJsonSerializer _jsonSerializer;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRegexValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRegexValidator.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.PropertyEditors.Validators;
 
-internal class RichTextRegexValidator : IRichTextRegexValidator
+internal sealed class RichTextRegexValidator : IRichTextRegexValidator
 {
     private readonly RegexValidator _regexValidator;
     private readonly IJsonSerializer _jsonSerializer;

--- a/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRequiredValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/Validators/RichTextRequiredValidator.cs
@@ -1,16 +1,15 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Serialization;
-using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Core.PropertyEditors.Validators;
 
-internal class RichTextRequiredValidator : RequiredValidator, IRichTextRequiredValidator
+internal sealed class RichTextRequiredValidator : RequiredValidator, IRichTextRequiredValidator
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly ILogger<RichTextRequiredValidator> _logger;
 
-    public RichTextRequiredValidator(ILocalizedTextService textService, IJsonSerializer jsonSerializer, ILogger<RichTextRequiredValidator> logger) : base()
+    public RichTextRequiredValidator(IJsonSerializer jsonSerializer, ILogger<RichTextRequiredValidator> logger) : base()
     {
         _jsonSerializer = jsonSerializer;
         _logger = logger;

--- a/src/Umbraco.Infrastructure/PropertyEditors/Validators/TrueFalseValueRequiredValidator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/Validators/TrueFalseValueRequiredValidator.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.PropertyEditors.Validators;
 /// <summary>
 /// Custom validator for true/false (toggle) required validation.
 /// </summary>
-internal class TrueFalseValueRequiredValidator : RequiredValidator
+internal sealed class TrueFalseValueRequiredValidator : RequiredValidator
 {
     /// <inheritdoc/>
     public override IEnumerable<ValidationResult> ValidateRequired(object? value, string? valueType)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
@@ -5,7 +5,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
-internal class BlockGridPropertyValueCreator : BlockPropertyValueCreatorBase<BlockGridModel, BlockGridItem, BlockGridLayoutItem, BlockGridConfiguration.BlockGridBlockConfiguration, BlockGridValue>
+internal sealed class BlockGridPropertyValueCreator : BlockPropertyValueCreatorBase<BlockGridModel, BlockGridItem, BlockGridLayoutItem, BlockGridConfiguration.BlockGridBlockConfiguration, BlockGridValue>
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly BlockGridPropertyValueConstructorCache _constructorCache;
@@ -68,7 +68,7 @@ internal class BlockGridPropertyValueCreator : BlockPropertyValueCreatorBase<Blo
 
     protected override BlockItemActivator<BlockGridItem> CreateBlockItemActivator() => new BlockGridItemActivator(BlockEditorConverter, _constructorCache);
 
-    private class BlockGridItemActivator : BlockItemActivator<BlockGridItem>
+    private sealed class BlockGridItemActivator : BlockItemActivator<BlockGridItem>
     {
         public BlockGridItemActivator(BlockEditorConverter blockConverter, BlockGridPropertyValueConstructorCache constructorCache)
             : base(blockConverter, constructorCache)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockListPropertyValueCreator.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
-internal class BlockListPropertyValueCreator : BlockPropertyValueCreatorBase<BlockListModel, BlockListItem, BlockListLayoutItem, BlockListConfiguration.BlockConfiguration, BlockListValue>
+internal sealed class BlockListPropertyValueCreator : BlockPropertyValueCreatorBase<BlockListModel, BlockListItem, BlockListLayoutItem, BlockListConfiguration.BlockConfiguration, BlockListValue>
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly BlockListPropertyValueConstructorCache _constructorCache;
@@ -36,7 +36,7 @@ internal class BlockListPropertyValueCreator : BlockPropertyValueCreatorBase<Blo
 
     protected override BlockItemActivator<BlockListItem> CreateBlockItemActivator() => new BlockListItemActivator(BlockEditorConverter, _constructorCache);
 
-    private class BlockListItemActivator : BlockItemActivator<BlockListItem>
+    private sealed class BlockListItemActivator : BlockItemActivator<BlockListItem>
     {
         public BlockListItemActivator(BlockEditorConverter blockConverter, BlockListPropertyValueConstructorCache constructorCache)
             : base(blockConverter, constructorCache)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Serialization;
 
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
-internal class RichTextBlockPropertyValueCreator : BlockPropertyValueCreatorBase<RichTextBlockModel, RichTextBlockItem, RichTextBlockLayoutItem, RichTextConfiguration.RichTextBlockConfiguration, RichTextBlockValue>
+internal sealed class RichTextBlockPropertyValueCreator : BlockPropertyValueCreatorBase<RichTextBlockModel, RichTextBlockItem, RichTextBlockLayoutItem, RichTextConfiguration.RichTextBlockConfiguration, RichTextBlockValue>
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly RichTextBlockPropertyValueConstructorCache _constructorCache;
@@ -39,7 +39,7 @@ internal class RichTextBlockPropertyValueCreator : BlockPropertyValueCreatorBase
 
     protected override BlockItemActivator<RichTextBlockItem> CreateBlockItemActivator() => new RichTextBlockItemActivator(BlockEditorConverter, _constructorCache);
 
-    private class RichTextBlockItemActivator : BlockItemActivator<RichTextBlockItem>
+    private sealed class RichTextBlockItemActivator : BlockItemActivator<RichTextBlockItem>
     {
         public RichTextBlockItemActivator(BlockEditorConverter blockConverter, RichTextBlockPropertyValueConstructorCache constructorCache)
             : base(blockConverter, constructorCache)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
@@ -231,7 +231,7 @@ public class RteBlockRenderingValueConverter : SimpleRichTextValueConverter, IDe
         };
     }
 
-    private class RichTextEditorIntermediateValue : IRichTextEditorIntermediateValue
+    private sealed class RichTextEditorIntermediateValue : IRichTextEditorIntermediateValue
     {
         public required string Markup { get; set; }
 

--- a/src/Umbraco.Infrastructure/PublishedCache/ReservedFieldNamesService.cs
+++ b/src/Umbraco.Infrastructure/PublishedCache/ReservedFieldNamesService.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Infrastructure.PublishedCache;
 
-internal class ReservedFieldNamesService : IReservedFieldNamesService
+internal sealed class ReservedFieldNamesService : IReservedFieldNamesService
 {
     private readonly ContentPropertySettings _contentPropertySettings;
     private readonly MemberPropertySettings _memberPropertySettings;

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -330,7 +330,7 @@ public class PublishedContentQuery : IPublishedContentQuery
     ///     This is used to contextualize the values in the search results when enumerating over them, so that the correct
     ///     culture values are used.
     /// </summary>
-    private class CultureContextualSearchResults : IEnumerable<PublishedSearchResult>
+    private sealed class CultureContextualSearchResults : IEnumerable<PublishedSearchResult>
     {
         private readonly string _culture;
         private readonly IVariationContextAccessor _variationContextAccessor;
@@ -365,7 +365,7 @@ public class PublishedContentQuery : IPublishedContentQuery
         /// <summary>
         ///     Resets the variation context when this is disposed.
         /// </summary>
-        private class CultureContextualSearchResultsEnumerator : IEnumerator<PublishedSearchResult>
+        private sealed class CultureContextualSearchResultsEnumerator : IEnumerator<PublishedSearchResult>
         {
             private readonly VariationContext? _originalContext;
             private readonly IVariationContextAccessor _variationContextAccessor;

--- a/src/Umbraco.Infrastructure/Routing/NotFoundHandlerHelper.cs
+++ b/src/Umbraco.Infrastructure/Routing/NotFoundHandlerHelper.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Core.Routing;
 ///     Used to determine the node to display when content is not found based on the configured error404 elements in
 ///     umbracoSettings.config
 /// </summary>
-internal class NotFoundHandlerHelper
+internal sealed class NotFoundHandlerHelper
 {
     internal static int? GetCurrentNotFoundPageId(
         ContentErrorPage[] error404Collection,

--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Routing
 {
-    internal class RedirectTracker : IRedirectTracker
+    internal sealed class RedirectTracker : IRedirectTracker
     {
         private readonly ILocalizationService _localizationService;
         private readonly IRedirectUrlService _redirectUrlService;

--- a/src/Umbraco.Infrastructure/Runtime/DefaultMainDomKeyGenerator.cs
+++ b/src/Umbraco.Infrastructure/Runtime/DefaultMainDomKeyGenerator.cs
@@ -7,7 +7,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Runtime;
 
-internal class DefaultMainDomKeyGenerator : IMainDomKeyGenerator
+internal sealed class DefaultMainDomKeyGenerator : IMainDomKeyGenerator
 {
     private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
     private readonly IHostingEnvironment _hostingEnvironment;

--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Runtime;
 
 namespace Umbraco.Cms.Infrastructure.Runtime;
 
-internal class FileSystemMainDomLock : IMainDomLock
+internal sealed class FileSystemMainDomLock : IMainDomLock
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly IHostingEnvironment _hostingEnvironment;
@@ -109,7 +109,7 @@ internal class FileSystemMainDomLock : IMainDomLock
 
     /// <summary>Releases the resources used by this <see cref="FileSystemMainDomLock" />.</summary>
     /// <param name="disposing">true to release both managed resources.</param>
-    protected virtual void Dispose(bool disposing)
+    private void Dispose(bool disposing)
     {
         if (disposing && !_disposed)
         {

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidationService.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidationService.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 namespace Umbraco.Cms.Infrastructure.Runtime;
 
 /// <inheritdoc />
-internal class RuntimeModeValidationService : IRuntimeModeValidationService
+internal sealed class RuntimeModeValidationService : IRuntimeModeValidationService
 {
     private readonly IOptionsMonitor<RuntimeSettings> _runtimeSettings;
     private readonly IServiceProvider _serviceProvider;

--- a/src/Umbraco.Infrastructure/Scoping/AmbientScopeContextStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/AmbientScopeContextStack.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Scoping;
 
 namespace Umbraco.Cms.Infrastructure.Scoping;
 
-internal class AmbientScopeContextStack : IAmbientScopeContextStack
+internal sealed class AmbientScopeContextStack : IAmbientScopeContextStack
 {
     private static Lock _lock = new();
     private static AsyncLocal<ConcurrentStack<IScopeContext>> _stack = new();

--- a/src/Umbraco.Infrastructure/Scoping/AmbientScopeStack.cs
+++ b/src/Umbraco.Infrastructure/Scoping/AmbientScopeStack.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 
 namespace Umbraco.Cms.Infrastructure.Scoping
 {
-    internal class AmbientScopeStack : IAmbientScopeStack
+    internal sealed class AmbientScopeStack : IAmbientScopeStack
     {
         private static Lock _lock = new();
         private static AsyncLocal<ConcurrentStack<IScope>> _stack = new ();

--- a/src/Umbraco.Infrastructure/Scoping/HttpScopeReference.cs
+++ b/src/Umbraco.Infrastructure/Scoping/HttpScopeReference.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Core.Scoping;
 ///     Disposed at the end of the request to cleanup any orphaned Scopes.
 /// </summary>
 /// <remarks>Registered as Scoped in DI (per request)</remarks>
-internal class HttpScopeReference : IHttpScopeReference
+internal sealed class HttpScopeReference : IHttpScopeReference
 {
     private readonly ScopeProvider _scopeProvider;
     private bool _disposedValue;
@@ -24,7 +24,7 @@ internal class HttpScopeReference : IHttpScopeReference
 
     public void Register() => _registered = true;
 
-    protected virtual void Dispose(bool disposing)
+    private void Dispose(bool disposing)
     {
         if (!_disposedValue)
         {

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Infrastructure.Scoping
     ///     Implements <see cref="IScope" />.
     /// </summary>
     /// <remarks>Not thread-safe obviously.</remarks>
-    internal class Scope : CoreScope, ICoreScope, IScope, Core.Scoping.IScope
+    internal sealed class Scope : CoreScope, ICoreScope, IScope, Core.Scoping.IScope
     {
         private readonly bool _autoComplete;
         private readonly CoreDebugSettings _coreDebugSettings;

--- a/src/Umbraco.Infrastructure/Scoping/ScopeContext.cs
+++ b/src/Umbraco.Infrastructure/Scoping/ScopeContext.cs
@@ -104,7 +104,7 @@ _enlisted ??= new Dictionary<string, IEnlistedObject>();
         return enlistedAs.Item;
     }
 
-    private class EnlistedObject<T> : IEnlistedObject
+    private sealed class EnlistedObject<T> : IEnlistedObject
     {
         private readonly Action<bool, T?>? _action;
 

--- a/src/Umbraco.Infrastructure/Scoping/ScopeProvider.cs
+++ b/src/Umbraco.Infrastructure/Scoping/ScopeProvider.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Infrastructure.Scoping
     /// <summary>
     /// Implements <see cref="IScopeProvider"/>.
     /// </summary>
-    internal class ScopeProvider :
+    internal sealed class ScopeProvider :
         ICoreScopeProvider,
         IScopeProvider,
         Core.Scoping.IScopeProvider,

--- a/src/Umbraco.Infrastructure/Security/PasswordChanger.cs
+++ b/src/Umbraco.Infrastructure/Security/PasswordChanger.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Core.Security;
 /// <summary>
 ///     Changes the password for an identity user
 /// </summary>
-internal class PasswordChanger<TUser> : IPasswordChanger<TUser> where TUser : UmbracoIdentityUser
+internal sealed class PasswordChanger<TUser> : IPasswordChanger<TUser> where TUser : UmbracoIdentityUser
 {
     private readonly ILogger<PasswordChanger<TUser>> _logger;
 

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemTroubleshootingInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemTroubleshootingInformationTelemetryProvider.cs
@@ -14,7 +14,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Telemetry.Providers;
 
-internal class SystemTroubleshootingInformationTelemetryProvider : IDetailedTelemetryProvider, ISystemTroubleshootingInformationService
+internal sealed class SystemTroubleshootingInformationTelemetryProvider : IDetailedTelemetryProvider, ISystemTroubleshootingInformationService
 {
     private readonly IHostEnvironment _hostEnvironment;
     private readonly HostingSettings _hostingSettings;
@@ -45,21 +45,21 @@ internal class SystemTroubleshootingInformationTelemetryProvider : IDetailedTele
         _modelsBuilderSettings = modelsBuilderSettings.CurrentValue;
     }
 
-    private string CurrentWebServer => GetWebServerName();
+    private static string CurrentWebServer => GetWebServerName();
 
-    private string ServerFramework => RuntimeInformation.FrameworkDescription;
+    private static string ServerFramework => RuntimeInformation.FrameworkDescription;
 
     private string ModelsBuilderMode => _modelsBuilderSettings.ModelsMode.ToString();
 
     private string RuntimeMode => _runtimeSettings.Mode.ToString();
 
-    private string CurrentCulture => Thread.CurrentThread.CurrentCulture.ToString();
+    private static string CurrentCulture => Thread.CurrentThread.CurrentCulture.ToString();
 
     private bool IsDebug => _hostingSettings.Debug;
 
     private string AspEnvironment => _hostEnvironment.EnvironmentName;
 
-    private string ServerOs => RuntimeInformation.OSDescription;
+    private static string ServerOs => RuntimeInformation.OSDescription;
 
     private string DatabaseProvider => _umbracoDatabaseFactory.CreateDatabase().DatabaseType.GetProviderName();
 
@@ -96,7 +96,7 @@ internal class SystemTroubleshootingInformationTelemetryProvider : IDetailedTele
             { "Current Server Role", CurrentServerRole },
         };
 
-    private string GetWebServerName()
+    private static string GetWebServerName()
     {
         var processName = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
 

--- a/src/Umbraco.Infrastructure/Telemetry/Services/UsageInformationService.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Services/UsageInformationService.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Infrastructure.Telemetry.Interfaces;
 
 namespace Umbraco.Cms.Core.Services;
 
-internal class UsageInformationService : IUsageInformationService
+internal sealed class UsageInformationService : IUsageInformationService
 {
     private readonly IMetricsConsentService _metricsConsentService;
     private readonly IEnumerable<IDetailedTelemetryProvider> _providers;

--- a/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Infrastructure.HybridCache;
 /// <summary>
 /// Rebuilds the published content cache in the database.
 /// </summary>
-internal class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
+internal sealed class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
 {
     private const string NuCacheSerializerKey = "Umbraco.Web.PublishedCache.NuCache.Serializer";
     private const string IsRebuildingDatabaseCacheRuntimeCacheKey = "temp_database_cache_rebuild_op";

--- a/src/Umbraco.PublishedCache.HybridCache/Factories/CacheNodeFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/CacheNodeFactory.cs
@@ -1,21 +1,18 @@
 ﻿using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Factories;
 
-internal class CacheNodeFactory : ICacheNodeFactory
+internal sealed class CacheNodeFactory : ICacheNodeFactory
 {
     private readonly IShortStringHelper _shortStringHelper;
     private readonly UrlSegmentProviderCollection _urlSegmentProviders;
-    private readonly IDocumentUrlService _documentUrlService;
 
-    public CacheNodeFactory(IShortStringHelper shortStringHelper, UrlSegmentProviderCollection urlSegmentProviders, IDocumentUrlService documentUrlService)
+    public CacheNodeFactory(IShortStringHelper shortStringHelper, UrlSegmentProviderCollection urlSegmentProviders)
     {
         _shortStringHelper = shortStringHelper;
         _urlSegmentProviders = urlSegmentProviders;
-        _documentUrlService = documentUrlService;
     }
 
     public ContentCacheNode ToContentCacheNode(IContent content, bool preview)
@@ -41,7 +38,7 @@ internal class CacheNodeFactory : ICacheNodeFactory
         };
     }
 
-    private bool GetPublishedValue(IContent content, bool preview)
+    private static bool GetPublishedValue(IContent content, bool preview)
     {
         switch (content.PublishedState)
         {
@@ -56,7 +53,7 @@ internal class CacheNodeFactory : ICacheNodeFactory
         }
     }
 
-    private int? GetTemplateId(IContent content, bool preview)
+    private static int? GetTemplateId(IContent content, bool preview)
     {
         switch (content.PublishedState)
         {

--- a/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.PublishedCache;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Factories;
 
-internal class PublishedContentFactory : IPublishedContentFactory
+internal sealed class PublishedContentFactory : IPublishedContentFactory
 {
     private readonly IElementsCache _elementsCache;
     private readonly IVariationContextAccessor _variationContextAccessor;
@@ -88,7 +88,7 @@ internal class PublishedContentFactory : IPublishedContentFactory
         return new PublishedMember(member, contentNode, _elementsCache, _variationContextAccessor);
     }
 
-    private Dictionary<string, PropertyData[]> GetPropertyValues(IPublishedContentType contentType, IMember member)
+    private static Dictionary<string, PropertyData[]> GetPropertyValues(IPublishedContentType contentType, IMember member)
     {
         var properties = member
             .Properties
@@ -111,7 +111,7 @@ internal class PublishedContentFactory : IPublishedContentFactory
         return properties;
     }
 
-    private void AddIf(IPublishedContentType contentType, IDictionary<string, PropertyData[]> properties, string alias, object? value)
+    private static void AddIf(IPublishedContentType contentType, IDictionary<string, PropertyData[]> properties, string alias, object? value)
     {
         IPublishedPropertyType? propertyType = contentType.GetPropertyType(alias);
         if (propertyType == null || propertyType.IsUserProperty)
@@ -135,14 +135,14 @@ internal class PublishedContentFactory : IPublishedContentFactory
     }
 
 
-    private IPublishedContent? GetPublishedContentAsDraft(IPublishedContent? content) =>
+    private static IPublishedContent? GetPublishedContentAsDraft(IPublishedContent? content) =>
         content == null ? null :
             // an object in the cache is either an IPublishedContentOrMedia,
             // or a model inheriting from PublishedContentExtended - in which
             // case we need to unwrap to get to the original IPublishedContentOrMedia.
             UnwrapIPublishedContent(content);
 
-    private PublishedContent UnwrapIPublishedContent(IPublishedContent content)
+    private static PublishedContent UnwrapIPublishedContent(IPublishedContent content)
     {
         while (content is PublishedContentWrapped wrapped)
         {

--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/SeedingNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/SeedingNotificationHandler.cs
@@ -9,7 +9,7 @@ using Umbraco.Cms.Infrastructure.HybridCache.Services;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.NotificationHandlers;
 
-internal class SeedingNotificationHandler : INotificationAsyncHandler<UmbracoApplicationStartedNotification>
+internal sealed class SeedingNotificationHandler : INotificationAsyncHandler<UmbracoApplicationStartedNotification>
 {
     private readonly IDocumentCacheService _documentCacheService;
     private readonly IMediaCacheService _mediaCacheService;

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/ContentSourceDto.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/ContentSourceDto.cs
@@ -3,7 +3,7 @@
 namespace Umbraco.Cms.Infrastructure.HybridCache.Persistence
 {
     // read-only dto
-    internal class ContentSourceDto : IReadOnlyContentBase
+    internal sealed class ContentSourceDto : IReadOnlyContentBase
     {
         public int Id { get; init; }
 

--- a/src/Umbraco.PublishedCache.HybridCache/PublishedMember.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedMember.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Infrastructure.HybridCache;
 // note
 // the whole PublishedMember thing should be refactored because as soon as a member
 // is wrapped on in a model, the inner IMember and all associated properties are lost
-internal class PublishedMember : PublishedContent, IPublishedMember
+internal sealed class PublishedMember : PublishedContent, IPublishedMember
 {
     private readonly IMember _member;
 

--- a/src/Umbraco.PublishedCache.HybridCache/PublishedProperty.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedProperty.cs
@@ -8,7 +8,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache;
 
-internal class PublishedProperty : PublishedPropertyBase
+internal sealed class PublishedProperty : PublishedPropertyBase
 {
     private readonly PublishedContent _content;
     private readonly bool _isPreviewing;
@@ -76,7 +76,7 @@ internal class PublishedProperty : PublishedPropertyBase
     // used to cache the CacheValues of this property
     internal string ValuesCacheKey => _valuesCacheKey ??= PropertyCacheValues(_content.Key, Alias, _isPreviewing);
 
-    private string PropertyCacheValues(Guid contentUid, string typeAlias, bool previewing)
+    private static string PropertyCacheValues(Guid contentUid, string typeAlias, bool previewing)
     {
         if (previewing)
         {
@@ -226,7 +226,7 @@ internal class PublishedProperty : PublishedPropertyBase
         return value;
     }
 
-    private object? GetDeliveryApiDefaultObject(CacheValue cacheValues, Func<object?> getValue)
+    private static object? GetDeliveryApiDefaultObject(CacheValue cacheValues, Func<object?> getValue)
     {
         if (cacheValues.DeliveryApiDefaultObjectInitialized == false)
         {
@@ -237,7 +237,7 @@ internal class PublishedProperty : PublishedPropertyBase
         return cacheValues.DeliveryApiDefaultObjectValue;
     }
 
-    private object? GetDeliveryApiExpandedObject(CacheValue cacheValues, Func<object?> getValue)
+    private static object? GetDeliveryApiExpandedObject(CacheValue cacheValues, Func<object?> getValue)
     {
         if (cacheValues.DeliveryApiExpandedObjectInitialized == false)
         {
@@ -248,7 +248,7 @@ internal class PublishedProperty : PublishedPropertyBase
         return cacheValues.DeliveryApiExpandedObjectValue;
     }
 
-    private class SourceInterValue
+    private sealed class SourceInterValue
     {
         private string? _culture;
         private string? _segment;
@@ -268,7 +268,7 @@ internal class PublishedProperty : PublishedPropertyBase
         public object? SourceValue { get; set; }
     }
 
-    private class CacheValues : CacheValue
+    private sealed class CacheValues : CacheValue
     {
         private readonly Lock _locko = new();
         private ConcurrentDictionary<CompositeStringStringKey, CacheValue>? _values;

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/HybridCacheSerializer.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/HybridCacheSerializer.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Serialization;
 
-internal class HybridCacheSerializer : IHybridCacheSerializer<ContentCacheNode>
+internal sealed class HybridCacheSerializer : IHybridCacheSerializer<ContentCacheNode>
 {
     private readonly ILogger<HybridCacheSerializer> _logger;
     private readonly MessagePackSerializerOptions _options;

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonContentNestedDataSerializer.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonContentNestedDataSerializer.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Infrastructure.HybridCache.Serialization;
 /// <summary>
 ///     Serializes/deserializes <see cref="ContentCacheDataModel" /> documents to the SQL Database as JSON.
 /// </summary>
-internal class JsonContentNestedDataSerializer : IContentCacheDataSerializer
+internal sealed class JsonContentNestedDataSerializer : IContentCacheDataSerializer
 {
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
@@ -47,7 +47,7 @@ internal class JsonContentNestedDataSerializer : IContentCacheDataSerializer
     /// <summary>
     /// Provides a converter for handling JSON objects that can be of various types (string, number, boolean, null, or complex types).
     /// </summary>
-    internal class JsonObjectConverter : JsonConverter<object>
+    internal sealed class JsonObjectConverter : JsonConverter<object>
     {
         /// <inheritdoc/>
         public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -65,5 +65,4 @@ internal class JsonContentNestedDataSerializer : IContentCacheDataSerializer
         public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
             => JsonSerializer.Serialize(writer, value, value.GetType(), options);
     }
-
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonContentNestedDataSerializerFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/JsonContentNestedDataSerializerFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Infrastructure.HybridCache.Serialization;
 
-internal class JsonContentNestedDataSerializerFactory : IContentCacheDataSerializerFactory
+internal sealed class JsonContentNestedDataSerializerFactory : IContentCacheDataSerializerFactory
 {
     private readonly Lazy<JsonContentNestedDataSerializer> _serializer = new();
 

--- a/src/Umbraco.PublishedCache.HybridCache/Serialization/MsgPackContentNestedDataSerializerFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Serialization/MsgPackContentNestedDataSerializerFactory.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Serialization;
 
-internal class MsgPackContentNestedDataSerializerFactory : IContentCacheDataSerializerFactory
+internal sealed class MsgPackContentNestedDataSerializerFactory : IContentCacheDataSerializerFactory
 {
     private readonly IPropertyCacheCompressionOptions _compressionOptions;
     private readonly IContentTypeService _contentTypeService;

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -13,7 +13,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
-internal class MediaCacheService : IMediaCacheService
+internal sealed class MediaCacheService : IMediaCacheService
 {
     private readonly IDatabaseCacheRepository _databaseCacheRepository;
     private readonly IIdKeyMap _idKeyMap;

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MemberCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MemberCacheService.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Infrastructure.HybridCache.Factories;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
-internal class MemberCacheService : IMemberCacheService
+internal sealed class MemberCacheService : IMemberCacheService
 {
     private readonly IPublishedContentFactory _publishedContentFactory;
 

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoEndpointBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoEndpointBuilder.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Web.Common.ApplicationBuilder;
 /// <summary>
 ///     A builder to allow encapsulating the enabled endpoints in Umbraco
 /// </summary>
-internal class UmbracoEndpointBuilder : IUmbracoEndpointBuilderContext
+internal sealed class UmbracoEndpointBuilder : IUmbracoEndpointBuilderContext
 {
     public UmbracoEndpointBuilder(IServiceProvider services, IRuntimeState runtimeState, IApplicationBuilder appBuilder, IEndpointRouteBuilder endpointRouteBuilder)
     {

--- a/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlRequestBeginNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlRequestBeginNotificationHandler.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Web.Common.AspNetCore;
 /// Notification handler which will listen to the <see cref="UmbracoRequestBeginNotification"/>, and ensure that
 /// the applicationUrl is set on the first request.
 /// </summary>
-internal class ApplicationUrlRequestBeginNotificationHandler : INotificationHandler<UmbracoRequestBeginNotification>
+internal sealed class ApplicationUrlRequestBeginNotificationHandler : INotificationHandler<UmbracoRequestBeginNotification>
 {
     private readonly IRequestAccessor _requestAccessor;
 

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreApplicationShutdownRegistry.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreApplicationShutdownRegistry.cs
@@ -38,7 +38,7 @@ public class AspNetCoreApplicationShutdownRegistry : IApplicationShutdownRegistr
         }
     }
 
-    private class RegisteredObjectWrapper
+    private sealed class RegisteredObjectWrapper
     {
         private readonly IRegisteredObject _inner;
 

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.Cms.Web.Common.AspNetCore;
 
-internal class AspNetCoreSessionManager : ISessionIdResolver, ISessionManager
+internal sealed class AspNetCoreSessionManager : ISessionIdResolver, ISessionManager
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
 

--- a/src/Umbraco.Web.Common/Cache/HttpContextRequestAppCache.cs
+++ b/src/Umbraco.Web.Common/Cache/HttpContextRequestAppCache.cs
@@ -175,7 +175,7 @@ public class HttpContextRequestAppCache : FastDictionaryAppCacheBase, IRequestCa
     /// <summary>
     ///     Used as Scoped instance to allow locking within a request
     /// </summary>
-    private class RequestLock
+    private sealed class RequestLock
     {
         public object SyncRoot { get; } = new();
     }

--- a/src/Umbraco.Web.Common/Controllers/PublishedRequestFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Controllers/PublishedRequestFilterAttribute.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Web.Common.Controllers;
 /// <summary>
 ///     Deals with custom headers for the umbraco request
 /// </summary>
-internal class PublishedRequestFilterAttribute : ResultFilterAttribute
+internal sealed class PublishedRequestFilterAttribute : ResultFilterAttribute
 {
     /// <summary>
     ///     Deals with custom headers for the umbraco request
@@ -48,7 +48,7 @@ internal class PublishedRequestFilterAttribute : ResultFilterAttribute
     /// <summary>
     ///     Gets the <see cref="UmbracoRouteValues" />
     /// </summary>
-    protected UmbracoRouteValues GetUmbracoRouteValues(ResultExecutingContext context)
+    protected static UmbracoRouteValues GetUmbracoRouteValues(ResultExecutingContext context)
     {
         UmbracoRouteValues? routeVals = context.HttpContext.Features.Get<UmbracoRouteValues>();
         if (routeVals == null)
@@ -60,7 +60,7 @@ internal class PublishedRequestFilterAttribute : ResultFilterAttribute
         return routeVals;
     }
 
-    private void AddCacheControlHeaders(ResultExecutingContext context, IPublishedRequest pcr)
+    private static void AddCacheControlHeaders(ResultExecutingContext context, IPublishedRequest pcr)
     {
         var cacheControlHeaders = new List<string>();
 

--- a/src/Umbraco.Web.Common/DependencyInjection/ScopedServiceProvider.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/ScopedServiceProvider.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 namespace Umbraco.Cms.Web.Common.DependencyInjection;
 
 /// <inheritdoc />
-internal class ScopedServiceProvider : IScopedServiceProvider
+internal sealed class ScopedServiceProvider : IScopedServiceProvider
 {
     private readonly IHttpContextAccessor _accessor;
 

--- a/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
@@ -30,7 +30,7 @@ public sealed class ModelBindingExceptionAttribute : TypeFilterAttribute
     {
     }
 
-    private class ModelBindingExceptionFilter : IExceptionFilter
+    private sealed class ModelBindingExceptionFilter : IExceptionFilter
     {
         private static readonly Regex GetPublishedModelsTypesRegex =
             new("Umbraco.Web.PublishedModels.(\\w+)", RegexOptions.Compiled);

--- a/src/Umbraco.Web.Common/Filters/UmbracoUserTimeoutFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/UmbracoUserTimeoutFilterAttribute.cs
@@ -17,7 +17,7 @@ public class UmbracoUserTimeoutFilterAttribute : TypeFilterAttribute
     {
     }
 
-    private class UmbracoUserTimeoutFilter : IActionFilter
+    private sealed class UmbracoUserTimeoutFilter : IActionFilter
     {
         public void OnActionExecuted(ActionExecutedContext context)
         {

--- a/src/Umbraco.Web.Common/Filters/ValidateUmbracoFormRouteStringAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ValidateUmbracoFormRouteStringAttribute.cs
@@ -22,9 +22,9 @@ public class ValidateUmbracoFormRouteStringAttribute : TypeFilterAttribute
     // TODO: Lets revisit this when we get members done and the front-end working and whether it can moved to an authz policy
     public ValidateUmbracoFormRouteStringAttribute()
         : base(typeof(ValidateUmbracoFormRouteStringFilter)) =>
-        Arguments = new object[] { };
+        Arguments = [];
 
-    internal class ValidateUmbracoFormRouteStringFilter : IAuthorizationFilter
+    internal sealed class ValidateUmbracoFormRouteStringFilter : IAuthorizationFilter
     {
         private readonly IDataProtectionProvider _dataProtectionProvider;
 

--- a/src/Umbraco.Web.Common/Hosting/UmbracoHostBuilderDecorator.cs
+++ b/src/Umbraco.Web.Common/Hosting/UmbracoHostBuilderDecorator.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace Umbraco.Cms.Web.Common.Hosting;
 
-internal class UmbracoHostBuilderDecorator : IHostBuilder
+internal sealed class UmbracoHostBuilderDecorator : IHostBuilder
 {
     private readonly IHostBuilder _inner;
     private readonly Action<IHost>? _onBuild;

--- a/src/Umbraco.Web.Common/Logging/Enrichers/ApplicationIdEnricher.cs
+++ b/src/Umbraco.Web.Common/Logging/Enrichers/ApplicationIdEnricher.cs
@@ -5,7 +5,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.Logging.Enrichers;
 
-internal class ApplicationIdEnricher : ILogEventEnricher
+internal sealed class ApplicationIdEnricher : ILogEventEnricher
 {
     public const string ApplicationIdProperty = "ApplicationId";
     private readonly IApplicationDiscriminator _applicationDiscriminator;

--- a/src/Umbraco.Web.Common/Logging/Enrichers/NoopEnricher.cs
+++ b/src/Umbraco.Web.Common/Logging/Enrichers/NoopEnricher.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Web.Common.Logging.Enrichers;
 /// <summary>
 ///     NoOp but useful for tricks to avoid disposal of the global logger.
 /// </summary>
-internal class NoopEnricher : ILogEventEnricher
+internal sealed class NoopEnricher : ILogEventEnricher
 {
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {

--- a/src/Umbraco.Web.Common/Logging/RegisteredReloadableLogger.cs
+++ b/src/Umbraco.Web.Common/Logging/RegisteredReloadableLogger.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Web.Common.Logging;
 ///     Ensures freeze is only called a single time even when resolving a logger from the snapshot container
 ///     built for <see cref="RefreshingRazorViewEngine" />.
 /// </remarks>
-internal class RegisteredReloadableLogger
+internal sealed class RegisteredReloadableLogger
 {
     private static readonly Lock _frozenLock = new();
     private static bool _frozen;

--- a/src/Umbraco.Web.Common/Media/MediaPrependBasePathFileProvider.cs
+++ b/src/Umbraco.Web.Common/Media/MediaPrependBasePathFileProvider.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Web.Common.Media;
 /// A PR has been submitted to the Dazinator project: https://github.com/dazinator/Dazinator.Extensions.FileProviders/pull/53
 /// If that PR is accepted, the Dazinator dependency should be updated and this class should be removed.
 /// </remarks>
-internal class MediaPrependBasePathFileProvider : IFileProvider
+internal sealed class MediaPrependBasePathFileProvider : IFileProvider
 {
     private readonly PathString _basePath;
     private readonly IFileProvider _underlyingFileProvider;
@@ -29,7 +29,7 @@ internal class MediaPrependBasePathFileProvider : IFileProvider
         _underlyingFileProvider = underlyingFileProvider;
     }
 
-    protected virtual bool TryMapSubPath(string originalSubPath, out PathString newSubPath)
+    private bool TryMapSubPath(string originalSubPath, out PathString newSubPath)
     {
         if (!string.IsNullOrEmpty(originalSubPath))
         {

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -31,7 +31,7 @@ namespace Umbraco.Cms.Web.Common.Middleware;
 ///         This is responsible for creating and assigning an <see cref="IUmbracoContext" />
 ///     </para>
 /// </remarks>
-internal class UmbracoRequestMiddleware : IMiddleware
+internal sealed class UmbracoRequestMiddleware : IMiddleware
 {
     private readonly IDefaultCultureAccessor _defaultCultureAccessor;
     private readonly IEventAggregator _eventAggregator;
@@ -158,7 +158,7 @@ internal class UmbracoRequestMiddleware : IMiddleware
         _profiler?.UmbracoApplicationEndRequest(context, _runtimeState.Level);
     }
 
-    private Uri? GetApplicationUrlFromCurrentRequest(HttpRequest request)
+    private static Uri? GetApplicationUrlFromCurrentRequest(HttpRequest request)
     {
         // We only consider GET and POST.
         // Especially the DEBUG sent when debugging the application is annoying because it uses http, even when the https is available.
@@ -173,7 +173,7 @@ internal class UmbracoRequestMiddleware : IMiddleware
     /// <summary>
     ///     Dispose some request scoped objects that we are maintaining the lifecycle for.
     /// </summary>
-    private void DisposeHttpContextItems(HttpRequest request)
+    private static void DisposeHttpContextItems(HttpRequest request)
     {
         // do not process if client-side request
         if (request.IsClientSideRequest())

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
@@ -18,7 +18,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto;
 
-internal class CollectibleRuntimeViewCompiler : IViewCompiler
+internal sealed class CollectibleRuntimeViewCompiler : IViewCompiler
 {
     private readonly Lock _cacheLock = new();
     private readonly Dictionary<string, CompiledViewDescriptor> _precompiledViews;
@@ -319,7 +319,7 @@ internal class CollectibleRuntimeViewCompiler : IViewCompiler
         }
     }
 
-    protected virtual CompiledViewDescriptor CompileAndEmit(string relativePath)
+    private CompiledViewDescriptor CompileAndEmit(string relativePath)
     {
         RazorProjectItem projectItem = _projectEngine.FileSystem.GetItem(relativePath, fileKind: null);
         RazorCodeDocument codeDocument = _projectEngine.Process(projectItem);
@@ -444,7 +444,7 @@ internal class CollectibleRuntimeViewCompiler : IViewCompiler
 
     // Taken from: https://github.com/dotnet/aspnetcore/blob/a450cb69b5e4549f5515cdb057a68771f56cefd7/src/Mvc/Mvc.Razor/src/ViewPath.cs
     // This normalizes the relative path to the view, ensuring that it matches with what we have as keys in _precompiledViews
-    private string NormalizePath(string path)
+    private static string NormalizePath(string path)
     {
         var addLeadingSlash = path[0] != '\\' && path[0] != '/';
         var transformSlashes = path.IndexOf('\\') != -1;

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/InMemoryAssemblyLoadContextManager.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/InMemoryAssemblyLoadContextManager.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Infrastructure.ModelsBuilder;
 
 namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto;
 
-internal class InMemoryAssemblyLoadContextManager
+internal sealed class InMemoryAssemblyLoadContextManager
 {
     private UmbracoAssemblyLoadContext? _currentAssemblyLoadContext;
 

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/InMemoryModelFactory.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/InMemoryModelFactory.cs
@@ -21,7 +21,7 @@ using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto
 {
-    internal class InMemoryModelFactory : IAutoPublishedModelFactory, IRegisteredObject, IDisposable
+    internal sealed class InMemoryModelFactory : IAutoPublishedModelFactory, IRegisteredObject, IDisposable
     {
         private static readonly Regex s_usingRegex = new Regex("^using(.*);", RegexOptions.Compiled | RegexOptions.Multiline);
         private static readonly Regex s_aattrRegex = new Regex("^\\[assembly:(.*)\\]", RegexOptions.Compiled | RegexOptions.Multiline);
@@ -572,7 +572,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto
             return assembly;
         }
 
-        private void TryDeleteUnusedAssemblies(string dllPathFile)
+        private static void TryDeleteUnusedAssemblies(string dllPathFile)
         {
             if (File.Exists(dllPathFile))
             {
@@ -818,7 +818,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto
             _hostingLifetime.UnregisterObject(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!_disposedValue)
             {
@@ -843,14 +843,14 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto
             Dispose(disposing: true);
         }
 
-        internal class Infos
+        internal sealed class Infos
         {
             public Dictionary<string, Type>? ModelTypeMap { get; set; }
 
             public Dictionary<string, ModelInfo>? ModelInfos { get; set; }
         }
 
-        internal class ModelInfo
+        internal sealed class ModelInfo
         {
             public Type? ParameterType { get; set; }
 

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/RuntimeCompilationCacheBuster.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/RuntimeCompilationCacheBuster.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto;
 
-internal class RuntimeCompilationCacheBuster
+internal sealed class RuntimeCompilationCacheBuster
 {
     private readonly IViewCompilerProvider _viewCompilerProvider;
     private readonly IRazorViewEngine _razorViewEngine;

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoAssemblyLoadContext.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoAssemblyLoadContext.cs
@@ -3,7 +3,7 @@ using System.Runtime.Loader;
 
 namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto;
 
-internal class UmbracoAssemblyLoadContext : AssemblyLoadContext
+internal sealed class UmbracoAssemblyLoadContext : AssemblyLoadContext
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="UmbracoAssemblyLoadContext" /> class.

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoCompilationException.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoCompilationException.cs
@@ -2,7 +2,7 @@
 
 namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto;
 
-internal class UmbracoCompilationException : Exception, ICompilationException
+internal sealed class UmbracoCompilationException : Exception, ICompilationException
 {
     public IEnumerable<CompilationFailure?>? CompilationFailures { get; init; }
 }

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoRazorReferenceManager.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoRazorReferenceManager.cs
@@ -17,7 +17,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto;
  *
  * This class is used by the the ViewCompiler (CollectibleRuntimeViewCompiler) to find the required references when compiling views.
  */
-internal class UmbracoRazorReferenceManager
+internal sealed class UmbracoRazorReferenceManager
 {
     private readonly ApplicationPartManager _partManager;
     private readonly MvcRazorRuntimeCompilationOptions _options;
@@ -33,7 +33,7 @@ internal class UmbracoRazorReferenceManager
         _options = options.Value;
     }
 
-    public virtual IReadOnlyList<MetadataReference> CompilationReferences
+    public IReadOnlyList<MetadataReference> CompilationReferences
     {
         get
         {

--- a/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoViewCompilerProvider.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/InMemoryAuto/UmbracoViewCompilerProvider.cs
@@ -9,7 +9,7 @@ using Umbraco.Cms.Core.Exceptions;
 
 namespace Umbraco.Cms.Web.Common.ModelsBuilder.InMemoryAuto;
 
-internal class UmbracoViewCompilerProvider : IViewCompilerProvider
+internal sealed class UmbracoViewCompilerProvider : IViewCompilerProvider
 {
     private readonly RazorProjectEngine _razorProjectEngine;
     private readonly UmbracoRazorReferenceManager _umbracoRazorReferenceManager;

--- a/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/ModelsBuilder/ModelsBuilderNotificationHandler.cs
@@ -15,7 +15,7 @@ namespace Umbraco.Cms.Web.Common.ModelsBuilder;
 ///     Handles <see cref="UmbracoApplicationStartingNotification" /> and <see cref="ServerVariablesParsingNotification" />
 ///     notifications to initialize MB
 /// </summary>
-internal class ModelsBuilderNotificationHandler :
+internal sealed class ModelsBuilderNotificationHandler :
     INotificationHandler<ServerVariablesParsingNotification>,
     INotificationHandler<ModelBindingErrorNotification>,
     INotificationHandler<TemplateSavingNotification>

--- a/src/Umbraco.Web.Common/Repositories/WebProfilerRepository.cs
+++ b/src/Umbraco.Web.Common/Repositories/WebProfilerRepository.cs
@@ -4,7 +4,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.Repositories;
 
-internal class WebProfilerRepository : IWebProfilerRepository
+internal sealed class WebProfilerRepository : IWebProfilerRepository
 {
     private const string CookieName = "UMB-DEBUG";
     private const string HeaderName = "X-UMB-DEBUG";

--- a/src/Umbraco.Web.Common/Routing/CustomRouteContentFinderDelegate.cs
+++ b/src/Umbraco.Web.Common/Routing/CustomRouteContentFinderDelegate.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Web.Common.Routing;
 
-internal class CustomRouteContentFinderDelegate
+internal sealed class CustomRouteContentFinderDelegate
 {
     private readonly Func<ActionExecutingContext, IPublishedContent> _findContent;
 

--- a/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/UmbracoSignInManager.cs
@@ -517,7 +517,7 @@ public abstract class UmbracoSignInManager<TUser> : SignInManager<TUser>
     }
 
     // borrowed from https://github.com/dotnet/aspnetcore/blob/master/src/Identity/Core/src/SignInManager.cs#L891
-    private class TwoFactorAuthenticationInfo
+    private sealed class TwoFactorAuthenticationInfo
     {
         public string? UserId { get; set; }
 

--- a/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
+++ b/src/Umbraco.Web.Common/Templates/TemplateRenderer.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Web.Common.Templates;
 ///     This allows you to render an MVC template based purely off of a node id and an optional alttemplate id as string
 ///     output.
 /// </remarks>
-internal class TemplateRenderer : ITemplateRenderer
+internal sealed class TemplateRenderer : ITemplateRenderer
 {
     private readonly IFileService _fileService;
     private readonly IHttpContextAccessor _httpContextAccessor;

--- a/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidationMetadataProvider.cs
+++ b/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidationMetadataProvider.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Web.Common.Validators;
 /// <summary>
 /// Ensures we bypass object graph validation for rendering models.
 /// </summary>
-internal class BypassRenderingModelValidationMetadataProvider : IValidationMetadataProvider
+internal sealed class BypassRenderingModelValidationMetadataProvider : IValidationMetadataProvider
 {
     public void CreateValidationMetadata(ValidationMetadataProviderContext context)
     {

--- a/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidatorProvider.cs
+++ b/src/Umbraco.Web.Common/Validators/BypassRenderingModelValidatorProvider.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Web.Common.Validators;
 /// <summary>
 /// Ensures we bypass property validation for rendering models.
 /// </summary>
-internal class BypassRenderingModelValidatorProvider : IModelValidatorProvider
+internal sealed class BypassRenderingModelValidatorProvider : IModelValidatorProvider
 {
     public void CreateValidators(ModelValidatorProviderContext context)
     {

--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -872,7 +872,7 @@ public static class HtmlHelperRenderExtensions
     /// <summary>
     ///     Used for rendering out the Form for BeginUmbracoForm
     /// </summary>
-    internal class UmbracoForm : MvcForm
+    internal sealed class UmbracoForm : MvcForm
     {
         private readonly string _surfaceControllerInput;
         private readonly ViewContext _viewContext;

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Web.Website.Routing;
  * This also handles rerouting under install/upgrade states.
  */
 
-internal class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+internal sealed class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
 {
     private readonly IRuntimeState _runtimeState;
     private readonly EndpointDataSource _endpointDataSource;

--- a/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/NotFoundSelectorPolicy.cs
@@ -13,7 +13,7 @@ namespace Umbraco.Cms.Web.Website.Routing;
 /// <summary>
 ///     Used to handle 404 routes that haven't been handled by the end user
 /// </summary>
-internal class NotFoundSelectorPolicy : MatcherPolicy, IEndpointSelectorPolicy
+internal sealed class NotFoundSelectorPolicy : MatcherPolicy, IEndpointSelectorPolicy
 {
     private readonly EndpointDataSource _endpointDataSource;
     private readonly Lazy<Endpoint> _notFound;

--- a/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/SurfaceControllerMatcherPolicy.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Web.Website.Routing;
 /// Ensures the surface controller requests takes priority over other things like virtual routes.
 /// Also ensures that requests to a surface controller on a virtual route will return 405, like HttpMethodMatcherPolicy ensures for non-virtual route requests.
 /// </summary>
-internal class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+internal sealed class SurfaceControllerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
 {
     private const string Http405EndpointDisplayName = "405 HTTP Method Not Supported";
 

--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -272,7 +272,7 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
         return values;
     }
 
-    private class PostedDataProxyInfo
+    private sealed class PostedDataProxyInfo
     {
         public string? ControllerName { get; set; }
 

--- a/src/Umbraco.Web.Website/Security/MemberAuthenticationBuilder.cs
+++ b/src/Umbraco.Web.Website/Security/MemberAuthenticationBuilder.cs
@@ -59,7 +59,7 @@ public class MemberAuthenticationBuilder : AuthenticationBuilder
     }
 
     // Ensures that the sign in scheme is always the Umbraco member external type
-    private class EnsureMemberScheme<TOptions> : IPostConfigureOptions<TOptions>
+    private sealed class EnsureMemberScheme<TOptions> : IPostConfigureOptions<TOptions>
         where TOptions : RemoteAuthenticationOptions
     {
         public void PostConfigure(string? name, TOptions options)

--- a/src/Umbraco.Web.Website/ViewEngines/PluginRazorViewEngineOptionsSetup.cs
+++ b/src/Umbraco.Web.Website/ViewEngines/PluginRazorViewEngineOptionsSetup.cs
@@ -23,7 +23,7 @@ public class PluginRazorViewEngineOptionsSetup : IConfigureOptions<RazorViewEngi
     /// <summary>
     ///     Expands the default view locations
     /// </summary>
-    private class ViewLocationExpander : IViewLocationExpander
+    private sealed class ViewLocationExpander : IViewLocationExpander
     {
         public IEnumerable<string> ExpandViewLocations(
             ViewLocationExpanderContext context, IEnumerable<string> viewLocations)

--- a/src/Umbraco.Web.Website/ViewEngines/RenderRazorViewEngineOptionsSetup.cs
+++ b/src/Umbraco.Web.Website/ViewEngines/RenderRazorViewEngineOptionsSetup.cs
@@ -22,7 +22,7 @@ public class RenderRazorViewEngineOptionsSetup : IConfigureOptions<RazorViewEngi
     /// <summary>
     ///     Expands the default view locations
     /// </summary>
-    private class ViewLocationExpander : IViewLocationExpander
+    private sealed class ViewLocationExpander : IViewLocationExpander
     {
         public IEnumerable<string> ExpandViewLocations(
             ViewLocationExpanderContext context, IEnumerable<string> viewLocations)

--- a/tests/Umbraco.Tests.Common/Builders/ContentDataBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/ContentDataBuilder.cs
@@ -7,7 +7,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.Common.Builders;
 
-internal class ContentDataBuilder : BuilderBase<ContentData>, IWithNameBuilder
+internal sealed class ContentDataBuilder : BuilderBase<ContentData>, IWithNameBuilder
 {
     private Dictionary<string, CultureVariation> _cultureInfos;
     private string _name;

--- a/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -150,7 +150,7 @@ public static class UmbracoBuilderExtensions
     }
 
     // replace the default so there is no background index rebuilder
-    private class TestBackgroundIndexRebuilder : ExamineIndexRebuilder
+    private sealed class TestBackgroundIndexRebuilder : ExamineIndexRebuilder
     {
         public TestBackgroundIndexRebuilder(
             IMainDom mainDom,

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
@@ -87,7 +87,6 @@ internal sealed class ContentTypeRepositoryTest : UmbracoIntegrationTest
                 AppCaches.Disabled,
                 LoggerFactory.CreateLogger<TemplateRepository>(),
                 FileSystems,
-                IOHelper,
                 ShortStringHelper,
                 Mock.Of<IViewHelper>(),
                 runtimeSettingsMock.Object);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -117,7 +117,7 @@ internal sealed class DocumentRepositoryTest : UmbracoIntegrationTest
         var runtimeSettingsMock = new Mock<IOptionsMonitor<RuntimeSettings>>();
         runtimeSettingsMock.Setup(x => x.CurrentValue).Returns(new RuntimeSettings());
 
-        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object);
+        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object);
         var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>());
         var commonRepository =
             new ContentTypeCommonRepository(scopeAccessor, templateRepository, appCaches, ShortStringHelper);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -63,7 +63,7 @@ internal sealed class TemplateRepositoryTest : UmbracoIntegrationTest
     private IOptionsMonitor<RuntimeSettings> RuntimeSettings => GetRequiredService<IOptionsMonitor<RuntimeSettings>>();
 
     private ITemplateRepository CreateRepository(IScopeProvider provider) =>
-        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, ViewHelper, RuntimeSettings);
+        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, ShortStringHelper, ViewHelper, RuntimeSettings);
 
     [Test]
     public void Can_Instantiate_Repository()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
@@ -57,8 +57,7 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
             Options.Create(new UserPasswordConfigurationSettings()),
             new SystemTextJsonSerializer(),
             mockRuntimeState.Object,
-            PermissionMappers,
-            AppPolicyCache);
+            PermissionMappers);
         return repository;
     }
 
@@ -165,8 +164,7 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
                 Options.Create(new UserPasswordConfigurationSettings()),
                 new SystemTextJsonSerializer(),
                 mockRuntimeState.Object,
-                PermissionMappers,
-                AppPolicyCache);
+                PermissionMappers);
 
             repository2.Delete(user);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/ImportResources.Designer.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/Importing/ImportResources.Designer.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.Importin
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class ImportResources {
+    internal sealed class ImportResources {
 
         private static global::System.Resources.ResourceManager resourceMan;
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/DbContext/UmbracoLock.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCore/DbContext/UmbracoLock.cs
@@ -1,6 +1,6 @@
 ﻿namespace Umbraco.Cms.Tests.Integration.Umbraco.Persistence.EFCore.DbContext;
 
-internal class UmbracoLock
+internal sealed class UmbracoLock
 {
     public int Id { get; set; }
 

--- a/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/OmitRecursionCustomization.cs
+++ b/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/OmitRecursionCustomization.cs
@@ -2,7 +2,7 @@ using AutoFixture;
 
 namespace Umbraco.Cms.Tests.UnitTests.AutoFixture.Customizations;
 
-internal class OmitRecursionCustomization : ICustomization
+internal sealed class OmitRecursionCustomization : ICustomization
 {
     public void Customize(IFixture fixture) =>
         fixture.Behaviors.Add(new OmitOnRecursionBehavior());

--- a/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
+++ b/tests/Umbraco.Tests.UnitTests/AutoFixture/Customizations/UmbracoCustomizations.cs
@@ -1,16 +1,13 @@
-using System.Linq;
 using AutoFixture;
 using AutoFixture.Kernel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Options;
 using Moq;
 using Umbraco.Cms.Api.Management.Controllers.Security;
 using Umbraco.Cms.Api.Management.Routing;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -20,7 +17,7 @@ using Umbraco.Cms.Web.Common.Security;
 
 namespace Umbraco.Cms.Tests.UnitTests.AutoFixture.Customizations;
 
-internal class UmbracoCustomizations : ICustomization
+internal sealed class UmbracoCustomizations : ICustomization
 {
     public void Customize(IFixture fixture)
     {

--- a/tools/Umbraco.JsonSchema/Options.cs
+++ b/tools/Umbraco.JsonSchema/Options.cs
@@ -1,6 +1,6 @@
 using CommandLine;
 
-internal class Options
+internal sealed class Options
 {
     [Option("outputFile", Default = "appsettings-schema.Umbraco.Cms.json", HelpText = "Output file to save the generated JSON schema for Umbraco CMS.")]
     public required string OutputFile { get; set; }

--- a/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs
@@ -1,8 +1,7 @@
-using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 
-internal class UmbracoCmsSchema
+internal sealed class UmbracoCmsSchema
 {
     public required UmbracoDefinition Umbraco { get; set; }
 

--- a/tools/Umbraco.JsonSchema/UmbracoJsonSchemaGenerator.cs
+++ b/tools/Umbraco.JsonSchema/UmbracoJsonSchemaGenerator.cs
@@ -5,7 +5,7 @@ using NJsonSchema;
 using NJsonSchema.Generation;
 
 /// <inheritdoc />
-internal class UmbracoJsonSchemaGenerator : JsonSchemaGenerator
+internal sealed class UmbracoJsonSchemaGenerator : JsonSchemaGenerator
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="UmbracoJsonSchemaGenerator" /> class.
@@ -26,7 +26,7 @@ internal class UmbracoJsonSchemaGenerator : JsonSchemaGenerator
     { }
 
     /// <inheritdoc />
-    private class UmbracoSystemTextJsonReflectionService : SystemTextJsonReflectionService
+    private sealed class UmbracoSystemTextJsonReflectionService : SystemTextJsonReflectionService
     {
         /// <inheritdoc />
         public override void GenerateProperties(JsonSchema schema, ContextualType contextualType, SystemTextJsonSchemaGeneratorSettings settings, JsonSchemaGenerator schemaGenerator, JsonSchemaResolver schemaResolver)


### PR DESCRIPTION
As the good Stephen Toub explains, [there is good reasons to make classes sealed](https://github.com/dotnet/runtime/issues/49944).

### Prerequisites

- [x] I have added steps to test this contribution in the description below