### PR TITLE
Querying extensions: Allow `ContentAtRoot()` to accept culture

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -826,7 +826,7 @@ public static class PublishedContentExtensions
     /// </param>
     /// <returns></returns>
     /// <remarks>
-    ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
+    ///     This can be useful in order to return all nodes in an entire site by a type when combined with ContentAtRoot
     /// </remarks>
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes, IVariationContextAccessor variationContextAccessor, string docTypeAlias, string? culture = null) => parentNodes.SelectMany(x =>
@@ -843,7 +843,7 @@ public static class PublishedContentExtensions
     /// </param>
     /// <returns></returns>
     /// <remarks>
-    ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
+    ///     This can be useful in order to return all nodes in an entire site by a type when combined with ContentAtRoot
     /// </remarks>
     public static IEnumerable<T> DescendantsOrSelf<T>(this IEnumerable<IPublishedContent> parentNodes, IVariationContextAccessor variationContextAccessor, string? culture = null)
         where T : class, IPublishedContent =>

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -35,6 +35,8 @@ public interface IPublishedContentQuery
 
     IEnumerable<IPublishedContent> ContentAtRoot();
 
+    IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null);
+
     IPublishedContent? Media(int id);
 
     IPublishedContent? Media(Guid id);

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -35,7 +35,7 @@ public interface IPublishedContentQuery
 
     IEnumerable<IPublishedContent> ContentAtRoot();
 
-    IEnumerable<IPublishedContent> ContentAtRoot(string culture) => throw new NotSupportedException();
+    IEnumerable<IPublishedContent> ContentAtRoot(string? culture) => culture is null ? ContentAtRoot() : throw new NotSupportedException();
 
     IPublishedContent? Media(int id);
 

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -33,6 +33,7 @@ public interface IPublishedContentQuery
     [Obsolete("The current implementation of this method is suboptimal and will be removed entirely in a future version. Scheduled for removal in v14")]
     IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars);
 
+    [Obsolete("Please use the method overload taking a culture parameter. Scheduled for removal in Umbraco 18.")]
     IEnumerable<IPublishedContent> ContentAtRoot();
 
     IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => throw new NotSupportedException();

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -33,8 +33,6 @@ public interface IPublishedContentQuery
     [Obsolete("The current implementation of this method is suboptimal and will be removed entirely in a future version. Scheduled for removal in v14")]
     IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars);
 
-    IEnumerable<IPublishedContent> ContentAtRoot();
-
     IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null);
 
     IPublishedContent? Media(int id);

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -33,7 +33,9 @@ public interface IPublishedContentQuery
     [Obsolete("The current implementation of this method is suboptimal and will be removed entirely in a future version. Scheduled for removal in v14")]
     IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars);
 
-    IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null);
+    IEnumerable<IPublishedContent> ContentAtRoot();
+
+    IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => throw new NotSupportedException();
 
     IPublishedContent? Media(int id);
 

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -33,10 +33,9 @@ public interface IPublishedContentQuery
     [Obsolete("The current implementation of this method is suboptimal and will be removed entirely in a future version. Scheduled for removal in v14")]
     IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars);
 
-    [Obsolete("Please use the method overload taking a culture parameter. Scheduled for removal in Umbraco 18.")]
     IEnumerable<IPublishedContent> ContentAtRoot();
 
-    IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => throw new NotSupportedException();
+    IEnumerable<IPublishedContent> ContentAtRoot(string culture) => throw new NotSupportedException();
 
     IPublishedContent? Media(int id);
 

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -153,7 +153,7 @@ public class PublishedContentQuery : IPublishedContentQuery
     public IEnumerable<IPublishedContent> ContentAtRoot()
         => ItemsAtRoot(_publishedSnapshot.Content);
 
-    public IEnumerable<IPublishedContent> ContentAtRoot(string culture)
+    public IEnumerable<IPublishedContent> ContentAtRoot(string? culture)
         => ItemsAtRoot(_publishedSnapshot.Content, culture);
 
     #endregion

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -150,9 +150,6 @@ public class PublishedContentQuery : IPublishedContentQuery
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars)
         => ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
 
-    public IEnumerable<IPublishedContent> ContentAtRoot()
-        => ItemsAtRoot(_publishedSnapshot.Content);
-
     public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null)
         => ItemsAtRoot(_publishedSnapshot.Content, culture);
 

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -150,6 +150,7 @@ public class PublishedContentQuery : IPublishedContentQuery
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars)
         => ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
 
+    [Obsolete("Please use the method overload taking a culture parameter. Scheduled for removal in Umbraco 18.")]
     public IEnumerable<IPublishedContent> ContentAtRoot()
         => ItemsAtRoot(_publishedSnapshot.Content);
 

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -153,6 +153,9 @@ public class PublishedContentQuery : IPublishedContentQuery
     public IEnumerable<IPublishedContent> ContentAtRoot()
         => ItemsAtRoot(_publishedSnapshot.Content);
 
+    public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null)
+        => ItemsAtRoot(_publishedSnapshot.Content, culture);
+
     #endregion
 
     #region Media
@@ -232,8 +235,8 @@ public class PublishedContentQuery : IPublishedContentQuery
         IPublishedCache? cache)
         => cache?.GetByXPath(xpath, vars) ?? Array.Empty<IPublishedContent>();
 
