### PR TITLE
Include /.well-known/jwks in the paths covered by OpenIddict

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/ProcessRequestContextHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/ProcessRequestContextHandler.cs
@@ -18,7 +18,7 @@ public class ProcessRequestContextHandler
         var backOfficePathSegment = Constants.System.DefaultUmbracoPath.TrimStart(Constants.CharArrays.Tilde)
             .EnsureStartsWith('/')
             .EnsureEndsWith('/');
-        _pathsToHandle = [backOfficePathSegment, "/.well-known/openid-configuration"];
+        _pathsToHandle = [backOfficePathSegment, "/.well-known/openid-configuration", "/.well-known/jwks"];
     }
 
     public ValueTask HandleAsync(OpenIddictServerEvents.ProcessRequestContext context)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #19652

### Description

#16549 (and the subsequent #16845) causes the linked issue. In essence, the `ProcessRequestContextHandler` from those PRs prevents OpenIddict from handling `/.well-known/jwks`, ultimately leading to a 404 response.

This PR fixes it by adding `/.well-known/jwks` to the allow-list of paths in`ProcessRequestContextHandler`.

### Testing this PR

First and foremost, verify that `/.well-known/openid-configuration` still works, and that the `jwks_uri` property in the response contains `"[host]/.well-known/jwks"` (it should remain unaffected by this PR).

Now verify that `/.well-known/jwks` also works 👍 