### PR TITLE
Media Table Collection View: Adds support for Label Templates

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/table/media-table-collection-view.element.ts
@@ -108,6 +108,7 @@ export class UmbMediaTableCollectionViewElement extends UmbLitElement {
 					name: this.localize.string(item.header),
 					alias: item.alias,
 					elementName: item.elementName,
+					labelTemplate: item.nameTemplate,
 					allowSorting: true,
 				};
 			});


### PR DESCRIPTION
### Description

Fixes #19835.

The `labelTemplate` property was not wired up in the Media Table Collection View component, meaning that dynamic labels and UFM syntax did not work.

#### How to test?

In the built-in data-type "List View - Media", use UFM syntax inside any of the column's label template field.
As an example, you could add a new column, using the `umbracoBytes` property-alias and use the label template `{=value | bytes}`.
On the Media section dashboard, view the Table (List) layout of the root collection, the value should be rendered using UFM. For the above example, any value in bytes should be rendered in kilobytes/megabytes.