### PR TITLE
Tiptap RTE: Custom CSS Variables for min/max height/width

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -2705,7 +2705,7 @@ export default {
 		trainingDescription:
 			'\n        <p>Want to master Umbraco? Spend a couple of minutes learning some best practices by watching one of these videos about using Umbraco. And visit <a href="https://umbraco.tv" target="_blank" rel="noopener">umbraco.tv</a> for even more Umbraco videos</p>\n    ',
 		learningBaseDescription:
-  			'  <p>Vil du mestre Umbraco? Brug et par minutter på at lære nogle best practices ved at besøge <a class="btn-link -underline" href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener">Umbraco Learning Base YouTube-kanalen</a>. Her finder du en masse videoer, der dækker mange aspekter af Umbraco.</p> ',
+			'  <p>Vil du mestre Umbraco? Brug et par minutter på at lære nogle best practices ved at besøge <a class="btn-link -underline" href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener">Umbraco Learning Base YouTube-kanalen</a>. Her finder du en masse videoer, der dækker mange aspekter af Umbraco.</p> ',
 		getStarted: 'To get you started',
 	},
 	settingsDashboard: {
@@ -2790,9 +2790,8 @@ export default {
 	tiptap: {
 		anchor: 'Anker',
 		anchor_input: 'Indtast anker-ID',
-		config_dimensions_description: 'Sæt den maksimale bredde og højde på editoren. Dette ekskluderer værktøjslinjens højde.',
-		maxDimensions: 'Maksimale dimensioner',
-		minDimensions: 'Minimale dimensioner',
+		config_dimensions_description:
+			'Angiver en fast bredde og højde for editoren. Dette ekskluderer værktøjslinjens og statuslinjens højder.',
 		config_extensions: 'Funktioner',
 		config_statusbar: 'Statuslinje',
 		config_toolbar: 'Værktøjslinje',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2781,7 +2781,8 @@ export default {
 	tiptap: {
 		anchor: 'Anchor',
 		anchor_input: 'Enter an anchor ID',
-		config_dimensions_description: 'Set the maximum width and height of the editor. This excludes the toolbar height.',
+		config_dimensions_description:
+			'Sets the fixed width and height of the editor. This excludes the toolbar and statusbar heights.',
 		config_extensions: 'Capabilities',
 		config_statusbar: 'Statusbar',
 		config_toolbar: 'Toolbar',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -2789,7 +2789,7 @@ export default {
 		anchor: 'Âncora',
 		anchor_input: 'Introduza um ID de âncora',
 		config_dimensions_description:
-			'Defina a largura e altura máximas do editor. Isto exclui a altura da barra de ferramentas.',
+			'Definir uma largura e altura fixas para o editor. Isso exclui as alturas da barra de ferramentas e da barra de estado.',
 		config_extensions: 'Capacidades',
 		config_statusbar: 'Barra de estado',
 		config_toolbar: 'Barra de ferramentas',

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -1,22 +1,22 @@
 import type { UmbPropertyEditorRteValueType } from '../types.js';
 import { UMB_BLOCK_RTE_PROPERTY_EDITOR_SCHEMA_ALIAS } from '../constants.js';
-import { property, state } from '@umbraco-cms/backoffice/external/lit';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
+import { property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbBlockRteEntriesContext, UmbBlockRteManagerContext } from '@umbraco-cms/backoffice/block-rte';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import {
+	UmbFormControlMixin,
+	UmbValidationContext,
+	UMB_VALIDATION_EMPTY_LOCALIZATION_KEY,
+} from '@umbraco-cms/backoffice/validation';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
 import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import type { UmbBlockRteTypeModel } from '@umbraco-cms/backoffice/block-rte';
 import type {
 	UmbPropertyEditorUiElement,
 	UmbPropertyEditorConfigCollection,
 } from '@umbraco-cms/backoffice/property-editor';
-import {
-	UMB_VALIDATION_EMPTY_LOCALIZATION_KEY,
-	UmbFormControlMixin,
-	UmbValidationContext,
-} from '@umbraco-cms/backoffice/validation';
-import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
-import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
 import type { StyleInfo } from '@umbraco-cms/backoffice/external/lit';
 
 export abstract class UmbPropertyEditorUiRteElementBase
@@ -106,6 +106,7 @@ export abstract class UmbPropertyEditorUiRteElementBase
 
 	/**
 	 * @deprecated _value is depreacated, use `super.value` instead.
+	 * @returns {UmbPropertyEditorRteValueType | undefined} The value of the property editor.
 	 */
 	@state()
 	protected get _value(): UmbPropertyEditorRteValueType | undefined {

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -17,6 +17,7 @@ import {
 } from '@umbraco-cms/backoffice/validation';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
+import type { StyleInfo } from '@umbraco-cms/backoffice/external/lit';
 
 export abstract class UmbPropertyEditorUiRteElementBase
 	extends UmbFormControlMixin<UmbPropertyEditorRteValueType | undefined, typeof UmbLitElement, undefined>(UmbLitElement)
@@ -31,6 +32,12 @@ export abstract class UmbPropertyEditorUiRteElementBase
 		this.#managerContext.setBlockTypes(blocks);
 
 		this.#managerContext.setEditorConfiguration(config);
+
+		const dimensions = config.getValueByAlias<{ width?: number; height?: number }>('dimensions');
+		this._css = {
+			'--umb-rte-max-width': dimensions?.width ? `${dimensions.width}px` : '100%',
+			'--umb-rte-height': dimensions?.height ? `${dimensions.height}px` : 'unset',
+		};
 	}
 
 	@property({
@@ -93,6 +100,9 @@ export abstract class UmbPropertyEditorUiRteElementBase
 
 	@state()
 	protected _config?: UmbPropertyEditorConfigCollection;
+
+	@state()
+	protected _css: StyleInfo = {};
 
 	/**
 	 * @deprecated _value is depreacated, use `super.value` instead.

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -240,8 +240,8 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				position: relative;
 				z-index: 0;
 
-				width: var(--umb-rte-width, 'unset');
-				min-width: var(--umb-rte-min-width, 'unset');
+				width: var(--umb-rte-width, unset);
+				min-width: var(--umb-rte-min-width, unset);
 				max-width: var(--umb-rte-max-width, 100%);
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -247,6 +247,10 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				display: block;
 				position: relative;
 				z-index: 0;
+
+				width: var(--umb-rte-width, 'unset');
+				min-width: var(--umb-rte-min-width, 'unset');
+				max-width: var(--umb-rte-max-width, 100%);
 			}
 
 			:host([readonly]) {
@@ -279,7 +283,11 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border: 1px solid var(--umb-tiptap-edge-border-color, var(--uui-color-border));
 				padding: 1rem;
 				box-sizing: border-box;
-				height: 100%;
+
+				height: var(--umb-rte-height, 100%);
+				min-height: var(--umb-rte-min-height, 100%);
+				max-height: var(--umb-rte-max-height, 100%);
+
 				width: 100%;
 				max-width: 100%;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -134,14 +134,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		const element = this.shadowRoot?.querySelector('#editor');
 		if (!element) return;
 
-		const dimensions = this.configuration?.getValueByAlias<{ width?: number; height?: number }>('dimensions');
-		if (dimensions?.width) {
-			this.setAttribute('style', `max-width: ${dimensions.width}px;`);
-		}
-		if (dimensions?.height) {
-			element.setAttribute('style', `height: ${dimensions.height}px;`);
-		}
-
 		const stylesheets = this.configuration?.getValueByAlias<Array<string>>('stylesheets');
 		if (stylesheets?.length) {
 			stylesheets.forEach((stylesheet) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap/property-editor-ui-tiptap.element.ts
@@ -1,6 +1,7 @@
 import type { UmbInputTiptapElement } from '../../components/input-tiptap/input-tiptap.element.js';
+import { css, customElement, html, styleMap } from '@umbraco-cms/backoffice/external/lit';
 import { UmbPropertyEditorUiRteElementBase } from '@umbraco-cms/backoffice/rte';
-import { css, customElement, html, type PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
+import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 
 import '../../components/input-tiptap/input-tiptap.element.js';
 
@@ -66,6 +67,7 @@ export class UmbPropertyEditorUiTiptapElement extends UmbPropertyEditorUiRteElem
 	override render() {
 		return html`
 			<umb-input-tiptap
+				style=${styleMap(this._css)}
 				.configuration=${this._config}
 				.requiredMessage=${this.mandatoryMessage}
 				.value=${this._markup}


### PR DESCRIPTION
### Description

Resolves #19588.

Whilst reviewing PR #19739 (that offered a fix for #19588), it added a new option to the Tiptap RTE data-type configuration for **Minimum dimensions**. This offered a way for an implementor to configure the RTE with both a minimum and maximum height.

The introduction of a new input field to the Tiptap RTE would add to an already complex set of configuration options.
After exploring alternative options, I decided to follow an approach that we've offered with styling other property-editors, by using CSS Variables.

This PR adds the following CSS Variables to the Tiptap RTE, (note that they are prefixed with a generic `rte` not `tiptap`):

- `--umb-rte-width`
- `--umb-rte-min-width`
- `--umb-rte-max-width`
- `--umb-rte-height`
- `--umb-rte-min-height`
- `--umb-rte-max-height`

This PR also updated the localization text for the "Dimensions" field description, as it previously said it was a "maximum" height/width, whereas it's actually a "fixed" height/width".

#### How to test?

In the data-type configuration of a Tiptap RTE, try with and without the "Dimensions" field being set, and seeing the rendered display on a document item.

If you're feeling adventurous, try adding a global custom CSS file to the backoffice, or via a custom `theme` extension, and setting the values of the custom CSS variables, e.g. `--umb-rte-min-height: 200px;`.
