### PR TITLE
Independently manage integrated authentication and trust certificate fields on installer from database settings

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Installer/InstallerViewModelsMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Installer/InstallerViewModelsMapDefinition.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Install.Models;
+using Umbraco.Cms.Core.Install.Models;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Api.Management.ViewModels.Installer;
@@ -119,6 +119,7 @@ public class InstallerViewModelsMapDefinition : IMapDefinition
         target.ServerPlaceholder = source.ServerPlaceholder ?? string.Empty;
         target.SortOrder = source.SortOrder;
         target.SupportsIntegratedAuthentication = source.SupportsIntegratedAuthentication;
+        target.SupportsTrustServerCertificate = source.SupportsTrustServerCertificate;
         target.IsConfigured = false; // Defaults to false, we'll set this to true if needed,
     }
 
@@ -136,6 +137,7 @@ public class InstallerViewModelsMapDefinition : IMapDefinition
         target.ServerPlaceholder = source.ServerPlaceholder;
         target.SortOrder = source.SortOrder;
         target.SupportsIntegratedAuthentication = source.SupportsIntegratedAuthentication;
+        target.SupportsTrustServerCertificate = source.SupportsTrustServerCertificate;
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -37379,7 +37379,8 @@
           "requiresServer",
           "serverPlaceholder",
           "sortOrder",
-          "supportsIntegratedAuthentication"
+          "supportsIntegratedAuthentication",
+          "supportsTrustServerCertificate"
         ],
         "type": "object",
         "properties": {
@@ -37417,6 +37418,9 @@
             "type": "boolean"
           },
           "supportsIntegratedAuthentication": {
+            "type": "boolean"
+          },
+          "supportsTrustServerCertificate": {
             "type": "boolean"
           },
           "requiresConnectionTest": {

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Installer/DatabaseSettingsPresentationModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Installer/DatabaseSettingsPresentationModel.cs
@@ -28,5 +28,7 @@ public class DatabaseSettingsPresentationModel
 
     public bool SupportsIntegratedAuthentication { get; set; }
 
+    public bool SupportsTrustServerCertificate { get; set; }
+
     public bool RequiresConnectionTest { get; set; }
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlAzureDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlAzureDatabaseProviderMetadata.cs
@@ -46,6 +46,9 @@ public class SqlAzureDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool SupportsIntegratedAuthentication => false;
 
     /// <inheritdoc />
+    public bool SupportsTrustServerCertificate => false;
+
+    /// <inheritdoc />
     public bool RequiresConnectionTest => true;
 
     /// <inheritdoc />

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlLocalDbDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlLocalDbDatabaseProviderMetadata.cs
@@ -46,6 +46,9 @@ public class SqlLocalDbDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool SupportsIntegratedAuthentication => false;
 
     /// <inheritdoc />
+    public bool SupportsTrustServerCertificate => false;
+
+    /// <inheritdoc />
     public bool RequiresConnectionTest => false;
 
     /// <inheritdoc />

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDatabaseProviderMetadata.cs
@@ -47,6 +47,9 @@ public class SqlServerDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool SupportsIntegratedAuthentication => true;
 
     /// <inheritdoc />
+    public bool SupportsTrustServerCertificate => true;
+
+    /// <inheritdoc />
     public bool RequiresConnectionTest => true;
 
     /// <inheritdoc />

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteDatabaseProviderMetadata.cs
@@ -43,6 +43,9 @@ public class SqliteDatabaseProviderMetadata : IDatabaseProviderMetadata
     public bool SupportsIntegratedAuthentication => false;
 
     /// <inheritdoc />
+    public bool SupportsTrustServerCertificate => false;
+
+    /// <inheritdoc />
     public bool RequiresConnectionTest => false;
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Models/Installer/DatabaseSettingsModel.cs
+++ b/src/Umbraco.Core/Models/Installer/DatabaseSettingsModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core.Models.Installer;
+namespace Umbraco.Cms.Core.Models.Installer;
 
 public class DatabaseSettingsModel
 {
@@ -21,6 +21,8 @@ public class DatabaseSettingsModel
     public bool RequiresCredentials { get; set; }
 
     public bool SupportsIntegratedAuthentication { get; set; }
+
+    public bool SupportsTrustServerCertificate { get; set; }
 
     public bool RequiresConnectionTest { get; set; }
 }

--- a/src/Umbraco.Infrastructure/Persistence/CustomConnectionStringDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Infrastructure/Persistence/CustomConnectionStringDatabaseProviderMetadata.cs
@@ -43,6 +43,9 @@ public class CustomConnectionStringDatabaseProviderMetadata : IDatabaseProviderM
     public bool SupportsIntegratedAuthentication => false;
 
     /// <inheritdoc />
+    public bool SupportsTrustServerCertificate => false;
+
+    /// <inheritdoc />
     public bool RequiresConnectionTest => true;
 
     /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DatabaseProviderMetadataExtensions.cs
@@ -58,6 +58,7 @@ public static class DatabaseProviderMetadataExtensions
             Server = server ?? string.Empty,
             Login = login ?? string.Empty,
             Password = password ?? string.Empty,
-            IntegratedAuth = integratedAuth == true && databaseProviderMetadata.SupportsIntegratedAuthentication
+            IntegratedAuth = integratedAuth == true && databaseProviderMetadata.SupportsIntegratedAuthentication,
+            TrustServerCertificate = databaseProviderMetadata.SupportsTrustServerCertificate,
         });
 }

