### PR TITLE
V16:  Cache Version Mechanism

### DIFF
--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
@@ -1,0 +1,28 @@
+﻿namespace Umbraco.Cms.Core.Cache;
+
+/// <summary>
+/// Provides methods to manage and validate cache versioning for repository entities,
+/// ensuring cache consistency with the underlying database.
+/// </summary>
+public interface IRepositoryCacheVersionService
+{
+    /// <summary>
+    /// Validates if the cache is synced with the database.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the cached entity.</typeparam>
+    /// <returns>True if cache is synced, false if cache needs fast-forwarding.</returns>
+    Task<bool> IsCacheSyncedAsync<TEntity>()
+        where TEntity : class;
+
+    /// <summary>
+    /// Registers a cache update for the specified entity type.
+    /// </summary>
+    /// <typeparam name="TEntity">The type of the cached entity.</typeparam>
+    Task SetCacheUpdatedAsync<TEntity>()
+        where TEntity : class;
+
+    /// <summary>
+    /// Registers that the cache has been synced with the database
+    /// </summary>
+    Task SetCachesSyncedAsync();
+}

--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
@@ -22,7 +22,7 @@ public interface IRepositoryCacheVersionService
         where TEntity : class;
 
     /// <summary>
-    /// Registers that the cache has been synced with the database
+    /// Registers that the cache has been synced with the database.
     /// </summary>
     Task SetCachesSyncedAsync();
 }

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -7,7 +7,7 @@ using Umbraco.Cms.Core.Scoping;
 namespace Umbraco.Cms.Core.Cache;
 
 /// <inheritdoc />
-public class RepositoryCacheVersionService : IRepositoryCacheVersionService
+internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
 {
     private readonly ICoreScopeProvider _scopeProvider;
     private readonly IRepositoryCacheVersionRepository _repositoryCacheVersionRepository;
@@ -112,7 +112,7 @@ public class RepositoryCacheVersionService : IRepositoryCacheVersionService
         scope.Complete();
     }
 
-    private string GetCacheKey<TEntity>()
+    internal string GetCacheKey<TEntity>()
         where TEntity : class =>
         typeof(TEntity).Name;
 }

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -114,5 +114,5 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
 
     internal string GetCacheKey<TEntity>()
         where TEntity : class =>
-        typeof(TEntity).Name;
+        typeof(TEntity).FullName ?? typeof(TEntity).Name;
 }

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -1,0 +1,117 @@
+﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+
+namespace Umbraco.Cms.Core.Cache;
+
+/// <inheritdoc />
+public class RepositoryCacheVersionService : IRepositoryCacheVersionService
+{
+    private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IRepositoryCacheVersionRepository _repositoryCacheVersionRepository;
+    private readonly ILogger<RepositoryCacheVersionService> _logger;
+    private readonly ConcurrentDictionary<string, Guid> _cacheVersions = new();
+
+    public RepositoryCacheVersionService(
+        ICoreScopeProvider scopeProvider,
+        IRepositoryCacheVersionRepository repositoryCacheVersionRepository,
+        ILogger<RepositoryCacheVersionService> logger)
+    {
+        _scopeProvider = scopeProvider;
+        _repositoryCacheVersionRepository = repositoryCacheVersionRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsCacheSyncedAsync<TEntity>()
+        where TEntity : class
+    {
+        _logger.LogDebug("Checking if cache for {EntityType} is synced", typeof(TEntity).Name);
+
+        // We have to take a read lock to ensure the cache is not being updated while we check the version
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        scope.ReadLock(Constants.Locks.CacheVersion);
+
+        var cacheKey = GetCacheKey<TEntity>();
+        if (_cacheVersions.TryGetValue(cacheKey, out Guid localVersion) is false)
+        {
+            _logger.LogDebug("Cache for {EntityType} is not initialized, considering it synced", typeof(TEntity).Name);
+
+            // We're not initialized yet, so cache is empty, which means cache is synced.
+            return true;
+        }
+
+        RepositoryCacheVersion? databaseVersion = await _repositoryCacheVersionRepository.GetAsync(cacheKey);
+        scope.Complete();
+
+        if (databaseVersion?.Version is null)
+        {
+            _logger.LogDebug("Cache for {EntityType} has no version in the database, considering it synced", typeof(TEntity).Name);
+
+            // If the database version is null, it means the cache has never been initialized, so we consider it synced.
+            return true;
+        }
+
+        // We could've parsed this in the repository layer; however, the fact that we are using a Guid is an implementation detail.
+        if (localVersion != Guid.Parse(databaseVersion.Version))
+        {
+            _logger.LogDebug(
+                "Cache for {EntityType} is not synced: local version {LocalVersion} does not match database version {DatabaseVersion}",
+                typeof(TEntity).Name,
+                localVersion,
+                databaseVersion.Version);
+            return false;
+        }
+
+        _logger.LogDebug("Cache for {EntityType} is synced", typeof(TEntity).Name);
+        return true;
+
+    }
+
+    /// <inheritdoc />
+    public async Task SetCacheUpdatedAsync<TEntity>()
+        where TEntity : class
+    {
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+
+        // We have to take a write lock to ensure the cache is not being read while we update the version
+        scope.WriteLock(Constants.Locks.CacheVersion);
+
+        var cacheKey = GetCacheKey<TEntity>();
+        var newVersion = Guid.NewGuid();
+
+        _logger.LogDebug("Setting cache for {EntityType} to version {Version}", typeof(TEntity).Name, newVersion);
+        await _repositoryCacheVersionRepository.SaveAsync(new RepositoryCacheVersion { Identifier = cacheKey, Version = newVersion.ToString() });
+        _cacheVersions[cacheKey] = newVersion;
+
+        scope.Complete();
+    }
+
+    /// <inheritdoc />
+    public async Task SetCachesSyncedAsync()
+    {
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        scope.ReadLock(Constants.Locks.CacheVersion);
+
+        // We always sync all caches versions, so it's safe to assume all caches are synced at this point.
+        IEnumerable<RepositoryCacheVersion> cacheVersions = await _repositoryCacheVersionRepository.GetAllAsync();
+
+        foreach (RepositoryCacheVersion version in cacheVersions)
+        {
+            if (version.Version is null)
+            {
+                continue;
+            }
+
+            _cacheVersions[version.Identifier] = Guid.Parse(version.Version);
+        }
+
+        scope.Complete();
+    }
+
+    private string GetCacheKey<TEntity>()
+        where TEntity : class =>
+        typeof(TEntity).Name;
+}

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -30,7 +30,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     {
         _logger.LogDebug("Checking if cache for {EntityType} is synced", typeof(TEntity).Name);
 
-        // We have to take a read lock to ensure the cache is not being updated while we check the version
+        // We have to take a read lock to ensure the cache is not being updated while we check the version.
         using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
         scope.ReadLock(Constants.Locks.CacheVersion);
 
@@ -77,7 +77,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
 
-        // We have to take a write lock to ensure the cache is not being read while we update the version
+        // We have to take a write lock to ensure the cache is not being read while we update the version.
         scope.WriteLock(Constants.Locks.CacheVersion);
 
         var cacheKey = GetCacheKey<TEntity>();

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -31,7 +31,7 @@ public class RepositoryCacheVersionService : IRepositoryCacheVersionService
         _logger.LogDebug("Checking if cache for {EntityType} is synced", typeof(TEntity).Name);
 
         // We have to take a read lock to ensure the cache is not being updated while we check the version
-        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
         scope.ReadLock(Constants.Locks.CacheVersion);
 
         var cacheKey = GetCacheKey<TEntity>();
@@ -44,7 +44,6 @@ public class RepositoryCacheVersionService : IRepositoryCacheVersionService
         }
 
         RepositoryCacheVersion? databaseVersion = await _repositoryCacheVersionRepository.GetAsync(cacheKey);
-        scope.Complete();
 
         if (databaseVersion?.Version is null)
         {
@@ -67,7 +66,6 @@ public class RepositoryCacheVersionService : IRepositoryCacheVersionService
 
         _logger.LogDebug("Cache for {EntityType} is synced", typeof(TEntity).Name);
         return true;
-
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Cache/SingleServerCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/SingleServerCacheVersionService.cs
@@ -1,0 +1,23 @@
+﻿namespace Umbraco.Cms.Core.Cache;
+
+/// <summary>
+/// A simple cache version service that assumes the cache is always in sync.
+/// <remarks>
+/// This is useful in scenarios where you have a single server setup and do not need to manage cache synchronization across multiple servers.
+/// </remarks>
+/// </summary>
+public class SingleServerCacheVersionService : IRepositoryCacheVersionService
+{
+    /// <inheritdoc />
+    public Task<bool> IsCacheSyncedAsync<TEntity>()
+        where TEntity : class
+        => Task.FromResult(true);
+
+    /// <inheritdoc />
+    public Task SetCacheUpdatedAsync<TEntity>()
+        where TEntity : class
+        => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task SetCachesSyncedAsync() => Task.CompletedTask;
+}

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -340,6 +340,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<ILocalizedTextService>(factory => new LocalizedTextService(
                 factory.GetRequiredService<Lazy<LocalizedTextServiceFileSources>>(),
                 factory.GetRequiredService<ILogger<LocalizedTextService>>()));
+            Services.AddUnique<IRepositoryCacheVersionService, RepositoryCacheVersionService>();
 
             Services.AddUnique<IEntityXmlSerializer, EntityXmlSerializer>();
 

--- a/src/Umbraco.Core/Models/RepositoryCacheVersion.cs
+++ b/src/Umbraco.Core/Models/RepositoryCacheVersion.cs
@@ -1,0 +1,17 @@
+namespace Umbraco.Cms.Core.Models;
+
+/// <summary>
+/// Represents a version of a repository cache.
+/// </summary>
+public class RepositoryCacheVersion
+{
+    /// <summary>
+    /// The unique identifier for the cache.
+    /// </summary>
+    public required string Identifier { get; init; }
+
+    /// <summary>
+    /// The identifier of the version of the cache.
+    /// </summary>
+    public required string? Version { get; init; }
+}

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -98,6 +98,8 @@ public static partial class Constants
             public const string Webhook2Headers = Webhook + "2Headers";
             public const string WebhookLog = Webhook + "Log";
             public const string WebhookRequest = Webhook + "Request";
+
+            public const string RepositoryCacheVersion = TableNamePrefix + "RepositoryCacheVersion";
         }
     }
 }

