### PR TITLE
Serverside generated preview URLs

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentPreviewUrlController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DocumentPreviewUrlController.cs
@@ -1,0 +1,34 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document;
+
+[ApiVersion("1.0")]
+public class DocumentPreviewUrlController : DocumentControllerBase
+{
+    private readonly IContentService _contentService;
+    private readonly IDocumentUrlFactory _documentUrlFactory;
+
+    public DocumentPreviewUrlController(
+        IContentService contentService,
+        IDocumentUrlFactory documentUrlFactory)
+    {
+        _contentService = contentService;
+        _documentUrlFactory = documentUrlFactory;
+    }
+
+    [MapToApiVersion("1.0")]
+    [HttpGet("preview-urls")]
+    [ProducesResponseType(typeof(IEnumerable<DocumentUrlInfoResponseModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPreviewUrls([FromQuery(Name = "id")] HashSet<Guid> ids)
+    {
+        IEnumerable<IContent> items = _contentService.GetByIds(ids);
+
+        return Ok(await _documentUrlFactory.CreatePreviewUrlSetsAsync(items));
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
@@ -7,19 +7,18 @@ namespace Umbraco.Cms.Api.Management.Factories;
 public class DocumentUrlFactory : IDocumentUrlFactory
 {
     private readonly IPublishedUrlInfoProvider _publishedUrlInfoProvider;
+    private readonly UrlProviderCollection _urlProviders;
 
-
-    public DocumentUrlFactory(IPublishedUrlInfoProvider publishedUrlInfoProvider)
-        => _publishedUrlInfoProvider = publishedUrlInfoProvider;
+    public DocumentUrlFactory(IPublishedUrlInfoProvider publishedUrlInfoProvider, UrlProviderCollection urlProviders)
+    {
+        _publishedUrlInfoProvider = publishedUrlInfoProvider;
+        _urlProviders = urlProviders;
+    }
 
     public async Task<IEnumerable<DocumentUrlInfo>> CreateUrlsAsync(IContent content)
     {
         ISet<UrlInfo> urlInfos = await _publishedUrlInfoProvider.GetAllAsync(content);
-
-        return urlInfos
-            .Where(urlInfo => urlInfo.IsUrl)
-            .Select(urlInfo => new DocumentUrlInfo { Culture = urlInfo.Culture, Url = urlInfo.Text })
-            .ToArray();
+        return CreateDocumentUrlInfos(urlInfos);
     }
 
     public async Task<IEnumerable<DocumentUrlInfoResponseModel>> CreateUrlSetsAsync(IEnumerable<IContent> contentItems)
@@ -34,4 +33,22 @@ public class DocumentUrlFactory : IDocumentUrlFactory
 
         return documentUrlInfoResourceSets;
     }
+
+    public Task<IEnumerable<DocumentUrlInfoResponseModel>> CreatePreviewUrlSetsAsync(IEnumerable<IContent> contentItems)
+    {
+        DocumentUrlInfoResponseModel[] documentUrlInfoResourceSets = contentItems.Select(content =>
+            {
+                IEnumerable<UrlInfo> previewUrls = _urlProviders.SelectMany(provider => provider.GetPreviewUrls(content));
+                return new DocumentUrlInfoResponseModel(content.Key, CreateDocumentUrlInfos(previewUrls));
+            })
+            .ToArray();
+
+        return Task.FromResult<IEnumerable<DocumentUrlInfoResponseModel>>(documentUrlInfoResourceSets);
+    }
+
+    private IEnumerable<DocumentUrlInfo> CreateDocumentUrlInfos(IEnumerable<UrlInfo> urlInfos)
+        => urlInfos
+            .Where(urlInfo => urlInfo.Url is not null)
+            .Select(urlInfo => new DocumentUrlInfo { Culture = urlInfo.Culture, Url = urlInfo.Url!.ToString(), Message = urlInfo.Message, IsExternal = urlInfo.IsExternal })
+            .ToArray();
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IDocumentUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDocumentUrlFactory.cs
@@ -8,4 +8,6 @@ public interface IDocumentUrlFactory
     Task<IEnumerable<DocumentUrlInfo>> CreateUrlsAsync(IContent content);
 
     Task<IEnumerable<DocumentUrlInfoResponseModel>> CreateUrlSetsAsync(IEnumerable<IContent> contentItems);
+
+    Task<IEnumerable<DocumentUrlInfoResponseModel>> CreatePreviewUrlSetsAsync(IEnumerable<IContent> contentItems);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/MediaUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MediaUrlFactory.cs
@@ -40,6 +40,7 @@ public class MediaUrlFactory : IMediaUrlFactory
             {
                 Culture = null,
                 Url = _absoluteUrlBuilder.ToAbsoluteUrl(mediaUrl).ToString(),
+                IsExternal = false,
             })
             .ToArray();
 

--- a/src/Umbraco.Cms.Api.Management/Factories/ReziseImageUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ReziseImageUrlFactory.cs
@@ -53,6 +53,7 @@ public class ReziseImageUrlFactory : IReziseImageUrlFactory
                     {
                         Culture = null,
                         Url = _absoluteUrlBuilder.ToAbsoluteUrl(url).ToString(),
+                        IsExternal = false,
                     };
                 }
 
@@ -76,6 +77,7 @@ public class ReziseImageUrlFactory : IReziseImageUrlFactory
             {
                 Culture = null,
                 Url = _absoluteUrlBuilder.ToAbsoluteUrl(relativeUrl).ToString(),
+                IsExternal = false,
             };
         }
     }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -9982,6 +9982,58 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document/preview-urls": {
+      "get": {
+        "tags": [
+          "Document"
+        ],
+        "operationId": "GetDocumentPreviewUrls",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "uniqueItems": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/DocumentUrlInfoResponseModel"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice-User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/document/sort": {
       "put": {
         "tags": [
@@ -38950,6 +39002,8 @@
       "DocumentUrlInfoModel": {
         "required": [
           "culture",
+          "isExternal",
+          "message",
           "url"
         ],
         "type": "object",
@@ -38960,6 +39014,13 @@
           },
           "url": {
             "type": "string"
+          },
+          "isExternal": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -41111,6 +41172,7 @@
       "MediaUrlInfoModel": {
         "required": [
           "culture",
+          "isExternal",
           "url"
         ],
         "type": "object",
@@ -41121,6 +41183,9 @@
           },
           "url": {
             "type": "string"
+          },
+          "isExternal": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Content/ContentUrlInfoBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Content/ContentUrlInfoBase.cs
@@ -5,4 +5,6 @@ public abstract class ContentUrlInfoBase
     public required string? Culture { get; init; }
 
     public required string Url { get; init; }
+
+    public required bool IsExternal { get; init; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentUrlInfo.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentUrlInfo.cs
@@ -2,6 +2,7 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 
-public sealed class DocumentUrlInfo : ContentUrlInfoBase
+public class DocumentUrlInfo : ContentUrlInfoBase
 {
+    public required string? Message { get; init; }
 }

--- a/src/Umbraco.Core/Events/AddUnroutableContentWarningsWhenPublishingNotificationHandler.cs
+++ b/src/Umbraco.Core/Events/AddUnroutableContentWarningsWhenPublishingNotificationHandler.cs
@@ -108,7 +108,7 @@ public class AddUnroutableContentWarningsWhenPublishingNotificationHandler : INo
             EventMessages eventMessages = _eventMessagesFactory.Get();
             foreach (var culture in successfulCultures)
             {
-                if (urls.Where(u => u.Culture == culture || culture == "*").All(u => u.IsUrl is false))
+                if (urls.Where(u => u.Culture == culture || culture == "*").All(u => u.Url is null))
                 {
                     eventMessages.Add(new EventMessage("Content published", "The document does not have a URL, possibly due to a naming collision with another document. More details can be found under Info.", EventMessageType.Warning));
 

--- a/src/Umbraco.Core/Routing/AliasUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/AliasUrlProvider.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Web;
@@ -120,7 +121,7 @@ public class AliasUrlProvider : IUrlProvider
             {
                 var path = "/" + alias;
                 var uri = new Uri(path, UriKind.Relative);
-                yield return UrlInfo.Url(_uriUtility.UriFromUmbraco(uri, _requestConfig).ToString());
+                yield return UrlInfo.FromUri(_uriUtility.UriFromUmbraco(uri, _requestConfig));
             }
         }
         else
@@ -152,13 +153,18 @@ public class AliasUrlProvider : IUrlProvider
                 {
                     var path = "/" + alias;
                     var uri = new Uri(CombinePaths(domainUri.Uri.GetLeftPart(UriPartial.Authority), path));
-                    yield return UrlInfo.Url(
-                        _uriUtility.UriFromUmbraco(uri, _requestConfig).ToString(),
-                        domainUri.Culture);
+                    yield return UrlInfo.FromUri(_uriUtility.UriFromUmbraco(uri, _requestConfig), domainUri.Culture);
                 }
             }
         }
     }
+
+    #endregion
+
+    #region GetPreviewUrls
+
+    /// <inheritdoc />
+    public IEnumerable<UrlInfo> GetPreviewUrls(IContent content) => [];
 
     #endregion
 

--- a/src/Umbraco.Core/Routing/DefaultMediaUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultMediaUrlProvider.cs
@@ -39,7 +39,7 @@ public class DefaultMediaUrlProvider : IMediaUrlProvider
         if (_mediaPathGenerators.TryGetMediaPath(propType?.EditorAlias, value, out var path))
         {
             Uri url = _urlAssembler.AssembleUrl(path!, current, mode);
-            return UrlInfo.Url(url.ToString(), culture);
+            return UrlInfo.FromUri(url, culture);
         }
 
         return null;

--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
@@ -136,7 +137,7 @@ public class DefaultUrlProvider : IUrlProvider
 
             var uri = new Uri(CombinePaths(d.Uri.GetLeftPart(UriPartial.Path), path));
             uri = _uriUtility.UriFromUmbraco(uri, _requestSettings);
-            yield return UrlInfo.Url(uri.ToString(), culture);
+            yield return UrlInfo.FromUri(uri, culture);
         }
     }
 
@@ -196,12 +197,19 @@ public class DefaultUrlProvider : IUrlProvider
         if (domainUri is not null || string.IsNullOrEmpty(culture) ||
             culture.Equals(defaultCulture, StringComparison.InvariantCultureIgnoreCase))
         {
-            var url = AssembleUrl(domainUri, path, current, mode).ToString();
-            return UrlInfo.Url(url, culture);
+            Uri url = AssembleUrl(domainUri, path, current, mode);
+            return UrlInfo.FromUri(url, culture);
         }
 
         return null;
     }
+
+    #endregion
+
+    #region GetPreviewUrls
+
+    /// <inheritdoc />
+    public IEnumerable<UrlInfo> GetPreviewUrls(IContent content) => [];
 
     #endregion
 

--- a/src/Umbraco.Core/Routing/IPublishedUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/IPublishedUrlProvider.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Core.Routing;

--- a/src/Umbraco.Core/Routing/IUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/IUrlProvider.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Core.Routing;
@@ -38,4 +39,11 @@ public interface IUrlProvider
     ///     </para>
     /// </remarks>
     IEnumerable<UrlInfo> GetOtherUrls(int id, Uri current);
+
+    /// <summary>
+    ///     Gets the preview URLs of a content item.
+    /// </summary>
+    /// <param name="content">The content item.</param>
+    /// <returns>The preview URLs of the content item.</returns>
+    IEnumerable<UrlInfo> GetPreviewUrls(IContent content);
 }

