### PR TITLE
Move compilation of some Regex generation to compile time instead of runtime, make some static ones compiled

### DIFF
--- a/src/Umbraco.Core/IO/ShadowFileSystem.cs
+++ b/src/Umbraco.Core/IO/ShadowFileSystem.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 namespace Umbraco.Cms.Core.IO;
 
-internal sealed class ShadowFileSystem : IFileSystem
+internal sealed partial class ShadowFileSystem : IFileSystem
 {
     private readonly IFileSystem _sfs;
 
@@ -392,14 +392,28 @@ internal sealed class ShadowFileSystem : IFileSystem
     }
 
     // copied from System.Web.Util.Wildcard internal
-    internal sealed class WildcardExpression
+    internal sealed partial class WildcardExpression
     {
-        private static readonly Regex MetaRegex = new("[\\+\\{\\\\\\[\\|\\(\\)\\.\\^\\$]");
-        private static readonly Regex QuestRegex = new("\\?");
-        private static readonly Regex StarRegex = new("\\*");
-        private static readonly Regex CommaRegex = new(",");
-        private static readonly Regex SlashRegex = new("(?=/)");
-        private static readonly Regex BackslashRegex = new("(?=[\\\\:])");
+        private static readonly Regex MetaRegex = GetMetaRegex();
+
+        [GeneratedRegex("[\\+\\{\\\\\\[\\|\\(\\)\\.\\^\\$]")]
+        private static partial Regex GetMetaRegex();
+
+        private static readonly Regex QuestRegex = GetQuestRegex();
+
+        [GeneratedRegex("\\?")]
+        private static partial Regex GetQuestRegex();
+
+        private static readonly Regex StarRegex = GetStarRegex();
+
+        [GeneratedRegex("\\*")]
+        private static partial Regex GetStarRegex();
+
+        private static readonly Regex CommaRegex = GetCommaRegex();
+
+        [GeneratedRegex(",")]
+        private static partial Regex GetCommaRegex();
+
         private readonly bool _caseInsensitive;
         private readonly string _pattern;
         private Regex? _regex;

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -15,15 +15,15 @@ public sealed class HtmlLocalLinkParser
     // <a type="document" href="/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}" title="other page">other page</a>
     internal static readonly Regex LocalLinkTagPattern = new(
         @"<a.+?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)})[^>]*?>",
-        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline);
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Singleline | RegexOptions.Compiled);
 
     internal static readonly Regex TypePattern = new(
         """type=['"](?<type>(?:media|document))['"]""",
-        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 
     internal static readonly Regex LocalLinkPattern = new(
         @"href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-zA-Z0-9-://]+)(?:\}|\%7D))",
-        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace | RegexOptions.Compiled);
 
     private readonly IPublishedUrlProvider _publishedUrlProvider;
 

--- a/src/Umbraco.Infrastructure/Persistence/NPocoDatabaseExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoDatabaseExtensions.cs
@@ -225,15 +225,17 @@ public static partial class NPocoDatabaseExtensions
     /// <returns></returns>
     public static string EscapeAtSymbols(string value)
     {
-        if (value.Contains("@") == false)
+        if (value.Contains('@') == false)
         {
             return value;
         }
 
         // this fancy regex will only match a single @ not a double, etc...
-        var regex = new Regex("(?<!@)@(?!@)");
-        return regex.Replace(value, "@@");
+        return AtRegex().Replace(value, "@@");
     }
+
+    [GeneratedRegex("(?<!@)@(?!@)")]
+    private static partial Regex AtRegex();
 
     /// <summary>
     ///     Returns the underlying connection as a typed connection - this is used to unwrap the profiled mini profiler stuff


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

This is not in any hot code path, this is just a little prep to possibly have all `Regex` generated at compile time instead of at runtime.  
If all runtime regex generation is removed, the regex generation code is never needed at runtime, only at compile time.  
This results in faster startup, as less IL ASM needs to be compiled