### PR TITLE
Fires the updated event when content types are updated

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
@@ -1,27 +1,27 @@
-import type { UmbContentTypeCompositionModel, UmbContentTypeDetailModel, UmbContentTypeSortModel } from '../types.js';
 import { UmbContentTypeStructureManager } from '../structure/index.js';
+import type { UmbContentTypeCompositionModel, UmbContentTypeDetailModel, UmbContentTypeSortModel } from '../types.js';
 import type { UmbContentTypeWorkspaceContext } from './content-type-workspace-context.interface.js';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import type {
-	UmbDetailRepository,
-	UmbRepositoryResponse,
-	UmbRepositoryResponseWithAsObservable,
-} from '@umbraco-cms/backoffice/repository';
-import {
-	UmbEntityDetailWorkspaceContextBase,
-	type UmbEntityDetailWorkspaceContextArgs,
-	type UmbEntityDetailWorkspaceContextCreateArgs,
-	type UmbRoutableWorkspaceContext,
-} from '@umbraco-cms/backoffice/workspace';
-import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
-import type { Observable } from '@umbraco-cms/backoffice/observable-api';
-import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbEntityDetailWorkspaceContextBase } from '@umbraco-cms/backoffice/workspace';
 import {
 	UmbEntityUpdatedEvent,
 	UmbRequestReloadChildrenOfEntityEvent,
 	UmbRequestReloadStructureForEntityEvent,
 } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import type { Observable } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import type {
+	UmbDetailRepository,
+	UmbRepositoryResponse,
+	UmbRepositoryResponseWithAsObservable,
+} from '@umbraco-cms/backoffice/repository';
+import type {
+	UmbEntityDetailWorkspaceContextArgs,
+	UmbEntityDetailWorkspaceContextCreateArgs,
+	UmbRoutableWorkspaceContext,
+} from '@umbraco-cms/backoffice/workspace';
+import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UmbContentTypeWorkspaceContextArgs extends UmbEntityDetailWorkspaceContextArgs {}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19738

### Description
As noted on the linked issue, the content type workspace overrides the update method from the entity detail workspace base, but doesn't fire the updated event like the base method does.  This PR adds it.

### Testing
To confirm the event fires I made a temporary local change to `UmbRepositoryDetailsManager` that already handles the event, adding `console.log(eventUnique + " updated.");` in `#onEntityUpdatedEvent`.