--- a/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -133,9 +134,18 @@ public class NewDefaultUrlProvider : IUrlProvider
 
             var uri = new Uri(CombinePaths(d.Uri.GetLeftPart(UriPartial.Path), path));
             uri = _uriUtility.UriFromUmbraco(uri, _requestSettings);
-            yield return UrlInfo.Url(uri.ToString(), culture);
+            yield return UrlInfo.FromUri(uri, culture);
         }
     }
+
+    #region GetPreviewUrls
+
+    /// <inheritdoc />
+    public IEnumerable<UrlInfo> GetPreviewUrls(IContent content) => [
+        UrlInfo.AsUrl($"/{Constants.System.UmbracoPathSegment}/preview?id={content.Key}")
+    ];
+
+    #endregion
 
     /// <summary>
     /// Gets the legacy route format by id
@@ -221,8 +231,8 @@ public class NewDefaultUrlProvider : IUrlProvider
             string.IsNullOrEmpty(culture) ||
             culture.Equals(defaultCulture, StringComparison.InvariantCultureIgnoreCase))
         {
-            var url = AssembleUrl(domainUri, path, current, mode).ToString();
-            return UrlInfo.Url(url, culture);
+            Uri url = AssembleUrl(domainUri, path, current, mode);
+            return UrlInfo.FromUri(url, culture);
         }
 
         return null;

