### PR TITLE
Extend logging (add delay and period)

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunner.cs
@@ -37,7 +37,8 @@ public class RecurringBackgroundJobHostedServiceRunner : IHostedService
                 _logger.LogDebug("Creating background hosted service for {job}", jobName);
                 IHostedService hostedService = _jobFactory(job);
 
-                _logger.LogInformation("Starting background hosted service for {job}", jobName);
+                _logger.LogInformation("Starting a background hosted service for {job} with a delay of {delay}, running every {period}", jobName, job.Delay, job.Period);
+
                 await hostedService.StartAsync(cancellationToken).ConfigureAwait(false);
 
                 _hostedServices.Add(new NamedServiceJob(jobName, hostedService));


### PR DESCRIPTION
A very small PR to extend the `RecurringBackgroundJobHostedServiceRunner`. At the moment we make extensive use of RecurringBackgroundJobs, and it’s quite useful to have a bit more information in the logging about the configured delay and how often the job runs.