### PR TITLE
Unattended install: Added the ability to set the telemetry level

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/InstallerBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/InstallerBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class InstallerBuilderExtensions
 
         builder.AddInstallSteps();
         services.AddTransient<IInstallService, InstallService>();
-        builder.AddNotificationAsyncHandler<UnattendedInstallNotification, CreateUnattendedUserNotificationHandler>();
+        builder.AddNotificationAsyncHandler<UnattendedInstallNotification, PostUnattendedInstallNotificationHandler>();
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>().Add<InstallerViewModelsMapDefinition>();
 
         return builder;

--- a/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Configuration.Models;
 
@@ -14,6 +15,7 @@ public class UnattendedSettings
 {
     private const bool StaticInstallUnattended = false;
     private const bool StaticUpgradeUnattended = false;
+    private const TelemetryLevel StaticTelemetryLevel = TelemetryLevel.Detailed;
 
     /// <summary>
     ///     Gets or sets a value indicating whether unattended installs are enabled.
@@ -58,4 +60,9 @@ public class UnattendedSettings
     ///     Gets or sets a value to use for creating a user with a password for Unattended Installs
     /// </summary>
     public string? UnattendedUserPassword { get; set; } = null;
+
+    /// <summary>
+    ///     Gets or sets a telemetry level to use for Unattended Installs
+    /// </summary>
+    public TelemetryLevel UnattendedTelemetryLevel { get; set; } = StaticTelemetryLevel;
 }

--- a/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
@@ -64,5 +64,6 @@ public class UnattendedSettings
     /// <summary>
     ///     Gets or sets a telemetry level to use for Unattended Installs
     /// </summary>
+    [DefaultValue(StaticTelemetryLevel)]
     public TelemetryLevel UnattendedTelemetryLevel { get; set; } = StaticTelemetryLevel;
 }

--- a/templates/UmbracoProject/.template.config/dotnetcli.host.json
+++ b/templates/UmbracoProject/.template.config/dotnetcli.host.json
@@ -63,6 +63,10 @@
       "longName": "password",
       "shortName": ""
     },
+    "UnattendedTelemetryLevel": {
+      "longName": "telemetry-level",
+      "shortName": ""
+    },
     "NoNodesViewPath": {
       "longName": "no-nodes-view-path",
       "shortName": ""

--- a/templates/UmbracoProject/.template.config/ide.host.json
+++ b/templates/UmbracoProject/.template.config/ide.host.json
@@ -63,6 +63,11 @@
       "isVisible": true
     },
     {
+      "id": "UnattendedTelemetryLevel",
+      "isVisible": true,
+      "defaultValue": "Detailed"
+    },
+    {
       "id": "NoNodesViewPath",
       "isVisible": true
     },

--- a/templates/UmbracoProject/.template.config/template.json
+++ b/templates/UmbracoProject/.template.config/template.json
@@ -82,7 +82,7 @@
       "replaces": "CUSTOM_VERSION",
       "isRequired": false
     },
-    "FinalVersion" : {
+    "FinalVersion": {
       "type": "generated",
       "generator": "switch",
       "datatype": "text",
@@ -103,8 +103,7 @@
         ]
       }
     },
-    "DotnetVersion":
-    {
+    "DotnetVersion": {
       "type": "generated",
       "generator": "switch",
       "datatype": "text",
@@ -299,6 +298,33 @@
         ]
       },
       "replaces": "UNATTENDED_USER_PASSWORD_FROM_TEMPLATE"
+    },
+    "UnattendedTelemetryLevel": {
+      "displayName": "Unattended telemetry level",
+      "description": "Specifies the level of telemetry information the installation will report.",
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "Detailed",
+      "choices": [
+        {
+          "choice": "Minimal",
+          "description": "Minimal information"
+        },
+        {
+          "choice": "Basic",
+          "description": "Basic information"
+        },
+        {
+          "choice": "Detailed",
+          "description": "Detailed information"
+        }
+      ],
+      "forms": {
+        "global": [
+          "jsonEncode"
+        ]
+      },
+      "replaces": "UNATTENDED_TELEMETRY_LEVEL_FROM_TEMPLATE"
     },
     "UsingUnattenedInstall": {
       "type": "computed",

--- a/templates/UmbracoProject/appsettings.Development.json
+++ b/templates/UmbracoProject/appsettings.Development.json
@@ -35,7 +35,8 @@
         "InstallUnattended": true,
         "UnattendedUserName": "UNATTENDED_USER_NAME_FROM_TEMPLATE",
         "UnattendedUserEmail": "UNATTENDED_USER_EMAIL_FROM_TEMPLATE",
-        "UnattendedUserPassword": "UNATTENDED_USER_PASSWORD_FROM_TEMPLATE"
+        "UnattendedUserPassword": "UNATTENDED_USER_PASSWORD_FROM_TEMPLATE",
+        "UnattendedTelemetryLevel": "UNATTENDED_TELEMETRY_LEVEL_FROM_TEMPLATE"
       },
       //#endif
       "Content": {


### PR DESCRIPTION
# What did I do
I added 'UnattendedTelemetryLevel' to the unattended installer configuration, I used the already existing unattended installer notification handler and renamed it to a better suiting more generic name so I could include the setting of telemetry level.
Also fixed some formatting and comments in the files I edited.

# Why did I do it
I noticed I could set the telemetry level from the regular installer but not from an unattended installation. 
I already applied a patch akin to this one in my own Umbraco project but I thought other people might also want the functionality to set the telemetry level from an unattended install hence this pull request.

# How to test
Add the already present [unattended installation settings](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/install/unattended-install#enable-the-unattended-installs-feature) and add a property in the map with "UnattendedTelemetryLevel" to either "Minimal", "Basic" or "Detailed" like so:
```json
"Umbraco": {
    "CMS": {
      "Unattended": {
        "InstallUnattended": true,
        "UnattendedUserEmail": "test@example.com",
        "UnattendedUserName": "tester",
        "UnattendedUserPassword": "yesverisecure123!",
        "UnattendedTelemetryLevel": "Basic"
      },
    }
  }
```
The unattended installer will now run and set the telemetry level to the value provided in the appsettings. If the level is not set in the appsettings it falls back to 'Detailed' like the regular installer.


If the pull request is merged I shall also update the documentation to match the functionality.
