### PR TITLE
Workspace Base: make nonesense getter method to make Lit happy

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.element.ts
@@ -62,6 +62,9 @@ export class UmbWorkspaceEditorElement extends UmbLitElement {
 	public set overrides(value: Array<UmbDeepPartialObject<ManifestWorkspaceView>> | undefined) {
 		this.#navigationContext.setOverrides(value);
 	}
+	public get overrides(): Array<UmbDeepPartialObject<ManifestWorkspaceView>> | undefined {
+		return undefined;
+	}
 
 	@state()
 	private _workspaceViews: Array<UmbWorkspaceViewContext> = [];


### PR DESCRIPTION
Lit started compalining about missing getter methods, therefor this fix.