### PR TITLE
UX: Fix overflow of `umb-editor-header` if the description is locked and too long

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/panel.less
+++ b/src/Umbraco.Web.UI.Client/src/less/panel.less
@@ -444,4 +444,7 @@ input.umb-panel-header-description {
     margin: 2px 0 0 0;
     height: 22px;
     line-height: 22px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editor-header.html
@@ -9,7 +9,7 @@
             </button>
         </div>
 
-        <div class="flex items-center" style="flex: 1;">
+        <div class="flex items-center" style="flex: 1; width: 100%;">
 
             <ng-form data-element="editor-icon" name="iconForm">
                 <button
@@ -25,7 +25,7 @@
                 </button>
             </ng-form>
 
-            <div id="nameField" class="umb-editor-header__name-and-description" style="flex: 1 1 auto;">
+            <div id="nameField" class="umb-editor-header__name-and-description" style="flex: 1; width: calc(100% - 75px);">
                 <div>
                     <p tabindex="0" class="sr-only" ng-show="accessibility.a11yMessageVisible">
                         {{accessibility.a11yMessage}}
@@ -78,7 +78,7 @@
                        ng-if="!hideDescription && !descriptionLocked"
                        ng-model="$parent.description"/>
 
-                <p class="umb-panel-header-locked-description" id="editor-description-{{$id}}" ng-if="descriptionLocked">{{ description }}</p>
+                <p class="umb-panel-header-locked-description" id="editor-description-{{$id}}" ng-if="descriptionLocked" title="{{description}}">{{ description }}</p>
 
             </div>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco.Forms.Issues/issues/1419

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
The `umb-editor-header` description would spill onto two lines rather than be hidden with ellipses if it were locked and too long (as per the linked issue above)

This change hides any overflowing text and adds a `title` attribute so the whole description can be read.

Top of the screenshot is before (as per the linked issue) and bottom screenshot is after

<img width="1423" height="522" alt="image" src="https://github.com/user-attachments/assets/1f72cd85-be7d-4432-8312-6db2613ca4e2" />


<!-- Thanks for contributing to Umbraco CMS! -->
