### PR TITLE
Fix logic with check for duplicate container name at level

### DIFF
--- a/src/Umbraco.Core/Services/EntityTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/EntityTypeContainerService.cs
@@ -107,7 +107,7 @@ internal abstract class EntityTypeContainerService<TTreeEntity, TEntityContainer
                     return EntityContainerOperationStatus.ParentNotFound;
                 }
 
-                if (_entityContainerRepository.HasDuplicateName(container.ParentId, container.Name!))
+                if (_entityContainerRepository.HasDuplicateName(parentContainer?.Id ?? Constants.System.Root, container.Name!))
                 {
                     return EntityContainerOperationStatus.DuplicateName;
                 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
@@ -149,7 +149,7 @@ internal class EntityContainerRepository : EntityRepositoryBase<int, EntityConta
     {
         NodeDto nodeDto = Database.FirstOrDefault<NodeDto>(Sql().SelectAll()
             .From<NodeDto>()
-            .Where<NodeDto>(dto => dto.Text == name &&  dto.NodeObjectType == NodeObjectTypeId && dto.ParentId == parentId));
+            .Where<NodeDto>(dto => dto.Text == name && dto.NodeObjectType == NodeObjectTypeId && dto.ParentId == parentId));
 
         return nodeDto is not null;
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeContainerServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/DataTypeContainerServiceTests.cs
@@ -5,7 +5,6 @@ using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
-using Umbraco.Cms.Infrastructure.Services;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -52,6 +51,26 @@ internal sealed class DataTypeContainerServiceTests : UmbracoIntegrationTest
         Assert.NotNull(created);
         Assert.AreEqual("Child Container", created.Name);
         Assert.AreEqual(root.Id, created.ParentId);
+    }
+
+    [TestCase("Existing Child Container", false)]
+    [TestCase("New Child Container", true)]
+    [TestCase("Root Container", true)]
+    public async Task Can_Create_Child_Container_Without_Duplicate_Name_At_Level(string containerName, bool expectSuccess)
+    {
+        EntityContainer root = (await DataTypeContainerService.CreateAsync(null, "Root Container", null, Constants.Security.SuperUserKey)).Result;
+        EntityContainer existingChild = (await DataTypeContainerService.CreateAsync(null, "Existing Child Container", root.Key, Constants.Security.SuperUserKey)).Result;
+
+        var result = await DataTypeContainerService.CreateAsync(null, containerName, root.Key, Constants.Security.SuperUserKey);
+        Assert.AreEqual(expectSuccess, result.Success);
+        if (expectSuccess)
+        {
+            Assert.AreEqual(EntityContainerOperationStatus.Success, result.Status);
+        }
+        else
+        {
+            Assert.AreEqual(EntityContainerOperationStatus.DuplicateName, result.Status);
+        }
     }
 
     [Test]


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19783

### Description
This PR fixes the logic for the checks for duplicate container names at a level, ensuring we check against the provided parent and not the root.  And integration test verifying the fix - that failed against the previous code and now passes - has been added.

### Testing
See reproduction steps in this comment: https://github.com/umbraco/Umbraco-CMS/issues/19783#issuecomment-3124780693
