### PR TITLE
Ensure appropriate create and update dates are set on updated dictionary items to allow distinguishing between created and update for server events

### DIFF
--- a/src/Umbraco.Core/Services/DictionaryItemService.cs
+++ b/src/Umbraco.Core/Services/DictionaryItemService.cs
@@ -159,7 +159,25 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
     /// <inheritdoc />
     public async Task<Attempt<IDictionaryItem, DictionaryItemOperationStatus>> UpdateAsync(
         IDictionaryItem dictionaryItem, Guid userKey)
-        => await SaveAsync(
+    {
+        // Create and update dates aren't tracked for dictionary items. They exist on IDictionaryItem due to the
+        // inheritance from IEntity, but we don't store them.
+        // However we have logic in ServerEventSender that will provide SignalR events for created and update operations,
+        // where these dates are used to distinguish between the two (whether or not the entity has an identity cannot
+        // be used here, as these events fire after persistence when the identity is known for both creates and updates).
+        // So ensure we set something that can be distinguished here.
+        if (dictionaryItem.CreateDate == default)
+        {
+            dictionaryItem.CreateDate = DateTime.MinValue;
+        }
+
+        if (dictionaryItem.UpdateDate == default)
+        {
+            // TODO (V17): To align with updates of system dates, this needs to change to DateTime.UtcNow.
+            dictionaryItem.UpdateDate = DateTime.Now;
+        }
+
+        return await SaveAsync(
             dictionaryItem,
             () =>
             {
@@ -174,6 +192,7 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             AuditType.Save,
             "Update DictionaryItem",
             userKey);
+    }
 
     /// <inheritdoc />
     public async Task<Attempt<IDictionaryItem?, DictionaryItemOperationStatus>> DeleteAsync(Guid id, Guid userKey)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves an issue found in internal testing:

> I stumbled upon a small bug in the Dictionary Item server event. It looks like it emits a "Created" event when the item is updated.

### Description
On investigating the issue here is due to dictionary items being a bit of a special case.  They are entities in the sense of implementing `IEntity` that gives them a create and updated date, but we don't store these in the database.  Hence it doesn't really matter what they are set to apart from in the logic with have in `ServerEventSender`, where we compare the two dates to determine whether to emit a `Created` or `Updated` event.

Note that we don't have access to using whether or not the entity has an identity, as these events fire after persistence when the identity is known for both creates and updates.

So I've added code into the update dictionary item event to set the dates explicitly to something that can be used to determine that this is an update not a create.  This means when the base `UpdatingEntity()` method is called, the dates won't be initialized to the same value.

### Testing
Put a break point in `ServerEventSender.NotifySavedAsync` and verify that the emitted event has the correct `EventType` for created and updated dictionary items.

### Merge and Release
Note the `TODO` added that should be actioned when this is merged into the `v17/feature/utc-system-dates` branch.
