### PR TITLE
Emails: Add `Expiry` header to emails

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/GlobalSettings.cs
@@ -182,6 +182,11 @@ public class GlobalSettings
     public bool IsSmtpServerConfigured => !string.IsNullOrWhiteSpace(Smtp?.Host);
 
     /// <summary>
+    ///     Gets a value indicating whether SMTP expiry date is configured.
+    /// </summary>
+    public bool IsSmtpExpirationConfigured => Smtp?.EmailExpiration != TimeSpan.MinValue;
+
+    /// <summary>
     ///     Gets a value indicating whether there is a physical pickup directory configured.
     /// </summary>
     public bool IsPickupDirectoryLocationConfigured => !string.IsNullOrWhiteSpace(Smtp?.PickupDirectoryLocation);

--- a/src/Umbraco.Core/Configuration/Models/SmtpSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SmtpSettings.cs
@@ -52,6 +52,7 @@ public class SmtpSettings : ValidatableEntryBase
 {
     internal const string StaticSecureSocketOptions = "Auto";
     internal const string StaticDeliveryMethod = "Network";
+    internal const string StaticEmailExpiration = "30.00:00:00";
 
     /// <summary>
     ///     Gets or sets a value for the SMTP from address to use for messages.
@@ -96,4 +97,13 @@ public class SmtpSettings : ValidatableEntryBase
     ///     Gets or sets a value for the SMTP password.
     /// </summary>
     public string? Password { get; set; }
+
+    /// <summary>
+    ///     Gets or sets a value for the time until an email expires.
+    /// </summary>
+    /// <remarks>
+    ///     The default value is 30 days
+    /// </remarks>
+    [DefaultValue(StaticEmailExpiration)]
+    public TimeSpan EmailExpiration { get; set; } = TimeSpan.Parse(StaticEmailExpiration);
 }

--- a/src/Umbraco.Core/Mail/IEmailSender.cs
+++ b/src/Umbraco.Core/Mail/IEmailSender.cs
@@ -11,5 +11,7 @@ public interface IEmailSender
 
     Task SendAsync(EmailMessage message, string emailType, bool enableNotification);
 
+    Task SendAsync(EmailMessage message, string emailType, bool enableNotification, TimeSpan? emailExpiration);
+
     bool CanSendRequiredEmail();
 }

--- a/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
+++ b/src/Umbraco.Core/Mail/NotImplementedEmailSender.cs
@@ -12,6 +12,10 @@ internal sealed class NotImplementedEmailSender : IEmailSender
         throw new NotImplementedException(
             "To send an Email ensure IEmailSender is implemented with a custom implementation");
 
+    public Task SendAsync(EmailMessage message, string emailType, bool enableNotification, TimeSpan? emailExpiration) =>
+        throw new NotImplementedException(
+            "To send an Email ensure IEmailSender is implemented with a custom implementation");
+
     public bool CanSendRequiredEmail()
         => throw new NotImplementedException(
             "To send an Email ensure IEmailSender is implemented with a custom implementation");

