### PR TITLE
Shared status: improve for segmented scenario

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
@@ -183,15 +183,23 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 			// TODO: Do not use the content variant id, but know wether the property is configured to vary by segment.
 			// Because we can view a default segment, then we do not know if the property is shared or not. [NL]
 			if (contextVariantId.segment !== null && propertyVariantId.segment === null) {
-				if (contextVariantId.culture !== null) {
+				// If the property does not have culture, then we know this also will be shared across cultures.
+				if (propertyVariantId.culture === null) {
 					shareMessage = 'content_sharedAcrossCultures';
 				} else {
+					// If not, then we know it will be only be shared across segments.
 					shareMessage = 'content_sharedAcrossSegments';
 				}
 			}
 			// TODO: Do not use the content variant id, but know wether the property is configured to vary by culture. (this is first a problem when we introduce the invariant-variant)
 			if (contextVariantId.culture !== null && propertyVariantId.culture === null) {
-				shareMessage = 'content_shared';
+				// If the property does have segment, then we know this will be shared across cultures and not across segments.
+				if (propertyVariantId.segment !== null) {
+					shareMessage = 'content_sharedAcrossCultures';
+				} else {
+					// if not then we know its shared across everything.
+					shareMessage = 'content_shared';
+				}
 			}
 		}
 		this.#variantDifference.setValue(shareMessage);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
@@ -197,7 +197,7 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 				if (propertyVariantId.segment !== null) {
 					shareMessage = 'content_sharedAcrossCultures';
 				} else {
-					// if not then we know its shared across everything.
+					// if not then we know it's shared across everything.
 					shareMessage = 'content_shared';
 				}
 			}


### PR DESCRIPTION
Still does not fix the problem of viewing segmented statuses on the default variant. but it fixes the other cases.

Like this:
<img width="448" height="454" alt="image" src="https://github.com/user-attachments/assets/3b929a5b-d07f-47f0-8102-d13432be504c" />
