### PR TITLE
Log Viewer: Fixes continuous polling (closes #20274)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -337,6 +337,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 	stopPolling() {
 		if (this.#intervalID) {
 			clearInterval(this.#intervalID);
+			this.#intervalID = null;
 		}
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -124,6 +124,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 	override hostDisconnected(): void {
 		super.hostDisconnected();
 		window.removeEventListener('changestate', this.onChangeState);
+		this.stopPolling();
 	}
 
 	onChangeState = () => {
@@ -320,7 +321,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 			return;
 		}
 
-		clearInterval(this.#intervalID as number);
+		this.stopPolling();
 	}
 
 	setPollingInterval(interval: UmbPoolingInterval) {
@@ -331,6 +332,12 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 		const direction = this.#sortingDirection.getValue();
 		const newDirection = direction === DirectionModel.ASCENDING ? DirectionModel.DESCENDING : DirectionModel.ASCENDING;
 		this.#sortingDirection.setValue(newDirection);
+	}
+
+	stopPolling() {
+		if (this.#intervalID) {
+			clearInterval(this.#intervalID);
+		}
 	}
 }
 


### PR DESCRIPTION
### Description

Fixes #20274.

Stops the log viewer from polling the server when the user has navigated away from the log viewer workspace.

### How to test?

Go to the Log Viewer workspace (Search view), start the polling. Notice in the browser dev-tools (Network tab) that the requests are being made at the set interval. Navigate away from the Log Viewer workspace. Notice that the server requests have now stopped.
