### PR TITLE
V16 - Introducing signs to variants

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentCollectionControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Content/ContentCollectionControllerBase.cs
@@ -121,15 +121,4 @@ public abstract class ContentCollectionControllerBase<TContent, TCollectionRespo
                 StatusCode = StatusCodes.Status500InternalServerError,
             },
         });
-
-    /// <summary>
-    /// Populates the signs for the collection response models.
-    /// </summary>
-    protected async Task PopulateSigns(IEnumerable<TCollectionResponseModel> itemViewModels)
-    {
-        foreach (ISignProvider signProvider in _signProviders.Where(x => x.CanProvideSigns<TCollectionResponseModel>()))
-        {
-            await signProvider.PopulateSignsAsync(itemViewModels);
-        }
-    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Collection/ByKeyDocumentCollectionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Collection/ByKeyDocumentCollectionController.cs
@@ -85,7 +85,6 @@ public class ByKeyDocumentCollectionController : DocumentCollectionControllerBas
         }
 
         List<DocumentCollectionResponseModel> collectionResponseModels = await _documentCollectionPresentationFactory.CreateCollectionModelAsync(collectionAttempt.Result!);
-        await PopulateSigns(collectionResponseModels);
         return CollectionResult(collectionResponseModels, collectionAttempt.Result!.Items.Total);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/ItemDocumentItemController.cs
@@ -17,25 +17,14 @@ public class ItemDocumentItemController : DocumentItemControllerBase
 {
     private readonly IEntityService _entityService;
     private readonly IDocumentPresentationFactory _documentPresentationFactory;
-    private readonly SignProviderCollection _signProviders;
 
     [ActivatorUtilitiesConstructor]
     public ItemDocumentItemController(
         IEntityService entityService,
-        IDocumentPresentationFactory documentPresentationFactory,
-        SignProviderCollection signProvider)
+        IDocumentPresentationFactory documentPresentationFactory)
     {
         _entityService = entityService;
         _documentPresentationFactory = documentPresentationFactory;
-        _signProviders = signProvider;
-    }
-
-    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18")]
-    public ItemDocumentItemController(
-        IEntityService entityService,
-        IDocumentPresentationFactory documentPresentationFactory)
-        : this(entityService, documentPresentationFactory, StaticServiceProvider.Instance.GetRequiredService<SignProviderCollection>())
-    {
     }
 
     [HttpGet]
@@ -55,15 +44,6 @@ public class ItemDocumentItemController : DocumentItemControllerBase
             .OfType<IDocumentEntitySlim>();
 
         IEnumerable<DocumentItemResponseModel> responseModels = documents.Select(_documentPresentationFactory.CreateItemResponseModel);
-        await PopulateSigns(responseModels);
         return Ok(responseModels);
-    }
-
-    private async Task PopulateSigns(IEnumerable<DocumentItemResponseModel> itemViewModels)
-    {
-        foreach (ISignProvider signProvider in _signProviders.Where(x => x.CanProvideSigns<DocumentItemResponseModel>()))
-        {
-            await signProvider.PopulateSignsAsync(itemViewModels);
-        }
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Collection/ByKeyMediaCollectionController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Collection/ByKeyMediaCollectionController.cs
@@ -84,7 +84,6 @@ public class ByKeyMediaCollectionController : MediaCollectionControllerBase
         }
 
         List<MediaCollectionResponseModel> collectionResponseModels = await _mediaCollectionPresentationFactory.CreateCollectionModelAsync(collectionAttempt.Result!);
-        await PopulateSigns(collectionResponseModels);
         return CollectionResult(collectionResponseModels, collectionAttempt.Result!.Items.Total);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -1,10 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.Mapping.Content;
+using Umbraco.Cms.Api.Management.Services.Signs;
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint.Item;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentPublishing;
@@ -23,7 +26,9 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
     private readonly IPublicAccessService _publicAccessService;
     private readonly TimeProvider _timeProvider;
     private readonly IIdKeyMap _idKeyMap;
+    private readonly SignProviderCollection _signProviderCollection;
 
+    [Obsolete("Please use the controller with all parameters. Scheduled for removal in Umbraco 18")]
     public DocumentPresentationFactory(
         IUmbracoMapper umbracoMapper,
         IDocumentUrlFactory documentUrlFactory,
@@ -31,6 +36,25 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         IPublicAccessService publicAccessService,
         TimeProvider timeProvider,
         IIdKeyMap idKeyMap)
+        : this(
+            umbracoMapper,
+            documentUrlFactory,
+            templateService,
+            publicAccessService,
+            timeProvider,
+            idKeyMap,
+            StaticServiceProvider.Instance.GetRequiredService<SignProviderCollection>())
+    {
+    }
+
+    public DocumentPresentationFactory(
+        IUmbracoMapper umbracoMapper,
+        IDocumentUrlFactory documentUrlFactory,
+        ITemplateService templateService,
+        IPublicAccessService publicAccessService,
+        TimeProvider timeProvider,
+        IIdKeyMap idKeyMap,
+        SignProviderCollection signProviderCollection)
     {
         _umbracoMapper = umbracoMapper;
         _documentUrlFactory = documentUrlFactory;
@@ -38,6 +62,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         _publicAccessService = publicAccessService;
         _timeProvider = timeProvider;
         _idKeyMap = idKeyMap;
+        _signProviderCollection = signProviderCollection;
     }
 
     [Obsolete("Schedule for removal in v17")]
@@ -105,6 +130,8 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
 
         responseModel.Variants = CreateVariantsItemResponseModels(entity);
 
+        PopulateSignsOnDocuments(responseModel).GetAwaiter().GetResult();
+
         return responseModel;
     }
 
@@ -125,23 +152,29 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
     {
         if (entity.Variations.VariesByCulture() is false)
         {
-            yield return new()
+            var model = new DocumentVariantItemResponseModel()
             {
                 Name = entity.Name ?? string.Empty,
                 State = DocumentVariantStateHelper.GetState(entity, null),
                 Culture = null,
             };
+
+            PopulateSignsOnVariants(model).GetAwaiter().GetResult();
+            yield return model;
             yield break;
         }
 
         foreach (KeyValuePair<string, string> cultureNamePair in entity.CultureNames)
         {
-            yield return new()
+            var model = new DocumentVariantItemResponseModel()
             {
                 Name = cultureNamePair.Value,
                 Culture = cultureNamePair.Key,
                 State = DocumentVariantStateHelper.GetState(entity, cultureNamePair.Key)
             };
+
+            PopulateSignsOnVariants(model).GetAwaiter().GetResult();
+            yield return model;
         }
     }
 
@@ -255,5 +288,21 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         }
 
         return Attempt.SucceedWithStatus(ContentPublishingOperationStatus.Success, model);
