### PR TITLE
Add support for programmatic creation of property types providing the data type key.

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Infrastructure.Persistence.Querying;
@@ -25,8 +26,9 @@ internal class ContentTypeRepository : ContentTypeRepositoryBase<IContentType>, 
         ILogger<ContentTypeRepository> logger,
         IContentTypeCommonRepository commonRepository,
         ILanguageRepository languageRepository,
-        IShortStringHelper shortStringHelper)
-        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        Lazy<IIdKeyMap> idKeyMap)
+        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper, idKeyMap)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -29,15 +29,22 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
     where TEntity : class, IContentTypeComposition
 {
     private readonly IShortStringHelper _shortStringHelper;
+    private readonly Lazy<IIdKeyMap> _idKeyMap;
 
-    protected ContentTypeRepositoryBase(IScopeAccessor scopeAccessor, AppCaches cache,
-        ILogger<ContentTypeRepositoryBase<TEntity>> logger, IContentTypeCommonRepository commonRepository,
-        ILanguageRepository languageRepository, IShortStringHelper shortStringHelper)
+    protected ContentTypeRepositoryBase(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<ContentTypeRepositoryBase<TEntity>> logger,
+        IContentTypeCommonRepository commonRepository,
+        ILanguageRepository languageRepository,
+        IShortStringHelper shortStringHelper,
+        Lazy<IIdKeyMap> idKeyMap)
         : base(scopeAccessor, cache, logger)
     {
         _shortStringHelper = shortStringHelper;
         CommonRepository = commonRepository;
         LanguageRepository = languageRepository;
+        _idKeyMap = idKeyMap;
     }
 
     protected IContentTypeCommonRepository CommonRepository { get; }
@@ -287,7 +294,7 @@ AND umbracoNode.nodeObjectType = @objectType",
             // If the Id of the DataType is not set, we resolve it from the db by its PropertyEditorAlias
             if (propertyType.DataTypeId == 0 || propertyType.DataTypeId == default)
             {
-                AssignDataTypeFromPropertyEditor(propertyType);
+                AssignDataTypeIdFromProvidedKeyOrPropertyEditor(propertyType);
             }
 
             PropertyTypeDto propertyTypeDto =
@@ -590,7 +597,7 @@ AND umbracoNode.id <> @id",
             // if the Id of the DataType is not set, we resolve it from the db by its PropertyEditorAlias
             if (propertyType.DataTypeId == 0 || propertyType.DataTypeId == default)
             {
-                AssignDataTypeFromPropertyEditor(propertyType);
+                AssignDataTypeIdFromProvidedKeyOrPropertyEditor(propertyType);
             }
 
             // validate the alias
@@ -1434,36 +1441,58 @@ AND umbracoNode.id <> @id",
     protected abstract TEntity? PerformGet(Guid id);
 
     /// <summary>
-    ///     Try to set the data type id based on its ControlId
+    ///     Try to set the data type Id based on the provided key or property editor alias.
     /// </summary>
     /// <param name="propertyType"></param>
-    private void AssignDataTypeFromPropertyEditor(IPropertyType propertyType)
+    private void AssignDataTypeIdFromProvidedKeyOrPropertyEditor(IPropertyType propertyType)
     {
-        // we cannot try to assign a data type of it's empty
-        if (propertyType.PropertyEditorAlias.IsNullOrWhiteSpace() == false)
+        // If a key is provided, use that.
+        if (propertyType.DataTypeKey != Guid.Empty)
         {
-            Sql<ISqlContext> sql = Sql()
-                .Select<DataTypeDto>(dt => dt.Select(x => x.NodeDto))
-                .From<DataTypeDto>()
-                .InnerJoin<NodeDto>().On<DataTypeDto, NodeDto>((dt, n) => dt.NodeId == n.NodeId)
-                .Where(
-                    "propertyEditorAlias = @propertyEditorAlias",
-                    new { propertyEditorAlias = propertyType.PropertyEditorAlias })
-                .OrderBy<DataTypeDto>(typeDto => typeDto.NodeId);
-            DataTypeDto? datatype = Database.FirstOrDefault<DataTypeDto>(sql);
-
-            // we cannot assign a data type if one was not found
-            if (datatype != null)
+            Attempt<int> dataTypeIdAttempt = _idKeyMap.Value.GetIdForKey(propertyType.DataTypeKey, UmbracoObjectTypes.DataType);
+            if (dataTypeIdAttempt.Success)
             {
-                propertyType.DataTypeId = datatype.NodeId;
-                propertyType.DataTypeKey = datatype.NodeDto.UniqueId;
+                propertyType.DataTypeId = dataTypeIdAttempt.Result;
+                return;
             }
             else
             {
                 Logger.LogWarning(
-                    "Could not assign a data type for the property type {PropertyTypeAlias} since no data type was found with a property editor {PropertyEditorAlias}",
-                    propertyType.Alias, propertyType.PropertyEditorAlias);
+                    "Could not assign a data type for the property type {PropertyTypeAlias} since no integer Id was found matching the key {DataTypeKey}. Falling back to look up via the property editor alias.",
+                    propertyType.Alias,
+                    propertyType.DataTypeKey);
             }
+        }
+
+        // Otherwise if a property editor alias is provided, try to find a data type that uses that alias.
+        if (propertyType.PropertyEditorAlias.IsNullOrWhiteSpace())
+        {
+            // We cannot try to assign a data type if it's empty.
+            return;
+        }
+
+        Sql<ISqlContext> sql = Sql()
+            .Select<DataTypeDto>(dt => dt.Select(x => x.NodeDto))
+            .From<DataTypeDto>()
+            .InnerJoin<NodeDto>().On<DataTypeDto, NodeDto>((dt, n) => dt.NodeId == n.NodeId)
+            .Where(
+                "propertyEditorAlias = @propertyEditorAlias",
+                new { propertyEditorAlias = propertyType.PropertyEditorAlias })
+            .OrderBy<DataTypeDto>(typeDto => typeDto.NodeId);
+        DataTypeDto? datatype = Database.FirstOrDefault<DataTypeDto>(sql);
+
+        // we cannot assign a data type if one was not found
+        if (datatype != null)
+        {
+            propertyType.DataTypeId = datatype.NodeId;
+            propertyType.DataTypeKey = datatype.NodeDto.UniqueId;
+        }
+        else
+        {
+            Logger.LogWarning(
+                "Could not assign a data type for the property type {PropertyTypeAlias} since no data type was found with a property editor {PropertyEditorAlias}",
+                propertyType.Alias,
+                propertyType.PropertyEditorAlias);
         }
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Infrastructure.Persistence.Querying;
@@ -24,8 +25,9 @@ internal class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType>, IMed
         ILogger<MediaTypeRepository> logger,
         IContentTypeCommonRepository commonRepository,
         ILanguageRepository languageRepository,
-        IShortStringHelper shortStringHelper)
-        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        Lazy<IIdKeyMap> idKeyMap)
+        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper, idKeyMap)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Querying;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Infrastructure.Persistence.Factories;
@@ -27,9 +28,10 @@ internal class MemberTypeRepository : ContentTypeRepositoryBase<IMemberType>, IM
         ILogger<MemberTypeRepository> logger,
         IContentTypeCommonRepository commonRepository,
         ILanguageRepository languageRepository,
