### PR TITLE
Installer: Improves user accessibility by adding missing <form> elements and setting the right focus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/installer/consent/installer-consent.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/consent/installer-consent.element.ts
@@ -8,7 +8,7 @@ import type {
 	TelemetryResponseModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { TelemetryLevelModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-installer-consent')
 export class UmbInstallerConsentElement extends UmbLitElement {
@@ -54,7 +54,8 @@ export class UmbInstallerConsentElement extends UmbLitElement {
 		this._installerContext?.appendData(value);
 	}
 
-	private _onNext() {
+	private _onNext(evt: SubmitEvent) {
+		evt.preventDefault();
 		this._installerContext?.nextStep();
 	}
 
@@ -75,6 +76,7 @@ export class UmbInstallerConsentElement extends UmbLitElement {
 
 		return html`
 			<uui-slider
+				${umbFocus()}
 				@input=${this._handleChange}
 				name="telemetryLevel"
 				label="telemetry-level"

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/consent/installer-consent.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/consent/installer-consent.element.ts
@@ -91,11 +91,15 @@ export class UmbInstallerConsentElement extends UmbLitElement {
 		return html`
 			<div id="container" class="uui-text" data-test="installer-telemetry">
 				<h1>Consent for telemetry data</h1>
-				${this._renderSlider()}
-				<div id="buttons">
-					<uui-button label="Back" @click=${this._onBack} look="secondary"></uui-button>
-					<uui-button id="button-install" @click=${this._onNext} label="Next" look="primary"></uui-button>
-				</div>
+				<uui-form>
+					<form id="consent-form" name="consent" @submit=${this._onNext}>
+						${this._renderSlider()}
+						<div id="buttons">
+							<uui-button label="Back" @click=${this._onBack} look="secondary"></uui-button>
+							<uui-button id="button-install" type="submit" label="Next" look="primary"></uui-button>
+						</div>
+					</form>
+				</uui-form>
 			</div>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
@@ -9,7 +9,7 @@ import type {
 	DatabaseSettingsPresentationModel,
 } from '@umbraco-cms/backoffice/external/backend-api';
 import { InstallService } from '@umbraco-cms/backoffice/external/backend-api';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { tryExecute, UmbApiError } from '@umbraco-cms/backoffice/resources';
 
 @customElement('umb-installer-database')
@@ -238,6 +238,7 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 		<uui-form-layout-item>
 			<uui-label for="server" slot="label" required>Server address</uui-label>
 			<uui-input
+				${umbFocus()}
 				type="text"
 				id="server"
 				name="server"
@@ -254,6 +255,7 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 		html` <uui-form-layout-item>
 			<uui-label for="database-name" slot="label" required>Database Name</uui-label>
 			<uui-input
+				${umbFocus()}
 				type="text"
 				.value=${value}
 				id="database-name"

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/user/installer-user.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/user/installer-user.element.ts
@@ -2,7 +2,7 @@ import type { UmbInstallerContext } from '../installer.context.js';
 import { UMB_INSTALLER_CONTEXT } from '../installer.context.js';
 import type { CSSResultGroup } from '@umbraco-cms/backoffice/external/lit';
 import { css, html, customElement, state } from '@umbraco-cms/backoffice/external/lit';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { umbFocus, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
 @customElement('umb-installer-user')
 export class UmbInstallerUserElement extends UmbLitElement {
@@ -67,9 +67,10 @@ export class UmbInstallerUserElement extends UmbLitElement {
 					<uui-form-layout-item>
 						<uui-label id="nameLabel" for="name" slot="label" required>Name</uui-label>
 						<uui-input
+							${umbFocus()}
 							type="text"
 							id="name"
-							.value=${this._userFormData?.name}
+							.value=${this._userFormData?.name ?? ''}
 							name="name"
 							label="name"
 							required
@@ -81,7 +82,7 @@ export class UmbInstallerUserElement extends UmbLitElement {
 						<uui-input
 							type="email"
 							id="email"
-							.value=${this._userFormData?.email}
+							.value=${this._userFormData?.email ?? ''}
 							name="email"
 							label="email"
 							required
@@ -95,7 +96,7 @@ export class UmbInstallerUserElement extends UmbLitElement {
 							name="password"
 							label="password"
 							minlength=${this._minimumPasswordLength}
-							.value=${this._userFormData?.password}
+							.value=${this._userFormData?.password ?? ''}
 							required
 							required-message="Password is required"></uui-input-password>
 					</uui-form-layout-item>


### PR DESCRIPTION
## Description

This has been nagging me for a while: You cannot complete the installer form only by pressing the <kbd>Enter</kbd> key. On the telemetry step, you must either tab or use your cursor to click 'Next'.

This pull request improves the user experience in the installer flow by enhancing form accessibility and usability. The main changes include adding automatic focus to key input fields, updating form handling to use proper HTML form semantics, and ensuring form fields have default values to prevent uncontrolled input errors.

**Accessibility and Form Usability Improvements:**

* Added the `umbFocus` directive to automatically focus the first relevant input fields in the consent, database, and user installer steps (`installer-consent.element.ts`, `installer-database.element.ts`, `installer-user.element.ts`). [[1]](diffhunk://#diff-c0eca849f2b951a0c819e1495f1bc0fdddab4d898157e5268e2175fb7c9b83d9L11-R11) [[2]](diffhunk://#diff-727e9e447e7450aba3214974527e3e19893517a99d4d986ade008be3690c08daL12-R12) [[3]](diffhunk://#diff-999727ad08aa5112d46ceb21a8127efb8854627c91c8344a32789453c504b82eL5-R5) [[4]](diffhunk://#diff-727e9e447e7450aba3214974527e3e19893517a99d4d986ade008be3690c08daR241) [[5]](diffhunk://#diff-727e9e447e7450aba3214974527e3e19893517a99d4d986ade008be3690c08daR258) [[6]](diffhunk://#diff-999727ad08aa5112d46ceb21a8127efb8854627c91c8344a32789453c504b82eR70-R73)
* Updated the consent step to wrap inputs in a `<form>` and handle the "Next" action via form submission, preventing the default event and ensuring accessibility and keyboard support (`installer-consent.element.ts`). [[1]](diffhunk://#diff-c0eca849f2b951a0c819e1495f1bc0fdddab4d898157e5268e2175fb7c9b83d9R96-R104) [[2]](diffhunk://#diff-c0eca849f2b951a0c819e1495f1bc0fdddab4d898157e5268e2175fb7c9b83d9L57-R58)

**Form Field Value Handling:**

* Ensured that user form fields (`name`, `email`, `password`) default to empty strings if no value is present, preventing uncontrolled input warnings and improving reliability (`installer-user.element.ts`). [[1]](diffhunk://#diff-999727ad08aa5112d46ceb21a8127efb8854627c91c8344a32789453c504b82eR70-R73) [[2]](diffhunk://#diff-999727ad08aa5112d46ceb21a8127efb8854627c91c8344a32789453c504b82eL84-R85) [[3]](diffhunk://#diff-999727ad08aa5112d46ceb21a8127efb8854627c91c8344a32789453c504b82eL98-R99)


## How to test

You can provoke the installer on the mock server by changing the following handler in `browser-handlers.ts`:
<img width="1217" height="143" alt="image" src="https://github.com/user-attachments/assets/9b4c4ca7-001d-41c7-b540-d34988673c44" />

Run `npm run dev:mock` and verify that you can complete the installer.