+    }
+
+    private async Task PopulateSignsOnDocuments(DocumentItemResponseModel model)
+    {
+        foreach (ISignProvider signProvider in _signProviderCollection.Where(x => x.CanProvideSigns<DocumentItemResponseModel>()))
+        {
+            await signProvider.PopulateSignsAsync(model);
+        }
+    }
+
+    private async Task PopulateSignsOnVariants(DocumentVariantItemResponseModel model)
+    {
+        foreach (ISignProvider signProvider in _signProviderCollection.Where(x => x.CanProvideSigns<DocumentVariantItemResponseModel>()))
+        {
+            await signProvider.PopulateSignsAsync(model);
+        }
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -130,7 +130,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
 
         responseModel.Variants = CreateVariantsItemResponseModels(entity);
 
-        PopulateSignsOnDocuments(responseModel).GetAwaiter().GetResult();
+        PopulateSignsOnDocuments(responseModel);
 
         return responseModel;
     }
@@ -159,7 +159,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
                 Culture = null,
             };
 
-            PopulateSignsOnVariants(model).GetAwaiter().GetResult();
+            PopulateSignsOnVariants(model);
             yield return model;
             yield break;
         }
@@ -173,7 +173,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
                 State = DocumentVariantStateHelper.GetState(entity, cultureNamePair.Key)
             };
 
-            PopulateSignsOnVariants(model).GetAwaiter().GetResult();
+            PopulateSignsOnVariants(model);
             yield return model;
         }
     }
@@ -290,19 +290,21 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         return Attempt.SucceedWithStatus(ContentPublishingOperationStatus.Success, model);
     }
 
-    private async Task PopulateSignsOnDocuments(DocumentItemResponseModel model)
+    private void PopulateSignsOnDocuments(DocumentItemResponseModel model)
     {
         foreach (ISignProvider signProvider in _signProviderCollection.Where(x => x.CanProvideSigns<DocumentItemResponseModel>()))
         {
-            await signProvider.PopulateSignsAsync(model);
+            IEnumerable<DocumentItemResponseModel> models = [model];
+            signProvider.PopulateSignsAsync(models).GetAwaiter().GetResult();
         }
     }
 