--- a/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
+++ b/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
@@ -52,7 +52,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
             // Handle "could not get URL"
             if (url is "#" or "#ex")
             {
-                urlInfos.Add(UrlInfo.Message(_localizedTextService.Localize("content", "getUrlException"), culture));
+                urlInfos.Add(UrlInfo.AsMessage(_localizedTextService.Localize("content", "getUrlException"), culture));
                 continue;
             }
 
@@ -65,7 +65,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
                 continue;
             }
 
-            urlInfos.Add(UrlInfo.Url(url, culture));
+            urlInfos.Add(UrlInfo.AsUrl(url, culture));
         }
 
         // If the content is trashed, we can't get the other URLs, as we have no parent structure to navigate through.
@@ -76,7 +76,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
 
         // Then get "other" urls - I.E. Not what you'd get with GetUrl(), this includes all the urls registered using domains.
         // for these 'other' URLs, we don't check whether they are routable, collide, anything - we just report them.
-        foreach (UrlInfo otherUrl in _publishedUrlProvider.GetOtherUrls(content.Id).OrderBy(x => x.Text).ThenBy(x => x.Culture))
+        foreach (UrlInfo otherUrl in _publishedUrlProvider.GetOtherUrls(content.Id).OrderBy(x => x.Message).ThenBy(x => x.Culture))
         {
             urlInfos.Add(otherUrl);
         }
