### PR TITLE
Fix issue create media folder throw error

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/audit-log/info-app/media-history-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/audit-log/info-app/media-history-workspace-info-app.element.ts
@@ -42,7 +42,9 @@ export class UmbMediaHistoryWorkspaceInfoAppElement extends UmbLitElement {
 	}
 
 	async #requestAuditLogs() {
-		const unique = this.#workspaceContext?.getUnique();
+		if (!this.#workspaceContext) return;
+
+		const unique = this.#workspaceContext.getUnique();
 		if (!unique) throw new Error('Media unique is required');
 
 		const { data } = await this.#auditLogRepository.requestAuditLog({


### PR DESCRIPTION
This PR fixes the issue https://github.com/umbraco/Umbraco-CMS/issues/19649.

`requestAuditLogs()` is used to get data for this history in media detail, but after clicking save, the close modal action is immediately called, so it will destroy the `workspaceContext `=>` #requestAuditLogs()` will throw an Error.
I will add to check the existence of `#workspaceContext` in `requestAuditLogs()` before doing other things.|
And because requestAuditLogs() is already called when opening the media detail, so the log is always getting updated when opening it.