### PR TITLE
Mark `MemberService.GetMembersByPropertyValue()` methods as obsolete

### DIFF
--- a/src/Umbraco.Core/Services/IMemberService.cs
+++ b/src/Umbraco.Core/Services/IMemberService.cs
@@ -385,6 +385,12 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
     /// <returns>
     ///     <see cref="IEnumerable{IMember}" />
     /// </returns>
+    /// <remarks>
+    /// Instead of using this method, which queries the database directly, we advise using search (Examine).
+    /// You can configure an `IValueSetValidator` to ensure all the properties you need are indexed.
+    /// <see href="https://docs.umbraco.com/umbraco-cms/reference/searching/examine/indexing#changing-ivaluesetvalidator" />
+    /// </remarks>
+    [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
     IEnumerable<IMember>? GetMembersByPropertyValue(
         string propertyTypeAlias,
         string value,
@@ -402,6 +408,12 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
     /// <returns>
     ///     <see cref="IEnumerable{IMember}" />
     /// </returns>
+    /// <remarks>
+    /// Instead of using this method, which queries the database directly, we advise using search (Examine).
+    /// You can configure an `IValueSetValidator` to ensure all the properties you need are indexed.
+    /// <see href="https://docs.umbraco.com/umbraco-cms/reference/searching/examine/indexing#changing-ivaluesetvalidator" />
+    /// </remarks>
+    [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
     IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, int value, ValuePropertyMatchType matchType = ValuePropertyMatchType.Exact);
 
     /// <summary>
@@ -412,6 +424,12 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
     /// <returns>
     ///     <see cref="IEnumerable{IMember}" />
     /// </returns>
+    /// <remarks>
+    /// Instead of using this method, which queries the database directly, we advise using search (Examine).
+    /// You can configure an `IValueSetValidator` to ensure all the properties you need are indexed.
+    /// <see href="https://docs.umbraco.com/umbraco-cms/reference/searching/examine/indexing#changing-ivaluesetvalidator" />
+    /// </remarks>
+    [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
     IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, bool value);
 
     /// <summary>
@@ -426,6 +444,12 @@ public interface IMemberService : IMembershipMemberService, IContentServiceBase<
     /// <returns>
     ///     <see cref="IEnumerable{IMember}" />
     /// </returns>
+    /// <remarks>
+    /// Instead of using this method, which queries the database directly, we advise using search (Examine).
+    /// You can configure an `IValueSetValidator` to ensure all the properties you need are indexed.
+    /// <see href="https://docs.umbraco.com/umbraco-cms/reference/searching/examine/indexing#changing-ivaluesetvalidator" />
+    /// </remarks>
+    [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
     IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, DateTime value, ValuePropertyMatchType matchType = ValuePropertyMatchType.Exact);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -612,13 +612,8 @@ namespace Umbraco.Cms.Core.Services
             return _memberRepository.GetPage(query, pageIndex, pageSize, out totalRecords, null, Ordering.By("LoginName"));
         }
 
-        /// <summary>
-        /// Gets a list of Members based on a property search
-        /// </summary>
-        /// <param name="propertyTypeAlias">Alias of the PropertyType to search for</param>
-        /// <param name="value"><see cref="string"/> Value to match</param>
-        /// <param name="matchType">The type of match to make as <see cref="StringPropertyMatchType"/>. Default is <see cref="StringPropertyMatchType.Exact"/></param>
-        /// <returns><see cref="IEnumerable{IMember}"/></returns>
+        /// <inheritdoc />
+        [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
         public IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, string value, StringPropertyMatchType matchType = StringPropertyMatchType.Exact)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
@@ -646,13 +641,8 @@ namespace Umbraco.Cms.Core.Services
             return _memberRepository.Get(query);
         }
 
-        /// <summary>
-        /// Gets a list of Members based on a property search
-        /// </summary>
-        /// <param name="propertyTypeAlias">Alias of the PropertyType to search for</param>
-        /// <param name="value"><see cref="int"/> Value to match</param>
-        /// <param name="matchType">The type of match to make as <see cref="StringPropertyMatchType"/>. Default is <see cref="StringPropertyMatchType.Exact"/></param>
-        /// <returns><see cref="IEnumerable{IMember}"/></returns>
+        /// <inheritdoc />
+        [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
         public IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, int value, ValuePropertyMatchType matchType = ValuePropertyMatchType.Exact)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
@@ -683,12 +673,8 @@ namespace Umbraco.Cms.Core.Services
             return _memberRepository.Get(query);
         }
 
-        /// <summary>
-        /// Gets a list of Members based on a property search
-        /// </summary>
-        /// <param name="propertyTypeAlias">Alias of the PropertyType to search for</param>
-        /// <param name="value"><see cref="bool"/> Value to match</param>
-        /// <returns><see cref="IEnumerable{IMember}"/></returns>
+        /// <inheritdoc />
+        [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
         public IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, bool value)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
@@ -698,13 +684,8 @@ namespace Umbraco.Cms.Core.Services
             return _memberRepository.Get(query);
         }
 
-        /// <summary>
-        /// Gets a list of Members based on a property search
-        /// </summary>
-        /// <param name="propertyTypeAlias">Alias of the PropertyType to search for</param>
-        /// <param name="value"><see cref="System.DateTime"/> Value to match</param>
-        /// <param name="matchType">The type of match to make as <see cref="StringPropertyMatchType"/>. Default is <see cref="StringPropertyMatchType.Exact"/></param>
-        /// <returns><see cref="IEnumerable{IMember}"/></returns>
+        /// <inheritdoc />
+        [Obsolete("Please use Search (Examine) instead, scheduled for removal in Umbraco 18.")]
         public IEnumerable<IMember>? GetMembersByPropertyValue(string propertyTypeAlias, DateTime value, ValuePropertyMatchType matchType = ValuePropertyMatchType.Exact)
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);


### PR DESCRIPTION
While assessing the impact of removing the default `Umbraco.DateTime` data types, I ran across these `MemberService.GetMembersByPropertyValue()` methods, which query the database directly and assume, based on the type provided (`int`, `string`, `DateTime`), which database columns they should query.

As we have search (Examine) in place by default, and an index is created by default for Members, I believe that we should discourage users from using these methods and advise them to use search instead.
If users do rely on these methods, they can still incorporate them in their own code.

With this in mind, I have marked the methods as obsolete and added a [link](https://docs.umbraco.com/umbraco-cms/reference/searching/examine/indexing#changing-ivaluesetvalidator) to the docs on how to include member properties in the index (as those aren't included by default).