### PR TITLE
Make remove button consistent with other multi value item remove button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
@@ -189,7 +189,7 @@ export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(
 							<uui-button
 								compact
 								label=${this.localize.term('actions_delete')}
-								look="primary"
+								look="outline"
 								?disabled=${this.disabled}
 								@click=${this.#onDelete}>
 								<uui-icon name="icon-trash"></uui-icon>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20167

### Description
Make remove button in configuration of (approved) color picker consistent with other datatype configuration.

<img width="2168" height="674" alt="image" src="https://github.com/user-attachments/assets/14d827d2-507d-42ae-80d4-f8b8c0bd9d37" />
