### PR TITLE
Adjust height of image crop input append

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
@@ -265,6 +265,7 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 				font-size: var(--uui-type-small-size);
 				display: flex;
 				align-items: center;
+				height: 100%;
 			}
 			.action-wrapper {
 				display: flex;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20166

### Description
Adjusted height of input append in image crop.

<img width="2172" height="479" alt="image" src="https://github.com/user-attachments/assets/a1e7fae9-97a1-41c4-b449-6320cd4122c6" />
