### PR TITLE
Make notification service able to handle segmented content

### DIFF
--- a/src/Umbraco.Core/Services/NotificationService.cs
+++ b/src/Umbraco.Core/Services/NotificationService.cs
@@ -385,48 +385,7 @@ public class NotificationService : INotificationService
         // build summary
         var summary = new StringBuilder();
 
-        if (content.ContentType.VariesByNothing())
-        {
-            if (!_contentSettings.Notifications.DisableHtmlEmail)
-            {
-                // create the HTML summary for invariant content
-
-                // list all of the property values like we used to
-                summary.Append("<table style=\"width: 100 %; \">");
-                foreach (IProperty p in content.Properties)
-                {
-                    // TODO: doesn't take into account variants
-                    var newText = p.GetValue() != null ? p.GetValue()?.ToString() : string.Empty;
-                    var oldText = newText;
-
-                    // check if something was changed and display the changes otherwise display the fields
-                    if (oldDoc?.Properties.Contains(p.PropertyType.Alias) ?? false)
-                    {
-                        IProperty? oldProperty = oldDoc.Properties[p.PropertyType.Alias];
-                        oldText = oldProperty?.GetValue() != null ? oldProperty.GetValue()?.ToString() : string.Empty;
-
-                        // replace HTML with char equivalent
-                        ReplaceHtmlSymbols(ref oldText);
-                        ReplaceHtmlSymbols(ref newText);
-                    }
-
-                    // show the values
-                    summary.Append("<tr>");
-                    summary.Append(
-                        "<th style='text-align: left; vertical-align: top; width: 25%;border-bottom: 1px solid #CCC'>");
-                    summary.Append(p.PropertyType.Name);
-                    summary.Append("</th>");
-                    summary.Append("<td style='text-align: left; vertical-align: top;border-bottom: 1px solid #CCC'>");
-                    summary.Append(newText);
-                    summary.Append("</td>");
-                    summary.Append("</tr>");
-                }
-
-                summary.Append("</table>");
-            }
-        }
-        else if (content.ContentType.VariesByCulture())
-        {
+        if (content.ContentType.VariesByCulture()) {
             // it's variant, so detect what cultures have changed
             if (!_contentSettings.Notifications.DisableHtmlEmail)
             {
@@ -465,8 +424,43 @@ public class NotificationService : INotificationService
         }
         else
         {
-            // not supported yet...
-            throw new NotSupportedException();
+            if (!_contentSettings.Notifications.DisableHtmlEmail)
+            {
+                // create the HTML summary for invariant content
+
+                // list all of the property values like we used to
+                summary.Append("<table style=\"width: 100 %; \">");
+                foreach (IProperty p in content.Properties)
+                {
+                    // TODO: doesn't take into account variants
+                    var newText = p.GetValue() != null ? p.GetValue()?.ToString() : string.Empty;
+                    var oldText = newText;
+
+                    // check if something was changed and display the changes otherwise display the fields
+                    if (oldDoc?.Properties.Contains(p.PropertyType.Alias) ?? false)
+                    {
+                        IProperty? oldProperty = oldDoc.Properties[p.PropertyType.Alias];
+                        oldText = oldProperty?.GetValue() != null ? oldProperty.GetValue()?.ToString() : string.Empty;
+
+                        // replace HTML with char equivalent
+                        ReplaceHtmlSymbols(ref oldText);
+                        ReplaceHtmlSymbols(ref newText);
+                    }
+
+                    // show the values
+                    summary.Append("<tr>");
+                    summary.Append(
+                        "<th style='text-align: left; vertical-align: top; width: 25%;border-bottom: 1px solid #CCC'>");
+                    summary.Append(p.PropertyType.Name);
+                    summary.Append("</th>");
+                    summary.Append("<td style='text-align: left; vertical-align: top;border-bottom: 1px solid #CCC'>");
+                    summary.Append(newText);
+                    summary.Append("</td>");
+                    summary.Append("</tr>");
+                }
+
+                summary.Append("</table>");
+            }
         }
 
         var protocol = _globalSettings.UseHttps ? "https" : "http";


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #20045

### Description

See the linked issue for a description.

### Testing this PR

You'll need to be able to receive notification emails from Umbraco. An easy way to do that is to configure the SMTP options to use the `SpecifiedPickupDirectory` in `appsettings.json`:

```json
{
  "Umbraco": {
    "CMS": {
      "Global": {
        "Smtp": {
          "From": "your@email.here",
          "DeliveryMethod": "SpecifiedPickupDirectory",
          "PickupDirectoryLocation": "C:\\Temp\\MailDrop"
        }
      },
      ....
```

You'll also need to enable segments for document types. This code snippet should do the trick in V13:

```cs
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI.Custom;

public class ServerVariablesParsingNotificationHandler : INotificationHandler<ServerVariablesParsingNotification>
{
    public void Handle(ServerVariablesParsingNotification notification)
    {
        if (!notification.ServerVariables.TryGetValue("umbracoSettings", out var umbracoSettingsObject)
            || umbracoSettingsObject is not IDictionary<string, object> umbracoSettings)
        {
            umbracoSettings = new Dictionary<string, object>();
            notification.ServerVariables.Add("umbracoSettings", umbracoSettings);
        }

        umbracoSettings["showAllowSegmentationForDocumentTypes"] = true;
    }
}

public class EnableSegmentsComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.AddNotificationHandler<ServerVariablesParsingNotification, ServerVariablesParsingNotificationHandler>();
}
```

With all that in place, create a new doctype with "Allow segmentation" enabled:

<img width="818" height="651" alt="image" src="https://github.com/user-attachments/assets/f246f350-4eed-420f-9e03-6752a4b793e1" />

Note that you don't actually need any segmented properties to test this PR 😄 

Now create a document of the segmented doctype, and sign up for any notification for that document. I've used the "Update" notification for testing, because it's easy to trigger.

<img width="744" height="655" alt="image" src="https://github.com/user-attachments/assets/93f03d52-8f7c-4b99-a049-6b1174fc1c62" />

When this is in place, trigger the notification (e.g. save the document again if you're using the "Update" notifcation).

Without this PR, the `NotSupportedException` from `NotificationService` bubbles all the way into the UI:

<img width="1330" height="512" alt="image" src="https://github.com/user-attachments/assets/0e16db13-68b8-44b5-9ae0-94fe36bac114" />


With this PR, the notification email should be sent (or generated on disk, if you configured `SpecifiedPickupDirectory`).