### PR TITLE
Pass in field to validation of datatype configuration field

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/ConfigurationEditor.cs
@@ -86,7 +86,7 @@ public class ConfigurationEditor : IConfigurationEditor
         => Fields
             .SelectMany(field =>
                 configuration.TryGetValue(field.Key, out var value)
-                    ? field.Validators.SelectMany(validator => validator.Validate(value, null, null, PropertyValidationContext.Empty()))
+                    ? field.Validators.SelectMany(validator => validator.Validate(value, null, null, PropertyValidationContext.Empty(), field))
                     : Enumerable.Empty<ValidationResult>())
             .ToArray();
 

--- a/src/Umbraco.Core/PropertyEditors/IValueValidator.cs
+++ b/src/Umbraco.Core/PropertyEditors/IValueValidator.cs
@@ -23,4 +23,22 @@ public interface IValueValidator
     ///     </para>
     /// </remarks>
     IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext);
+
+    /// <summary>
+    ///     Validates a value.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="valueType">The value type.</param>
+    /// <param name="dataTypeConfiguration">A datatype configuration.</param>
+    /// <param name="validationContext">The context in which the value is being validated.</param>
+    /// <param name="configurationField">The configuration field being validated.</param>
+    /// <returns>Validation results.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         The value can be a string, a Json structure (JObject, JArray...)... corresponding to what was posted by an
+    ///         editor.
+    ///     </para>
+    /// </remarks>
+    IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext, ConfigurationField configurationField)
+        => throw new NotImplementedException();
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorMinMaxValidatorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorMinMaxValidatorBase.cs
@@ -22,12 +22,16 @@ internal abstract class BlockEditorMinMaxValidatorBase<TValue, TLayout> : IValue
     protected BlockEditorMinMaxValidatorBase(ILocalizedTextService textService) => TextService = textService;
 
     /// <summary>
-    /// Gets the <see cref="ILocalizedTextService"/>
+    /// Gets the <see cref="ILocalizedTextService"/>.
     /// </summary>
     protected ILocalizedTextService TextService { get; }
 
     /// <inheritdoc/>
     public abstract IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext);
+
+    /// <inheritdoc/>
+    public virtual IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext, ConfigurationField configurationField)
+        => throw new NotImplementedException();
 
     /// <summary>
     /// Validates the number of blocks are within the configured minimum and maximum values.

--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
@@ -26,7 +26,7 @@ internal sealed class ColorPickerConfigurationEditor : ConfigurationEditor<Color
         public ColorListValidator(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
             => _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
 
-        public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext)
+        public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext, ConfigurationField field)
         {
             var stringValue = value?.ToString();
             if (stringValue.IsNullOrWhiteSpace())
@@ -46,7 +46,7 @@ internal sealed class ColorPickerConfigurationEditor : ConfigurationEditor<Color
 
             if (items is null)
             {
-                yield return new ValidationResult($"The configuration value {stringValue} is not a valid color picker configuration", new[] { "items" });
+                yield return new ValidationResult($"The configuration value {stringValue} is not a valid color picker configuration", [field.Key]);
                 yield break;
             }
 
@@ -54,7 +54,7 @@ internal sealed class ColorPickerConfigurationEditor : ConfigurationEditor<Color
             {
                 if (Regex.IsMatch(item.Value, "^([0-9a-f]{3}|[0-9a-f]{6})$", RegexOptions.IgnoreCase) == false)
                 {
-                    yield return new ValidationResult($"The value {item.Value} is not a valid hex color", new[] { "items" });
+                    yield return new ValidationResult($"The value {item.Value} is not a valid hex color", [field.Key]);
                 }
             }
         }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
@@ -26,7 +26,22 @@ internal sealed class ColorPickerConfigurationEditor : ConfigurationEditor<Color
         public ColorListValidator(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
             => _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
 
-        public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration, PropertyValidationContext validationContext, ConfigurationField field)
+        public IEnumerable<ValidationResult> Validate(
+            object? value,
+            string? valueType,
+            object? dataTypeConfiguration,
+            PropertyValidationContext validationContext)
+            => ValidateInternal(value, "items");
+
+        public IEnumerable<ValidationResult> Validate(
+            object? value,
+            string? valueType,
+            object? dataTypeConfiguration,
+            PropertyValidationContext validationContext,
+            ConfigurationField field)
+            => ValidateInternal(value, field.Key);
+
+        private IEnumerable<ValidationResult> ValidateInternal(object? value, string fieldName)
         {
             var stringValue = value?.ToString();
             if (stringValue.IsNullOrWhiteSpace())
@@ -46,7 +61,7 @@ internal sealed class ColorPickerConfigurationEditor : ConfigurationEditor<Color
 
             if (items is null)
             {
-                yield return new ValidationResult($"The configuration value {stringValue} is not a valid color picker configuration", [field.Key]);
+                yield return new ValidationResult($"The configuration value {stringValue} is not a valid color picker configuration", [fieldName]);
                 yield break;
             }
 
@@ -54,7 +69,7 @@ internal sealed class ColorPickerConfigurationEditor : ConfigurationEditor<Color
             {
                 if (Regex.IsMatch(item.Value, "^([0-9a-f]{3}|[0-9a-f]{6})$", RegexOptions.IgnoreCase) == false)
                 {
-                    yield return new ValidationResult($"The value {item.Value} is not a valid hex color", [field.Key]);
+                    yield return new ValidationResult($"The value {item.Value} is not a valid hex color", [fieldName]);
                 }
             }
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Fixes part of discussion https://github.com/umbraco/Umbraco-CMS/discussions/20280

Currently the validate method assumes the configuration field is `items`, but not necessary if re-using the validators across property editors in core and in custom property editors.

I guess we possible can obsolete the original `Validate` method not taking `ConfigurationField` as parameter. I considered if field could be a property on `PropertyValidationContext`, but it seems it is used for other things at content node properties.

<img width="2154" height="651" alt="chrome_s4zGY1mpxL" src="https://github.com/user-attachments/assets/24a525f3-8564-433b-b86e-e79769ebd76f" />

I have checked in for `ValueListUniqueValueValidator`.

<img width="1536" height="1089" alt="devenv_bIgBA5m9xe" src="https://github.com/user-attachments/assets/d289299b-81d6-4ec4-805d-441960cb24bf" />

In `BlockEditorMinMaxValidatorBase` class I am not sure if it is the right approach - perhaps not needed here as use in BlockList and BlockGrid property editors, while the others are used in datatype configuration editor.