### PR TITLE
Fixes exception when converting UDIs in a PropertyValueConverter

### DIFF
--- a/src/Umbraco.Infrastructure/Serialization/JsonUdiConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonUdiConverter.cs
@@ -16,7 +16,7 @@ public sealed class JsonUdiConverter : JsonConverter<Udi>
     /// <inheritdoc />
     public override Udi? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.GetString() is string value && !string.IsNullOrWhiteSpace(value))
+        if (reader.GetString() is string value && string.IsNullOrWhiteSpace(value) is false)
         {
             return UdiParser.Parse(value);
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Deploy/ArtifactBaseTests.cs
@@ -12,23 +12,35 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Deploy;
 [TestFixture]
 public class ArtifactBaseTests
 {
-    [Test]
-    public void CanSerialize()
-    {
-        var udi = new GuidUdi("test", Guid.Parse("3382d5433b5749d08919bc9961422a1f"));
-        var artifact = new TestArtifact(udi, new List<ArtifactDependency>()) { Name = "Test Name", Alias = "testAlias" };
-
-        var serialized = JsonSerializer.Serialize(artifact, new JsonSerializerOptions()
+    private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
         {
             Converters =
             {
                 new JsonUdiConverter(),
             }
-        });
+        };
 
-        var expected =
-            "{\"Udi\":\"umb://test/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Checksum\":\"test checksum value\",\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";
+    [Test]
+    public void Can_Serialize()
+    {
+        var udi = new GuidUdi("document", Guid.Parse("3382d5433b5749d08919bc9961422a1f"));
+        var artifact = new TestArtifact(udi, []) { Name = "Test Name", Alias = "testAlias" };
+
+        string serialized = JsonSerializer.Serialize(artifact, _jsonSerializerOptions);
+
+        var expected = "{\"Udi\":\"umb://document/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Checksum\":\"test checksum value\",\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";
         Assert.AreEqual(expected, serialized);
+    }
+
+    [Test]
+    public void Can_Deserialize()
+    {
+        var serialized = "{\"Udi\":\"umb://document/3382d5433b5749d08919bc9961422a1f\",\"Dependencies\":[],\"Checksum\":\"test checksum value\",\"Name\":\"Test Name\",\"Alias\":\"testAlias\"}";
+
+        TestArtifact? deserialized = JsonSerializer.Deserialize<TestArtifact>(serialized, _jsonSerializerOptions);
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual("Test Name", deserialized.Name);
+        Assert.AreEqual("testAlias", deserialized.Alias);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonUdiConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonUdiConverterTests.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Serialization;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Serialization;
+
+[TestFixture]
+public class JsonUdiConverterTests
+{
+    private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+    {
+        Converters =
+        {
+            new JsonUdiConverter(),
+        },
+    };
+
+    [Test]
+    public void Can_Serialize()
+    {
+        var udi = new GuidUdi("document", Guid.Parse("3382d5433b5749d08919bc9961422a1f"));
+        var artifact = new Test { Udi = udi };
+
+        string serialized = JsonSerializer.Serialize(artifact, _jsonSerializerOptions);
+
+        var expected = "{\"Udi\":\"umb://document/3382d5433b5749d08919bc9961422a1f\"}";
+        Assert.AreEqual(expected, serialized);
+    }
+
+    [Test]
+    public void Can_Deserialize()
+    {
+        var serialized = "{\"Udi\":\"umb://document/3382d5433b5749d08919bc9961422a1f\"}";
+
+        Test? deserialized = JsonSerializer.Deserialize<Test>(serialized, _jsonSerializerOptions);
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(Guid.Parse("3382d5433b5749d08919bc9961422a1f"), deserialized.Udi.Guid);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase(" ")]
+    public void Will_Deserialize_To_Null_With_Null_Or_Whitepsace_Udi(string? serializedUdi)
+    {
+        var serializedUdiPart = serializedUdi is null ? "null" : $"\"{serializedUdi}\"";
+        var serialized = "{\"Udi\":" + serializedUdiPart + "}";
+
+        Test? deserialized = JsonSerializer.Deserialize<Test>(serialized, _jsonSerializerOptions);
+        Assert.IsNotNull(deserialized);
+        Assert.IsNull(deserialized.Udi);
+    }
+
+    [Test]
+    public void Throws_On_Invalid_Udi()
+    {
+        var serialized = "{\"Udi\":\"invalid-udi\"}";
+
+        Assert.Throws<FormatException>(() =>
+            JsonSerializer.Deserialize<Test>(serialized, _jsonSerializerOptions));
+    }
+
+    private class Test
+    {
+        public GuidUdi? Udi { get; set; }
+    }
+}


### PR DESCRIPTION
When using the standard JsonUdiConverter it will throw an exception when it tries to deserialize `""` 

As part of a migration this may be the case, instead it should use the tryparse

My PR changes this to use TryParse to fix this exception