### PR TITLE
AppSettings: Improves the templates so they reflect the latest recommended settings

### DIFF
--- a/src/Umbraco.Web.UI/appsettings.Development.template.json
+++ b/src/Umbraco.Web.UI/appsettings.Development.template.json
@@ -1,5 +1,5 @@
 {
-  "$schema" : "./appsettings-schema.json",
+  "$schema": "./appsettings-schema.json",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",
@@ -37,10 +37,6 @@
       },
       "Hosting": {
         "Debug": true
-      },
-      "RuntimeMinification": {
-        "useInMemoryCache": true,
-        "cacheBuster": "Timestamp"
       }
     }
   }

--- a/src/Umbraco.Web.UI/appsettings.template.json
+++ b/src/Umbraco.Web.UI/appsettings.template.json
@@ -18,13 +18,12 @@
       "Content": {
         "Notifications": {
           "Email": "your@email.here"
-        },
-        "MacroErrors": "Throw"
+        }
       },
       "Global": {
         "DefaultUILanguage": "en-us",
         "HideTopLevelNodeFromPath": true,
-        "TimeOutInMinutes": 20,
+        "TimeOut": "00:20:00",
         "UseHttps": false
       },
       "Hosting": {
@@ -33,14 +32,10 @@
       "RequestHandler": {
         "ConvertUrlsToAscii": "try"
       },
-      "RuntimeMinification": {
-        "dataFolder": "umbraco/Data/TEMP/Smidge",
-        "version": "637642136775050602"
-      },
       "Security": {
         "KeepUserLoggedIn": false,
         "UsernameIsEmail": true,
-        "HideDisabledUsersInBackoffice": false,
+        "HideDisabledUsersInBackOffice": false,
         "AllowedUserNameCharacters": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-'._@+\\",
         "UserPassword": {
           "RequiredLength": 10,
@@ -58,9 +53,6 @@
           "RequireUppercase": false,
           "MaxFailedAccessAttemptsBeforeLockout": 5
         }
-      },
-      "Tours": {
-        "EnableTours": true
       },
       "ModelsBuilder": {
         "ModelsMode": "InMemoryAuto"


### PR DESCRIPTION
This pull request updates the configuration templates in `appsettings.template.json` and `appsettings.Development.template.json` for the Umbraco Web UI. The changes mainly focus on cleaning up unused or outdated settings, updating timeout configuration, and fixing a property name for consistency.

Configuration cleanup and updates:

* Removed the entire `RuntimeMinification` section from both `appsettings.template.json` and `appsettings.Development.template.json` to eliminate unused or deprecated configuration options. [[1]](diffhunk://#diff-83ccafe367c91b7e9d98144af4cd5b19f25f5aa498b2bd770697988bd4c06877L36-R38) [[2]](diffhunk://#diff-ecfc096d00bc4074cac9eb390fe6a6aa1c1f8143800db7abbfca1b4baaf23fa6L40-L43)
* Removed the `Tours` section from `appsettings.template.json`, disabling tour-related configuration by default.
* Updated the session timeout configuration in `appsettings.template.json` from `TimeOutInMinutes: 20` to the more explicit `TimeOut: "00:20:00"`.

Naming consistency:

* Corrected the property name from `HideDisabledUsersInBackoffice` to `HideDisabledUsersInBackOffice` in the `Security` section of `appsettings.template.json` for improved consistency.

Other minor changes:

* Removed the `MacroErrors` configuration from the `Content` section in `appsettings.template.json`.