### PR TITLE
Adds id to the webhook item response model

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
@@ -120,6 +120,7 @@ public class ItemTypeMapDefinition : IMapDefinition
     // Umbraco.Code.MapAll
     private static void Map(IWebhook source, WebhookItemResponseModel target, MapperContext context)
     {
+        target.Id = source.Key;
         target.Name = source.Name ?? source.Url;
         target.Url = source.Url;
         target.Enabled = source.Enabled;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -48124,12 +48124,29 @@
         "required": [
           "enabled",
           "events",
+          "id",
           "name",
+          "signs",
           "types",
           "url"
         ],
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "signs": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SignModel"
+                }
+              ]
+            },
+            "readOnly": true
+          },
           "enabled": {
             "type": "boolean"
           },

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Webhook/Item/WebhookItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Webhook/Item/WebhookItemResponseModel.cs
@@ -1,6 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
 namespace Umbraco.Cms.Api.Management.ViewModels.Webhook.Item;
 
-public class WebhookItemResponseModel
+public class WebhookItemResponseModel : ItemResponseModelBase
 {
     public bool Enabled { get; set; } = true;
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
Adds the `Id` property to the webhook item response model that was found to be missing.

### Testing
Manual testing can be done on the endpoint:

```
/umbraco/management/api/v1/item/webhook?id={id}
```

Which should give a response like:

``
[
  {
    "enabled": true,
    "name": "Test",
    "events": "Umbraco.ContentMoved,Umbraco.ContentPublish",
    "url": "https://webhook.site/33d2002e-cca7-479d-aee1-575d659a4820",
    "types": "",
    "id": "9249cbb3-9d0c-4d1c-8520-fab30ed565da",
    "signs": []
  }
]
```