--- a/src/Umbraco.Core/Persistence/Constants-Locks.cs
+++ b/src/Umbraco.Core/Persistence/Constants-Locks.cs
@@ -80,5 +80,10 @@ public static partial class Constants
         ///     All webhook logs.
         /// </summary>
         public const int WebhookLogs = -343;
+
+        /// <summary>
+        ///    The cache version.
+        /// </summary>
+        public const int CacheVersion = -344;
     }
 }

--- a/src/Umbraco.Core/Persistence/Constants-Locks.cs
+++ b/src/Umbraco.Core/Persistence/Constants-Locks.cs
@@ -84,6 +84,6 @@ public static partial class Constants
         /// <summary>
         ///    The cache version.
         /// </summary>
-        public const int CacheVersion = -344;
+        public const int CacheVersion = -346;
     }
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IRepositoryCacheVersionRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IRepositoryCacheVersionRepository.cs
@@ -1,0 +1,24 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Persistence.Repositories;
+
+/// <summary>
+/// Defines methods for accessing and persisting <see cref="RepositoryCacheVersion"/> entities.
+/// </summary>
+public interface IRepositoryCacheVersionRepository : IRepository
+{
+    /// <summary>
+    /// Gets a <see cref="RepositoryCacheVersion"/> by its identifier.
+    /// </summary>
+    /// <param name="identifier">The unique identifier of the cache version.</param>
+    /// <returns>
+    /// A <see cref="RepositoryCacheVersion"/> if found; otherwise, <c>null</c>.
+    /// </returns>
+    Task<RepositoryCacheVersion?> GetAsync(string identifier);
+
+    /// <summary>
+    /// Saves the specified <see cref="RepositoryCacheVersion"/>.
+    /// </summary>
+    /// <param name="repositoryCacheVersion">The cache version entity to save.</param>
+    Task SaveAsync(RepositoryCacheVersion repositoryCacheVersion);
+}

--- a/src/Umbraco.Core/Persistence/Repositories/IRepositoryCacheVersionRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IRepositoryCacheVersionRepository.cs
@@ -17,6 +17,14 @@ public interface IRepositoryCacheVersionRepository : IRepository
     Task<RepositoryCacheVersion?> GetAsync(string identifier);
 
     /// <summary>
+    /// Gets all <see cref="RepositoryCacheVersion"/> entities.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerable{RepositoryCacheVersion}"/> containing all cache versions.
+    /// </returns>
+    Task<IEnumerable<RepositoryCacheVersion>> GetAllAsync();
+
+    /// <summary>
     /// Saves the specified <see cref="RepositoryCacheVersion"/>.
     /// </summary>
     /// <param name="repositoryCacheVersion">The cache version entity to save.</param>

--- a/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
@@ -34,7 +34,7 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
         : base(cache, scopeAccessor, repositoryCacheVersionService) =>
         _options = options ?? throw new ArgumentNullException(nameof(options));
 
-    [Obsolete("Use the constructor with RepositoryCachePolicyOptions parameter instead.")]
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     public DefaultRepositoryCachePolicy(
         IAppPolicyCache cache,
         IScopeAccessor scopeAccessor,

--- a/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
@@ -24,9 +26,26 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
     private static readonly TEntity[] _emptyEntities = new TEntity[0]; // const
     private readonly RepositoryCachePolicyOptions _options;
 
-    public DefaultRepositoryCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, RepositoryCachePolicyOptions options)
-        : base(cache, scopeAccessor) =>
+    public DefaultRepositoryCachePolicy(
+        IAppPolicyCache cache,
+        IScopeAccessor scopeAccessor,
+        RepositoryCachePolicyOptions options,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(cache, scopeAccessor, repositoryCacheVersionService) =>
         _options = options ?? throw new ArgumentNullException(nameof(options));
+
+    [Obsolete("Use the constructor with RepositoryCachePolicyOptions parameter instead.")]
+    public DefaultRepositoryCachePolicy(
+        IAppPolicyCache cache,
+        IScopeAccessor scopeAccessor,
+        RepositoryCachePolicyOptions options)
+        : this(
+            cache,
+            scopeAccessor,
+            options,
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+    {
+    }
 
     protected string EntityTypeCacheKey { get; } = $"uRepo_{typeof(TEntity).Name}_";
 

--- a/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
@@ -31,6 +31,8 @@ public class MemberRepositoryUsernameCachePolicy : DefaultRepositoryCachePolicy<
 
     public IMember? GetByUserName(string key, string? username, Func<string?, IMember?> performGetByUsername, Func<string[]?, IEnumerable<IMember>?> performGetAll)
     {
+        EnsureCacheIsSynced();
+
         var cacheKey = GetEntityCacheKey(key + username);
         IMember? fromCache = Cache.GetCacheItem<IMember>(cacheKey);
 
@@ -52,6 +54,9 @@ public class MemberRepositoryUsernameCachePolicy : DefaultRepositoryCachePolicy<
 
     public void DeleteByUserName(string key, string? username)
     {
+        // We've removed an entity, register cache change for other servers.
+        RegisterCacheChange();
+
         var cacheKey = GetEntityCacheKey(key + username);
         Cache.ClearByKey(cacheKey);
     }

--- a/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
@@ -20,7 +20,7 @@ public class MemberRepositoryUsernameCachePolicy : DefaultRepositoryCachePolicy<
     {
     }
 
-    [Obsolete("Use the constructor with IRepositoryCacheVersionService instead. Scheuled for removal in V18.")]
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     public MemberRepositoryUsernameCachePolicy(
         IAppPolicyCache cache,
         IScopeAccessor scopeAccessor,

--- a/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.Models;
+﻿using System.Runtime.Versioning;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
 
@@ -6,7 +7,25 @@ namespace Umbraco.Cms.Core.Cache;
 
 public class MemberRepositoryUsernameCachePolicy : DefaultRepositoryCachePolicy<IMember, string>
 {
-    public MemberRepositoryUsernameCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, RepositoryCachePolicyOptions options) : base(cache, scopeAccessor, options)
+    public MemberRepositoryUsernameCachePolicy(
+        IAppPolicyCache cache,
+        IScopeAccessor scopeAccessor,
+        RepositoryCachePolicyOptions options,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            cache,
+            scopeAccessor,
+            options,
+            repositoryCacheVersionService)
+    {
+    }
+
+    [Obsolete("Use the constructor with IRepositoryCacheVersionService instead. Scheuled for removal in V18.")]
+    public MemberRepositoryUsernameCachePolicy(
+        IAppPolicyCache cache,
+        IScopeAccessor scopeAccessor,
+        RepositoryCachePolicyOptions options)
+        : base(cache, scopeAccessor, options)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Cache/RepositoryCachePolicyBase.cs
+++ b/src/Umbraco.Infrastructure/Cache/RepositoryCachePolicyBase.cs
@@ -88,7 +88,7 @@ public abstract class RepositoryCachePolicyBase<TEntity, TId> : IRepositoryCache
     /// <summary>
     /// Ensures that the cache is synced with the database.
     /// </summary>
-    protected void EsnureCacheIsSynced()
+    protected void EnsureCacheIsSynced()
     {
         var synced = _cacheVersionService.IsCacheSyncedAsync<TEntity>().GetAwaiter().GetResult();
         if (synced is false)

--- a/src/Umbraco.Infrastructure/Cache/RepositoryCachePolicyBase.cs
+++ b/src/Umbraco.Infrastructure/Cache/RepositoryCachePolicyBase.cs
@@ -100,5 +100,5 @@ public abstract class RepositoryCachePolicyBase<TEntity, TId> : IRepositoryCache
     /// <summary>
     /// Registers a change in the cache.
     /// </summary>
-    protected void RegisterCacheChange() => _cacheVersionService.SetCacheUpdatedAsync<TEntity>().Wait();
+    protected void RegisterCacheChange() => _cacheVersionService.SetCacheUpdatedAsync<TEntity>().GetAwaiter().GetResult();
 }

--- a/src/Umbraco.Infrastructure/Cache/RepositoryCachePolicyBase.cs
+++ b/src/Umbraco.Infrastructure/Cache/RepositoryCachePolicyBase.cs
@@ -32,7 +32,7 @@ public abstract class RepositoryCachePolicyBase<TEntity, TId> : IRepositoryCache
         _cacheVersionService = cacheVersionService;
     }
 
-    [Obsolete("Use the constructor with IRepositoryCacheVersionService parameter instead. Scheduled for removal in V18.")]
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     protected RepositoryCachePolicyBase(IAppPolicyCache globalCache, IScopeAccessor scopeAccessor)
     : this(
         globalCache,

--- a/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Infrastructure.Scoping;
 
@@ -21,8 +23,21 @@ namespace Umbraco.Cms.Core.Cache;
 internal class SingleItemsOnlyRepositoryCachePolicy<TEntity, TId> : DefaultRepositoryCachePolicy<TEntity, TId>
     where TEntity : class, IEntity
 {
+    public SingleItemsOnlyRepositoryCachePolicy(
+        IAppPolicyCache cache,
+        IScopeAccessor scopeAccessor,
+        RepositoryCachePolicyOptions options,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(cache, scopeAccessor, options,  repositoryCacheVersionService)
+    {
+    }
+
     public SingleItemsOnlyRepositoryCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, RepositoryCachePolicyOptions options)
-        : base(cache, scopeAccessor, options)
+        : this(
+            cache,
+            scopeAccessor,
+            options,
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
     {
     }
 

--- a/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
@@ -32,6 +32,7 @@ internal class SingleItemsOnlyRepositoryCachePolicy<TEntity, TId> : DefaultRepos
     {
     }
 
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     public SingleItemsOnlyRepositoryCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, RepositoryCachePolicyOptions options)
         : this(
             cache,

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
@@ -82,6 +82,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IUserDataRepository, UserDataRepository>();
         builder.Services.AddUnique<INavigationRepository, ContentNavigationRepository>();
         builder.Services.AddUnique<IPublishStatusRepository, PublishStatusRepository>();
+        builder.Services.AddUnique<IRepositoryCacheVersionRepository, RepositoryCacheVersionRepository>();
 
         return builder;
     }

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1050,6 +1050,7 @@ internal class DatabaseDataCreator
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.MainDom, Name = "MainDom" });
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.WebhookRequest, Name = "WebhookRequest" });
         _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.WebhookLogs, Name = "WebhookLogs" });
