### PR TITLE
Add flag to exclude trashed media

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -210,6 +210,7 @@ export class UmbMediaPickerModalElement extends UmbModalBaseElement<UmbMediaPick
 		const query = this._searchQuery;
 		const { data } = await this.#mediaSearchProvider.search({
 			query,
+			includeTrashed: false,
 			searchFrom: this._searchFrom,
 			culture: this.#contextCulture,
 			...this.data?.search?.queryParams,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/19743

### Description
Add the includeTrashed as false, to exclude all trashed media on the search result for the media-picker.
As the issue description when using the browser UI trashed media is exclude but when you began to search everything is showed, witch doesn´t make any point, that you can search for trashed media and select it.

How to test.
* Add a document type and add a media picker property
* Add two medias. give the name as ex. "Lucas-portrait", "Lucas-wide"
* Trash one of the medias.
* Create a new node and in the media picker, in the browser see only media witch is not trashed.
* Then search ex. "Lucas" and see only the items witch is not trashed.