### PR TITLE
Reloads the template tree when creating a document type with a template

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
@@ -20,8 +20,10 @@ import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 import type { UmbRoutableWorkspaceContext } from '@umbraco-cms/backoffice/workspace';
 import type { UmbPathPatternTypeAsEncodedParamsType } from '@umbraco-cms/backoffice/router';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
-import { UmbTemplateDetailRepository } from '@umbraco-cms/backoffice/template';
+import { UMB_TEMPLATE_ROOT_ENTITY_TYPE, UmbTemplateDetailRepository } from '@umbraco-cms/backoffice/template';
 import { CompositionTypeModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 
 type DetailModelType = UmbDocumentTypeDetailModel;
 export class UmbDocumentTypeWorkspaceContext
@@ -188,6 +190,16 @@ export class UmbDocumentTypeWorkspaceContext
 		if (!templateScaffold) throw new Error('Could not create template scaffold');
 		const { data: template } = await this.#templateRepository.create(templateScaffold, null);
 		if (!template) throw new Error('Could not create template');
+
+		const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+		if (!eventContext) {
+			throw new Error('Could not get the action event context');
+		}
+		const event = new UmbRequestReloadChildrenOfEntityEvent({
+			entityType: UMB_TEMPLATE_ROOT_ENTITY_TYPE,
+			unique: null,
+		});
+		eventContext.dispatchEvent(event);
 
 		const templateEntity = { id: template.unique };
 		const allowedTemplates = this.getAllowedTemplateIds() ?? [];


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves https://github.com/umbraco/Umbraco-CMS/issues/19723

### Description
When creating a document type with a template, following creation the document type tree is refreshed but the template tree is not.  You need to reload the children of the "Templates" tree to see the added template.

With this update in place the "Templates" tree will reload automatically when the template is created.

### Testing
Open the document type and template tree, then create a document type with a template.  After save you should see the new tree items for the document type and the template appear without further user interaction.