### PR TITLE
Member workspace: Fix for loading inside modal

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/item/member-item-ref.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/item/member-item-ref.element.ts
@@ -48,6 +48,7 @@ export class UmbMemberItemRefElement extends UmbLitElement {
 		]);
 
 		new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
+			.addUniquePaths(['unique'])
 			.onSetup(() => {
 				return { data: { entityType: UMB_MEMBER_ENTITY_TYPE, preset: {} } };
 			})

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/paths.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/paths.ts
@@ -17,4 +17,7 @@ export const UMB_CREATE_MEMBER_WORKSPACE_PATH_PATTERN = new UmbPathPattern<{
 	memberTypeUnique: string;
 }>('create/:memberTypeUnique', UMB_MEMBER_WORKSPACE_PATH);
 
-export const UMB_EDIT_MEMBER_WORKSPACE_PATH_PATTERN = new UmbPathPattern<{ unique: string }>('edit/:unique');
+export const UMB_EDIT_MEMBER_WORKSPACE_PATH_PATTERN = new UmbPathPattern<{ unique: string }>(
+	'edit/:unique',
+	UMB_MEMBER_WORKSPACE_PATH,
+);

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context-token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context-token.ts
@@ -1,3 +1,4 @@
+import { UMB_MEMBER_ENTITY_TYPE } from '../../entity.js';
 import type { UmbMemberWorkspaceContext } from './member-workspace.context.js';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbSubmittableWorkspaceContext } from '@umbraco-cms/backoffice/workspace';
@@ -8,5 +9,5 @@ export const UMB_MEMBER_WORKSPACE_CONTEXT = new UmbContextToken<
 >(
 	'UmbWorkspaceContext',
 	undefined,
-	(context): context is UmbMemberWorkspaceContext => context.getEntityType?.() === 'member',
+	(context): context is UmbMemberWorkspaceContext => context.getEntityType?.() === UMB_MEMBER_ENTITY_TYPE,
 );

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -81,10 +81,10 @@ export class UmbMemberWorkspaceContext
 			{
 				path: 'edit/:unique',
 				component: () => new UmbMemberWorkspaceEditorElement(),
-				setup: (_component, info) => {
+				setup: async (_component, info) => {
 					this.removeUmbControllerByAlias(UmbWorkspaceIsNewRedirectControllerAlias);
 					const unique = info.match.params.unique;
-					this.load(unique);
+					await this.load(unique);
 				},
 			},
 		]);

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -3,12 +3,12 @@ import type { UmbMemberDetailModel, UmbMemberVariantModel } from '../../types.js
 import { UmbMemberPropertyDatasetContext } from '../../property-dataset-context/member-property-dataset.context.js';
 import { UMB_MEMBER_ENTITY_TYPE, UMB_MEMBER_ROOT_ENTITY_TYPE } from '../../entity.js';
 import { UMB_MEMBER_DETAIL_REPOSITORY_ALIAS } from '../../repository/detail/manifests.js';
+import { UMB_CREATE_MEMBER_WORKSPACE_PATH_PATTERN, UMB_EDIT_MEMBER_WORKSPACE_PATH_PATTERN } from '../../paths.js';
 import {
 	UMB_MEMBER_WORKSPACE_ALIAS,
 	UMB_MEMBER_WORKSPACE_VIEW_MEMBER_ALIAS,
 	UMB_MEMBER_DETAIL_MODEL_VARIANT_SCAFFOLD,
 } from './constants.js';
-import { UmbMemberWorkspaceEditorElement } from './member-workspace-editor.element.js';
 import { UmbMemberTypeDetailRepository, type UmbMemberTypeDetailModel } from '@umbraco-cms/backoffice/member-type';
 import {
 	UmbWorkspaceIsNewRedirectController,
@@ -65,8 +65,8 @@ export class UmbMemberWorkspaceContext
 
 		this.routes.setRoutes([
 			{
-				path: 'create/:memberTypeUnique',
-				component: () => new UmbMemberWorkspaceEditorElement(),
+				path: UMB_CREATE_MEMBER_WORKSPACE_PATH_PATTERN.toString(),
+				component: () => import('./member-workspace-editor.element.js'),
 				setup: async (_component, info) => {
 					const memberTypeUnique = info.match.params.memberTypeUnique;
 					await this.create(memberTypeUnique);
@@ -79,8 +79,8 @@ export class UmbMemberWorkspaceContext
 				},
 			},
 			{
-				path: 'edit/:unique',
-				component: () => new UmbMemberWorkspaceEditorElement(),
+				path: UMB_EDIT_MEMBER_WORKSPACE_PATH_PATTERN.toString(),
+				component: () => import('./member-workspace-editor.element.js'),
 				setup: async (_component, info) => {
 					this.removeUmbControllerByAlias(UmbWorkspaceIsNewRedirectControllerAlias);
 					const unique = info.match.params.unique;


### PR DESCRIPTION
### Description

Fixes #20085.

The logic for for the Member's workspace default routing wasn't working (this could be a potential bug with `redirectTo`?), but following the logic/pattern (using the `resolve` method) from the Document workspace, I have refactored accordingly.

### How to test?

Using the Member Picker property-editor, try clicking on the member name to open the edit workspace in the modal. It shouldn't 404 anymore.

