### PR TITLE
V17 - Removed obseleted code from Cms.Api.Common

### DIFF
--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
@@ -15,20 +15,6 @@ public class SubTypesSelector : ISubTypesSelector
     private readonly IEnumerable<ISubTypesHandler> _subTypeHandlers;
     private readonly IUmbracoJsonTypeInfoResolver _umbracoJsonTypeInfoResolver;
 
-    [Obsolete("The settings parameter is not required anymore, use the other constructor instead. Scheduled for removal in Umbraco 17.")]
-    public SubTypesSelector(
-        IOptions<GlobalSettings> settings,
-        IHostingEnvironment hostingEnvironment,
-        IHttpContextAccessor httpContextAccessor,
-        IEnumerable<ISubTypesHandler> subTypeHandlers,
-        IUmbracoJsonTypeInfoResolver umbracoJsonTypeInfoResolver)
-    {
-        _hostingEnvironment = hostingEnvironment;
-        _httpContextAccessor = httpContextAccessor;
-        _subTypeHandlers = subTypeHandlers;
-        _umbracoJsonTypeInfoResolver = umbracoJsonTypeInfoResolver;
-    }
-
     public SubTypesSelector(
         IHostingEnvironment hostingEnvironment,
         IHttpContextAccessor httpContextAccessor,


### PR DESCRIPTION
### Description
A ton of obsoleted code, that has been scheduled for removal in Umbraco 17 has been removed, and their usages has been adjusted (If there was any)

Mainly this PR is the removal of obsoleted code from the Umbraco.Cms.Api.Common


<!-- Thanks for contributing to Umbraco CMS! -->
