### PR TITLE
Update label for tree item caret to identify if open or closed 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
@@ -2210,6 +2210,7 @@ export default {
 		searchContentTree: "Chwilio'r coeden cynnwys",
 		maxAmount: 'Uchafswm',
 		expandChildItems: 'Ehangu eitemau plentyn ar gyfer',
+		collapseChildItems: 'Cuddio eitemau plant ar gyfer',
 		openContextNode: 'Agor nod cyd-destun ar gyfer',
 	},
 	references: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -2349,6 +2349,7 @@ export default {
 		maxAmount: 'Maximum antal',
 		contextDialogDescription: 'Perform action %0% on the %1% node',
 		expandChildItems: 'Udvid underordnede elementer for',
+		collapseChildItems: 'Skjul underordnede elementer for',
 		openContextNode: 'Åbn kontekstnode for',
 	},
 	references: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2407,6 +2407,7 @@ export default {
 		searchContentTree: 'Search content tree',
 		maxAmount: 'Maximum amount',
 		expandChildItems: 'Expand child items for',
+		collapseChildItems: 'Collapse child items for',
 		openContextNode: 'Open context node for',
 	},
 	references: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
@@ -1872,6 +1872,7 @@ export default {
 		searchContentTree: "Chercher dans l'arborescence de contenu",
 		maxAmount: 'Quantité maximum',
 		expandChildItems: 'Afficher les éléments enfant pour',
+		collapseChildItems: 'Cacher les éléments enfant pour',
 		openContextNode: 'Ouvrir le noeud de contexte pour',
 	},
 	references: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -2406,6 +2406,7 @@ export default {
 		searchContentTree: 'Pesquisar Árvore de Conteúdo',
 		maxAmount: 'Quantidade máxima',
 		expandChildItems: 'Expandir itens filhos para',
+		collapseChildItems: 'Fechar itens filhos para',
 		openContextNode: 'Abrir nó de contexto para',
 	},
 	references: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