+        _database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.CacheVersion, Name = "CacheVersion" });
     }
 
     private void CreateContentTypeData()

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
@@ -90,6 +90,7 @@ public class DatabaseSchemaCreator
         typeof(WebhookLogDto),
         typeof(WebhookRequestDto),
         typeof(UserDataDto),
+        typeof(RepositoryCacheVersionDto),
     };
 
     private readonly IUmbracoDatabase _database;

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -119,5 +119,8 @@ public class UmbracoPlan : MigrationPlan
         // To 16.0.0
         To<V_16_0_0.MigrateTinyMceToTiptap>("{C6681435-584F-4BC8-BB8D-BC853966AF0B}");
         To<V_16_0_0.AddDocumentPropertyPermissions>("{D1568C33-A697-455F-8D16-48060CB954A1}");
+
+        // TO 16.2.0
+        To<V_16_2_0.AddRepositoryCacheVersionTable>("{A1B3F5D6-4C8B-4E7A-9F8C-1D2B3E4F5A6B}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -119,8 +119,5 @@ public class UmbracoPlan : MigrationPlan
         // To 16.0.0
         To<V_16_0_0.MigrateTinyMceToTiptap>("{C6681435-584F-4BC8-BB8D-BC853966AF0B}");
         To<V_16_0_0.AddDocumentPropertyPermissions>("{D1568C33-A697-455F-8D16-48060CB954A1}");
-
-        // TO 16.2.0
-        To<V_16_2_0.AddRepositoryCacheVersionTable>("{A1B3F5D6-4C8B-4E7A-9F8C-1D2B3E4F5A6B}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
@@ -68,9 +68,9 @@ public class UmbracoPremigrationPlan : MigrationPlan
         To<V_14_0_0.AddPropertyEditorUiAliasColumn>("{EEB1F012-B44D-4AB4-8756-F7FB547345B4}");
         To<V_14_0_0.AddListViewKeysToDocumentTypes>("{0F49E1A4-AFD8-4673-A91B-F64E78C48174}");
 
-        // TO 16.2.0
-        // The lock and table are required to access caches
-        // When logging in, we save the user to the cache so these needs to have run.
+        // To 16.2.0
+        // The lock and table are required to access caches.
+        // When logging in, we save the user to the cache so these need to have run.
         To<V_16_2_0.AddCacheVersionDatabaseLock>("{1DC39DC7-A88A-4912-8E60-4FD36246E8D1}");
         To<V_16_2_0.AddRepositoryCacheVersionTable>("{A1B3F5D6-4C8B-4E7A-9F8C-1D2B3E4F5A6B}");
     }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
@@ -67,5 +67,11 @@ public class UmbracoPremigrationPlan : MigrationPlan
         To<V_15_0_0.AddDocumentUrl>("{B9133686-B758-404D-AF12-708AA80C7E44}");
         To<V_14_0_0.AddPropertyEditorUiAliasColumn>("{EEB1F012-B44D-4AB4-8756-F7FB547345B4}");
         To<V_14_0_0.AddListViewKeysToDocumentTypes>("{0F49E1A4-AFD8-4673-A91B-F64E78C48174}");
+
+        // TO 16.2.0
+        // The lock and table are required to access caches
+        // When logging in, we save the user to the cache so these needs to have run.
+        To<V_16_2_0.AddCacheVersionDatabaseLock>("{1DC39DC7-A88A-4912-8E60-4FD36246E8D1}");
+        To<V_16_2_0.AddRepositoryCacheVersionTable>("{A1B3F5D6-4C8B-4E7A-9F8C-1D2B3E4F5A6B}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_2_0/AddCacheVersionDatabaseLock.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_2_0/AddCacheVersionDatabaseLock.cs
@@ -1,0 +1,33 @@
+﻿using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_16_2_0;
+
+public class AddCacheVersionDatabaseLock : AsyncMigrationBase
+{
+    public AddCacheVersionDatabaseLock(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override Task MigrateAsync()
+    {
+        Sql<ISqlContext> sql = Database.SqlContext.Sql()
+            .Select<LockDto>()
+            .From<LockDto>()
+            .Where<LockDto>(x => x.Id == Constants.Locks.CacheVersion);
+
+        LockDto? cacheVersionLock = Database.Fetch<LockDto>(sql).FirstOrDefault();
+
+
+        if (cacheVersionLock is null)
+        {
+            Database.Insert(Constants.DatabaseSchema.Tables.Lock, "id", false, new LockDto { Id = Constants.Locks.CacheVersion, Name = "CacheVersion" });
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_2_0/AddRepositoryCacheVersionTable.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_2_0/AddRepositoryCacheVersionTable.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.Table;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_16_2_0;
+
+public class AddRepositoryCacheVersionTable : AsyncMigrationBase
+{
+    public AddRepositoryCacheVersionTable(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override Task MigrateAsync()
+    {
+        if (TableExists(RepositoryCacheVersionDto.TableName) is false)
+        {
+            Create.Table<RepositoryCacheVersionDto>().Do();
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RepositoryCacheVersionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RepositoryCacheVersionDto.cs
@@ -11,10 +11,10 @@ public class RepositoryCacheVersionDto
 {
     internal const string TableName = Constants.DatabaseSchema.Tables.RepositoryCacheVersion;
 
-    [Column("cacheIdentifier")]
+    [Column("identifier")]
     [Length(256)]
     [PrimaryKeyColumn(AutoIncrement = false, Clustered = true)]
-    public required string CacheIdentifier { get; set; }
+    public required string Identifier { get; set; }
 
     [Column("version")]
     [Length(256)]

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RepositoryCacheVersionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RepositoryCacheVersionDto.cs
@@ -1,0 +1,23 @@
+using NPoco;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+[TableName(TableName)]
+[PrimaryKey("cacheIdentifier")]
+[ExplicitColumns]
+public class RepositoryCacheVersionDto
+{
+    internal const string TableName = Constants.DatabaseSchema.Tables.RepositoryCacheVersion;
+
+    [Column("cacheIdentifier")]
+    [Length(256)]
+    [PrimaryKeyColumn(AutoIncrement = false, Clustered = true)]
+    public required string CacheIdentifier { get; set; }
+
+    [Column("version")]
+    [Length(256)]
+    [NullSetting(NullSetting = NullSettings.Null)]
+    public string? Version { get; set; }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/RepositoryCacheVersionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/RepositoryCacheVersionDto.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
 namespace Umbraco.Cms.Infrastructure.Persistence.Dtos;
 
 [TableName(TableName)]
-[PrimaryKey("cacheIdentifier")]
+[PrimaryKey("identifier", AutoIncrement = false)]
 [ExplicitColumns]
 public class RepositoryCacheVersionDto
 {
@@ -13,7 +13,7 @@ public class RepositoryCacheVersionDto
 
     [Column("identifier")]
     [Length(256)]
-    [PrimaryKeyColumn(AutoIncrement = false, Clustered = true)]
+    [PrimaryKeyColumn(Name = "PK_umbracoRepositoryCacheVersion", AutoIncrement = false, Clustered = true)]
     public required string Identifier { get; set; }
 
     [Column("version")]

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
@@ -21,8 +21,16 @@ internal class AuditEntryRepository : EntityRepositoryBase<int, IAuditEntry>, IA
     /// <summary>
     ///     Initializes a new instance of the <see cref="AuditEntryRepository" /> class.
     /// </summary>
-    public AuditEntryRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<AuditEntryRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public AuditEntryRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<AuditEntryRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
@@ -14,8 +14,15 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class AuditRepository : EntityRepositoryBase<int, IAuditItem>, IAuditRepository
 {
-    public AuditRepository(IScopeAccessor scopeAccessor, ILogger<AuditRepository> logger)
-        : base(scopeAccessor, AppCaches.NoCache, logger)
+    public AuditRepository(
+        IScopeAccessor scopeAccessor,
+        ILogger<AuditRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            AppCaches.NoCache,
+            logger,
+            repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ConsentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ConsentRepository.cs
@@ -20,8 +20,16 @@ internal class ConsentRepository : EntityRepositoryBase<int, IConsent>, IConsent
     /// <summary>
     ///     Initializes a new instance of the <see cref="ConsentRepository" /> class.
     /// </summary>
-    public ConsentRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<ConsentRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public ConsentRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<ConsentRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -63,7 +63,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             _eventAggregator = eventAggregator;
         }
 
-        [Obsolete("Use the constructor with IRepositoryCacheVersionService instead. Scheduled for removal in v18.")]
+        [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
         protected ContentRepositoryBase(
             IScopeAccessor scopeAccessor,
             AppCaches cache,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -25,8 +25,16 @@ internal class ContentTypeRepository : ContentTypeRepositoryBase<IContentType>, 
         ILogger<ContentTypeRepository> logger,
         IContentTypeCommonRepository commonRepository,
         ILanguageRepository languageRepository,
-        IShortStringHelper shortStringHelper)
-        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            commonRepository,
+            languageRepository,
+            shortStringHelper,
+            repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -30,10 +30,15 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
 {
     private readonly IShortStringHelper _shortStringHelper;
 
-    protected ContentTypeRepositoryBase(IScopeAccessor scopeAccessor, AppCaches cache,
-        ILogger<ContentTypeRepositoryBase<TEntity>> logger, IContentTypeCommonRepository commonRepository,
-        ILanguageRepository languageRepository, IShortStringHelper shortStringHelper)
-        : base(scopeAccessor, cache, logger)
+    protected ContentTypeRepositoryBase(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<ContentTypeRepositoryBase<TEntity>> logger,
+        IContentTypeCommonRepository commonRepository,
+        ILanguageRepository languageRepository,
+        IShortStringHelper shortStringHelper,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
         _shortStringHelper = shortStringHelper;
         CommonRepository = commonRepository;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeContainerRepository.cs
@@ -11,8 +11,9 @@ internal class DataTypeContainerRepository : EntityContainerRepository, IDataTyp
     public DataTypeContainerRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
-        ILogger<DataTypeContainerRepository> logger)
-        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DataTypeContainer)
+        ILogger<DataTypeContainerRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DataTypeContainer, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -39,8 +39,14 @@ internal class DataTypeRepository : EntityRepositoryBase<int, IDataType>, IDataT
         PropertyEditorCollection editors,
         ILogger<DataTypeRepository> logger,
         ILoggerFactory loggerFactory,
-        IConfigurationEditorJsonSerializer serializer)
-        : base(scopeAccessor, cache, logger)
+        IConfigurationEditorJsonSerializer serializer,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService
+            )
     {
         _editors = editors;
         _serializer = serializer;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintContainerRepository.cs
@@ -11,8 +11,8 @@ internal class DocumentBlueprintContainerRepository : EntityContainerRepository,
     public DocumentBlueprintContainerRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
-        ILogger<DocumentBlueprintContainerRepository> logger)
-        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DocumentBlueprintContainer)
+        ILogger<DocumentBlueprintContainerRepository> logger, IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DocumentBlueprintContainer, repositoryCacheVersionService)
     {
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -87,7 +87,7 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
             repositoryCacheVersionService);
     }
 
-    [Obsolete("Use constructor with IRepositoryCacheVersionService instead. Scheduled for removal in v18.")]
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     public DocumentRepository(
         IScopeAccessor scopeAccessor,
         AppCaches appCaches,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1,8 +1,10 @@
 using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
@@ -33,31 +35,59 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
     private readonly ILoggerFactory _loggerFactory;
     private readonly IScopeAccessor _scopeAccessor;
     private readonly IJsonSerializer _serializer;
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
     private readonly ITagRepository _tagRepository;
     private readonly ITemplateRepository _templateRepository;
     private PermissionRepository<IContent>? _permissionRepository;
 
-    /// <summary>
-    ///     Constructor
-    /// </summary>
-    /// <param name="scopeAccessor"></param>
-    /// <param name="appCaches"></param>
-    /// <param name="logger"></param>
-    /// <param name="loggerFactory"></param>
-    /// <param name="contentTypeRepository"></param>
-    /// <param name="templateRepository"></param>
-    /// <param name="tagRepository"></param>
-    /// <param name="languageRepository"></param>
-    /// <param name="relationRepository"></param>
-    /// <param name="relationTypeRepository"></param>
-    /// <param name="dataValueReferenceFactories"></param>
-    /// <param name="dataTypeService"></param>
-    /// <param name="serializer"></param>
-    /// <param name="eventAggregator"></param>
-    /// <param name="propertyEditors">
-    ///     Lazy property value collection - must be lazy because we have a circular dependency since some property editors
-    ///     require services, yet these services require property editors
-    /// </param>
+    public DocumentRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches appCaches,
+        ILogger<DocumentRepository> logger,
+        ILoggerFactory loggerFactory,
+        IContentTypeRepository contentTypeRepository,
+        ITemplateRepository templateRepository,
+        ITagRepository tagRepository,
+        ILanguageRepository languageRepository,
+        IRelationRepository relationRepository,
+        IRelationTypeRepository relationTypeRepository,
+        PropertyEditorCollection propertyEditors,
+        DataValueReferenceFactoryCollection dataValueReferenceFactories,
+        IDataTypeService dataTypeService,
+        IJsonSerializer serializer,
+        IEventAggregator eventAggregator,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            appCaches,
+            logger,
+            languageRepository,
+            relationRepository,
+            relationTypeRepository,
+            propertyEditors,
+            dataValueReferenceFactories,
+            dataTypeService,
+            eventAggregator,
+            repositoryCacheVersionService)
+    {
+        _contentTypeRepository =
+            contentTypeRepository ?? throw new ArgumentNullException(nameof(contentTypeRepository));
+        _templateRepository = templateRepository ?? throw new ArgumentNullException(nameof(templateRepository));
+        _tagRepository = tagRepository ?? throw new ArgumentNullException(nameof(tagRepository));
+        _serializer = serializer;
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _appCaches = appCaches;
+        _loggerFactory = loggerFactory;
+        _scopeAccessor = scopeAccessor;
+        _contentByGuidReadRepository = new ContentByGuidReadRepository(
+            this,
+            scopeAccessor,
+            appCaches,
+            loggerFactory.CreateLogger<ContentByGuidReadRepository>(),
+            repositoryCacheVersionService);
+    }
+
+    [Obsolete("Use constructor with IRepositoryCacheVersionService instead. Scheduled for removal in v18.")]
     public DocumentRepository(
         IScopeAccessor scopeAccessor,
         AppCaches appCaches,
@@ -74,19 +104,24 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
         IDataTypeService dataTypeService,
         IJsonSerializer serializer,
         IEventAggregator eventAggregator)
-        : base(scopeAccessor, appCaches, logger, languageRepository, relationRepository, relationTypeRepository,
-            propertyEditors, dataValueReferenceFactories, dataTypeService, eventAggregator)
+        : this(
+            scopeAccessor,
+            appCaches,
+            logger,
+            loggerFactory,
+            contentTypeRepository,
+            templateRepository,
+            tagRepository,
+            languageRepository,
+            relationRepository,
+            relationTypeRepository,
+            propertyEditors,
+            dataValueReferenceFactories,
+            dataTypeService,
+            serializer,
+            eventAggregator,
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
     {
-        _contentTypeRepository =
-            contentTypeRepository ?? throw new ArgumentNullException(nameof(contentTypeRepository));
-        _templateRepository = templateRepository ?? throw new ArgumentNullException(nameof(templateRepository));
-        _tagRepository = tagRepository ?? throw new ArgumentNullException(nameof(tagRepository));
-        _serializer = serializer;
-        _appCaches = appCaches;
-        _loggerFactory = loggerFactory;
-        _scopeAccessor = scopeAccessor;
-        _contentByGuidReadRepository = new ContentByGuidReadRepository(this, scopeAccessor, appCaches,
-            loggerFactory.CreateLogger<ContentByGuidReadRepository>());
     }
 
     protected override DocumentRepository This => this;
@@ -101,7 +136,8 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
                                                                        new PermissionRepository<IContent>(
                                                                            _scopeAccessor,
                                                                            _appCaches,
-                                                                           _loggerFactory.CreateLogger<PermissionRepository<IContent>>());
+                                                                           _loggerFactory.CreateLogger<PermissionRepository<IContent>>(),
+                                                                           _repositoryCacheVersionService);
 
     /// <inheritdoc />
     public ContentScheduleCollection GetContentSchedule(int contentId)
@@ -1557,9 +1593,13 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
     {
         private readonly DocumentRepository _outerRepo;
 
-        public ContentByGuidReadRepository(DocumentRepository outerRepo, IScopeAccessor scopeAccessor, AppCaches cache,
-            ILogger<ContentByGuidReadRepository> logger)
-            : base(scopeAccessor, cache, logger) =>
+        public ContentByGuidReadRepository(
+            DocumentRepository outerRepo,
+            IScopeAccessor scopeAccessor,
+            AppCaches cache,
+            ILogger<ContentByGuidReadRepository> logger,
+            IRepositoryCacheVersionService repositoryCacheVersionService)
+            : base(scopeAccessor, cache, logger, repositoryCacheVersionService) =>
             _outerRepo = outerRepo;
 
         protected override IContent? PerformGet(Guid id)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentTypeContainerRepository.cs
@@ -8,8 +8,17 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class DocumentTypeContainerRepository : EntityContainerRepository, IDocumentTypeContainerRepository
 {
-    public DocumentTypeContainerRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<DocumentTypeContainerRepository> logger)
-        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DocumentTypeContainer)
+    public DocumentTypeContainerRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<DocumentTypeContainerRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            Constants.ObjectTypes.DocumentTypeContainer,
+            repositoryCacheVersionService)
     {
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
@@ -15,8 +15,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class DomainRepository : EntityRepositoryBase<int, IDomain>, IDomainRepository
 {
-    public DomainRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<DomainRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public DomainRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<DomainRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     { }
 
     public IDomain? GetByName(string domainName)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
@@ -16,9 +16,13 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// </summary>
 internal class EntityContainerRepository : EntityRepositoryBase<int, EntityContainer>, IEntityContainerRepository
 {
-    public EntityContainerRepository(IScopeAccessor scopeAccessor, AppCaches cache,
-        ILogger<EntityContainerRepository> logger, Guid containerObjectType)
-        : base(scopeAccessor, cache, logger)
+    public EntityContainerRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<EntityContainerRepository> logger,
+        Guid containerObjectType,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
         Guid[] allowedContainers =
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
@@ -41,7 +41,7 @@ public abstract class EntityRepositoryBase<TId, TEntity> : RepositoryBase, IRead
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    [Obsolete("Use the constructor with IRepositoryCacheVersionService instead. Scheduled for removal in v18.")]
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     protected EntityRepositoryBase(IScopeAccessor scopeAccessor, AppCaches appCaches,
         ILogger<EntityRepositoryBase<TId, TEntity>> logger)
         : this(

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
@@ -1,7 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Persistence;
 using Umbraco.Cms.Core.Persistence.Querying;
@@ -20,6 +22,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 public abstract class EntityRepositoryBase<TId, TEntity> : RepositoryBase, IReadWriteQueryRepository<TId, TEntity>
     where TEntity : class, IEntity
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
     private static RepositoryCachePolicyOptions? _defaultOptions;
     private IRepositoryCachePolicy<TEntity, TId>? _cachePolicy;
     private IQuery<TEntity>? _hasIdQuery;
@@ -27,9 +30,27 @@ public abstract class EntityRepositoryBase<TId, TEntity> : RepositoryBase, IRead
     /// <summary>
     ///     Initializes a new instance of the <see cref="EntityRepositoryBase{TId, TEntity}" /> class.
     /// </summary>
-    protected EntityRepositoryBase(IScopeAccessor scopeAccessor, AppCaches appCaches, ILogger<EntityRepositoryBase<TId, TEntity>> logger)
-        : base(scopeAccessor, appCaches) =>
+    protected EntityRepositoryBase(
+        IScopeAccessor scopeAccessor,
+        AppCaches appCaches,
+        ILogger<EntityRepositoryBase<TId, TEntity>> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, appCaches)
+    {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    [Obsolete("Use the constructor with IRepositoryCacheVersionService instead. Scheduled for removal in v18.")]
+    protected EntityRepositoryBase(IScopeAccessor scopeAccessor, AppCaches appCaches,
+        ILogger<EntityRepositoryBase<TId, TEntity>> logger)
+        : this(
+            scopeAccessor,
+            appCaches,
+            logger,
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+    {
+    }
 
     /// <summary>
     ///     Gets the logger
@@ -194,7 +215,7 @@ public abstract class EntityRepositoryBase<TId, TEntity> : RepositoryBase, IRead
     ///     Create the repository cache policy
     /// </summary>
     protected virtual IRepositoryCachePolicy<TEntity, TId> CreateCachePolicy()
-        => new DefaultRepositoryCachePolicy<TEntity, TId>(GlobalIsolatedCache, ScopeAccessor, DefaultOptions);
+        => new DefaultRepositoryCachePolicy<TEntity, TId>(GlobalIsolatedCache, ScopeAccessor, DefaultOptions, _repositoryCacheVersionService);
 
     protected abstract TEntity? PerformGet(TId? id);
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -16,9 +16,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class ExternalLoginRepository : EntityRepositoryBase<int, IIdentityUserLogin>, IExternalLoginWithKeyRepository
 {
-    public ExternalLoginRepository(IScopeAccessor scopeAccessor, AppCaches cache,
-        ILogger<ExternalLoginRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public ExternalLoginRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<ExternalLoginRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger,  repositoryCacheVersionService)
     {
     }
     /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/KeyValueRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/KeyValueRepository.cs
@@ -14,8 +14,11 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class KeyValueRepository : EntityRepositoryBase<string, IKeyValue>, IKeyValueRepository
 {
-    public KeyValueRepository(IScopeAccessor scopeAccessor, ILogger<KeyValueRepository> logger)
-        : base(scopeAccessor, AppCaches.NoCache, logger)
+    public KeyValueRepository(
+        IScopeAccessor scopeAccessor,
+        ILogger<KeyValueRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, AppCaches.NoCache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -24,8 +24,12 @@ internal class LanguageRepository : EntityRepositoryBase<int, ILanguage>, ILangu
     private readonly Dictionary<string, int> _codeIdMap = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<int, string> _idCodeMap = new();
 
-    public LanguageRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<LanguageRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public LanguageRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<LanguageRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger,  repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
@@ -14,8 +14,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class LogViewerQueryRepository : EntityRepositoryBase<int, ILogViewerQuery>, ILogViewerQueryRepository
 {
-    public LogViewerQueryRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<LogViewerQueryRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public LogViewerQueryRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<LogViewerQueryRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -78,6 +78,7 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             repositoryCacheVersionService);
     }
 
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     public MediaRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -1,8 +1,10 @@
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -48,9 +50,20 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
         DataValueReferenceFactoryCollection dataValueReferenceFactories,
         IDataTypeService dataTypeService,
         IJsonSerializer serializer,
-        IEventAggregator eventAggregator)
-        : base(scopeAccessor, cache, logger, languageRepository, relationRepository, relationTypeRepository,
-            propertyEditorCollection, dataValueReferenceFactories, dataTypeService, eventAggregator)
+        IEventAggregator eventAggregator,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            languageRepository,
+            relationRepository,
+            relationTypeRepository,
+            propertyEditorCollection,
+            dataValueReferenceFactories,
+            dataTypeService,
+            eventAggregator,
+            repositoryCacheVersionService)
     {
         _cache = cache;
         _mediaTypeRepository = mediaTypeRepository ?? throw new ArgumentNullException(nameof(mediaTypeRepository));
@@ -61,7 +74,44 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             this,
             scopeAccessor,
             cache,
-            loggerFactory.CreateLogger<MediaByGuidReadRepository>());
+            loggerFactory.CreateLogger<MediaByGuidReadRepository>(),
+            repositoryCacheVersionService);
+    }
+
+    public MediaRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<MediaRepository> logger,
+        ILoggerFactory loggerFactory,
+        IMediaTypeRepository mediaTypeRepository,
+        ITagRepository tagRepository,
+        ILanguageRepository languageRepository,
+        IRelationRepository relationRepository,
+        IRelationTypeRepository relationTypeRepository,
+        PropertyEditorCollection propertyEditorCollection,
+        MediaUrlGeneratorCollection mediaUrlGenerators,
+        DataValueReferenceFactoryCollection dataValueReferenceFactories,
+        IDataTypeService dataTypeService,
+        IJsonSerializer serializer,
+        IEventAggregator eventAggregator)
+        : this(scopeAccessor,
+            cache,
+            logger,
+            loggerFactory,
+            mediaTypeRepository,
+            tagRepository,
+            languageRepository,
+            relationRepository,
+            relationTypeRepository,
+            propertyEditorCollection,
+            mediaUrlGenerators,
+            dataValueReferenceFactories,
+            dataTypeService,
+            serializer,
+            eventAggregator,
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>()
+            )
+    {
     }
 
     protected override MediaRepository This => this;
@@ -526,8 +576,13 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
     {
         private readonly MediaRepository _outerRepo;
 
-        public MediaByGuidReadRepository(MediaRepository outerRepo, IScopeAccessor scopeAccessor, AppCaches cache, ILogger<MediaByGuidReadRepository> logger)
-            : base(scopeAccessor, cache, logger) =>
+        public MediaByGuidReadRepository(
+            MediaRepository outerRepo,
+            IScopeAccessor scopeAccessor,
+            AppCaches cache,
+            ILogger<MediaByGuidReadRepository> logger,
+            IRepositoryCacheVersionService repositoryCacheVersionService)
+            : base(scopeAccessor, cache, logger,  repositoryCacheVersionService) =>
             _outerRepo = outerRepo;
 
         protected override IMedia? PerformGet(Guid id)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeContainerRepository.cs
@@ -8,8 +8,17 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class MediaTypeContainerRepository : EntityContainerRepository, IMediaTypeContainerRepository
 {
-    public MediaTypeContainerRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<MediaTypeContainerRepository> logger)
-        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.MediaTypeContainer)
+    public MediaTypeContainerRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<MediaTypeContainerRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            Constants.ObjectTypes.MediaTypeContainer,
+            repositoryCacheVersionService)
     {
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -24,8 +24,16 @@ internal class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType>, IMed
         ILogger<MediaTypeRepository> logger,
         IContentTypeCommonRepository commonRepository,
         ILanguageRepository languageRepository,
-        IShortStringHelper shortStringHelper)
-        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper)
+        IShortStringHelper shortStringHelper,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            commonRepository,
+            languageRepository,
+            shortStringHelper,
+            repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -19,9 +19,13 @@ internal class MemberGroupRepository : EntityRepositoryBase<int, IMemberGroup>, 
 {
     private readonly IEventMessagesFactory _eventMessagesFactory;
 
-    public MemberGroupRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<MemberGroupRepository> logger,
-        IEventMessagesFactory eventMessagesFactory)
-        : base(scopeAccessor, cache, logger) =>
+    public MemberGroupRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<MemberGroupRepository> logger,
+        IEventMessagesFactory eventMessagesFactory,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService) =>
         _eventMessagesFactory = eventMessagesFactory;
 
     protected Guid NodeObjectTypeId => Constants.ObjectTypes.MemberGroup;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -5,6 +6,7 @@ using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
@@ -56,9 +58,20 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
         IDataTypeService dataTypeService,
         IJsonSerializer serializer,
         IEventAggregator eventAggregator,
-        IOptions<MemberPasswordConfigurationSettings> passwordConfiguration)
-        : base(scopeAccessor, cache, logger, languageRepository, relationRepository, relationTypeRepository,
-            propertyEditors, dataValueReferenceFactories, dataTypeService, eventAggregator)
+        IOptions<MemberPasswordConfigurationSettings> passwordConfiguration,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            languageRepository,
+            relationRepository,
+            relationTypeRepository,
+            propertyEditors,
+            dataValueReferenceFactories,
+            dataTypeService,
+            eventAggregator,
+            repositoryCacheVersionService)
     {
         _memberTypeRepository =
             memberTypeRepository ?? throw new ArgumentNullException(nameof(memberTypeRepository));
@@ -68,7 +81,46 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
         _memberGroupRepository = memberGroupRepository;
         _passwordConfiguration = passwordConfiguration.Value;
         _memberByUsernameCachePolicy =
-            new MemberRepositoryUsernameCachePolicy(GlobalIsolatedCache, ScopeAccessor, DefaultOptions);
+            new MemberRepositoryUsernameCachePolicy(GlobalIsolatedCache, ScopeAccessor, DefaultOptions, repositoryCacheVersionService);
+    }
+
+    [Obsolete("Use the constructor with IRepositoryCacheVersionService parameter instead. Scheduled for removal in v18.")]
+    public MemberRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<MemberRepository> logger,
+        IMemberTypeRepository memberTypeRepository,
+        IMemberGroupRepository memberGroupRepository,
+        ITagRepository tagRepository,
+        ILanguageRepository languageRepository,
+        IRelationRepository relationRepository,
+        IRelationTypeRepository relationTypeRepository,
+        IPasswordHasher passwordHasher,
+        PropertyEditorCollection propertyEditors,
+        DataValueReferenceFactoryCollection dataValueReferenceFactories,
+        IDataTypeService dataTypeService,
+        IJsonSerializer serializer,
+        IEventAggregator eventAggregator,
+        IOptions<MemberPasswordConfigurationSettings> passwordConfiguration)
+        : this(
+            scopeAccessor,
+            cache,
+            logger,
+            memberTypeRepository,
+            memberGroupRepository,
+            tagRepository,
+            languageRepository,
+            relationRepository,
+            relationTypeRepository,
+            passwordHasher,
+            propertyEditors,
+            dataValueReferenceFactories,
+            dataTypeService,
+            serializer,
+            eventAggregator,
+            passwordConfiguration,
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+    {
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -84,7 +84,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
             new MemberRepositoryUsernameCachePolicy(GlobalIsolatedCache, ScopeAccessor, DefaultOptions, repositoryCacheVersionService);
     }
 
-    [Obsolete("Use the constructor with IRepositoryCacheVersionService parameter instead. Scheduled for removal in v18.")]
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     public MemberRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -27,8 +27,16 @@ internal class MemberTypeRepository : ContentTypeRepositoryBase<IMemberType>, IM
         ILogger<MemberTypeRepository> logger,
         IContentTypeCommonRepository commonRepository,
         ILanguageRepository languageRepository,
-        IShortStringHelper shortStringHelper)
-        : base(scopeAccessor, cache, logger, commonRepository, languageRepository, shortStringHelper) =>
+        IShortStringHelper shortStringHelper,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            commonRepository,
+            languageRepository,
+            shortStringHelper,
+            repositoryCacheVersionService) =>
         _shortStringHelper = shortStringHelper;
 
     protected override bool SupportsPublishing => MemberType.SupportsPublishingConst;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PermissionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PermissionRepository.cs
@@ -26,8 +26,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 internal class PermissionRepository<TEntity> : EntityRepositoryBase<int, ContentPermissionSet>
     where TEntity : class, IEntity
 {
-    public PermissionRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<PermissionRepository<TEntity>> logger)
-        : base(scopeAccessor, cache, logger)
+    public PermissionRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<PermissionRepository<TEntity>> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
@@ -15,8 +15,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class PublicAccessRepository : EntityRepositoryBase<Guid, PublicAccessEntry>, IPublicAccessRepository
 {
-    public PublicAccessRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<PublicAccessRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public PublicAccessRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<PublicAccessRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -14,8 +14,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedirectUrl>, IRedirectUrlRepository
 {
-    public RedirectUrlRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<RedirectUrlRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public RedirectUrlRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<RedirectUrlRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -26,8 +26,13 @@ internal class RelationRepository : EntityRepositoryBase<int, IRelation>, IRelat
     private readonly IEntityRepositoryExtended _entityRepository;
     private readonly IRelationTypeRepository _relationTypeRepository;
 
-    public RelationRepository(IScopeAccessor scopeAccessor, ILogger<RelationRepository> logger, IRelationTypeRepository relationTypeRepository, IEntityRepositoryExtended entityRepository)
-        : base(scopeAccessor, AppCaches.NoCache, logger)
+    public RelationRepository(
+        IScopeAccessor scopeAccessor,
+        ILogger<RelationRepository> logger,
+        IRelationTypeRepository relationTypeRepository,
+        IEntityRepositoryExtended entityRepository,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, AppCaches.NoCache, logger, repositoryCacheVersionService)
     {
         _relationTypeRepository = relationTypeRepository;
         _entityRepository = entityRepository;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationTypeRepository.cs
@@ -19,8 +19,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// </summary>
 internal sealed class RelationTypeRepository : EntityRepositoryBase<int, IRelationType>, IRelationTypeRepository
 {
-    public RelationTypeRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<RelationTypeRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public RelationTypeRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<RelationTypeRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RepositoryCacheVersionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RepositoryCacheVersionRepository.cs
@@ -25,13 +25,13 @@ internal class RepositoryCacheVersionRepository : RepositoryBase, IRepositoryCac
         }
 
         Sql<ISqlContext> query = Sql()
-            .Select<RepositoryCacheVersionDto>()
+            .Select<RepositoryCacheVersionDto>(x => x.Version)
             .From<RepositoryCacheVersionDto>()
             .Where<RepositoryCacheVersionDto>(x => x.Identifier == identifier);
 
-        RepositoryCacheVersionDto? dto = (await Database.FetchAsync<RepositoryCacheVersionDto>(query)).FirstOrDefault();
+        var version = await Database.ExecuteScalarAsync<string?>(query);
 
-        return Map(dto);
+        return new RepositoryCacheVersion { Identifier = identifier, Version = version };
     }
 
     public async Task<IEnumerable<RepositoryCacheVersion>> GetAllAsync()
@@ -48,10 +48,7 @@ internal class RepositoryCacheVersionRepository : RepositoryBase, IRepositoryCac
     public async Task SaveAsync(RepositoryCacheVersion repositoryCacheVersion)
     {
         RepositoryCacheVersionDto dto = Map(repositoryCacheVersion);
-        await Database.InsertOrUpdateAsync(
-            dto,
-            "SET identifier = @identifier, version = @version",
-            new { identifier = dto.Identifier, version = dto.Version, });
+        await Database.InsertOrUpdateAsync(dto, null, null);
     }
 
     private static RepositoryCacheVersionDto Map(RepositoryCacheVersion entity)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RepositoryCacheVersionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RepositoryCacheVersionRepository.cs
@@ -34,6 +34,16 @@ internal class RepositoryCacheVersionRepository : RepositoryBase, IRepositoryCac
         return Map(dto);
     }
 
+    public async Task<IEnumerable<RepositoryCacheVersion>> GetAllAsync()
+    {
+        Sql<ISqlContext> query = Sql()
+            .Select<RepositoryCacheVersionDto>()
+            .From<RepositoryCacheVersionDto>();
+
+        IEnumerable<RepositoryCacheVersionDto> dtos = await Database.FetchAsync<RepositoryCacheVersionDto>(query);
+        return dtos.Select(Map).Where(x => x is not null)!;
+    }
+
     /// <inheritdoc/>
     public async Task SaveAsync(RepositoryCacheVersion repositoryCacheVersion)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RepositoryCacheVersionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RepositoryCacheVersionRepository.cs
@@ -1,0 +1,52 @@
+using NPoco;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+
+/// <inheritdoc cref="IRepositoryCacheVersionRepository" />
+internal class RepositoryCacheVersionRepository : RepositoryBase, IRepositoryCacheVersionRepository
+{
+    public RepositoryCacheVersionRepository(IScopeAccessor scopeAccessor, AppCaches appCaches)
+        : base(scopeAccessor, appCaches)
+    {
+    }
+
+    /// <inheritdoc/>
+    public async Task<RepositoryCacheVersion?> GetAsync(string identifier)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            throw new ArgumentException("Identifier cannot be null or whitespace.", nameof(identifier));
+        }
+
+        Sql<ISqlContext> query = Sql()
+            .Select<RepositoryCacheVersionDto>()
+            .From<RepositoryCacheVersionDto>()
+            .Where<RepositoryCacheVersionDto>(x => x.Identifier == identifier);
+
+        RepositoryCacheVersionDto? dto = (await Database.FetchAsync<RepositoryCacheVersionDto>(query)).FirstOrDefault();
+
+        return Map(dto);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(RepositoryCacheVersion repositoryCacheVersion)
+    {
+        RepositoryCacheVersionDto dto = Map(repositoryCacheVersion);
+        await Database.InsertOrUpdateAsync(
+            dto,
+            "SET identifier = @identifier, version = @version",
+            new { identifier = dto.Identifier, version = dto.Version, });
+    }
+
+    private static RepositoryCacheVersionDto Map(RepositoryCacheVersion entity)
+        => new() { Identifier = entity.Identifier, Version = entity.Version };
+
+    private static RepositoryCacheVersion? Map(RepositoryCacheVersionDto? dto)
+        => dto is null ? null : new RepositoryCacheVersion { Identifier = dto.Identifier, Version = dto.Version };
+}

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
@@ -14,8 +14,11 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 internal class ServerRegistrationRepository : EntityRepositoryBase<int, IServerRegistration>,
     IServerRegistrationRepository
 {
-    public ServerRegistrationRepository(IScopeAccessor scopeAccessor, ILogger<ServerRegistrationRepository> logger)
-        : base(scopeAccessor, AppCaches.NoCache, logger)
+    public ServerRegistrationRepository(
+        IScopeAccessor scopeAccessor,
+        ILogger<ServerRegistrationRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, AppCaches.NoCache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimpleGetRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimpleGetRepository.cs
@@ -18,8 +18,12 @@ internal abstract class SimpleGetRepository<TId, TEntity, TDto> : EntityReposito
     where TEntity : class, IEntity
     where TDto : class
 {
-    protected SimpleGetRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<SimpleGetRepository<TId, TEntity, TDto>> logger)
-        : base(scopeAccessor, cache, logger)
+    protected SimpleGetRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<SimpleGetRepository<TId, TEntity, TDto>> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -17,8 +17,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class TagRepository : EntityRepositoryBase<int, ITag>, ITagRepository
 {
-    public TagRepository(IScopeAccessor scopeAccessor, AppCaches cache, ILogger<TagRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public TagRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<TagRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -38,8 +38,9 @@ internal class TemplateRepository : EntityRepositoryBase<int, ITemplate>, ITempl
         IIOHelper ioHelper,
         IShortStringHelper shortStringHelper,
         IViewHelper viewHelper,
-        IOptionsMonitor<RuntimeSettings> runtimeSettings)
-        : base(scopeAccessor, cache, logger)
+        IOptionsMonitor<RuntimeSettings> runtimeSettings,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
         _ioHelper = ioHelper;
         _shortStringHelper = shortStringHelper;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TwoFactorLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TwoFactorLoginRepository.cs
@@ -14,9 +14,12 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal class TwoFactorLoginRepository : EntityRepositoryBase<int, ITwoFactorLogin>, ITwoFactorLoginRepository
 {
-    public TwoFactorLoginRepository(IScopeAccessor scopeAccessor, AppCaches cache,
-        ILogger<TwoFactorLoginRepository> logger)
-        : base(scopeAccessor, cache, logger)
+    public TwoFactorLoginRepository(
+        IScopeAccessor scopeAccessor,
+        AppCaches cache,
+        ILogger<TwoFactorLoginRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserGroupRepository.cs
@@ -56,6 +56,7 @@ public class UserGroupRepository : EntityRepositoryBase<int, IUserGroup>, IUserG
         _permissionMappers = permissionMappers.ToDictionary(x => x.Context);
     }
 
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
     public UserGroupRepository(
         IScopeAccessor scopeAccessor,
         AppCaches appCaches,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -55,6 +55,7 @@ internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserReposito
     /// <param name="runtimeState">State of the runtime.</param>
     /// <param name="permissionMappers">The permission mappers.</param>
     /// <param name="globalCache">The app policy cache.</param>
+    /// <param name="repositoryCacheVersionService"></param>
     /// <exception cref="System.ArgumentNullException">
     ///     mapperCollection
     ///     or
@@ -72,8 +73,9 @@ internal class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserReposito
         IJsonSerializer jsonSerializer,
         IRuntimeState runtimeState,
         IEnumerable<IPermissionMapper> permissionMappers,
-        IAppPolicyCache globalCache)
-        : base(scopeAccessor, appCaches, logger)
+        IAppPolicyCache globalCache,
+        IRepositoryCacheVersionService repositoryCacheVersionService)
+        : base(scopeAccessor, appCaches, logger, repositoryCacheVersionService)
     {
         _scopeAccessor = scopeAccessor;
         _mapperCollection = mapperCollection ?? throw new ArgumentNullException(nameof(mapperCollection));

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
@@ -1,0 +1,106 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Console)]
+internal sealed class RepositoryCacheVersionServiceTests : UmbracoIntegrationTest
+{
+    private IRepositoryCacheVersionService RepositoryCacheVersionService => GetRequiredService<IRepositoryCacheVersionService>();
+
+    private IRepositoryCacheVersionRepository RepositoryCacheVersionRepository => GetRequiredService<IRepositoryCacheVersionRepository>();
+
+    private ICoreScopeProvider CoreScopeProvider => GetRequiredService<ICoreScopeProvider>();
+
+    [Test]
+    public async Task Cache_Is_Initially_Synced()
+    {
+        var isSynced = await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>();
+        Assert.IsTrue(isSynced, "Cache should be initially synced.");
+    }
+
+    [Test]
+    public async Task SetCacheUpdatedAsync_Writes_Version_To_Database()
+    {
+        using var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true);
+        var initial = await RepositoryCacheVersionRepository.GetAsync(GetCacheKey());
+        Assert.IsNull(initial?.Version, "Initial cache version should be null before update.");
+
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+
+        var cacheVersion = await RepositoryCacheVersionRepository.GetAsync(GetCacheKey());
+        Assert.IsNotNull(cacheVersion, "Cache version should exist in the database after update.");
+        Assert.IsFalse(string.IsNullOrEmpty(cacheVersion.Version), "Cache version string should not be null or empty.");
+    }
+
+    [Test]
+    public async Task Cache_Is_Out_Of_Sync_If_Updated_Remotely()
+    {
+        // Simulate an update
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        var isSynced = await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>();
+
+        // We should be synced now.
+        Assert.IsTrue(isSynced);
+
+        using (var scope = CoreScopeProvider.CreateCoreScope())
+        {
+            // Simulate a remote update to the database
+            await RepositoryCacheVersionRepository.SaveAsync(GetRepositoryRandomCacheVersion());
+            scope.Complete();
+        }
+
+        // Now the cache should be out of sync
+        isSynced = await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>();
+        Assert.IsFalse(isSynced, "Cache should be out of sync after remote update.");
+    }
+
+    [Test]
+    public async Task SetCacheUpdatedAsync_Updates_Cache_Version()
+    {
+        using var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true);
+
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        var initialCacheVersion = await RepositoryCacheVersionRepository.GetAsync(GetCacheKey());
+        Assert.IsNotNull(initialCacheVersion, "Initial cache version should not be null.");
+
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        var updatedCacheVersion = await RepositoryCacheVersionRepository.GetAsync(GetCacheKey());
+        Assert.IsNotNull(updatedCacheVersion, "Updated cache version should not be null.");
+
+        Assert.AreNotEqual(initialCacheVersion.Version, updatedCacheVersion.Version, "Cache version should be updated.");
+    }
+
+    [Test]
+    public async Task CacheVersion_Is_Unique_Per_Repository_Type()
+    {
+        using var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true);
+
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IMedia>();
+
+        var contentVersion = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        var mediaKey = ((RepositoryCacheVersionService)RepositoryCacheVersionService).GetCacheKey<IMedia>();
+        var mediaVersion = (await RepositoryCacheVersionRepository.GetAsync(mediaKey))?.Version;
+
+        Assert.IsNotNull(contentVersion);
+        Assert.IsNotNull(mediaVersion);
+        Assert.AreNotEqual(contentVersion, mediaVersion, "Cache versions should be unique for different repository types.");
+    }
+
+    private RepositoryCacheVersion GetRepositoryRandomCacheVersion()
+        => new()
+        {
+            Identifier = GetCacheKey(),
+            Version = Guid.NewGuid().ToString(),
+        };
+
+    private string GetCacheKey()
+        => ((RepositoryCacheVersionService)RepositoryCacheVersionService).GetCacheKey<IContent>();
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/AuditRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/AuditRepositoryTest.cs
@@ -2,8 +2,10 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -34,7 +36,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = ScopeProvider.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
             repo.Save(new AuditItem(-1, AuditType.System, -1, UmbracoObjectTypes.Document.GetName(), "This is a System audit trail"));
 
             var dtos = ScopeAccessor.AmbientScope.Database.Fetch<LogDto>("WHERE id > -1");
@@ -82,7 +84,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -95,7 +97,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             var page = repo.GetPagedResultsByQuery(sp.CreateQuery<IAuditItem>(), 0, 10, out var total, Direction.Descending, null, null);
 
@@ -110,7 +112,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -123,7 +125,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             var query = sp.CreateQuery<IAuditItem>().Where(x => x.UserId == -1);
 
@@ -159,7 +161,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -172,7 +174,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             var page = repo.GetPagedResultsByQuery(
                     sp.CreateQuery<IAuditItem>(),
@@ -196,7 +198,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -209,7 +211,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger);
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
 
             var page = repo.GetPagedResultsByQuery(
                     sp.CreateQuery<IAuditItem>(),

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
@@ -90,7 +90,8 @@ internal sealed class ContentTypeRepositoryTest : UmbracoIntegrationTest
                 IOHelper,
                 ShortStringHelper,
                 Mock.Of<IViewHelper>(),
-                runtimeSettingsMock.Object);
+                runtimeSettingsMock.Object,
+                Mock.Of<IRepositoryCacheVersionService>());
             var repository = ContentTypeRepository;
             Template[] templates =
             {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -103,7 +103,7 @@ internal sealed class DocumentRepositoryTest : UmbracoIntegrationTest
 
         var ctRepository = CreateRepository(scopeAccessor, out contentTypeRepository, out TemplateRepository tr);
         var editors = new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
-        dtdRepository = new DataTypeRepository(scopeAccessor, appCaches, editors, LoggerFactory.CreateLogger<DataTypeRepository>(), LoggerFactory, ConfigurationEditorJsonSerializer);
+        dtdRepository = new DataTypeRepository(scopeAccessor, appCaches, editors, LoggerFactory.CreateLogger<DataTypeRepository>(), LoggerFactory, ConfigurationEditorJsonSerializer, Mock.Of<IRepositoryCacheVersionService>());
         return ctRepository;
     }
 
@@ -117,16 +117,16 @@ internal sealed class DocumentRepositoryTest : UmbracoIntegrationTest
         var runtimeSettingsMock = new Mock<IOptionsMonitor<RuntimeSettings>>();
         runtimeSettingsMock.Setup(x => x.CurrentValue).Returns(new RuntimeSettings());
 
-        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object);
-        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>());
+        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object,  Mock.Of<IRepositoryCacheVersionService>());
+        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
         var commonRepository =
             new ContentTypeCommonRepository(scopeAccessor, templateRepository, appCaches, ShortStringHelper);
         var languageRepository =
-            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>());
-        contentTypeRepository = new ContentTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper);
-        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
+            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        contentTypeRepository = new ContentTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>());
+        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
         var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