-    private async Task PopulateSignsOnVariants(DocumentVariantItemResponseModel model)
+    private void PopulateSignsOnVariants(DocumentVariantItemResponseModel model)
     {
         foreach (ISignProvider signProvider in _signProviderCollection.Where(x => x.CanProvideSigns<DocumentVariantItemResponseModel>()))
         {
-            await signProvider.PopulateSignsAsync(model);
+            IEnumerable<DocumentVariantItemResponseModel> models = [model];
+            signProvider.PopulateSignsAsync(models).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -294,8 +294,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
     {
         foreach (ISignProvider signProvider in _signProviderCollection.Where(x => x.CanProvideSigns<DocumentItemResponseModel>()))
         {
-            IEnumerable<DocumentItemResponseModel> models = [model];
-            signProvider.PopulateSignsAsync(models).GetAwaiter().GetResult();
+            signProvider.PopulateSignsAsync([model]).GetAwaiter().GetResult();
         }
     }
 
@@ -303,8 +302,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
     {
         foreach (ISignProvider signProvider in _signProviderCollection.Where(x => x.CanProvideSigns<DocumentVariantItemResponseModel>()))
         {
-            IEnumerable<DocumentVariantItemResponseModel> models = [model];
-            signProvider.PopulateSignsAsync(models).GetAwaiter().GetResult();
+            signProvider.PopulateSignsAsync([model]).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProvider.cs
@@ -19,12 +19,15 @@ public class HasPendingChangesSignProvider : ISignProvider
 
 
     /// <inheritdoc/>
-    public Task PopulateSignsAsync<TItem>(TItem item)
+    public Task PopulateSignsAsync<TItem>(IEnumerable<TItem> items)
         where TItem : IHasSigns
     {
-        if (HasPendingChanges(item))
+        foreach (TItem item in items)
         {
-            item.AddSign(Alias);
+            if (HasPendingChanges(item))
+            {
+                item.AddSign(Alias);
+            }
         }
 
         return Task.CompletedTask;

--- a/src/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProvider.cs
@@ -1,8 +1,5 @@
 ﻿using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Document;
-using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
-using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
-using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Services.Signs;
@@ -17,20 +14,17 @@ public class HasPendingChangesSignProvider : ISignProvider
     /// <inheritdoc/>
     public bool CanProvideSigns<TItem>()
         where TItem : IHasSigns =>
-        typeof(TItem) == typeof(DocumentTreeItemResponseModel) ||
-        typeof(TItem) == typeof(DocumentCollectionResponseModel) ||
-        typeof(TItem) == typeof(DocumentItemResponseModel);
+        typeof(TItem) == typeof(DocumentVariantItemResponseModel) ||
+        typeof(TItem) == typeof(DocumentVariantResponseModel);
+
 
     /// <inheritdoc/>
-    public Task PopulateSignsAsync<TItem>(IEnumerable<TItem> itemViewModels)
+    public Task PopulateSignsAsync<TItem>(TItem item)
         where TItem : IHasSigns
     {
-        foreach (TItem item in itemViewModels)
+        if (HasPendingChanges(item))
         {
-            foreach (IHasSigns variant in HasPendingChanges(item))
-            {
-                variant.AddSign(Alias);
-            }
+            item.AddSign(Alias);
         }
 
         return Task.CompletedTask;
@@ -39,11 +33,10 @@ public class HasPendingChangesSignProvider : ISignProvider
     /// <summary>
     /// Determines if the given item has any variant that has pending changes.
     /// </summary>
-    private static IEnumerable<IHasSigns> HasPendingChanges(object item) => item switch
+    private static bool HasPendingChanges(object item) => item switch
     {
-        DocumentTreeItemResponseModel { Variants: var v } => v.Where(x => x.State == DocumentVariantState.PublishedPendingChanges),
-        DocumentCollectionResponseModel { Variants: var v } => v.Where(x => x.State == DocumentVariantState.PublishedPendingChanges),
-        DocumentItemResponseModel { Variants: var v } => v.Where(x => x.State == DocumentVariantState.PublishedPendingChanges),
-        _ => [],
+        DocumentVariantItemResponseModel variant => variant.State == DocumentVariantState.PublishedPendingChanges,
+        DocumentVariantResponseModel variant => variant.State == DocumentVariantState.PublishedPendingChanges,
+        _ => false,
     };
 }

--- a/src/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProvider.cs
@@ -27,9 +27,9 @@ public class HasPendingChangesSignProvider : ISignProvider
     {
         foreach (TItem item in itemViewModels)
         {
-            if (HasPendingChanges(item))
+            foreach (IHasSigns variant in HasPendingChanges(item))
             {
-                item.AddSign(Alias);
+                variant.AddSign(Alias);
             }
         }
 
@@ -39,11 +39,11 @@ public class HasPendingChangesSignProvider : ISignProvider
     /// <summary>
     /// Determines if the given item has any variant that has pending changes.
     /// </summary>
-    private bool HasPendingChanges(object item) => item switch
+    private static IEnumerable<IHasSigns> HasPendingChanges(object item) => item switch
     {
-        DocumentTreeItemResponseModel { Variants: var v } when v.Any(x => x.State == DocumentVariantState.PublishedPendingChanges) => true,
-        DocumentCollectionResponseModel { Variants: var v } when v.Any(x => x.State == DocumentVariantState.PublishedPendingChanges) => true,
-        DocumentItemResponseModel { Variants: var v } when v.Any(x => x.State == DocumentVariantState.PublishedPendingChanges) => true,
-        _ => false,
+        DocumentTreeItemResponseModel { Variants: var v } => v.Where(x => x.State == DocumentVariantState.PublishedPendingChanges),
+        DocumentCollectionResponseModel { Variants: var v } => v.Where(x => x.State == DocumentVariantState.PublishedPendingChanges),
+        DocumentItemResponseModel { Variants: var v } => v.Where(x => x.State == DocumentVariantState.PublishedPendingChanges),
+        _ => [],
     };
 }

--- a/src/Umbraco.Cms.Api.Management/Services/Signs/HasScheduleSignProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Signs/HasScheduleSignProvider.cs
@@ -1,7 +1,9 @@
 using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Constants = Umbraco.Cms.Core.Constants;
 
@@ -29,13 +31,107 @@ internal class HasScheduleSignProvider : ISignProvider
         typeof(TItem) == typeof(DocumentItemResponseModel);
 
     /// <inheritdoc/>
-    public Task PopulateSignsAsync<TItem>(IEnumerable<TItem> itemViewModels)
+    public Task PopulateSignsAsync<TItem>(IEnumerable<TItem> items)
         where TItem : IHasSigns
     {
-        IEnumerable<Guid> contentKeysScheduledForPublishing = _contentService.GetScheduledContentKeys(itemViewModels.Select(x => x.Id));
-        foreach (Guid key in contentKeysScheduledForPublishing)
+        IEnumerable<Guid> keys = _contentService.GetScheduledContentKeys(items.Select(x => x.Id).ToArray());
+
+        foreach (Guid key in keys)
         {
-            itemViewModels.First(x => x.Id == key).AddSign(Alias);
+            TItem item = items.First(x => x.Id == key);
+
+            switch (item)
+            {
+                case DocumentTreeItemResponseModel document:
+                {
+                    var variants = new List<DocumentVariantItemResponseModel>();
+                    if (document.Variants.Count() == 1)
+                    {
+                        DocumentVariantItemResponseModel variant = document.Variants.First();
+                        variant.AddSign(Alias);
+                        variants.Add(variant);
+                    }
+                    else
+                    {
+                        IEnumerable<ContentSchedule> schedules =
+                            _contentService.GetContentScheduleByContentId(key).GetSchedule();
+                        IEnumerable<string> culturesWithSchedule = schedules
+                            .Select(schedule => schedule.Culture);
+
+                        foreach (DocumentVariantItemResponseModel variant in document.Variants)
+                        {
+                            if (variant.Culture != null && culturesWithSchedule.Contains(variant.Culture))
+                            {
+                                variant.AddSign(Alias);
+                                variants.Add(variant);
+                            }
+                        }
+                    }
+
+                    document.Variants = variants;
+                    break;
+                }
+
+                case DocumentCollectionResponseModel document:
+                {
+                    var variants = new List<DocumentVariantResponseModel>();
+                    if (document.Variants.Count() == 1)
+                    {
+                        DocumentVariantResponseModel variant = document.Variants.First();
+                        variant.AddSign(Alias);
+                        variants.Add(variant);
+                    }
+                    else
+                    {
+                        IEnumerable<ContentSchedule> schedules =
+                            _contentService.GetContentScheduleByContentId(key).GetSchedule();
+                        IEnumerable<string> culturesWithSchedule = schedules
+                            .Select(schedule => schedule.Culture);
+
+                        foreach (DocumentVariantResponseModel variant in document.Variants)
+                        {
+                            if (variant.Culture != null && culturesWithSchedule.Contains(variant.Culture))
+                            {
+                                variant.AddSign(Alias);
+                                variants.Add(variant);
+                            }
+                        }
+                    }
+
+                    document.Variants = variants;
+                    break;
+                }
+
+                case DocumentItemResponseModel document:
+                {
+                    var variants = new List<DocumentVariantItemResponseModel>();
+                    if (document.Variants.Count() == 1)
+                    {
+                        DocumentVariantItemResponseModel variant = document.Variants.First();
+                        variant.AddSign(Alias);
+                        variants.Add(variant);
+                    }
+                    else
+                    {
+                        IEnumerable<ContentSchedule> schedules =
+                            _contentService.GetContentScheduleByContentId(key).GetSchedule();
+                        IEnumerable<string> culturesWithSchedule = schedules
+                            .Select(schedule => schedule.Culture);
+
+                        foreach (DocumentVariantItemResponseModel variant in document.Variants)
+                        {
+                            if (variant.Culture != null && culturesWithSchedule.Contains(variant.Culture))
+                            {
+                                variant.AddSign(Alias);
+                                variants.Add(variant);
+                            }
+                        }
+                    }
+
+                    document.Variants = variants;
+                    break;
+                }
+            }
         }
 
         return Task.CompletedTask;

--- a/src/Umbraco.Cms.Api.Management/Services/Signs/ISignProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Signs/ISignProvider.cs
@@ -18,7 +18,6 @@ public interface ISignProvider
     /// Populates the provided item view models with signs.
     /// </summary>
     /// <typeparam name="TItem">Type of item view model supporting signs.</typeparam>
-    /// <param name="itemViewModels">The collection of item view models to be populated with signs.</param>
-    Task PopulateSignsAsync<TItem>(IEnumerable<TItem> itemViewModels)
+    Task PopulateSignsAsync<TItem>(TItem item)
         where TItem : IHasSigns;
 }

--- a/src/Umbraco.Cms.Api.Management/Services/Signs/ISignProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Signs/ISignProvider.cs
@@ -18,6 +18,6 @@ public interface ISignProvider
     /// Populates the provided item view models with signs.
     /// </summary>
     /// <typeparam name="TItem">Type of item view model supporting signs.</typeparam>
-    Task PopulateSignsAsync<TItem>(TItem item)
+    Task PopulateSignsAsync<TItem>(IEnumerable<TItem> items)
         where TItem : IHasSigns;
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVariantItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVariantItemResponseModel.cs
@@ -2,7 +2,25 @@
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 
-public class DocumentVariantItemResponseModel : VariantItemResponseModelBase
+public class DocumentVariantItemResponseModel : VariantItemResponseModelBase, IHasSigns
 {
+    private readonly List<SignModel> _signs = [];
+
+    public Guid Id { get; }
+
+    public IEnumerable<SignModel> Signs
+    {
+        get => _signs.AsEnumerable();
+        set
+        {
+            _signs.Clear();
+            _signs.AddRange(value);
+        }
+    }
+
+    public void AddSign(string alias) => _signs.Add(new SignModel { Alias = alias });
+
+    public void RemoveSign(string alias) => _signs.RemoveAll(x => x.Alias == alias);
+
     public required DocumentVariantState State { get; set; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVariantResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVariantResponseModel.cs
@@ -2,7 +2,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Content;
 
 namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 
-public class DocumentVariantResponseModel : VariantResponseModelBase
+public class DocumentVariantResponseModel : VariantResponseModelBase, IHasSigns
 {
     public DocumentVariantState State { get; set; }
 
@@ -11,4 +11,22 @@ public class DocumentVariantResponseModel : VariantResponseModelBase
     public DateTimeOffset? ScheduledPublishDate { get; set; }
 
     public DateTimeOffset? ScheduledUnpublishDate { get; set; }
+
+    private readonly List<SignModel> _signs = [];
+
+    public Guid Id { get; }
+
+    public IEnumerable<SignModel> Signs
+    {
+        get => _signs.AsEnumerable();
+        set
+        {
+            _signs.Clear();
+            _signs.AddRange(value);
+        }
+    }
+
+    public void AddSign(string alias) => _signs.Add(new SignModel { Alias = alias });
+
+    public void RemoveSign(string alias) => _signs.RemoveAll(x => x.Alias == alias);
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
 
@@ -57,7 +58,7 @@ public interface IDocumentRepository : IContentRepository<int, IContent>, IReadR
     /// <returns>
     ///     The provided collection of content keys filtered for those that are scheduled for publishing.
     /// </returns>
-    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds);
+    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds) => ImmutableDictionary<int, IEnumerable<ContentSchedule>>.Empty;
 
     /// <summary>
     ///     Get the count of published items

--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
@@ -53,11 +53,11 @@ public interface IDocumentRepository : IContentRepository<int, IContent>, IReadR
     /// <summary>
     ///     Gets the content keys from the provided collection of keys that are scheduled for publishing.
     /// </summary>
-    /// <param name="keys">The content keys.</param>
+    /// <param name="documentIds">The IDs of the documents.</param>
     /// <returns>
     ///     The provided collection of content keys filtered for those that are scheduled for publishing.
     /// </returns>
-    IEnumerable<Guid> GetScheduledContentKeys(Guid[] keys) => [];
+    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds);
 
     /// <summary>
     ///     Get the count of published items

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1010,23 +1010,13 @@ public class ContentService : RepositoryService, IContentService
 
 
     /// <inheritdoc/>
-    public IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds)
+    public IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(Guid[] keys)
     {
-        if (documentIds.Length == 0)
+        if (keys.Length == 0)
         {
             return ImmutableDictionary<int, IEnumerable<ContentSchedule>>.Empty;
         }
 
-        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
-        {
-            scope.ReadLock(Constants.Locks.ContentTree);
-            scope.ReadLock(Constants.Locks.Languages);
-            return _documentRepository.GetContentSchedulesByIds(documentIds);
-        }
-    }
-
-    public IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(Guid[] keys)
-    {
         List<int> contentIds = [];
         foreach (var key in keys)
         {
@@ -1039,7 +1029,11 @@ public class ContentService : RepositoryService, IContentService
             contentIds.Add(contentId.Result);
         }
 
-        return GetContentSchedulesByIds(contentIds.ToArray());
+        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            scope.ReadLock(Constants.Locks.ContentTree);
+            return _documentRepository.GetContentSchedulesByIds(contentIds.ToArray());
+        }
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
@@ -1009,19 +1010,36 @@ public class ContentService : RepositoryService, IContentService
 
 
     /// <inheritdoc/>
-    public IEnumerable<Guid> GetScheduledContentKeys(IEnumerable<Guid> keys)
+    public IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds)
     {
-        Guid[] idsA = keys.ToArray();
-        if (idsA.Length == 0)
+        if (documentIds.Length == 0)
         {
-            return Enumerable.Empty<Guid>();
+            return ImmutableDictionary<int, IEnumerable<ContentSchedule>>.Empty;
         }
 
         using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             scope.ReadLock(Constants.Locks.ContentTree);
-            return _documentRepository.GetScheduledContentKeys(idsA);
+            scope.ReadLock(Constants.Locks.Languages);
+            return _documentRepository.GetContentSchedulesByIds(documentIds);
         }
+    }
+
+    public IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(Guid[] keys)
+    {
+        List<int> contentIds = [];
+        foreach (var key in keys)
+        {
+            Attempt<int> contentId = _idKeyMap.GetIdForKey(key, UmbracoObjectTypes.Document);
+            if (contentId.Success is false)
+            {
+                continue;
+            }
+
+            contentIds.Add(contentId.Result);
+        }
+
+        return GetContentSchedulesByIds(contentIds.ToArray());
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
@@ -278,20 +279,11 @@ public interface IContentService : IContentServiceBase<IContent>
     /// <summary>
     ///     Gets a dictionary of content Ids and their matching content schedules.
     /// </summary>
-    /// <param name="documentIds">The IDs of the documents.</param>
-    /// <returns>
-    ///     A dictionary with a nodeId and an IEnumerable of matching ContentSchedules.
-    /// </returns>
-    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds);
-
-    /// <summary>
-    ///     Gets a dictionary of content Ids and their matching content schedules.
-    /// </summary>
     /// <param name="keys">The content keys.</param>
     /// <returns>
     ///     A dictionary with a nodeId and an IEnumerable of matching ContentSchedules.
     /// </returns>
-    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(Guid[] keys);
+    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(Guid[] keys) => ImmutableDictionary<int, IEnumerable<ContentSchedule>>.Empty;
 
 
     #endregion

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -276,13 +276,23 @@ public interface IContentService : IContentServiceBase<IContent>
     bool HasChildren(int id);
 
     /// <summary>
-    ///     Gets the content keys from the provided collection of keys that are scheduled for publishing.
+    ///     Gets a dictionary of content Ids and their matching content schedules.
+    /// </summary>
+    /// <param name="documentIds">The IDs of the documents.</param>
+    /// <returns>
+    ///     A dictionary with a nodeId and an IEnumerable of matching ContentSchedules.
+    /// </returns>
+    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds);
+
+    /// <summary>
+    ///     Gets a dictionary of content Ids and their matching content schedules.
     /// </summary>
     /// <param name="keys">The content keys.</param>
     /// <returns>
-    ///     The provided collection of content keys filtered for those that are scheduled for publishing.
+    ///     A dictionary with a nodeId and an IEnumerable of matching ContentSchedules.
     /// </returns>
-    IEnumerable<Guid> GetScheduledContentKeys(IEnumerable<Guid> keys) => [];
+    IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(Guid[] keys);
+
 
     #endregion
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1672,24 +1672,30 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
     }
 
     /// <inheritdoc />
