### PR TITLE
Use GeneratedRegex, FrozenSet, new Lock object & static

### DIFF
--- a/src/Umbraco.Cms.Api.Management/ServerEvents/UserConnectionManager.cs
+++ b/src/Umbraco.Cms.Api.Management/ServerEvents/UserConnectionManager.cs
@@ -7,7 +7,7 @@ internal sealed class UserConnectionManager : IUserConnectionManager
 {
     // We use a normal dictionary instead of ConcurrentDictionary, since we need to lock the set anyways.
     private readonly Dictionary<Guid, HashSet<string>> _connections = new();
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     /// <inheritdoc/>
     public ISet<string> GetConnections(Guid userKey)

--- a/src/Umbraco.Core/Extensions/StringExtensions.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/src/Umbraco.Core/Routing/SiteDomainMapper.cs
+++ b/src/Umbraco.Core/Routing/SiteDomainMapper.cs
@@ -65,7 +65,7 @@ namespace Umbraco.Cms.Core.Routing
             }
         }
 
-        private IEnumerable<string> ValidateDomains(IEnumerable<string> domains) =>
+        private static IEnumerable<string> ValidateDomains(IEnumerable<string> domains) =>
             // must use authority format w/optional scheme and port, but no path
             // any domain should appear only once
             domains.Select(domain =>
@@ -368,7 +368,7 @@ namespace Umbraco.Cms.Core.Routing
             // therefore it is safe to return and exit the configuration lock
         }
 
-        private DomainAndUri? MapDomain(
+        private static DomainAndUri? MapDomain(
             IReadOnlyCollection<DomainAndUri> domainAndUris,
             Dictionary<string, string[]>? qualifiedSites,
             string currentAuthority,

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Umbraco.Cms.Core.Routing;
-using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.Cms.Core.Templates;
 
@@ -84,7 +83,7 @@ public sealed class HtmlLocalLinkParser
 
     // under normal circumstances, the type attribute is preceded by a space
     // to cover the rare occasion where it isn't, we first replace with a space and then without.
-    private string StripTypeAttributeFromTag(string tag, string type) =>
+    private static string StripTypeAttributeFromTag(string tag, string type) =>
         tag.Replace($" type=\"{type}\"", string.Empty)
             .Replace($"type=\"{type}\"", string.Empty);
 

--- a/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
@@ -85,7 +85,7 @@ public sealed class ModelBindingExceptionAttribute : TypeFilterAttribute
         ///         The application is in an unstable state and is going to be restarted. The application is restarting now.
         ///     </para>
         /// </remarks>
-        private bool IsMessageAboutTheSameModelType(string exceptionMessage)
+        private static bool IsMessageAboutTheSameModelType(string exceptionMessage)
         {
             MatchCollection matches = GetPublishedModelsTypesRegex.Matches(exceptionMessage);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Using GeneratedRegex has these benefits:
> The source generator will give your regex the following benefits:
    All the throughput benefits of RegexOptions.Compiled.
    The startup benefits of not having to do all the regex parsing, analysis, and compilation at run time.
    The option of using ahead-of-time compilation with the code generated for the regex.
    Better debuggability and understanding of the regex.
    The possibility to reduce the size of your trimmed app by trimming out large swaths of code associated with RegexCompiler (and potentially even reflection emit itself).

https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-source-generators#when-to-use-it

There are also other places where it could be done, but it will make public classes partial, a change in interface.  
It can be solved by creating a new separate internal partial static class with the source generated stuff, but that moves the regex out of the class to another file...  
Should I also do that or do you have other preferences or solutions to that problem?

P.S.: Also used a FrozenSet, new Lock object and made some private methods static.