-        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);
+        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
         var propertyEditors =
             new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
         var dataValueReferences =

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DomainRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DomainRepositoryTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -32,7 +33,7 @@ internal sealed class DomainRepositoryTest : UmbracoIntegrationTest
     {
         var accessor = (IScopeAccessor)provider;
         var domainRepository =
-            new DomainRepository(accessor, AppCaches.NoCache, LoggerFactory.CreateLogger<DomainRepository>());
+            new DomainRepository(accessor, AppCaches.NoCache, LoggerFactory.CreateLogger<DomainRepository>(), Mock.Of<IRepositoryCacheVersionService>());
         return domainRepository;
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/KeyValueRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/KeyValueRepositoryTests.cs
@@ -2,7 +2,9 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
@@ -64,5 +66,5 @@ internal sealed class KeyValueRepositoryTests : UmbracoIntegrationTest
     }
 
     private IKeyValueRepository CreateRepository(ICoreScopeProvider provider) =>
-        new KeyValueRepository((IScopeAccessor)provider, LoggerFactory.CreateLogger<KeyValueRepository>());
+        new KeyValueRepository((IScopeAccessor)provider, LoggerFactory.CreateLogger<KeyValueRepository>(),  Mock.Of<IRepositoryCacheVersionService>());
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LanguageRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LanguageRepositoryTest.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -365,7 +366,7 @@ internal sealed class LanguageRepositoryTest : UmbracoIntegrationTest
         }
     }
 