-    public IEnumerable<Guid> GetScheduledContentKeys(Guid[] keys)
+    public IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds)
     {
-        var action = ContentScheduleAction.Release.ToString();
-        DateTime now = DateTime.UtcNow;
+        Sql<ISqlContext> sql = Sql()
+            .Select<ContentScheduleDto>()
+            .From<ContentScheduleDto>()
+            .WhereIn<ContentScheduleDto>(contentScheduleDto => contentScheduleDto.NodeId, documentIds);
 
-        Sql<ISqlContext> sql = SqlContext.Sql();
-        sql
-            .Select<NodeDto>(x => x.UniqueId)
-            .From<DocumentDto>()
-            .InnerJoin<ContentDto>().On<DocumentDto, ContentDto>(left => left.NodeId, right => right.NodeId)
-            .InnerJoin<NodeDto>().On<ContentDto, NodeDto>(left => left.NodeId, right => right.NodeId)
-            .WhereIn<NodeDto>(x => x.UniqueId, keys)
-            .WhereIn<NodeDto>(x => x.NodeId, Sql()
-                .Select<ContentScheduleDto>(x => x.NodeId)
-                .From<ContentScheduleDto>()
-                .Where<ContentScheduleDto>(x => x.Action == action && x.Date >= now));
+        List<ContentScheduleDto>? contentScheduleDtos = Database.Fetch<ContentScheduleDto>(sql);
 
-        return Database.Fetch<Guid>(sql);
+        IDictionary<int, IEnumerable<ContentSchedule>> dictionary = contentScheduleDtos
+            .GroupBy(contentSchedule => contentSchedule.NodeId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(scheduleDto => new ContentSchedule(
+                    scheduleDto.Id,
+                    LanguageRepository.GetIsoCodeById(scheduleDto.LanguageId) ?? Constants.System.InvariantCulture,
+                    scheduleDto.Date,
+                    scheduleDto.Action == ContentScheduleAction.Release.ToString()
+                        ? ContentScheduleAction.Release
+                        : ContentScheduleAction.Expire))
+                    .ToList().AsEnumerable()); // We have to materialize it here,
+                                               // to avoid this being used after the scope is disposed.
+
+        return dictionary;
     }
 
     /// <inheritdoc />

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -688,7 +688,7 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
-    public void Can_Get_Scheduled_Content_Keys()
+    public void Can_Get_Content_Schedules_By_Keys()
     {
         // Arrange
         var root = ContentService.GetById(Textpage.Id);
@@ -699,11 +699,32 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         ContentService.Publish(content, content.AvailableCultures.ToArray());
 
         // Act
-        var keys = ContentService.GetScheduledContentKeys([Textpage.Key, Subpage.Key, Subpage2.Key]).ToList();
+        var keys = ContentService.GetContentSchedulesByIds([Textpage.Key, Subpage.Key, Subpage2.Key]).ToList();
 
         // Assert
         Assert.AreEqual(1, keys.Count);
-        Assert.AreEqual(Subpage.Key, keys.First());
+        Assert.AreEqual(keys[0].Key, Subpage.Id);
+        Assert.AreEqual(keys[0].Value.First().Id, contentSchedule.FullSchedule.First().Id);
+    }
+
+    [Test]
+    public void Can_Get_Content_Schedules_By_Content_Id()
+    {
+        // Arrange
+        var root = ContentService.GetById(Textpage.Id);
+        ContentService.Publish(root!, root!.AvailableCultures.ToArray());
+        var content = ContentService.GetById(Subpage.Id);
+        var contentSchedule = ContentScheduleCollection.CreateWithEntry(DateTime.UtcNow.AddDays(1), null);
+        ContentService.PersistContentSchedule(content!, contentSchedule);
+        ContentService.Publish(content, content.AvailableCultures.ToArray());
+
+        // Act
+        var keys = ContentService.GetContentSchedulesByIds([Textpage.Id, Subpage.Id, Subpage2.Id]).ToList();
+
+        // Assert
+        Assert.AreEqual(1, keys.Count);
+        Assert.AreEqual(keys[0].Key, Subpage.Id);
+        Assert.AreEqual(keys[0].Value.First().Id, contentSchedule.FullSchedule.First().Id);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -708,26 +708,6 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
     }
 
     [Test]
