### PR TITLE
Adds abstraction around boot time checks for database availability

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -90,6 +90,9 @@ public static partial class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<RuntimeUnattendedUpgradeNotification, UnattendedUpgrader>();
         builder.AddNotificationAsyncHandler<RuntimePremigrationsUpgradeNotification, PremigrationUpgrader>();
 
+        // Database availability check.
+        builder.Services.AddUnique<IDatabaseAvailabilityCheck, DefaultDatabaseAvailabilityCheck>();
+
         // Add runtime mode validation
         builder.Services.AddSingleton<IRuntimeModeValidationService, RuntimeModeValidationService>();
         builder.RuntimeModeValidators()

--- a/src/Umbraco.Infrastructure/Persistence/DefaultDatabaseAvailabilityCheck.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DefaultDatabaseAvailabilityCheck.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging;
+
+namespace Umbraco.Cms.Infrastructure.Persistence;
+
+/// <summary>
+/// Checks if a configured database is available on boot using the default method of 5 attempts with a 1 second delay between each one.
+/// </summary>
+internal class DefaultDatabaseAvailabilityCheck : IDatabaseAvailabilityCheck
+{
+    private const int NumberOfAttempts = 5;
+    private const int DefaultAttemptDelayMilliseconds = 1000;
+
+    private readonly ILogger<DefaultDatabaseAvailabilityCheck> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultDatabaseAvailabilityCheck"/> class.
+    /// </summary>
+    /// <param name="logger"></param>
+    public DefaultDatabaseAvailabilityCheck(ILogger<DefaultDatabaseAvailabilityCheck> logger) => _logger = logger;
+
+    /// <summary>
+    /// Gets or sets the number of milliseconds to delay between attempts.
+    /// </summary>
+    /// <remarks>
+    /// Exposed for testing purposes, hence settable only internally.
+    /// </remarks>
+    public int AttemptDelayMilliseconds { get; internal set; } = DefaultAttemptDelayMilliseconds;
+
+    /// <inheritdoc/>
+    public bool IsDatabaseAvailable(IUmbracoDatabaseFactory databaseFactory)
+    {
+        bool canConnect;
+        for (var i = 0; ;)
+        {
+            canConnect = databaseFactory.CanConnect;
+            if (canConnect || ++i == NumberOfAttempts)
+            {
+                break;
+            }
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Could not immediately connect to database, trying again.");
+            }
+
+            // Wait for the configured time before trying again.
+            Thread.Sleep(AttemptDelayMilliseconds);
+        }
+
+        return canConnect;
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/IDatabaseAvailabilityCheck.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IDatabaseAvailabilityCheck.cs
@@ -1,0 +1,16 @@
+namespace Umbraco.Cms.Infrastructure.Persistence;
+
+/// <summary>
+/// Checks if a configured database is available on boot.
+/// </summary>
+public interface IDatabaseAvailabilityCheck
+{
+    /// <summary>
+    /// Checks if the database is available for Umbraco to boot.
+    /// </summary>
+    /// <param name="databaseFactory">The <see cref="IUmbracoDatabaseFactory"/>.</param>
+    /// <returns>
+    /// A value indicating whether the database is available.
+    /// </returns>
+    bool IsDatabaseAvailable(IUmbracoDatabaseFactory databaseFactory);
+}

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeState.cs
@@ -31,6 +31,7 @@ public class RuntimeState : IRuntimeState
     private readonly IConflictingRouteService _conflictingRouteService = null!;
     private readonly IEnumerable<IDatabaseProviderMetadata> _databaseProviderMetadata = null!;
     private readonly IRuntimeModeValidationService _runtimeModeValidationService = null!;
+    private readonly IDatabaseAvailabilityCheck _databaseAvailabilityCheck = null!;
 
     /// <summary>
     /// The initial <see cref="RuntimeState"/>
@@ -46,6 +47,7 @@ public class RuntimeState : IRuntimeState
     /// <summary>
     /// Initializes a new instance of the <see cref="RuntimeState" /> class.
     /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 18.")]
     public RuntimeState(
        IOptions<GlobalSettings> globalSettings,
        IOptions<UnattendedSettings> unattendedSettings,
@@ -56,6 +58,34 @@ public class RuntimeState : IRuntimeState
        IConflictingRouteService conflictingRouteService,
        IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata,
        IRuntimeModeValidationService runtimeModeValidationService)
+       : this(
+             globalSettings,
+             unattendedSettings,
+             umbracoVersion,
+             databaseFactory,
+             logger,
+             packageMigrationState,
+             conflictingRouteService,
+             databaseProviderMetadata,
+             runtimeModeValidationService,
+             StaticServiceProvider.Instance.GetRequiredService<IDatabaseAvailabilityCheck>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RuntimeState" /> class.
+    /// </summary>
+    public RuntimeState(
+       IOptions<GlobalSettings> globalSettings,
+       IOptions<UnattendedSettings> unattendedSettings,
+       IUmbracoVersion umbracoVersion,
+       IUmbracoDatabaseFactory databaseFactory,
+       ILogger<RuntimeState> logger,
+       PendingPackageMigrations packageMigrationState,
+       IConflictingRouteService conflictingRouteService,
+       IEnumerable<IDatabaseProviderMetadata> databaseProviderMetadata,
+       IRuntimeModeValidationService runtimeModeValidationService,
+       IDatabaseAvailabilityCheck databaseAvailabilityCheck)
     {
         _globalSettings = globalSettings;
         _unattendedSettings = unattendedSettings;
@@ -66,6 +96,7 @@ public class RuntimeState : IRuntimeState
         _conflictingRouteService = conflictingRouteService;
         _databaseProviderMetadata = databaseProviderMetadata;
         _runtimeModeValidationService = runtimeModeValidationService;
+        _databaseAvailabilityCheck = databaseAvailabilityCheck;
     }
 
     /// <inheritdoc />
@@ -242,7 +273,7 @@ public class RuntimeState : IRuntimeState
     {
         try
         {
-            if (!TryDbConnect(databaseFactory))
+            if (_databaseAvailabilityCheck.IsDatabaseAvailable(databaseFactory) is false)
             {
                 return UmbracoDatabaseState.CannotConnect;
             }
@@ -304,28 +335,5 @@ public class RuntimeState : IRuntimeState
             _logger.LogDebug("Final upgrade state is {FinalMigrationState}, database contains {DatabaseState}", FinalMigrationState, CurrentMigrationState ?? "<null>");
         }
         return CurrentMigrationState != FinalMigrationState;
-    }
-
-    private bool TryDbConnect(IUmbracoDatabaseFactory databaseFactory)
-    {
-        // anything other than install wants a database - see if we can connect
-        // (since this is an already existing database, assume localdb is ready)
-        bool canConnect;
-        var tries = 5;
-        for (var i = 0; ;)
-        {
-            canConnect = databaseFactory.CanConnect;
-            if (canConnect || ++i == tries)
-            {
-                break;
-            }
-            if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
-            {
-                _logger.LogDebug("Could not immediately connect to database, trying again.");
-            }
-            Thread.Sleep(1000);
-        }
-
-        return canConnect;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/DefaultDatabaseAvailabilityCheckTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/DefaultDatabaseAvailabilityCheckTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Install.Models;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence;
+
+[TestFixture]
+public class DefaultDatabaseAvailabilityCheckTests
+{
+    [Test]
+    public void IsDatabaseAvailable_WithDatabaseUnavailable_ReturnsFalse()
+    {
+        var mockDatabaseFactory = new Mock<IUmbracoDatabaseFactory>();
+        mockDatabaseFactory
+            .Setup(x => x.CanConnect)
+            .Returns(false);
+
+        var sut = CreateDefaultDatabaseAvailabilityCheck();
+        var result = sut.IsDatabaseAvailable(mockDatabaseFactory.Object);
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void IsDatabaseAvailable_WithDatabaseImmediatelyAvailable_ReturnsTrue()
+    {
+        var mockDatabaseFactory = new Mock<IUmbracoDatabaseFactory>();
+        mockDatabaseFactory
+            .Setup(x => x.CanConnect)
+            .Returns(true);
+
+        var sut = CreateDefaultDatabaseAvailabilityCheck();
+        var result = sut.IsDatabaseAvailable(mockDatabaseFactory.Object);
+        Assert.IsTrue(result);
+    }
+
+    [TestCase(5, true)]
+    [TestCase(6, false)]
+    public void IsDatabaseAvailable_WithDatabaseImmediatelyAvailableAfterMultipleAttempts_ReturnsExpectedResult(int attemptsUntilConnection, bool expectedResult)
+    {
+        var attemptResults = new Queue<bool>();
+        for (var i = 0; i < attemptsUntilConnection - 1; i++)
+        {
+            attemptResults.Enqueue(false);
+        }
+
+        attemptResults.Enqueue(true);
+
+        var mockDatabaseFactory = new Mock<IUmbracoDatabaseFactory>();
+        mockDatabaseFactory
+            .Setup(x => x.CanConnect)
+            .Returns(attemptResults.Dequeue);
+
+        var sut = CreateDefaultDatabaseAvailabilityCheck();
+        var result = sut.IsDatabaseAvailable(mockDatabaseFactory.Object);
+        Assert.AreEqual(expectedResult, result);
+    }
+
+    private static DefaultDatabaseAvailabilityCheck CreateDefaultDatabaseAvailabilityCheck()
+        => new(new NullLogger<DefaultDatabaseAvailabilityCheck>())
+        {
+            AttemptDelayMilliseconds = 1 // Set to 1 ms for faster tests.
+        };
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/DefaultDatabaseAvailabilityCheckTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/DefaultDatabaseAvailabilityCheckTests.cs
@@ -40,6 +40,11 @@ public class DefaultDatabaseAvailabilityCheckTests
     [TestCase(6, false)]
     public void IsDatabaseAvailable_WithDatabaseImmediatelyAvailableAfterMultipleAttempts_ReturnsExpectedResult(int attemptsUntilConnection, bool expectedResult)
     {
+        if (attemptsUntilConnection < 1)
+        {
+            throw new ArgumentException($"{nameof(attemptsUntilConnection)} must be greater than or equal to 1.", nameof(attemptsUntilConnection));
+        }
+
         var attemptResults = new Queue<bool>();
         for (var i = 0; i < attemptsUntilConnection - 1; i++)
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses https://github.com/umbraco/Umbraco-CMS/issues/17363

### Description
The linked issue notes some problems that can occur at boot time when the database isn't yet available.  We currently have a hard-coded behaviour to try 5 times with a 1 second delay in between, and if following that we can't connect to the database, we throw an exception and stop.

It seemed it might be better if we gave developers more control here, so this update doesn't change behaviour, but abstracts what we have behind an interface so it could be swapped for something more appropriate for the hosting environment.  Maybe waiting for some other result, or using a different strategy like exponential back-off or just increased delay, to give more time for the database to come online.

### Testing
Verify Umbraco continues to behave as before when it comes to booting up with a database available and not available.
