### PR TITLE
fix: pins the UmbracoExtension `@hey-api/*` versions to that of the Backoffice client

### DIFF
--- a/templates/UmbracoExtension/Client/package.json
+++ b/templates/UmbracoExtension/Client/package.json
@@ -9,8 +9,8 @@
     "generate-client": "node scripts/generate-openapi.js https://localhost:44339/umbraco/swagger/umbracoextension/swagger.json"
   },
   "devDependencies": {
-    "@hey-api/client-fetch": "^0.10.0",
-    "@hey-api/openapi-ts": "^0.66.7",
+    "@hey-api/client-fetch": "0.12.0",
+    "@hey-api/openapi-ts": "0.71.0",
     "@umbraco-cms/backoffice": "^UMBRACO_VERSION_FROM_TEMPLATE",
     "chalk": "^5.4.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Description

This is a quick fix to handle the NPM error that is currently there because the Backoffice NPM client has moved on to another version. There will be a more comprehensive fix for 16.3, however this PR aims to make the 16.2 UmbracoExtension usable without running custom commands.

## How to test

1. Install the 16.2.0-rc template
2. Run the `dotnet new umbraco-extension --version 16.2.0-rc -ex`
3. Verify that `npm install` initially fails
4. Now change the versions in package.json to the proposed changes here in this PR
5. Run `npm install` again and verify it now works