### PR TITLE
Fixes regression with hidden tab labels in the Content Editor

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
@@ -201,7 +201,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 			fullPath === this._activePath ||
 			(!this._hasRootGroups && index === 0 && this._routerPath + '/' === this._activePath);
 		return html`<uui-tab
-			.label=${this.localize.string(name ?? '#general_unnamed')}
+			label=${this.localize.string(name ?? '#general_unnamed')}
 			.active=${active}
 			href=${fullPath}
 			data-mark="content-tab:${path}"


### PR DESCRIPTION
### Description

Fixes regression with hidden tabs in the Content Editor.

Regression occurred in #19255, originally fixed in #19370.
