### PR TITLE
V16: Fix member validation endpoints

### DIFF
--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.ContentEditing.Validation;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -48,15 +49,65 @@ internal sealed class MemberEditingService : IMemberEditingService
     public Task<IMember?> GetAsync(Guid key)
         => Task.FromResult(_memberService.GetById(key));
 
-    public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCreateAsync(MemberCreateModel createModel)
-        => await _memberContentEditingService.ValidateAsync(createModel, createModel.ContentTypeKey);
+    public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCreateAsync(
+        MemberCreateModel createModel)
+    {
+        MemberEditingOperationStatus validationStatus = await ValidateMemberDataAsync(createModel, null, createModel.Password);
+        if (validationStatus is not MemberEditingOperationStatus.Success)
+        {
+            return Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, new ContentValidationResult() { ValidationErrors = new List<PropertyValidationError>(){ MapStatusToPropertyValidationError(validationStatus)}});
+        }
+        return await _memberContentEditingService.ValidateAsync(createModel, createModel.ContentTypeKey);
+    }
+
+    private PropertyValidationError MapStatusToPropertyValidationError(MemberEditingOperationStatus memberEditingOperationStatus)
+    {
+        string alias;
+        string[] errorMessages;
+        switch (memberEditingOperationStatus)
+        {
+            case MemberEditingOperationStatus.InvalidName:
+                alias = "name";
+                errorMessages = ["Invalid or empty name"];
+                break;
+            case MemberEditingOperationStatus.InvalidPassword:
+                alias = "password";
+                errorMessages = ["Invalid password"];
+                break;
+            case MemberEditingOperationStatus.InvalidUsername:
+                alias = "username";
+                errorMessages = ["Invalid username"];
+                break;
+            case MemberEditingOperationStatus.InvalidEmail:
+                alias = "email";
+                errorMessages = ["Invalid email"];
+                break;
+            case MemberEditingOperationStatus.DuplicateUsername:
+                alias = "username";
+                errorMessages = ["Duplicate username"];
+                break;
+            case MemberEditingOperationStatus.DuplicateEmail:
+                alias = "email";
+                errorMessages = ["Duplicate email"];
+                break;
+            default:
+                alias = string.Empty;
+                errorMessages = [];
+                break;
+        }
+
+        return new PropertyValidationError { Alias = alias, Culture = null, Segment = null, ErrorMessages = errorMessages, JsonPath = string.Empty };
+    }
 
     public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateUpdateAsync(Guid key, MemberUpdateModel updateModel)
     {
         IMember? member = _memberService.GetById(key);
-        return member is not null
-            ? await _memberContentEditingService.ValidateAsync(updateModel, member.ContentType.Key)
-            : Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, new ContentValidationResult());
+        if (member is null)
+        {
+            return Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, new ContentValidationResult());
+        }
+        MemberEditingOperationStatus validationStatus = await ValidateMemberDataAsync(updateModel, member.Key, updateModel.NewPassword);
+        return await _memberContentEditingService.ValidateAsync(updateModel, member.ContentType.Key);
     }
 
     public async Task<Attempt<MemberCreateResult, MemberEditingStatus>> CreateAsync(MemberCreateModel createModel, IUser user)

--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -242,7 +242,7 @@ internal sealed class MemberEditingService : IMemberEditingService
         {
             if (propertyValidation.Status is ContentEditingOperationStatus.ContentTypeNotFound)
             {
-                Attempt.FailWithStatus(ContentEditingOperationStatus.ContentTypeNotFound, new ContentValidationResult());
+                return Attempt.FailWithStatus(ContentEditingOperationStatus.ContentTypeNotFound, new ContentValidationResult());
             }
             else
             {

--- a/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
+++ b/src/Umbraco.Infrastructure/Services/MemberEditingService.cs
@@ -55,7 +55,7 @@ internal sealed class MemberEditingService : IMemberEditingService
         MemberEditingOperationStatus validationStatus = await ValidateMemberDataAsync(createModel, null, createModel.Password);
         if (validationStatus is not MemberEditingOperationStatus.Success)
         {
-            return Attempt.FailWithStatus(ContentEditingOperationStatus.NotFound, new ContentValidationResult() { ValidationErrors = new List<PropertyValidationError>(){ MapStatusToPropertyValidationError(validationStatus)}});
+            return Attempt.FailWithStatus(ContentEditingOperationStatus.PropertyValidationError, new ContentValidationResult() { ValidationErrors = new List<PropertyValidationError>(){ MapStatusToPropertyValidationError(validationStatus)}});
         }
         return await _memberContentEditingService.ValidateAsync(createModel, createModel.ContentTypeKey);
     }

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/validation/member-validation.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/validation/member-validation.server.data-source.ts
@@ -94,7 +94,6 @@ export class UmbMemberValidationServerDataSource {
 				path: { id: model.unique },
 				body,
 			}),
-			{ disableNotifications: true },
 		);
 
 		if (data && typeof data === 'string') {


### PR DESCRIPTION
# Notes
- The validation endpoint for members would only validate the properties given by the MemberType, and not all the default one for members, such as name, email etc.
- This PR remedies that, by refactoring the validation methods to also call the `ValidateMemberData` method, which was already used to validate these properties, when saving or creating.
- This will only return 1 problem at a time for now, might need to refactor the `ValidateMemberData` function to return a list of errors, instead of just 1.

# How to test
- You can test the member create validation endpoitn, by calling xx and using this json, this should an error, you can tweak this values to be correct, to get different errors/ no errors if everything is passed correctly 😁 
```
{
  "values": [
  ],
  "variants": [
    {
      "name": "TestName"
    }
  ],
  "email": "aa",
  "username": "aa",
  "password": "aa",
  "memberType": {
    "id": "d59be02f-1df9-4228-aa1e-01917d806cda"
  },
  "groups": [
  ],
  "isApproved": true
}
```