### PR TITLE
Provides an abstraction for creating the JavaScriptEncoder used in SystemTextConfigurationEditorJsonSerializer

### DIFF
--- a/src/Umbraco.Core/Serialization/IConfigurationEditorJsonSerializerEncoderFactory.cs
+++ b/src/Umbraco.Core/Serialization/IConfigurationEditorJsonSerializerEncoderFactory.cs
@@ -1,0 +1,15 @@
+using System.Text.Encodings.Web;
+
+namespace Umbraco.Cms.Core.Serialization;
+
+/// <summary>
+/// Provides a factory method for creating a <see cref="JavaScriptEncoder"/> for use in the serialization of configuration editor JSON.
+/// </summary>
+public interface IConfigurationEditorJsonSerializerEncoderFactory
+{
+    /// <summary>
+    /// Creates a <see cref="JavaScriptEncoder"/> for use in the serialization of configuration editor JSON.
+    /// </summary>
+    /// <returns>A <see cref="JavaScriptEncoder"/> instance.</returns>
+    JavaScriptEncoder CreateEncoder();
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -124,6 +124,7 @@ public static partial class UmbracoBuilderExtensions
 
         builder.Services.AddSingleton<IJsonSerializer, SystemTextJsonSerializer>();
         builder.Services.AddSingleton<IConfigurationEditorJsonSerializer, SystemTextConfigurationEditorJsonSerializer>();
+        builder.Services.AddUnique<IConfigurationEditorJsonSerializerEncoderFactory, DefaultConfigurationEditorJsonSerializerEncoderFactory>();
         builder.Services.AddUnique<IWebhookJsonSerializer, SystemTextWebhookJsonSerializer>();
 
         // register database builder

--- a/src/Umbraco.Infrastructure/Serialization/DefaultConfigurationEditorJsonSerializerEncoderFactory.cs
+++ b/src/Umbraco.Infrastructure/Serialization/DefaultConfigurationEditorJsonSerializerEncoderFactory.cs
@@ -1,0 +1,12 @@
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Cms.Infrastructure.Serialization;
+
+/// <inheritdoc />
+public sealed class DefaultConfigurationEditorJsonSerializerEncoderFactory : IConfigurationEditorJsonSerializerEncoderFactory
+{
+    /// <inheritdoc />
+    public JavaScriptEncoder CreateEncoder() => JavaScriptEncoder.Create(UnicodeRanges.BasicLatin);
+}

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 
@@ -14,10 +16,22 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJson
     /// <summary>
     /// Initializes a new instance of the <see cref="SystemTextConfigurationEditorJsonSerializer" /> class.
     /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 18.")]
     public SystemTextConfigurationEditorJsonSerializer()
+        : this(
+              StaticServiceProvider.Instance.GetRequiredService<IConfigurationEditorJsonSerializerEncoderFactory>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SystemTextConfigurationEditorJsonSerializer" /> class.
+    /// </summary>
+    public SystemTextConfigurationEditorJsonSerializer(IConfigurationEditorJsonSerializerEncoderFactory configurationEditorJsonSerializerEncoderFactory)
         => _jsonSerializerOptions = new JsonSerializerOptions()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+
+            Encoder = configurationEditorJsonSerializerEncoderFactory.CreateEncoder(),
 
             // In some cases, configs aren't camel cased in the DB, so we have to resort to case insensitive
             // property name resolving when creating configuration objects (deserializing DB configs).
@@ -40,6 +54,7 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJson
                 .WithAddedModifier(UseAttributeConfiguredPropertyNames()),
         };
 
+    /// <inheritdoc/>
     protected override JsonSerializerOptions JsonSerializerOptions => _jsonSerializerOptions;
 
     /// <summary>

--- a/tests/Umbraco.TestData/UmbracoTestDataController.cs
+++ b/tests/Umbraco.TestData/UmbracoTestDataController.cs
@@ -299,7 +299,7 @@ public class UmbracoTestDataController : SurfaceController
             throw new InvalidOperationException($"No {editorAlias} editor found");
         }
 
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 
         dt = new DataType(editor, serializer)
         {

--- a/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/DataTypeBuilder.cs
@@ -138,7 +138,7 @@ public class DataTypeBuilder
         var creatorId = _creatorId ?? 1;
         var databaseType = _databaseType ?? ValueStorageType.Ntext;
         var sortOrder = _sortOrder ?? 0;
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 
         var dataType = new DataType(editor, serializer, parentId)
         {

--- a/tests/Umbraco.Tests.UnitTests/TestHelpers/PublishedSnapshotServiceTestBase.cs
+++ b/tests/Umbraco.Tests.UnitTests/TestHelpers/PublishedSnapshotServiceTestBase.cs
@@ -165,7 +165,7 @@
 //
 //     protected static DataType[] GetDefaultDataTypes()
 //     {
-//         var serializer = new SystemTextConfigurationEditorJsonSerializer();
+//         var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 //
 //         // create data types, property types and content types
 //         var dataType =

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/VariationTests.cs
@@ -644,7 +644,7 @@ public class VariationTests
             dataValueEditorFactory,
             ioHelper);
 
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 
         var mockDataTypeService = new Mock<IDataTypeService>();
         Mock.Get(dataTypeService).Setup(x => x.GetDataType(It.Is<int>(y => y == Constants.DataTypes.Textbox)))

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ColorListValidatorTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ColorListValidatorTest.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
 public class ColorListValidatorTest
 {
     private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer()
-        => new SystemTextConfigurationEditorJsonSerializer();
+        => new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 
     [Test]
     public void Expects_Array_Of_ColorPickerItems_Not_Single_String()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ConvertersTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ConvertersTests.cs
@@ -57,7 +57,7 @@ public class ConvertersTests
         var converters =
             registerFactory.GetRequiredService<PropertyValueConverterCollection>();
 
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var dataTypeServiceMock = new Mock<IDataTypeService>();
         var dataType1 = new DataType(
             new VoidEditor(

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
@@ -61,7 +61,7 @@ public class DataValueReferenceFactoryCollectionTests
         var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
         var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
         var trackedUdi4 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var property =
             new Property(
                 new PropertyType(ShortStringHelper, new DataType(labelEditor, serializer))
@@ -105,7 +105,7 @@ public class DataValueReferenceFactoryCollectionTests
         var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
         var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
         var trackedUdi4 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var property =
             new Property(
                 new PropertyType(ShortStringHelper, new DataType(mediaPicker, serializer))
@@ -149,7 +149,7 @@ public class DataValueReferenceFactoryCollectionTests
         var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
         var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
         var trackedUdi4 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var property =
             new Property(new PropertyType(ShortStringHelper, new DataType(mediaPicker, serializer))
             {
@@ -198,7 +198,7 @@ public class DataValueReferenceFactoryCollectionTests
 
         var labelPropertyEditor = new LabelPropertyEditor(DataValueEditorFactory, IOHelper);
         var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => labelPropertyEditor.Yield()));
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 
         var result = collection.GetAllAutomaticRelationTypesAliases(propertyEditors).ToArray();
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/EnsureUniqueValuesValidatorTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/EnsureUniqueValuesValidatorTest.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
 public class EnsureUniqueValuesValidatorTest
 {
     private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer()
-        => new SystemTextConfigurationEditorJsonSerializer();
+        => new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 
     [Test]
     public void Expects_Array_Of_String_Not_Single_String()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiValuePropertyEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiValuePropertyEditorTests.cs
@@ -31,7 +31,7 @@ public class MultiValuePropertyEditorTests
     public void MultipleValueEditor_WithMultipleValues_Format_Data_For_Cache()
     {
         var dataValueEditorFactoryMock = new Mock<IDataValueEditorFactory>();
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var checkBoxListPropertyEditor = new CheckBoxListPropertyEditor(
             dataValueEditorFactoryMock.Object,
             Mock.Of<IIOHelper>(),
@@ -66,7 +66,7 @@ public class MultiValuePropertyEditorTests
     public void MultipleValueEditor_WithSingleValue_Format_Data_For_Cache()
     {
         var dataValueEditorFactoryMock = new Mock<IDataValueEditorFactory>();
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var checkBoxListPropertyEditor = new CheckBoxListPropertyEditor(
             dataValueEditorFactoryMock.Object,
             Mock.Of<IIOHelper>(),
@@ -100,7 +100,7 @@ public class MultiValuePropertyEditorTests
     {
         var dataValueEditorFactoryMock = new Mock<IDataValueEditorFactory>();
 
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var checkBoxListPropertyEditor = new CheckBoxListPropertyEditor(
             dataValueEditorFactoryMock.Object,
             Mock.Of<IIOHelper>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/ConvertersTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/ConvertersTests.cs
@@ -26,7 +26,7 @@ public class ConvertersTests
         var converters =
             new PropertyValueConverterCollection(() => new IPropertyValueConverter[] { new SimpleConverter1() });
 
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var dataTypeServiceMock = new Mock<IDataTypeService>();
         var dataType = new DataType(
             new VoidEditor(Mock.Of<IDataValueEditorFactory>()), serializer)
@@ -103,7 +103,7 @@ public class ConvertersTests
             new SimpleConverter2(cacheMock.Object)
         ]);
 
-        var serializer = new SystemTextConfigurationEditorJsonSerializer();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var dataTypeServiceMock = new Mock<IDataTypeService>();
         var dataType = new DataType(
             new VoidEditor(Mock.Of<IDataValueEditorFactory>()), serializer)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/PropertyCacheLevelTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Published/PropertyCacheLevelTests.cs
@@ -28,7 +28,7 @@ public class PropertyCacheLevelTests
 
         var converters = new PropertyValueConverterCollection(() => new IPropertyValueConverter[] { converter });
 
-        var configurationEditorJsonSerializer = new SystemTextConfigurationEditorJsonSerializer();
+        var configurationEditorJsonSerializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
         var dataTypeServiceMock = new Mock<IDataTypeService>();
         var dataType = new DataType(
             new VoidEditor(Mock.Of<IDataValueEditorFactory>()), configurationEditorJsonSerializer)
@@ -103,7 +103,7 @@ public class PropertyCacheLevelTests
 
         var dataTypeServiceMock = new Mock<IDataTypeService>();
         var dataType = new DataType(
-            new VoidEditor(Mock.Of<IDataValueEditorFactory>()), new SystemTextConfigurationEditorJsonSerializer())
+            new VoidEditor(Mock.Of<IDataValueEditorFactory>()), new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory()))
         { Id = 1 };
         dataTypeServiceMock.Setup(x => x.GetAll()).Returns(dataType.Yield);
 
@@ -171,7 +171,7 @@ public class PropertyCacheLevelTests
 
         var dataTypeServiceMock = new Mock<IDataTypeService>();
         var dataType = new DataType(
-            new VoidEditor(Mock.Of<IDataValueEditorFactory>()), new SystemTextConfigurationEditorJsonSerializer())
+            new VoidEditor(Mock.Of<IDataValueEditorFactory>()), new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory()))
         { Id = 1 };
         dataTypeServiceMock.Setup(x => x.GetAll()).Returns(dataType.Yield);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Querying/ExpressionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Querying/ExpressionTests.cs
@@ -26,7 +26,7 @@ public class ExpressionTests : BaseUsingSqlSyntax
     {
         var dataType = new DataType(
                 new VoidEditor(Mock.Of<IDataValueEditorFactory>()),
-                new SystemTextConfigurationEditorJsonSerializer())
+                new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory()))
         { Id = 12345 };
         Expression<Func<PropertyType, bool>> predicate = p => p.DataTypeId == dataType.Id;
         var modelToSqlExpressionHelper = new ModelToSqlExpressionVisitor<PropertyType>(SqlContext.SqlSyntax, Mappers);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PublishedCache/PublishedMediaTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PublishedCache/PublishedMediaTests.cs
@@ -27,7 +27,7 @@
 //         base.Setup();
 //
 //         var dataTypes = GetDefaultDataTypes().ToList();
-//         var serializer = new SystemTextConfigurationEditorJsonSerializer();
+//         var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultConfigurationEditorJsonSerializerEncoderFactory());
 //         var rteDataType = new DataType(new VoidEditor("RTE", Mock.Of<IDataValueEditorFactory>()), serializer) { Id = 4 };
 //         dataTypes.Add(rteDataType);
 //         _dataTypes = dataTypes.ToArray();


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Provides a solution to https://github.com/umbraco/Umbraco-CMS/issues/19812

### Description
When serializing the data type configuration to the database we use `SystemTextConfigurationEditorJsonSerializer` which uses a default `JavaScriptEncoder`.  The linked issue shows how a project may want to customize this, but controlling how particular `UnicodeRanges` are encoded.

It doesn't seem we can just change the default behaviour here - as we don't know what ranges are appropriate to consider for a given project.  We could provide `UnicodeRanges.All`, but at minimum that would be a behaviourally breaking change and at worst could lead to errors where certain strings aren't encoded with escaping as we'd expect.

So I've added an interface with a default implementation of the current behaviour to allow this to be overridden.

### Testing

Verify that for example a check box list with values containing non-Latin characters can be saved with configuration and used in content.
Verify that the non-Latin values continue to be escaped in the database, via:

```
select * from umbracoPropertyData where PropertyTypeId = {id}
select * from umbracoDataType where nodeid = {id}
```

Add a custom implementation such as the following and verify that the expect changes to the stored values in the database are made, that the data type configuration can be saved and that content using the data type can be updated.

```
using System.Text.Encodings.Web;
using System.Text.Unicode;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Serialization;

namespace Umbraco.Cms.Web.UI.Custom.SystemTextConfigurationEditor;

public class SystemTextConfigurationEditorComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Services.AddUnique<IConfigurationEditorJsonSerializerEncoderFactory, MyConfigurationEditorJsonSerializerEncoderFactory>();
    }
}

internal class MyConfigurationEditorJsonSerializerEncoderFactory : IConfigurationEditorJsonSerializerEncoderFactory
{
    public JavaScriptEncoder CreateEncoder() => JavaScriptEncoder.Create(UnicodeRanges.BasicLatin, UnicodeRanges.Cyrillic);
}
```