### PR TITLE
Fix issue unsaved changes always displayed when trying to move away from blueprint

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/entity.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/entity.ts
@@ -6,6 +6,9 @@ export type UmbDocumentBlueprintRootEntityType = typeof UMB_DOCUMENT_BLUEPRINT_R
 export type UmbDocumentBlueprintEntityType = typeof UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE;
 export type UmbDocumentBlueprintFolderEntityType = typeof UMB_DOCUMENT_BLUEPRINT_FOLDER_ENTITY_TYPE;
 
+export const UMB_DOCUMENT_BLUEPRINT_PROPERTY_VALUE_ENTITY_TYPE = `${UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE}-property-value`;
+export type UmbDocumentBlueprintPropertyValueEntityType = typeof UMB_DOCUMENT_BLUEPRINT_PROPERTY_VALUE_ENTITY_TYPE;
+
 export type UmbDocumentBlueprintEntityTypeUnion =
 	| UmbDocumentBlueprintRootEntityType
 	| UmbDocumentBlueprintEntityType

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/detail/document-blueprint-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/detail/document-blueprint-detail.server.data-source.ts
@@ -1,5 +1,5 @@
 import type { UmbDocumentBlueprintDetailModel } from '../../types.js';
-import { UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE } from '../../entity.js';
+import { UMB_DOCUMENT_BLUEPRINT_ENTITY_TYPE, UMB_DOCUMENT_BLUEPRINT_PROPERTY_VALUE_ENTITY_TYPE } from '../../entity.js';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbDataSourceResponse, UmbDetailDataSource } from '@umbraco-cms/backoffice/repository';
 import type {
@@ -9,7 +9,6 @@ import type {
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { DocumentBlueprintService } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE } from '@umbraco-cms/backoffice/document';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
 
 /**
@@ -194,7 +193,7 @@ export class UmbDocumentBlueprintServerDataSource implements UmbDetailDataSource
 			values: data.values.map((value) => {
 				return {
 					editorAlias: value.editorAlias,
-					entityType: UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE,
+					entityType: UMB_DOCUMENT_BLUEPRINT_PROPERTY_VALUE_ENTITY_TYPE,
 					culture: value.culture || null,
 					segment: value.segment || null,
 					alias: value.alias,
@@ -203,13 +202,15 @@ export class UmbDocumentBlueprintServerDataSource implements UmbDetailDataSource
 			}),
 			variants: data.variants.map((variant) => {
 				return {
-					state: variant.state,
 					culture: variant.culture || null,
 					segment: variant.segment || null,
+					state: variant.state,
 					name: variant.name,
 					publishDate: variant.publishDate || null,
 					createDate: variant.createDate,
 					updateDate: variant.updateDate,
+					scheduledPublishDate: variant.scheduledPublishDate || null,
+					scheduledUnpublishDate: variant.scheduledUnpublishDate || null
 				};
 			}),
 			documentType: {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR fixes the issue https://github.com/umbraco/Umbraco-CMS/issues/19551

**Reason**:
There is a difference between persisted data and current data after loading the data. 
For blueprints that use blocklists, the current data is updated right after the first data load, the value's entityType is assiged to '`'document-blueprint-property-value'` while right before it was assigned to persisted data with the value ` 'document-property-value'`. 
In addition, the lack of 2 properties `scheduledPublishDate `and `scheduledUnpublishDate `in the `createDocumentBlueprintDetailModel `funtion also causes a between persisted and current data.

**Solution**:
I modified the createDocumentBlueprintDetailModel function to ensure the data between persisted and current data is consistent.

<!-- Thanks for contributing to Umbraco CMS! -->
