### PR TITLE
Content editing: Correct handling of read-only of name field when `A` action is removed in `SendingContentNotification`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontent.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/content/umbvariantcontent.directive.js
@@ -109,7 +109,7 @@
 
         function onAppChanged(activeApp) {
             // set the name field to readonly if the user don't have update permissions or the active content app is not "Content" or "Info"
-            const allowUpdate = vm.editor.content.allowedActions.includes('A');
+            const allowUpdate = vm.content.allowedActions.includes('A');
             const isContentBasedApp = activeApp && contentAppHelper.isContentBasedApp(activeApp);
             vm.nameReadonly = !allowUpdate || !isContentBasedApp;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

When modifying allowed actions in `SendingContentNotification` and action `A` is not present, the name field was still editable.
I noticed the modified model (actions) in `ContentItemDisplay` in `notification.Content` property didn't affect `vm.editor.content` but `vm.content`.

Here it is clear `vm.content.allowedActions` is updated content, while `vm.editor,content.allowedActions` is just the normal editor model based on allowed actions for current user:

<img width="1272" height="760" alt="image" src="https://github.com/user-attachments/assets/89e552be-2045-499f-a21d-931832c026ae" />

Name field is readonly:

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/42ba58f1-6c40-44a5-aed3-3027e1568680" />


Also discussed here:
https://forum.umbraco.com/t/readonly-content-name-field/5090

### Test notes

Place the following class in `Composors` folder in **Umbraco.Web.UI** project:

```
using System.Data;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Actions;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models.ContentEditing;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.PublishedCache;
using Umbraco.Cms.Core.Security;
using Umbraco.Cms.Web.Common.PublishedModels;
using Umbraco.Extensions;

namespace Umbraco.Cms.Web.UI.Composers
{
    public class SiteComposer : IComposer
    {
        public void Compose(IUmbracoBuilder builder)
        {
            builder.AddNotificationHandler<SendingContentNotification, EditorSendingContentNotificationHandler>();
        }
    }

    public class EditorSendingContentNotificationHandler : INotificationHandler<SendingContentNotification>
    {
        private readonly IBackOfficeSecurityAccessor _backOfficeSecurity;
        private readonly IPublishedContentQuery _publishedContentQuery;
        private readonly IPublishedSnapshotAccessor _publishedSnapshotAccessor;

        public EditorSendingContentNotificationHandler(
            IBackOfficeSecurityAccessor backOfficeSecurity,
            IPublishedContentQuery publishedContentQuery,
            IPublishedSnapshotAccessor publishedSnapshotAccessor)
        {
            _backOfficeSecurity = backOfficeSecurity;
            _publishedContentQuery = publishedContentQuery;
            _publishedSnapshotAccessor = publishedSnapshotAccessor;
        }

        public void Handle(SendingContentNotification notification)
        {
            /*if (!notification.Content.ContentTypeAlias.Equals("blogpost") || !notification.Content.ContentTypeAlias.Equals("contact"))
                return;

            var currentUser = _backOfficeSecurity?.BackOfficeSecurity?.CurrentUser;
            if (currentUser == null)
                return;

            var userGroupAliasses = currentUser!.Groups.Select(userGroup => userGroup.Alias).ToList();*/

            // Skip if user is admin.
            /*if (userGroupAliasses.Any(alias => alias.Equals(Constants.Security.AdminGroupAlias)))
            {
                return;
            }*/

            notification.Content.Urls = null;

            List<string> readOnlyProperties = [];

            // Hide tabs/properties depending on user access.
            var tabAliases = notification.Content.Variants.First().Tabs
                .Select(x => x.Alias)
                .WhereNotNull()
                .ToList();

            ReadOnlyProperties(notification.Content, readOnlyProperties);

            //HideTabs(notification.Content, tabAliases);

            HideActions(notification.Content,
            [
                $"{ActionUpdate.ActionLetter}",
                $"{ActionUnpublish.ActionLetter}",
                $"{ActionPublish.ActionLetter}",
                $"{ActionRollback.ActionLetter}",
                $"{ActionDelete.ActionLetter}"
            ]);
        }

        private static void ReadOnlyProperties(ContentItemDisplay contentItemDisplay, List<string> propertyAliases)
        {
            if (propertyAliases.Any())
            {
                foreach (var tab in contentItemDisplay.Variants.First().Tabs)
                {
                    List<ContentPropertyDisplay> properties = new();

                    foreach (var prop in tab.Properties!)
                    {
                        if (propertyAliases.Contains(prop.Alias))
                        {
                            prop.Readonly = true;
                            //prop.Editor = "Umbraco.Label";
                            //prop.View = "readonlyvalue";
                        }

                        properties.Add(prop);
                    }

                    tab.Properties = properties;
                }
            }
        }

        private static void HideActions(ContentItemDisplay contentItemDisplay, string[] actions)
        {
            contentItemDisplay.AllowedActions = contentItemDisplay.AllowedActions?.Where(x => !actions.Contains(x));
        }

        private static void HideTabs(ContentItemDisplay contentItemDisplay, List<string> tabAliases)
        {
            if (tabAliases.Any())
            {
                contentItemDisplay.Variants.First().Tabs = contentItemDisplay.Variants.First().Tabs.Where(tab => !tabAliases.Contains(tab.Alias!) && tab.Properties?.Any() == true);
            }
        }

        private static void HideProperties(ContentItemDisplay contentItemDisplay, List<string> propertyAliases)
        {
            if (propertyAliases.Any())
            {
                foreach (var tab in contentItemDisplay.Variants.First().Tabs)
                {
                    tab.Properties = tab.Properties?.Where(property => !propertyAliases.Contains(property.Alias));
                }
            }
        }

        private static void HideEmptyTabs(ContentItemDisplay contentItemDisplay)
        {
            contentItemDisplay.Variants.First().Tabs = contentItemDisplay.Variants.First().Tabs.Where(tab => tab.Properties?.Any() == true);
        }
    }
}
```