### PR TITLE
UX: Make installed package details read only instead of disabled (closes #20218)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
@@ -122,7 +122,7 @@ export class UmbInstalledPackagesSectionViewItemElement extends UmbLitElement {
 						name=${ifDefined(this.name)}
 						version="${ifDefined(this.version ?? undefined)}"
 						@open=${this.#onConfigure}
-						?disabled="${!this._packageView}">
+						?readonly="${!this._packageView}">
 						${this.customIcon ? html`<umb-icon slot="icon" name=${this.customIcon}></umb-icon>` : nothing}
 						<div slot="tag">
 							${this.hasPendingMigrations


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20218

### Description
Make package item readonly instead of disabled, which solves the text contrast issue.

Furthermore it allows the select text in package item, e.g. name or version.

<img width="2560" height="437" alt="image" src="https://github.com/user-attachments/assets/c3cf2b18-cfff-4935-b031-c464da75ae07" />
