### PR TITLE
Caching: Don't remove null values from hybrid cache to avoid broken content references repeatedly requiring a database hit (closes #18892)

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -132,10 +132,8 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             GetEntryOptions(key, preview),
             GenerateTags(key));
 
-        // We don't want to cache removed items, this may cause issues if the L2 serializer changes.
         if (contentCacheNode is null)
         {
-            await _hybridCache.RemoveAsync(cacheKey);
             return null;
         }
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -135,11 +135,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         // We don't want to cache removed items, this may cause issues if the L2 serializer changes.
         if (contentCacheNode is null)
         {
-            // We don't have to remove if it's published, we'll clear this node again if deleted/published
-            if (preview)
-            {
-                await _hybridCache.RemoveAsync(cacheKey);
-            }
+            await _hybridCache.RemoveAsync(cacheKey);
             return null;
         }
 
@@ -344,9 +340,12 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
         foreach (ContentCacheNode content in contentByContentTypeKey)
         {
-            // Always remove both types of nodes regardless of published status, as we might have cached null values..
-            await _hybridCache.RemoveAsync(GetCacheKey(content.Key, true));
-            await _hybridCache.RemoveAsync(GetCacheKey(content.Key, false));
+            _hybridCache.RemoveAsync(GetCacheKey(content.Key, true)).GetAwaiter().GetResult();
+
+            if (content.IsDraft is false)
+            {
+                _hybridCache.RemoveAsync(GetCacheKey(content.Key, false)).GetAwaiter().GetResult();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/18892

# Notes
- Thanks to some investigate work from @enkelmedia, fetching deleted nodes from for example a MultiNodeTree picker, will try to fetch the deleted content, resulting in a Database hit.
- This PR remedies that, by also caching null values.
- A little background on the decision not to cache null values, was that we had no way of deleting nodes with keys that we did not know. Now we can delete all content by tags, so we have a way of removing them again 😁 


# How to test
- Make content picker datatype which can choose multiple content
- Make a content type using that datatype
- Create 2 different documents, 1 referencing the other, save and publish, then delete the referenced content.
- In your template for the existing content, try getting the value of the multi node picker with `@Model.Value("propertytype name here")`
- This should no longer result in a database hit (atleast after the first get), as we will cache the null value