-    private LanguageRepository CreateRepository(IScopeProvider provider) => new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>());
+    private LanguageRepository CreateRepository(IScopeProvider provider) => new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
     private async Task CreateTestData()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
@@ -55,12 +55,12 @@ internal sealed class MediaRepositoryTest : UmbracoIntegrationTest
         var commonRepository =
             new ContentTypeCommonRepository(scopeAccessor, TemplateRepository, appCaches, ShortStringHelper);
         var languageRepository =
-            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>());
-        mediaTypeRepository = new MediaTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaTypeRepository>(), commonRepository, languageRepository, ShortStringHelper);
-        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>());
-        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
+            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        mediaTypeRepository = new MediaTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>());
+        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
         var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
-        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);
+        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
         var propertyEditors =
             new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
         var mediaUrlGenerators = new MediaUrlGeneratorCollection(() => Enumerable.Empty<IMediaUrlGenerator>());
@@ -81,7 +81,8 @@ internal sealed class MediaRepositoryTest : UmbracoIntegrationTest
             dataValueReferences,
             DataTypeService,
             JsonSerializer,
-            Mock.Of<IEventAggregator>());
+            Mock.Of<IEventAggregator>(),
+            Mock.Of<IRepositoryCacheVersionService>());
         return repository;
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaTypeRepositoryTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -411,8 +412,8 @@ internal sealed class MediaTypeRepositoryTest : UmbracoIntegrationTest
     }
 
     private MediaTypeRepository CreateRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<MediaTypeRepository>(), CommonRepository, LanguageRepository, ShortStringHelper);
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<MediaTypeRepository>(), CommonRepository, LanguageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>());
 
     private EntityContainerRepository CreateContainerRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<EntityContainerRepository>(), Constants.ObjectTypes.MediaTypeContainer);
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<EntityContainerRepository>(), Constants.ObjectTypes.MediaTypeContainer, Mock.Of<IRepositoryCacheVersionService>());
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
@@ -26,7 +26,7 @@ internal sealed class MemberTypeRepositoryTest : UmbracoIntegrationTest
     {
         var commonRepository = GetRequiredService<IContentTypeCommonRepository>();
         var languageRepository = GetRequiredService<ILanguageRepository>();
-        return new MemberTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper);
+        return new MemberTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>());
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/PublicAccessRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/PublicAccessRepositoryTest.cs
@@ -4,7 +4,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -33,7 +35,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -55,7 +57,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         using (var scope = provider.CreateScope())
         {
             ScopeAccessor.AmbientScope.Database.AsUmbracoDatabase().EnableSqlTrace = true;
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -89,7 +91,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         using (var scope = provider.CreateScope())
         {
             ScopeAccessor.AmbientScope.Database.AsUmbracoDatabase().EnableSqlTrace = true;
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
             PublicAccessRule[] rules =
             {
@@ -123,7 +125,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -152,7 +154,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(),Mock.Of<IRepositoryCacheVersionService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -173,7 +175,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
             var allEntries = new List<PublicAccessEntry>();
             for (var i = 0; i < 10; i++)
@@ -233,7 +235,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(),  Mock.Of<IRepositoryCacheVersionService>());
 
             PublicAccessRule[] rules1 = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry1 = new PublicAccessEntry(content[0], content[1], content[2], rules1);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RedirectUrlRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RedirectUrlRepositoryTests.cs
@@ -3,7 +3,9 @@
 
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Services;
@@ -235,7 +237,7 @@ internal sealed class RedirectUrlRepositoryTests : UmbracoIntegrationTest
     }
 
     private IRedirectUrlRepository CreateRepository(IScopeProvider provider) =>
-        new RedirectUrlRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<RedirectUrlRepository>());
+        new RedirectUrlRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<RedirectUrlRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
     private IContent _textpage;
     private IContent _subpage;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationRepositoryTest.cs
