### PR TITLE
Adjust styling for inherited content type property

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -198,11 +198,9 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		} else {
 			return html`
 				<div id="header">
-					<div>
-						<b>${this.property.name}</b>
-						<i>${this.property.alias}</i>
-						<p>${this.property.description}</p>
-					</div>
+					<p><b>${this.property.name}</b></p>
+					<p><i>${this.property.alias}</i></p>
+					<p>${this.property.description}</p>
 				</div>
 				<div id="editor">
 					${this.renderPropertyTags()}
@@ -453,6 +451,12 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				border-radius: var(--uui-border-radius);
 			}
 
+			:host([_inherited]) {
+				#header {
+					padding: 0 var(--uui-size-3, 9px);
+				}
+			}
+
 			p {
 				margin-bottom: 0;
 			}
@@ -461,10 +465,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				position: sticky;
 				top: var(--uui-size-space-4);
 				height: min-content;
-			}
-
-			#header > div {
-				padding: 0 var(--uui-size-space-3, 9px);
 			}
 
 			#header i {
@@ -478,7 +478,6 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 			}
 			#editor:not(uui-button) {
 				background-color: var(--uui-color-background);
-				border: 1px dashed var(--uui-button-border-color, var(--uui-color-border-standalone, #c2c2c2));
 				border-radius: var(--uui-button-border-radius, var(--uui-border-radius, 3px));
 				min-height: 143px;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -198,9 +198,11 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		} else {
 			return html`
 				<div id="header">
-					<b>${this.property.name}</b>
-					<i>${this.property.alias}</i>
-					<p>${this.property.description}</p>
+					<div>
+						<b>${this.property.name}</b>
+						<i>${this.property.alias}</i>
+						<p>${this.property.description}</p>
+					</div>
 				</div>
 				<div id="editor">
 					${this.renderPropertyTags()}
@@ -461,6 +463,10 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				height: min-content;
 			}
 
+			#header > div {
+				padding: 0 var(--uui-size-space-3, 9px);
+			}
+
 			#header i {
 				opacity: 0.55;
 			}
@@ -469,6 +475,12 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 				position: relative;
 				--uui-button-background-color: var(--uui-color-background);
 				--uui-button-background-color-hover: var(--uui-color-background);
+			}
+			#editor:not(uui-button) {
+				background-color: var(--uui-color-background);
+				border: 1px dashed var(--uui-button-border-color, var(--uui-color-border-standalone, #c2c2c2));
+				border-radius: var(--uui-button-border-radius, var(--uui-border-radius, 3px));
+				min-height: 143px;
 			}
 			#editor uui-action-bar {
 				--uui-button-background-color: var(--uui-color-surface);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20169

### Description
Adjusted styling for inherited properties to be more consistent with other properties, but slightly different.

<img width="2169" height="725" alt="image" src="https://github.com/user-attachments/assets/c944b171-10f1-48d9-a161-b80089ecef01" />
