### PR TITLE
Content picker search with start node configured not taking user start nodes into account

### DIFF
--- a/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
@@ -90,7 +90,7 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
                 }
 
                 if (searchFrom != null && searchFrom != Constants.Conventions.MemberTypes.AllMembersListId &&
-                    searchFrom.Trim() != "-1")
+                    searchFrom.Trim() != Constants.System.RootString)
                 {
                     sb.Append("+__NodeTypeAlias:");
                     sb.Append(searchFrom);
@@ -350,13 +350,13 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
 
         abortQuery = false;
 
-        if (searchFrom is "-1")
+        if (searchFrom is Constants.System.RootString)
         {
             searchFrom = null;
         }
 
-        var userStartNodes = ignoreUserStartNodes ? [-1] : GetUserStartNodes(objectType);
-        if (searchFrom is null && userStartNodes.Contains(-1))
+        var userStartNodes = ignoreUserStartNodes ? [Constants.System.Root] : GetUserStartNodes(objectType);
+        if (searchFrom is null && userStartNodes.Contains(Constants.System.Root))
         {
             // If we have no searchFrom and the user either has access to the root node or we are ignoring user
             // start nodes, we don't need to filter by path.
@@ -462,14 +462,14 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
             _ => throw new NotSupportedException($"The object type {objectType} is not supported for start nodes."),
         };
 
-        return startNodes ?? [-1]; // If no start nodes are defined, we assume the user has access to the root node (-1).
+        return startNodes ?? [Constants.System.Root]; // If no start nodes are defined, we assume the user has access to the root node (-1).
     }
 
     private string[] GetEntityPaths(UmbracoObjectTypes objectType, int[] entityIds) =>
         entityIds switch
         {
             [] => [],
-            _ when entityIds.Contains(-1) => ["-1"],
+            _ when entityIds.Contains(Constants.System.Root) => [Constants.System.RootString],
             _ => _entityService.GetAllPaths(objectType, entityIds).Select(x => x.Path).ToArray(),
         };
 

--- a/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
+++ b/src/Umbraco.Examine.Lucene/BackOfficeExamineSearcher.cs
@@ -438,7 +438,14 @@ public class BackOfficeExamineSearcher : IBackOfficeExamineSearcher
     }
 
     private static bool StartsWithPath(string path1, string path2)
-        => $"{path1},".StartsWith($"{path2},", StringComparison.Ordinal);
+    {
+        if (path1.StartsWith(path2) == false)
+        {
+            return false;
+        }
+
+        return path1.Length == path2.Length || path1[path2.Length] == ',';
+    }
 
     private int[] GetUserStartNodes(UmbracoObjectTypes objectType)
     {

--- a/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/ContentTreeController.cs
@@ -100,7 +100,13 @@ public class ContentTreeController : ContentTreeControllerBase, ISearchableTreeW
 
     public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null)
     {
-        IEnumerable<SearchResultEntity> results = _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out var totalFound, searchFrom);
+        IEnumerable<SearchResultEntity> results = _treeSearcher.ExamineSearch(
+            query,
+            UmbracoEntityTypes.Document,
+            pageSize,
+            pageIndex,
+            out var totalFound,
+            searchFrom: searchFrom);
         return new EntitySearchResults(results, totalFound);
     }
 
@@ -399,7 +405,14 @@ public class ContentTreeController : ContentTreeControllerBase, ISearchableTreeW
 
     public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null, string? culture = null)
     {
-        var results = _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Document, pageSize, pageIndex, out long totalFound, culture: culture, searchFrom: searchFrom);
+        var results = _treeSearcher.ExamineSearch(
+            query,
+            UmbracoEntityTypes.Document,
+            pageSize,
+            pageIndex,
+            out long totalFound,
+            culture: culture,
+            searchFrom: searchFrom);
         return new EntitySearchResults(results, totalFound);
     }
 }