@@ -105,7 +105,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
                 _logger.LogDebug(logMsg, url, uri, culture);
             }
 
-            var urlInfo = UrlInfo.Message(_localizedTextService.Localize("content", "routeErrorCannotRoute"), culture);
+            var urlInfo = UrlInfo.AsMessage(_localizedTextService.Localize("content", "routeErrorCannotRoute"), culture);
             return Attempt.Succeed(urlInfo);
         }
 
@@ -118,7 +118,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
         {
             var collidingContent = publishedRequest.PublishedContent?.Key.ToString();
 
-            var urlInfo = UrlInfo.Message(_localizedTextService.Localize("content", "routeError", [collidingContent]), culture);
+            var urlInfo = UrlInfo.AsMessage(_localizedTextService.Localize("content", "routeError", [collidingContent]), culture);
             return Attempt.Succeed(urlInfo);
         }
 

--- a/src/Umbraco.Core/Routing/UrlInfo.cs
+++ b/src/Umbraco.Core/Routing/UrlInfo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Serialization;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Routing;
 
@@ -11,17 +12,37 @@ public class UrlInfo : IEquatable<UrlInfo>
     /// <summary>
     ///     Initializes a new instance of the <see cref="UrlInfo" /> class.
     /// </summary>
-    public UrlInfo(string text, bool isUrl, string? culture)
+    public UrlInfo(Uri url, string? culture, string? message = null, bool isExternal = false)
     {
-        if (string.IsNullOrWhiteSpace(text))
+        Url = url;
+        Culture = culture;
+        Message = message;
+        IsExternal = isExternal;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UrlInfo" /> class as a "message only" - that is, not an actual URL.
+    /// </summary>
+    public UrlInfo(string message, string? culture = null)
+    {
+        if (message.IsNullOrWhiteSpace())
         {
-            throw new ArgumentException("Value cannot be null or whitespace.", nameof(text));
+            throw new ArgumentException("Value cannot be null or whitespace.", nameof(message));
         }
 
-        IsUrl = isUrl;
-        Text = text;
+        Url = null;
+        Message = message;
         Culture = culture;
     }
+
+    public static UrlInfo AsUrl(string url, string? culture = null, bool isExternal = false)
+        => new(new Uri(url, UriKind.RelativeOrAbsolute), culture: culture, isExternal: isExternal);
+
+    public static UrlInfo AsMessage(string message, string? culture = null)
+        => new(message, culture);
+
+    public static UrlInfo FromUri(Uri uri, string? culture = null, bool isExternal = false)
+        => new(uri, culture: culture, isExternal: isExternal);
 
     /// <summary>
     ///     Gets the culture.
@@ -30,34 +51,30 @@ public class UrlInfo : IEquatable<UrlInfo>
     public string? Culture { get; }
 
     /// <summary>
-    ///     Gets a value indicating whether the URL is a true URL.
+    ///     Gets the URL.
     /// </summary>
-    /// <remarks>Otherwise, it is a message.</remarks>
-    [DataMember(Name = "isUrl")]
-    public bool IsUrl { get; }
+    [DataMember(Name = "url")]
+    public Uri? Url { get; }
 
     /// <summary>
-    ///     Gets the text, which is either the URL, or a message.
+    ///     Gets the message.
     /// </summary>
-    [DataMember(Name = "text")]
-    public string Text { get; }
+    [DataMember(Name = "message")]
+    public string? Message { get; }
+
+    /// <summary>
+    ///     Gets whether this is considered an external or a local URL (remote or local host).
+    /// </summary>
+    [DataMember(Name = "isExternal")]
+    public bool IsExternal { get; }
 
     public static bool operator ==(UrlInfo left, UrlInfo right) => Equals(left, right);
-
-    /// <summary>
-    ///     Creates a <see cref="UrlInfo" /> instance representing a true URL.
-    /// </summary>
-    public static UrlInfo Url(string text, string? culture = null) => new(text, true, culture);
 
     /// <summary>
     ///     Checks equality
     /// </summary>
     /// <param name="other"></param>
     /// <returns></returns>
-    /// <remarks>
-    ///     Compare both culture and Text as invariant strings since URLs are not case sensitive, nor are culture names within
-    ///     Umbraco
-    /// </remarks>
     public bool Equals(UrlInfo? other)
     {
         if (ReferenceEquals(null, other))
@@ -70,14 +87,11 @@ public class UrlInfo : IEquatable<UrlInfo>
             return true;
         }
 
-        return string.Equals(Culture, other.Culture, StringComparison.InvariantCultureIgnoreCase) &&
-               IsUrl == other.IsUrl && string.Equals(Text, other.Text, StringComparison.InvariantCultureIgnoreCase);
+        return string.Equals(Culture, other.Culture, StringComparison.InvariantCultureIgnoreCase)
+               && Url == other.Url
+               && string.Equals(Message, other.Message, StringComparison.InvariantCultureIgnoreCase)
+               && IsExternal == other.IsExternal;
     }
