### PR TITLE
Allow saving blueprints with validation errors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
@@ -131,6 +131,11 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 				display: block;
 				width: 100%;
 				height: 100%;
+
+				--uui-color-invalid: var(--uui-color-warning);
+				--uui-color-invalid-emphasis: var(--uui-color-warning-emphasis);
+				--uui-color-invalid-standalone: var(--uui-color-warning-standalone);
+				--uui-color-invalid-contrast: var(--uui-color-warning-contrast);
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
@@ -45,6 +45,7 @@ export class UmbDocumentBlueprintWorkspaceContext
 			contentTypeDetailRepository: UmbDocumentTypeDetailRepository,
 			contentVariantScaffold: UMB_DOCUMENT_DETAIL_MODEL_VARIANT_SCAFFOLD,
 			contentTypePropertyName: 'documentType',
+			ignoreValidationResultOnSubmit: true,
 		});
 
 		this.observe(


### PR DESCRIPTION
Fixes #19506

The style changes were based on `UmbDocumentWorkspaceContext._handleSave()`.
Since we only want to show warnings, and never errors, the `document-blueprint-workspace-editor` host element styles was adjusted instead.

In order to test, create a blueprint from a document type with a required field and attempt to save the blueprint without filling in that field.