### PR TITLE
Template with Block List field with Inline Editing Mode causes Collection List View to shrink

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -210,7 +210,12 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 				this.observe(
 					contentTypeId ? manager.blockTypeOf(contentTypeId) : undefined,
 					(blockType) => {
-						if (blockType?.editorSize) {
+						if (!blockType?.editorSize) return;
+
+						const editorConfig = manager.getEditorConfiguration();
+						const useInlineEditing = editorConfig?.find((x) => x.alias === 'useInlineEditingAsDefault')?.value;
+
+						if (!useInlineEditing) {
 							this.setEditorSize(blockType.editorSize);
 						}
 					},


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This PR fixes the issue https://github.com/umbraco/Umbraco-CMS/issues/18687
The error happened on the UI when opening a child content of a collection list view. This content contains a block list that enabled inline editing mode and the element in the block has editor size of small.
<img width="450" height="200" alt="image" src="https://github.com/user-attachments/assets/8ca6d52b-b772-41cb-8a74-06c8b3e0e37f" />

#### Solution:
I added a check for inline editing mode, if it is enabled it will not set the editor size value for the modal.
#### After fix:
<img width="450" height="200" alt="image" src="https://github.com/user-attachments/assets/7e391c44-9b66-429c-835f-296bc1386f97" />


<!-- Thanks for contributing to Umbraco CMS! -->