-    public void Can_Get_Content_Schedules_By_Content_Id()
-    {
-        // Arrange
-        var root = ContentService.GetById(Textpage.Id);
-        ContentService.Publish(root!, root!.AvailableCultures.ToArray());
-        var content = ContentService.GetById(Subpage.Id);
-        var contentSchedule = ContentScheduleCollection.CreateWithEntry(DateTime.UtcNow.AddDays(1), null);
-        ContentService.PersistContentSchedule(content!, contentSchedule);
-        ContentService.Publish(content, content.AvailableCultures.ToArray());
-
-        // Act
-        var keys = ContentService.GetContentSchedulesByIds([Textpage.Id, Subpage.Id, Subpage2.Id]).ToList();
-
-        // Assert
-        Assert.AreEqual(1, keys.Count);
-        Assert.AreEqual(keys[0].Key, Subpage.Id);
-        Assert.AreEqual(keys[0].Value.First().Id, contentSchedule.FullSchedule.First().Id);
-    }
-
-    [Test]
     public void Can_Get_Content_For_Release()
     {
         // Arrange

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProviderTests.cs
@@ -11,116 +11,66 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Services.Signs;
 internal class HasPendingChangesSignProviderTests
 {
     [Test]
-    public void HasPendingChangesSignProvider_Can_Provide_Document_Tree_Signs()
+    public void HasPendingChangesSignProvider_Can_Provide_Variant_Item_Signs()
     {
         var sut = new HasPendingChangesSignProvider();
-        Assert.IsTrue(sut.CanProvideSigns<DocumentTreeItemResponseModel>());
+        Assert.IsTrue(sut.CanProvideSigns<DocumentVariantItemResponseModel>());
     }
 
     [Test]
-    public void HasPendingChangesSignProvider_Can_Provide_Document_Collection_Signs()
+    public void HasPendingChangesSignProvider_Can_Provide_Variant_Signs()
     {
         var sut = new HasPendingChangesSignProvider();
-        Assert.IsTrue(sut.CanProvideSigns<DocumentCollectionResponseModel>());
+        Assert.IsTrue(sut.CanProvideSigns<DocumentVariantResponseModel>());
     }
 
     [Test]
-    public void HasPendingChangesSignProvider_Can_Provide_Document_Item_Signs()
-    {
-        var sut = new HasPendingChangesSignProvider();
-        Assert.IsTrue(sut.CanProvideSigns<DocumentItemResponseModel>());
-    }
-
-    [Test]
-    public async Task HasPendingChangesSignProvider_Should_Populate_Document_Tree_Signs()
+    public async Task HasPendingChangesSignProvider_Should_Populate_Variant_Item_Signs()
     {
         var sut = new HasPendingChangesSignProvider();
 
-        var viewModels = new List<DocumentTreeItemResponseModel>
+        var variant1 = new DocumentVariantItemResponseModel()
         {
-            new() { Id = Guid.NewGuid() },
-            new()
-            {
-                Id = Guid.NewGuid(), Variants =
-                [
-                    new()
-                    {
-                        State = DocumentVariantState.PublishedPendingChanges,
-                        Culture = null,
-                        Name = "Test",
-                    },
-                ],
-            },
+            State = DocumentVariantState.PublishedPendingChanges, Culture = null, Name = "Test",
         };
 
-        await sut.PopulateSignsAsync(viewModels);
+        var variant2 = new DocumentVariantItemResponseModel()
+        {
+            State = DocumentVariantState.Published, Culture = null, Name = "Test",
+        };
 
-        Assert.AreEqual(viewModels[0].Signs.Count(), 0);
-        Assert.AreEqual(viewModels[1].Signs.Count(), 1);
+        await sut.PopulateSignsAsync(variant1);
+        await sut.PopulateSignsAsync(variant2);
 
-        var signModel = viewModels[1].Signs.First();
+        Assert.AreEqual(variant1.Signs.Count(), 1);
+        Assert.AreEqual(variant2.Signs.Count(), 0);
+
+        var signModel = variant1.Signs.First();
         Assert.AreEqual("Umb.PendingChanges", signModel.Alias);
     }
 
     [Test]
-    public async Task HasPendingChangesSignProvider_Should_Populate_Document_Collection_Signs()
+    public async Task HasPendingChangesSignProvider_Should_Populate_Variant_Signs()
     {
         var sut = new HasPendingChangesSignProvider();
 
-        var viewModels = new List<DocumentCollectionResponseModel>
+        var variant1 = new DocumentVariantResponseModel()
         {
-            new() { Id = Guid.NewGuid() },
-            new()
-            {
-                Id = Guid.NewGuid(), Variants =
-                [
-                    new()
-                    {
-                        State = DocumentVariantState.PublishedPendingChanges,
-                        Culture = null,
-                        Name = "Test",
-                    },
-                ],
-            },
+            State = DocumentVariantState.PublishedPendingChanges, Culture = null, Name = "Test",
         };
 
-        await sut.PopulateSignsAsync(viewModels);
-
-        Assert.AreEqual(viewModels[0].Signs.Count(), 0);
-        Assert.AreEqual(viewModels[1].Signs.Count(), 1);
-
-        var signModel = viewModels[1].Signs.First();
-        Assert.AreEqual("Umb.PendingChanges", signModel.Alias);
-    }
-
-    [Test]
-    public async Task HasPendingChangesSignProvider_Should_Populate_Document_Item_Signs()
-    {
-        var sut = new HasPendingChangesSignProvider();
-
-        var viewModels = new List<DocumentItemResponseModel>
+        var variant2 = new DocumentVariantResponseModel()
         {
-            new() { Id = Guid.NewGuid() },
-            new()
-            {
-                Id = Guid.NewGuid(), Variants =
-                [
-                    new()
-                    {
-                        State = DocumentVariantState.PublishedPendingChanges,
-                        Culture = null,
-                        Name = "Test",
-                    },
-                ],
-            },
+            State = DocumentVariantState.Published, Culture = null, Name = "Test",
         };
 
-        await sut.PopulateSignsAsync(viewModels);
+        await sut.PopulateSignsAsync(variant1);
+        await sut.PopulateSignsAsync(variant2);
 
-        Assert.AreEqual(viewModels[0].Signs.Count(), 0);
-        Assert.AreEqual(viewModels[1].Signs.Count(), 1);
+        Assert.AreEqual(variant1.Signs.Count(), 1);
+        Assert.AreEqual(variant2.Signs.Count(), 0);
 
-        var signModel = viewModels[1].Signs.First();
+        var signModel = variant1.Signs.First();
         Assert.AreEqual("Umb.PendingChanges", signModel.Alias);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasPendingChangesSignProviderTests.cs
@@ -29,23 +29,28 @@ internal class HasPendingChangesSignProviderTests
     {
         var sut = new HasPendingChangesSignProvider();
 
-        var variant1 = new DocumentVariantItemResponseModel()
+        var variants = new List<DocumentVariantItemResponseModel>
         {
-            State = DocumentVariantState.PublishedPendingChanges, Culture = null, Name = "Test",
+            new()
+            {
+                State = DocumentVariantState.PublishedPendingChanges,
+                Culture = null,
+                Name = "Test",
+            },
+            new()
+            {
+                State = DocumentVariantState.Published,
+                Culture = null,
+                Name = "Test2",
+            },
         };
 
-        var variant2 = new DocumentVariantItemResponseModel()
-        {
-            State = DocumentVariantState.Published, Culture = null, Name = "Test",
-        };
+        await sut.PopulateSignsAsync(variants);
 
-        await sut.PopulateSignsAsync(variant1);
-        await sut.PopulateSignsAsync(variant2);
+        Assert.AreEqual(variants[0].Signs.Count(), 1);
+        Assert.AreEqual(variants[1].Signs.Count(), 0);
 
-        Assert.AreEqual(variant1.Signs.Count(), 1);
-        Assert.AreEqual(variant2.Signs.Count(), 0);
-
-        var signModel = variant1.Signs.First();
+        var signModel = variants[0].Signs.First();
         Assert.AreEqual("Umb.PendingChanges", signModel.Alias);
     }
 
@@ -54,23 +59,28 @@ internal class HasPendingChangesSignProviderTests
     {
         var sut = new HasPendingChangesSignProvider();
 
-        var variant1 = new DocumentVariantResponseModel()
+        var variants = new List<DocumentVariantResponseModel>
         {
-            State = DocumentVariantState.PublishedPendingChanges, Culture = null, Name = "Test",
+            new()
+            {
+                State = DocumentVariantState.PublishedPendingChanges,
+                Culture = null,
+                Name = "Test",
+            },
+            new()
+            {
+                State = DocumentVariantState.Published,
+                Culture = null,
+                Name = "Test2",
+            },
         };
 
-        var variant2 = new DocumentVariantResponseModel()
-        {
-            State = DocumentVariantState.Published, Culture = null, Name = "Test",
-        };
+        await sut.PopulateSignsAsync(variants);
 
-        await sut.PopulateSignsAsync(variant1);
-        await sut.PopulateSignsAsync(variant2);
+        Assert.AreEqual(variants[0].Signs.Count(), 1);
+        Assert.AreEqual(variants[1].Signs.Count(), 0);
 
-        Assert.AreEqual(variant1.Signs.Count(), 1);
-        Assert.AreEqual(variant2.Signs.Count(), 0);
-
-        var signModel = variant1.Signs.First();
+        var signModel = variants[0].Signs.First();
         Assert.AreEqual("Umb.PendingChanges", signModel.Alias);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasScheduleSignProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasScheduleSignProviderTests.cs
@@ -1,6 +1,8 @@
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Services.Signs;
+using Umbraco.Cms.Api.Management.ViewModels.Content;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
@@ -53,17 +55,20 @@ internal class HasScheduleSignProviderTests
             .Returns([entities[1].Key]);
         var sut = new HasScheduleSignProvider(contentServiceMock.Object);
 
+        var variant1 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test" };
+        var variant2 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
+
         var viewModels = new List<DocumentTreeItemResponseModel>
         {
-            new() { Id = entities[0].Key }, new() { Id = entities[1].Key },
+            new() { Id = entities[0].Key, Variants = [variant1] }, new() { Id = entities[1].Key, Variants = [variant2] },
         };
 
         await sut.PopulateSignsAsync(viewModels);
 
-        Assert.AreEqual(viewModels[0].Signs.Count(), 0);
-        Assert.AreEqual(viewModels[1].Signs.Count(), 1);
+        Assert.AreEqual(viewModels[0].Variants.First().Signs.Count(), 0);
+        Assert.AreEqual(viewModels[1].Variants.First().Signs.Count(), 1);
 
-        var signModel = viewModels[1].Signs.First();
+        var signModel = viewModels[1].Variants.First().Signs.First();
         Assert.AreEqual("Umb.ScheduledForPublish", signModel.Alias);
     }
 
@@ -81,17 +86,20 @@ internal class HasScheduleSignProviderTests
             .Returns([entities[1].Key]);
         var sut = new HasScheduleSignProvider(contentServiceMock.Object);
 
+        var variant1 = new DocumentVariantResponseModel() { State = DocumentVariantState.Published, Name = "Test" };
+        var variant2 = new DocumentVariantResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
+
         var viewModels = new List<DocumentCollectionResponseModel>
         {
-            new() { Id = entities[0].Key }, new() { Id = entities[1].Key },
+            new() { Id = entities[0].Key, Variants = [variant1] }, new() { Id = entities[1].Key, Variants = [variant2] },
         };
 
         await sut.PopulateSignsAsync(viewModels);
 
-        Assert.AreEqual(viewModels[0].Signs.Count(), 0);
-        Assert.AreEqual(viewModels[1].Signs.Count(), 1);
+        Assert.AreEqual(viewModels[0].Variants.First().Signs.Count(), 0);
+        Assert.AreEqual(viewModels[1].Variants.First().Signs.Count(), 1);
 
-        var signModel = viewModels[1].Signs.First();
+        var signModel = viewModels[1].Variants.First().Signs.First();
         Assert.AreEqual("Umb.ScheduledForPublish", signModel.Alias);
     }
 
@@ -109,17 +117,20 @@ internal class HasScheduleSignProviderTests
             .Returns([entities[1].Key]);
         var sut = new HasScheduleSignProvider(contentServiceMock.Object);
 
+        var variant1 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test" };
+        var variant2 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
+
         var viewModels = new List<DocumentItemResponseModel>
         {
-            new() { Id = entities[0].Key }, new() { Id = entities[1].Key },
+            new() { Id = entities[0].Key, Variants = [variant1] }, new() { Id = entities[1].Key, Variants = [variant2] },
         };
 
         await sut.PopulateSignsAsync(viewModels);
 
-        Assert.AreEqual(viewModels[0].Signs.Count(), 0);
-        Assert.AreEqual(viewModels[1].Signs.Count(), 1);
+        Assert.AreEqual(viewModels[0].Variants.First().Signs.Count(), 0);
+        Assert.AreEqual(viewModels[1].Variants.First().Signs.Count(), 1);
 
-        var signModel = viewModels[1].Signs.First();
+        var signModel = viewModels[1].Variants.First().Signs.First();
         Assert.AreEqual("Umb.ScheduledForPublish", signModel.Alias);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasScheduleSignProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/Signs/HasScheduleSignProviderTests.cs
@@ -6,6 +6,8 @@ using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Collection;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 
@@ -18,8 +20,9 @@ internal class HasScheduleSignProviderTests
     public void HasScheduleSignProvider_Can_Provide_Document_Tree_Signs()
     {
         var contentServiceMock = new Mock<IContentService>();
+        var idKeyMapMock = new Mock<IIdKeyMap>();
 
-        var sut = new HasScheduleSignProvider(contentServiceMock.Object);
+        var sut = new HasScheduleSignProvider(contentServiceMock.Object, idKeyMapMock.Object);
         Assert.IsTrue(sut.CanProvideSigns<DocumentTreeItemResponseModel>());
     }
 
@@ -27,8 +30,9 @@ internal class HasScheduleSignProviderTests
     public void HasScheduleSignProvider_Can_Provide_Document_Collection_Signs()
     {
         var contentServiceMock = new Mock<IContentService>();
+        var idKeyMapMock = new Mock<IIdKeyMap>();
 
-        var sut = new HasScheduleSignProvider(contentServiceMock.Object);
+        var sut = new HasScheduleSignProvider(contentServiceMock.Object, idKeyMapMock.Object);
         Assert.IsTrue(sut.CanProvideSigns<DocumentCollectionResponseModel>());
     }
 
@@ -36,8 +40,9 @@ internal class HasScheduleSignProviderTests
     public void HasScheduleSignProvider_Can_Provide_Document_Item_Signs()
     {
         var contentServiceMock = new Mock<IContentService>();
+        var idKeyMapMock = new Mock<IIdKeyMap>();
 
-        var sut = new HasScheduleSignProvider(contentServiceMock.Object);
+        var sut = new HasScheduleSignProvider(contentServiceMock.Object, idKeyMapMock.Object);
         Assert.IsTrue(sut.CanProvideSigns<DocumentItemResponseModel>());
     }
 
@@ -49,26 +54,37 @@ internal class HasScheduleSignProviderTests
             new() { Key = Guid.NewGuid(), Name = "Item 1" }, new() { Key = Guid.NewGuid(), Name = "Item 2" },
         };
 
+        var idKeyMapMock = new Mock<IIdKeyMap>();
+        idKeyMapMock.Setup(x => x.GetIdForKey(entities[0].Key, UmbracoObjectTypes.Document))
+            .Returns(Attempt.Succeed(1));
+        idKeyMapMock.Setup(x => x.GetIdForKey(entities[1].Key, UmbracoObjectTypes.Document))
+            .Returns(Attempt.Succeed(2));
+
+        Guid[] keys = entities.Select(x => x.Key).ToArray();
         var contentServiceMock = new Mock<IContentService>();
         contentServiceMock
-            .Setup(x => x.GetScheduledContentKeys(It.IsAny<IEnumerable<Guid>>()))
-            .Returns([entities[1].Key]);
-        var sut = new HasScheduleSignProvider(contentServiceMock.Object);
+            .Setup(x => x.GetContentSchedulesByIds(keys))
+            .Returns(CreateContentSchedules());
 
-        var variant1 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test" };
-        var variant2 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
+
+        var sut = new HasScheduleSignProvider(contentServiceMock.Object, idKeyMapMock.Object);
+
+        var variant1 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test1", Culture = "en-EN" };
+        var variant2 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test1", Culture = "da-DA" };
+        var variant3 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
 
         var viewModels = new List<DocumentTreeItemResponseModel>
         {
-            new() { Id = entities[0].Key, Variants = [variant1] }, new() { Id = entities[1].Key, Variants = [variant2] },
+            new() { Id = entities[0].Key, Variants = [variant1, variant2] }, new() { Id = entities[1].Key, Variants = [variant3] },
         };
 
         await sut.PopulateSignsAsync(viewModels);
 
-        Assert.AreEqual(viewModels[0].Variants.First().Signs.Count(), 0);
+        Assert.AreEqual(viewModels[0].Variants.FirstOrDefault(x => x.Culture == "da-DA").Signs.Count(), 0);
+        Assert.AreEqual(viewModels[0].Variants.FirstOrDefault(x => x.Culture == "en-EN").Signs.Count(), 1);
         Assert.AreEqual(viewModels[1].Variants.First().Signs.Count(), 1);
 
-        var signModel = viewModels[1].Variants.First().Signs.First();
+        var signModel = viewModels[0].Variants.First().Signs.First();
         Assert.AreEqual("Umb.ScheduledForPublish", signModel.Alias);
     }
 
