### PR TITLE
Removes 'rollup' and 'glob' from NOTICES.txt

### DIFF
--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -115,14 +115,6 @@ Copyright: 2023 Shannon Deminick
 
 ---
 
-Glob: A library for matching file paths using glob patterns
-
-URL: https://github.com/isaacs/node-glob
-License: ISC License
-Copyright: 2009-2023 Isaac Z. Schlueter and Contributors
-
----
-
 Globals: A library for managing global variables in JavaScript
 
 URL: https://github.com/sindresorhus/globals

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -3,7 +3,9 @@ Third-Party Notices
 
 This file contains notices and attributions for third-party software used in the Umbraco CMS project.
 
-It is not a license and does not grant any rights to use the third-party software.
+Third-party software may contain dependencies that are not explicitly listed here.
+
+This notice is not a license and does not grant any rights to use the third-party software.
 
 Umbraco CMS is licensed under the MIT License, which can be found in the LICENSE file.
 
@@ -353,38 +355,6 @@ Remark-gfm: A GitHub Flavored Markdown plugin for Remark
 URL: https://github.com/remarkjs/remark-gfm
 License: MIT License
 Copyright: Titus Wormer
-
----
-
-Rollup: A module bundler for JavaScript
-
-URL: https://rollupjs.org/
-License: MIT License
-Copyright: 2015-present Rollup contributors
-
----
-
-Rollup Plugins: A collection of Rollup plugins
-
-URL: https://github.com/rollup/plugins
-License: MIT License
-Copyright: 2019-present Rollup Plugins contributors
-
----
-
-Rollup-plugin-esbuild: A Rollup plugin for using esbuild
-
-URL: https://github.com/egoist/rollup-plugin-esbuild
-License: MIT License
-Copyright: 2020 EGOIST
-
----
-
-Rollup-plugin-import-css: A Rollup plugin for importing CSS files
-
-URL: https://github.com/jleeson/rollup-plugin-import-css
-License: MIT License
-Copyright: 2020 Jacob Leeson
 
 ---
 


### PR DESCRIPTION
This pull request updates the third-party notices in the `NOTICES.txt` file to improve clarity and remove outdated entries. The most important changes include clarifying the scope of third-party dependencies and cleaning up the list of attributions.

Documentation improvements:

* Clarified that third-party software may have dependencies not explicitly listed and updated the introductory notice for better accuracy.

Third-party attribution cleanup:

The following notices no longer apply with #19716:

* Removed the attribution for the `Glob` library, which is no longer listed as a dependency.
* Removed multiple Rollup-related attributions (`Rollup`, `Rollup Plugins`, `Rollup-plugin-esbuild`, and `Rollup-plugin-import-css`) from the notice file, indicating these are no longer relevant dependencies.