### PR TITLE
Dropdown: Allow empty option

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/property-editor-ui-dropdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/property-editor-ui-dropdown.element.ts
@@ -98,6 +98,10 @@ export class UmbPropertyEditorUIDropdownElement
 		} else {
 			this.addFormControlElement(this.shadowRoot!.querySelector('umb-input-dropdown-list')!);
 		}
+
+		if (!this.mandatory && !this._multiple) {
+			this._options.unshift({ name: '', value: '', selected: false, invalid: false });
+		}
 	}
 
 	#onChange(event: CustomEvent & { target: UmbInputDropdownListElement }) {


### PR DESCRIPTION
### Description

Fixes #20029.

If a dropdown property-editor is not marked as mandatory and is in single-mode, then an empty option is added to the top of the dropdown, so that the value can be unset.

This doesn't apply to multiple-mode, as values can already be deselected.