@@ -80,26 +96,36 @@ internal class HasScheduleSignProviderTests
             new() { Key = Guid.NewGuid(), Name = "Item 1" }, new() { Key = Guid.NewGuid(), Name = "Item 2" },
         };
 
+        var idKeyMapMock = new Mock<IIdKeyMap>();
+        idKeyMapMock.Setup(x => x.GetIdForKey(entities[0].Key, UmbracoObjectTypes.Document))
+            .Returns(Attempt.Succeed(1));
+        idKeyMapMock.Setup(x => x.GetIdForKey(entities[1].Key, UmbracoObjectTypes.Document))
+            .Returns(Attempt.Succeed(2));
+
+        Guid[] keys = entities.Select(x => x.Key).ToArray();
         var contentServiceMock = new Mock<IContentService>();
         contentServiceMock
-            .Setup(x => x.GetScheduledContentKeys(It.IsAny<IEnumerable<Guid>>()))
-            .Returns([entities[1].Key]);
-        var sut = new HasScheduleSignProvider(contentServiceMock.Object);
+            .Setup(x => x.GetContentSchedulesByIds(keys))
+            .Returns(CreateContentSchedules());
 
-        var variant1 = new DocumentVariantResponseModel() { State = DocumentVariantState.Published, Name = "Test" };
-        var variant2 = new DocumentVariantResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
+        var sut = new HasScheduleSignProvider(contentServiceMock.Object, idKeyMapMock.Object);
+
+        var variant1 = new DocumentVariantResponseModel() { State = DocumentVariantState.Published, Name = "Test1", Culture = "en-EN" };
+        var variant2 = new DocumentVariantResponseModel() { State = DocumentVariantState.Published, Name = "Test1", Culture = "da-DA" };
+        var variant3 = new DocumentVariantResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
 
         var viewModels = new List<DocumentCollectionResponseModel>
         {
-            new() { Id = entities[0].Key, Variants = [variant1] }, new() { Id = entities[1].Key, Variants = [variant2] },
+            new() { Id = entities[0].Key, Variants = [variant1, variant2] }, new() { Id = entities[1].Key, Variants = [variant3] },
         };
 
         await sut.PopulateSignsAsync(viewModels);
 
