### PR TITLE
Add request caching around published content factory

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Factories/IPublishedContentFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/IPublishedContentFactory.cs
@@ -1,12 +1,25 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Factories;
 
+/// <summary>
+/// Defines a factory to create <see cref="IPublishedContent"/> and <see cref="IPublishedMember"/> from a <see cref="ContentCacheNode"/> or <see cref="IMember"/>.
+/// </summary>
 internal interface IPublishedContentFactory
 {
+    /// <summary>
+    /// Converts a <see cref="ContentCacheNode"/> to an <see cref="IPublishedContent"/> if document type.
+    /// </summary>
     IPublishedContent? ToIPublishedContent(ContentCacheNode contentCacheNode, bool preview);
+
+    /// <summary>
+    /// Converts a <see cref="ContentCacheNode"/> to an <see cref="IPublishedContent"/> of media type.
+    /// </summary>
     IPublishedContent? ToIPublishedMedia(ContentCacheNode contentCacheNode);
 
+    /// <summary>
+    /// Converts a <see cref="IMember"/> to an <see cref="IPublishedMember"/>.
+    /// </summary>
     IPublishedMember ToPublishedMember(IMember member);
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
@@ -44,8 +44,8 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
         {
             _logger.LogDebug(
                 "Creating IPublishedContent for document {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Id,
-                contentCacheNode.Data?.Name ?? "No Name");
+                contentCacheNode.Data?.Name ?? "No Name",
+                contentCacheNode.Id);
 
             IPublishedContentType contentType = _publishedContentTypeCache.Get(PublishedItemType.Content, contentCacheNode.ContentTypeId);
             var contentNode = new ContentNode(
@@ -74,8 +74,8 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
         {
             _logger.LogDebug(
                 "Using cached IPublishedContent for document {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Id,
-                contentCacheNode.Data?.Name ?? "No Name");
+                contentCacheNode.Data?.Name ?? "No Name",
+                contentCacheNode.Id);
         }
 
         return publishedContent;
@@ -90,8 +90,8 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
         {
             _logger.LogDebug(
                 "Creating IPublishedContent for media {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Id,
-                contentCacheNode.Data?.Name ?? "No Name");
+                contentCacheNode.Data?.Name ?? "No Name",
+                contentCacheNode.Id);
 
             IPublishedContentType contentType = _publishedContentTypeCache.Get(PublishedItemType.Media, contentCacheNode.ContentTypeId);
             var contentNode = new ContentNode(
@@ -115,8 +115,8 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
         {
             _logger.LogDebug(
                 "Using cached IPublishedContent for media {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Id,
-                contentCacheNode.Data?.Name ?? "No Name");
+                contentCacheNode.Data?.Name ?? "No Name",
+                contentCacheNode.Id);
         }
 
         return publishedContent;
@@ -131,8 +131,8 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
         {
             _logger.LogDebug(
                 "Creating IPublishedMember for member {MemberName} ({MemberId}).",
-                member.Id,
-                member.Username);
+                member.Username,
+                member.Id);
 
             IPublishedContentType contentType = _publishedContentTypeCache.Get(PublishedItemType.Member, member.ContentTypeId);
 
@@ -165,8 +165,8 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
         {
             _logger.LogDebug(
                 "Using cached IPublishedMember for member {MemberName} ({MemberId}).",
-                member.Id,
-                member.Username);
+                member.Username,
+                member.Id);
         }
 
         return publishedMember;

