### PR TITLE
QA Skip the known failing smoke test to avoid blocking other PRs

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/BlockGrid/Block/BlockGridBlockAdvanced.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/DataType/BlockGrid/Block/BlockGridBlockAdvanced.spec.ts
@@ -240,7 +240,9 @@ test('can remove a icon color from a block', async ({umbracoApi, umbracoUi}) => 
   expect(await umbracoApi.dataType.doesBlockEditorBlockContainIconColor(blockGridEditorName, contentElementTypeId, '')).toBeTruthy();
 });
 
-test('can add a thumbnail to a block', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+// Remove skip when the front-end is ready. Currently it is not possible to add a thumbnail to a block
+// Issue link: https://github.com/umbraco/Umbraco-CMS/issues/20264
+test.skip('can add a thumbnail to a block', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const mediaName = 'TestMedia';
   await umbracoApi.media.ensureNameNotExists(mediaName);


### PR DESCRIPTION
The smoke test for adding a thumbnail to a block is currently failing (https://github.com/umbraco/Umbraco-CMS/issues/20264), so I’ve skipped it for now to avoid blocking other PRs.