### PR TITLE
Workspace Actions: set attributes on the right element for label to work

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-entity-action-menu/workspace-entity-action-menu.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-entity-action-menu/workspace-entity-action-menu.element.ts
@@ -31,11 +31,10 @@ export class UmbWorkspaceEntityActionMenuElement extends UmbLitElement {
 		if (!this._entityType) return nothing;
 		if (this._unique === undefined) return nothing;
 
-		return html`<umb-entity-actions-dropdown>
-			<uui-symbol-more
-				slot="label"
-				data-mark="workspace:action-menu-button"
-				label=${this.localize.term('general_actions')}></uui-symbol-more>
+		return html`<umb-entity-actions-dropdown
+			data-mark="workspace:action-menu-button"
+			label=${this.localize.term('general_actions')}>
+			<uui-symbol-more slot="label"></uui-symbol-more>
 		</umb-entity-actions-dropdown>`;
 	}
 


### PR DESCRIPTION
Fixes the label for Workspace Actions button