### PR TITLE
Add slightly more padding at top so user card outline is not cutoff

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
@@ -189,7 +189,7 @@ export class UmbBodyLayoutElement extends LitElement {
 			:host([header-transparent]:not([main-no-padding])) #main:not(*[style='display: none'] + *) {
 				/* The following styling is only applied if the clear-header IS present,
 				the main-no-padding attribute is NOT present, and the header is NOT hidden */
-				padding-top: var(--uui-size-space-1);
+				padding-top: var(--uui-size-space-2);
 			}
 			:host([main-no-padding]) #main {
 				padding: 0;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
As the title says :)

**Before**

**After**

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/aed4d8f3-25b5-470e-be2d-22c5261910ca" />