@@ -574,9 +574,9 @@ internal sealed class RelationRepositoryTest : UmbracoIntegrationTest
         using (var scope = ScopeProvider.CreateScope())
         {
             var accessor = (IScopeAccessor)ScopeProvider;
-            var relationTypeRepository = new RelationTypeRepository(accessor, AppCaches.Disabled, Mock.Of<ILogger<RelationTypeRepository>>());
+            var relationTypeRepository = new RelationTypeRepository(accessor, AppCaches.Disabled, Mock.Of<ILogger<RelationTypeRepository>>(), Mock.Of<IRepositoryCacheVersionService>());
             var entityRepository = new EntityRepository(accessor, AppCaches.Disabled);
-            var relationRepository = new RelationRepository(accessor, Mock.Of<ILogger<RelationRepository>>(), relationTypeRepository, entityRepository);
+            var relationRepository = new RelationRepository(accessor, Mock.Of<ILogger<RelationRepository>>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
 
             relationTypeRepository.Save(_relateContent);
             relationTypeRepository.Save(_relateContentType);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationTypeRepositoryTest.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -23,7 +24,7 @@ internal sealed class RelationTypeRepositoryTest : UmbracoIntegrationTest
     public void SetUp() => CreateTestData();
 
     private RelationTypeRepository CreateRepository(ICoreScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
     [Test]
     public void Can_Perform_Add_On_RelationTypeRepository()
@@ -240,7 +241,7 @@ internal sealed class RelationTypeRepositoryTest : UmbracoIntegrationTest
         ICoreScopeProvider provider = ScopeProvider;
         using (var scope = provider.CreateCoreScope())
         {
-            var repository = new RelationTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
+            var repository = new RelationTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
             repository.Save(relateContent); // Id 2
             repository.Save(relateContentType); // Id 3

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ServerRegistrationRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ServerRegistrationRepositoryTest.cs
@@ -4,6 +4,7 @@
 using System.Data.Common;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
@@ -28,7 +29,7 @@ internal sealed class ServerRegistrationRepositoryTest : UmbracoIntegrationTest
     private AppCaches _appCaches;
 
     private ServerRegistrationRepository CreateRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, LoggerFactory.CreateLogger<ServerRegistrationRepository>());
+        new((IScopeAccessor)provider, LoggerFactory.CreateLogger<ServerRegistrationRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 
     [Test]
     public void Cannot_Add_Duplicate_Server_Identities()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
@@ -2,6 +2,7 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
@@ -1140,5 +1141,5 @@ internal sealed class TagRepositoryTest : UmbracoIntegrationTest
     }
 
     private TagRepository CreateRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>());
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -63,7 +63,7 @@ internal sealed class TemplateRepositoryTest : UmbracoIntegrationTest
     private IOptionsMonitor<RuntimeSettings> RuntimeSettings => GetRequiredService<IOptionsMonitor<RuntimeSettings>>();
 
     private ITemplateRepository CreateRepository(IScopeProvider provider) =>
-        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, ViewHelper, RuntimeSettings);
+        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, IOHelper, ShortStringHelper, ViewHelper, RuntimeSettings, Mock.Of<IRepositoryCacheVersionService>());
 
     [Test]
     public void Can_Instantiate_Repository()
