### PR TITLE
Adds configuration for document and media hybrid cache seed batch size

### DIFF
--- a/src/Umbraco.Core/Models/CacheSettings.cs
+++ b/src/Umbraco.Core/Models/CacheSettings.cs
@@ -8,18 +8,38 @@ public class CacheSettings
 {
     internal const int StaticDocumentBreadthFirstSeedCount = 100;
     internal const int StaticMediaBreadthFirstSeedCount = 100;
+    internal const int StaticDocumentSeedBatchSize = 100;
+    internal const int StaticMediaSeedBatchSize = 100;
 
     /// <summary>
-    ///     Gets or sets a value for the collection of content type ids to always have in the cache.
+    /// Gets or sets a value for the collection of content type ids to always have in the cache.
     /// </summary>
     public List<Guid> ContentTypeKeys { get; set; } =
         new();
 
+    /// <summary>
+    /// Gets or sets a value for the document breadth first seed count.
+    /// </summary>
     [DefaultValue(StaticDocumentBreadthFirstSeedCount)]
     public int DocumentBreadthFirstSeedCount { get; set; } = StaticDocumentBreadthFirstSeedCount;
 
+    /// <summary>
+    /// Gets or sets a value for the media breadth first seed count.
+    /// </summary>
     [DefaultValue(StaticMediaBreadthFirstSeedCount)]
     public int MediaBreadthFirstSeedCount { get; set; } = StaticDocumentBreadthFirstSeedCount;
+
+    /// <summary>
+    /// Gets or sets a value for the document seed batch size.
+    /// </summary>
+    [DefaultValue(StaticDocumentSeedBatchSize)]
+    public int DocumentSeedBatchSize { get; set; } = StaticDocumentSeedBatchSize;
+
+    /// <summary>
+    /// Gets or sets a value for the media seed batch size.
+    /// </summary>
+    [DefaultValue(StaticMediaSeedBatchSize)]
+    public int MediaSeedBatchSize { get; set; } = StaticMediaSeedBatchSize;
 
     public CacheEntry Entry { get; set; } = new CacheEntry();
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -195,8 +195,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         sw.Start();
 #endif
 
-        const int GroupSize = 100;
-        foreach (IEnumerable<Guid> group in SeedKeys.InGroupsOf(GroupSize))
+        foreach (IEnumerable<Guid> group in SeedKeys.InGroupsOf(_cacheSettings.DocumentSeedBatchSize))
         {
             var uncachedKeys = new HashSet<Guid>();
             foreach (Guid key in group)

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -158,8 +158,7 @@ internal sealed class MediaCacheService : IMediaCacheService
         sw.Start();
 #endif
 
-        const int GroupSize = 100;
-        foreach (IEnumerable<Guid> group in SeedKeys.InGroupsOf(GroupSize))
+        foreach (IEnumerable<Guid> group in SeedKeys.InGroupsOf(_cacheSettings.MediaSeedBatchSize))
         {
             var uncachedKeys = new HashSet<Guid>();
             foreach (Guid key in group)


### PR DESCRIPTION
Extends on https://github.com/umbraco/Umbraco-CMS/pull/19890 by moving constant values for batch sizes to configuration.