### PR TITLE
Log the migration plan name when can't migrate from state

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
@@ -365,7 +365,7 @@ public class MigrationPlan
     ///     Throws an exception when the initial state is unknown.
     /// </summary>
     public virtual void ThrowOnUnknownInitialState(string state) =>
-        throw new InvalidOperationException($"The migration plan does not support migrating from state \"{state}\".");
+        throw new InvalidOperationException($"The migration plan \"{Name}\" does not support migrating from state \"{state}\".");
 
     /// <summary>
     ///     Follows a path (for tests and debugging).


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
When switching branches that have run migrations, particularly with packages installed, this error will often come up:

```
Umbraco.Cms.Core.Exceptions.BootFailedException: An error occurred while running the unattended upgrade.
The database configuration failed with the following message: The migration plan does not support migrating from state "{741C22CF-5FB8-4343-BF79-B97A58C2CCBA}".
```

To help fix this, I've added the plan name to the message.  So it's clearer which migration plan is failing,  So it now logs:

```
Umbraco.Cms.Core.Exceptions.BootFailedException: An error occurred while running the unattended upgrade.
The database configuration failed with the following message: The migration plan "Umbraco.Core" does not support migrating from state "{741C22CF-5FB8-4343-BF79-B97A58C2CCBA}".
```

### Testing
Modify the value of the migration plan state and restart.

```
update umbracoKeyValue
set value = '{<some random GUID>}'
where [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
```