--- a/src/Umbraco.Web.BackOffice/Trees/MediaTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MediaTreeController.cs
@@ -76,8 +76,13 @@ public class MediaTreeController : ContentTreeControllerBase, ISearchableTree, I
     public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex,
         string? searchFrom = null)
     {
-        IEnumerable<SearchResultEntity> results = _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Media, pageSize,
-            pageIndex, out var totalFound, searchFrom);
+        IEnumerable<SearchResultEntity> results = _treeSearcher.ExamineSearch(
+            query,
+            UmbracoEntityTypes.Media,
+            pageSize,
+            pageIndex,
+            out var totalFound,
+            searchFrom: searchFrom);
         return new EntitySearchResults(results, totalFound);
     }
 

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTreeController.cs
@@ -51,7 +51,12 @@ public class MemberTreeController : TreeController, ISearchableTree, ITreeNodeCo
 
     public async Task<EntitySearchResults> SearchAsync(string query, int pageSize, long pageIndex, string? searchFrom = null)
     {
-        IEnumerable<SearchResultEntity> results = _treeSearcher.ExamineSearch(query, UmbracoEntityTypes.Member, pageSize, pageIndex, out var totalFound, searchFrom);
+        IEnumerable<SearchResultEntity> results = _treeSearcher.ExamineSearch(
+            query,
+            UmbracoEntityTypes.Member,
+            pageSize, pageIndex,
+            out var totalFound,
+            searchFrom: searchFrom);
         return new EntitySearchResults(results, totalFound);
     }
 

--- a/src/Umbraco.Web.BackOffice/Trees/MemberTreeController.cs
+++ b/src/Umbraco.Web.BackOffice/Trees/MemberTreeController.cs
@@ -54,7 +54,8 @@ public class MemberTreeController : TreeController, ISearchableTree, ITreeNodeCo
         IEnumerable<SearchResultEntity> results = _treeSearcher.ExamineSearch(
             query,
             UmbracoEntityTypes.Member,
-            pageSize, pageIndex,
+            pageSize,
+            pageIndex,
             out var totalFound,
             searchFrom: searchFrom);
         return new EntitySearchResults(results, totalFound);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
@@ -73,9 +73,9 @@ public class BackOfficeExamineSearcherTests : ExamineBaseTest
         builder.Services.AddHostedService<QueuedHostedService>();
     }
 
-    private IEnumerable<ISearchResult> BackOfficeExamineSearch(string query, int pageSize = 20, int pageIndex = 0) =>
+    private IEnumerable<ISearchResult> BackOfficeExamineSearch(string query, int pageSize = 20, int pageIndex = 0, bool ignoreUserStartNodes = false) =>
         BackOfficeExamineSearcher.Search(query, UmbracoEntityTypes.Document,
-            pageSize, pageIndex, out _, ignoreUserStartNodes: true);
+            pageSize, pageIndex, out _, ignoreUserStartNodes: ignoreUserStartNodes);
 
     private async Task SetupUserIdentity(string userId)
     {


### PR DESCRIPTION
Fixes #19432

When using a Content Picker, selecting a start node and leaving "Ignore User Start Nodes" unselected, a user with no permissions to see that node or its children, would still be able to see them if using the search box.
This PR re-arranges the logic to handle this scenario.

V16 also has the same issue, independently of whether list view is enabled or not. It does seem that more changes might be required to handle "Ignore User Start Nodes" appropriately. Once this is PR is approved, I will try to cherry pick and see what additional changes are required.

**Testing**
Follow the instructions in the reported issue and create different accounts with different permission configurations to ensure that the search returns the expected results when:
- User has no start node restriction
- User has access to a parent node in which both the Test page and the Overview page are children of
- User only has access to the Test page

Also test the different picker configurations:
- With and without start node selected
- With and without "Ignore User Start Nodes" selected

Since the adjusted method is also used by the backoffice search (search icon on the top right of the backoffice), also check that still works!