### PR TITLE
Fixed behaviour on database cache rebuild to update only for requested content types

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DatabaseCacheRebuilder.cs
@@ -120,7 +120,7 @@ internal sealed class DatabaseCacheRebuilder : IDatabaseCacheRebuilder
     private Task PerformRebuild()
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        _databaseCacheRepository.Rebuild();
+        _databaseCacheRepository.Rebuild([], [], []);
 
         // If the serializer type has changed, we also need to update it in the key value store.
         var currentSerializerValue = _keyValueService.GetValue(NuCacheSerializerKey);

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -101,10 +101,11 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
             | ContentCacheDataSerializerEntityType.Media
             | ContentCacheDataSerializerEntityType.Member);
 
-        // If contentTypeIds, mediaTypeIds and memberTypeIds are null, truncate table as all records will be deleted (as these 3 are the only types in the table).
-        if (contentTypeIds != null && !contentTypeIds.Any()
-                                   && mediaTypeIds != null && !mediaTypeIds.Any()
-                                   && memberTypeIds != null && !memberTypeIds.Any())
+        // If contentTypeIds, mediaTypeIds and memberTypeIds are all non-null but empty,
+        // truncate the table as all records will be deleted (as these 3 are the only types in the table).
+        if (contentTypeIds is not null && contentTypeIds.Count == 0 &&
+            mediaTypeIds is not null && mediaTypeIds.Count == 0 &&
+            memberTypeIds is not null && memberTypeIds.Count == 0)
         {
             if (Database.DatabaseType == DatabaseType.SqlServer2012)
             {
@@ -280,10 +281,15 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     // assumes content tree lock
     private void RebuildContentDbCache(IContentCacheDataSerializer serializer, int groupSize, IReadOnlyCollection<int>? contentTypeIds)
     {
+        if (contentTypeIds is null)
+        {
+            return;
+        }
+
         Guid contentObjectType = Constants.ObjectTypes.Document;
 
         // remove all - if anything fails the transaction will rollback
-        if (contentTypeIds == null || contentTypeIds.Count == 0)
+        if (contentTypeIds.Count == 0)
         {
             // must support SQL-CE
             Database.Execute(
@@ -310,7 +316,7 @@ WHERE cmsContentNu.nodeId IN (
 
         // insert back - if anything fails the transaction will rollback
         IQuery<IContent> query = SqlContext.Query<IContent>();
-        if (contentTypeIds != null && contentTypeIds.Count > 0)
+        if (contentTypeIds.Count > 0)
         {
             query = query.WhereIn(x => x.ContentTypeId, contentTypeIds); // assume number of ctypes won't blow IN(...)
         }
@@ -345,13 +351,17 @@ WHERE cmsContentNu.nodeId IN (
     }
 
     // assumes media tree lock
-    private void RebuildMediaDbCache(IContentCacheDataSerializer serializer, int groupSize,
-        IReadOnlyCollection<int>? contentTypeIds)
+    private void RebuildMediaDbCache(IContentCacheDataSerializer serializer, int groupSize, IReadOnlyCollection<int>? contentTypeIds)
     {
+        if (contentTypeIds is null)
+        {
+            return;
+        }
+
         Guid mediaObjectType = Constants.ObjectTypes.Media;
 
         // remove all - if anything fails the transaction will rollback
-        if (contentTypeIds is null || contentTypeIds.Count == 0)
+        if (contentTypeIds.Count == 0)
         {
             // must support SQL-CE
             Database.Execute(
@@ -378,7 +388,7 @@ WHERE cmsContentNu.nodeId IN (
 
         // insert back - if anything fails the transaction will rollback
         IQuery<IMedia> query = SqlContext.Query<IMedia>();
-        if (contentTypeIds is not null && contentTypeIds.Count > 0)
+        if (contentTypeIds.Count > 0)
         {
             query = query.WhereIn(x => x.ContentTypeId, contentTypeIds); // assume number of ctypes won't blow IN(...)
         }
@@ -398,13 +408,17 @@ WHERE cmsContentNu.nodeId IN (
     }
 
     // assumes member tree lock
-    private void RebuildMemberDbCache(IContentCacheDataSerializer serializer, int groupSize,
-        IReadOnlyCollection<int>? contentTypeIds)
+    private void RebuildMemberDbCache(IContentCacheDataSerializer serializer, int groupSize, IReadOnlyCollection<int>? contentTypeIds)
     {
+        if (contentTypeIds is null)
+        {
+            return;
+        }
+
         Guid memberObjectType = Constants.ObjectTypes.Member;
 
         // remove all - if anything fails the transaction will rollback
-        if (contentTypeIds == null || contentTypeIds.Count == 0)
+        if (contentTypeIds.Count == 0)
         {
             // must support SQL-CE
             Database.Execute(
@@ -431,7 +445,7 @@ WHERE cmsContentNu.nodeId IN (
 
         // insert back - if anything fails the transaction will rollback
         IQuery<IMember> query = SqlContext.Query<IMember>();
-        if (contentTypeIds != null && contentTypeIds.Count > 0)
+        if (contentTypeIds.Count > 0)
         {
             query = query.WhereIn(x => x.ContentTypeId, contentTypeIds); // assume number of ctypes won't blow IN(...)
         }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -258,7 +258,7 @@ internal sealed class MediaCacheService : IMediaCacheService
     public void Rebuild(IReadOnlyCollection<int> contentTypeIds)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        _databaseCacheRepository.Rebuild(contentTypeIds.ToList());
+        _databaseCacheRepository.Rebuild(mediaTypeIds: contentTypeIds.ToList());
 
         IEnumerable<Guid> mediaTypeKeys = contentTypeIds.Select(x => _idKeyMap.GetKeyForId(x, UmbracoObjectTypes.MediaType))
             .Where(x => x.Success)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19902

### Description
The linked PR shows that saving document types is very slow when an installation has a lot of members.  On the face of it this shouldn't have a significant impact.

I found it's happening as the logic in rebuilding the database cache doesn't look to be correct.  According to the code comments on the interface for the parameters for each of the three types or content type, we should consider "null" as "don't do anything with this content type and "empty" to be to "rebuild everything for the content type", e.g.:

```
    /// <param name="memberTypeIds">
    ///     If not null will process content for the matching members types, if empty will process all
    ///     members.
    /// </param>
```

In the implementation though this was mixed up, and we were rebuilding everything on null inputs too.

Arguably this is behaviourally breaking but seems like this is a bug to fix - it resolves the issue and now the behaviour matches with the XML header comments on the interface.

I also found and fixed another bug where we were passing media type keys as document type keys in the `MediaCacheService`.  Likely didn't previously cause a problem as media would be fully rebuilt anyway due to the incorrect behaviour, but now that's amended it's important these are passed correctly too.

### Testing
You can test with a breakpoint in `DatabaseCacheRepository.Rebuild()` and verifying that with these changes in place, we don't rebuild the member or media cache when saving a document type (or other combinations).