### PR TITLE
Document type references: Backend implementation of endpoints and services

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDataTypeDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDataTypeDocumentTypeController.cs
@@ -1,0 +1,41 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+public class ReferencedByDataTypeDocumentTypeController : DocumentTypeControllerBase
+{
+    private readonly IContentTypeReferenceService _contentTypeReferenceService;
+
+    public ReferencedByDataTypeDocumentTypeController(IContentTypeReferenceService contentTypeReferenceService) => _contentTypeReferenceService = contentTypeReferenceService;
+
+    [HttpGet("{id:guid}/referenced-by-data-types")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(PagedViewModel<ReferenceByIdModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ReferencedBy(
+        CancellationToken cancellationToken,
+        Guid id,
+        int skip = 0,
+        int take = 100)
+    {
+        PagedModel<Guid> documentKeys = await _contentTypeReferenceService.GetReferencedElementsFromDataTypesAsync(id, cancellationToken, skip, take);
+
+        var pagedViewModel = new PagedViewModel<ReferenceByIdModel>
+        {
+            Total = documentKeys.Total,
+            Items = documentKeys.Items.Select(x => new ReferenceByIdModel(x)),
+        };
+
+        return Ok(pagedViewModel);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentDocumentTypeController.cs
@@ -1,0 +1,42 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+public class ReferencedByDocumentDocumentTypeController : DocumentTypeControllerBase
+{
+    private readonly IContentTypeReferenceService _contentTypeReferenceService;
+
+    public ReferencedByDocumentDocumentTypeController(IContentTypeReferenceService contentTypeReferenceService) => _contentTypeReferenceService = contentTypeReferenceService;
+
+    [HttpGet("{id:guid}/referenced-by")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(PagedViewModel<ReferenceByIdModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ReferencedBy(
+        CancellationToken cancellationToken,
+        Guid id,
+        int skip = 0,
+        int take = 100)
+    {
+        PagedModel<Guid> documentKeys = await _contentTypeReferenceService.GetReferencedDocumentKeysAsync(id, cancellationToken, skip, take);
+
+        var pagedViewModel = new PagedViewModel<ReferenceByIdModel>
+        {
+            Total = documentKeys.Total,
+            Items = documentKeys.Items.Select(x => new ReferenceByIdModel(x)),
+        };
+
+        return Ok(pagedViewModel);
+    }
+
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentTypeController.cs
@@ -1,0 +1,41 @@
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
+
+[ApiVersion("1.0")]
+[Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
+public class ReferencedByDocumentTypeController : DocumentTypeControllerBase
+{
+    private readonly IContentTypeReferenceService _contentTypeReferenceService;
+
+    public ReferencedByDocumentTypeController(IContentTypeReferenceService contentTypeReferenceService) => _contentTypeReferenceService = contentTypeReferenceService;
+
+    [HttpGet("{id:guid}/referenced-by")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(PagedViewModel<Guid>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AllowedChildrenByKey(
+        CancellationToken cancellationToken,
+        Guid id,
+        int skip = 0,
+        int take = 100)
+    {
+        PagedModel<Guid> documentKeys = await _contentTypeReferenceService.GetReferencedDocumentKeysAsync(id, cancellationToken, skip, take);
+
+        var pagedViewModel = new PagedViewModel<Guid>
+        {
+            Total = documentKeys.Total,
+            Items = documentKeys.Items,
+        };
+
+        return Ok(pagedViewModel);
+    }
+
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentTypeController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -19,7 +20,7 @@ public class ReferencedByDocumentTypeController : DocumentTypeControllerBase
 
     [HttpGet("{id:guid}/referenced-by")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedViewModel<Guid>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedViewModel<ReferenceByIdModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> AllowedChildrenByKey(
         CancellationToken cancellationToken,
@@ -29,10 +30,10 @@ public class ReferencedByDocumentTypeController : DocumentTypeControllerBase
     {
         PagedModel<Guid> documentKeys = await _contentTypeReferenceService.GetReferencedDocumentKeysAsync(id, cancellationToken, skip, take);
 
-        var pagedViewModel = new PagedViewModel<Guid>
+        var pagedViewModel = new PagedViewModel<ReferenceByIdModel>
         {
             Total = documentKeys.Total,
-            Items = documentKeys.Items,
+            Items = documentKeys.Items.Select(x => new ReferenceByIdModel(x)),
         };
 
         return Ok(pagedViewModel);

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentTypeDocumentTypeController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/ReferencedByDocumentTypeDocumentTypeController.cs
@@ -12,23 +12,23 @@ namespace Umbraco.Cms.Api.Management.Controllers.DocumentType;
 
 [ApiVersion("1.0")]
 [Authorize(Policy = AuthorizationPolicies.TreeAccessDocumentTypes)]
-public class ReferencedByDocumentTypeController : DocumentTypeControllerBase
+public class ReferencedByDocumentTypeDocumentTypeController : DocumentTypeControllerBase
 {
     private readonly IContentTypeReferenceService _contentTypeReferenceService;
 
-    public ReferencedByDocumentTypeController(IContentTypeReferenceService contentTypeReferenceService) => _contentTypeReferenceService = contentTypeReferenceService;
+    public ReferencedByDocumentTypeDocumentTypeController(IContentTypeReferenceService contentTypeReferenceService) => _contentTypeReferenceService = contentTypeReferenceService;
 
-    [HttpGet("{id:guid}/referenced-by")]
+    [HttpGet("{id:guid}/referenced-by-document-types")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedViewModel<ReferenceByIdModel>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> AllowedChildrenByKey(
+    public async Task<IActionResult> ReferencedBy(
         CancellationToken cancellationToken,
         Guid id,
         int skip = 0,
         int take = 100)
     {
-        PagedModel<Guid> documentKeys = await _contentTypeReferenceService.GetReferencedDocumentKeysAsync(id, cancellationToken, skip, take);
+        PagedModel<Guid> documentKeys = await _contentTypeReferenceService.GetReferencedDocumentTypeKeysAsync(id, cancellationToken, skip, take);
 
         var pagedViewModel = new PagedViewModel<ReferenceByIdModel>
         {
@@ -38,5 +38,4 @@ public class ReferencedByDocumentTypeController : DocumentTypeControllerBase
 
         return Ok(pagedViewModel);
     }
-
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -327,6 +327,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IOEmbedService, OEmbedService>();
             Services.AddUnique<IRelationService, RelationService>();
             Services.AddUnique<IMemberTypeService, MemberTypeService>();
+            Services.AddUnique<IContentTypeReferenceService, ContentTypeReferenceService>();
             Services.AddUnique<IMemberContentEditingService, MemberContentEditingService>();
             Services.AddUnique<IMemberTypeEditingService, MemberTypeEditingService>();
             Services.AddUnique<INotificationService, NotificationService>();

--- a/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepository.cs
@@ -30,5 +30,5 @@ public interface IContentTypeRepository : IContentTypeRepositoryBase<IContentTyp
 
     IEnumerable<int> GetAllContentTypeIds(string[] aliases);
 
-    PagedModel<Guid> GetChildren(Guid parentKey);
+    PagedModel<Guid> GetChildren(Guid parentKey) => throw new NotImplementedException();
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IContentTypeRepository.cs
@@ -29,4 +29,6 @@ public interface IContentTypeRepository : IContentTypeRepositoryBase<IContentTyp
     IEnumerable<string> GetAllContentTypeAliases(params Guid[] objectTypes);
 
     IEnumerable<int> GetAllContentTypeIds(string[] aliases);
+
+    PagedModel<Guid> GetChildren(Guid parentKey);
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IDataTypeRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDataTypeRepository.cs
@@ -25,4 +25,6 @@ public interface IDataTypeRepository : IReadWriteQueryRepository<int, IDataType>
     /// <param name="id"></param>
     /// <returns></returns>
     IReadOnlyDictionary<Udi, IEnumerable<string>> FindListViewUsages(int id) => throw new NotImplementedException();
+
+    PagedModel<Guid> GetBlockEditorsReferencingContentType(Guid contentTypeId, int skip, int take) => throw new NotImplementedException();
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
@@ -104,5 +104,5 @@ public interface IDocumentRepository : IContentRepository<int, IContent>, IReadR
     /// </summary>
     bool RecycleBinSmells();
 
-    PagedModel<Guid> GetReferencingDocumentsByDocumentTypeKey(Guid documentTypeKey);
+    PagedModel<Guid> GetReferencingDocumentsByDocumentTypeKey(Guid documentTypeKey) => throw new NotImplementedException();
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentRepository.cs
@@ -103,4 +103,6 @@ public interface IDocumentRepository : IContentRepository<int, IContent>, IReadR
     ///     Returns true if there is any content in the recycle bin
     /// </summary>
     bool RecycleBinSmells();
+
+    PagedModel<Guid> GetReferencingDocumentsByDocumentTypeKey(Guid documentTypeKey);
 }

--- a/src/Umbraco.Core/Services/ContentTypeReferenceService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeReferenceService.cs
@@ -9,12 +9,14 @@ public class ContentTypeReferenceService : IContentTypeReferenceService
     private readonly IDocumentRepository _documentRepository;
     private readonly IContentTypeRepository _contentTypeRepository;
     private readonly ICoreScopeProvider _coreScopeProvider;
+    private readonly IDataTypeRepository _dataTypeRepository;
 
-    public ContentTypeReferenceService(IDocumentRepository documentRepository, IContentTypeRepository contentTypeRepository, ICoreScopeProvider coreScopeProvider)
+    public ContentTypeReferenceService(IDocumentRepository documentRepository, IContentTypeRepository contentTypeRepository, ICoreScopeProvider coreScopeProvider, IDataTypeRepository dataTypeRepository)
     {
         _documentRepository = documentRepository;
         _contentTypeRepository = contentTypeRepository;
         _coreScopeProvider = coreScopeProvider;
+        _dataTypeRepository = dataTypeRepository;
     }
 
     public Task<PagedModel<Guid>> GetReferencedDocumentKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take)
@@ -27,12 +29,21 @@ public class ContentTypeReferenceService : IContentTypeReferenceService
         return Task.FromResult(keys);
     }
 
-    public Task<PagedModel<Guid>> GetReferencedDocumentTypeKeysAsync(Guid key, CancellationToken cancellationToken,
-        int skip, int take)
+    public Task<PagedModel<Guid>> GetReferencedDocumentTypeKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take)
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
 
         PagedModel<Guid> keys = _contentTypeRepository.GetChildren(key);
+        scope.Complete();
+
+        return Task.FromResult(keys);
+    }
+
+    public Task<PagedModel<Guid>> GetReferencedElementsFromDataTypesAsync(Guid key, CancellationToken cancellationToken, int skip, int take)
+    {
+        using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
+
+        PagedModel<Guid> keys = _dataTypeRepository.GetBlockEditorsReferencingContentType(key, skip, take);
         scope.Complete();
 
         return Task.FromResult(keys);

--- a/src/Umbraco.Core/Services/ContentTypeReferenceService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeReferenceService.cs
@@ -1,0 +1,27 @@
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+
+namespace Umbraco.Cms.Core.Services;
+
+public class ContentTypeReferenceService : IContentTypeReferenceService
+{
+    private readonly IDocumentRepository _documentRepository;
+    private readonly ICoreScopeProvider _coreScopeProvider;
+
+    public ContentTypeReferenceService(IDocumentRepository documentRepository, ICoreScopeProvider coreScopeProvider)
+    {
+        _documentRepository = documentRepository;
+        _coreScopeProvider = coreScopeProvider;
+    }
+
+    public Task<PagedModel<Guid>> GetReferencedDocumentKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take)
+    {
+        using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
+
+        PagedModel<Guid> keys = _documentRepository.GetReferencingDocumentsByDocumentTypeKey(key);
+        scope.Complete();
+
+        return Task.FromResult(keys);
+    }
+}

--- a/src/Umbraco.Core/Services/ContentTypeReferenceService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeReferenceService.cs
@@ -7,11 +7,13 @@ namespace Umbraco.Cms.Core.Services;
 public class ContentTypeReferenceService : IContentTypeReferenceService
 {
     private readonly IDocumentRepository _documentRepository;
+    private readonly IContentTypeRepository _contentTypeRepository;
     private readonly ICoreScopeProvider _coreScopeProvider;
 
-    public ContentTypeReferenceService(IDocumentRepository documentRepository, ICoreScopeProvider coreScopeProvider)
+    public ContentTypeReferenceService(IDocumentRepository documentRepository, IContentTypeRepository contentTypeRepository, ICoreScopeProvider coreScopeProvider)
     {
         _documentRepository = documentRepository;
+        _contentTypeRepository = contentTypeRepository;
         _coreScopeProvider = coreScopeProvider;
     }
 
@@ -20,6 +22,17 @@ public class ContentTypeReferenceService : IContentTypeReferenceService
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
 
         PagedModel<Guid> keys = _documentRepository.GetReferencingDocumentsByDocumentTypeKey(key);
+        scope.Complete();
+
+        return Task.FromResult(keys);
+    }
+
+    public Task<PagedModel<Guid>> GetReferencedDocumentTypeKeysAsync(Guid key, CancellationToken cancellationToken,
+        int skip, int take)
+    {
+        using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
+
+        PagedModel<Guid> keys = _contentTypeRepository.GetChildren(key);
         scope.Complete();
 
         return Task.FromResult(keys);

--- a/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
+++ b/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
@@ -20,7 +20,7 @@ public interface IContentTypeReferenceService
     Task<PagedModel<Guid>> GetReferencedDocumentTypeKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take);
 
     /// <summary>
-    ///     Gets all property type aliases.
+    ///     Gets data type keys that reference element types.
     /// </summary>
     /// <returns></returns>
     Task<PagedModel<Guid>> GetReferencedElementsFromDataTypesAsync(Guid key, CancellationToken cancellationToken, int skip, int take);

--- a/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
+++ b/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
@@ -1,0 +1,8 @@
+﻿using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services;
+
+public interface IContentTypeReferenceService
+{
+    Task<PagedModel<Guid>> GetReferencedDocumentKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take);
+}

--- a/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
+++ b/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
@@ -8,14 +8,20 @@ namespace Umbraco.Cms.Core.Services;
 public interface IContentTypeReferenceService
 {
     /// <summary>
-    ///     Gets docuiment keys of all documents using the given document type key.
+    ///     Gets document keys of all documents using the given document type key.
     /// </summary>
     /// <returns></returns>
     Task<PagedModel<Guid>> GetReferencedDocumentKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take);
 
     /// <summary>
-    ///     Gets all property type aliases.
+    ///     Gets keys of all the document type inhereting from given document type key.
     /// </summary>
     /// <returns></returns>
     Task<PagedModel<Guid>> GetReferencedDocumentTypeKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take);
+
+    /// <summary>
+    ///     Gets all property type aliases.
+    /// </summary>
+    /// <returns></returns>
+    Task<PagedModel<Guid>> GetReferencedElementsFromDataTypesAsync(Guid key, CancellationToken cancellationToken, int skip, int take);
 }

--- a/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
+++ b/src/Umbraco.Core/Services/IContentTypeReferenceService.cs
@@ -2,7 +2,20 @@
 
 namespace Umbraco.Cms.Core.Services;
 
+/// <summary>
+///     Gets various references of document types, like documents, blocks, or other document types.
+/// </summary>
 public interface IContentTypeReferenceService
 {
+    /// <summary>
+    ///     Gets docuiment keys of all documents using the given document type key.
+    /// </summary>
+    /// <returns></returns>
     Task<PagedModel<Guid>> GetReferencedDocumentKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take);
+
+    /// <summary>
+    ///     Gets all property type aliases.
+    /// </summary>
+    /// <returns></returns>
+    Task<PagedModel<Guid>> GetReferencedDocumentTypeKeysAsync(Guid key, CancellationToken cancellationToken, int skip, int take);
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -116,8 +116,6 @@ internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContent
             .Where<ContentType2ContentTypeDto>(c => c.ParentId == contentTypeId.Value);
 
         List<Guid>? contentGuids = Database.Fetch<Guid>(sql);
-
-
         return new PagedModel<Guid>()
         {
             Items = contentGuids,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -93,8 +93,6 @@ internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContent
 
     public PagedModel<Guid> GetChildren(Guid parentKey)
     {
-
-        // TODO: Make this one query.
         // Get content type id
         Sql<ISqlContext> sqlContentTypeId = Sql()
             .Select<ContentTypeDto>(x => x.NodeId)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -221,6 +221,7 @@ internal sealed class DataTypeRepository : EntityRepositoryBase<int, IDataType>,
         {
             Constants.PropertyEditors.Aliases.BlockGrid,
             Constants.PropertyEditors.Aliases.BlockList,
+            Constants.PropertyEditors.Aliases.RichText,
         };
         // Get All contentTypes where isContainer (list view enabled) is set to true
         Sql<ISqlContext> sql = Sql()
@@ -254,20 +255,47 @@ internal sealed class DataTypeRepository : EntityRepositoryBase<int, IDataType>,
                 _serializer,
                 _dataValueEditorFactory);
 
-            BlockListConfiguration.BlockConfiguration[]? configurations = ConfigurationEditor.ConfigurationAs<BlockListConfiguration>(dataType.ConfigurationObject)?.Blocks;
-
-            if(configurations is null)
+            switch (dataType.EditorAlias)
             {
-                continue;
-            }
+                case Constants.PropertyEditors.Aliases.BlockGrid:
+                    BlockGridConfiguration? blockGridConfigurations = ConfigurationEditor.ConfigurationAs<BlockGridConfiguration>(dataType.ConfigurationObject);
 
-            foreach (BlockListConfiguration.BlockConfiguration configuration in configurations)
-            {
-                keys.Add(configuration.ContentElementTypeKey);
-                if (configuration.SettingsElementTypeKey.HasValue)
-                {
-                    keys.Add(configuration.SettingsElementTypeKey.Value);
-                }
+                    if(blockGridConfigurations is null)
+                    {
+                        continue;
+                    }
+
+                    if (blockGridConfigurations.Blocks.Any(configuration => configuration.ContentElementTypeKey == contentTypeId || configuration.SettingsElementTypeKey == contentTypeId))
+                    {
+                        keys.Add(dataType.Key);
+                    }
+                    break;
+                case Constants.PropertyEditors.Aliases.BlockList:
+                    BlockListConfiguration.BlockConfiguration[]? blockListConfigurations = ConfigurationEditor.ConfigurationAs<BlockListConfiguration>(dataType.ConfigurationObject)?.Blocks;
+
+                    if(blockListConfigurations is null)
+                    {
+                        continue;
+                    }
+
+                    if (blockListConfigurations.Any(configuration => configuration.ContentElementTypeKey == contentTypeId || configuration.SettingsElementTypeKey == contentTypeId))
+                    {
+                        keys.Add(dataType.Key);
+                    }
+                    break;
+                case Constants.PropertyEditors.Aliases.RichText:
+                    RichTextConfiguration? rteConfig = ConfigurationEditor.ConfigurationAs<RichTextConfiguration>(dataType.ConfigurationObject);
+
+                    if (rteConfig?.Blocks is null)
+                    {
+                        continue;
+                    }
+
+                    if (rteConfig.Blocks.Any(configuration => configuration.ContentElementTypeKey == contentTypeId || configuration.SettingsElementTypeKey == contentTypeId))
+                    {
+                        keys.Add(dataType.Key);
+                    }
+                    break;
             }
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1560,7 +1560,6 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
 
         List<Guid>? contentGuids = Database.Fetch<Guid>(sql);
 
-
         return new PagedModel<Guid>()
         {
             Items = contentGuids,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1537,7 +1537,6 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
 
     public PagedModel<Guid> GetReferencingDocumentsByDocumentTypeKey(Guid documentTypeKey)
     {
-        // TODO: Make this one query.
         Sql<ISqlContext> sqlContentTypeId = Sql()
             .Select<ContentTypeDto>(x => x.NodeId)
             .From<ContentTypeDto>()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeReferenceServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeReferenceServiceTests.cs
@@ -1,8 +1,12 @@
 ﻿using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentTypeEditing;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
@@ -11,18 +15,28 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
 internal class ContentTypeReferenceServiceTests : ContentTypeEditingServiceTestsBase
 {
-    private IContentTypeReferenceService ContentTypeReferenceService => GetRequiredService<IContentTypeReferenceService>();
+    private IContentTypeReferenceService ContentTypeReferenceService =>
+        GetRequiredService<IContentTypeReferenceService>();
+
     private IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
 
+    private PropertyEditorCollection PropertyEditorCollection => GetRequiredService<PropertyEditorCollection>();
+
+    private IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
+
+    private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer => GetRequiredService<IConfigurationEditorJsonSerializer>();
+
     [Test]
-    public async Task Get_Referenced_DocumentKeys_New()
+    public async Task Get_Referenced_DocumentKeys()
     {
-        // var compositionCreateModel = ContentTypeCreateModel("Composition", "composition");
         var contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType();
-        var compositionContentType = (await ContentTypeEditingService.CreateAsync(contentTypeCreateModel, Constants.Security.SuperUserKey)).Result!;
+        var compositionContentType =
+            (await ContentTypeEditingService.CreateAsync(contentTypeCreateModel, Constants.Security.SuperUserKey))
+            .Result!;
         var contentCreateModel = ContentEditingBuilder.CreateSimpleContent(compositionContentType.Key);
         var content = await ContentEditingService.CreateAsync(contentCreateModel, Constants.Security.SuperUserKey);
-        var keys = await ContentTypeReferenceService.GetReferencedDocumentKeysAsync(compositionContentType.Key, CancellationToken.None, 0, 100);
+        var keys = await ContentTypeReferenceService.GetReferencedDocumentKeysAsync(compositionContentType.Key,
+            CancellationToken.None, 0, 100);
 
         // Assert
         Assert.Multiple(() =>
@@ -40,11 +54,14 @@ internal class ContentTypeReferenceServiceTests : ContentTypeEditingServiceTests
 
         var compositionCreateModel = ContentTypeCreateModel("Composition", "composition");
         compositionCreateModel.Properties = new[] { propertyType1 };
-        var compositionContentType = (await ContentTypeEditingService.CreateAsync(compositionCreateModel, Constants.Security.SuperUserKey)).Result!;
+        var compositionContentType =
+            (await ContentTypeEditingService.CreateAsync(compositionCreateModel, Constants.Security.SuperUserKey))
+            .Result!;
 
         var createModel = ContentTypeCreateModel("Test", "test");
         createModel.Properties = new[] { propertyType2 };
-        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result!;
+        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey))
+            .Result!;
 
         var updateModel = ContentTypeUpdateModel("Test", "test");
         updateModel.Properties = new[] { propertyType2 };
@@ -55,7 +72,8 @@ internal class ContentTypeReferenceServiceTests : ContentTypeEditingServiceTests
 
         await ContentTypeEditingService.UpdateAsync(contentType, updateModel, Constants.Security.SuperUserKey);
 
-        var keys = await ContentTypeReferenceService.GetReferencedDocumentTypeKeysAsync(compositionContentType.Key, CancellationToken.None, 0, 100);
+        var keys = await ContentTypeReferenceService.GetReferencedDocumentTypeKeysAsync(compositionContentType.Key,
+            CancellationToken.None, 0, 100);
 
         // Assert
         Assert.Multiple(() =>
@@ -63,6 +81,102 @@ internal class ContentTypeReferenceServiceTests : ContentTypeEditingServiceTests
             Assert.That(keys.Items.Count(), Is.EqualTo(1));
             Assert.That(keys.Items.First(), Is.EqualTo(contentType.Key));
         });
+    }
 
+    [Test]
+    public async Task Get_Referenced_DocumentTypes_From_BlockList()
+    {
+        var elementTypeCreateModel = ContentTypeEditingBuilder.CreateElementType();
+        var elementType = (await ContentTypeEditingService.CreateAsync(elementTypeCreateModel, Constants.Security.SuperUserKey)).Result!;
+        var blockListConfig = new BlockListConfiguration.BlockConfiguration[] {
+            new()
+            {
+                ContentElementTypeKey = elementType.Key, SettingsElementTypeKey = elementType.Key
+
+            }
+        };
+
+        var dataType = new DataType(PropertyEditorCollection[Constants.PropertyEditors.Aliases.BlockList], ConfigurationEditorJsonSerializer)
+        {
+            ConfigurationData = new Dictionary<string, object> { { "blocks", blockListConfig } },
+            Name = "My Block Editor",
+            DatabaseType = ValueStorageType.Ntext,
+            ParentId = Constants.System.Root,
+            CreateDate = DateTime.UtcNow
+        };
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        var keys = await ContentTypeReferenceService.GetReferencedElementsFromDataTypesAsync(elementType.Key, CancellationToken.None, 0, 100);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(keys.Items.Count(), Is.EqualTo(1));
+            Assert.That(keys.Items.First(), Is.EqualTo(dataType.Key));
+        });
+    }
+
+    [Test]
+    public async Task Get_Referenced_DocumentTypes_From_BlockGrid()
+    {
+        var elementTypeCreateModel = ContentTypeEditingBuilder.CreateElementType();
+        var elementType = (await ContentTypeEditingService.CreateAsync(elementTypeCreateModel, Constants.Security.SuperUserKey)).Result!;
+        var blockListConfig = new BlockGridConfiguration.BlockGridBlockConfiguration[] {
+            new()
+            {
+                ContentElementTypeKey = elementType.Key, SettingsElementTypeKey = elementType.Key
+            }
+        };
+
+        var dataType = new DataType(PropertyEditorCollection[Constants.PropertyEditors.Aliases.BlockGrid], ConfigurationEditorJsonSerializer)
+        {
+            ConfigurationData = new Dictionary<string, object> { { "blocks", blockListConfig } },
+            Name = "My Block Editor",
+            DatabaseType = ValueStorageType.Ntext,
+            ParentId = Constants.System.Root,
+            CreateDate = DateTime.UtcNow
+        };
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        var keys = await ContentTypeReferenceService.GetReferencedElementsFromDataTypesAsync(elementType.Key, CancellationToken.None, 0, 100);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(keys.Items.Count(), Is.EqualTo(1));
+            Assert.That(keys.Items.First(), Is.EqualTo(dataType.Key));
+        });
+    }
+
+    [Test]
+    public async Task Get_Referenced_DocumentTypes_From_RichText()
+    {
+        var elementTypeCreateModel = ContentTypeEditingBuilder.CreateElementType();
+        var elementType = (await ContentTypeEditingService.CreateAsync(elementTypeCreateModel, Constants.Security.SuperUserKey)).Result!;
+        var blockListConfig = new RichTextConfiguration.RichTextBlockConfiguration[] {
+            new()
+            {
+                ContentElementTypeKey = elementType.Key, SettingsElementTypeKey = elementType.Key
+            }
+        };
+
+        var dataType = new DataType(PropertyEditorCollection[Constants.PropertyEditors.Aliases.RichText], ConfigurationEditorJsonSerializer)
+        {
+            ConfigurationData = new Dictionary<string, object> { { "blocks", blockListConfig } },
+            Name = "My Block Editor",
+            DatabaseType = ValueStorageType.Ntext,
+            ParentId = Constants.System.Root,
+            CreateDate = DateTime.UtcNow
+        };
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        var keys = await ContentTypeReferenceService.GetReferencedElementsFromDataTypesAsync(elementType.Key, CancellationToken.None, 0, 100);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(keys.Items.Count(), Is.EqualTo(1));
+            Assert.That(keys.Items.First(), Is.EqualTo(dataType.Key));
+        });
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeReferenceServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeReferenceServiceTests.cs
@@ -1,0 +1,68 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentTypeEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal class ContentTypeReferenceServiceTests : ContentTypeEditingServiceTestsBase
+{
+    private IContentTypeReferenceService ContentTypeReferenceService => GetRequiredService<IContentTypeReferenceService>();
+    private IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
+
+    [Test]
+    public async Task Get_Referenced_DocumentKeys_New()
+    {
+        // var compositionCreateModel = ContentTypeCreateModel("Composition", "composition");
+        var contentTypeCreateModel = ContentTypeEditingBuilder.CreateSimpleContentType();
+        var compositionContentType = (await ContentTypeEditingService.CreateAsync(contentTypeCreateModel, Constants.Security.SuperUserKey)).Result!;
+        var contentCreateModel = ContentEditingBuilder.CreateSimpleContent(compositionContentType.Key);
+        var content = await ContentEditingService.CreateAsync(contentCreateModel, Constants.Security.SuperUserKey);
+        var keys = await ContentTypeReferenceService.GetReferencedDocumentKeysAsync(compositionContentType.Key, CancellationToken.None, 0, 100);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(keys.Items.Count(), Is.EqualTo(1));
+            Assert.That(keys.Items.First(), Is.EqualTo(content.Result.Content.Key));
+        });
+    }
+
+    [Test]
+    public async Task Get_Referenced_DocumentTypeKeys()
+    {
+        var propertyType1 = ContentTypePropertyTypeModel("Test Property 1", "testProperty1");
+        var propertyType2 = ContentTypePropertyTypeModel("Test Property 2", "testProperty2");
+
+        var compositionCreateModel = ContentTypeCreateModel("Composition", "composition");
+        compositionCreateModel.Properties = new[] { propertyType1 };
+        var compositionContentType = (await ContentTypeEditingService.CreateAsync(compositionCreateModel, Constants.Security.SuperUserKey)).Result!;
+
+        var createModel = ContentTypeCreateModel("Test", "test");
+        createModel.Properties = new[] { propertyType2 };
+        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result!;
+
+        var updateModel = ContentTypeUpdateModel("Test", "test");
+        updateModel.Properties = new[] { propertyType2 };
+        updateModel.Compositions = new[]
+        {
+            new Composition { Key = compositionContentType.Key, CompositionType = CompositionType.Composition }
+        };
+
+        await ContentTypeEditingService.UpdateAsync(contentType, updateModel, Constants.Security.SuperUserKey);
+
+        var keys = await ContentTypeReferenceService.GetReferencedDocumentTypeKeysAsync(compositionContentType.Key, CancellationToken.None, 0, 100);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(keys.Items.Count(), Is.EqualTo(1));
+            Assert.That(keys.Items.First(), Is.EqualTo(contentType.Key));
+        });
+
+    }
+}


### PR DESCRIPTION
# Notes
- This is a feature, that aims to let the user know, if the document type is referenced anywhere, the most common use case is, when you go to delete a document type, you would like to know if it is used somewhere before deleting it, as it can have massive consequences.
- This PR remedies that, by implemeting a service that covers 3 different uses:
  - Referenced by documents, supply a document type key, and you will get back a list of all the document keys that is created from that document type
  - Referenced by other document types, supply a document type key, and you will get back a list of all the document type keys, that inherit from that document type.
  - Datatypes referincing that document type, supply a document type key (element), and it will return a list of all the data type keys, (blocklist, blockgrid & richtext data types) that references this doucment type (element type)


# How to test

- You can look at the integration tests created for inspiration.
- For the first use case, create a document type (or multiple)
- Create some content from this document type, keep a track of how many you create
  - Call the service with the document type you created, and assert it returns the correct number and correct guids
- For the second use case, create 2 document types, 1 inheriting from the other. ( again you can do multiple here)
  - Call the service with the document type that is inherited FROM, assert it returns the correct number of document types and the GUIDS are correct
- For the third and last use case, this time, start by creating a document type, but create it as an element.
  - Create a document type, with a block list/blockgrid/richtext, that uses the element you've created
  - Call the service with the element type key you've created, assert it returns the correct number and GUIDS