### PR TITLE
Prevent RTE being marked as dirty when content containt empty paragraph

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
+++ b/src/Umbraco.Web.UI.Client/src/common/services/tinymce.service.js
@@ -1465,7 +1465,8 @@ function tinyMceService($rootScope, $q, imageHelper, $locale, $http, $timeout, s
 
       function syncContent() {
 
-        const content = args.editor.getContent();
+        //get the content from tinyMCE and replace Non-breaking space character to HTML Entity
+        const content = args.editor.getContent().replace('\u00A0', '&nbsp;');
 
         if (getPropertyValue() === content) {
           return;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! --> https://github.com/umbraco/Umbraco-CMS/issues/18127 https://github.com/umbraco/Umbraco-CMS/issues/16922

### Description

In Tinymce, an empty paragraph is filled with a non-breaking space character. When saving the content, the DOMParser replaces this empty non-breaking space character with an `&nbsp;` entity. This causes the editor to be dirty when the content contains an empty paragraph. By making these the same before the comparison, this is prevented.

**Tesing**

- In Umbraco 13 add a Richtext editor (Umbraco.TinyMCE) to a Doctype.
- Optionally add an Blockgrid editor and add an element that contains an Richtext editor.
- Create a page of this doctype and put 2 lines of text in the editor and separate them with an empty paragraph (simply push Enter).
- Save the page.
- Click inside the editor and then click outside the editor.
- Navigate to another page, a "Unsaved changes"-dialog will appear, even without changing anything.

Apply the patch and try the last 2 steps again. The "Unsaved changes"-dialog doesn't appear anymore.




<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
