### PR TITLE
Localization: Fixes an issue where the fallback localization was not available after changing DefaultUILanguage (fixes #20216)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -118,6 +118,9 @@ export class UmbLocalizationRegistry {
 			)
 			// Subscribe to the observable to trigger the loading of translations
 			.subscribe();
+
+		// Always register the fallback language (en) to ensure there is always at least one language available
+		this.loadLanguage(UMB_DEFAULT_LOCALIZATION_CULTURE);
 	}
 
 	#loadExtension = async (extension: ManifestLocalization) => {


### PR DESCRIPTION
## Description

Fixes #20216

This pull request makes a small but important change to the localization registry to improve language fallback behavior. Now, the fallback language (`en`) is always registered to ensure that there's at least one language available.

* Always registers the fallback language (`UMB_DEFAULT_LOCALIZATION_CULTURE`, which is `en`) in the `UmbLocalizationRegistry` to guarantee a default language is loaded.

On a side note, I also found that the default admin user created after installation always has "en-US" set as display language, despite any other value set in the global settings. This appears to be intended behavior, but it is slightly confusing because any new user created will have the value found in DefaultUILanguage after creation. That could be changed as well, but that is outside the scope of this bug fix.

## How to test

> [!WARNING]
> Test with a new database!

1. Set `Umbraco::CMS::Global::DefaultUILanguage` to something else, such as "sv-SE"
2. Install Umbraco and log in
3. Edit the user profile and set the language to "Svenska" (sv)
4. Log out and back in
5. Verify that no localization keys are shown and that non-translated keys are shown in English