### PR TITLE
Fix null reference exception when removing all blocks from shared RTE in culture variant content

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -362,7 +362,7 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         var mergedInvariant = UpdateSourceInvariantData(source, target, canUpdateInvariantData);
 
         // if the structure (invariant) is not defined after merger, the target content does not matter
-        if (mergedInvariant is null)
+        if (mergedInvariant?.Layout is null)
         {
             return null;
         }
@@ -393,14 +393,14 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
         RestoreMissingValues(
             source.BlockValue.ContentData,
             target.BlockValue.ContentData,
-            mergedInvariant.Layout!,
+            mergedInvariant.Layout,
             (layoutItem, itemData) => layoutItem.ContentKey == itemData.Key,
             canUpdateInvariantData,
             allowedCultures);
         RestoreMissingValues(
             source.BlockValue.SettingsData,
             target.BlockValue.SettingsData,
-            mergedInvariant.Layout!,
+            mergedInvariant.Layout,
             (layoutItem, itemData) => layoutItem.SettingsKey == itemData.Key,
             canUpdateInvariantData,
             allowedCultures);


### PR DESCRIPTION
Fixes #19763

Testing steps can be found in the original issue.
Make sure to set the document type to vary by culture.

For reference, the issue was introduced in #18802 and was caused by the fact that while in block list, the `target` would come as `null`, for the RTE, the `target` was not `null`, but there would be no blocks, which would cause the layout to be `null`, which wasn't being handled correctly.