-        IShortStringHelper shortStringHelper)
-        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper) =>
-        _shortStringHelper = shortStringHelper;
+        IShortStringHelper shortStringHelper,
+        Lazy<IIdKeyMap> idKeyMap)
+        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper, idKeyMap)
+         => _shortStringHelper = shortStringHelper;
 
     protected override bool SupportsPublishing => MemberType.SupportsPublishingConst;
 

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTest.cs
@@ -56,6 +56,8 @@ public abstract class UmbracoIntegrationTest : UmbracoIntegrationTestBase
 
     protected IShortStringHelper ShortStringHelper => Services.GetRequiredService<IShortStringHelper>();
 
+    protected IIdKeyMap IdKeyMap => Services.GetRequiredService<IIdKeyMap>();
+
     protected GlobalSettings GlobalSettings => Services.GetRequiredService<IOptions<GlobalSettings>>().Value;
 
     protected IMapperCollection Mappers => Services.GetRequiredService<IMapperCollection>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -120,7 +120,7 @@ public class DocumentRepositoryTest : UmbracoIntegrationTest
             new ContentTypeCommonRepository(scopeAccessor, templateRepository, appCaches, ShortStringHelper);
         var languageRepository =
             new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>());
-        contentTypeRepository = new ContentTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper);
+        contentTypeRepository = new ContentTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, new Lazy<IIdKeyMap>(() => IdKeyMap));
         var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
         var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
         var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
@@ -55,7 +55,7 @@ public class MediaRepositoryTest : UmbracoIntegrationTest
             new ContentTypeCommonRepository(scopeAccessor, TemplateRepository, appCaches, ShortStringHelper);
         var languageRepository =
             new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>());
