### PR TITLE
Localization/UX: Add a new general translation for "Fields"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -857,6 +857,7 @@ export default {
 		email: 'E-mail',
 		error: 'Fejl',
 		field: 'Felt',
+		fields: 'Felter',
 		fieldFor: 'Felt for %0%',
 		findDocument: 'Find',
 		first: 'Første',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -860,6 +860,7 @@ export default {
 		email: 'Email',
 		error: 'Error',
 		field: 'Field',
+		fields: 'Fields',
 		fieldFor: 'Field for %0%',
 		toggleFor: 'Toggle for %0%',
 		findDocument: 'Find',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
@@ -479,6 +479,7 @@ export default {
 		error: 'Feil',
 		excludeFromSubFolders: 'Søk bare i denne mappen',
 		field: 'Felt',
+		fields: 'Felter',
 		fieldFor: 'Felt for %0%',
 		findDocument: 'Finn',
 		first: 'Første',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -847,6 +847,7 @@ export default {
 		email: 'Email',
 		error: 'Erro',
 		field: 'Campo',
+		fields: 'Campos',
 		fieldFor: 'Campo para %0%',
 		toggleFor: 'Alternar para %0%',
 		findDocument: 'Encontrar',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
@@ -853,6 +853,7 @@ export default {
 		email: 'Email',
 		error: 'Lỗi',
 		field: 'Trường',
+		fields: 'Trường',
 		fieldFor: 'Trường cho %0%',
 		toggleFor: 'Chuyển đổi cho %0%',
 		findDocument: 'Tìm kiếm',

--- a/src/Umbraco.Web.UI.Client/src/packages/search/examine-management-dashboard/modal/fields-settings/examine-fields-settings-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/search/examine-management-dashboard/modal/fields-settings/examine-fields-settings-modal.element.ts
@@ -59,6 +59,7 @@ export class UmbExamineFieldsSettingsModalElement extends UmbModalBaseElement<
 
 			uui-scroll-container {
 				overflow-y: scroll;
+				height: 100%;
 				max-height: 100%;
 				min-height: 0;
 				flex: 1;

--- a/src/Umbraco.Web.UI.Client/src/packages/search/examine-management-dashboard/modal/fields-settings/examine-fields-settings-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/search/examine-management-dashboard/modal/fields-settings/examine-fields-settings-modal.element.ts
@@ -13,7 +13,7 @@ export class UmbExamineFieldsSettingsModalElement extends UmbModalBaseElement<
 	UmbExamineFieldsSettingsModalValue
 > {
 	override render() {
-		return html`<umb-body-layout headline=${this.localize.term('examineManagement_fields')}>
+		return html`<umb-body-layout headline=${this.localize.term('general_fields')}>
 			<uui-scroll-container id="field-settings"> ${this.#renderFields()} </uui-scroll-container>
 			<div slot="actions">
 				<uui-button

--- a/src/Umbraco.Web.UI.Client/src/packages/search/examine-management-dashboard/views/section-view-examine-searchers.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/search/examine-management-dashboard/views/section-view-examine-searchers.ts
@@ -208,7 +208,7 @@ export class UmbDashboardExamineSearcherElement extends UmbLitElement {
 							<uui-table-head-cell style="width:0">Score</uui-table-head-cell>
 							<uui-table-head-cell style="width:0">${this.localize.term('general_id')}</uui-table-head-cell>
 							<uui-table-head-cell>${this.localize.term('general_name')}</uui-table-head-cell>
-							<uui-table-head-cell>${this.localize.term('examineManagement_fields')}</uui-table-head-cell>
+							<uui-table-head-cell>${this.localize.term('general_fields')}</uui-table-head-cell>
 							${this.renderHeadCells()}
 						</uui-table-head>
 						${this._searchResults?.map((rowData) => {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20234

### Description
As the title says - added a new translation key for "Fields", while preserving the original one `examineManagement_fields` in lowercase.

This new translation key can be used in other parts of backoffice along with the existing `general_field` translation.

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/60600173-cd7b-4f43-b468-04ce2447bd8f" />

I also made the `uui-scroll-container` 100% height.

I think we can just use `overflow-y: auto` instead of `overflow-y: scroll;`?

So it looks like this:

<img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/43b1e5ee-4090-469f-8a74-ac11e31d49b5" />

<img width="2560" height="753" alt="image" src="https://github.com/user-attachments/assets/648fc714-07c9-462e-96df-9e268cb7b8d0" />

but ideally remove padding in modal `#main` and add to scroll container instead?