### PR TITLE
Segments: Auto unfold the culture variant in non-culture-variant mode

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-split-view-variant-selector.element.ts
@@ -5,8 +5,7 @@ import { customElement, html, state } from '@umbraco-cms/backoffice/external/lit
 import { DocumentVariantStateModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { UmbWorkspaceSplitViewVariantSelectorElement } from '@umbraco-cms/backoffice/workspace';
 
-const elementName = 'umb-document-workspace-split-view-variant-selector';
-@customElement(elementName)
+@customElement('umb-document-workspace-split-view-variant-selector')
 export class UmbDocumentWorkspaceSplitViewVariantSelectorElement extends UmbWorkspaceSplitViewVariantSelectorElement<UmbDocumentVariantOptionModel> {
 	protected override _variantSorter = sortVariants;
 
@@ -68,6 +67,6 @@ export class UmbDocumentWorkspaceSplitViewVariantSelectorElement extends UmbWork
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbDocumentWorkspaceSplitViewVariantSelectorElement;
+		'umb-document-workspace-split-view-variant-selector': UmbDocumentWorkspaceSplitViewVariantSelectorElement;
 	}
 }


### PR DESCRIPTION
In a Segment only variant scenario then unfold the Culture Variant, so we can see all the segments up front:
<img width="747" height="304" alt="image" src="https://github.com/user-attachments/assets/16d46807-a4cc-458d-89a1-4e4f3536f623" />
