### PR TITLE
fix validation context initialization

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -298,7 +298,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			this.variantOptions,
 			(variantOptions) => {
 				variantOptions.forEach((variantOption) => {
-					const missingThis = this.#variantValidationContexts.filter((x) => {
+					const missingThis = !this.#variantValidationContexts.some((x) => {
 						const variantId = x.getVariantId();
 						if (!variantId) return;
 						return variantId.culture === variantOption.culture && variantId.segment === variantOption.segment;


### PR DESCRIPTION
error 40 have been made on this check. It is suppose to check if the Validation Context is already present, if so then not create a new one. It turned out in other works that this was not working, cause `filter` always returns an array that was truthy.