### PR TITLE
Retrieve only user external logins when invalidate following removal of backoffice external user login

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -1085,10 +1085,11 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
     /// <inheritdoc />
     public void InvalidateSessionsForRemovedProviders(IEnumerable<string> currentLoginProviders)
     {
-        // Get all the user or member keys associated with the removed providers.
+        // Get all the user keys associated with the removed providers.
         Sql<ISqlContext> idsQuery = SqlContext.Sql()
             .Select<ExternalLoginDto>(x => x.UserOrMemberKey)
             .From<ExternalLoginDto>()
+            .Where<ExternalLoginDto>(x => !x.LoginProvider.StartsWith(Constants.Security.MemberExternalAuthenticationTypePrefix)) // Only invalidate sessions relating to backoffice users, not members.
             .WhereNotIn<ExternalLoginDto>(x => x.LoginProvider, currentLoginProviders);
         List<Guid> userAndMemberKeysAssociatedWithRemovedProviders = Database.Fetch<Guid>(idsQuery);
         if (userAndMemberKeysAssociatedWithRemovedProviders.Count == 0)
@@ -1096,7 +1097,7 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
             return;
         }
 
-        // Filter for actual users and convert to integer IDs.
+        // Convert to user integer IDs.
         var userIdsAssociatedWithRemovedProviders = userAndMemberKeysAssociatedWithRemovedProviders
             .Select(ConvertUserKeyToUserId)
             .Where(x => x.HasValue)
@@ -1119,7 +1120,6 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
         // User Ids are stored as integers in the umbracoUser table, but as a GUID representation
         // of that integer in umbracoExternalLogin (converted via IntExtensions.ToGuid()).
         // We need to parse that to get the user Ids to invalidate.
-        // Note also that umbracoExternalLogin contains members too, as proper GUIDs, so we need to ignore them.
         IntExtensions.TryParseFromGuid(userOrMemberKey, out int? userId) ? userId : null;
 
     #endregion

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -1091,14 +1091,14 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
             .From<ExternalLoginDto>()
             .Where<ExternalLoginDto>(x => !x.LoginProvider.StartsWith(Constants.Security.MemberExternalAuthenticationTypePrefix)) // Only invalidate sessions relating to backoffice users, not members.
             .WhereNotIn<ExternalLoginDto>(x => x.LoginProvider, currentLoginProviders);
-        List<Guid> userAndMemberKeysAssociatedWithRemovedProviders = Database.Fetch<Guid>(idsQuery);
-        if (userAndMemberKeysAssociatedWithRemovedProviders.Count == 0)
+        List<Guid> userKeysAssociatedWithRemovedProviders = Database.Fetch<Guid>(idsQuery);
+        if (userKeysAssociatedWithRemovedProviders.Count == 0)
         {
             return;
         }
 
         // Convert to user integer IDs.
-        var userIdsAssociatedWithRemovedProviders = userAndMemberKeysAssociatedWithRemovedProviders
+        var userIdsAssociatedWithRemovedProviders = userKeysAssociatedWithRemovedProviders
             .Select(ConvertUserKeyToUserId)
             .Where(x => x.HasValue)
             .Select(x => x!.Value)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19742

### Description
The initial implementation of https://github.com/umbraco/Umbraco-CMS/pull/19273, added to ensure backoffice user sessions relating to removed login providers are invalidated, distinguished between users and members, such that only the former were invalidated.

It did so though by retrieving all logins, and filtering out those that were users based on the fact that the GUID could be recognised as one derived from an integer.

That causes the linked issue though if there are 2000+ members, as we aren't retrieving them in groups as we do usually when this situation could occur.

There's a better way though, in that we filter at the database to only retrieve the users in the first place - which we can do, as we know the prefix of the login provider.

So that's what's been applied here.

### Testing

Visual inspection maybe enough here as I've repeated the testing that is described on the original PR linked above (which requires set up of an external login provider).

### Release

This will need cherry-picking/re-applying for 16.  
