### PR TITLE
E2E Pipeline: QA Remove continue on error condition

### DIFF
--- a/build/nightly-E2E-run-tests-template.yml
+++ b/build/nightly-E2E-run-tests-template.yml
@@ -51,7 +51,6 @@ steps:
   # Test
   - pwsh: ${{ parameters.testCommand }}
     displayName: Run Playwright tests
-    continueOnError: true
     workingDirectory: tests/Umbraco.Tests.AcceptanceTest
     env:
       CI: true

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockGrid/BlockGridArea.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockGrid/BlockGridArea.spec.ts
@@ -36,6 +36,7 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.dataType.ensureNameNotExists(blockGridDataTypeName);
 });
 
+// FLAKY TEST FOR PIPELINE TEST; REMOVE AFTER
 test('can create content with a block grid with an empty block in a area', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   firstElementTypeId = await umbracoApi.documentType.createEmptyElementType(firstElementTypeName);
@@ -47,6 +48,7 @@ test('can create content with a block grid with an empty block in a area', {tag:
   await umbracoUi.content.goToContentWithName(contentName);
 
   // Act
+  await umbracoUi.content.clickAddBlockGridElementWithName(firstElementTypeName);
   await umbracoUi.content.clickAddBlockGridElementWithName(firstElementTypeName);
   await umbracoUi.content.clickSelectBlockElementWithName(firstElementTypeName);
   await umbracoUi.content.clickLinkWithName(areaCreateLabel);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockGrid/BlockGridArea.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/BlockGrid/BlockGridArea.spec.ts
@@ -36,7 +36,6 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.dataType.ensureNameNotExists(blockGridDataTypeName);
 });
 
-// FLAKY TEST FOR PIPELINE TEST; REMOVE AFTER
 test('can create content with a block grid with an empty block in a area', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   firstElementTypeId = await umbracoApi.documentType.createEmptyElementType(firstElementTypeName);
@@ -48,7 +47,6 @@ test('can create content with a block grid with an empty block in a area', {tag:
   await umbracoUi.content.goToContentWithName(contentName);
 
   // Act
-  await umbracoUi.content.clickAddBlockGridElementWithName(firstElementTypeName);
   await umbracoUi.content.clickAddBlockGridElementWithName(firstElementTypeName);
   await umbracoUi.content.clickSelectBlockElementWithName(firstElementTypeName);
   await umbracoUi.content.clickLinkWithName(areaCreateLabel);


### PR DESCRIPTION
This PR removes the continueOnError as it resulted in smokeTests not being caught on github