-        Assert.AreEqual(viewModels[0].Variants.First().Signs.Count(), 0);
+        Assert.AreEqual(viewModels[0].Variants.FirstOrDefault(x => x.Culture == "da-DA").Signs.Count(), 0);
+        Assert.AreEqual(viewModels[0].Variants.FirstOrDefault(x => x.Culture == "en-EN").Signs.Count(), 1);
         Assert.AreEqual(viewModels[1].Variants.First().Signs.Count(), 1);
 
-        var signModel = viewModels[1].Variants.First().Signs.First();
+        var signModel = viewModels[0].Variants.First().Signs.First();
         Assert.AreEqual("Umb.ScheduledForPublish", signModel.Alias);
     }
 
@@ -111,26 +137,51 @@ internal class HasScheduleSignProviderTests
             new() { Key = Guid.NewGuid(), Name = "Item 1" }, new() { Key = Guid.NewGuid(), Name = "Item 2" },
         };
 
+        var idKeyMapMock = new Mock<IIdKeyMap>();
+        idKeyMapMock.Setup(x => x.GetIdForKey(entities[0].Key, UmbracoObjectTypes.Document))
+            .Returns(Attempt.Succeed(1));
+        idKeyMapMock.Setup(x => x.GetIdForKey(entities[1].Key, UmbracoObjectTypes.Document))
+            .Returns(Attempt.Succeed(2));
+
+        Guid[] keys = entities.Select(x => x.Key).ToArray();
         var contentServiceMock = new Mock<IContentService>();
         contentServiceMock
