### PR TITLE
Verify that the request cache is available before using it in PublishedContentFactory

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
@@ -39,14 +39,18 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     public IPublishedContent? ToIPublishedContent(ContentCacheNode contentCacheNode, bool preview)
     {
         var cacheKey = $"{nameof(PublishedContentFactory)}DocumentCache_{contentCacheNode.Id}_{preview}";
-        IPublishedContent? publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
-        if (publishedContent is not null)
+        IPublishedContent? publishedContent;
+        if (_appCaches.RequestCache.IsAvailable)
         {
-            _logger.LogDebug(
-                "Using cached IPublishedContent for document {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Data?.Name ?? "No Name",
-                contentCacheNode.Id);
-            return publishedContent;
+            publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
+            if (publishedContent is not null)
+            {
+                _logger.LogDebug(
+                    "Using cached IPublishedContent for document {ContentCacheNodeName} ({ContentCacheNodeId}).",
+                    contentCacheNode.Data?.Name ?? "No Name",
+                    contentCacheNode.Id);
+                return publishedContent;
+            }
         }
 
         _logger.LogDebug(
@@ -73,7 +77,7 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
             publishedContent ??= GetPublishedContentAsDraft(publishedContent);
         }
 
-        if (publishedContent is not null)
+        if (_appCaches.RequestCache.IsAvailable && publishedContent is not null)
         {
             _appCaches.RequestCache.Set(cacheKey, publishedContent);
         }
@@ -85,14 +89,18 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     public IPublishedContent? ToIPublishedMedia(ContentCacheNode contentCacheNode)
     {
         var cacheKey = $"{nameof(PublishedContentFactory)}MediaCache_{contentCacheNode.Id}";
-        IPublishedContent? publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
-        if (publishedContent is not null)
+        IPublishedContent? publishedContent;
+        if (_appCaches.RequestCache.IsAvailable)
         {
-            _logger.LogDebug(
-                "Using cached IPublishedContent for media {ContentCacheNodeName} ({ContentCacheNodeId}).",
-                contentCacheNode.Data?.Name ?? "No Name",
-                contentCacheNode.Id);
-            return publishedContent;
+            publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
+            if (publishedContent is not null)
+            {
+                _logger.LogDebug(
+                    "Using cached IPublishedContent for media {ContentCacheNodeName} ({ContentCacheNodeId}).",
+                    contentCacheNode.Data?.Name ?? "No Name",
+                    contentCacheNode.Id);
+                return publishedContent;
+            }
         }
 
         _logger.LogDebug(
@@ -114,7 +122,7 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
 
         publishedContent = GetModel(contentNode, false);
 
-        if (publishedContent is not null)
+        if (_appCaches.RequestCache.IsAvailable && publishedContent is not null)
         {
             _appCaches.RequestCache.Set(cacheKey, publishedContent);
         }
@@ -126,15 +134,19 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     public IPublishedMember ToPublishedMember(IMember member)
     {
         string cacheKey = $"{nameof(PublishedContentFactory)}MemberCache_{member.Id}";
-        IPublishedMember? publishedMember = _appCaches.RequestCache.GetCacheItem<IPublishedMember?>(cacheKey);
-        if (publishedMember is not null)
+        IPublishedMember? publishedMember;
+        if (_appCaches.RequestCache.IsAvailable)
         {
-            _logger.LogDebug(
-                "Using cached IPublishedMember for member {MemberName} ({MemberId}).",
-                member.Username,
-                member.Id);
+            publishedMember = _appCaches.RequestCache.GetCacheItem<IPublishedMember?>(cacheKey);
+            if (publishedMember is not null)
+            {
+                _logger.LogDebug(
+                    "Using cached IPublishedMember for member {MemberName} ({MemberId}).",
+                    member.Username,
+                    member.Id);
 
-            return publishedMember;
+                return publishedMember;
+            }
         }
 
         _logger.LogDebug(
@@ -168,7 +180,10 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
             contentData);
         publishedMember = new PublishedMember(member, contentNode, _elementsCache, _variationContextAccessor);
 
-        _appCaches.RequestCache.Set(cacheKey, publishedMember);
+        if (_appCaches.RequestCache.IsAvailable)
+        {
+            _appCaches.RequestCache.Set(cacheKey, publishedMember);
+        }
 
         return publishedMember;
     }

--- a/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactory.cs
@@ -39,7 +39,7 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     public IPublishedContent? ToIPublishedContent(ContentCacheNode contentCacheNode, bool preview)
     {
         var cacheKey = $"{nameof(PublishedContentFactory)}DocumentCache_{contentCacheNode.Id}_{preview}";
-        IPublishedContent? publishedContent;
+        IPublishedContent? publishedContent = null;
         if (_appCaches.RequestCache.IsAvailable)
         {
             publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
@@ -89,7 +89,7 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     public IPublishedContent? ToIPublishedMedia(ContentCacheNode contentCacheNode)
     {
         var cacheKey = $"{nameof(PublishedContentFactory)}MediaCache_{contentCacheNode.Id}";
-        IPublishedContent? publishedContent;
+        IPublishedContent? publishedContent = null;
         if (_appCaches.RequestCache.IsAvailable)
         {
             publishedContent = _appCaches.RequestCache.GetCacheItem<IPublishedContent?>(cacheKey);
@@ -134,7 +134,7 @@ internal sealed class PublishedContentFactory : IPublishedContentFactory
     public IPublishedMember ToPublishedMember(IMember member)
     {
         string cacheKey = $"{nameof(PublishedContentFactory)}MemberCache_{member.Id}";
-        IPublishedMember? publishedMember;
+        IPublishedMember? publishedMember = null;
         if (_appCaches.RequestCache.IsAvailable)
         {
             publishedMember = _appCaches.RequestCache.GetCacheItem<IPublishedMember?>(cacheKey);

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/Factories/PublishedContentFactoryTests.cs
@@ -32,9 +32,9 @@ internal sealed class PublishedContentFactoryTests : UmbracoIntegrationTestWithC
     {
         var requestCache = new DictionaryAppCache();
         var appCaches = new AppCaches(
-                NoAppCache.Instance,
-                requestCache,
-                new IsolatedCaches(type => NoAppCache.Instance));
+            NoAppCache.Instance,
+            requestCache,
+            new IsolatedCaches(type => NoAppCache.Instance));
         builder.Services.AddUnique(appCaches);
     }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Rectifies an omission in https://github.com/umbraco/Umbraco-CMS/pull/19990

### Description
In https://github.com/umbraco/Umbraco-CMS/pull/19990 a request cache was added around the construction of `IPublishedContent` instances.  It didn't have a check that the request cache was available.  As far as I can see this doesn't cause any issues at runtime as the calls to the cache gracefully handle if it can't be supported, but I figured it was better to be explicit and make this check.

### Testing
Verify existing integration tests pass, and consider adding breaking points or debug logging configuration to verify the cache is used when the item has already been retrieved in the current request.