### PR TITLE
Fix spell error from Segmment to Segment

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -50,7 +50,7 @@ public static class UmbracoBuilderExtensions
                 : provider.GetRequiredService<RequestContextOutputExpansionStrategyV2>();
         });
         builder.Services.AddSingleton<IRequestCultureService, RequestCultureService>();
-        builder.Services.AddSingleton<IRequestSegmmentService, RequestSegmentService>();
+        builder.Services.AddSingleton<IRequestSegmentService, RequestSegmentService>();
         builder.Services.AddSingleton<IRequestRoutingService, RequestRoutingService>();
         builder.Services.AddSingleton<IRequestRedirectService, RequestRedirectService>();
         builder.Services.AddSingleton<IRequestPreviewService, RequestPreviewService>();

--- a/src/Umbraco.Cms.Api.Delivery/Filters/ContextualizeFromAcceptHeadersAttribute.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Filters/ContextualizeFromAcceptHeadersAttribute.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -16,12 +16,12 @@ internal sealed class ContextualizeFromAcceptHeadersAttribute : TypeFilterAttrib
     private sealed class LocalizeFromAcceptLanguageHeaderAttributeFilter : IActionFilter
     {
         private readonly IRequestCultureService _requestCultureService;
-        private readonly IRequestSegmmentService _requestSegmentService;
+        private readonly IRequestSegmentService _requestSegmentService;
         private readonly IVariationContextAccessor _variationContextAccessor;
 
         public LocalizeFromAcceptLanguageHeaderAttributeFilter(
             IRequestCultureService requestCultureService,
-            IRequestSegmmentService requestSegmentService,
+            IRequestSegmentService requestSegmentService,
             IVariationContextAccessor variationContextAccessor)
         {
             _requestCultureService = requestCultureService;

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestSegmentService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestSegmentService.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.DeliveryApi;
 
 namespace Umbraco.Cms.Api.Delivery.Services;
 
-internal sealed class RequestSegmentService : RequestHeaderHandler, IRequestSegmmentService
+internal sealed class RequestSegmentService : RequestHeaderHandler, IRequestSegmentService
 {
     public RequestSegmentService(IHttpContextAccessor httpContextAccessor)
         : base(httpContextAccessor)

--- a/src/Umbraco.Core/DeliveryApi/IRequestSegmentService.cs
+++ b/src/Umbraco.Core/DeliveryApi/IRequestSegmentService.cs
@@ -1,6 +1,6 @@
-﻿namespace Umbraco.Cms.Core.DeliveryApi;
+namespace Umbraco.Cms.Core.DeliveryApi;
 
-public interface IRequestSegmmentService
+public interface IRequestSegmentService
 {
     /// <summary>
     ///     Gets the requested segment from the "Accept-Segment" header, if present.


### PR DESCRIPTION
Fund a spelling error, while using the IRequestSegment services. I saw that the service was correct spelled, along with the interface fil, but not the Interface itself. 