### PR TITLE
Resolve compistion properties on a block for the RTE.

### DIFF
--- a/src/Umbraco.Infrastructure/Extensions/RichTextEditorValueExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/RichTextEditorValueExtensions.cs
@@ -31,7 +31,25 @@ internal static class RichTextEditorValueExtensions
         {
             foreach (BlockPropertyValue item in dataItem.Values)
             {
-                item.PropertyType = elementTypes.FirstOrDefault(x => x.Key == dataItem.ContentTypeKey)?.PropertyTypes.FirstOrDefault(pt => pt.Alias == item.Alias);
+                IContentType? elementType = elementTypes.FirstOrDefault(x => x.Key == dataItem.ContentTypeKey);
+                if (elementType is null)
+                {
+                    continue;
+                }
+
+                IPropertyType? resovledProperty = elementType?.PropertyTypes.FirstOrDefault(pt => pt.Alias == item.Alias);
+                if (resovledProperty is not null)
+                {
+                    item.PropertyType = resovledProperty;
+                    continue;
+                }
+
+                resovledProperty = elementType?.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == item.Alias);
+                if (resovledProperty is not null)
+                {
+                    item.PropertyType = resovledProperty;
+                    continue;
+                }
             }
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20089

### Description
As in the bug report i created. When you have a block to the Rich text editor and the block contained a composition. Then published and save broke. The value for the composition property couldn´t be resolved into a IPropertyType so i was null, al the way done. 

I debugged it into the EnsurePropertyTypePopulatedOnBlocks witch resolved the Properties for Rich text editor blocks, to only look for alias on the property list, witch is correct in a way but missing out on the composition.

The change is to ensure everything is resovled.

Steps to test:
Create a elemet type witch contains a headline property.
Create a new element with a composition of headline property, and add a description property.
Create a documentype and add a Tiptap editor witch the posibility to add the above block to the list.

Create a node and add some text, the block and some more text and save.
Go grab some coffe and come back and think what the hell is the block therefor and delete it and save, and be happy with your newly saved changes.