-    private static IEnumerable<IPublishedContent> ItemsAtRoot(IPublishedCache? cache)
-        => cache?.GetAtRoot() ?? Array.Empty<IPublishedContent>();
+    private static IEnumerable<IPublishedContent> ItemsAtRoot(IPublishedCache? cache, string? culture = null)
+        => cache?.GetAtRoot(culture) ?? Array.Empty<IPublishedContent>();
 
     #endregion
 

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -150,6 +150,9 @@ public class PublishedContentQuery : IPublishedContentQuery
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars)
         => ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
 
+    public IEnumerable<IPublishedContent> ContentAtRoot()
+        => ItemsAtRoot(_publishedSnapshot.Content);
+
     public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null)
         => ItemsAtRoot(_publishedSnapshot.Content, culture);
 

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -150,11 +150,10 @@ public class PublishedContentQuery : IPublishedContentQuery
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars)
         => ItemsByXPath(xpath, vars, _publishedSnapshot.Content);
 
-    [Obsolete("Please use the method overload taking a culture parameter. Scheduled for removal in Umbraco 18.")]
     public IEnumerable<IPublishedContent> ContentAtRoot()
         => ItemsAtRoot(_publishedSnapshot.Content);
 
-    public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null)
+    public IEnumerable<IPublishedContent> ContentAtRoot(string culture)
         => ItemsAtRoot(_publishedSnapshot.Content, culture);
 
     #endregion

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -211,7 +211,7 @@ public static class FriendlyPublishedContentExtensions
     /// </param>
     /// <returns></returns>
     /// <remarks>
-    ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
+    ///     This can be useful in order to return all nodes in an entire site by a type when combined with ContentAtRoot
     /// </remarks>
     public static IEnumerable<IPublishedContent> DescendantsOrSelfOfType(
         this IEnumerable<IPublishedContent> parentNodes, string docTypeAlias, string? culture = null)
@@ -227,7 +227,7 @@ public static class FriendlyPublishedContentExtensions
     /// </param>
     /// <returns></returns>
     /// <remarks>
-    ///     This can be useful in order to return all nodes in an entire site by a type when combined with TypedContentAtRoot
+    ///     This can be useful in order to return all nodes in an entire site by a type when combined with ContentAtRoot
     /// </remarks>
     public static IEnumerable<T> DescendantsOrSelf<T>(
         this IEnumerable<IPublishedContent> parentNodes,

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -349,6 +349,8 @@ public class UmbracoHelper
 
     public IEnumerable<IPublishedContent> ContentAtRoot() => _publishedContentQuery.ContentAtRoot();
 
+    public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => _publishedContentQuery.ContentAtRoot(culture);
+
     #endregion
 
     #region Media

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -347,6 +347,8 @@ public class UmbracoHelper
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars) =>
         _publishedContentQuery.ContentAtXPath(xpath, vars);
 
+    public IEnumerable<IPublishedContent> ContentAtRoot() => _publishedContentQuery.ContentAtRoot();
+
     public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => _publishedContentQuery.ContentAtRoot(culture);
 
     #endregion

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -347,6 +347,7 @@ public class UmbracoHelper
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars) =>
         _publishedContentQuery.ContentAtXPath(xpath, vars);
 
+    [Obsolete("Please use the method overload taking a culture parameter. Scheduled for removal in Umbraco 18.")]
     public IEnumerable<IPublishedContent> ContentAtRoot() => _publishedContentQuery.ContentAtRoot();
 
     public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => _publishedContentQuery.ContentAtRoot(culture);

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -349,7 +349,7 @@ public class UmbracoHelper
 
     public IEnumerable<IPublishedContent> ContentAtRoot() => _publishedContentQuery.ContentAtRoot();
 
-    public IEnumerable<IPublishedContent> ContentAtRoot(string culture) => _publishedContentQuery.ContentAtRoot(culture);
+    public IEnumerable<IPublishedContent> ContentAtRoot(string? culture) => _publishedContentQuery.ContentAtRoot(culture);
 
     #endregion
 

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -347,8 +347,6 @@ public class UmbracoHelper
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars) =>
         _publishedContentQuery.ContentAtXPath(xpath, vars);
 
-    public IEnumerable<IPublishedContent> ContentAtRoot() => _publishedContentQuery.ContentAtRoot();
-
     public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => _publishedContentQuery.ContentAtRoot(culture);
 
     #endregion

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -347,10 +347,9 @@ public class UmbracoHelper
     public IEnumerable<IPublishedContent> ContentAtXPath(XPathExpression xpath, params XPathVariable[] vars) =>
         _publishedContentQuery.ContentAtXPath(xpath, vars);
 
-    [Obsolete("Please use the method overload taking a culture parameter. Scheduled for removal in Umbraco 18.")]
     public IEnumerable<IPublishedContent> ContentAtRoot() => _publishedContentQuery.ContentAtRoot();
 
-    public IEnumerable<IPublishedContent> ContentAtRoot(string? culture = null) => _publishedContentQuery.ContentAtRoot(culture);
+    public IEnumerable<IPublishedContent> ContentAtRoot(string culture) => _publishedContentQuery.ContentAtRoot(culture);
 
     #endregion
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20117

### Description
This PR allow `ContentAtRoot()` to query specific culture just like `GetAtRoot()` in published content query.