-
-    /// <summary>
-    ///     Creates a <see cref="UrlInfo" /> instance representing a message.
-    /// </summary>
-    public static UrlInfo Message(string text, string? culture = null) => new(text, false, culture);
 
     public override bool Equals(object? obj)
     {
@@ -104,14 +118,16 @@ public class UrlInfo : IEquatable<UrlInfo>
         unchecked
         {
             var hashCode = Culture != null ? StringComparer.InvariantCultureIgnoreCase.GetHashCode(Culture) : 0;
-            hashCode = (hashCode * 397) ^ IsUrl.GetHashCode();
             hashCode = (hashCode * 397) ^
-                       (Text != null ? StringComparer.InvariantCultureIgnoreCase.GetHashCode(Text) : 0);
+                       (Url != null ? Url.GetHashCode() : 0);
+            hashCode = (hashCode * 397) ^
+                       (Message != null ? StringComparer.InvariantCultureIgnoreCase.GetHashCode(Message) : 0);
+            hashCode = (hashCode * 397) ^ IsExternal.GetHashCode();
             return hashCode;
         }
     }
 
     public static bool operator !=(UrlInfo left, UrlInfo right) => !Equals(left, right);
 
-    public override string ToString() => Text;
+    public override string ToString() => Url?.ToString() ?? Message ?? "[empty]";
 }

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services.Navigation;
@@ -143,7 +144,7 @@ namespace Umbraco.Cms.Core.Routing
 
             UrlInfo? url = _urlProviders.Select(provider => provider.GetUrl(content, mode, culture, current))
                 .FirstOrDefault(u => u is not null);
