### PR TITLE
Content Details Workspace: Throw error when save data is invalid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -897,7 +897,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 				() => false,
 			);
 			if (valid || this.#ignoreValidationResultOnSubmit) {
-				return this.performCreateOrUpdate(variantIds, saveData);
+				return await this.performCreateOrUpdate(variantIds, saveData);
 			} else {
 				throw new Error('Content is not valid');
 			}


### PR DESCRIPTION
### Description

When using the Content Details workspace (e.g. document, media, members), and attempting to save invalid data, the state of the save/submit button does not reflect the response.

<img width="616" height="404" alt="image" src="https://github.com/user-attachments/assets/a786cc6a-4b56-49db-b5f5-05e3813dca5e" />

### How to test?

On a Member, try entering invalid data, e.g. a malformed email address. Notice that the Save button displays the failed state, (a cross, not a tick/check icon).
