### PR TITLE
Avoid throwing an exception on getting references when migrating content with changed data types

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -49,7 +49,7 @@ internal abstract class BlockEditorPropertyValueEditor : BlockValuePropertyValue
     /// <inheritdoc />
     public override IEnumerable<UmbracoEntityReference> GetReferences(object? value)
     {
-        // Group by property editor alias to avoid duplicate lookups and optimize value parsing.
+        // Group by property editor alias to avoid duplicate lookups and optimize value parsing
         foreach (var valuesByPropertyEditorAlias in GetAllPropertyValues(value).GroupBy(x => x.PropertyType.PropertyEditorAlias, x => x.Value))
         {
             if (!_propertyEditors.TryGet(valuesByPropertyEditorAlias.Key, out IDataEditor? dataEditor))

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
@@ -26,7 +26,7 @@ internal class BlockEditorValues
         _logger = logger;
     }
 
-    public BlockEditorData? DeserializeAndClean(object? propertyValue, bool throwOnError = true)
+    public BlockEditorData? DeserializeAndClean(object? propertyValue)
     {
         var propertyValueAsString = propertyValue?.ToString();
         if (string.IsNullOrWhiteSpace(propertyValueAsString))
@@ -34,27 +34,7 @@ internal class BlockEditorValues
             return null;
         }
 
-        BlockEditorData blockEditorData;
-        try
-        {
-            blockEditorData = _dataConverter.Deserialize(propertyValueAsString);
-        }
-        catch (JsonSerializationException ex)
-        {
-            if (throwOnError)
-            {
-                throw;
-            }
-            else
-            {
-                _logger.LogWarning(
-                    "Could not deserialize the provided property value into a block editor value: {PropertyValue}. Error: {ErrorMessage}.",
-                    propertyValueAsString,
-                    ex.Message);
-                return null;
-            }
-        }
-
+        BlockEditorData blockEditorData = _dataConverter.Deserialize(propertyValueAsString);
         return Clean(blockEditorData);
     }
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorValues.cs
@@ -2,7 +2,6 @@
 // See LICENSE for more details.
 
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Umbraco.Cms.Core.Cache.PropertyEditors;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/19784

### Description
This PR adds an option to log rather than throw when encountering an exception deserializating block values, that can be used to avoid an exception when retrieving references.

We have had cases where content is being migrated to a new data type via uSync or Deploy, where the parsed content is in a format for nested content rather than block list, and this then blows up, preventing the migration.  It happens when retrieving references, which isn't essential to the operation, so it's reasonable to to just skip values that can't be parsed into an excepted format, and from where references can be obtained.

### Testing
Testing is tricky, so it maybe that visual inspection is enough here.  But I've been able to trigger the problem from a clean install with this setup, and verified that after this update the migration succeeds:

- Install `Umbraco.Deploy.OnPrem`.
- Create standard doctype A and element type B.
- On doctype A, create a nested content property which allows adding elements of type B.
- Create an instance of A with some nested content.
- Make a change to the content item and save without publishing.
- Export the content instance along with the related schema to a zip file using the Deploy export feature.
- Delete the content, nested content data type and document types.
- Configure the Deploy migrator for nested content to block list with:

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Deploy.Infrastructure.Migrators;

internal class DeployImportMigrationComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.DeployArtifactMigrators()
            .Append<ReplaceNestedContentDataTypeArtifactMigrator>();

        builder.DeployPropertyTypeMigrators()
            .Append<NestedContentPropertyTypeMigrator>();
    }
}
```

- Import the content and schema.