### PR TITLE
Fixed layout and formatting of saved search delete dialog on the log viewer

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-search-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-search-input.element.ts
@@ -1,17 +1,17 @@
 import type { UmbLogViewerWorkspaceContext } from '../../../logviewer-workspace.context.js';
 import { UMB_APP_LOG_VIEWER_CONTEXT } from '../../../logviewer-workspace.context-token.js';
 import { UMB_LOG_VIEWER_SAVE_SEARCH_MODAL } from './log-viewer-search-input-modal.modal-token.js';
-import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 import { css, html, customElement, query, state } from '@umbraco-cms/backoffice/external/lit';
-import { Subject, debounceTime, tap } from '@umbraco-cms/backoffice/external/rxjs';
-import type { SavedLogSearchResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 import { query as getQuery, path, toQueryString } from '@umbraco-cms/backoffice/router';
+import { Subject, debounceTime, tap } from '@umbraco-cms/backoffice/external/rxjs';
 import { umbConfirmModal, umbOpenModal } from '@umbraco-cms/backoffice/modal';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { SavedLogSearchResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbDropdownElement } from '@umbraco-cms/backoffice/components';
+import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 
 import './log-viewer-search-input-modal.element.js';
-import type { UmbDropdownElement } from '@umbraco-cms/backoffice/components';
-import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-log-viewer-search-input')
 export class UmbLogViewerSearchInputElement extends UmbLitElement {

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-search-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/views/search/components/log-viewer-search-input.element.ts
@@ -11,6 +11,7 @@ import { umbConfirmModal, umbOpenModal } from '@umbraco-cms/backoffice/modal';
 
 import './log-viewer-search-input-modal.element.js';
 import type { UmbDropdownElement } from '@umbraco-cms/backoffice/components';
+import { escapeHTML } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-log-viewer-search-input')
 export class UmbLogViewerSearchInputElement extends UmbLitElement {
@@ -101,7 +102,7 @@ export class UmbLogViewerSearchInputElement extends UmbLitElement {
 	async #removeSearch(name: string) {
 		await umbConfirmModal(this, {
 			headline: this.localize.term('logViewer_deleteSavedSearch'),
-			content: `${this.localize.term('defaultdialogs_confirmdelete')} ${name}?`,
+			content: this.localize.term('defaultdialogs_confirmdelete', escapeHTML(name)),
 			color: 'danger',
 			confirmLabel: 'Delete',
 		});


### PR DESCRIPTION
### Description
Previously this displayed as:

> Are you sure you want to delete? {saved search name}?

Now it's:

> Are you sure you want to delete {saved search name}?

<img width="547" height="196" alt="image" src="https://github.com/user-attachments/assets/d02e0808-eadb-4a47-9331-451fe4b4d48c" />

### Testing

Create a saved search via the log viewer and try to delete it.