-            return url?.Text ?? "#"; // legacy wants this
+            return url?.Url?.ToString() ?? "#"; // legacy wants this
         }
 
         public string GetUrlFromRoute(int id, string? route, string? culture)
@@ -152,7 +153,7 @@ namespace Umbraco.Cms.Core.Routing
             NewDefaultUrlProvider? provider = _urlProviders.OfType<NewDefaultUrlProvider>().FirstOrDefault();
             var url = provider == null
                 ? route // what else?
-                : provider.GetUrlFromRoute(route, id, umbracoContext.CleanedUmbracoUrl, Mode, culture)?.Text;
+                : provider.GetUrlFromRoute(route, id, umbracoContext.CleanedUmbracoUrl, Mode, culture)?.Url?.ToString();
             return url ?? "#";
         }
 
@@ -261,7 +262,7 @@ namespace Umbraco.Cms.Core.Routing
                     provider.GetMediaUrl(content, propertyAlias, mode, culture, current))
                 .FirstOrDefault(u => u is not null);
 
-            return url?.Text ?? string.Empty;
+            return url?.Url?.ToString() ?? string.Empty;
         }
 
         #endregion

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishedUrlInfoProviderTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishedUrlInfoProviderTests.cs
@@ -29,13 +29,13 @@ internal sealed class PublishedUrlInfoProviderTests : PublishedUrlInfoProviderTe
 
         // Assert the url of subpage is correct
         Assert.AreEqual(1, subPageUrls.Count);
-        Assert.IsTrue(subPageUrls.First().IsUrl);
-        Assert.AreEqual("/text-page-1/", subPageUrls.First().Text);
+        Assert.IsNotNull(subPageUrls.First().Url);
+        Assert.AreEqual("/text-page-1/", subPageUrls.First().Url!.ToString());
         Assert.AreEqual(Subpage.Key, DocumentUrlService.GetDocumentKeyByRoute("/text-page-1/", "en-US", null, false));
 
         // Assert the url of child of second root is not exposed
         Assert.AreEqual(1, childOfSecondRootUrls.Count);