-            .Setup(x => x.GetScheduledContentKeys(It.IsAny<IEnumerable<Guid>>()))
-            .Returns([entities[1].Key]);
-        var sut = new HasScheduleSignProvider(contentServiceMock.Object);
+            .Setup(x => x.GetContentSchedulesByIds(keys))
+            .Returns(CreateContentSchedules());
 
-        var variant1 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test" };
-        var variant2 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
+        var sut = new HasScheduleSignProvider(contentServiceMock.Object, idKeyMapMock.Object);
+
+        var variant1 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test1", Culture = "en-EN" };
+        var variant2 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.Published, Name = "Test1", Culture = "da-DA" };
+        var variant3 = new DocumentVariantItemResponseModel() { State = DocumentVariantState.PublishedPendingChanges, Name = "Test" };
 
         var viewModels = new List<DocumentItemResponseModel>
         {
-            new() { Id = entities[0].Key, Variants = [variant1] }, new() { Id = entities[1].Key, Variants = [variant2] },
+            new() { Id = entities[0].Key, Variants = [variant1, variant2] }, new() { Id = entities[1].Key, Variants = [variant3] },
         };
 
         await sut.PopulateSignsAsync(viewModels);
 
-        Assert.AreEqual(viewModels[0].Variants.First().Signs.Count(), 0);
+        Assert.AreEqual(viewModels[0].Variants.FirstOrDefault(x => x.Culture == "da-DA").Signs.Count(), 0);
+        Assert.AreEqual(viewModels[0].Variants.FirstOrDefault(x => x.Culture == "en-EN").Signs.Count(), 1);
         Assert.AreEqual(viewModels[1].Variants.First().Signs.Count(), 1);
 
-        var signModel = viewModels[1].Variants.First().Signs.First();
+        var signModel = viewModels[0].Variants.First().Signs.First();
         Assert.AreEqual("Umb.ScheduledForPublish", signModel.Alias);
+    }
+
+    private Dictionary<int, IEnumerable<ContentSchedule>> CreateContentSchedules()
+    {
+        Dictionary<int, IEnumerable<ContentSchedule>> contentSchedules = new Dictionary<int, IEnumerable<ContentSchedule>>();
+
+        contentSchedules.Add(1, [
+            new ContentSchedule("en-EN", DateTime.Now.AddDays(1), ContentScheduleAction.Release), // Scheduled for release
+            new ContentSchedule("da-DA", DateTime.Now.AddDays(-1), ContentScheduleAction.Release) // Not Scheduled for release
+        ]);
+        contentSchedules.Add(2, [
+            new ContentSchedule("*", DateTime.Now.AddDays(1), ContentScheduleAction.Release) // Scheduled for release
+        ]);
+
+        return contentSchedules;
     }
 }


### PR DESCRIPTION
### Description
This PR Makes it so the SignProviders `HasPendingChangesSignProvider` & `HasScheduleSignProvider` applies its signs to the given variants of the the document. The purpose of this, is to make it easier to tell which variant of the document has theese specifications.

A part of this PR is also moving some of the code, to the respective factories, due to it being more logical to handle these variant changes within the factories where the variants are being created. For future reference, a restructuring of the other sign providers, to also make use of factories could be a good change, since some of them still has their uses applied in controllers.¨
To accompany this, i have also reinstated some constructors that has been marked as obsolete - As far as i could tell, these have not been included in any releases and therefore it shouldn't be deemed as a breaking change.

The `HasScheduleSignProvider` was tougher than i expected, to apply these signs to its variants, therefore the code is a slight bit more complex and includes 2 DB Calls, please take a solid look at that, and suggest any refactoring if applicable.

Have a great day 😄 

<!-- Thanks for contributing to Umbraco CMS! -->
