### PR TITLE
View Context: observe parent activation to make sure children follows along.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -139,7 +139,7 @@ export class UmbViewController extends UmbControllerBase {
 		const wasActive = this.isActive;
 		this.#attached = true;
 		super.hostConnected();
-		// CHeck that we have a providerController, otherwise this is not provided. [NL]
+		// Check that we have a providerController, otherwise this is not provided. [NL]
 		if (this.#autoActivate && !wasActive) {
 			this._internal_activate();
 		}
@@ -152,7 +152,7 @@ export class UmbViewController extends UmbControllerBase {
 		this.#active.setValue(false);
 		super.hostDisconnected();
 		if (wasAttached === true && wasActive) {
-			// CHeck that we have a providerController, otherwise this is not provided. [NL]
+			// Check that we have a providerController, otherwise this is not provided. [NL]
 			this.#propagateActivation();
 		}
 	}


### PR DESCRIPTION
There is a bug when a modal is opening from a view context that is not bottom most. Example a Content Picker on a Document.
When returning, the triggerede view context is not the bottom most, making it ignore the activiate because it knows it has a more specific View Context. But instead the Child View Context should watch the parent one to know that is should re-active.
This feature has not been released yet and therefor the ignorer for release.