--- a/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
@@ -38,44 +38,44 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     /// <inheritdoc/>
     public IPublishedContent? ToIPublishedContent(ContentCacheNode contentCacheNode, bool preview)
     {
-        string cacheKey = $"{nameof(PublishedContentFactory)}DocumentCache_{contentCacheNode.Id}_{preview}";
+        var cacheKey = $"{nameof(PublishedContentFactory)}DocumentCache_{contentCacheNode.Id}_{preview}";
         IPublishedContent? publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
-        if (publishedContent is null)
-        {
-            _logger.LogDebug(
-                "Creating IPublishedContent for document {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Data?.Name ?? "No Name",
-                contentCacheNode.Id);
-
-            IPublishedContentType contentType = _publishedContentTypeCache.Get(PublishedItemType.Content, contentCacheNode.ContentTypeId);
-            var contentNode = new ContentNode(
-                contentCacheNode.Id,
-                contentCacheNode.Key,
-                contentCacheNode.SortOrder,
-                contentCacheNode.CreateDate,
-                contentCacheNode.CreatorId,
-                contentType,
-                preview ? contentCacheNode.Data : null,
-                preview ? null : contentCacheNode.Data);
-
-            publishedContent = GetModel(contentNode, preview);
-
-            if (preview)
-            {
-                publishedContent ??= GetPublishedContentAsDraft(publishedContent);
-            }
-
-            if (publishedContent is not null)
-            {
-                _appCaches.RequestCache.Set(cacheKey, publishedContent);
-            }
-        }
-        else
+        if (publishedContent is not null)
         {
             _logger.LogDebug(
                 "Using cached IPublishedContent for document {ContentCacheNodeName} ({ContentCacheNodeId}).",
                 contentCacheNode.Data?.Name ?? "No Name",
                 contentCacheNode.Id);
+            return publishedContent;
+        }
+
+        _logger.LogDebug(
+            "Creating IPublishedContent for document {ContentCacheNodeName} ({ContentCacheNodeId}).",
+            contentCacheNode.Data?.Name ?? "No Name",
+            contentCacheNode.Id);
+
+        IPublishedContentType contentType =
+            _publishedContentTypeCache.Get(PublishedItemType.Content, contentCacheNode.ContentTypeId);
+        var contentNode = new ContentNode(
+            contentCacheNode.Id,
+            contentCacheNode.Key,
+            contentCacheNode.SortOrder,
+            contentCacheNode.CreateDate,
+            contentCacheNode.CreatorId,
+            contentType,
+            preview ? contentCacheNode.Data : null,
+            preview ? null : contentCacheNode.Data);
+
+        publishedContent = GetModel(contentNode, preview);
+
+        if (preview)
+        {
+            publishedContent ??= GetPublishedContentAsDraft(publishedContent);
+        }
+
+        if (publishedContent is not null)
+        {
+            _appCaches.RequestCache.Set(cacheKey, publishedContent);
         }
 
         return publishedContent;
@@ -84,39 +84,39 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     /// <inheritdoc/>
     public IPublishedContent? ToIPublishedMedia(ContentCacheNode contentCacheNode)
     {
-        string cacheKey = $"{nameof(PublishedContentFactory)}MediaCache_{contentCacheNode.Id}";
+        var cacheKey = $"{nameof(PublishedContentFactory)}MediaCache_{contentCacheNode.Id}";
         IPublishedContent? publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
-        if (publishedContent is null)
-        {
-            _logger.LogDebug(
-                "Creating IPublishedContent for media {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Data?.Name ?? "No Name",
-                contentCacheNode.Id);
-
-            IPublishedContentType contentType = _publishedContentTypeCache.Get(PublishedItemType.Media, contentCacheNode.ContentTypeId);
-            var contentNode = new ContentNode(
-                contentCacheNode.Id,
-                contentCacheNode.Key,
-                contentCacheNode.SortOrder,
-                contentCacheNode.CreateDate,
-                contentCacheNode.CreatorId,
-                contentType,
-                null,
-                contentCacheNode.Data);
-
-            publishedContent = GetModel(contentNode, false);
-
-            if (publishedContent is not null)
-            {
-                _appCaches.RequestCache.Set(cacheKey, publishedContent);
-            }
-        }
-        else
+        if (publishedContent is not null)
         {
             _logger.LogDebug(
                 "Using cached IPublishedContent for media {ContentCacheNodeName} ({ContentCacheNodeId}).",
                 contentCacheNode.Data?.Name ?? "No Name",
                 contentCacheNode.Id);
+            return publishedContent;
+        }
+
+        _logger.LogDebug(
+            "Creating IPublishedContent for media {ContentCacheNodeName} ({ContentCacheNodeId}).",
+            contentCacheNode.Data?.Name ?? "No Name",
+            contentCacheNode.Id);
+
+        IPublishedContentType contentType =
+            _publishedContentTypeCache.Get(PublishedItemType.Media, contentCacheNode.ContentTypeId);
+        var contentNode = new ContentNode(
+            contentCacheNode.Id,
+            contentCacheNode.Key,
+            contentCacheNode.SortOrder,
+            contentCacheNode.CreateDate,
+            contentCacheNode.CreatorId,
+            contentType,
+            null,
+            contentCacheNode.Data);
+
+        publishedContent = GetModel(contentNode, false);
+
+        if (publishedContent is not null)
+        {
+            _appCaches.RequestCache.Set(cacheKey, publishedContent);
         }
 
         return publishedContent;
@@ -127,47 +127,48 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     {
         string cacheKey = $"{nameof(PublishedContentFactory)}MemberCache_{member.Id}";
         IPublishedMember? publishedMember = _appCaches.RequestCache.GetCacheItem<IPublishedMember?>(cacheKey);
-        if (publishedMember is null)
-        {
-            _logger.LogDebug(
-                "Creating IPublishedMember for member {MemberName} ({MemberId}).",
-                member.Username,
-                member.Id);
-
-            IPublishedContentType contentType = _publishedContentTypeCache.Get(PublishedItemType.Member, member.ContentTypeId);
-
-            // Members are only "mapped" never cached, so these default values are a bit weird, but they are not used.
-            var contentData = new ContentData(
-                member.Name,
-                null,
-                0,
-                member.UpdateDate,
-                member.CreatorId,
-                null,
-                true,
-                GetPropertyValues(contentType, member),
-                null);
-
-            var contentNode = new ContentNode(
-                member.Id,
-                member.Key,
-                member.SortOrder,
-                member.UpdateDate,
-                member.CreatorId,
-                contentType,
-                null,
-                contentData);
-            publishedMember = new PublishedMember(member, contentNode, _elementsCache, _variationContextAccessor);
-
-            _appCaches.RequestCache.Set(cacheKey, publishedMember);
-        }
-        else
+        if (publishedMember is not null)
         {
             _logger.LogDebug(
                 "Using cached IPublishedMember for member {MemberName} ({MemberId}).",
                 member.Username,
                 member.Id);
+
+            return publishedMember;
         }
+
+        _logger.LogDebug(
+            "Creating IPublishedMember for member {MemberName} ({MemberId}).",
+            member.Username,
+            member.Id);
+
+        IPublishedContentType contentType =
+            _publishedContentTypeCache.Get(PublishedItemType.Member, member.ContentTypeId);
+
+        // Members are only "mapped" never cached, so these default values are a bit weird, but they are not used.
+        var contentData = new ContentData(
+            member.Name,
+            null,
+            0,
+            member.UpdateDate,
+            member.CreatorId,
+            null,
+            true,
+            GetPropertyValues(contentType, member),
+            null);
+
+        var contentNode = new ContentNode(
+            member.Id,
+            member.Key,
+            member.SortOrder,
+            member.UpdateDate,
+            member.CreatorId,
+            contentType,
+            null,
+            contentData);
+        publishedMember = new PublishedMember(member, contentNode, _elementsCache, _variationContextAccessor);
+
+        _appCaches.RequestCache.Set(cacheKey, publishedMember);
 
         return publishedMember;
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactoryTests.cs
@@ -1,0 +1,147 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.HybridCache;
+using Umbraco.Cms.Infrastructure.HybridCache.Factories;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class PublishedContentFactoryTests : UmbracoIntegrationTestWithContent
+{
+    private IPublishedContentFactory PublishedContentFactory => GetRequiredService<IPublishedContentFactory>();
+
+    private IPublishedValueFallback PublishedValueFallback => GetRequiredService<IPublishedValueFallback>();
+
+    private IMediaService MediaService => GetRequiredService<IMediaService>();
+
+    private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
+
+    private IMemberService MemberService => GetRequiredService<IMemberService>();
+
+    private IMemberTypeService MemberTypeService => GetRequiredService<IMemberTypeService>();
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        var requestCache = new DictionaryAppCache();
+        var appCaches = new AppCaches(
+                NoAppCache.Instance,
+                requestCache,
+                new IsolatedCaches(type => NoAppCache.Instance));
+        builder.Services.AddUnique(appCaches);
+    }
+
+    [Test]
+    public void Can_Create_Published_Content_For_Document()
+    {
+        var contentCacheNode = new ContentCacheNode
+        {
+            Id = Textpage.Id,
+            Key = Textpage.Key,
+            ContentTypeId = Textpage.ContentType.Id,
+            CreateDate = Textpage.CreateDate,
+            CreatorId = Textpage.CreatorId,
+            SortOrder = Textpage.SortOrder,
+            Data = new ContentData(
+                Textpage.Name,
+                "text-page",
+                Textpage.VersionId,
+                Textpage.UpdateDate,
+                Textpage.WriterId,
+                Textpage.TemplateId,
+                true,
+                new Dictionary<string, PropertyData[]>
+                {
+                    {
+                        "title", new[]
+                        {
+                            new PropertyData
+                            {
+                                Value = "Test title",
+                                Culture = string.Empty,
+                                Segment = string.Empty,
+                            },
+                        }
+                    },
+                },
+                null),
+        };
+        var result = PublishedContentFactory.ToIPublishedContent(contentCacheNode, false);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(Textpage.Id, result.Id);
+        Assert.AreEqual(Textpage.Name, result.Name);
+        Assert.AreEqual("Test title", result.Properties.Single(x => x.Alias == "title").Value<string>(PublishedValueFallback));
+
+        // Verify that requesting the same content again returns the same instance (from request cache).
+        var result2 = PublishedContentFactory.ToIPublishedContent(contentCacheNode, false);
+        Assert.AreSame(result, result2);
+    }
+
+    [Test]
+    public async Task Can_Create_Published_Content_For_Media()
+    {
+        var mediaType = new MediaTypeBuilder().Build();
+        mediaType.AllowedAsRoot = true;
+        await MediaTypeService.CreateAsync(mediaType, Constants.Security.SuperUserKey);
+
+        var media = new MediaBuilder()
+            .WithMediaType(mediaType)
+            .WithName("Media 1")
+            .Build();
+        MediaService.Save(media);
+
+        var contentCacheNode = new ContentCacheNode
+        {
+            Id = media.Id,
+            Key = media.Key,
+            ContentTypeId = media.ContentType.Id,
+            Data = new ContentData(
+                media.Name,
+                null,
+                0,
+                media.UpdateDate,
+                media.WriterId,
+                null,
+                false,
+                new Dictionary<string, PropertyData[]>(),
+                null),
+        };
+        var result = PublishedContentFactory.ToIPublishedMedia(contentCacheNode);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(media.Id, result.Id);
+        Assert.AreEqual(media.Name, result.Name);
+
+        // Verify that requesting the same content again returns the same instance (from request cache).
+        var result2 = PublishedContentFactory.ToIPublishedMedia(contentCacheNode);
+        Assert.AreSame(result, result2);
+    }
+
+    [Test]
+    public async Task Can_Create_Published_Member_For_Member()
+    {
+        var memberType = new MemberTypeBuilder().Build();
+        await MemberTypeService.CreateAsync(memberType, Constants.Security.SuperUserKey);
+
+        var member = new MemberBuilder()
+            .WithMemberType(memberType)
+            .WithName("Member 1")
+            .Build();
+        MemberService.Save(member);
+
+        var result = PublishedContentFactory.ToPublishedMember(member);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(member.Id, result.Id);
+        Assert.AreEqual(member.Name, result.Name);
+
+        // Verify that requesting the same content again returns the same instance (from request cache).
+        var result2 = PublishedContentFactory.ToPublishedMember(member);
+        Assert.AreSame(result, result2);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Relates to https://github.com/umbraco/Umbraco-CMS/issues/18892

### Description
We've had some discussion on the linked issue and internally about the potential performance concern of having to translate from the object stored into the hybrid cache and the `IPublishedContent` instance.  It can be argued if this is likely to be a concern in typical page generation, but, as noted, it seems straightforward to at least request cache this.

As such I've applied that in this PR.

Given it's only cached for the request, we don't have to be concerned about cache invalidation.

Looking at a small site - the Umbraco starter kit - it does seem we can instantiate the same `IPublishedContent` multiple times in a single page request.

When this update is applied, loading a product page, which has the navigation bar, from the starter kit creates 9 `IPublishedContent` instances.  Without the request cache, it creates 35.

And so this should have a positive, even if often small or even negligible, impact - and I can't see it can cause any harm.

### Testing
Verify pages render from the cache as expected.
Using a breakpoint in `PublishedContentFactory` verify that the items are retrieved from the cache on all but the first time for a page request.



