### PR TITLE
Tiptap RTE: Reduce loading layout shift

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -188,7 +188,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		return html`
 			${when(loading, () => html`<div id="loader"><uui-loader></uui-loader></div>`)}
 			${when(!loading, () => html`${this.#renderStyles()}${this.#renderToolbar()}`)}
-			<div id="editor" data-mark="input:tiptap-rte"></div>
+			<div id="editor" data-mark="input:tiptap-rte" ?data-loaded=${!loading}></div>
 			${when(!loading, () => this.#renderStatusbar())}
 		`;
 	}
@@ -272,7 +272,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				display: flex;
 				overflow: auto;
 				border-radius: var(--uui-border-radius);
-				border: 1px solid var(--umb-tiptap-edge-border-color, var(--uui-color-border));
+				border: 1px solid transparent;
 				padding: 1rem;
 				box-sizing: border-box;
 
@@ -282,6 +282,10 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				width: 100%;
 				max-width: 100%;
+
+				&[data-loaded] {
+					border-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
+				}
 
 				> .tiptap {
 					height: 100%;

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-statusbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-statusbar.element.ts
@@ -99,6 +99,7 @@ export class UmbTiptapStatusbarElement extends UmbLitElement {
 			border-top-left-radius: 0;
 			border-top-right-radius: 0;
 			border-top: 0;
+			box-sizing: border-box;
 
 			min-height: var(--uui-size-layout-1);
 			max-height: var(--uui-size-layout-2);

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
@@ -105,6 +105,7 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 			border-top-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
 			border-left-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
 			border-right-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
+			box-sizing: border-box;
 
 			background-color: var(--uui-color-surface);
 			color: var(--color-text);

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/tiptap-toolbar.element.ts
@@ -9,11 +9,11 @@ import type { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/
 import '../cascading-menu-popover/cascading-menu-popover.element.js';
 
 /**
-* Provides a sticky toolbar for the {@link UmbInputTiptapElement}
-* @element umb-tiptap-toolbar
-* @cssprop --umb-tiptap-edge-border-color - Defines the edge border color
-* @cssprop --umb-tiptap-top - Defines the top value for the sticky toolbar
-*/
+ * Provides a sticky toolbar for the {@link UmbInputTiptapElement}
+ * @element umb-tiptap-toolbar
+ * @cssprop --umb-tiptap-edge-border-color - Defines the edge border color
+ * @cssprop --umb-tiptap-top - Defines the top value for the sticky toolbar
+ */
 @customElement('umb-tiptap-toolbar')
 export class UmbTiptapToolbarElement extends UmbLitElement {
 	#attached = false;
@@ -114,7 +114,7 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 			flex-direction: column;
 
 			position: sticky;
-			top: var(--umb-tiptap-top,-25px);
+			top: var(--umb-tiptap-top, -25px);
 			left: 0;
 			right: 0;
 			padding: var(--uui-size-3);
@@ -130,17 +130,21 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 			flex-direction: row;
 			flex-wrap: wrap;
 
+			min-height: var(--uui-size-12, 36px);
+
 			.group {
 				display: inline-flex;
 				flex-wrap: wrap;
 				align-items: stretch;
+
+				min-height: var(--uui-size-12, 36px);
 
 				&:not(:last-child)::after {
 					content: '';
 					background-color: var(--uui-color-border);
 					width: 1px;
 					place-self: center;
-					height: 22px;
+					height: var(--uui-size-7, 21px);
 					margin: 0 var(--uui-size-3);
 				}
 			}


### PR DESCRIPTION
### Description

One of the issues outlined in #19728 is the layout shift once the Tiptap RTE has loaded.
The main reason for this is that each toolbar item is an extension, which is loaded in asynchronously, and when there are numerous toolbar items, this can visually appear quite jarring.

> [!IMPORTANT]
> This does not resolve #19728, as there are other issues to investigate there.

An immediate fix for this is to add a minimum-height for the toolbar's rows and groups, so that the vertical layout shift is reduced.
Longer term, we're exploring the options of use of placeholder/skeleton elements and ways to optimise extension loading/caching.

#### How to test?

Try loading the Tiptap RTE on a document before and after this patch. Specifically notice how the toolbar items are loaded in, after the initial load, and then on subsequent loads. A good scenario is to try within a Block List element, either inline or sidebar modal, (it's quicker to see the build-up/tear-down of the RTE component).