### PR TITLE
Add a backing field for EditorUIAlias and track changes when its set.

### DIFF
--- a/src/Umbraco.Core/Models/DataType.cs
+++ b/src/Umbraco.Core/Models/DataType.cs
@@ -17,6 +17,7 @@ public class DataType : TreeEntityBase, IDataType
     private IDictionary<string, object> _configurationData;
     private ValueStorageType _databaseType;
     private IDataEditor? _editor;
+    private string? _editorUIAlias;
     private bool _hasConfigurationObject;
 
     /// <summary>
@@ -60,7 +61,11 @@ public class DataType : TreeEntityBase, IDataType
 
     /// <inheritdoc />
     [DataMember]
-    public string? EditorUiAlias { get; set; }
+    public string? EditorUiAlias
+    {
+        get => _editorUIAlias;
+        set => SetPropertyValueAndDetectChanges(value, ref _editorUIAlias, nameof(EditorUiAlias));
+    }
 
     /// <inheritdoc />
     [DataMember]


### PR DESCRIPTION

### Description

Fixes : #19732 

The `EditorUIAlias` property in the `DataType` model was missing value tracking, so the Dirty methods (`IsDirty`, `GetDirtyProperties`, etc) where not registering any changes if this value is updated.

This PR adds the backing field and updates the get and set methods in the DataType model so tracking will pick up any changes. 

* Adds a new private string field _editorUIAlias to the DataType model. 
* Uses this as the backing field for EditorUIAlias property
* Update Set method to call `SetPropertyValueAndDetectChanges` when the value is set