--- a/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
@@ -15,27 +15,38 @@ namespace Umbraco.Cms.Infrastructure.Mail
     public class BasicSmtpEmailSenderClient : IEmailSenderClient
     {
         private readonly GlobalSettings _globalSettings;
-        public BasicSmtpEmailSenderClient(IOptionsMonitor<GlobalSettings> globalSettings)
-        {
-            _globalSettings = globalSettings.CurrentValue;
-        }
 
+        /// <inheritdoc />
+        public BasicSmtpEmailSenderClient(IOptionsMonitor<GlobalSettings> globalSettings)
+            => _globalSettings = globalSettings.CurrentValue;
+
+        /// <inheritdoc />
         public async Task SendAsync(EmailMessage message)
+            => await SendAsync(message, _globalSettings.Smtp?.EmailExpiration);
+
+        /// <inheritdoc />
+        public async Task SendAsync(EmailMessage message, TimeSpan? emailExpiration)
         {
             using var client = new SmtpClient();
 
             await client.ConnectAsync(
                 _globalSettings.Smtp!.Host,
-            _globalSettings.Smtp.Port,
+                _globalSettings.Smtp.Port,
                 (SecureSocketOptions)(int)_globalSettings.Smtp.SecureSocketOptions);
 
             if (!string.IsNullOrWhiteSpace(_globalSettings.Smtp.Username) &&
-            !string.IsNullOrWhiteSpace(_globalSettings.Smtp.Password))
+                !string.IsNullOrWhiteSpace(_globalSettings.Smtp.Password))
             {
                 await client.AuthenticateAsync(_globalSettings.Smtp.Username, _globalSettings.Smtp.Password);
             }
 
             var mimeMessage = message.ToMimeMessage(_globalSettings.Smtp!.From);
+
+            if (emailExpiration != TimeSpan.MinValue)
+            {
+                // Header needs to be in RFC 1123/2822 compatible format
+                mimeMessage.Headers.Add("Expires", DateTimeOffset.UtcNow.Add(emailExpiration.GetValueOrDefault()).ToString("R"));
+            }
 
             if (_globalSettings.Smtp.DeliveryMethod == SmtpDeliveryMethod.Network)
             {

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -75,12 +75,42 @@ public class EmailSender : IEmailSender
     /// <summary>
     ///     Sends the message async
     /// </summary>
+    /// <param name="message"></param>
+    /// <param name="emailType"></param>
     /// <returns></returns>
     public async Task SendAsync(EmailMessage message, string emailType) =>
-        await SendAsyncInternal(message, emailType, false);
+        await SendAsyncInternal(message, emailType, false, _globalSettings.Smtp?.EmailExpiration);
 
+    /// <summary>
+    ///     Sends the message async
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="emailType"></param>
+    /// <param name="emailExpiration"></param>
+    /// <returns></returns>
+    public async Task SendAsync(EmailMessage message, string emailType, TimeSpan? emailExpiration) =>
+        await SendAsyncInternal(message, emailType, false, emailExpiration);
+
+    /// <summary>
+    ///     Sends the message async
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="emailType"></param>
+    /// <param name="enableNotification"></param>
+    /// <returns></returns>
     public async Task SendAsync(EmailMessage message, string emailType, bool enableNotification) =>
-        await SendAsyncInternal(message, emailType, enableNotification);
+        await SendAsyncInternal(message, emailType, enableNotification, _globalSettings.Smtp?.EmailExpiration);
+
+    /// <summary>
+    ///     Sends the message async
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="emailType"></param>
+    /// <param name="enableNotification"></param>
+    /// <param name="emailExpiration"></param>
+    /// <returns></returns>
+    public async Task SendAsync(EmailMessage message, string emailType, bool enableNotification, TimeSpan? emailExpiration) =>
+        await SendAsyncInternal(message, emailType, enableNotification, emailExpiration);
 
     /// <summary>
     ///     Returns true if the application should be able to send a required application email
@@ -93,7 +123,7 @@ public class EmailSender : IEmailSender
                                           || _globalSettings.IsPickupDirectoryLocationConfigured
                                           || _notificationHandlerRegistered;
 
-    private async Task SendAsyncInternal(EmailMessage message, string emailType, bool enableNotification)
+    private async Task SendAsyncInternal(EmailMessage message, string emailType, bool enableNotification, TimeSpan? emailExpiration)
     {
         if (enableNotification)
         {
@@ -173,7 +203,7 @@ public class EmailSender : IEmailSender
             while (true);
         }
 
-        await _emailSenderClient.SendAsync(message);
+        await _emailSenderClient.SendAsync(message, emailExpiration);
     }
 
 }

--- a/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/Interfaces/IEmailSenderClient.cs
@@ -3,15 +3,23 @@ using Umbraco.Cms.Core.Models.Email;
 namespace Umbraco.Cms.Infrastructure.Mail.Interfaces
 {
     /// <summary>
-    /// Client for sending an email from a MimeMessage
+    /// Client for sending an email from a MimeMessage.
     /// </summary>
     public interface IEmailSenderClient
     {
         /// <summary>
-        /// Sends the email message
+        /// Sends the email message.
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
         public Task SendAsync(EmailMessage message);
+
+        /// <summary>
+        /// Sends the email message with an expiration date.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="emailExpiration"></param>
+        /// <returns></returns>
+        public Task SendAsync(EmailMessage message, TimeSpan? emailExpiration);
     }
 }

--- a/src/Umbraco.Infrastructure/Security/EmailUserForgotPasswordSender.cs
+++ b/src/Umbraco.Infrastructure/Security/EmailUserForgotPasswordSender.cs
@@ -68,7 +68,7 @@ public class EmailUserForgotPasswordSender : IUserForgotPasswordSender
 
         var message = new EmailMessage(senderEmail, address.ToString(), emailSubject, emailBody, true);
 
-        await _emailSender.SendAsync(message, Constants.Web.EmailTypes.PasswordReset, true);
+        await _emailSender.SendAsync(message, Constants.Web.EmailTypes.PasswordReset, true, new TimeSpan(1, 0, 0));
     }
 
     public bool CanSend() => _securitySettings.AllowPasswordReset && _emailSender.CanSendRequiredEmail();

--- a/src/Umbraco.Infrastructure/Security/EmailUserInviteSender.cs
+++ b/src/Umbraco.Infrastructure/Security/EmailUserInviteSender.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Net;
 using Microsoft.Extensions.Options;
 using MimeKit;
@@ -67,7 +67,7 @@ public class EmailUserInviteSender : IUserInviteSender
 
         var message = new EmailMessage(senderEmail, address.ToString(), emailSubject, emailBody, true);
 
-        await _emailSender.SendAsync(message, Constants.Web.EmailTypes.UserInvite, true);
+        await _emailSender.SendAsync(message, Constants.Web.EmailTypes.UserInvite, true, new TimeSpan(72, 0, 0));
     }
 
     public bool CanSendInvites() => _emailSender.CanSendRequiredEmail();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

As part of our discussions with the Sustainability team, we are proposing adding the standardised `Expiry:` header to emails sent from the `EmailSender`. The idea is that a growing number of email providers are beginning to support the standard and will delete the email(s) at the specified expiry date, thus reducing the number of emails stored over long periods of time contributing to higher carbon emissions.

This value is set as a `TimeSpan` of `30.00:00:00` (30 days) and is user configurable 

References:
- https://www.zerocarbon.email/documentation/define-expiration-times-emails/
- https://www.ietf.org/archive/id/draft-billon-expires-08.html

<!-- Thanks for contributing to Umbraco CMS! -->
