### PR TITLE
Repository Details Manager: Prevent making requests for empty arrays

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-details.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-details.manager.ts
@@ -182,15 +182,17 @@ export class UmbRepositoryDetailsManager<DetailType extends { unique: string }> 
 	}
 
 	async #requestNewDetails(uniques?: Array<DetailType['unique']>): Promise<void> {
+		if (!uniques?.length) return;
+
 		await this.#init;
 		if (!this.repository) throw new Error('Repository is not initialized');
 
-		const newRequestedUniques = uniques?.filter((unique) => {
+		const newRequestedUniques = uniques.filter((unique) => {
 			const item = this.#statuses.getValue().find((status) => status.unique === unique);
 			return !item;
 		});
 
-		newRequestedUniques?.forEach((unique) => {
+		newRequestedUniques.forEach((unique) => {
 			this.#requestDetails(unique);
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-details.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-details.manager.ts
@@ -76,6 +76,8 @@ export class UmbRepositoryDetailsManager<DetailType extends { unique: string }> 
 		this.observe(
 			this.uniques,
 			(uniques) => {
+				if (!uniques?.length) return;
+
 				// remove entries based on no-longer existing uniques:
 				const removedEntries = this.#entries
 					.getValue()

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-details.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-details.manager.ts
@@ -76,8 +76,6 @@ export class UmbRepositoryDetailsManager<DetailType extends { unique: string }> 
 		this.observe(
 			this.uniques,
 			(uniques) => {
-				if (!uniques?.length) return;
-
 				// remove entries based on no-longer existing uniques:
 				const removedEntries = this.#entries
 					.getValue()
@@ -90,7 +88,7 @@ export class UmbRepositoryDetailsManager<DetailType extends { unique: string }> 
 					this.removeUmbControllerByAlias('observeEntry_' + entry);
 				});
 
-				this.#requestNewDetails();
+				this.#requestNewDetails(uniques);
 			},
 			null,
 		);
@@ -183,18 +181,16 @@ export class UmbRepositoryDetailsManager<DetailType extends { unique: string }> 
 		return this.#entries.asObservablePart((items) => items.find((item) => item.unique === unique));
 	}
 
-	async #requestNewDetails(): Promise<void> {
+	async #requestNewDetails(uniques?: Array<DetailType['unique']>): Promise<void> {
 		await this.#init;
 		if (!this.repository) throw new Error('Repository is not initialized');
 
-		const requestedUniques = this.getUniques();
-
-		const newRequestedUniques = requestedUniques.filter((unique) => {
+		const newRequestedUniques = uniques?.filter((unique) => {
 			const item = this.#statuses.getValue().find((status) => status.unique === unique);
 			return !item;
 		});
 
-		newRequestedUniques.forEach((unique) => {
+		newRequestedUniques?.forEach((unique) => {
 			this.#requestDetails(unique);
 		});
 	}


### PR DESCRIPTION
### Description

Fixes #19604.

In the Repository Details Manager ([`UmbRepositoryDetailsManager`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Client/src/packages/core/repository/repository-details.manager.ts)), when the `uniques` are initialized with an empty array, the observer is triggered and a call to `#requestNewDetails()` is made, (but there are no uniques or details to request).

With issue #19604 for the Block Grid, a race condition occurs, that when the unique of an element-type is set with the Repository Details Manager, the `#init` Promise made by the initialized value (empty array) had not been resolved, so by the time it is resolved, the `#requestNewDetails()` method resumes with the uniques of the element-types (due to microtask scheduling between the Promise resolution and setting the element-type IDs).

An interim fix for this is to prevent `#requestNewDetails()` from being called if the `uniques` array is empty.

