### PR TITLE
Tiptap RTE: Clear Formatting, resets nodes to "paragraph"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/toolbar/clear-formatting.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/toolbar/clear-formatting.tiptap-toolbar-api.ts
@@ -3,6 +3,6 @@ import type { Editor } from '@umbraco-cms/backoffice/external/tiptap';
 
 export default class UmbTiptapToolbarClearFormattingExtensionApi extends UmbTiptapToolbarElementApiBase {
 	override execute(editor?: Editor) {
-		editor?.chain().focus().unsetAllMarks().unsetClassName().unsetStyles().run();
+		editor?.chain().focus().clearNodes().unsetAllMarks().unsetClassName().unsetStyles().run();
 	}
 }


### PR DESCRIPTION
### Description

Fixes #19752.

Updated Tiptap RTE's **Clear Formatting** toolbar button feature to reset any nodes (e.g. headings) back to the default _paragraph_.

#### How to test?

In a Tiptap RTE, (with Clear Formatting toolbar button added), enter a variety of rich-text, (e.g. headings, bold, italic, etc.); press the Clear Formatting button, the formatting of the text should be removed, leaved plain-text paragraphs.