--- a/src/Umbraco.Infrastructure/Persistence/IDatabaseProviderMetadata.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IDatabaseProviderMetadata.cs
@@ -72,6 +72,12 @@ public interface IDatabaseProviderMetadata
     bool SupportsIntegratedAuthentication { get; }
 
     /// <summary>
+    ///     Gets a value indicating whether "Trust the database certificate" is supported (e.g. SQL Server &amp; Oracle).
+    /// </summary>
+    [DataMember(Name = "supportsTrustServerCertificate")]
+    bool SupportsTrustServerCertificate => false;
+
+    /// <summary>
     ///     Gets a value indicating whether the connection should be tested before continuing install process.
     /// </summary>
     [DataMember(Name = "requiresConnectionTest")]

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
@@ -268,20 +268,8 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 	private _renderCredentials = () => html`
 		<h2 class="uui-h4">Credentials</h2>
 		<hr />
-		<uui-form-layout-item>
-			<uui-checkbox
-				name="useIntegratedAuthentication"
-				label="Use integrated authentication"
-				@change=${this._handleChange}
-				.checked=${this.databaseFormData.useIntegratedAuthentication || false}></uui-checkbox>
-		</uui-form-layout-item>
-		<uui-form-layout-item>
-			<uui-checkbox
-				name="trustServerCertificate"
-				label="Trust the database certificate"
-				@change=${this._handleChange}
-				.checked=${this.databaseFormData.trustServerCertificate || false}></uui-checkbox>
-		</uui-form-layout-item>
+		${this._renderIntegratedAuthentication()}
+		${this._renderTrustDatabaseCertificate()}
 
 			${
 				!this.databaseFormData.useIntegratedAuthentication
@@ -315,6 +303,34 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 			}
 		</uui-form-layout-item>
 	`;
+
+	private _renderIntegratedAuthentication() {
+		if (this._selectedDatabase?.supportsIntegratedAuthentication) {
+			return html`<uui-form-layout-item>
+				<uui-checkbox
+					name="useIntegratedAuthentication"
+					label="Use integrated authentication"
+					@change=${this._handleChange}
+					.checked=${this.databaseFormData.useIntegratedAuthentication || false}></uui-checkbox>
+			</uui-form-layout-item>`;
+		} else {
+			return null;
+		}
+	}
+
+	private _renderTrustDatabaseCertificate() {
+		if (this._selectedDatabase?.supportsTrustServerCertificate) {
+			return html`<uui-form-layout-item>
+				<uui-checkbox
+					name="trustServerCertificate"
+					label="Trust the database certificate"
+					@change=${this._handleChange}
+					.checked=${this.databaseFormData.trustServerCertificate || false}></uui-checkbox>
+			</uui-form-layout-item>`;
+		} else {
+			return null;
+		}
+	}
 
 	private _renderCustom = () => html`
 		<uui-form-layout-item>

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/install.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/install.handlers.ts
@@ -45,6 +45,7 @@ export const handlers = [
 						serverPlaceholder: '',
 						requiresCredentials: false,
 						supportsIntegratedAuthentication: false,
+						supportsTrustServerCertificate: false,
 						requiresConnectionTest: false,
 					},
 					{
@@ -58,6 +59,7 @@ export const handlers = [
 						serverPlaceholder: '(local)\\SQLEXPRESS',
 						requiresCredentials: true,
 						supportsIntegratedAuthentication: true,
+						supportsTrustServerCertificate: true,
 						requiresConnectionTest: true,
 					},
 					{
@@ -71,6 +73,7 @@ export const handlers = [
 						serverPlaceholder: 'undefined',
 						requiresCredentials: false,
 						supportsIntegratedAuthentication: false,
+						supportsTrustServerCertificate: false,
 						requiresConnectionTest: true,
 					},
 				],

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
@@ -553,6 +553,7 @@ export type DatabaseSettingsPresentationModel = {
     serverPlaceholder: string;
     requiresCredentials: boolean;
     supportsIntegratedAuthentication: boolean;
+    supportsTrustServerCertificate: boolean;
     requiresConnectionTest: boolean;
 };
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/20031

### Description
This PR migrates https://github.com/umbraco/Umbraco-CMS/pull/20032 for merging into `main`.

It resolve the fact that although we have separate settings for whether or not integrated authentication is supported, we don't use it on the client.  And "trust certificate" is not a setting made available at all.

With this update we have settings for each field that can be independently managed per database type, with the values reflected in the installed UI,

### Testing
Experiment by setting `SupportsIntegratedAuthentication` or `SupportsTrustServerCertificate` on e.g. `SqlServerDatabaseProviderMetadata` to different values and verify they are reflected in the installer UI if you start up Umbraco without a connection string configured.
