### PR TITLE
V16: Media Picker property editor does not handle dropped files appropriately

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -293,7 +293,7 @@ export default {
 		notCreated: 'Ikke oprettet',
 		updateDate: 'Sidst redigeret',
 		updateDateDesc: 'Tidspunkt for seneste redigering',
-		uploadClear: 'Fjern fil',
+		uploadClear: 'Fjern fil(er)',
 		uploadClearImageContext: 'Klik her for at fjerne billedet fra medie filen',
 		uploadClearFileContext: 'Klik her for at fjerne filen fra medie filen',
 		urls: 'Link til dokument',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -277,7 +277,7 @@ export default {
 		notCreated: 'Nicht angelegt',
 		updateDate: 'Zuletzt bearbeitet am',
 		updateDateDesc: 'Letzter Änderungszeitpunkt des Dokuments',
-		uploadClear: 'Datei entfernen',
+		uploadClear: 'Datei(en) entfernen',
 		uploadClearImageContext: 'Klicke hier um das das Bild vom Medienelement zu entfernen.',
 		uploadClearFileContext: 'Klicke hier um das das Bild vom Medienelement zu entfernen.',
 		urls: 'Link zum Dokument',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -176,7 +176,7 @@ export default {
 		confirmActionConfirm: 'Confirm',
 		morePublishingOptions: 'More publishing options',
 		submitChanges: 'Submit',
-		viewSystemDetails:"View Umbraco CMS system information and version number"
+		viewSystemDetails: 'View Umbraco CMS system information and version number',
 	},
 	auditTrailsMedia: {
 		delete: 'Media deleted',
@@ -295,7 +295,7 @@ export default {
 		notCreated: 'Not created',
 		updateDate: 'Last edited',
 		updateDateDesc: 'Date/time this document was edited',
-		uploadClear: 'Remove file(s)',
+		uploadClear: 'Clear file(s)',
 		uploadClearImageContext: 'Click here to remove the image from the media item',
 		uploadClearFileContext: 'Click here to remove the file from the media item',
 		urls: 'Link to document',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker-input/picker-input.context.ts
@@ -112,8 +112,8 @@ export class UmbPickerInputContext<
 
 		await umbConfirmModal(this, {
 			color: 'danger',
-			headline: `Remove ${item.name}?`,
-			content: 'Are you sure you want to remove this item',
+			headline: `#actions_remove ${item.name}?`,
+			content: `#defaultdialogs_confirmremove ${item.name}?`,
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
@@ -170,7 +170,8 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 					compact
 					@click=${this.#handleRemove}
 					label=${this.localize.term('content_uploadClear')}>
-					<uui-icon name="icon-trash"></uui-icon>${this.localize.term('content_uploadClear')}
+					<uui-icon name="icon-trash"></uui-icon>
+					<umb-localize key="content_uploadClear">Clear file(s)</umb-localize>
 				</uui-button>
 			</div>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/imaging/imaging.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/imaging/imaging.repository.ts
@@ -51,7 +51,7 @@ export class UmbImagingRepository extends UmbRepositoryBase implements UmbApi {
 				continue;
 			}
 
-			const url = urlModels?.[0].url;
+			const url = urlModels?.[0]?.url;
 
 			this.#dataStore.addCrop(unique, url ?? '', imagingModel);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -177,7 +177,7 @@ export class UmbInputImageCropperElement extends UmbFormControlMixin<
 			<umb-image-cropper-field .value=${this.value} .file=${this._file?.temporaryFile?.file} @change=${this.#onChange}>
 				<uui-button slot="actions" compact label=${this.localize.term('content_uploadClear')} @click=${this.#onRemove}>
 					<uui-icon name="icon-trash"></uui-icon>
-					<umb-localize key="content_uploadClear">Remove file(s)</umb-localize>
+					<umb-localize key="content_uploadClear">Clear file(s)</umb-localize>
 				</uui-button>
 			</umb-image-cropper-field>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -264,11 +264,6 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 	async #populateCards() {
 		const mediaItems = this.#itemManager.getItems();
 
-		if (!mediaItems.length) {
-			this._cards = [];
-			return;
-		}
-
 		this._cards =
 			this.value?.map((item) => {
 				const media = mediaItems.find((x) => x.unique === item.mediaKey);

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -382,26 +382,22 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 	}
 
 	#renderAddButton() {
-		if (this._cards && this._cards.length && !this.multiple) return;
-		if (this.readonly && this._cards.length > 0) {
-			return nothing;
-		} else {
-			return html`
-				<uui-button
-					id="btn-add"
-					look="placeholder"
-					@blur=${() => {
-						this.pristine = false;
-						this.checkValidity();
-					}}
-					@click=${this.#openPicker}
-					label=${this.localize.term('general_choose')}
-					?disabled=${this.readonly}>
-					<uui-icon name="icon-add"></uui-icon>
-					${this.localize.term('general_choose')}
-				</uui-button>
-			`;
-		}
+		if (this.readonly) return nothing;
+		return html`
+			<uui-button
+				id="btn-add"
+				look="placeholder"
+				@blur=${() => {
+					this.pristine = false;
+					this.checkValidity();
+				}}
+				@click=${this.#openPicker}
+				label=${this.localize.term('general_choose')}
+				?disabled=${this.readonly}>
+				<uui-icon name="icon-add"></uui-icon>
+				${this.localize.term('general_choose')}
+			</uui-button>
+		`;
 	}
 
 	#renderItem(item: UmbRichMediaCardModel) {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -329,16 +329,20 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 	}
 
 	async #onRemove(item: UmbRichMediaCardModel) {
-		await umbConfirmModal(this, {
-			color: 'danger',
-			headline: `${this.localize.term('actions_remove')} ${item.name}?`,
-			content: `${this.localize.term('defaultdialogs_confirmremove')} ${item.name}?`,
-			confirmLabel: this.localize.term('actions_remove'),
-		});
+		try {
+			await umbConfirmModal(this, {
+				color: 'danger',
+				headline: `${this.localize.term('actions_remove')} ${item.name}?`,
+				content: `${this.localize.term('defaultdialogs_confirmremove')} ${item.name}?`,
+				confirmLabel: this.localize.term('actions_remove'),
+			});
 
-		this.value = this.value?.filter((x) => x.key !== item.unique);
+			this.value = this.value?.filter((x) => x.key !== item.unique);
 
-		this.dispatchEvent(new UmbChangeEvent());
+			this.dispatchEvent(new UmbChangeEvent());
+		} catch {
+			// User cancelled the action
+		}
 	}
 
 	async #onUploadCompleted(e: CustomEvent) {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -292,7 +292,10 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		return true;
 	};
 
-	#addItems(uniques: string[]) {
+	#addItems(additionalMediaKeys: string[]) {
+		// Check that the unique is not already added
+		const uniques = additionalMediaKeys.filter((key) => !this.value?.some((item) => item.mediaKey === key));
+
 		if (!uniques.length) return;
 
 		const additions: Array<UmbMediaPickerPropertyValueEntry> = uniques.map((unique) => ({

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -355,9 +355,11 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		`;
 	}
 
+	// TODO: Consider removing the "progress element" from the dropzone and render that using a context instead. This would allow the media picker to show inline progress items instead [JOV]
 	#renderDropzone() {
 		if (this.readonly) return nothing;
 		return html`<umb-dropzone-media
+			id="dropzone"
 			?multiple=${this.multiple}
 			@change=${this.#onUploadCompleted}></umb-dropzone-media>`;
 	}
@@ -432,7 +434,7 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		`;
 	}
 
-	static override styles = [
+	static override readonly styles = [
 		css`
 			:host {
 				position: relative;
@@ -442,6 +444,10 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 				gap: var(--uui-size-space-5);
 				grid-template-columns: repeat(auto-fill, minmax(var(--umb-card-medium-min-width), 1fr));
 				grid-auto-rows: var(--umb-card-medium-min-width);
+			}
+
+			#dropzone {
+				margin-bottom: var(--uui-size-space-5);
 			}
 
 			#btn-add {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -345,9 +345,13 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		}
 	}
 
-	async #onUploadCompleted(e: CustomEvent) {
-		const completed = e.detail as Array<UmbUploadableItem>;
-		const uploaded = completed.map((file) => file.unique);
+	async #onUploadCompleted(e: UmbDropzoneChangeEvent) {
+		if (this.readonly) return;
+
+		// If there are any finished uploadable items, we need to add them to the value
+		const uploaded = e.items
+			.filter((file) => file.status === UmbFileDropzoneItemStatus.COMPLETE)
+			.map((file) => file.unique);
 		this.#addItems(uploaded);
 	}
 
@@ -360,10 +364,9 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 
 	#renderDropzone() {
 		if (this.readonly) return nothing;
-		if (this._cards && this._cards.length >= this.max) return;
 		return html`<umb-dropzone-media
-			?multiple=${this.max > 1}
-			@complete=${this.#onUploadCompleted}></umb-dropzone-media>`;
+			?multiple=${this.multiple}
+			@change=${this.#onUploadCompleted}></umb-dropzone-media>`;
 	}
 
 	#renderItems() {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -1,7 +1,8 @@
 import { UMB_IMAGE_CROPPER_EDITOR_MODAL, UMB_MEDIA_PICKER_MODAL } from '../../modals/index.js';
 import type { UmbMediaItemModel, UmbCropModel, UmbMediaPickerPropertyValueEntry } from '../../types.js';
 import { UMB_MEDIA_ITEM_REPOSITORY_ALIAS } from '../../repository/constants.js';
-import type { UmbUploadableItem } from '@umbraco-cms/backoffice/dropzone';
+import { UmbFileDropzoneItemStatus } from '@umbraco-cms/backoffice/dropzone';
+import type { UmbDropzoneChangeEvent } from '@umbraco-cms/backoffice/dropzone';
 import { css, customElement, html, nothing, property, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { umbConfirmModal, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -1,10 +1,10 @@
-import { UMB_IMAGE_CROPPER_EDITOR_MODAL, UMB_MEDIA_PICKER_MODAL } from '../../modals/index.js';
+import { UMB_IMAGE_CROPPER_EDITOR_MODAL } from '../../modals/index.js';
 import type { UmbMediaItemModel, UmbCropModel, UmbMediaPickerPropertyValueEntry } from '../../types.js';
 import { UMB_MEDIA_ITEM_REPOSITORY_ALIAS } from '../../repository/constants.js';
+import { UmbMediaPickerInputContext } from '../input-media/input-media.context.js';
 import { UmbFileDropzoneItemStatus } from '@umbraco-cms/backoffice/dropzone';
 import type { UmbDropzoneChangeEvent } from '@umbraco-cms/backoffice/dropzone';
 import { css, customElement, html, nothing, property, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
-import { umbConfirmModal, UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -15,6 +15,7 @@ import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UmbTreeStartNode } from '@umbraco-cms/backoffice/tree';
 import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { UmbRepositoryItemsManager } from '@umbraco-cms/backoffice/repository';
+import { UMB_MEDIA_TYPE_ENTITY_TYPE } from '@umbraco-cms/backoffice/media-type';
 
 import '@umbraco-cms/backoffice/imaging';
 
@@ -101,6 +102,7 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 	public override set value(value: Array<UmbMediaPickerPropertyValueEntry> | undefined) {
 		super.value = value;
 		this.#sorter.setModel(value);
+		this.#pickerContext.setSelection(value?.map((item) => item.mediaKey) ?? []);
 		this.#itemManager.setUniques(value?.map((x) => x.mediaKey));
 		// Maybe the new value is using an existing media, and there we need to update the cards despite no repository update.
 		this.#populateCards();
@@ -177,6 +179,8 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 
 	readonly #itemManager = new UmbRepositoryItemsManager<UmbMediaItemModel>(this, UMB_MEDIA_ITEM_REPOSITORY_ALIAS);
 
+	readonly #pickerContext = new UmbMediaPickerInputContext(this);
+
 	constructor() {
 		super();
 
@@ -229,6 +233,10 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 			.observeRouteBuilder((routeBuilder) => {
 				this._routeBuilder = routeBuilder;
 			});
+
+		this.observe(this.#pickerContext.selection, (selection) => {
+			this.#addItems(selection);
+		});
 
 		this.addValidator(
 			'valueMissing',
@@ -303,35 +311,27 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
-	async #openPicker() {
-		const modalManager = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-		const modalHandler = modalManager?.open(this, UMB_MEDIA_PICKER_MODAL, {
-			data: {
+	#openPicker() {
+		this.#pickerContext.openPicker(
+			{
 				multiple: this.multiple,
 				startNode: this.startNode,
 				pickableFilter: this.#pickableFilter,
 			},
-			value: { selection: [] },
-		});
-
-		const data = await modalHandler?.onSubmit().catch(() => null);
-		if (!data) return;
-
-		const selection = data.selection.filter((x) => x !== null) as string[];
-		this.#addItems(selection);
+			{
+				allowedContentTypes: this.allowedContentTypeIds?.map((id) => ({
+					unique: id,
+					entityType: UMB_MEDIA_TYPE_ENTITY_TYPE,
+				})),
+				includeTrashed: false,
+			},
+		);
 	}
 
 	async #onRemove(item: UmbRichMediaCardModel) {
 		try {
-			await umbConfirmModal(this, {
-				color: 'danger',
-				headline: `${this.localize.term('actions_remove')} ${item.name}?`,
-				content: `${this.localize.term('defaultdialogs_confirmremove')} ${item.name}?`,
-				confirmLabel: this.localize.term('actions_remove'),
-			});
-
+			await this.#pickerContext.requestRemoveItem(item.media);
 			this.value = this.value?.filter((x) => x.key !== item.unique);
-
 			this.dispatchEvent(new UmbChangeEvent());
 		} catch {
 			// User cancelled the action

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -201,7 +201,8 @@ export class UmbInputUploadFieldElement extends UmbLitElement {
 	#renderButtonRemove() {
 		return html`
 			<uui-button compact @click=${this.#handleRemove} label=${this.localize.term('content_uploadClear')}>
-				<uui-icon name="icon-trash"></uui-icon>${this.localize.term('content_uploadClear')}
+				<uui-icon name="icon-trash"></uui-icon>
+				<umb-localize key="content_uploadClear">Clear file(s)</umb-localize>
 			</uui-button>
 		`;
 	}


### PR DESCRIPTION
## Description

This PR cleans up the `<umb-input-rich-media />` component, resolving the TODOs and other comments. The inner dropzone was listening on the "complete" event, which is deprecated, so we changed to the `change` event, which is what fixes #19401 as well.

## Changes

* Refactored the `UmbInputRichMediaElement` to use a dedicated `UmbMediaPickerInputContext` for managing selection and removal of media items, simplifying the picker logic and improving maintainability. (This is exactly what the UmbInputMedia element does as well to ensure that already selected images are pre-selected when opening the media picker modal.)
* Added loading state indicators to media cards and ensured picker context selection updates the displayed items. (Thereby fixing a TODO left in the element)
* Updated localization strings for the "Clear file(s)" button to clarify what it does (it said "Remove file(s)" before)
* Updated confirmation dialogs in picker inputs to use localization keys for headlines and content (The "Do you want to remove this file?" modal was not localized before).
* New feature: The media picker will now accept more files than its configured maximum, and as a result the validation system will kick in to warn the user. This is so the user can add new images before removing the old ones (thereby resolving a TODO in the code).