### PR TITLE
V16: keepUserLoggedIn has no effect

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/index.ts
@@ -1,5 +1,6 @@
 export * from './avatar/index.js';
 export * from './change-password/index.js';
+export * from './config/index.js';
 export * from './detail/index.js';
 export * from './disable/index.js';
 export * from './enable/index.js';


### PR DESCRIPTION
## Description

Fixes #18220 

- fix: Observes the current-user config for the 'keepUserLoggedIn' value and tries to refresh the token when the worker attempts to log out the user
- feat: Exports the **UmbCurrentUserConfigRepository**

This pull request enhances the authentication session timeout handling by introducing support for the "keep user logged in" feature. The main changes involve observing the user's configuration to determine whether the session should be extended instead of logging out, and integrating the current user config repository into the session timeout controller.

**Session Timeout Logic Improvements:**

* The `UmbAuthSessionTimeoutController` now observes the user's "keepUserLoggedIn" configuration and, if enabled, will attempt to validate the token instead of logging the user out when the session times out. [[1]](diffhunk://#diff-c3ecd44ac2db6595747db15db2cd1c89467ce40ee88703965c61a4f7727d36f1R28-R36) [[2]](diffhunk://#diff-c3ecd44ac2db6595747db15db2cd1c89467ce40ee88703965c61a4f7727d36f1R85-R97)

**Integration with User Configuration:**

* Added `UmbCurrentUserConfigRepository` to the session timeout controller to access and observe the user's configuration, specifically the "keepUserLoggedIn" setting. [[1]](diffhunk://#diff-c3ecd44ac2db6595747db15db2cd1c89467ce40ee88703965c61a4f7727d36f1R5-R11) [[2]](diffhunk://#diff-c3ecd44ac2db6595747db15db2cd1c89467ce40ee88703965c61a4f7727d36f1R75-R76)
* Exported the user config repository from the user package, making it available for use in other parts of the application.