### PR TITLE
V16: Creating a new sub template should not show Discard Changes dialog

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -67,15 +67,16 @@ export class UmbTemplateWorkspaceContext
 
 	override async load(unique: string) {
 		const response = await super.load(unique);
-		if (response.data) {
-			this.setMasterTemplate(response.data.masterTemplate?.unique ?? null);
-		}
+		await this.setMasterTemplate(response.data?.masterTemplate?.unique ?? null);
 		return response;
 	}
 
 	async create(parent: UmbEntityModel) {
 		const data = await this.createScaffold({
 			parent,
+			preset: {
+				masterTemplate: parent.unique ? { unique: parent.unique } : null,
+			},
 		});
 
 		// Set or reset the master template


### PR DESCRIPTION
## Description

Sets the masterTemplate at each opportunity to avoid Discard Changes dialog