### PR TITLE
V16 QA Added acceptance tests for removing user groups from a user

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^2.0.37",
-        "@umbraco/playwright-testhelpers": "^16.0.37",
+        "@umbraco/playwright-testhelpers": "^16.0.39",
         "camelize": "^1.0.0",
         "dotenv": "^16.3.1",
         "node-fetch": "^2.6.7"
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "16.0.37",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-16.0.37.tgz",
-      "integrity": "sha512-hpYrQJRxB8yK/1B2THsh2NDBaXM4DdM4npnjjFSwujBxnjOFjpJj8VfDU/D4eR8pyzZUu9qV4UkzrGxDuf9uvQ==",
+      "version": "16.0.39",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-16.0.39.tgz",
+      "integrity": "sha512-rZ/e3Kc9Dzkd7L+V5J3VyGlODnUNLye4kksnaKdRM4PKAsSW6U1f8t3402+lywtTo0oot7JNrVvooJuLwuwc+w==",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.37",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^2.0.37",
-    "@umbraco/playwright-testhelpers": "^16.0.37",
+    "@umbraco/playwright-testhelpers": "^16.0.39",
     "camelize": "^1.0.0",
     "dotenv": "^16.3.1",
     "node-fetch": "^2.6.7"

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
@@ -95,8 +95,10 @@ test('can add multiple user groups to a user', async ({umbracoApi, umbracoUi}) =
 
 test('can remove a user group from a user', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  const userGroup = await umbracoApi.userGroup.getByName(defaultUserGroupName);
-  await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroup.id]);
+  const secondUserGroupName = 'Translators';
+  const userGroupWriters = await umbracoApi.userGroup.getByName(defaultUserGroupName);
+  const userGroupTranslators = await umbracoApi.userGroup.getByName(secondUserGroupName);
+  await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroupWriters.id, userGroupTranslators.id]);
   await umbracoUi.user.goToUsers();
 
   // Act
@@ -107,8 +109,7 @@ test('can remove a user group from a user', {tag: '@smoke'}, async ({umbracoApi,
 
   // Assert
   await umbracoUi.user.isSuccessStateVisibleForSaveButton();
-  const userData = await umbracoApi.user.getByName(nameOfTheUser);
-  expect(userData.userGroupIds).toEqual([]);
+  expect(await umbracoApi.user.doesUserContainUserGroupIds(nameOfTheUser, [userGroupTranslators.id])).toBeTruthy();
 });
 
 test('can update culture for a user', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
@@ -596,4 +597,45 @@ test('can order by newest user', async ({umbracoApi, umbracoUi}) => {
 
 // TODO: Sometimes the frontend does not switch from grid to table, or table to grid.
 test.skip('can change from grid to table view', async ({page, umbracoApi, umbracoUi}) => {
+});
+
+test('can remove admin user group from a user', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const adminUserGroupName = 'Administrators';
+  const editorUserGroupName = 'Editors';
+  const adminUserGroupData = await umbracoApi.userGroup.getByName(adminUserGroupName);
+  await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [adminUserGroupData.id]);
+  await umbracoUi.user.goToUsers();
+
+  // Act
+  await umbracoUi.user.clickUserWithName(nameOfTheUser);
+  // Removes the admin user group
+  await umbracoUi.user.clickRemoveButtonForUserGroupWithName(adminUserGroupName);
+  await umbracoUi.user.clickConfirmRemoveButton();
+  // Adds another user group
+  await umbracoUi.user.clickChooseUserGroupsButton();
+  await umbracoUi.user.clickButtonWithName(editorUserGroupName);
+  await umbracoUi.user.clickChooseModalButton();
+  await umbracoUi.user.clickSaveButton();
+
+  // Assert
+  await umbracoUi.user.isSuccessStateVisibleForSaveButton();
+  const editorUserGroupData = await umbracoApi.userGroup.getByName(editorUserGroupName);
+  expect(await umbracoApi.user.doesUserContainUserGroupIds(nameOfTheUser, [editorUserGroupData.id])).toBeTruthy();
+});
+
+test('cannot remove all user group from a user', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const userGroup = await umbracoApi.userGroup.getByName(defaultUserGroupName);
+  await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroup.id]);
+  await umbracoUi.user.goToUsers();
+
+  // Act
+  await umbracoUi.user.clickUserWithName(nameOfTheUser);
+  await umbracoUi.user.clickRemoveButtonForUserGroupWithName(defaultUserGroupName);
+  await umbracoUi.user.clickConfirmRemoveButton();;
+  await umbracoUi.user.clickSaveButton();
+
+  // Assert
+  await umbracoUi.user.isErrorNotificationVisible();
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/User.spec.ts
@@ -599,7 +599,9 @@ test('can order by newest user', async ({umbracoApi, umbracoUi}) => {
 test.skip('can change from grid to table view', async ({page, umbracoApi, umbracoUi}) => {
 });
 
-test('can remove admin user group from a user', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
+// This test is skipped because currently it is impossible to remove the admin user group from a user
+// Related issue: https://github.com/umbraco/Umbraco-CMS/issues/19917
+test.skip('can remove admin user group from a user', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const adminUserGroupName = 'Administrators';
   const editorUserGroupName = 'Editors';
@@ -624,7 +626,9 @@ test('can remove admin user group from a user', {tag: '@release'}, async ({umbra
   expect(await umbracoApi.user.doesUserContainUserGroupIds(nameOfTheUser, [editorUserGroupData.id])).toBeTruthy();
 });
 
-test('cannot remove all user group from a user', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
+// This test is skipped because currently it is possible to remove all user groups from a user
+// Related issue: https://github.com/umbraco/Umbraco-CMS/issues/19992
+test.skip('cannot remove all user group from a user', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const userGroup = await umbracoApi.userGroup.getByName(defaultUserGroupName);
   await umbracoApi.user.createDefaultUser(nameOfTheUser, userEmail, [userGroup.id]);


### PR DESCRIPTION
This PR updates and adds additional acceptance tests related to removing user groups from a user to address the following issues:
https://github.com/umbraco/Umbraco-CMS/issues/19917
https://github.com/umbraco/Umbraco-CMS/issues/19992