### PR TITLE
Permissions: Only check for document permissions when verifying entity actions for a document (closes #20097)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/conditions/document-user-permission.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/conditions/document-user-permission.condition.ts
@@ -70,7 +70,7 @@ export class UmbDocumentUserPermissionCondition
 		if (!this.#entityType) return;
 		if (this.#unique === undefined) return;
 
-		const hasDocumentPermissions = this.#entityType === UMB_DOCUMENT_ENTITY_TYPE && this.#documentPermissions.length > 0;
+		const hasDocumentPermissions = this.#isDocumentWithPermissions();
 
 		// If there are no permissions for any documents we use the fallback permissions
 		if (!hasDocumentPermissions) {
@@ -102,6 +102,10 @@ export class UmbDocumentUserPermissionCondition
 
 		// We found permissions - check them
 		this.#check(match.verbs);
+	}
+
+	#isDocumentWithPermissions() {
+		return this.#entityType === UMB_DOCUMENT_ENTITY_TYPE && this.#documentPermissions.length > 0;
 	}
 
 	#check(verbs: Array<string>) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/conditions/document-user-permission.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/conditions/document-user-permission.condition.ts
@@ -7,7 +7,7 @@ import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@um
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { DocumentPermissionPresentationModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
-import { UMB_DOCUMENT_ENTITY_TYPE } from '@umbraco-cms/backoffice/document';
+import { UMB_DOCUMENT_ENTITY_TYPE } from '../../../entity.js';
 
 export class UmbDocumentUserPermissionCondition
 	extends UmbConditionBase<UmbDocumentUserPermissionConditionConfig>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/20097

### Description
Although I haven't been able to replicate the reported issue, I can see the proposed solution is sensible, as it allows us to by-pass complex logic for verifying document specific permissions, when we aren't working with a document.

So I've applied that here.

### Testing
To verify, use a set up such as:
- Create a user in only the "Editors" group
- Add a document specific permission to a document that removes some permissions that the editor normally has.
- Verify when expanding the entity actions menu that the default editor permissions appear on documents without the document specific permission, but that the restricted set appears on those that have it defined
- Verify that default editor permissions appear on all entity action lists that aren't based on documents (e.g. media, members, dictionary). 