### PR TITLE
Caching: Fixes regression of the caching of null representations for missing dictionary items

### DIFF
--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -68,9 +68,9 @@ public static class AppCacheExtensions
 
         // If we've retrieved the specific string that represents null in the cache, return it only if we are requesting it (via a typed request for a string).
         // Otherwise consider it a null value.
-        if (result == (object)Cms.Core.Constants.Cache.NullRepresentationInCache)
+        if (RetrievedNullRepresentationInCache(result))
         {
-            return typeof(T) == typeof(string) ? (T)result : default;
+            return RequestedNullRepresentationInCache<T>() ? (T)result : default;
         }
 
         return result.TryConvertTo<T>().Result;

--- a/src/Umbraco.Core/Cache/AppCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/AppCacheExtensions.cs
@@ -43,9 +43,16 @@ public static class AppCacheExtensions
     public static T? GetCacheItem<T>(this IAppCache provider, string cacheKey)
     {
         var result = provider.Get(cacheKey);
-        if (IsRetrievedItemNull(result))
+        if (result == null)
         {
             return default;
+        }
+
+        // If we've retrieved the specific string that represents null in the cache, return it only if we are requesting it (via a typed request for a string).
+        // Otherwise consider it a null value.
+        if (RetrievedNullRepresentationInCache(result))
+        {
+            return RequestedNullRepresentationInCache<T>() ? (T)result : default;
         }
 
         return result.TryConvertTo<T>().Result;
@@ -54,13 +61,23 @@ public static class AppCacheExtensions
     public static T? GetCacheItem<T>(this IAppCache provider, string cacheKey, Func<T> getCacheItem)
     {
         var result = provider.Get(cacheKey, () => getCacheItem());
-        if (IsRetrievedItemNull(result))
+        if (result == null)
         {
             return default;
+        }
+
+        // If we've retrieved the specific string that represents null in the cache, return it only if we are requesting it (via a typed request for a string).
+        // Otherwise consider it a null value.
+        if (result == (object)Cms.Core.Constants.Cache.NullRepresentationInCache)
+        {
+            return typeof(T) == typeof(string) ? (T)result : default;
         }
 
         return result.TryConvertTo<T>().Result;
     }
 
-    private static bool IsRetrievedItemNull(object? result) => result is null or (object)Cms.Core.Constants.Cache.NullRepresentationInCache;
+    private static bool RetrievedNullRepresentationInCache(object result) => result == (object)Cms.Core.Constants.Cache.NullRepresentationInCache;
+
+    private static bool RequestedNullRepresentationInCache<T>() => typeof(T) == typeof(string);
+
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -20,6 +23,15 @@ public class DictionaryRepositoryTest : UmbracoIntegrationTest
     public void SetUp() => CreateTestData();
 
     private IDictionaryRepository CreateRepository() => GetRequiredService<IDictionaryRepository>();
+
+    private IDictionaryRepository CreateRepositoryWithCache() =>
+
+        // Create a repository with a real runtime cache.
+        new DictionaryRepository(
+            GetRequiredService<IScopeAccessor>(),
+            AppCaches.Create(Mock.Of<IRequestCache>()),
+            GetRequiredService<ILogger<DictionaryRepository>>(),
+            GetRequiredService<ILoggerFactory>());
 
     [Test]
     public void Can_Perform_Get_By_Key_On_DictionaryRepository()
@@ -392,6 +404,116 @@ public class DictionaryRepositoryTest : UmbracoIntegrationTest
         foreach (var kvp in keyMap)
         {
             Console.WriteLine("{0}: {1}", kvp.Key, kvp.Value);
+        }
+    }
+
+    [Test]
+    public void Can_Perform_Cached_Request_For_Existing_Value_By_Key_On_DictionaryRepository_With_Cache()
+    {
+        var repository = CreateRepositoryWithCache();
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More");
+
+            Assert.AreEqual("Read More", dictionaryItem.Translations.Single(x => x.LanguageIsoCode == "en-US").Value);
+        }
+
+        // Modify the value directly in the database. This won't be reflected in the repository cache and hence if the cache
+        // is working as expected we should get the same value as above.
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            scope.Database.Execute("UPDATE cmsLanguageText SET value = 'Read More (updated)' WHERE value = 'Read More' and LanguageId = 1");
+            scope.Complete();
+        }
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More");
+
+            Assert.AreEqual("Read More", dictionaryItem.Translations.Single(x => x.LanguageIsoCode == "en-US").Value);
+        }
+    }
+
+    [Test]
+    public void Can_Perform_Cached_Request_For_NonExisting_Value_By_Key_On_DictionaryRepository_With_Cache()
+    {
+        var repository = CreateRepositoryWithCache();
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More Updated");
+
+            Assert.IsNull(dictionaryItem);
+        }
+
+        // Modify the value directly in the database such that it now exists. This won't be reflected in the repository cache and hence if the cache
+        // is working as expected we should get the same null value as above.
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            scope.Database.Execute("UPDATE cmsDictionary SET [key] = 'Read More Updated' WHERE [key] = 'Read More'");
+            scope.Complete();
+        }
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More Updated");
+
+            Assert.IsNull(dictionaryItem);
+        }
+    }
+
+    [Test]
+    public void Cannot_Perform_Cached_Request_For_Existing_Value_By_Key_On_DictionaryRepository_Without_Cache()
+    {
+        var repository = CreateRepository();
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More");
+
+            Assert.AreEqual("Read More", dictionaryItem.Translations.Single(x => x.LanguageIsoCode == "en-US").Value);
+        }
+
+        // Modify the value directly in the database. As we don't have caching enabled on the repository we should get the new value.
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            scope.Database.Execute("UPDATE cmsLanguageText SET value = 'Read More (updated)' WHERE value = 'Read More' and LanguageId = 1");
+            scope.Complete();
+        }
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More");
+
+            Assert.AreEqual("Read More (updated)", dictionaryItem.Translations.Single(x => x.LanguageIsoCode == "en-US").Value);
+        }
+    }
+
+    [Test]
+    public void Cannot_Perform_Cached_Request_For_NonExisting_Value_By_Key_On_DictionaryRepository_Without_Cache()
+    {
+        var repository = CreateRepository();
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More Updated");
+
+            Assert.IsNull(dictionaryItem);
+        }
+
+        // Modify the value directly in the database such that it now exists. As we don't have caching enabled on the repository we should get the new value.
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            scope.Database.Execute("UPDATE cmsDictionary SET [key] = 'Read More Updated' WHERE [key] = 'Read More'");
+            scope.Complete();
+        }
+
+        using (ScopeProvider.CreateScope())
+        {
+            var dictionaryItem = repository.Get("Read More Updated");
+
+            Assert.IsNotNull(dictionaryItem);
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses https://github.com/umbraco/Umbraco-CMS/issues/20336

### Description
In an earlier PR, we added an update to the dictionary repository such that it cached null values, and prevented multiple database hits for dictionary keys that did not exist: https://github.com/umbraco/Umbraco-CMS/pull/15576

We then resolved this issue raised that identified some issues resulting when using localised text in the backoffice (supported in Umbraco 13): https://github.com/umbraco/Umbraco-CMS/pull/19350

Unfortunately it seems this caused a regression on the original feature.

In this PR I've resolved the regression and tested that the backoffice translations work as expected.

I've also added integration tests to verify the cache behaviour.

### Testing

See replication steps described in https://github.com/umbraco/Umbraco-CMS/issues/20336

With the code in this PR in place, verify that you no longer see the database requests for missing dictionary items.

### Release

Once approved and merged for 13.12, this will need cherry-picking up for 16.4.