### PR TITLE
Refactoring DatabaseCacheRepository to de-duplicate code and remove warnings

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -444,7 +444,7 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
                 )",
             new { objType = nodeObjectType });
 
-    private void DeleteForObjectTypeAndContentTypes(Guid nodeObjectType, IReadOnlyCollection<int>? contentTypeIds) =>
+    private void DeleteForObjectTypeAndContentTypes(Guid nodeObjectType, IReadOnlyCollection<int> contentTypeIds) =>
         Database.Execute(
             $@"
                 DELETE FROM cmsContentNu

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
@@ -3,6 +3,9 @@ using Umbraco.Cms.Infrastructure.HybridCache.Serialization;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Persistence;
 
+/// <summary>
+/// Defines a repository for persisting content cache data.
+/// </summary>
 internal interface IDatabaseCacheRepository
 {
     /// <summary>


### PR DESCRIPTION
### Description
In attempts to investigate and improve performance I did some clean-up of this class - de-duplicating code and resolving warnings.

There's nothing concrete in here performance-wise but seems like it'll be useful to have the refactoring in anyway.  In particular it cleans up three database queries that were duplicated three times.

### Testing
Visual inspection, pipeline will verify that existing tests pass.
For manual testing put a break point in `DatabaseCacheRepository.Rebuild` and save content types to check flow of data being removed and added.