### PR TITLE
Ensure the directory exists before creating the SQLite database

### DIFF
--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseCreator.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseCreator.cs
@@ -86,6 +86,7 @@ public class SqliteDatabaseCreator : IDatabaseCreator
         // Copy our blank(ish) wal mode sqlite database to its final location.
         try
         {
+            EnsureDatabaseDirectory(original.DataSource);
             File.Copy(tempFile, original.DataSource, true);
         }
         catch (Exception ex)
@@ -102,6 +103,15 @@ public class SqliteDatabaseCreator : IDatabaseCreator
         {
             // We can swallow this, no worries if we can't nuke the practically empty database file.
             _logger.LogWarning(ex, "Unable to cleanup temporary sqlite database file {path}", tempFile);
+        }
+    }
+
+    private static void EnsureDatabaseDirectory(string dataSource)
+    {
+        var directoryPath = Path.GetDirectoryName(dataSource);
+        if (string.IsNullOrEmpty(directoryPath) is false && Directory.Exists(directoryPath) is false)
+        {
+            Directory.CreateDirectory(directoryPath);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19948

### Description
This linked issue indicates a problem when using unattended installs with a SQLite database for a newly cloned repository.  The `/umbraco/Data` directory doesn't exist which leads to an exception being thrown.

I couldn't actually replicate this.  In my tests I would always find a `MainDom_*.lock` file written into `/umbraco/Data/Temp`, so by the time the SQLite database was being created in the unattended install, the directory was already there.

Nonetheless it's fairly easy to see what the fix would be if it wasn't - and if using storage in another location ensuring the directory exists would still be useful.  So I've applied it here - a check to see if the directory where the SQLite database is going to be copied to exists, and if it doesn't, create it.

### Testing
To test I found I needed to use a non-default location, so configure the something like the following for the database connection string:

```
  "ConnectionStrings": {
    "umbracoDbDSN": "Data Source=c://temp//test//UmbracoUnattended.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
  }
```

And the following for unattended install:

```
  "Unattended": {
    "InstallUnattended": true,
    "UnattendedUserName": "{user name}",
    "UnattendedUserEmail": "{email}",
    "UnattendedUserPassword": "{password}",
  },
```

Start up Umbraco.  You should find that before these changes an exception would be thrown due to the directory not existing:

```
System.IO.DirectoryNotFoundException: Could not find a part of the path 'c:\temp\test\UmbracoUnattended.sqlite.db'.
```

But with these changes in place it'll create it and start up normally.
