### PR TITLE
Fix DecimalPropertyEditor on non-English systems

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
@@ -64,11 +64,18 @@ public class DecimalPropertyEditor : DataEditor
             => TryParsePropertyValue(editorValue.Value);
 
         private static decimal? TryParsePropertyValue(object? value)
-            => value is decimal decimalValue
-                ? decimalValue
-                : decimal.TryParse(value?.ToString(), CultureInfo.InvariantCulture, out var parsedDecimalValue)
-                    ? parsedDecimalValue
-                    : null;
+            => value switch
+            {
+                decimal d => d,
+                double db => (decimal)db,
+                float f => (decimal)f,
+                IFormattable f => decimal.TryParse(f.ToString(null, CultureInfo.InvariantCulture), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedDecimalValue)
+                        ? parsedDecimalValue
+                        : null,
+                _ => decimal.TryParse(value?.ToString(), CultureInfo.CurrentCulture, out var parsedDecimalValue)
+                        ? parsedDecimalValue
+                        : null
+            };
 
         /// <summary>
         /// Base validator for the decimal property editor validation against data type configured values.


### PR DESCRIPTION
This PR addresses #20214 in two ways. 

First, since the value passed in from the client will always be a double, it adds direct conversions from double and float, without going via a string. This also saves unnecessarily allocating a string.

Second, it fixes the string parsing by using `CurrentCulture`, since that is what `ToString()` with no arguments will do. I also added a case for `IFormattable`, since this will allow us to actually specify `CultureInfo.InvariantCulture` for both `ToString()` and parsing.