### PR TITLE
Fixes divide by zero error on retrieving take 0 from the recycle bin root API endpoint

### DIFF
--- a/src/Umbraco.Core/Services/EntityService.cs
+++ b/src/Umbraco.Core/Services/EntityService.cs
@@ -440,7 +440,7 @@ public class EntityService : RepositoryService, IEntityService
 
         if (take == 0)
         {
-            totalRecords = CountChildren(parentId, childObjectType, filter);
+            totalRecords = CountChildren(parentId, childObjectType, filter: filter);
             return Enumerable.Empty<IEntitySlim>();
         }
 
@@ -484,6 +484,12 @@ public class EntityService : RepositoryService, IEntityService
         if (ResolveKey(key, objectType, out int parentId) is false)
         {
             totalRecords = 0;
+            return Enumerable.Empty<IEntitySlim>();
+        }
+
+        if (take == 0)
+        {
+            totalRecords = CountChildren(parentId, objectType, true, filter);
             return Enumerable.Empty<IEntitySlim>();
         }
 
@@ -693,17 +699,18 @@ public class EntityService : RepositoryService, IEntityService
         }
     }
 
-    private int CountChildren(int id, UmbracoObjectTypes objectType, IQuery<IUmbracoEntity>? filter = null) =>
-        CountChildren(id, new HashSet<UmbracoObjectTypes>() { objectType }, filter);
+    private int CountChildren(int id, UmbracoObjectTypes objectType, bool trashed = false, IQuery<IUmbracoEntity>? filter = null) =>
+        CountChildren(id, new HashSet<UmbracoObjectTypes>() { objectType }, trashed, filter);
 
     private int CountChildren(
         int id,
         IEnumerable<UmbracoObjectTypes> objectTypes,
+        bool trashed = false,
         IQuery<IUmbracoEntity>? filter = null)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
-            IQuery<IUmbracoEntity> query = Query<IUmbracoEntity>().Where(x => x.ParentId == id && x.Trashed == false);
+            IQuery<IUmbracoEntity> query = Query<IUmbracoEntity>().Where(x => x.ParentId == id && x.Trashed == trashed);
 
             var objectTypeGuids = objectTypes.Select(x => x.GetGuid()).ToHashSet();
             return _entityRepository.CountByQuery(query, objectTypeGuids, filter);
@@ -782,7 +789,7 @@ public class EntityService : RepositoryService, IEntityService
 
             if (take == 0)
             {
-                totalRecords = CountChildren(parentId, childObjectTypes, filter);
+                totalRecords = CountChildren(parentId, childObjectTypes, filter: filter);
                 return Array.Empty<IEntitySlim>();
             }
 


### PR DESCRIPTION
### Description

Fixes an issue found in internal testing where a request for `take` of `0` would trigger an error when the skip/take options were converted to paging parameters.  The fix aligns with the same done for retrieving document root and other collections where skip/take options are available.

### Testing

Request the following management API endpoint:

```
/umbraco/management/api/v1/recycle-bin/document/root?skip=0&take=0
```

Previously this would fail with a 500 error.  Now you should get back a response like:

```
{
  "total": 1,
  "items": []
}
```