### PR TITLE
Update ClaimsIdentityExtensions

### DIFF
--- a/src/Umbraco.Core/Constants-Security.cs
+++ b/src/Umbraco.Core/Constants-Security.cs
@@ -89,18 +89,6 @@ public static partial class Constants
 
         public const string MemberExternalAuthenticationTypePrefix = "UmbracoMembers.";
 
-        [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
-        public const string StartContentNodeIdClaimType =
-            "http://umbraco.org/2015/02/identity/claims/backoffice/startcontentnode";
-
-        [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
-        public const string StartMediaNodeIdClaimType =
-            "http://umbraco.org/2015/02/identity/claims/backoffice/startmedianode";
-
-        [Obsolete("Please use IUser.AllowedSections instead. Will be removed in V15.")]
-        public const string AllowedApplicationsClaimType =
-            "http://umbraco.org/2015/02/identity/claims/backoffice/allowedapp";
-
         public const string SessionIdClaimType = "http://umbraco.org/2015/02/identity/claims/backoffice/sessionid";
 
         public const string TicketExpiresClaimType =

--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -336,22 +336,7 @@ public static class ClaimsIdentityExtensions
             }
         }
     }
-
-
-
-    /// <summary>
-    ///     Get the start content nodes from a ClaimsIdentity
-    /// </summary>
-    /// <param name="identity"></param>
-    /// <returns>Array of start content nodes</returns>
-    [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
-    public static int[] GetStartContentNodes(this ClaimsIdentity identity) =>
-        identity.FindAll(x => x.Type == Constants.Security.StartContentNodeIdClaimType)
-            .Select(node => int.TryParse(node.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)
-                ? i
-                : default)
-            .Where(x => x != default).ToArray();
-
+    
     /// <summary>
     ///     Get the start media nodes from a ClaimsIdentity
     /// </summary>

--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -248,38 +248,6 @@ public static class ClaimsIdentityExtensions
                 identity));
         }
 
-        // NOTE: this can be removed when the obsolete claim type has been deleted
-        if (identity.HasClaim(x => x.Type == Constants.Security.StartContentNodeIdClaimType) == false &&
-            startContentNodes != null)
-        {
-            foreach (var startContentNode in startContentNodes)
-            {
-                identity.AddClaim(new Claim(
-                    Constants.Security.StartContentNodeIdClaimType,
-                    startContentNode.ToInvariantString(),
-                    ClaimValueTypes.Integer32,
-                    AuthenticationType,
-                    AuthenticationType,
-                    identity));
-            }
-        }
-
-        // NOTE: this can be removed when the obsolete claim type has been deleted
-        if (identity.HasClaim(x => x.Type == Constants.Security.StartMediaNodeIdClaimType) == false &&
-            startMediaNodes != null)
-        {
-            foreach (var startMediaNode in startMediaNodes)
-            {
-                identity.AddClaim(new Claim(
-                    Constants.Security.StartMediaNodeIdClaimType,
-                    startMediaNode.ToInvariantString(),
-                    ClaimValueTypes.Integer32,
-                    AuthenticationType,
-                    AuthenticationType,
-                    identity));
-            }
-        }
-
         if (identity.HasClaim(x => x.Type == ClaimTypes.Locality) == false)
         {
             identity.AddClaim(new Claim(
@@ -301,22 +269,6 @@ public static class ClaimsIdentityExtensions
                 AuthenticationType,
                 AuthenticationType,
                 identity));
-        }
-
-        // Add each app as a separate claim
-        // NOTE: this can be removed when the obsolete claim type has been deleted
-        if (identity.HasClaim(x => x.Type == Constants.Security.AllowedApplicationsClaimType) == false && allowedApps != null)
-        {
-            foreach (var application in allowedApps)
-            {
-                identity.AddClaim(new Claim(
-                    Constants.Security.AllowedApplicationsClaimType,
-                    application,
-                    ClaimValueTypes.String,
-                    AuthenticationType,
-                    AuthenticationType,
-                    identity));
-            }
         }
 
         // Claims are added by the ClaimsIdentityFactory because our UserStore supports roles, however this identity might

--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -336,19 +336,6 @@ public static class ClaimsIdentityExtensions
             }
         }
     }
-    
-    /// <summary>
-    ///     Get the start media nodes from a ClaimsIdentity
-    /// </summary>
-    /// <param name="identity"></param>
-    /// <returns>Array of start media nodes</returns>
-    [Obsolete("Please use the UserExtensions class to access user start node info. Will be removed in V15.")]
-    public static int[] GetStartMediaNodes(this ClaimsIdentity identity) =>
-        identity.FindAll(x => x.Type == Constants.Security.StartMediaNodeIdClaimType)
-            .Select(node => int.TryParse(node.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i)
-                ? i
-                : default)
-            .Where(x => x != default).ToArray();
 
     /// <summary>
     ///     Get the allowed applications from a ClaimsIdentity

--- a/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Umbraco.Core/Extensions/ClaimsIdentityExtensions.cs
@@ -338,15 +338,6 @@ public static class ClaimsIdentityExtensions
     }
 
     /// <summary>
-    ///     Get the allowed applications from a ClaimsIdentity
-    /// </summary>
-    /// <param name="identity"></param>
-    /// <returns></returns>
-    [Obsolete("Please use IUser.AllowedSections instead. Will be removed in V15.")]
-    public static string[] GetAllowedApplications(this ClaimsIdentity identity) => identity
-        .FindAll(x => x.Type == Constants.Security.AllowedApplicationsClaimType).Select(app => app.Value).ToArray();
-
-    /// <summary>
     ///     Get the user ID from a ClaimsIdentity
     /// </summary>
     /// <param name="identity"></param>

