### PR TITLE
Tiptap RTE: Fixes undo when RTE is emptied

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
@@ -84,10 +84,6 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 			umb-icon,
 			umb-ufm-render {
 				z-index: 1;
-
-				&::selection {
-					color: var(--uui-color-default-contrast);
-				}
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/heading/heading.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/heading/heading.tiptap-api.ts
@@ -13,7 +13,11 @@ export default class UmbTiptapHeadingExtensionApi extends UmbTiptapExtensionApiB
 		h5,
 		h6 {
 			margin-top: 0;
-			margin-bottom: 0.5em;
+			margin-bottom: 1rem;
+
+			&:first-child {
+				margin-top: 0.25rem;
+			}
 		}
 	`;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/property-editor-ui-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/property-editor-ui-tiptap.element.ts
@@ -20,13 +20,6 @@ export class UmbPropertyEditorUiTiptapElement extends UmbPropertyEditorUiRteElem
 		const tipTapElement = event.target;
 		const markup = tipTapElement.value;
 
-		// If we don't get any markup clear the property editor value.
-		if (tipTapElement.isEmpty()) {
-			this.value = undefined;
-			this._fireChangeEvent();
-			return;
-		}
-
 		// Remove unused Blocks of Blocks Layout. Leaving only the Blocks that are present in Markup.
 		const usedContentKeys: string[] = [];
 


### PR DESCRIPTION
### Description

Fixes #20076.

When the Tiptap RTE is empty, the internal value is set to `undefined`, however in a scenario when the RTE has content and then all content is removed (think <kbd>CTRL + A</kbd>, <kbd>DEL</kbd>), it is not possible to restore any Block data, (since the underlying value was `undefined`).

The fix here is to not intentionally set the underlying value as `undefined`.

This PR contains a couple of other cosmetic fixes related to RTE selection and heading styles.

#### How to test?

With a Tiptap RTE that has some rich-text and Block data; select and delete all contents, try to undo, notice that the Block data can now be restored.
