### PR TITLE
Change to layout of default Content area dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/umbraco-news/umbraco-news-dashboard.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/umbraco-news/umbraco-news-dashboard.element.ts
@@ -74,8 +74,7 @@ export class UmbUmbracoNewsDashboardElement extends UmbLitElement {
 			#info-links {
 				display: grid;
 				grid-template-columns: repeat(auto-fill, minmax(20%, 1fr));
-				grid-gap: var(--uui-size-space-4);
-				max-width: 1000px;
+				grid-gap: var(--uui-size-space-5);
 			}
 
 			.info-link {


### PR DESCRIPTION
I have removed the max-width on the wrapper and increased the padding on the small pods to match the larger pod. This improves consistency with all other default dashboards in other sections of the CMS (Settings, Forms, etc), none of which had a max-width applied and where all pods have larger padding.

Screenshot of the Content dashboard before: 

<img width="1823" height="995" alt="umb cms content dashboard initial" src="https://github.com/user-attachments/assets/b0ef2e73-d1b5-4939-83b4-7544ce594462" />

Screenshot of the Settings dashboard:

<img width="1824" height="998" alt="umb cms settings dashboard" src="https://github.com/user-attachments/assets/b5ff724c-ef73-49db-8a4d-4f1d1759a526" />

Screenshot of the updated Content dashboard: 

<img width="1825" height="998" alt="umb cms content dashboard now" src="https://github.com/user-attachments/assets/2cf5f79f-6c1a-4f5b-b5f4-ce6ab60045cf" />

I appreciate that this is a minor amendment, but since this dashboard is the first thing most users are exposed to when they log in, it should be consistent with the dashboards throughout the CMS. 

Thanks! 