### PR TITLE
Use a regex to filter our invalid culture codes rather than relying on the culture being installed on the operating system

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
@@ -267,6 +267,6 @@ public partial class PreviewController : Controller
     [GeneratedRegex("^\\/(?<id>\\d*)(\\?culture=(?<culture>[\\w-]*))?$")]
     private static partial Regex DefaultPreviewRedirectRegex();
 
-    [GeneratedRegex(@"^[a-zA-Z0-9-]+$")]
+    [GeneratedRegex(@"^[a-z]{2,3}[-0-9a-z]*$", RegexOptions.IgnoreCase)]
     private static partial Regex CultureCodeRegex();
 }

--- a/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/PreviewController.cs
@@ -178,26 +178,31 @@ public partial class PreviewController : Controller
         return RedirectPermanent($"../../{id}{query}");
     }
 
-    private static bool ValidateProvidedCulture(string culture)
+    /// <summary>
+    /// Validates the provided culture code.
+    /// </summary>
+    /// <remarks>
+    /// Marked as internal to expose for unit tests.
+    /// </remarks>
+    internal static bool ValidateProvidedCulture(string culture)
     {
         if (string.IsNullOrEmpty(culture))
         {
             return true;
         }
 
-        // We can be confident the backoffice will have provided a valid culture in linking to the
-        // preview, so we don't need to check that the culture matches an Umbraco language.
-        // We are only concerned here with protecting against XSS attacks from a fiddled preview
-        // URL, so we can just confirm we have a valid culture.
-        try
-        {
-            CultureInfo.GetCultureInfo(culture, true);
-            return true;
-        }
-        catch (CultureNotFoundException)
+        // Culture codes are expected to match this pattern.
+        if (CultureCodeRegex().IsMatch(culture) is false)
         {
             return false;
         }
+
+        // We can be confident the backoffice will have provided a valid culture in linking to the
+        // preview, so we don't need to check that the culture matches an Umbraco language (or is even a
+        // valid culture code).
+        // We are only concerned here with protecting against XSS attacks from a fiddled preview
+        // URL, so we can proceed if the the regex is matched.
+        return true;
     }
 
     public ActionResult? EnterPreview(int id)
@@ -261,4 +266,7 @@ public partial class PreviewController : Controller
 
     [GeneratedRegex("^\\/(?<id>\\d*)(\\?culture=(?<culture>[\\w-]*))?$")]
     private static partial Regex DefaultPreviewRedirectRegex();
+
+    [GeneratedRegex(@"^[a-zA-Z0-9-]+$")]
+    private static partial Regex CultureCodeRegex();
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/PreviewControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.BackOffice/Controllers/PreviewControllerTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using NUnit.Framework;
+using Umbraco.Cms.Web.BackOffice.Controllers;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.BackOffice.Controllers;
+
+[TestFixture]
+public class PreviewControllerTests
+{
+    [TestCase("en-US", true)] // A framework culture.
+    [TestCase("en-JP", true)] // A valid culture string, but not one that's in the framework.
+    [TestCase("a!", false)]   // Not a valid culture string.
+    [TestCase("<script>alert(123)</script>", false)]
+    public void ValidateProvidedCulture_Validates_Culture(string culture, bool expectValid)
+    {
+        var result = PreviewController.ValidateProvidedCulture(culture);
+        Assert.AreEqual(expectValid, result);
+    }
+
+    [Test]
+    public void ValidateProvidedCulture_Validates_Culture_For_All_Framework_Cultures()
+    {
+        var cultures = CultureInfo.GetCultures(CultureTypes.AllCultures);
+        foreach (var culture in cultures)
+        {
+            Assert.IsTrue(PreviewController.ValidateProvidedCulture(culture.Name), $"{culture.Name} is not considered a valid culture.");
+            Assert.IsTrue(PreviewController.ValidateProvidedCulture(culture.Name.ToUpperInvariant()), $"{culture.Name.ToUpperInvariant()} is not considered a valid culture.");
+            Assert.IsTrue(PreviewController.ValidateProvidedCulture(culture.Name.ToLowerInvariant()), $"{culture.Name.ToLowerInvariant()} is not considered a valid culture.");
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/19817

### Description
The linked issue flags a security hardening introduced to ensure that the culture code provided in the preview URL is valid.  We did this by verifying that the culture code provided one can be used to construct a `CultureInfo`.  However this failed unnecessarily for culture codes that were valid syntactically but not installed on the operation system and exposed by .NET.

Given we have this to prevent XSS vulnerabilities, it would seem enough to verify the culture code contains only valid characters.  So that's what this PR does.

### Testing
Preview a page in Umbraco and verify that the provided culture code is accepted and the preview shown.

Manipulate the culture code provided in the querystring to create an invalid one and verify that an exception is thrown.

### Release
Needs to be merged/re-applied to Umbraco 16.