-        mediaTypeRepository = new MediaTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaTypeRepository>(), commonRepository, languageRepository, ShortStringHelper);
+        mediaTypeRepository = new MediaTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, new Lazy<IIdKeyMap>(() => IdKeyMap));
         var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>());
         var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
         var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaTypeRepositoryTest.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -411,7 +412,7 @@ public class MediaTypeRepositoryTest : UmbracoIntegrationTest
     }
 
     private MediaTypeRepository CreateRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<MediaTypeRepository>(), CommonRepository, LanguageRepository, ShortStringHelper);
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<MediaTypeRepository>(), CommonRepository, LanguageRepository, ShortStringHelper, new Lazy<IIdKeyMap>(() => IdKeyMap));
 
     private EntityContainerRepository CreateContainerRepository(IScopeProvider provider) =>
         new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<EntityContainerRepository>(), Constants.ObjectTypes.MediaTypeContainer);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -26,7 +27,7 @@ public class MemberTypeRepositoryTest : UmbracoIntegrationTest
     {
         var commonRepository = GetRequiredService<IContentTypeCommonRepository>();
         var languageRepository = GetRequiredService<ILanguageRepository>();
-        return new MemberTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper);
+        return new MemberTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper, new Lazy<IIdKeyMap>(() => IdKeyMap));
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -265,7 +265,7 @@ public class TemplateRepositoryTest : UmbracoIntegrationTest
             var commonRepository =
                 new ContentTypeCommonRepository(scopeAccessor, templateRepository, AppCaches, ShortStringHelper);
             var languageRepository = new LanguageRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>());
-            var contentTypeRepository = new ContentTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper);
+            var contentTypeRepository = new ContentTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, new Lazy<IIdKeyMap>(() => IdKeyMap));
             var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
             var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
             var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19715

### Description
The linked issue shows that when programmatically creating a property type, only the integer `DataTypeId` is used when determining the data type to use.  If `DataTypeKey` is provided, this isn't used and the data type is looked up by property alias.  And as there can be more than one of these, you may not end up with the data type you expect.

This PR uses the `IIdKeyMap` to populate the integer Id from the GUID key if only the latter is provided.

### Testing
Can be tested with the following surface controller.

Before the update this would create a property type using the "Label (decimal)" data type, even though "Label (jnteger)" was provided.  With this update you should see the expected data type used:

```
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Cache;
using Umbraco.Cms.Core.Logging;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Routing;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Strings;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Infrastructure.Persistence;
using Umbraco.Cms.Web.Website.Controllers;

namespace Umbraco.Cms.Web.UI.Controllers;

public class MyTestController : SurfaceController
{
    private readonly IContentTypeService _contentTypeService;
    private readonly IShortStringHelper _shortStringHelper;

    public MyTestController(
        IUmbracoContextAccessor umbracoContextAccessor,
        IUmbracoDatabaseFactory databaseFactory,
        ServiceContext services,
        AppCaches appCaches,
        IProfilingLogger profilingLogger,
        IPublishedUrlProvider publishedUrlProvider,
        IContentTypeService contentTypeService,
        IShortStringHelper shortStringHelper)
        : base(umbracoContextAccessor, databaseFactory, services, appCaches, profilingLogger, publishedUrlProvider)
    {
        _contentTypeService = contentTypeService;
        _shortStringHelper = shortStringHelper;
    }

    public async Task<IActionResult> AddPropertyType()
    {
        IContentType ct = _contentTypeService.Get("startPage") ?? throw new InvalidOperationException("Content type 'startPage' not found.");

        const string PropertyAlias = "MyTestPropertyAlias";
        if (!ct.PropertyTypeExists(PropertyAlias))
        {
            // Initialize a new tab
            var propertyGroup = new PropertyGroup(false)
            {
                Alias = "info",
                Name = "Information",
                Type = PropertyGroupType.Tab,
                SortOrder = 1
            };

            var propertyType = new PropertyType(_shortStringHelper, Core.Constants.PropertyEditors.Aliases.Label, ValueStorageType.Integer)
            {
                Alias = PropertyAlias,
                Name = "My Test Property",
                Description = "My test property description.",
                Mandatory = true,
                SortOrder = 1,
                DataTypeKey = Guid.Parse("8e7f995c-bd81-4627-9932-c40e568ec788"),
            };

            propertyGroup.PropertyTypes!.Add(propertyType);

            // Add the tab to the content type
            ct.PropertyGroups.Add(propertyGroup);
        }

        _contentTypeService.Save(ct);
        return Ok("Done");
    }
}
```

<img width="461" height="301" alt="image" src="https://github.com/user-attachments/assets/e28f5e4b-d098-4b33-8fdf-eddf80d573da" />