--- a/src/Umbraco.Web.Common/Profiler/ConfigureMiniProfilerOptions.cs
+++ b/src/Umbraco.Web.Common/Profiler/ConfigureMiniProfilerOptions.cs
@@ -2,20 +2,19 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using OpenIddict.Abstractions;
 using StackExchange.Profiling;
 using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.Profiler;
 
-internal sealed class ConfigureMiniProfilerOptions : IConfigureOptions<MiniProfilerOptions>
+internal sealed class ConfigureMiniProfilerOptions(IHostingEnvironment hostingEnvironment, IUserService userService)
+    : IConfigureOptions<MiniProfilerOptions>
 {
-    private readonly string _backOfficePath;
-
-    public ConfigureMiniProfilerOptions(IHostingEnvironment hostingEnvironment)
-        => _backOfficePath = hostingEnvironment.GetBackOfficePath();
+    private readonly string _backOfficePath = hostingEnvironment.GetBackOfficePath();
 
     public void Configure(MiniProfilerOptions options)
     {
@@ -38,7 +37,18 @@ internal sealed class ConfigureMiniProfilerOptions : IConfigureOptions<MiniProfi
         AuthenticateResult authenticateResult = await request.HttpContext.AuthenticateBackOfficeAsync();
         ClaimsIdentity? identity = authenticateResult.Principal?.GetUmbracoIdentity();
 
-        return identity?.GetClaims(Core.Constants.Security.AllowedApplicationsClaimType)
-            .InvariantContains(Core.Constants.Applications.Settings) ?? false;
+        Guid? userKey = identity?.GetUserKey();
+        if (userKey == null)
+        {
+            return false;
+        }
+
+        IUser? user = await userService.GetAsync(userKey.Value);
+        if (user == null)
+        {
+            return false;
+        }
+
+        return user.AllowedSections.Contains(Core.Constants.Applications.Settings) == true;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/BackOffice/UmbracoBackOfficeIdentityTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/BackOffice/UmbracoBackOfficeIdentityTests.cs
@@ -26,11 +26,6 @@ public class UmbracoBackOfficeIdentityTests
             // This is the id that 'identity' uses to check for the username.
             new Claim(ClaimTypes.Name, "testing", ClaimValueTypes.String, TestIssuer, TestIssuer),
             new Claim(ClaimTypes.GivenName, "hello world", ClaimValueTypes.String, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.StartContentNodeIdClaimType, "-1", ClaimValueTypes.Integer32, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.StartMediaNodeIdClaimType, "5543", ClaimValueTypes.Integer32, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.StartMediaNodeIdClaimType, "5555", ClaimValueTypes.Integer32, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.AllowedApplicationsClaimType, "content", ClaimValueTypes.String, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.AllowedApplicationsClaimType, "media", ClaimValueTypes.String, TestIssuer, TestIssuer),
             new Claim(ClaimTypes.Locality, "en-us", ClaimValueTypes.String, TestIssuer, TestIssuer),
             new Claim(ClaimsIdentity.DefaultRoleClaimType, "admin", ClaimValueTypes.String, TestIssuer, TestIssuer),
             new Claim(Constants.Security.SecurityStampClaimType, securityStamp, ClaimValueTypes.String, TestIssuer, TestIssuer),
@@ -47,9 +42,6 @@ public class UmbracoBackOfficeIdentityTests
         Assert.AreEqual(securityStamp, verifiedIdentity.GetSecurityStamp());
         Assert.AreEqual("testing", verifiedIdentity.GetUsername());
         Assert.AreEqual("hello world", verifiedIdentity.GetRealName());
-        Assert.AreEqual(1, verifiedIdentity.GetStartContentNodes().Length);
-        Assert.IsTrue(verifiedIdentity.GetStartMediaNodes().UnsortedSequenceEqual(new[] { 5543, 5555 }));
-        Assert.IsTrue(new[] { "content", "media" }.SequenceEqual(verifiedIdentity.GetAllowedApplications()));
         Assert.AreEqual("en-us", verifiedIdentity.GetCultureString());
         Assert.IsTrue(new[] { "admin" }.SequenceEqual(verifiedIdentity.GetRoles()));
 
@@ -82,10 +74,6 @@ public class UmbracoBackOfficeIdentityTests
             new Claim(ClaimTypes.NameIdentifier, string.Empty, ClaimValueTypes.Integer32, TestIssuer, TestIssuer),
             new Claim(ClaimTypes.Name, "testing", ClaimValueTypes.String, TestIssuer, TestIssuer),
             new Claim(ClaimTypes.GivenName, "hello world", ClaimValueTypes.String, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.StartContentNodeIdClaimType, "-1", ClaimValueTypes.Integer32, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.StartMediaNodeIdClaimType, "5543", ClaimValueTypes.Integer32, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.AllowedApplicationsClaimType, "content", ClaimValueTypes.String, TestIssuer, TestIssuer),
-            new Claim(Constants.Security.AllowedApplicationsClaimType, "media", ClaimValueTypes.String, TestIssuer, TestIssuer),
             new Claim(ClaimTypes.Locality, "en-us", ClaimValueTypes.String, TestIssuer, TestIssuer),
             new Claim(ClaimsIdentity.DefaultRoleClaimType, "admin", ClaimValueTypes.String, TestIssuer, TestIssuer),
         });


### PR DESCRIPTION
Delete Extentions methods as these were obsolete and already scheduled for removal in v15.

- [x] Delete `GetStartContentNodes()`
- [x] Delete `GetStartMediaNodes()`
- [x] Delete `GetAllowedApplications()`
- [x] Delete ClaimType from Constants