### PR TITLE
Tree: Optimize tree root calls

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
@@ -156,8 +156,6 @@ export class UmbDefaultTreeContext<
 			this.#loadRootItems(reload);
 			return;
 		}
-
-		this.#loadTreeRoot();
 	}
 
 	async #loadTreeRoot() {

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/data-type-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/data-type-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbDataTypeTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbDataTypeTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/tree/dictionary-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/tree/dictionary-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbDictionaryTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbDictionaryTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/document-blueprint-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/document-blueprint-tree.repository.ts
@@ -18,7 +18,7 @@ export class UmbDocumentBlueprintTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbDocumentBlueprintTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/document-type-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/document-type-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbDocumentTypeTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbDocumentTypeTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/data/document-recycle-bin-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/data/document-recycle-bin-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbDocumentRecycleBinTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data = {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/document-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/document-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbDocumentTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbDocumentTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/media-type-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/media-type-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbMediaTypeTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbMediaTypeTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/media-recycle-bin-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbMediaRecycleBinTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data = {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.repository.ts
@@ -25,7 +25,7 @@ export class UmbMediaTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbMediaTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/member-type-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/member-type-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbMemberTypeTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbMemberTypeTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/tree/static-file-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/tree/static-file-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbStaticFileTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbStaticFileTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/partial-view-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/partial-view-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbPartialViewTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbPartialViewTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/script-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/script-tree.repository.ts
@@ -12,7 +12,7 @@ export class UmbScriptTreeRepository extends UmbTreeRepositoryBase<UmbScriptTree
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbScriptTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/stylesheet-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/stylesheet-tree.repository.ts
@@ -14,7 +14,7 @@ export class UmbStylesheetTreeRepository extends UmbTreeRepositoryBase<
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbStylesheetTreeRootModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/template-tree.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/template-tree.repository.ts
@@ -15,7 +15,7 @@ export class UmbTemplateTreeRepository
 	}
 
 	async requestTreeRoot() {
-		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 1 });
+		const { data: treeRootData } = await this._treeSource.getRootItems({ skip: 0, take: 0 });
 		const hasChildren = treeRootData ? treeRootData.total > 0 : false;
 
 		const data: UmbTemplateTreeRootModel = {


### PR DESCRIPTION
This pull request updates the logic for requesting tree root items across all tree repository classes. The main change is to request zero items (`take: 0`) instead of one (`take: 1`) when checking for the existence of children in tree root queries. 

It also removed an unnecessary call to load the root in `UmbDefaultTreeContext` that resulted in a double server request.