### PR TITLE
UX: Alignment of date range in log viewer (closes #20220)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/components/log-viewer-date-range-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/components/log-viewer-date-range-selector.element.ts
@@ -102,7 +102,7 @@ export class UmbLogViewerDateRangeSelectorElement extends UmbLitElement {
 
 			:host([horizontal]) .input-container {
 				display: flex;
-				align-items: baseline;
+				align-items: center;
 				gap: var(--uui-size-space-3);
 			}
 		`,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20220

### Description
Center alignment of daterange in logviewer search.

<img width="596" height="241" alt="image" src="https://github.com/user-attachments/assets/4397be72-7635-43a6-bef4-2d70317354a1" />
