### PR TITLE
Media: Prevent svg image to extend outside the editor bounds

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/preview/input-upload-field-svg.element.ts
@@ -30,6 +30,7 @@ export default class UmbInputUploadFieldSvgElement extends UmbLitElement impleme
 				background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" fill-opacity=".1"><path d="M50 0h50v50H50zM0 50h50v50H0z"/></svg>');
 				background-repeat: repeat;
 				background-size: 10px 10px;
+				max-width: 100%;
 			}
 		`,
 	];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This PR fixes issue 19832 (https://github.com/umbraco/Umbraco-CMS/issues/19832)

### Description

When resizing the window to a smaller width value the svg image is extending outside the bounds of its parent

In order to test the change go to Backoffice and click on `Media` tab, then create a new SVG media with the following image:

![sfumato](https://github.com/user-attachments/assets/75da2ffd-37b3-40f8-a699-34d55bbf0d90)
Resize the window horizontally so the width value changes. Now the svg image should not exceed its parent.

Before:
<img width="2028" height="913" alt="image" src="https://github.com/user-attachments/assets/2efad28e-6219-4cec-8b34-337b652c4e17" />

After (setting `max-width: 100%`):
<img width="1095" height="1004" alt="image" src="https://github.com/user-attachments/assets/65f57c61-cb93-44d2-bde5-21d917aa8230" />

