### PR TITLE
Tiptap RTE: Block selection

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -354,7 +354,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			:host {
 				position: relative;
 				display: block;
-				user-select: none;
+				user-select: all;
 				user-drag: auto;
 				white-space: nowrap;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -360,7 +360,6 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			}
 			:host(.ProseMirror-selectednode) {
 				umb-ref-rte-block {
-					cursor: not-allowed;
 					outline: 3px solid var(--uui-color-focus);
 				}
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -358,8 +358,10 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 				user-drag: auto;
 				white-space: nowrap;
 			}
+
 			:host(.ProseMirror-selectednode) {
 				umb-ref-rte-block {
+					--uui-color-default-contrast: initial;
 					outline: 3px solid var(--uui-color-focus);
 				}
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
@@ -74,6 +74,7 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 			/* HACK: Stretches a space character (&emsp;) to be full-width to make the RTE block appear text-selectable. [LK,NL] */
 			.selection-background {
 				position: absolute;
+				pointer-events: none;
 				font-size: 100vw;
 				inset: 0;
 				overflow: hidden;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
@@ -49,7 +49,7 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 		const blockValue = { ...this.content, $settings: this.settings };
 		return html`
 			<uui-ref-node standalone href=${(this.config?.showContentEdit ? this._workspaceEditPath : undefined) ?? ''}>
-				<div class="selection-background">&emsp;</div>
+				<div class="selection-background" aria-hidden="true">&emsp;</div>
 				<umb-icon slot="icon" .name=${this.icon}></umb-icon>
 				<umb-ufm-render slot="name" inline .markdown=${this.label} .value=${blockValue}></umb-ufm-render>
 			</uui-ref-node>

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
@@ -49,6 +49,7 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 		const blockValue = { ...this.content, $settings: this.settings };
 		return html`
 			<uui-ref-node standalone href=${(this.config?.showContentEdit ? this._workspaceEditPath : undefined) ?? ''}>
+				<div class="selection-background">&emsp;</div>
 				<umb-icon slot="icon" .name=${this.icon}></umb-icon>
 				<umb-ufm-render slot="name" inline .markdown=${this.label} .value=${blockValue}></umb-ufm-render>
 			</uui-ref-node>
@@ -66,6 +67,21 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 			:host([unpublished]) umb-icon,
 			:host([unpublished]) umb-ufm-render {
 				opacity: 0.6;
+			}
+
+			/* HACK: Stretches a space character (&emsp;) to be full-width to make the RTE block appear text-selectable. [LK,NL] */
+			.selection-background {
+				position: absolute;
+				font-size: 100vw;
+				inset: 0;
+				overflow: hidden;
+				z-index: 0;
+			}
+
+			umb-icon,
+			umb-ufm-render {
+				z-index: 1;
+
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
@@ -61,9 +61,11 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 			:host {
 				display: block;
 			}
+
 			uui-ref-node {
 				min-height: var(--uui-size-16);
 			}
+
 			:host([unpublished]) umb-icon,
 			:host([unpublished]) umb-ufm-render {
 				opacity: 0.6;
@@ -82,6 +84,9 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 			umb-ufm-render {
 				z-index: 1;
 
+				&::selection {
+					color: var(--uui-color-default-contrast);
+				}
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/ufm-render/ufm-render.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/ufm-render/ufm-render.element.ts
@@ -50,6 +50,10 @@ export class UmbUfmRenderElement extends UmbLitElement {
 	static override styles = [
 		UmbTextStyles,
 		css`
+			:host {
+				position: relative;
+			}
+
 			* {
 				max-width: 100%;
 				word-wrap: break-word;

--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^2.0.37",
-        "@umbraco/playwright-testhelpers": "^16.0.29",
+        "@umbraco/playwright-testhelpers": "^16.0.32",
         "camelize": "^1.0.0",
         "dotenv": "^16.3.1",
         "node-fetch": "^2.6.7"
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "16.0.29",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-16.0.29.tgz",
-      "integrity": "sha512-Zk0Ip2rZO0T15mbjQqu9SXI9TFckja/Y4KpHCRzwRgTbkDKr9pT7TENCcvegymVX2GpH6Cs9fu7OPvUABLK9cg==",
+      "version": "16.0.32",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-16.0.32.tgz",
+      "integrity": "sha512-HB/xHnu36XOyQjNnpSe1j9DoZ61tY7OvnkNQT73MhGcrhfnNdn/Hf+6nFN7gutUTcxn+L6COeXzexQclSjYr+g==",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.37",
         "node-fetch": "^2.6.7"

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^2.0.37",
-    "@umbraco/playwright-testhelpers": "^16.0.29",
+    "@umbraco/playwright-testhelpers": "^16.0.32",
     "camelize": "^1.0.0",
     "dotenv": "^16.3.1",
     "node-fetch": "^2.6.7"

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockGrid/ComplexBlockGridTest.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockGrid/ComplexBlockGridTest.spec.ts
@@ -108,7 +108,7 @@ test('can update property value nested in a block grid area with an RTE with a b
   await umbracoUi.content.isFailedStateButtonVisible();
   await umbracoUi.content.doesErrorNotificationHaveText(NotificationConstantHelper.error.documentCouldNotBePublished, true, true);
   // Updates the textstring block with the correct value
-  await umbracoUi.content.clickBlockElementWithName(blockListElementTypeName);
+  await umbracoUi.content.clickBlockElementInRTEWithName(blockListElementTypeName);
   await umbracoUi.content.clickEditBlockListEntryWithName(textStringElementTypeName);
   await umbracoUi.content.enterPropertyValue(textStringElementDataTypeName, correctPropertyValue);
   await umbracoUi.content.clickUpdateButtonForModalWithElementTypeNameAndGroupName(textStringElementTypeName, textStringElementGroupName);
@@ -124,7 +124,7 @@ test('can update property value nested in a block grid area with an RTE with a b
   await umbracoUi.reloadPage();
   // Waits to make sure the page has loaded
   await umbracoUi.waitForTimeout(2000);
-  await umbracoUi.content.clickBlockElementWithName(blockListElementTypeName);
+  await umbracoUi.content.clickBlockElementInRTEWithName(blockListElementTypeName);
   // Needs to wait to make sure it has loaded
   await umbracoUi.waitForTimeout(2000);
   await umbracoUi.content.clickEditBlockListEntryWithName(textStringElementTypeName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/RichTextEditor/VariantTipTapBlocks.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/RichTextEditor/VariantTipTapBlocks.spec.ts
@@ -61,7 +61,7 @@ test('invariant document type with invariant tiptap RTE with invariant block wit
   await umbracoUi.content.isSuccessStateVisibleForSaveAndPublishButton();
   expect(await umbracoApi.document.isDocumentPublished(contentId)).toBeTruthy();
   await umbracoUi.reloadPage();
-  await umbracoUi.content.clickBlockElementWithName(blockName);
+  await umbracoUi.content.clickBlockElementInRTEWithName(blockName);
   await umbracoUi.content.doesPropertyContainValue(textStringName, textStringText);
 });
 
@@ -128,7 +128,7 @@ test('variant document type with variant tiptap RTE with variant block with an v
   await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.published);
   expect(await umbracoApi.document.isDocumentPublished(contentId)).toBeTruthy();
   await umbracoUi.reloadPage();
-  await umbracoUi.content.clickBlockElementWithName(blockName);
+  await umbracoUi.content.clickBlockElementInRTEWithName(blockName);
   await umbracoUi.content.doesPropertyContainValue(textStringName, textStringText);
 });
 
@@ -154,7 +154,7 @@ test('variant document type with invariant tiptap RTE with variant block with an
   await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.published);
   expect(await umbracoApi.document.isDocumentPublished(contentId)).toBeTruthy();
   await umbracoUi.reloadPage();
-  await umbracoUi.content.clickBlockElementWithName(blockName);
+  await umbracoUi.content.clickBlockElementInRTEWithName(blockName);
   await umbracoUi.content.doesPropertyContainValue(textStringName, textStringText);
 });
 
@@ -180,6 +180,6 @@ test('variant document type with invariant tiptap RTE with variant block with an
   await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.published);
   expect(await umbracoApi.document.isDocumentPublished(contentId)).toBeTruthy();
   await umbracoUi.reloadPage();
-  await umbracoUi.content.clickBlockElementWithName(blockName);
+  await umbracoUi.content.clickBlockElementInRTEWithName(blockName);
   await umbracoUi.content.doesPropertyContainValue(textStringName, textStringText);
 });


### PR DESCRIPTION
### Description

Fixes #19790.

Adds support to make RTE block appear selected when surrounding text is highlighted.

This is a slight CSS hack, as it adds an element with a single full-width space (`&emsp;`) to the `<umb-ref-rte-block>` component, so when the block is selected, it will appear highlighted.

#### How to test?

Go to an RTE that has Block elements, make a text selection (by click+drag, or a select all <kbd>CTRL + A</kbd>) and notice that the blocks appear selected.

To note, if the text selection is copied, the text-content of the block is not copied, but the markup is, e.g. it can be pasted within Tiptap RTE, but not a text-editor/notepad.