@@ -317,6 +317,7 @@ export default {
 		searchContentTree: 'Sök i innehållsträdet',
 		maxAmount: 'Maximalt värde',
 		expandChildItems: 'Visa underliggande noder för',
+		collapseChildItems: 'Dölj underliggande noder för',
 		openContextNode: 'Öppna kontext för',
 	},
 	prompt: {

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
@@ -2409,6 +2409,7 @@ export default {
 		searchContentTree: 'Tìm kiếm cây nội dung',
 		maxAmount: 'Số lượng tối đa',
 		expandChildItems: 'Mở rộng các mục con cho',
+		collapseChildItems: 'Thu gọn các mục con cho',
 		openContextNode: 'Mở nút ngữ cảnh cho %0%',
 	},
 	references: {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
@@ -136,7 +136,7 @@ export abstract class UmbTreeItemElementBase<
 				.loading=${this._isLoading}
 				.hasChildren=${this._hasChildren}
 				.showChildren=${this._isOpen}
-				.caretLabel=${this.localize.term('visuallyHiddenTexts_expandChildItems') + ' ' + this._label}
+				.caretLabel=${this._isOpen ? this.localize.term('visuallyHiddenTexts_collapseChildItems') +  ' ' + this._label: this.localize.term('visuallyHiddenTexts_expandChildItems') + ' ' + this._label}
 				label=${this._label}
 				href="${ifDefined(this._isSelectableContext ? undefined : this._href)}">
 				${this.renderIconContainer()} ${this.renderLabel()} ${this.#renderActions()} ${this.#renderChildItems()}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -1,4 +1,3 @@
-
 import { UmbTiptapRteContext } from '../../contexts/tiptap-rte.context.js';
 import type { UmbTiptapExtensionApi } from '../../extensions/types.js';
 import type { UmbTiptapStatusbarValue, UmbTiptapToolbarValue } from '../types.js';
@@ -173,13 +172,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 		this._editor = new Editor({
 			element: element,
-			editable: !this.readonly,
-			editorProps: {
-				attributes: {
-					'aria-label': this.label || this.localize.term('rte_label'),
-					'aria-required': this.required ? 'true' : 'false',
-				},
-			},
+			editorProps: { attributes: { 'aria-label': this.label ?? 'Rich Text Editor' } },
 			extensions: tiptapExtensions,
 			content: this.#value,
 			injectCSS: false, // Prevents injecting CSS into `window.document`, as it never applies to the shadow DOM. [LK]

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -291,6 +291,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border: 1px solid transparent;
 				padding: 1rem;
 				box-sizing: border-box;
+				transition: border-color 120ms ease-out;
 
 				height: var(--umb-rte-height, 100%);
 				min-height: var(--umb-rte-min-height, 100%);
@@ -301,6 +302,10 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				&[data-loaded] {
 					border-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
+
+					&:hover:not(:has(.ProseMirror-focused)) {
+						border-color: var(--uui-color-border-standalone);
+					}
 				}
 
 				> .tiptap {
@@ -330,11 +335,15 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				}
 			}
 
-			umb-tiptap-toolbar + #editor {
+				umb-tiptap-toolbar + #editor {
 				border-top: 0;
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 			}
+			#editor:has(.ProseMirror-focused) {
+				border-color: var(--uui-color-border-standalone);
+				
+				
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -172,6 +172,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 		this._editor = new Editor({
 			element: element,
+			editable: !this.readonly,
 			editorProps: { attributes: { 'aria-label': this.label ?? 'Rich Text Editor' } },
 			extensions: tiptapExtensions,
 			content: this.#value,

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -1,3 +1,4 @@
+
 import { UmbTiptapRteContext } from '../../contexts/tiptap-rte.context.js';
 import type { UmbTiptapExtensionApi } from '../../extensions/types.js';
 import type { UmbTiptapStatusbarValue, UmbTiptapToolbarValue } from '../types.js';
@@ -173,7 +174,12 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		this._editor = new Editor({
 			element: element,
 			editable: !this.readonly,
-			editorProps: { attributes: { 'aria-label': this.label ?? 'Rich Text Editor' } },
+			editorProps: {
+				attributes: {
+					'aria-label': this.label || this.localize.term('rte_label'),
+					'aria-required': this.required ? 'true' : 'false',
+				},
+			},
 			extensions: tiptapExtensions,
 			content: this.#value,
 			injectCSS: false, // Prevents injecting CSS into `window.document`, as it never applies to the shadow DOM. [LK]
@@ -291,7 +297,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				border: 1px solid transparent;
 				padding: 1rem;
 				box-sizing: border-box;
-				transition: border-color 120ms ease-out;
 
 				height: var(--umb-rte-height, 100%);
 				min-height: var(--umb-rte-min-height, 100%);
@@ -302,10 +307,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 
 				&[data-loaded] {
 					border-color: var(--umb-tiptap-edge-border-color, var(--uui-color-border));
-
-					&:hover:not(:has(.ProseMirror-focused)) {
-						border-color: var(--uui-color-border-standalone);
-					}
 				}
 
 				> .tiptap {
@@ -335,15 +336,11 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				}
 			}
 
-				umb-tiptap-toolbar + #editor {
+			umb-tiptap-toolbar + #editor {
 				border-top: 0;
 				border-top-left-radius: 0;
 				border-top-right-radius: 0;
 			}
-			#editor:has(.ProseMirror-focused) {
-				border-color: var(--uui-color-border-standalone);
-				
-				
 		`,
 	];
 }


### PR DESCRIPTION

### Description

Added localized term on label for tree item caret button, to say expand or collapse, depending on the state.

I am currently unsure if this should be implemented in [\menu-item-layout\menu-item-layout.element.ts](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts) as well.

<!-- Thanks for contributing to Umbraco CMS! -->
