### PR TITLE
Block level segment variation

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValidatorBase.cs
@@ -23,7 +23,10 @@ public abstract class BlockEditorValidatorBase<TValue, TLayout> : ComplexEditorV
         var elementTypeValidation = new List<ElementTypeValidationModel>();
         var isWildcardCulture = validationContext.Culture == "*";
         var validationContextCulture = isWildcardCulture ? null : validationContext.Culture.NullOrWhiteSpaceAsNull();
-        elementTypeValidation.AddRange(GetBlockEditorDataValidation(blockEditorData, validationContextCulture, validationContext.Segment));
+        foreach (var segment in validationContext.SegmentsBeingValidated.DefaultIfEmpty(null))
+        {
+            elementTypeValidation.AddRange(GetBlockEditorDataValidation(blockEditorData, validationContextCulture, segment));
+        }
 
         if (validationContextCulture is null)
         {
@@ -119,12 +122,9 @@ public abstract class BlockEditorValidatorBase<TValue, TLayout> : ComplexEditorV
                         continue;
                     }
 
-                    if (segment != "*")
+                    if (segment != "*" && blockPropertyValue.Segment.InvariantEquals(segment) is false)
                     {
-                        if (propertyType.VariesBySegment() != (segment is not null) || blockPropertyValue.Segment.InvariantEquals(segment) is false)
-                        {
-                            continue;
-                        }
+                        continue;
                     }
 
                     elementValidation.AddPropertyTypeValidation(

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/settings/document-type-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/settings/document-type-workspace-view-settings.element.ts
@@ -207,7 +207,6 @@ export class UmbDocumentTypeWorkspaceViewSettingsElement extends UmbLitElement i
 
 	#renderVaryBySegmentProperty() {
 		if (!this._useSegments) return nothing;
-		if (this._isElement) return nothing;
 
 		return html`
 			<umb-property-layout

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -1932,4 +1932,132 @@ internal partial class BlockListElementLevelVariationTests
             Assert.AreEqual(expectedPickedContent.Key, actualPickedPublishedContent.Key);
         }
     }
+
+    [Test]
+    public async Task Missing_Segment_Performs_Fallback_To_Default_Segment()
+    {
+        var elementType = CreateElementType(ContentVariation.Segment);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Segment, blockListDataType);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new List<BlockPropertyValue>
+            {
+                new() { Alias = "invariantText", Value = "The invariant content value" },
+                new() { Alias = "variantText", Value = "The variant content value (Default)" },
+                new() { Alias = "variantText", Value = "The variant content value (Segment 2)", Segment = "s2" }
+            },
+            [],
+            true);
+
+        AssertPropertyValues(null, "The invariant content value", "The variant content value (Default)");
+
+        AssertPropertyValues("s1", "The invariant content value", "The variant content value (Default)");
+
+        AssertPropertyValues("s2", "The invariant content value", "The variant content value (Segment 2)");
+
+        var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
+        blockListValue.ContentData[0].Values.Add(new BlockPropertyValue { Alias = "variantText", Value = "The variant content value (Segment 1)", Segment = "s1" });
+
+        blockListValue.Expose =
+        [
+            new() { ContentKey = blockListValue.ContentData[0].Key },
+            new() { ContentKey = blockListValue.ContentData[0].Key, Segment = "s1" },
+            new() { ContentKey = blockListValue.ContentData[0].Key, Segment = "s2" },
+        ];
+
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+        PublishContent(content, contentType);
+
+        AssertPropertyValues(null, "The invariant content value", "The variant content value (Default)");
+
+        AssertPropertyValues("s1", "The invariant content value", "The variant content value (Segment 1)");
+
+        AssertPropertyValues("s2", "The invariant content value", "The variant content value (Segment 2)");
+
+        void AssertPropertyValues(string? segment, string expectedInvariantContentValue, string expectedVariantContentValue)
+        {
+            SetVariationContext(null, segment);
+            var publishedContent = GetPublishedContent(content.Key);
+
+            var value = publishedContent.Value<BlockListModel>("blocks");
+            Assert.IsNotNull(value);
+            Assert.AreEqual(1, value.Count);
+
+            var blockListItem = value.First();
+            Assert.AreEqual(2, blockListItem.Content.Properties.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedInvariantContentValue, blockListItem.Content.Value<string>("invariantText"));
+                Assert.AreEqual(expectedVariantContentValue, blockListItem.Content.Value<string>("variantText"));
+            });
+        }
+    }
+
+    [Test]
+    public async Task Missing_Property_Value_For_Existing_Segment_Does_Not_Perform_Fallback_To_Default_Segment()
+    {
+        var elementType = CreateElementType(ContentVariation.Segment);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Segment, blockListDataType);
+
+        var content = CreateContent(contentType, elementType, [], false);
+        var blockListValue = BlockListPropertyValue(
+            elementType,
+            [
+                (
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    new BlockProperty(
+                        new List<BlockPropertyValue>
+                        {
+                            new() { Alias = "invariantText", Value = "The invariant content value" },
+                            new() { Alias = "variantText", Value = "The variant content value (Default)" },
+                            new() { Alias = "variantText", Value = "The variant content value (Segment 2)", Segment = "s2"}
+                        },
+                        [],
+                        null,
+                        null)
+                )
+            ]);
+
+        blockListValue.Expose =
+        [
+            new() { ContentKey = blockListValue.ContentData[0].Key },
+            new() { ContentKey = blockListValue.ContentData[0].Key, Segment = "s1" },
+            new() { ContentKey = blockListValue.ContentData[0].Key, Segment = "s2" },
+        ];
+
+        content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
+        ContentService.Save(content);
+        PublishContent(content, contentType);
+
+        AssertPropertyValues(null, "The invariant content value", "The variant content value (Default)");
+
+        AssertPropertyValues("s1", "The invariant content value", string.Empty);
+
+        AssertPropertyValues("s2", "The invariant content value", "The variant content value (Segment 2)");
+
+
+        void AssertPropertyValues(string? segment, string expectedInvariantContentValue, string expectedVariantContentValue)
+        {
+            SetVariationContext(null, segment);
+            var publishedContent = GetPublishedContent(content.Key);
+
+            var value = publishedContent.Value<BlockListModel>("blocks");
+            Assert.IsNotNull(value);
+            Assert.AreEqual(1, value.Count);
+
+            var blockListItem = value.First();
+            Assert.AreEqual(2, blockListItem.Content.Properties.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedInvariantContentValue, blockListItem.Content.Value<string>("invariantText"));
+                Assert.AreEqual(expectedVariantContentValue, blockListItem.Content.Value<string>("variantText"));
+            });
+        }
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

TBD 😆 

### Testing this PR

First and foremost: Block editors configured for block level variation should allow for segment variation - either with or without culture variation. That is:

- An element type should be able to vary by segment alone.
- An element type should be able to vary by _both_ language and segment.

Furthermore, this PR anticipates an upcoming shift in segmented content behavior. In short, non-existing (non-created) segment variations should fallback to the default segment (language with no segment) at block level:

- A block that has _not_ been created for a given segment should fallback to its default segment.
- A block that _has_ been created for a given segment should forcefully render in that segment for _all_ properties, even the ones that have not been filled out in that segment. In other words, there should be _no_ property level fallback to the default segment - only block level fallback should be performed when applicable.

All of the above should be supported both for editing (CRUD) and for validation, so make sure to test it with various permutations of mandatory and/or pattern validated properties.
