### PR TITLE
Tiptap RTE: Fixes embedded media spacing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-span.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-span.extension.ts
@@ -37,6 +37,8 @@ function serializeStyles(items: Record<string, string>): string {
 export const Span = Mark.create<SpanOptions>({
 	name: 'span',
 
+	priority: 50,
+
 	addOptions() {
 		return { HTMLAttributes: {} };
 	},

--- a/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-umb-embedded-media.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-umb-embedded-media.extension.ts
@@ -25,19 +25,13 @@ export const umbEmbeddedMedia = Node.create({
 	},
 
 	parseHTML() {
-		return [
-			{
-				tag: 'div',
-				priority: 100,
-				getAttrs: (dom) => dom.classList.contains('umb-embed-holder') && null,
-			},
-		];
+		return [{ tag: '.umb-embed-holder', priority: 100 }];
 	},
 
 	renderHTML({ HTMLAttributes }) {
 		const { markup, ...attrs } = HTMLAttributes;
 		const embed = document.createRange().createContextualFragment(markup);
-		return ['div', mergeAttributes({ class: 'umb-embed-holder' }, attrs), embed];
+		return [this.options.inline ? 'span' : 'div', mergeAttributes({ class: 'umb-embed-holder' }, attrs), embed];
 	},
 
 	addCommands() {

--- a/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-umb-embedded-media.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/tiptap/extensions/tiptap-umb-embedded-media.extension.ts
@@ -1,6 +1,10 @@
 import { mergeAttributes, Node } from '@tiptap/core';
 
-export const umbEmbeddedMedia = Node.create({
+export interface UmbEmbeddedMediaOptions {
+	inline: boolean;
+}
+
+export const umbEmbeddedMedia = Node.create<UmbEmbeddedMediaOptions>({
 	name: 'umbEmbeddedMedia',
 	group() {
 		return this.options.inline ? 'inline' : 'block';

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/embedded-media.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/core/embedded-media.tiptap-api.ts
@@ -9,27 +9,27 @@ export default class UmbTiptapEmbeddedMediaExtensionApi extends UmbTiptapExtensi
 		.umb-embed-holder {
 			display: inline-block;
 			position: relative;
-		}
 
-		.umb-embed-holder > * {
-			user-select: none;
-			pointer-events: none;
-		}
+			&::before {
+				z-index: 1000;
+				width: 100%;
+				height: 100%;
+				position: absolute;
+				content: ' ';
+			}
 
-		.umb-embed-holder.ProseMirror-selectednode {
-			outline: 2px solid var(--uui-palette-spanish-pink-light);
-		}
+			&.ProseMirror-selectednode {
+				outline: 3px solid var(--uui-color-focus);
 
-		.umb-embed-holder::before {
-			z-index: 1000;
-			width: 100%;
-			height: 100%;
-			position: absolute;
-			content: ' ';
-		}
+				&::before {
+					background: rgba(0, 0, 0, 0.1);
+				}
 
-		.umb-embed-holder.ProseMirror-selectednode::before {
-			background: rgba(0, 0, 0, 0.025);
+				> * {
+					user-select: none;
+					pointer-events: none;
+				}
+			}
 		}
 	`;
 }


### PR DESCRIPTION
### Description

Fixes #19521.

This patch alters how Tiptap RTE renders embedded media items. Previous they were rendered using a `<div>`, but this caused issues ([as explained in my comment on the original issue](http://github.com/umbraco/Umbraco-CMS/issues/19521#issuecomment-2961848399)), this has been altered to use a `<span>` to make the embedded media item act as a native inline block.

Also, I've taken this opportunity to align the styling of the selection of embedded media items with other rich-media selections within the RTE, e.g. blue border outline.

#### How to test?

See #19521 for reproduction steps.

Prior to this fix, view a Tiptap RTE with an existing embedded media item, notice that each save of the document will add extra paragraphs before & after the embedded media item.

With this fix, notice that the each save will not add extra paragraphs. However it will not have removed the existing extra paragraphs, (as they were added outside of the Embedded Media extension code).
