### PR TITLE
Layout header top custom property

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property-layout/property-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property-layout/property-layout.element.ts
@@ -124,11 +124,12 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 			#headerColumn {
 				position: relative;
 				height: min-content;
+				top: var(--umb-property-layout-header-top);
 			}
 			/*@container (width > 600px) {*/
 			:host(:not([orientation='vertical'])) #headerColumn {
 				position: sticky;
-				top: calc(var(--uui-size-space-2) * -1);
+				top: var(--umb-property-layout-header-top, calc(var(--uui-size-space-2) * -1));
 			}
 			/*}*/
 


### PR DESCRIPTION
### Prerequisites

- [ x ] I have added steps to test this contribution in the description below


### Description

As discussed with Niels Lyngsø, this introduces a custom property to adjust the top property for #headerColumn, with the existing value as fallback.

In property-layout.element.ts I have added --umb-property-layout-header-top as the default to set the top value for #headerColumn. 

