### PR TITLE
Extension Insights: Fixes CSS alignment (fixes #20170)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/components/collection-filter-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/components/collection-filter-field.element.ts
@@ -33,6 +33,10 @@ export class UmbCollectionFilterFieldElement extends UmbLitElement {
 
 	static override readonly styles = [
 		css`
+			:host {
+				display: flex;
+			}
+
 			uui-input {
 				width: 100%;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/extension-insights/collection/extension-collection.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/extension-insights/collection/extension-collection.element.ts
@@ -49,19 +49,18 @@ export class UmbExtensionCollectionElement extends UmbCollectionDefaultElement {
 	static override styles = [
 		css`
 			#toolbar {
-				flex: 1;
 				display: flex;
 				gap: var(--uui-size-space-5);
 				justify-content: space-between;
 				align-items: center;
-			}
 
-			umb-collection-filter-field {
-				width: 100%;
-			}
+				umb-collection-filter-field {
+					flex: 1;
+				}
 
-			uui-select {
-				width: 100%;
+				uui-select {
+					flex: 1;
+				}
 			}
 		`,
 	];


### PR DESCRIPTION
### Description

Fixes #20170.

Adjusts alignment of the Extension Insights collection toolbar.

