### PR TITLE
Converting DateTime.MinValue to sqlDateTime's minimum value

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditorTests.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models.Editors;
@@ -10,28 +10,32 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.PropertyEditors;
 
 public class DateTimePropertyEditorTests
 {
+    // Various time formats with years below the minimum, so we expect to increase the date to the minimum supported by SQL Server.
     [TestCase("01/01/0001 10:00", "01/01/1753 10:00", "hh:mm")]
+    [TestCase("01/01/0001 10:00", "01/01/1753 10:00", "HH:mm")]
     [TestCase("01/01/0001 10:00", "01/01/1753 10:00", "hh mm")]
     [TestCase("10/10/1000 10:00", "10/10/1753 10:00", "hh:mm:ss")]
     [TestCase("10/10/1000 10:00", "10/10/1753 10:00", "hh-mm-ss")]
-    [TestCase("10/10/1000 10:00", "10/10/1753 10:00", "hh/mm/ss")]
-    [TestCase("10/10/1000 10:00", "10/10/1753 10:00", "hh%mm%ss")] // Weird format separators customers potentially might use.
+
+    // Time format with year above the minimum, so we expect to not convert.
     [TestCase("01/01/2000 10:00", "01/01/2000 10:00", "HH:mm")]
-    [TestCase("01/01/0001 10:00", "01/01/0001 10:00", "dd:MM:yyyy hh:mm")] // Inconvertible format doesn't get converted.
-    public void Ensure_Correct_DateTime_Conversion(DateTime actualDateTime, DateTime expectedDateTime, string format)
+
+    // Date formats, so we don't convert even if the year is below the minimum.
+    [TestCase("01/01/0001 10:00", "01/01/0001 10:00", "dd-MM-yyyy hh:mm")]
+    [TestCase("01/01/0001 10:00", "01/01/0001 10:00", "dd-MM-yyyy")]
+        [TestCase("01/01/0001 10:00", "01/01/0001 10:00", "yyyy-MM-d")]
+    public void Time_Only_Format_Ensures_DateTime_Can_Be_Persisted(DateTime actualDateTime, DateTime expectedDateTime, string format)
     {
         var dateTimePropertyEditor = new DateTimePropertyEditor.DateTimePropertyValueEditor(
             Mock.Of<IShortStringHelper>(),
             Mock.Of<IJsonSerializer>(),
             Mock.Of<IIOHelper>(),
-            new DataEditorAttribute("Alias"));
+            new DataEditorAttribute("Alias") { ValueType = ValueTypes.DateTime.ToString() });
 
-        Dictionary<string, object> dictionary = new Dictionary<string, object> { { "Format", format } };
+        Dictionary<string, object> dictionary = new Dictionary<string, object> { { DateTimePropertyEditor.DateTimePropertyValueEditor.DateTypeConfigurationFormatKey, format } };
         ContentPropertyData propertyData = new ContentPropertyData(actualDateTime, dictionary);
-        var value = dateTimePropertyEditor.FromEditor(propertyData, null);
+        var value = (DateTime)dateTimePropertyEditor.FromEditor(propertyData, null);
 
-        DateTime converted = DateTime.Parse(value as string ?? string.Empty);
-        Assert.IsInstanceOf<DateTime>(converted);
-        Assert.AreEqual(expectedDateTime, converted);
+        Assert.AreEqual(expectedDateTime, value);
     }
 }


### PR DESCRIPTION

If there's an existing issue for this PR then this fixes [<!-- link to the issue here! -->](https://github.com/umbraco/Umbraco-CMS/issues/19865)

### Description
A bug was discovered, whereas if you a date property editor with a time only format, any documents created with this would be unable to save.

It turns out, that when only a time has been set, and no date is ever picked, we recieve the date 01/01/0001, which is `DateTime.MinValue` - Our issue here is that SQLServer's DateTime datatype has a minimum value of 01/01/1753, so anything below that will cause issues.

I have just made a small check in the value converter to check if the date we are receiving is 01/01/0001, if it is, we just


Closes #19865

<!-- Thanks for contributing to Umbraco CMS! -->
