### PR TITLE
Add defensive coding to the member application initializer

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Handlers/InitializeMemberApplicationNotificationHandler.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Handlers/InitializeMemberApplicationNotificationHandler.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.Security;
 
 namespace Umbraco.Cms.Api.Delivery.Handlers;
@@ -16,16 +17,21 @@ internal sealed class InitializeMemberApplicationNotificationHandler : INotifica
     private readonly ILogger<InitializeMemberApplicationNotificationHandler> _logger;
     private readonly DeliveryApiSettings _deliveryApiSettings;
     private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly IServerRoleAccessor _serverRoleAccessor;
+    private static readonly SemaphoreSlim _locker = new(1);
+    private static bool _isInitialized = false;
 
     public InitializeMemberApplicationNotificationHandler(
         IRuntimeState runtimeState,
         IOptions<DeliveryApiSettings> deliveryApiSettings,
         ILogger<InitializeMemberApplicationNotificationHandler> logger,
-        IServiceScopeFactory serviceScopeFactory)
+        IServiceScopeFactory serviceScopeFactory,
+        IServerRoleAccessor serverRoleAccessor)
     {
         _runtimeState = runtimeState;
         _logger = logger;
         _serviceScopeFactory = serviceScopeFactory;
+        _serverRoleAccessor = serverRoleAccessor;
         _deliveryApiSettings = deliveryApiSettings.Value;
     }
 
@@ -36,34 +42,55 @@ internal sealed class InitializeMemberApplicationNotificationHandler : INotifica
             return;
         }
 
-        // we cannot inject the IMemberApplicationManager because it ultimately takes a dependency on the DbContext ... and during
-        // install that is not allowed (no connection string means no DbContext)
-        using IServiceScope scope = _serviceScopeFactory.CreateScope();
-        IMemberApplicationManager memberApplicationManager = scope.ServiceProvider.GetRequiredService<IMemberApplicationManager>();
-
-        if (_deliveryApiSettings.MemberAuthorization?.AuthorizationCodeFlow?.Enabled is not true)
+        if (_serverRoleAccessor.CurrentServerRole is ServerRole.Subscriber)
         {
-            await memberApplicationManager.DeleteMemberApplicationAsync(cancellationToken);
+            // subscriber instances should not alter the member application
             return;
         }
 
-        if (ValidateRedirectUrls(_deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LoginRedirectUrls) is false)
+        try
         {
-            await memberApplicationManager.DeleteMemberApplicationAsync(cancellationToken);
-            return;
-        }
+            await _locker.WaitAsync(cancellationToken);
+            if (_isInitialized)
+            {
+                return;
+            }
 
-        if (_deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LogoutRedirectUrls.Any()
-            && ValidateRedirectUrls(_deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LogoutRedirectUrls) is false)
+            _isInitialized = true;
+
+            // we cannot inject the IMemberApplicationManager because it ultimately takes a dependency on the DbContext ... and during
+            // install that is not allowed (no connection string means no DbContext)
+            using IServiceScope scope = _serviceScopeFactory.CreateScope();
+            IMemberApplicationManager memberApplicationManager = scope.ServiceProvider.GetRequiredService<IMemberApplicationManager>();
+
+            if (_deliveryApiSettings.MemberAuthorization?.AuthorizationCodeFlow?.Enabled is not true)
+            {
+                await memberApplicationManager.DeleteMemberApplicationAsync(cancellationToken);
+                return;
+            }
+
+            if (ValidateRedirectUrls(_deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LoginRedirectUrls) is false)
+            {
+                await memberApplicationManager.DeleteMemberApplicationAsync(cancellationToken);
+                return;
+            }
+
+            if (_deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LogoutRedirectUrls.Any()
+                && ValidateRedirectUrls(_deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LogoutRedirectUrls) is false)
+            {
+                await memberApplicationManager.DeleteMemberApplicationAsync(cancellationToken);
+                return;
+            }
+
+            await memberApplicationManager.EnsureMemberApplicationAsync(
+                _deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LoginRedirectUrls,
+                _deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LogoutRedirectUrls,
+                cancellationToken);
+        }
+        finally
         {
-            await memberApplicationManager.DeleteMemberApplicationAsync(cancellationToken);
-            return;
+            _locker.Release();
         }
-
-        await memberApplicationManager.EnsureMemberApplicationAsync(
-            _deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LoginRedirectUrls,
-            _deliveryApiSettings.MemberAuthorization.AuthorizationCodeFlow.LogoutRedirectUrls,
-            cancellationToken);
     }
 
     private bool ValidateRedirectUrls(Uri[] redirectUrls)


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/19729

### Description

The linked issue describes a concurrency issue during boot time.

This is ultimately triggered by `UmbracoApplicationStartingNotification` somehow being fired twice, which should not be possible but clearly it happens.

I have not been able to reproduce it, so this PR adds defensive coding around the notification handler to guard against concurrent updates.

### Testing this PR

1. Umbraco should boot as per usual 👍 
2. It should still be possible to configure [member auth for the Delivery API](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/protected-content-in-the-delivery-api).
   - Test different configurations and verify that the `umbracoOpenIddictApplications` table is updated accordingly at boot time.