@@ -262,14 +262,14 @@ internal sealed class TemplateRepositoryTest : UmbracoIntegrationTest
             var templateRepository = CreateRepository(provider);
             var globalSettings = new GlobalSettings();
             var serializer = new SystemTextJsonSerializer();
-            var tagRepository = new TagRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>());
+            var tagRepository = new TagRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
             var commonRepository =
                 new ContentTypeCommonRepository(scopeAccessor, templateRepository, AppCaches, ShortStringHelper);
-            var languageRepository = new LanguageRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>());
-            var contentTypeRepository = new ContentTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper);
-            var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>());
+            var languageRepository = new LanguageRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var contentTypeRepository = new ContentTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>());
+            var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
             var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
-            var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository);
+            var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
             var propertyEditors =
                 new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
             var dataValueReferences =

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
@@ -58,7 +58,8 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
             new SystemTextJsonSerializer(),
             mockRuntimeState.Object,
             PermissionMappers,
-            AppPolicyCache);
+            AppPolicyCache,
+            Mock.Of<IRepositoryCacheVersionService>());
         return repository;
     }
 
@@ -166,7 +167,8 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
                 new SystemTextJsonSerializer(),
                 mockRuntimeState.Object,
                 PermissionMappers,
-                AppPolicyCache);
+                AppPolicyCache,
+                Mock.Of<IRepositoryCacheVersionService>());
 
             repository2.Delete(user);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RedirectUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RedirectUrlServiceTests.cs
