### PR TITLE
PropertyType constructor sets the DataTypeKey if IDataType has identity

### DIFF
--- a/src/Umbraco.Core/Models/IPropertyType.cs
+++ b/src/Umbraco.Core/Models/IPropertyType.cs
@@ -24,6 +24,9 @@ public interface IPropertyType : IEntity, IRememberBeingDirty
     /// </summary>
     int DataTypeId { get; set; }
 
+    /// <summary>
+    ///     Gets or sets the Guid unique identifier of the datatype for this property type.
+    /// </summary>
     Guid DataTypeKey { get; set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Models/PropertyType.cs
+++ b/src/Umbraco.Core/Models/PropertyType.cs
@@ -47,6 +47,7 @@ public class PropertyType : EntityBase, IPropertyType, IEquatable<PropertyType>
         if (dataType.HasIdentity)
         {
             _dataTypeId = dataType.Id;
+            _dataTypeKey = dataType.Key;
         }
 
         _propertyEditorAlias = dataType.EditorAlias;
@@ -159,6 +160,7 @@ public class PropertyType : EntityBase, IPropertyType, IEquatable<PropertyType>
         set => SetPropertyValueAndDetectChanges(value, ref _dataTypeId, nameof(DataTypeId));
     }
 
+    /// <inheritdoc />
     [DataMember]
     public Guid DataTypeKey
     {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #20296 

### Description
* I added code to set the DataTypeKey on PropertyType constructor if the IDataType provided has identity, as it did for DataTypeId.
* If the DataTypeKey was not explicitly set after the PropertyType construction, this resulted in a constraint violation when saving the ContentType, and it could be easily overlooked.
* I also documented the DataTypeKey property on IPropertyType 
* (closes #20296)

<!-- Thanks for contributing to Umbraco CMS! -->
