### PR TITLE
Make the OpenAPI security scheme name for the Management API valid

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/ManagementApiConfiguration.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/ManagementApiConfiguration.cs
@@ -4,7 +4,7 @@ namespace Umbraco.Cms.Api.Management.DependencyInjection;
 
 internal static class ManagementApiConfiguration
 {
-    internal const string ApiSecurityName = "Backoffice User";
+    internal const string ApiSecurityName = "Backoffice-User";
     internal const string ApiTitle = "Umbraco Management API";
 
     internal const string ApiName = "management";

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -53,7 +53,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -199,7 +199,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -259,7 +259,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -368,7 +368,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -508,7 +508,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -639,7 +639,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -695,7 +695,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -811,7 +811,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -875,7 +875,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -939,7 +939,7 @@
         "deprecated": true,
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -974,7 +974,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1120,7 +1120,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1180,7 +1180,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -1289,7 +1289,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -1429,7 +1429,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1506,7 +1506,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1555,7 +1555,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1614,7 +1614,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1662,7 +1662,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1733,7 +1733,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1796,7 +1796,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1860,7 +1860,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -1922,7 +1922,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -2092,7 +2092,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2152,7 +2152,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -2261,7 +2261,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -2401,7 +2401,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2470,7 +2470,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2612,7 +2612,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2758,7 +2758,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2807,7 +2807,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2855,7 +2855,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2918,7 +2918,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -2973,7 +2973,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -3119,7 +3119,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -3179,7 +3179,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -3288,7 +3288,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -3428,7 +3428,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -3544,7 +3544,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -3604,7 +3604,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -3750,7 +3750,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -3810,7 +3810,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -3919,7 +3919,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -4059,7 +4059,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4179,7 +4179,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4228,7 +4228,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4276,7 +4276,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4347,7 +4347,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4410,7 +4410,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4474,7 +4474,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4620,7 +4620,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4680,7 +4680,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -4763,7 +4763,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -4903,7 +4903,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -4989,7 +4989,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5067,7 +5067,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5144,7 +5144,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5301,7 +5301,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5362,7 +5362,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5504,7 +5504,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5646,7 +5646,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5701,7 +5701,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5794,7 +5794,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5829,7 +5829,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -5975,7 +5975,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6035,7 +6035,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -6144,7 +6144,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -6284,7 +6284,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6430,7 +6430,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6479,7 +6479,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6545,7 +6545,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6593,7 +6593,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6664,7 +6664,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6727,7 +6727,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6791,7 +6791,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6890,7 +6890,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -6964,7 +6964,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -7082,7 +7082,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -7200,7 +7200,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -7329,7 +7329,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -7475,7 +7475,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -7535,7 +7535,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -7644,7 +7644,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -7784,7 +7784,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -7863,7 +7863,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -7994,7 +7994,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -8054,7 +8054,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -8220,7 +8220,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -8336,7 +8336,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -8447,7 +8447,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -8510,7 +8510,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -8624,7 +8624,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -8755,7 +8755,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -8838,7 +8838,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -8896,7 +8896,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -9010,7 +9010,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9152,7 +9152,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9305,7 +9305,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9388,7 +9388,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9448,7 +9448,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9512,7 +9512,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9576,7 +9576,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9718,7 +9718,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9860,7 +9860,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9927,7 +9927,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -9962,7 +9962,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10093,7 +10093,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10145,7 +10145,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10276,7 +10276,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10325,7 +10325,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10417,7 +10417,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10491,7 +10491,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10602,7 +10602,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10676,7 +10676,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10818,7 +10818,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10881,7 +10881,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10936,7 +10936,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -10991,7 +10991,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11039,7 +11039,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11110,7 +11110,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11173,7 +11173,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11237,7 +11237,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11327,7 +11327,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11361,7 +11361,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11416,7 +11416,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11475,7 +11475,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11570,7 +11570,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11686,7 +11686,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11774,7 +11774,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11851,7 +11851,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11921,7 +11921,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -11973,7 +11973,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -12029,7 +12029,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -12150,7 +12150,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -12400,7 +12400,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -12432,7 +12432,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -12484,7 +12484,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -12628,7 +12628,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -12684,7 +12684,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -12792,7 +12792,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -12931,7 +12931,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -12986,7 +12986,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13053,7 +13053,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13148,7 +13148,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13233,7 +13233,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13288,7 +13288,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -13406,7 +13406,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13465,7 +13465,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -13547,7 +13547,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13603,7 +13603,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13641,7 +13641,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13679,7 +13679,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13755,7 +13755,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13814,7 +13814,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13866,7 +13866,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -13925,7 +13925,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -14071,7 +14071,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -14131,7 +14131,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -14214,7 +14214,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -14354,7 +14354,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -14440,7 +14440,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -14517,7 +14517,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -14674,7 +14674,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -14735,7 +14735,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -14877,7 +14877,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15019,7 +15019,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15074,7 +15074,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15167,7 +15167,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15202,7 +15202,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15348,7 +15348,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15408,7 +15408,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -15517,7 +15517,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -15657,7 +15657,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15803,7 +15803,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15851,7 +15851,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15922,7 +15922,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -15985,7 +15985,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16049,7 +16049,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16170,7 +16170,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16219,7 +16219,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16311,7 +16311,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16457,7 +16457,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16517,7 +16517,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -16626,7 +16626,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -16766,7 +16766,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16845,7 +16845,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -16961,7 +16961,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17072,7 +17072,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17136,7 +17136,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17200,7 +17200,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17342,7 +17342,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17409,7 +17409,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17445,7 +17445,7 @@
         "deprecated": true,
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17576,7 +17576,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17628,7 +17628,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17759,7 +17759,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17833,7 +17833,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -17944,7 +17944,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18018,7 +18018,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18160,7 +18160,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18223,7 +18223,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18278,7 +18278,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18333,7 +18333,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18381,7 +18381,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18452,7 +18452,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18515,7 +18515,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18579,7 +18579,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18628,7 +18628,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18683,7 +18683,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -18801,7 +18801,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -18850,7 +18850,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -18959,7 +18959,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -19099,7 +19099,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19154,7 +19154,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19203,7 +19203,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19262,7 +19262,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19408,7 +19408,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19468,7 +19468,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -19551,7 +19551,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -19691,7 +19691,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19768,7 +19768,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19894,7 +19894,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -19987,7 +19987,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20022,7 +20022,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20077,7 +20077,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20197,7 +20197,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20246,7 +20246,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20316,7 +20316,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20462,7 +20462,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20522,7 +20522,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -20631,7 +20631,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -20771,7 +20771,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20835,7 +20835,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -20899,7 +20899,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21041,7 +21041,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21108,7 +21108,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21143,7 +21143,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21274,7 +21274,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21348,7 +21348,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21383,7 +21383,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21418,7 +21418,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21470,7 +21470,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21531,7 +21531,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21641,7 +21641,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21676,7 +21676,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21731,7 +21731,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -21875,7 +21875,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -21935,7 +21935,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -22018,7 +22018,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -22132,7 +22132,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -22193,7 +22193,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -22248,7 +22248,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -22296,7 +22296,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -22442,7 +22442,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -22501,7 +22501,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -22609,7 +22609,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -22748,7 +22748,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -22904,7 +22904,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23050,7 +23050,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23109,7 +23109,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -23217,7 +23217,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23272,7 +23272,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23331,7 +23331,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23378,7 +23378,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23440,7 +23440,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23495,7 +23495,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23551,7 +23551,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23586,7 +23586,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -23663,7 +23663,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23725,7 +23725,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23758,7 +23758,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23790,7 +23790,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23823,7 +23823,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23899,7 +23899,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -23963,7 +23963,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -24020,7 +24020,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24055,7 +24055,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -24110,7 +24110,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24159,7 +24159,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24214,7 +24214,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24274,7 +24274,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24352,7 +24352,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24400,7 +24400,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24546,7 +24546,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -24605,7 +24605,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -24713,7 +24713,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -24852,7 +24852,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25008,7 +25008,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25154,7 +25154,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25213,7 +25213,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -25321,7 +25321,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25368,7 +25368,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25430,7 +25430,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25485,7 +25485,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25537,7 +25537,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25618,7 +25618,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25653,7 +25653,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25758,7 +25758,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -25889,7 +25889,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26074,7 +26074,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26130,7 +26130,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26200,7 +26200,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26235,7 +26235,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26283,7 +26283,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26327,7 +26327,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26386,7 +26386,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26438,7 +26438,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26486,7 +26486,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26632,7 +26632,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -26691,7 +26691,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -26799,7 +26799,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -26938,7 +26938,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27094,7 +27094,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27240,7 +27240,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27299,7 +27299,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -27407,7 +27407,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27454,7 +27454,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27516,7 +27516,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27571,7 +27571,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27644,7 +27644,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27699,7 +27699,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27734,7 +27734,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -27837,7 +27837,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27886,7 +27886,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -27945,7 +27945,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28091,7 +28091,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28151,7 +28151,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -28260,7 +28260,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -28400,7 +28400,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28435,7 +28435,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28525,7 +28525,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28560,7 +28560,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28608,7 +28608,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28671,7 +28671,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28726,7 +28726,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28790,7 +28790,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28895,7 +28895,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -28966,7 +28966,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -29060,7 +29060,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29092,7 +29092,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29192,7 +29192,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29241,7 +29241,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29364,7 +29364,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -29434,7 +29434,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -29540,7 +29540,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29586,7 +29586,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29677,7 +29677,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29726,7 +29726,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -29831,7 +29831,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -29949,7 +29949,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -30002,7 +30002,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -30062,7 +30062,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -30145,7 +30145,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -30259,7 +30259,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -30384,7 +30384,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -30507,7 +30507,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -30635,7 +30635,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -30684,7 +30684,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -30830,7 +30830,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -30933,7 +30933,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -31000,7 +31000,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -31060,7 +31060,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -31169,7 +31169,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -31309,7 +31309,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -31372,7 +31372,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -31491,7 +31491,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -31551,7 +31551,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -31693,7 +31693,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -31809,7 +31809,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -31852,7 +31852,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -31945,7 +31945,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32067,7 +32067,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32178,7 +32178,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -32318,7 +32318,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32353,7 +32353,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32385,7 +32385,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32420,7 +32420,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32522,7 +32522,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -32657,7 +32657,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -32725,7 +32725,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32815,7 +32815,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32905,7 +32905,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32940,7 +32940,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -32975,7 +32975,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -33035,7 +33035,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -33098,7 +33098,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -33158,7 +33158,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -33289,7 +33289,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -33420,7 +33420,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -33566,7 +33566,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -33820,7 +33820,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34033,7 +34033,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34138,7 +34138,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34187,7 +34187,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34242,7 +34242,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -34386,7 +34386,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34446,7 +34446,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -34555,7 +34555,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       },
@@ -34695,7 +34695,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34759,7 +34759,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34814,7 +34814,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -34869,7 +34869,7 @@
         },
         "security": [
           {
-            "Backoffice User": [ ]
+            "Backoffice-User": [ ]
           }
         ]
       }
@@ -47582,7 +47582,7 @@
       }
     },
     "securitySchemes": {
-      "Backoffice User": {
+      "Backoffice-User": {
         "type": "oauth2",
         "description": "Umbraco Authentication",
         "flows": {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #19729

### Description

This PR changes the OpenAPI security scheme name for the Management API from `Backoffice User` to `Backoffice-User`.

See the linked issue for an excellent description of the reasoning behind 👍 

I have verified that the change does not affect any auto generated code for the backoffice client.

### Testing this PR

First and foremost, the backoffice should still work 😆 

Grab the OpenAPI json for the Management API from `/umbraco/swagger`, and use the [OpenAPI validator at swagger.io](https://validator.swagger.io/#/Validator/validateByContent) to validate it. You should see a fine little badge:

<img width="1004" height="981" alt="image" src="https://github.com/user-attachments/assets/97db45d6-eb70-4ddb-8cad-b808e6ff2ab5" />