-        Assert.IsFalse(childOfSecondRootUrls.First().IsUrl);
+        Assert.IsNull(childOfSecondRootUrls.First().Url);
 
         // Ensure the url without hide top level is not finding the child of second root
         Assert.AreNotEqual(childOfSecondRoot.Key, DocumentUrlService.GetDocumentKeyByRoute("/second-root/text-page-1/", "en-US", null, false));

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishedUrlInfoProvider_hidetoplevel_false.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishedUrlInfoProvider_hidetoplevel_false.cs
@@ -35,11 +35,11 @@ internal sealed class PublishedUrlInfoProvider_hidetoplevel_false : PublishedUrl
         var childOfSecondRootUrls = await PublishedUrlInfoProvider.GetAllAsync(childOfSecondRoot);
 
         Assert.AreEqual(1, subPageUrls.Count);
-        Assert.IsTrue(subPageUrls.First().IsUrl);
-        Assert.AreEqual("/textpage/text-page-1/", subPageUrls.First().Text);
+        Assert.IsNotNull(subPageUrls.First().Url);
+        Assert.AreEqual("/textpage/text-page-1/", subPageUrls.First().Url!.ToString());
 
         Assert.AreEqual(1, childOfSecondRootUrls.Count);
-        Assert.IsTrue(childOfSecondRootUrls.First().IsUrl);
-        Assert.AreEqual("/second-root/text-page-1/", childOfSecondRootUrls.First().Text);
+        Assert.IsNotNull(childOfSecondRootUrls.First().Url);
+        Assert.AreEqual("/second-root/text-page-1/", childOfSecondRootUrls.First().Url!.ToString());
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
@@ -233,8 +233,8 @@ internal sealed class DomainAndUrlsTests : UmbracoIntegrationTest
             foreach (var culture in Cultures)
             {
                 var domain = GetDomainUrlFromCultureCode(culture);
-                Assert.IsTrue(rootUrls.Any(x => x.Text == domain));
-                Assert.IsTrue(rootUrls.Any(x => x.Text == "https://localhost" + domain));
+                Assert.IsTrue(rootUrls.Any(x => x.Url?.ToString() == domain && x.Message == null));
+                Assert.IsTrue(rootUrls.Any(x => x.Url?.ToString() == "https://localhost" + domain && x.Message == null));
             }
         });
     }
@@ -263,14 +263,14 @@ internal sealed class DomainAndUrlsTests : UmbracoIntegrationTest
             Assert.AreEqual(4, rootUrls.Count());
 
             //We expect two for the domain that is setup
-            Assert.IsTrue(rootUrls.Any(x => x.IsUrl && x.Text == domain && x.Culture == culture));
-            Assert.IsTrue(rootUrls.Any(x => x.IsUrl && x.Text == "https://localhost" + domain && x.Culture == culture));
+            Assert.IsTrue(rootUrls.Any(x => x.Url?.ToString() == domain && x.Culture == culture && x.Message == null));
+            Assert.IsTrue(rootUrls.Any(x => x.Url?.ToString() == "https://localhost" + domain && x.Culture == culture && x.Message == null));
 
             //We expect the default language to be routable on the default path "/"
-            Assert.IsTrue(rootUrls.Any(x => x.IsUrl && x.Text == "/" && x.Culture == Cultures[0]));
+            Assert.IsTrue(rootUrls.Any(x => x.Url?.ToString() == "/" && x.Culture == Cultures[0] && x.Message == null));
 
             //We dont expect non-default languages without a domain to be routable
-            Assert.IsTrue(rootUrls.Any(x => x.IsUrl == false && x.Culture == Cultures[2]));
+            Assert.IsTrue(rootUrls.Any(x => x.Url == null && x.Culture == Cultures[2]));
         });
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlImageSourceParserTests.cs
@@ -98,7 +98,7 @@ public class HtmlImageSourceParserTests
                 It.IsAny<UrlMode>(),
                 It.IsAny<string>(),
                 It.IsAny<Uri>()))
-            .Returns(UrlInfo.Url("/media/1001/my-image.jpg"));
+            .Returns(UrlInfo.AsUrl("/media/1001/my-image.jpg"));
 
         var umbracoContextAccessor = new TestUmbracoContextAccessor();
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -182,7 +182,7 @@ public class HtmlLocalLinkParserTests
                 It.IsAny<UrlMode>(),
                 It.IsAny<string>(),
                 It.IsAny<Uri>()))