@@ -38,8 +38,11 @@ internal sealed class RedirectUrlServiceTests : UmbracoIntegrationTestWithConten
 
         using (var scope = ScopeProvider.CreateScope())
         {
-            var repository = new RedirectUrlRepository((IScopeAccessor)ScopeProvider, AppCaches.Disabled,
-                Mock.Of<ILogger<RedirectUrlRepository>>());
+            var repository = new RedirectUrlRepository(
+                (IScopeAccessor)ScopeProvider,
+                AppCaches.Disabled,
+                Mock.Of<ILogger<RedirectUrlRepository>>(),
+                Mock.Of<IRepositoryCacheVersionService>());
             var rootContent = ContentService.GetRootContent().First();
             var subPages = ContentService.GetPagedChildren(rootContent.Id, 0, 3, out _).ToList();
             _firstSubPage = subPages[0];

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/SingleItemsOnlyCachePolicyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/SingleItemsOnlyCachePolicyTests.cs
@@ -36,7 +36,7 @@ public class SingleItemsOnlyCachePolicyTests
             .Callback((string cacheKey, Func<object> o, TimeSpan? t, bool b) => cached.Add(cacheKey));
         cache.Setup(x => x.SearchByKey(It.IsAny<string>())).Returns(new AuditItem[] { });
 
-        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), Mock.Of<IRepositoryCacheVersionService>());
 
         var unused = defaultPolicy.GetAll(
             new object[] { },
@@ -57,7 +57,7 @@ public class SingleItemsOnlyCachePolicyTests
         cache.Setup(x => x.Insert(It.IsAny<string>(), It.IsAny<Func<object>>(), It.IsAny<TimeSpan?>(), It.IsAny<bool>()))
             .Callback(() => isCached = true);
 
-        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), Mock.Of<IRepositoryCacheVersionService>());
 
         var unused = defaultPolicy.Get(1, id => new AuditItem(1, AuditType.Copy, 123, "test", "blah"), ids => null);
         Assert.IsTrue(isCached);


### PR DESCRIPTION
This pull request introduces a new cache versioning mechanism for repositories, helping to ensure cache consistency with the database in multi-server scenarios. This is the first part of an effort to load balance the backoffice, and by extension, the isolated caches. All this PR does is create a mechanism for us to know if the cache is out of sync; the next part is to be able to synchronize the cache. 

Since this can be reviewed as a discrete unit, I've opted to make it its own PR and target a long-lived feature branch.

## Testing

Navigate around the backoffice and see that the new cache version table gets created and updated, also try and manually change the version guide to see that the cache is registered as invalid