### PR TITLE
Removed the dot "." in front of the jpg file extension example.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/upload-field/Umbraco.UploadField.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/upload-field/Umbraco.UploadField.ts
@@ -12,7 +12,7 @@ export const manifest: ManifestPropertyEditorSchema = {
 					alias: 'fileExtensions',
 					label: 'Accepted file extensions',
 					description:
-						'Insert one extension per line, for example `.jpg`.\n\nYou can also use mime types, for example `image/*` or `application/pdf`.',
+						'Insert one extension per line, for example `jpg`.\n\nYou can also use mime types, for example `image/*` or `application/pdf`.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.AcceptedUploadTypes',
 				},
 			],


### PR DESCRIPTION
### Prerequisites

Addresses https://github.com/umbraco/Umbraco-CMS/issues/20331

### Description

Removed the dot "." in the file extension example, otherwise the validation will fail and you will not be able to upload the jpg image.


<!-- Thanks for contributing to Umbraco CMS! -->
