### PR TITLE
Tiptap RTE: Adds hover and focus border input states

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -261,6 +261,15 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				max-width: var(--umb-rte-max-width, 100%);
 			}
 
+			:host(:hover) {
+				--umb-tiptap-edge-border-color: var(--uui-color-border-standalone);
+			}
+
+			:host(:focus),
+			:host(:focus-within) {
+				--umb-tiptap-edge-border-color: var(--uui-color-border-emphasis);
+			}
+
 			:host([readonly]) {
 				pointer-events: none;
 
@@ -302,10 +311,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				&[data-loaded] {
 					border-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
-
-					&:hover:not(:has(.ProseMirror-focused)) {
-						border-color: var(--uui-color-border-standalone);
-					}
 				}
 
 				> .tiptap {
@@ -340,8 +345,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 			}
-			#editor:has(.ProseMirror-focused) {
-				border-color: var(--uui-color-border-standalone);
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -1,4 +1,3 @@
-
 import { UmbTiptapRteContext } from '../../contexts/tiptap-rte.context.js';
 import type { UmbTiptapExtensionApi } from '../../extensions/types.js';
 import type { UmbTiptapStatusbarValue, UmbTiptapToolbarValue } from '../types.js';
@@ -173,13 +172,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 		this._editor = new Editor({
 			element: element,
-			editable: !this.readonly,
-			editorProps: {
-				attributes: {
-					'aria-label': this.label || this.localize.term('rte_label'),
-					'aria-required': this.required ? 'true' : 'false',
-				},
-			},
+			editorProps: { attributes: { 'aria-label': this.label ?? 'Rich Text Editor' } },
 			extensions: tiptapExtensions,
 			content: this.#value,
 			injectCSS: false, // Prevents injecting CSS into `window.document`, as it never applies to the shadow DOM. [LK]

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -291,6 +291,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border: 1px solid transparent;
 				padding: 1rem;
 				box-sizing: border-box;
+				transition: border-color 120ms ease-out;
 
 				height: var(--umb-rte-height, 100%);
 				min-height: var(--umb-rte-min-height, 100%);
@@ -301,6 +302,10 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				&[data-loaded] {
 					border-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
+
+					&:hover:not(:has(.ProseMirror-focused)) {
+						border-color: var(--uui-color-border-standalone);
+					}
 				}
 
 				> .tiptap {
@@ -330,11 +335,15 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				}
 			}
 
-			umb-tiptap-toolbar + #editor {
+				umb-tiptap-toolbar + #editor {
 				border-top: 0;
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 			}
+			#editor:has(.ProseMirror-focused) {
+				border-color: var(--uui-color-border-standalone);
+				
+				
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -291,6 +291,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border: 1px solid transparent;
 				padding: 1rem;
 				box-sizing: border-box;
+				transition: border-color 120ms ease-out;
 
 				height: var(--umb-rte-height, 100%);
 				min-height: var(--umb-rte-min-height, 100%);
@@ -301,6 +302,10 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				&[data-loaded] {
 					border-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
+
+					&:hover:not(:has(.ProseMirror-focused)) {
+						border-color: var(--uui-color-border-standalone);
+					}
 				}
 
 				> .tiptap {
@@ -330,11 +335,13 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				}
 			}
 
-			umb-tiptap-toolbar + #editor {
+				umb-tiptap-toolbar + #editor {
 				border-top: 0;
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 			}
+			#editor:has(.ProseMirror-focused) {
+				border-color: var(--uui-color-border-standalone);
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -172,6 +172,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 		this._editor = new Editor({
 			element: element,
+			editable: !this.readonly,
 			editorProps: { attributes: { 'aria-label': this.label ?? 'Rich Text Editor' } },
 			extensions: tiptapExtensions,
 			content: this.#value,

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -300,7 +300,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border: 1px solid transparent;
 				padding: 1rem;
 				box-sizing: border-box;
-				transition: border-color 120ms ease-out;
 
 				height: var(--umb-rte-height, 100%);
 				min-height: var(--umb-rte-min-height, 100%);
@@ -338,6 +337,12 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 					border-bottom-left-radius: 0;
 					border-bottom-right-radius: 0;
 				}
+			}
+
+			#editor,
+			umb-tiptap-toolbar,
+			umb-tiptap-statusbar {
+				transition: border-color 120ms ease-out;
 			}
 
 			umb-tiptap-toolbar + #editor {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -335,7 +335,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				}
 			}
 
-				umb-tiptap-toolbar + #editor {
+			umb-tiptap-toolbar + #editor {
 				border-top: 0;
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -1,3 +1,4 @@
+
 import { UmbTiptapRteContext } from '../../contexts/tiptap-rte.context.js';
 import type { UmbTiptapExtensionApi } from '../../extensions/types.js';
 import type { UmbTiptapStatusbarValue, UmbTiptapToolbarValue } from '../types.js';
@@ -173,7 +174,12 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		this._editor = new Editor({
 			element: element,
 			editable: !this.readonly,
-			editorProps: { attributes: { 'aria-label': this.label ?? 'Rich Text Editor' } },
+			editorProps: {
+				attributes: {
+					'aria-label': this.label || this.localize.term('rte_label'),
+					'aria-required': this.required ? 'true' : 'false',
+				},
+			},
 			extensions: tiptapExtensions,
 			content: this.#value,
 			injectCSS: false, // Prevents injecting CSS into `window.document`, as it never applies to the shadow DOM. [LK]
@@ -291,7 +297,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border: 1px solid transparent;
 				padding: 1rem;
 				box-sizing: border-box;
-				transition: border-color 120ms ease-out;
 
 				height: var(--umb-rte-height, 100%);
 				min-height: var(--umb-rte-min-height, 100%);
@@ -302,10 +307,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				&[data-loaded] {
 					border-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
-
-					&:hover:not(:has(.ProseMirror-focused)) {
-						border-color: var(--uui-color-border-standalone);
-					}
 				}
 
 				> .tiptap {
@@ -335,15 +336,11 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				}
 			}
 
-				umb-tiptap-toolbar + #editor {
+			umb-tiptap-toolbar + #editor {
 				border-top: 0;
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 			}
-			#editor:has(.ProseMirror-focused) {
-				border-color: var(--uui-color-border-standalone);
-				
-				
 		`,
 	];
 }


### PR DESCRIPTION
### Description
Added a border on TipTap RTE editor input field when hovering and in focus mode to provide a visible indication when they have the input in focus.

<!-- Thanks for contributing to Umbraco CMS! -->
