### PR TITLE
Block List: Fixed clipboard label for nested block items (closes #19929)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-element-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-element-manager.ts
@@ -84,7 +84,12 @@ export class UmbBlockElementManager<LayoutDataType extends UmbBlockLayoutBaseMod
 
 		// Ugly, but we just inherit these from the workspace context: [NL]
 		this.name = host.name;
-		this.getName = host.getName;
+
+		this.getName = () => {
+			const contentTypeLabel = this.structure.getOwnerContentType()?.name;
+			const blockLabel = host.getName();
+			return `${contentTypeLabel} ${blockLabel}`;
+		};
 
 		this.propertyViewGuard.fallbackToPermitted();
 		this.propertyWriteGuard.fallbackToPermitted();
@@ -94,6 +99,7 @@ export class UmbBlockElementManager<LayoutDataType extends UmbBlockLayoutBaseMod
 				this.structure.loadType(id);
 			}
 		});
+
 		this.observe(this.unique, (key) => {
 			if (key) {
 				this.validation.setDataPath('$.' + dataPathPropertyName + `[?(@.key == '${key}')]`);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -26,6 +26,7 @@ import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UUIModalSidebarSize } from '@umbraco-cms/backoffice/external/uui';
 
 export type UmbBlockWorkspaceElementManagerNames = 'content' | 'settings';
+
 export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseModel = UmbBlockLayoutBaseModel>
 	extends UmbSubmittableWorkspaceContextBase<LayoutDataType>
 	implements UmbRoutableWorkspaceContext
@@ -470,7 +471,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 	}
 
 	getName() {
-		return 'block name content element type here...';
+		return '';
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/copy/copy-to-clipboard.property-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/copy/copy-to-clipboard.property-action.ts
@@ -70,4 +70,5 @@ export class UmbCopyToClipboardPropertyAction extends UmbPropertyActionBase<Meta
 		});
 	}
 }
+
 export { UmbCopyToClipboardPropertyAction as api };


### PR DESCRIPTION
### Description

Fixes #19929.

When copying a block item (at document level), the clipboard uses a concatenation of the document's name, property label and block dynamic label to provide the display label. However when copying nested block items, the Block Workspace does not have a corresponding name, so a hard-coded string was previously used.

The PR removed the hard-coded string and provides the owning element-type name as the initial prefix.

The format will be as follows... `[Element Type Name] - [Property Label] - [Block Label]`.


