### PR TITLE
Tiptap RTE: Include Tiptap's default styles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/css/rte-content.css
+++ b/src/Umbraco.Web.UI.Client/src/css/rte-content.css
@@ -19,3 +19,82 @@
 	padding: 10px;
 	border-radius: 5px;
 }
+
+/* Default Tiptap RTE styles.
+ * Copied from: https://github.com/ueberdosis/tiptap/blob/v2.11.7/packages/core/src/style.ts
+ * as we disable the `injectCSS` option in the Tiptap editor.
+ */
+
+.ProseMirror {
+	position: relative;
+}
+
+.ProseMirror {
+	word-wrap: break-word;
+	white-space: pre-wrap;
+	white-space: break-spaces;
+	-webkit-font-variant-ligatures: none;
+	font-variant-ligatures: none;
+	font-feature-settings: 'liga' 0; /* the above doesn't seem to work in Edge */
+}
+
+.ProseMirror [contenteditable='false'] {
+	white-space: normal;
+}
+
+.ProseMirror [contenteditable='false'] [contenteditable='true'] {
+	white-space: pre-wrap;
+}
+
+.ProseMirror pre {
+	white-space: pre-wrap;
+}
+
+img.ProseMirror-separator {
+	display: inline !important;
+	border: none !important;
+	margin: 0 !important;
+	width: 0 !important;
+	height: 0 !important;
+}
+
+.ProseMirror-gapcursor {
+	display: none;
+	pointer-events: none;
+	position: absolute;
+	margin: 0;
+}
+
+.ProseMirror-gapcursor:after {
+	content: '';
+	display: block;
+	position: absolute;
+	top: -2px;
+	width: 20px;
+	border-top: 1px solid black;
+	animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite;
+}
+
+@keyframes ProseMirror-cursor-blink {
+	to {
+		visibility: hidden;
+	}
+}
+
+.ProseMirror-hideselection *::selection {
+	background: transparent;
+}
+
+.ProseMirror-hideselection *::-moz-selection {
+	background: transparent;
+}
+
+.ProseMirror-hideselection * {
+	caret-color: transparent;
+}
+
+.ProseMirror-focused .ProseMirror-gapcursor {
+	display: block;
+}
+
+/* End of default Tiptap RTE styles */

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -175,6 +175,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 			editable: !this.readonly,
 			extensions: tiptapExtensions,
 			content: this.#value,
+			injectCSS: false, // Prevents injecting CSS into `window.document`, as it never applies to the shadow DOM. [LK]
 			//enableContentCheck: true,
 			onBeforeCreate: ({ editor }) => {
 				this._extensions.forEach((ext) => ext.setEditor(editor));


### PR DESCRIPTION
### Description

By default the Tiptap editor would include its default CSS to the current document, e.g. `window.document`. However these would never be applied to the shadow DOM of the `<input-tiptap>` component, so never used.

By adding them to our "rte-content.css" file, we can include them in the RTE.

To note, one of the rules `.ProseMirror-hideselection * { caret-color: transparent; }` will resolve issue #19791.

#### How to test?

Try out the Tiptap RTE with and without this patch, are there any notable differences? (hopefully not)

To test out issue #19791, add a non-inline Block element to the RTE, then use keyboard navigation to select the Block. Before this patch, the cursor caret would be on the next line. After the patch, the caret is not visible when the Block is selected.