### PR TITLE
Remove .Children and .Parent from IPublishedContent

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
@@ -97,13 +97,6 @@ public interface IPublishedContent : IPublishedElement
     PublishedItemType ItemType { get; }
 
     /// <summary>
-    ///     Gets the parent of the content item.
-    /// </summary>
-    /// <remarks>The parent of root content is <c>null</c>.</remarks>
-    [Obsolete("Please use either the IPublishedContent.Parent<>() extension method in the Umbraco.Extensions namespace, or IDocumentNavigationQueryService if you only need keys. Scheduled for removal in V16.")]
-    IPublishedContent? Parent { get; }
-
-    /// <summary>
     ///     Gets a value indicating whether the content is draft.
     /// </summary>
     /// <remarks>

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedContent.cs
@@ -131,10 +131,4 @@ public interface IPublishedContent : IPublishedElement
     ///     </para>
     /// </remarks>
     bool IsPublished(string? culture = null);
-
-    /// <summary>
-    ///     Gets the children of the content item that are available for the current culture.
-    /// </summary>
-    [Obsolete("Please use either the IPublishedContent.Children() extension method in the Umbraco.Extensions namespace, or IDocumentNavigationQueryService if you only need keys. Scheduled for removal in V16.")]
-    IEnumerable<IPublishedContent> Children { get; }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
@@ -72,11 +72,6 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
         /// <inheritdoc />
         public abstract bool IsPublished(string? culture = null);
 
-        /// <inheritdoc />
-        [Obsolete("Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
-        public virtual IEnumerable<IPublishedContent> Children => GetChildren();
-
-
         /// <inheritdoc cref="IPublishedElement.Properties"/>
         public abstract IEnumerable<IPublishedProperty> Properties { get; }
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.PublishedCache;
@@ -71,10 +71,6 @@ namespace Umbraco.Cms.Core.Models.PublishedContent
 
         /// <inheritdoc />
         public abstract bool IsPublished(string? culture = null);
-
-        /// <inheritdoc />
-        [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
-        public abstract IPublishedContent? Parent { get; }
 
         /// <inheritdoc />
         [Obsolete("Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -95,10 +95,6 @@ public abstract class PublishedContentWrapped : IPublishedContent
     public virtual PublishedItemType ItemType => _content.ItemType;
 
     /// <inheritdoc />
-    [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
-    public virtual IPublishedContent? Parent => _content.Parent;
-
-    /// <inheritdoc />
     public virtual bool IsDraft(string? culture = null) => _content.IsDraft(culture);
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -100,10 +100,6 @@ public abstract class PublishedContentWrapped : IPublishedContent
     /// <inheritdoc />
     public virtual bool IsPublished(string? culture = null) => _content.IsPublished(culture);
 
-    /// <inheritdoc />
-    [Obsolete("Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
-    public virtual IEnumerable<IPublishedContent> Children => _content.Children;
-
     /// <inheritdoc cref="IPublishedElement.Properties" />
     public virtual IEnumerable<IPublishedProperty> Properties => _content.Properties;
 

--- a/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
+++ b/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
@@ -69,9 +69,6 @@ public sealed class InternalPublishedContent : IPublishedContent
 
     public PublishedItemType ItemType => PublishedItemType.Content;
 
-    [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
-    public IPublishedContent? Parent => this.Parent<IPublishedContent>(StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>(), StaticServiceProvider.Instance.GetRequiredService<IPublishedContentStatusFilteringService>());
-
     public bool IsDraft(string? culture = null) => false;
 
     public bool IsPublished(string? culture = null) => true;

--- a/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
+++ b/src/Umbraco.Core/PublishedCache/Internal/InternalPublishedContent.cs
@@ -72,14 +72,7 @@ public sealed class InternalPublishedContent : IPublishedContent
     public bool IsDraft(string? culture = null) => false;
 
     public bool IsPublished(string? culture = null) => true;
-
-    [Obsolete("Please use TryGetChildrenKeys() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
-    public IEnumerable<IPublishedContent> Children => this.Children(
-        StaticServiceProvider.Instance.GetRequiredService<IDocumentNavigationQueryService>(),
-        StaticServiceProvider.Instance.GetRequiredService<IPublishedContentStatusFilteringService>());
-
-    public IEnumerable<IPublishedContent> ChildrenForAllCultures => Children;
-
+    
     public IPublishedContentType ContentType { get; set; }
 
     public IEnumerable<IPublishedProperty> Properties { get; set; }

--- a/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -161,9 +161,6 @@ internal class PublishedContent : PublishedContentBase
             return 0;
         }
     }
-
-    [Obsolete("Please use TryGetParentKey() on IDocumentNavigationQueryService or IMediaNavigationQueryService instead. Scheduled for removal in V16.")]
-    public override IPublishedContent? Parent => GetParent();
 
     /// <inheritdoc />
     public override IReadOnlyDictionary<string, PublishedCultureInfo> Cultures


### PR DESCRIPTION
I have removed `Children` and `Parent` from `IPublishedContent`, as these were obsolete and already scheduled for removal in v16.