### PR TITLE
Micro-optimization: Use Array.ConvertAll instead of LINQ .Select .ToArray

### DIFF
--- a/src/Umbraco.Core/Cache/Refreshers/Implement/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/DataTypeCacheRefresher.cs
@@ -198,7 +198,7 @@ public sealed class DataTypeCacheRefresher : PayloadCacheRefresherBase<DataTypeC
             removedContentTypes.AddRange(_publishedContentTypeCache.ClearByDataTypeId(payload.Id));
         }
 
-        var changedIds = payloads.Select(x => x.Id).ToArray();
+        var changedIds = Array.ConvertAll(payloads, x => x.Id);
         _publishedContentTypeFactory.NotifyDataTypeChanges(changedIds);
 
         _publishedModelFactory.WithSafeLiveFactoryReset(() =>

--- a/src/Umbraco.Core/IO/IOHelper.cs
+++ b/src/Umbraco.Core/IO/IOHelper.cs
@@ -199,7 +199,7 @@ public abstract class IOHelper : IIOHelper
             Directory.CreateDirectory(tempFolderPath);
         }
 
-        return tempFolderPaths.Select(x => new DirectoryInfo(x)).ToArray();
+        return Array.ConvertAll(tempFolderPaths, x => new DirectoryInfo(x));
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/ModelType.cs
@@ -138,7 +138,7 @@ public class ModelType : Type
             throw new PanicException($"The type {type} has not generic type definition");
         }
 
-        Type[] args = type.GetGenericArguments().Select(x => Map(x, modelTypes, true)).ToArray();
+        Type[] args = Array.ConvertAll(type.GetGenericArguments(), x => Map(x, modelTypes, true));
         return def.MakeGenericType(args);
     }
 
@@ -248,7 +248,7 @@ public class ModelType : Type
             throw new PanicException($"The type {type} has not generic type definition");
         }
 
-        var args = type.GetGenericArguments().Select(x => MapToName(x, map, true)).ToArray();
+        var args = Array.ConvertAll(type.GetGenericArguments(), x => MapToName(x, map, true));
         var defFullName = def.FullName?[..def.FullName.IndexOf('`')];
         return defFullName + "<" + string.Join(", ", args) + ">";
     }

--- a/src/Umbraco.Core/Models/Stylesheet.cs
+++ b/src/Umbraco.Core/Models/Stylesheet.cs
@@ -110,7 +110,7 @@ public class Stylesheet : File, IStylesheet
         {
             // re-parse it so we can check what properties are different and adjust the event handlers
             StylesheetRule[] parsed = StylesheetHelper.ParseRules(Content).ToArray();
-            var names = parsed.Select(x => x.Name).ToArray();
+            var names = Array.ConvertAll(parsed, x => x.Name);
             StylesheetProperty[] existing = _properties.Value.Where(x => names.InvariantContains(x.Name)).ToArray();
 
             // update existing

--- a/src/Umbraco.Core/ReflectionUtilities.cs
+++ b/src/Umbraco.Core/ReflectionUtilities.cs
@@ -523,7 +523,7 @@ public static class ReflectionUtilities
     {
         // get type and args
         Type? ctorDeclaring = ctor.DeclaringType;
-        Type[] ctorParameters = ctor.GetParameters().Select(x => x.ParameterType).ToArray();
+        Type[] ctorParameters = Array.ConvertAll(ctor.GetParameters(), x => x.ParameterType);
 
         // validate arguments
         if (lambdaParameters.Length != ctorParameters.Length)
@@ -701,7 +701,7 @@ public static class ReflectionUtilities
         // get type and args
         Type? methodDeclaring = method.DeclaringType;
         Type methodReturned = method.ReturnType;
-        Type[] methodParameters = method.GetParameters().Select(x => x.ParameterType).ToArray();
+        Type[] methodParameters = Array.ConvertAll(method.GetParameters(), x => x.ParameterType);
 
         var isStatic = method.IsStatic;
         (Type? lambdaDeclaring, Type[] lambdaParameters, Type lambdaReturned) =

--- a/tests/Umbraco.Tests.Benchmarks/CollectionBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/CollectionBenchmarks.cs
@@ -69,6 +69,25 @@ namespace Umbraco.Tests.Benchmarks
             }
         }
 
+        /// <summary>
+        /// A guess on what size array is typically used for .ToArray()
+        /// </summary>
+        private static readonly int[] _shortArray = Enumerable.Range(0, 8).ToArray();
+
+        /// <summary>
+        /// Native array convert, without type checks and less allocations
+        /// </summary>
+        /// <returns>Something to not optimize it away.</returns>
+        [Benchmark]
+        public int[] NativeArrayToArray() => Array.ConvertAll(_shortArray, value => _shortArray.Length ^ value);
+
+        /// <summary>
+        /// Use LINQ to convert an array, with type checks, extra allocations & extra branches that the branch predictor has to keep track of
+        /// </summary>
+        /// <returns>Something to not optimize it away.</returns>
+        [Benchmark]
+        public int[] LinqOnArrayToArray() => _shortArray.Select(value => _shortArray.Length ^ value).ToArray();
+
         //BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
         //Intel Core i7-10750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
         //.NET SDK 8.0.401


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description
This is around 2x faster on .NET 9, and much faster on previous versions.

It is probably not in any insanely hot code paths, but I see it used in recursion.

I could not get benchmarks to run in the project, I had to use a separate project for it, so I haven't updated the numbers in the bench