### PR TITLE
Property editors: Ensure values no longer allowed as options in checkbox list configuration are removed from the value, such that they will be removed from the persisted data when saved

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/checkboxlist/checkboxlist.controller.js
@@ -31,6 +31,10 @@ angular.module("umbraco").controller("Umbraco.PropertyEditors.CheckboxListContro
                 if ($scope.model.value === null || $scope.model.value === undefined) {
                     $scope.model.value = [];
                 }
+
+                // ensure any values that are not in the config are removed from the model.value (i.e. if the config has changed since the value was saved).
+                var validValues = vm.configItems.map(item => item.value);
+                $scope.model.value = $scope.model.value.filter(val => validValues.includes(val));
                 
                 // update view model.
                 generateViewModel($scope.model.value);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Brought to attention from Umbraco support case.

### Description
> I have a customer that had updated a Checkboxlists predefined values, and those new values are reflecting in the backoffice to pick from but when they pick one and publish the content node, the frontend is still showing one of the old predefined values?

I've verified I can replicate the problem via:

- Creating a property using check box list with options A, B and C
- Created a document using the property and checked A and B
- Rendered and as expected I see A and B
- Removed B as an option
- As expected - on the front-end, I still see A and B
- As expected - in the backoffice I can now only select A and C
- Republished the page with and without changing the values - I still see B on the front-end and can't get rid of it.

So basically once a value is allowed for selection and selected, you can't remove it.

I've resolved it in this PR by, on the client, when initialising the checkbox list property editor, removing any values from the model that are no longer valid according to the configuration.  With that done, when the document is saved, the no longer valid values are removed.

Maybe this isn't how we'd want to handle it in the latest version, where we try not to silently modify values and rather given the editor the option to see and explicitly remove the no longer valid value - for 13 I think this is a reasonable approach, it requires much less effort on the client-side.  And otherwise you are a bit stuck, short of modifying values in the database tables.
