### PR TITLE
Expanding Sibling Endpoints to Include all Tree Items

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/SiblingMemberTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/SiblingMemberTypeTreeController.cs
@@ -19,7 +19,7 @@ public class SiblingMemberTypeTreeController : MemberTypeTreeControllerBase
 
     [HttpGet("siblings")]
     [ProducesResponseType(typeof(SubsetViewModel<MemberTypeTreeItemResponseModel>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<SubsetViewModel<MemberTypeTreeItemResponseModel>>> GetSiblingMemberTypes(
+    public async Task<ActionResult<SubsetViewModel<MemberTypeTreeItemResponseModel>>> Siblings(
         CancellationToken cancellationToken,
         Guid target,
         int before,

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/SiblingMemberTypeTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Tree/SiblingMemberTypeTreeController.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.Services.Signs;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Controllers.MemberType.Tree;
+
+public class SiblingMemberTypeTreeController : MemberTypeTreeControllerBase
+{
+    public SiblingMemberTypeTreeController(
+        IEntityService entityService,
+        SignProviderCollection signProviders,
+        IMemberTypeService memberTypeService)
+        : base(entityService, signProviders, memberTypeService)
+    {
+    }
+
+    [HttpGet("siblings")]
+    [ProducesResponseType(typeof(SubsetViewModel<MemberTypeTreeItemResponseModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<SubsetViewModel<MemberTypeTreeItemResponseModel>>> GetSiblingMemberTypes(
+        CancellationToken cancellationToken,
+        Guid target,
+        int before,
+        int after)
+        => await GetSiblings(target, before, after);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/SiblingPartialViewTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/PartialView/Tree/SiblingPartialViewTreeController.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Api.Management.Controllers.PartialView.Tree;
+
+public class SiblingPartialViewTreeController : PartialViewTreeControllerBase
+{
+    public SiblingPartialViewTreeController(FileSystems fileSystems)
+        : base(fileSystems)
+    {
+    }
+
+    [HttpGet("siblings")]
+    [ProducesResponseType(typeof(SubsetViewModel<FileSystemTreeItemPresentationModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<SubsetViewModel<FileSystemTreeItemPresentationModel>>> Siblings(
+        CancellationToken cancellationToken,
+        string path,
+        int before,
+        int after)
+        => await GetSiblings(path, before, after);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/SiblingsScriptTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Script/Tree/SiblingsScriptTreeController.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Script.Tree;
+
+public class SiblingsScriptTreeController : ScriptTreeControllerBase
+{
+    public SiblingsScriptTreeController(FileSystems fileSystems) : base(fileSystems)
+    {
+    }
+
+    [HttpGet("siblings")]
+    [ProducesResponseType(typeof(SubsetViewModel<FileSystemTreeItemPresentationModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<SubsetViewModel<FileSystemTreeItemPresentationModel>>> Siblings(
+        CancellationToken cancellationToken,
+        string path,
+        int before,
+        int after)
+        => await GetSiblings(path, before, after);
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/SiblingStylesheetTreeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Stylesheet/Tree/SiblingStylesheetTreeController.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels.Tree;
+using Umbraco.Cms.Core.IO;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Stylesheet.Tree;
+
+public class SiblingStylesheetTreeController : StylesheetTreeControllerBase
+{
+    public SiblingStylesheetTreeController(FileSystems fileSystems) : base(fileSystems)
+    {
+    }
+
+    [HttpGet("siblings")]
+    [ProducesResponseType(typeof(SubsetViewModel<FileSystemTreeItemPresentationModel>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<SubsetViewModel<FileSystemTreeItemPresentationModel>>> Siblings(
+        CancellationToken cancellationToken,
+        string path,
+        int before,
+        int after)
+        => await GetSiblings(path, before, after);
+}


### PR DESCRIPTION
### Description
When sibling endpoints were introduced it only included the following:

- Data Types Tree
- Document Type Tree
- Media Type Tree
- Document Blueprints Tree
- Media Tree
- Document Tree
- Template Tree

With this expansion it will include the rest of the tree items, which are the following:

- Content Recycle Bin
- Media Recycle Bin
- Member Types
- Partial Views
- Stylesheets
- Scripts

<!-- Thanks for contributing to Umbraco CMS! -->
