### PR TITLE
Support persistence of unrestricted selections from the check box list.

### DIFF
--- a/src/Umbraco.Core/Models/ValueStorageType.cs
+++ b/src/Umbraco.Core/Models/ValueStorageType.cs
@@ -14,13 +14,13 @@ public enum ValueStorageType
     // changing the casing of values.
 
     /// <summary>
-    ///     Store property value as NText.
+    ///     Store property value as NVarchar(max).
     /// </summary>
     [EnumMember]
     Ntext,
 
     /// <summary>
-    ///     Store property value as NVarChar.
+    ///     Store property value as NVarChar(512).
     /// </summary>
     [EnumMember]
     Nvarchar,

--- a/src/Umbraco.Core/PropertyEditors/ValueTypes.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueTypes.cs
@@ -45,7 +45,7 @@ public static class ValueTypes
     public const string Json = "JSON"; // NText
 
     /// <summary>
-    ///     Text value (maps to text database type).
+    ///     Text value (maps to nvarchar(max) database type).
     /// </summary>
     public const string Text = "TEXT"; // NText
 
@@ -55,7 +55,7 @@ public static class ValueTypes
     public const string Time = "TIME"; // Date
 
     /// <summary>
-    ///     Text value (maps to varchar database type).
+    ///     Text value (maps to nvarchar(512) database type).
     /// </summary>
     public const string String = "STRING"; // NVarchar
 

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -2060,7 +2060,7 @@ internal sealed class DatabaseDataCreator
                     NodeId = -43,
                     EditorAlias = Constants.PropertyEditors.Aliases.CheckBoxList,
                     EditorUiAlias = "Umb.PropertyEditorUi.CheckBoxList",
-                    DbType = "Nvarchar",
+                    DbType = "Ntext",
                 });
         }
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -126,5 +126,6 @@ public class UmbracoPlan : MigrationPlan
 
         // To 17.0.0
         To<V_17_0_0.AddGuidsToAuditEntries>("{17D5F6CA-CEB8-462A-AF86-4B9C3BF91CF1}");
+        To<V_17_0_0.MigrateCheckboxListDataTypesAndPropertyData>("{EB1E50B7-CD5E-4B6B-B307-36237DD2C506}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/MigrateCheckboxListDataTypesAndPropertyData.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/MigrateCheckboxListDataTypesAndPropertyData.cs
@@ -1,0 +1,50 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_0_0;
+
+/// <summary>
+/// Migrates data types based on the Umbraco.CheckBoxList property editor to store data in the text column without length restriction.
+/// Also migrates the data for properties this property editor from the length restricted field (varcharValue - nvarchar(512)), to the
+/// one without a restriction (textValue - nvarchar(max)).
+/// </summary>
+public class MigrateCheckboxListDataTypesAndPropertyData : AsyncMigrationBase
+{
+    private readonly IDataTypeService _dataTypeService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MigrateCheckboxListDataTypesAndPropertyData"/> class.
+    /// </summary>
+    public MigrateCheckboxListDataTypesAndPropertyData(IMigrationContext context, IDataTypeService dataTypeService)
+        : base(context) => _dataTypeService = dataTypeService;
+
+    /// <inheritdoc/>
+    protected override async Task MigrateAsync()
+    {
+        // Update the definition of the datatypes.
+        IEnumerable<IDataType> dataTypes = await _dataTypeService.GetByEditorAliasAsync("Umbraco.CheckBoxList");
+        foreach (IDataType dataType in dataTypes)
+        {
+            dataType.DatabaseType = ValueStorageType.Ntext;
+            await _dataTypeService.UpdateAsync(dataType, Constants.Security.SuperUserKey);
+        }
+
+        // Copy from varcharValue to textValue and set varcharValue to null for all property data stored using data types based on
+        // the Umbraco.CheckBoxList property editor.
+        string sql = @"
+UPDATE umbracoPropertyData
+SET textValue = varcharValue, varcharValue = NULL
+WHERE propertyTypeId IN (
+	SELECT id
+    FROM cmsPropertyType
+	WHERE dataTypeId IN (
+		SELECT nodeId
+        FROM umbracoDataType
+        WHERE propertyEditorAlias = 'Umbraco.CheckBoxList'
+	)
+)
+AND varcharValue IS NOT NULL";
+        await Database.ExecuteAsync(sql);
+    }
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/CheckBoxListPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/CheckBoxListPropertyEditor.cs
@@ -12,6 +12,7 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 [DataEditor(
     Constants.PropertyEditors.Aliases.CheckBoxList,
+    ValueType = ValueTypes.Text, // We use the Text value type to ensure we don't run out of storage space in the database field with large lists with multiple values selected.
     ValueEditorIsReusable = true)]
 public class CheckBoxListPropertyEditor : DataEditor
 {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/19828

### Description
The linked issue raises an issue that has come up before around saving property data for the checkbox list when many selections are made.  We store the results as JSON and so it's possible to overrun the database field where the property data is stored (`umbracoPropertyData.varcharValue` which is `nvarchar(512)`.

The PR makes the necessary updates to use the `textValue` column which is `nvarchar(max)`:

- Updates the `ValueType` on the property editor, which means new data types created with that property editor will use the unrestricted text column for storage.
- Updates the initial data type created on new installs to use the unrestricted text column for storage.
- Provides a migration that will:
    - Update all existing data types based on the check box list property editor to use the unrestricted text column for storage.
    - Migrates all property data stored from to the unrestricted text column for storage.

### Testing
Verify new installs create a checkbox list data type that persists data in the unrestricted text column.
Verify existing data types are converted to use the unrestricted text column.
Verify existing property data is moved to the the unrestricted text column.
Verify existing content can be edited, updated and saved as expected.

Migration has been checked on SQLite and SQL Server.

### Release
Note that I've targeted this for Umbraco 17.  The reason is the migration on `umbracoPropertyData` that could be time-consuming if there's a lot of data stored, and it's likely better in a release with a longer RC period and the expectation of a more significant upgrade than a minor release would suggest.

Useful queries:

```
select * from umbracoDataType where propertyEditorAlias = 'Umbraco.CheckBoxList'
select * from umbracoPropertyData
where propertyTypeId in (
	select id from cmsPropertyType
	where dataTypeId IN (
		select nodeId from umbracoDataType where propertyEditorAlias = 'Umbraco.CheckBoxList'
	)
)
```


