### PR TITLE
Handle content blueprint server events

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/ServerEventExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/ServerEventExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.ServerEvents;
 using Umbraco.Cms.Api.Management.ServerEvents.Authorizers;
@@ -28,6 +28,7 @@ internal static class ServerEventExtensions
     private static IUmbracoBuilder AddEvents(this IUmbracoBuilder builder)
     {
         builder.AddNotificationAsyncHandler<ContentSavedNotification, ServerEventSender>();
+        builder.AddNotificationAsyncHandler<ContentSavedBlueprintNotification, ServerEventSender>();
         builder.AddNotificationAsyncHandler<ContentTypeSavedNotification, ServerEventSender>();
         builder.AddNotificationAsyncHandler<MediaSavedNotification, ServerEventSender>();
         builder.AddNotificationAsyncHandler<MediaTypeSavedNotification, ServerEventSender>();

--- a/src/Umbraco.Cms.Api.Management/ServerEvents/ServerEventSender.cs
+++ b/src/Umbraco.Cms.Api.Management/ServerEvents/ServerEventSender.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
@@ -10,6 +10,7 @@ namespace Umbraco.Cms.Api.Management.ServerEvents;
 
 internal sealed class ServerEventSender :
     INotificationAsyncHandler<ContentSavedNotification>,
+    INotificationAsyncHandler<ContentSavedBlueprintNotification>,
     INotificationAsyncHandler<ContentTypeSavedNotification>,
     INotificationAsyncHandler<MediaSavedNotification>,
     INotificationAsyncHandler<MediaTypeSavedNotification>,
@@ -56,26 +57,28 @@ internal sealed class ServerEventSender :
 {
     private readonly IServerEventRouter _serverEventRouter;
 
-    public ServerEventSender(IServerEventRouter serverEventRouter)
-    {
-        _serverEventRouter = serverEventRouter;
-    }
+    public ServerEventSender(IServerEventRouter serverEventRouter) => _serverEventRouter = serverEventRouter;
 
     private async Task NotifySavedAsync<T>(SavedNotification<T> notification, string source)
         where T : IEntity
     {
         foreach (T entity in notification.SavedEntities)
         {
-            var eventModel = new ServerEvent
-            {
-                EventType = entity.CreateDate == entity.UpdateDate
-                    ? Constants.ServerEvents.EventType.Created : Constants.ServerEvents.EventType.Updated,
-                Key = entity.Key,
-                EventSource = source,
-            };
-
-            await _serverEventRouter.RouteEventAsync(eventModel);
+            await RouteCreatedOrUpdatedEvent(source, entity);
         }
+    }
+
+    private async Task RouteCreatedOrUpdatedEvent<T>(string source, T entity) where T : IEntity
+    {
+        var eventModel = new ServerEvent
+        {
+            EventType = entity.CreateDate == entity.UpdateDate
+                ? Constants.ServerEvents.EventType.Created : Constants.ServerEvents.EventType.Updated,
+            Key = entity.Key,
+            EventSource = source,
+        };
+
+        await _serverEventRouter.RouteEventAsync(eventModel);
     }
 
     private async Task NotifyDeletedAsync<T>(DeletedNotification<T> notification, string source)
@@ -108,6 +111,9 @@ internal sealed class ServerEventSender :
 
     public async Task HandleAsync(ContentSavedNotification notification, CancellationToken cancellationToken) =>
         await NotifySavedAsync(notification, Constants.ServerEvents.EventSource.Document);
+
+    public async Task HandleAsync(ContentSavedBlueprintNotification notification, CancellationToken cancellationToken) =>
+        await RouteCreatedOrUpdatedEvent(Constants.ServerEvents.EventSource.DocumentBlueprint, notification.SavedBlueprint);
 
     public async Task HandleAsync(ContentTypeSavedNotification notification, CancellationToken cancellationToken) =>
         await NotifySavedAsync(notification, Constants.ServerEvents.EventSource.DocumentType);

--- a/src/Umbraco.Core/Constants-ServerEvents.cs
+++ b/src/Umbraco.Core/Constants-ServerEvents.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core;
+namespace Umbraco.Cms.Core;
 
 public static partial class Constants
 {
@@ -7,6 +7,8 @@ public static partial class Constants
         public static class EventSource
         {
             public const string Document = "Umbraco:CMS:Document";
+
+            public const string DocumentBlueprint = "Umbraco:CMS:DocumentBlueprint";
 
             public const string DocumentType = "Umbraco:CMS:DocumentType";
 
@@ -53,6 +55,7 @@ public static partial class Constants
 
         public static class EventType
         {
+            // TODO (V17): Convert these statics to consts.
             public static string Created = "Created";
 
             public static string Updated = "Updated";


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
This hooks up the server events for content blueprints, that were found to be missing.

### Testing
Put a breakpoint in `ServerEventSender.RouteCreatedOrUpdatedEvent` and save a content blueprint.  You should see an appropriate "Created" or "Updated" event is routed.
