### PR TITLE
Build: Separate eslint logic for **/*.ts files

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/eslint/rules/umb-class-prefix.cjs
+++ b/src/Umbraco.Web.UI.Client/devops/eslint/rules/umb-class-prefix.cjs
@@ -1,3 +1,5 @@
+const ALLOWED_PREFIXES = ['Umb', 'Example'];
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
 	meta: {
@@ -11,10 +13,10 @@ module.exports = {
 	},
 	create: function (context) {
 		function checkClassName(node) {
-			if (node.id && node.id.name && !node.id.name.startsWith('Umb')) {
+			if (node.id && node.id.name && !ALLOWED_PREFIXES.some(prefix => node.id.name.startsWith(prefix))) {
 				context.report({
 					node: node.id,
-					message: 'Class declaration should be prefixed with "Umb"',
+					message: `Class declaration should be prefixed with one of the following prefixes: ${ALLOWED_PREFIXES.join(', ')}`,
 				});
 			}
 		}

--- a/src/Umbraco.Web.UI.Client/eslint.config.js
+++ b/src/Umbraco.Web.UI.Client/eslint.config.js
@@ -38,15 +38,6 @@ export default [
 
 	// Global config
 	{
-		languageOptions: {
-			parserOptions: {
-				project: true,
-				tsconfigRootDir: import.meta.dirname,
-			},
-			globals: {
-				...globals.browser,
-			},
-		},
 		plugins: {
 			import: importPlugin,
 			'local-rules': localRules,
@@ -77,13 +68,6 @@ export default [
 					excludedFileNames: ['umbraco-package'],
 				},
 			],
-			'@typescript-eslint/no-non-null-assertion': 'off',
-			'@typescript-eslint/no-explicit-any': 'warn',
-			'@typescript-eslint/no-unused-vars': 'error',
-			'@typescript-eslint/consistent-type-exports': 'error',
-			'@typescript-eslint/consistent-type-imports': 'error',
-			'@typescript-eslint/no-import-type-side-effects': 'warn',
-			'@typescript-eslint/no-deprecated': 'warn',
 			'jsdoc/check-tag-names': [
 				'warn',
 				{
@@ -95,6 +79,27 @@ export default [
 	},
 
 	// Pattern-specific overrides
+	{
+		files: ['**/*.ts'],
+		languageOptions: {
+			parserOptions: {
+				project: true,
+				tsconfigRootDir: import.meta.dirname,
+			},
+			globals: {
+				...globals.browser,
+			},
+		},
+		rules: {
+			'@typescript-eslint/no-non-null-assertion': 'off',
+			'@typescript-eslint/no-explicit-any': 'warn',
+			'@typescript-eslint/no-unused-vars': 'error',
+			'@typescript-eslint/consistent-type-exports': 'error',
+			'@typescript-eslint/consistent-type-imports': 'error',
+			'@typescript-eslint/no-import-type-side-effects': 'warn',
+			'@typescript-eslint/no-deprecated': 'warn',
+		},
+	},
 	{
 		files: ['**/*.js'],
 		...tseslint.configs.disableTypeChecked,


### PR DESCRIPTION
## Description

To avoid errors for .js files, this separates the rules for .ts files to its own pattern only leaving the global rules to work for all types of files.