### PR TITLE
V16: Unwarranted redirect after auth

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -19,7 +19,7 @@ import {
 	umbExtensionsRegistry,
 } from '@umbraco-cms/backoffice/extension-registry';
 import { filter, first, firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
-import { hasOwnOpener, retrieveStoredPath } from '@umbraco-cms/backoffice/utils';
+import { hasOwnOpener, redirectToStoredPath } from '@umbraco-cms/backoffice/utils';
 import { UmbApiInterceptorController } from '@umbraco-cms/backoffice/resources';
 import { umbHttpClient } from '@umbraco-cms/backoffice/http-client';
 
@@ -65,6 +65,7 @@ export class UmbAppElement extends UmbLitElement {
 				if (!this.#authContext) {
 					(component as UmbAppOauthElement).failure = true;
 					console.error('[Fatal] Auth context is not available');
+					redirectToStoredPath(this.backofficePath);
 					return;
 				}
 
@@ -73,6 +74,7 @@ export class UmbAppElement extends UmbLitElement {
 				if (!hasCode) {
 					(component as UmbAppOauthElement).failure = true;
 					console.error('[Fatal] No code in query parameters');
+					redirectToStoredPath(this.backofficePath);
 					return;
 				}
 
@@ -86,17 +88,7 @@ export class UmbAppElement extends UmbLitElement {
 							filter((x) => !!x),
 							first(),
 						),
-						() => {
-							// Redirect to the saved state or root
-							const url = retrieveStoredPath();
-							const isBackofficePath = url?.pathname.startsWith(this.backofficePath) ?? true;
-
-							if (isBackofficePath) {
-								history.replaceState(null, '', url?.toString() ?? '');
-							} else {
-								window.location.href = url?.toString() ?? this.backofficePath;
-							}
-						},
+						() => redirectToStoredPath(this.backofficePath),
 					);
 				}
 

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -83,7 +83,7 @@ export class UmbAppElement extends UmbLitElement {
 						// If we are in the main window (i.e. no opener), we should redirect to the root after the authorization request is completed.
 						// The authorization request will be completed in the active window (main or popup) and the authorization signal will be sent.
 						// If we are in a popup window, the storage event in UmbAuthContext will catch the signal and close the window.
-						// If we are in the main window, the signal will be caught right here and the user will be redirected to the root.
+						// If we are in the main window, the signal will be caught right here and the user will be redirected to their previous path (or root).
 						if (!hasOwnOpener(this.backofficePath)) {
 							if (result === null) {
 								// If the result is null, it could mean that no new token was required, so we can redirect the user

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -61,7 +61,7 @@ export class UmbAppElement extends UmbLitElement {
 		{
 			path: 'oauth_complete',
 			component: () => import('./app-oauth.element.js'),
-			setup: (component) => {
+			setup: async (component) => {
 				if (!this.#authContext) {
 					(component as UmbAppOauthElement).failure = true;
 					console.error('[Fatal] Auth context is not available');
@@ -77,32 +77,30 @@ export class UmbAppElement extends UmbLitElement {
 				}
 
 				// Complete the authorization request, which will send the authorization signal
-				this.#authContext
-					.completeAuthorizationRequest()
-					.then((result) => {
-						// If we are in the main window (i.e. no opener), we should redirect to the root after the authorization request is completed.
-						// The authorization request will be completed in the active window (main or popup) and the authorization signal will be sent.
-						// If we are in a popup window, the storage event in UmbAuthContext will catch the signal and close the window.
-						// If we are in the main window, the signal will be caught right here and the user will be redirected to their previous path (or root).
-						if (!hasOwnOpener(this.backofficePath)) {
-							if (result === null) {
-								// If the result is null, it could mean that no new token was required, so we can redirect the user
-								// This could happen if the user is already authorized or accidentally enters the oauth_complete url
-								redirectToStoredPath(this.backofficePath);
-								return;
-							}
+				try {
+					const result = await this.#authContext.completeAuthorizationRequest();
 
-							// Listen for the first authorization signal after the initial authorization request
-							// When it hits, we should redirect the user to the backoffice
-							this.observe(this.#authContext?.authorizationSignal.pipe(first()), () => {
-								redirectToStoredPath(this.backofficePath);
-							});
+					// If we are in the main window (i.e. no opener), we should redirect to the root after the authorization request is completed.
+					// The authorization request will be completed in the active window (main or popup) and the authorization signal will be sent.
+					// If we are in a popup window, the storage event in UmbAuthContext will catch the signal and close the window.
+					// If we are in the main window, the signal will be caught right here and the user will be redirected to their previous path (or root).
+					if (!hasOwnOpener(this.backofficePath)) {
+						if (result === null) {
+							// If the result is null, it could mean that no new token was required, so we can redirect the user
+							// This could happen if the user is already authorized or accidentally enters the oauth_complete url
+							redirectToStoredPath(this.backofficePath);
+							return;
 						}
-					})
-					.catch(() => {
-						(component as UmbAppOauthElement).failure = true;
-						console.error('[Fatal] Authorization request failed');
-					});
+
+						// Listen for the first authorization signal after the initial authorization request
+						await firstValueFrom(this.#authContext!.authorizationSignal);
+						// When it hits, we should redirect the user to the backoffice
+						redirectToStoredPath(this.backofficePath);
+					}
+				} catch {
+					(component as UmbAppOauthElement).failure = true;
+					console.error('[Fatal] Authorization request failed');
+				}
 			},
 		},
 		{

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -81,17 +81,23 @@ export class UmbAppElement extends UmbLitElement {
 				// If we are in a popup window, the storage event in UmbAuthContext will catch the signal and close the window.
 				// If we are in the main window, the signal will be caught right here and the user will be redirected to the root.
 				if (!hasOwnOpener(this.backofficePath)) {
-					this.observe(this.#authContext.authorizationSignal, () => {
-						// Redirect to the saved state or root
-						const url = retrieveStoredPath();
-						const isBackofficePath = url?.pathname.startsWith(this.backofficePath) ?? true;
+					this.observe(
+						this.#authContext.isAuthorized.pipe(
+							filter((x) => !!x),
+							first(),
+						),
+						() => {
+							// Redirect to the saved state or root
+							const url = retrieveStoredPath();
+							const isBackofficePath = url?.pathname.startsWith(this.backofficePath) ?? true;
 
-						if (isBackofficePath) {
-							history.replaceState(null, '', url?.toString() ?? '');
-						} else {
-							window.location.href = url?.toString() ?? this.backofficePath;
-						}
-					});
+							if (isBackofficePath) {
+								history.replaceState(null, '', url?.toString() ?? '');
+							} else {
+								window.location.href = url?.toString() ?? this.backofficePath;
+							}
+						},
+					);
 				}
 
 				// Complete the authorization request, which will send the authorization signal

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -19,7 +19,7 @@ import {
 	umbExtensionsRegistry,
 } from '@umbraco-cms/backoffice/extension-registry';
 import { filter, first, firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
-import { hasOwnOpener, retrieveStoredPath } from '@umbraco-cms/backoffice/utils';
+import { hasOwnOpener, redirectToStoredPath } from '@umbraco-cms/backoffice/utils';
 import { UmbApiInterceptorController } from '@umbraco-cms/backoffice/resources';
 import { umbHttpClient } from '@umbraco-cms/backoffice/http-client';
 
@@ -76,32 +76,33 @@ export class UmbAppElement extends UmbLitElement {
 					return;
 				}
 
-				// If we are in the main window (i.e. no opener), we should redirect to the root after the authorization request is completed.
-				// The authorization request will be completed in the active window (main or popup) and the authorization signal will be sent.
-				// If we are in a popup window, the storage event in UmbAuthContext will catch the signal and close the window.
-				// If we are in the main window, the signal will be caught right here and the user will be redirected to the root.
-				if (!hasOwnOpener(this.backofficePath)) {
-					this.observe(
-						this.#authContext.isAuthorized.pipe(
-							filter((x) => !!x),
-							first(),
-						),
-						() => {
-							// Redirect to the saved state or root
-							const url = retrieveStoredPath();
-							const isBackofficePath = url?.pathname.startsWith(this.backofficePath) ?? true;
-
-							if (isBackofficePath) {
-								history.replaceState(null, '', url?.toString() ?? '');
-							} else {
-								window.location.href = url?.toString() ?? this.backofficePath;
-							}
-						},
-					);
-				}
-
 				// Complete the authorization request, which will send the authorization signal
-				this.#authContext.completeAuthorizationRequest().catch(() => undefined);
+				this.#authContext
+					.completeAuthorizationRequest()
+					.then((result) => {
+						// If we are in the main window (i.e. no opener), we should redirect to the root after the authorization request is completed.
+						// The authorization request will be completed in the active window (main or popup) and the authorization signal will be sent.
+						// If we are in a popup window, the storage event in UmbAuthContext will catch the signal and close the window.
+						// If we are in the main window, the signal will be caught right here and the user will be redirected to the root.
+						if (!hasOwnOpener(this.backofficePath)) {
+							if (result === null) {
+								// If the result is null, it could mean that no new token was required, so we can redirect the user
+								// This could happen if the user is already authorized or accidentally enters the oauth_complete url
+								redirectToStoredPath(this.backofficePath);
+								return;
+							}
+
+							// Listen for the first authorization signal after the initial authorization request
+							// When it hits, we should redirect the user to the backoffice
+							this.observe(this.#authContext?.authorizationSignal.pipe(first()), () => {
+								redirectToStoredPath(this.backofficePath);
+							});
+						}
+					})
+					.catch(() => {
+						(component as UmbAppOauthElement).failure = true;
+						console.error('[Fatal] Authorization request failed');
+					});
 			},
 		},
 		{

--- a/src/Umbraco.Web.UI.Client/src/external/openid/src/authorization_request_handler.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/openid/src/authorization_request_handler.ts
@@ -118,7 +118,7 @@ export abstract class AuthorizationRequestHandler {
 	/**
 	 * Completes the authorization request if necessary & when possible.
 	 */
-	completeAuthorizationRequestIfPossible(): Promise<void> {
+	completeAuthorizationRequestIfPossible(): Promise<AuthorizationRequestResponse | null> {
 		// call complete authorization if possible to see there might
 		// be a response that needs to be delivered.
 		log(`Checking to see if there is an authorization response to be delivered.`);
@@ -133,6 +133,7 @@ export abstract class AuthorizationRequestHandler {
 			if (result && this.notifier) {
 				this.notifier.onAuthorizationComplete(result.request, result.response, result.error);
 			}
+			return result;
 		});
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth-flow.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth-flow.ts
@@ -236,7 +236,7 @@ export class UmbAuthFlow {
 	 * @returns true if the user is logged in, false otherwise.
 	 */
 	isAuthorized(): boolean {
-		return !!this.#tokenResponse;
+		return !!this.#tokenResponse.getValue();
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/path/stored-path.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/path/stored-path.function.ts
@@ -35,12 +35,13 @@ export function setStoredPath(path: string): void {
  * Redirect the user to the stored path or the base path if not available.
  * If the basePath matches the start of the stored path, the browser will replace the state instead of redirecting.
  * @param {string} basePath - The base path to redirect to if no stored path is available.
+ * @param {boolean} [force=false] - If true, will redirect using Location
  */
-export function redirectToStoredPath(basePath: string): void {
+export function redirectToStoredPath(basePath: string, force = false): void {
 	const url = retrieveStoredPath();
 	const isBackofficePath = url?.pathname.startsWith(basePath) ?? true;
 
-	if (isBackofficePath) {
+	if (isBackofficePath && !force) {
 		history.replaceState(null, '', url?.toString() ?? '');
 	} else {
 		window.location.href = url?.toString() ?? basePath;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/path/stored-path.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/path/stored-path.function.ts
@@ -30,3 +30,19 @@ export function setStoredPath(path: string): void {
 	}
 	sessionStorage.setItem(UMB_STORAGE_REDIRECT_URL, url.toString());
 }
+
+/**
+ * Redirect the user to the stored path or the base path if not available.
+ * If the basePath matches the start of the stored path, the browser will replace the state instead of redirecting.
+ * @param {string} basePath - The base path to redirect to if no stored path is available.
+ */
+export function redirectToStoredPath(basePath: string): void {
+	const url = retrieveStoredPath();
+	const isBackofficePath = url?.pathname.startsWith(basePath) ?? true;
+
+	if (isBackofficePath) {
+		history.replaceState(null, '', url?.toString() ?? '');
+	} else {
+		window.location.href = url?.toString() ?? basePath;
+	}
+}


### PR DESCRIPTION
## Description

Fixes #17642 
Fixes #18334 
Fixes #19750 

This pull request refines the OAuth authorization flow in the backoffice app, improving both the handling and redirection logic after authentication. The main focus is to ensure users are redirected to their intended location after completing OAuth, and to improve error handling and code clarity. Key changes include updating the authorization completion logic to return more informative results, centralizing redirect logic, and improving error feedback.

### OAuth flow and redirect improvements

* Updated the OAuth completion route setup in `UmbAppElement` to use an async function, handle errors more gracefully, and redirect users to their previous path or root after authorization using the new `redirectToStoredPath` utility. [[1]](diffhunk://#diff-2ca57cfd62ecdfd35669364c2b717e3339baadff442ccf9905342785e8494909L64-R64) [[2]](diffhunk://#diff-2ca57cfd62ecdfd35669364c2b717e3339baadff442ccf9905342785e8494909R79-L98)
* Replaced the use of `retrieveStoredPath` with the new `redirectToStoredPath` function for more consistent and centralized redirect behavior. [[1]](diffhunk://#diff-2ca57cfd62ecdfd35669364c2b717e3339baadff442ccf9905342785e8494909L22-R22) [[2]](diffhunk://#diff-36323b7f9234453169cd7a819341ccca9daa057fe0611d1bc092ce8743e22b01R33-R48)

### Authorization request handler enhancements

* Changed the return type of `completeAuthorizationRequestIfPossible` in `AuthorizationRequestHandler` to return an `AuthorizationRequestResponse | null` instead of `void`, allowing for more informative handling of the authorization result.

### Utility function addition

* Added the `redirectToStoredPath` function to centralize and standardize the logic for redirecting users after authentication, replacing previous ad-hoc implementations.

## How to test

*Unwarranted redirects*

1. Log in and go to somewhere in the backoffice (does not matter where)
2. Open a new tab with middle-click (so that the window.opener is activated)
3. Check that the first tab does not redirect

*Stuck on oauth_complete*
1. Log in
2. Go back in the browser so you hit the login screen
3. Log in again
4. You should now see a redirect to /oauth_complete, then to the backoffice (it may happen twice because the first try invalidates the existing session, which is expected)
5. Verify that you at no point get stuck on /oauth_complete without any response or indication