-            .Returns(UrlInfo.Url("/my-test-url"));
+            .Returns(UrlInfo.AsUrl("/my-test-url"));
         var contentType = new PublishedContentType(
             Guid.NewGuid(),
             666,
@@ -212,7 +212,7 @@ public class HtmlLocalLinkParserTests
                 It.IsAny<UrlMode>(),
                 It.IsAny<string>(),
                 It.IsAny<Uri>()))
-            .Returns(UrlInfo.Url("/media/1001/my-image.jpg"));
+            .Returns(UrlInfo.AsUrl("/media/1001/my-image.jpg"));
 
         var umbracoContextAccessor = new TestUmbracoContextAccessor();
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR is part the effort to create a "new" backoffice replacement of the [custom preview URLs](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/additional-preview-environments-support) concept from the "old" backoffice.

Moving forward, the URL providers will be responsible for generating all preview URLs - both internal and external ones.

To that end:

- The `IUrlProvider` interface has been extended with the `GetPreviewUrls()` method.
- The `UrlInfo` class has been revamped to support URLs more gracefully, including an option to add a notation (`message`) per URL.

All of this makes the PR breaking.

The client will adhere to the preview URLs returned from the new `preview-urls` endpoint. A preview URL contains information about whether it's an internally (locally) or externally hosted preview environment, so these can be handled differently clientside if need be (e.g. initializing a user state that allows previewing locally).

### Testing this PR

Requesting the new `preview-urls` endpoint should yield the default preview URL for the passed key(s)

For example: `/umbraco/management/api/v1/document/preview-urls?id=f5b814c7-f435-4dda-93f3-9dd153fefa7f`

...should yield:

```json
[
  {
    "id": "f5b814c7-f435-4dda-93f3-9dd153fefa7f",
    "urlInfos": [
      {
        "message": null,
        "culture": null,
        "url": "/umbraco/preview?id=f5b814c7-f435-4dda-93f3-9dd153fefa7f",
        "isExternal": false
      }
    ]
  }
]
```

Adding a custom URL provider with custom preview URLs should append those preview URLs to the endpoint output.

For example, with this URL provider:

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Routing;

namespace My.Site;

public class MyUrlProvider : IUrlProvider
{
    public UrlInfo? GetUrl(IPublishedContent content, UrlMode mode, string? culture, Uri current)
        => null;

    public IEnumerable<UrlInfo> GetOtherUrls(int id, Uri current)
        => [];

    public IEnumerable<UrlInfo> GetPreviewUrls(IContent content) => [
        new(
            url: new Uri($"https://preview.me/en/{content.Key}"),
            culture: "en-US",
            message: "Preview.me (EN)",
            isExternal: true),
        new(
            url: new Uri($"https://preview.me/da/{content.Key}"),
            culture: "da-DK",
            message: "Preview.me (DA)",
            isExternal: true)
    ];
}

public class MyUrlProviderComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.AddUrlProvider<MyUrlProvider>();
}
```

...the `preview-urls` endpoint should yield:

```json
[
  {
    "id": "f5b814c7-f435-4dda-93f3-9dd153fefa7f",
    "urlInfos": [
      {
        "message": null,
        "culture": null,
        "url": "/umbraco/preview?id=f5b814c7-f435-4dda-93f3-9dd153fefa7f",
        "isExternal": false
      },
      {
        "message": "Preview.me (EN)",
        "culture": "en-US",
        "url": "https://preview.me/en/f5b814c7-f435-4dda-93f3-9dd153fefa7f",
        "isExternal": true
      },
      {
        "message": "Preview.me (DA)",
        "culture": "da-DK",
        "url": "https://preview.me/da/f5b814c7-f435-4dda-93f3-9dd153fefa7f",
        "isExternal": true
      }
    ]
  }
]
```
