### PR TITLE
Change hardcoded text to be translatedeable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -2664,6 +2664,8 @@ export default {
 		toolbar_removeGroup: 'Fjern gruppe',
 		toolbar_removeItem: 'Fjern handling',
 		toolbar_emptyGroup: 'Tom',
+		statusbar_characters: () => 'tegn',
+		statusbar_words: () => 'ord',
 	},
 	collection: {
 		noItemsTitle: 'Intet indhold',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2812,6 +2812,8 @@ export default {
 		charmap_extlatin: 'Extended Latin',
 		charmap_symbols: 'Symbols',
 		charmap_arrows: 'Arrows',
+		statusbar_characters: (count: number) => count === 1 ? 'character' : 'characters',
+		statusbar_words: (count: number) => count === 1 ? 'word' : 'words',
 	},
 	linkPicker: {
 		modalSource: 'Source',

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/statusbar/word-count.tiptap-statusbar-element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/statusbar/word-count.tiptap-statusbar-element.ts
@@ -41,8 +41,8 @@ export class UmbTiptapStatusbarWordCountElement extends UmbLitElement {
 
 	override render() {
 		const label = this._showCharacters
-			? this._characters.toLocaleString() + ' ' + (this._characters === 1 ? 'character' : 'characters')
-			: this._words.toLocaleString() + ' ' + (this._words === 1 ? 'word' : 'words');
+			? this._characters.toLocaleString() + ' ' + this.localize.term('tiptap_statusbar_characters', this._characters)
+			: this._words.toLocaleString() + ' ' + this.localize.term('tiptap_statusbar_words', this._words);
 		return html`<uui-button compact label=${label} @click=${this.#onClick}></uui-button>`;
 	}
 }


### PR DESCRIPTION
Change the tiptap-statusbar word/character from being hardcoded to come from the localize. Added text for both EN and DA language