### PR TITLE
#19775 fixed get user data by applying OrderBy after counting

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserDataRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserDataRepository.cs
@@ -44,7 +44,7 @@ internal sealed class UserDataRepository : IUserDataRepository
             sql = ApplyFilter(sql, filter);
         }
 
-        // Fetchin total before applying OrderBy to avoid issue with count subquery.
+        // Fetching the total before applying OrderBy to avoid issue with count subquery.
         var totalItems = _scopeAccessor.AmbientScope?.Database.Count(sql!) ?? 0;
 
         sql = sql.OrderBy<UserDataDto>(dto => dto.Identifier); // need to order to skiptake


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/19775

### Description
Fixes 500 error in repository for User Data by applying the `OrderBy` after total items has been counter. This avoids the problem with having `OrderBy` inside a subquery. See the [issue](https://github.com/umbraco/Umbraco-CMS/issues/19775) for details about the error.
