### PR TITLE
Variants: Implements validation hints to the variant selector (closes #19953)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -106,7 +106,11 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 					this._hintMap.clear();
 					hints?.forEach((hint) => {
 						if (this.#isVariantHint(hint) && hint.variantId) {
-							this._hintMap.set(hint.variantId.toString(), hint);
+							// Add the hint if there is no existing hint for this variantId or if the existing hint has a lower weight
+							const existingHint = this._hintMap.get(hint.variantId.toString());
+							if (!existingHint || existingHint.weight < hint.weight) {
+								this._hintMap.set(hint.variantId.toString(), hint);
+							}
 						}
 					});
 					this.requestUpdate('_hintMap');


### PR DESCRIPTION
## Description

Closes #19953

This pull request enhances the `umb-workspace-split-view-variant-selector` component by integrating contextual hint badges for variants. The main improvements involve consuming the hint context, mapping variant-specific hints, and displaying badges for relevant variants in the UI.

**Hint context integration and display:**

* Consumes the `UMB_HINT_CONTEXT` and observes descending hints, populating a `_hintMap` of `variantId` to `UmbVariantHint` for efficient lookup. [[1]](diffhunk://#diff-c852f39a1f0048eb1c86d2b3b75879e51f040dbdfb939801dfb262b9c24e71e9R13-R14) [[2]](diffhunk://#diff-c852f39a1f0048eb1c86d2b3b75879e51f040dbdfb939801dfb262b9c24e71e9R101-R133)
* Adds logic to display the highest-priority hint badge for inactive variants in both the main selector button and the variant list, using the new `#renderHintBadge` method. [[1]](diffhunk://#diff-c852f39a1f0048eb1c86d2b3b75879e51f040dbdfb939801dfb262b9c24e71e9R331-R340) [[2]](diffhunk://#diff-c852f39a1f0048eb1c86d2b3b75879e51f040dbdfb939801dfb262b9c24e71e9R369) [[3]](diffhunk://#diff-c852f39a1f0048eb1c86d2b3b75879e51f040dbdfb939801dfb262b9c24e71e9R424) [[4]](diffhunk://#diff-c852f39a1f0048eb1c86d2b3b75879e51f040dbdfb939801dfb262b9c24e71e9R434-R440)
* Ensures that each variant option in the list shows its associated hint badge when not active, improving user awareness of variant-specific issues or statuses.

**Supporting logic and refactoring:**

* Implements a type guard `#isVariantHint` to distinguish `UmbVariantHint` objects from other hints.
* Refactors rendering logic to use the hint map and active state consistently.

## Screenshots

**The validation hint happened on another variant than the active**
<img width="562" height="75" alt="image" src="https://github.com/user-attachments/assets/482a9d27-7199-4080-9884-8e3f85b95df4" />

----

<img width="543" height="164" alt="image" src="https://github.com/user-attachments/assets/d46d4c07-add0-41ec-b0fa-81dee4ff317d" />

----

**Go to the variant with a hint**
<img width="673" height="400" alt="image" src="https://github.com/user-attachments/assets/a2030128-f183-4153-b82b-6774476e06cf" />