### PR TITLE
Correct the population of the parent for sibling items when retrieved under a folder

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
@@ -73,9 +73,7 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
         }
 
         IEntitySlim? entity = siblings.FirstOrDefault();
-        Guid? parentKey = entity?.ParentId > 0
-            ? EntityService.GetKey(entity.ParentId, ItemObjectType).Result
-            : Constants.System.RootKey;
+        Guid? parentKey = GetParentKey(entity);
 
         TItem[] treeItemViewModels = MapTreeItemViewModels(parentKey, siblings);
 
@@ -85,6 +83,14 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
 
         return Ok(result);
     }
+
+    /// <summary>
+    /// Gets the parent key for an entity, or root if null or no parent.
+    /// </summary>
+    protected virtual Guid? GetParentKey(IEntitySlim? entity) =>
+        entity?.ParentId > 0
+            ? EntityService.GetKey(entity.ParentId, ItemObjectType).Result
+            : Constants.System.RootKey;
 
     protected virtual async Task<ActionResult<IEnumerable<TItem>>> GetAncestors(Guid descendantKey, bool includeSelf = true)
     {

--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/FolderTreeControllerBase.cs
@@ -45,6 +45,30 @@ public abstract class FolderTreeControllerBase<TItem> : NamedEntityTreeControlle
 
     protected abstract UmbracoObjectTypes FolderObjectType { get; }
 
+    /// <inheritdoc/>
+    protected override Guid? GetParentKey(IEntitySlim? entity)
+    {
+        if (entity is null || entity.ParentId <= 0)
+        {
+            return Constants.System.RootKey;
+        }
+
+        Attempt<Guid> getKeyAttempt = EntityService.GetKey(entity.ParentId, ItemObjectType);
+        if (getKeyAttempt.Success)
+        {
+            return getKeyAttempt.Result;
+        }
+
+        // Parent could be a folder, so try that too.
+        getKeyAttempt = EntityService.GetKey(entity.ParentId, FolderObjectType);
+        if (getKeyAttempt.Success)
+        {
+            return getKeyAttempt.Result;
+        }
+
+        return Constants.System.RootKey;
+    }
+
     protected void RenderFoldersOnly(bool foldersOnly) => _foldersOnly = foldersOnly;
 
     protected override IEntitySlim[] GetPagedRootEntities(int skip, int take, out long totalItems)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

This PR resolves the following issue found in testing:

> I am running into an issue with the siblings endpoints where the parentId of items in a folder is "00000000-0000-0000-0000-000000000000". The screenshot is specifically for the Document Type Tree, but I looks like a problem for all Trees with folders.

<img width="689" height="720" alt="image" src="https://github.com/user-attachments/assets/7b92081e-a7fe-4789-8f69-6a8b3bebf064" />

To resolve I've introduced and overridden a method for retrieving the parent key for an entity, such that for entities that have folder support, the folder object type is checked in addition to the item object type when retrieving the key.

