### PR TITLE
Dependencies: Update ImageSharp to latest patch releases (13)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,8 +73,8 @@
     <PackageVersion Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.Map" Version="1.0.2" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.7" />
-    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.3" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.5" />
     <PackageVersion Include="Smidge.InMemory" Version="4.6.0" />
     <PackageVersion Include="Smidge.Nuglify" Version="4.6.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
+++ b/src/Umbraco.Cms.Imaging.ImageSharp2/Umbraco.Cms.Imaging.ImageSharp2.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.10, 3)" />
+    <PackageReference Include="SixLabors.ImageSharp" VersionOverride="[2.1.11, 3)" />
     <PackageReference Include="SixLabors.ImageSharp.Web" VersionOverride="[2.0.2, 3)" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates Umbraco 13's dependencies on ImageSharp to the latest patch releases for ImageSharp 2 and 3.