### PR TITLE
Collection view: Wrong `Last edited` date displayed in document collection view (closes #19988)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/repository/document-collection.server.data-source.ts
@@ -48,7 +48,9 @@ export class UmbDocumentCollectionServerDataSource implements UmbCollectionDataS
 					unique: item.id,
 					entityType: UMB_DOCUMENT_ENTITY_TYPE,
 					contentTypeAlias: item.documentType.alias,
-					createDate: new Date(variant.createDate),
+					createDate: item.variants
+						.map((v) => new Date(v.createDate))
+						.reduce((earliest, current) => (current < earliest ? current : earliest)),
 					creator: item.creator,
 					icon: item.documentType.icon,
 					isProtected: item.isProtected,
@@ -56,7 +58,9 @@ export class UmbDocumentCollectionServerDataSource implements UmbCollectionDataS
 					name: variant.name,
 					sortOrder: item.sortOrder,
 					state: variant.state,
-					updateDate: new Date(variant.updateDate),
+					updateDate: item.variants
+						.map((v) => new Date(v.updateDate))
+						.reduce((latest, current) => (current > latest ? current : latest)),
 					updater: item.updater,
 					values: item.values.map((item) => {
 						return { alias: item.alias, value: item.value as string };


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #19988

### Description

When a document has collection view configured and its children vary by culture, the `Last edited` / `updateDate` displayed per document was the `updateDate` of the first variant returned by the API, and not the actual last update date (independently of the variant), which is what the server uses to sort on.
This has now been adjusted to always display the last update date.

#### Testing

1. Add a new language to the backoffice, example: `German (Switzerland)`.
2. Create a document type, with name "News", allowed at root, with a collection view configured (it can be the default `List View - Content`).
3. Create another document type, "News Item", which varies by culture.
4. Allow the "News Item" as a child of the "News" document type.
5. Create a document of type "News", and several documents of type "News Item" inside it in the default culture, `en-US`.
6. For one of the news items in between, create and publish a version in `German (Switzerland)`.

**Before the fix:**
The items are in order, but since the `Last edited` date is not showing the correct value, it looks like they aren't.
<img width="616" height="276" alt="image" src="https://github.com/user-attachments/assets/c31f84fe-e208-4c3e-9885-49e18f6b2803" />

**After the fix:**
The items are in order, looking at the `Last edited` date.
<img width="616" height="276" alt="image" src="https://github.com/user-attachments/assets/5841dddb-ff43-4d6f-ad27-abe38afd8c81" />
