### PR TITLE
Exception handling: Improve error messaging on invalid umbraco-package.json file.

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Extensions/HtmlHelperBackOfficeExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/Extensions/HtmlHelperBackOfficeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Umbraco.Cms.Core;
@@ -24,29 +24,18 @@ public static class HtmlHelperBackOfficeExtensions
         IBackOfficePathGenerator backOfficePathGenerator,
         IPackageManifestService packageManifestService)
     {
-        try
-        {
-            PackageManifestImportmap packageImports = await packageManifestService.GetPackageManifestImportmapAsync();
+        PackageManifestImportmap packageImports = await packageManifestService.GetPackageManifestImportmapAsync();
 
-            var sb = new StringBuilder();
-            sb.AppendLine("""<script type="importmap">""");
-            sb.AppendLine(jsonSerializer.Serialize(packageImports));
-            sb.AppendLine("</script>");
+        var sb = new StringBuilder();
+        sb.AppendLine("""<script type="importmap">""");
+        sb.AppendLine(jsonSerializer.Serialize(packageImports));
+        sb.AppendLine("</script>");
 
-            // Inject the BackOffice cache buster into the import string to handle BackOffice assets
-            var importmapScript = sb.ToString()
-                .Replace(backOfficePathGenerator.BackOfficeVirtualDirectory, backOfficePathGenerator.BackOfficeAssetsPath)
-                .Replace(Constants.Web.CacheBusterToken, backOfficePathGenerator.BackOfficeCacheBustHash);
+        // Inject the BackOffice cache buster into the import string to handle BackOffice assets
+        var importmapScript = sb.ToString()
+            .Replace(backOfficePathGenerator.BackOfficeVirtualDirectory, backOfficePathGenerator.BackOfficeAssetsPath)
+            .Replace(Constants.Web.CacheBusterToken, backOfficePathGenerator.BackOfficeCacheBustHash);
 
-            return html.Raw(importmapScript);
-        }
-        catch (NotSupportedException ex)
-        {
-            throw new NotSupportedException("Failed to serialize the BackOffice import map", ex);
-        }
-        catch (Exception ex)
-        {
-            throw new Exception("Failed to generate the BackOffice import map", ex);
-        }
+        return html.Raw(importmapScript);
     }
 }

--- a/src/Umbraco.Infrastructure/Manifest/PackageManifestReader.cs
+++ b/src/Umbraco.Infrastructure/Manifest/PackageManifestReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.IO;
@@ -92,10 +93,15 @@ internal class PackageManifestReader : IPackageManifestReader
                     packageManifests.Add(packageManifest);
                 }
             }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(
+                    $"The package manifest file {fileInfo.PhysicalPath} could not be parsed as it does not contain valid JSON. Please see the inner exception for details.", ex);
+            }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unable to load package manifest file: {FileName}", fileInfo.Name);
-                throw;
+                throw new InvalidOperationException(
+                    $"The package manifest file {fileInfo.PhysicalPath} could not be parsed due to an unexpected error. Please see the inner exception for details.", ex);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses https://github.com/umbraco/Umbraco-CMS/issues/20322

### Description
In investigating the linked issue I could see we did have some try/catch handling around an issue with an invalid `umbraco-package.json` file, but it wasn't ideal as it:
- Was wrapped around the whole generation of the import map, so couldn't be precisely targeted to a deserialization error.
- Provided no information about what file had the problem and what the issue was.

With this PR you'll get a more targeted exception:

<img width="1877" height="303" alt="image" src="https://github.com/user-attachments/assets/27bcc289-41bc-446d-8bad-d2451c882628" />

### Testing

- Add a backoffice extension in `App_Plugins/{extension-name}/umbraco-package.json
- Break the JSON in the file, e.g. by removing the final `}`
- Verify that a message like the one shown above is displayed when accessing the backoffice

