### PR TITLE
Configuration: Fixed integer overflow in setting MaxRequestBodySize and MultipartBodyLengthLimit

### DIFF
--- a/src/Umbraco.Web.Common/Security/ConfigureFormOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureFormOptions.cs
@@ -14,6 +14,6 @@ public class ConfigureFormOptions : IConfigureOptions<FormOptions>
 
         // convert from KB to bytes
         options.MultipartBodyLengthLimit = _runtimeSettings.Value.MaxRequestLength.HasValue
-            ? _runtimeSettings.Value.MaxRequestLength.Value * 1024
+            ? (long)_runtimeSettings.Value.MaxRequestLength.Value * 1024
             : long.MaxValue;
 }

--- a/src/Umbraco.Web.Common/Security/ConfigureKestrelServerOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureKestrelServerOptions.cs
@@ -15,6 +15,6 @@ public class ConfigureKestrelServerOptions : IConfigureOptions<KestrelServerOpti
 
         // convert from KB to bytes, 52428800 bytes (50 MB) is the same as in the IIS settings
         options.Limits.MaxRequestBodySize = _runtimeSettings.Value.MaxRequestLength.HasValue
-            ? _runtimeSettings.Value.MaxRequestLength.Value * 1024
+            ? (long)_runtimeSettings.Value.MaxRequestLength.Value * 1024
             : 52428800;
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20343

### Description
We have an integer overflow exception when we attempt to convert a configured KB value into bytes.  It's caused by multiplying two ints together to make a long - if the two ints go over int.MaxValue the result is zero.

I've fixed this by casting one of the ints to a long before doing the calculation.

### Testing
You can test this via breakpoints at the places of the changed code on start up, veryfiny that the value is set to a non-zero value when configured in `Umbraco:Cms` to be, e.g. as follows:

```
  "Runtime": {
    "MaxRequestLength": 4194304
  },
```

And verify that you can save and publish nodes (previously having this value coerced to zero would cause an exception to be thrown).

### Release

Once verified and merged for 13, needs to be cherry-picked up to 16.
