### PR TITLE
Fix issue with use of EF Core scopes within notification handlers

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore/Scoping/EFCoreScope.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Scoping/EFCoreScope.cs
@@ -127,11 +127,6 @@ internal class EFCoreScope<TDbContext> : CoreScope, IEfCoreScope<TDbContext>
 
         Locks.ClearLocks(InstanceId);
 
-        if (ParentScope is null)
-        {
-            Locks.EnsureLocksCleared(InstanceId);
-        }
-
         _efCoreScopeProvider.PopAmbientScope();
 
         HandleScopeContext();

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -364,7 +364,9 @@ namespace Umbraco.Cms.Infrastructure.Scoping
             if (this != _scopeProvider.AmbientScope)
             {
                 var failedMessage =
-                    $"The {nameof(Scope)} {InstanceId} being disposed is not the Ambient {nameof(Scope)} {_scopeProvider.AmbientScope?.InstanceId.ToString() ?? "NULL"}. This typically indicates that a child {nameof(Scope)} was not disposed, or flowed to a child thread that was not awaited, or concurrent threads are accessing the same {nameof(Scope)} (Ambient context) which is not supported. If using Task.Run (or similar) as a fire and forget tasks or to run threads in parallel you must suppress execution context flow with ExecutionContext.SuppressFlow() and ExecutionContext.RestoreFlow().";
+                    $"The {nameof(Scope)} {InstanceId} being disposed is not the Ambient {nameof(Scope)} {_scopeProvider.AmbientScope?.InstanceId.ToString() ?? "NULL"}." +
+                    $" This typically indicates that a child {nameof(Scope)} was not disposed, or flowed to a child thread that was not awaited, or concurrent threads are accessing the same {nameof(Scope)} (Ambient context) which is not supported." +
+                    $" If using Task.Run (or similar) as a fire and forget tasks or to run threads in parallel you must suppress execution context flow with ExecutionContext.SuppressFlow() and ExecutionContext.RestoreFlow().";
 
 #if DEBUG_SCOPES
                 Scope ambient = _scopeProvider.AmbientScope;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Potentially fixes https://github.com/umbraco/Umbraco-CMS/issues/18977

### Description
_Caveat: scopes are complicated, and am not pretending I've got my head around them fully.  This fix was mostly found via trial and error as at least some understanding was acquired._

In debugging I found that actually the exception reported in the linked issue doesn't seem to be the key one.  We do get that, but in stepping through I could see we actually got a first exception in the disposal of `EFCoreScope`, and that failing seems to cause the one we actually see when the `Scope` is being disposed.  The second exception overwrites the first in terms of what is surfaced to the user interface.

In terms of the fix, I _think_ it's correct here that we don't attempt to ensure locks cleared when disposing an `EFCoreScope` scope.  In the context of a notification handler, other locks may exist and that will prevent the scope from being disposed.  That avoids throwing an exception, the `EFCoreScope` scope is disposed and we no longer get the reported and visible exception either.  As an `EFCoreScope` always has a parent `Scope`, we can rely on the disposal of that to ensure the locks are cleared.

### Verification

To test I've used the following use case, logging a message every time a content item is saved.

Entity definition:

```
public class ContentLogMessage
{
    public int Id { get; set; }

    public Guid ContentKey { get; set; }

    public string Message { get; set; } = string.Empty;
}
```

Database context:

```
using Microsoft.EntityFrameworkCore;

namespace Umbraco.Cms.Web.UI.Custom.EFCore;

public class ContentLogMessageContext : DbContext
{
    public ContentLogMessageContext(DbContextOptions<ContentLogMessageContext> options)
        : base(options)
    {
    }

    public required DbSet<ContentLogMessage> ContentLogMessages { get; set; }

    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
        modelBuilder.Entity<ContentLogMessage>(entity =>
        {
            entity.ToTable("contentMessageLog");
            entity.HasKey(e => e.Id);
            entity.Property(e => e.Id).HasColumnName("id");
            entity.Property(e => e.ContentKey).HasColumnName("contentKey");
            entity.Property(e => e.Message).HasColumnName("message");
        });
}
```

Notification handler:

```
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Persistence.EFCore.Scoping;

public class ContentMessageLogNotificationHandler(IEFCoreScopeProvider<ContentLogMessageContext> scopeProvider)
    : INotificationAsyncHandler<ContentSavingNotification>
{
    public async Task HandleAsync(ContentSavingNotification notification, CancellationToken cancellationToken)
    {
        using IEfCoreScope<ContentLogMessageContext> scope = scopeProvider.CreateScope();

        foreach (IContent content in notification.SavedEntities)
        {
            await scope.ExecuteWithContextAsync<Task>(async db =>
            {
                var logMessage = new ContentLogMessage
                {
                    ContentKey = content.Key,
                    Message = $"Content saving at {DateTime.Now}",
                };
                db.ContentLogMessages.Add(logMessage);
                await db.SaveChangesAsync();
            });

        }

        scope.Complete();
    }
}
```

Composer:

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Notifications;

public class ContentLogMessageContextComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Services.AddUmbracoDbContext<ContentLogMessageContext>((sp, options) =>
        {
            options.UseUmbracoDatabaseProvider(sp);
        });

        builder.AddNotificationAsyncHandler<ContentSavingNotification, ContentMessageLogNotificationHandler>();
    }
}
```

With this in place no errors are thrown, the content is saved and the log message is written to the database.



