### PR TITLE
Add styling for drag handle at color picker item input

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/multiple-color-picker-input/multiple-color-picker-item-input.element.ts
@@ -149,7 +149,7 @@ export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(
 		return html`
 			<umb-form-validation-message id="validation-message" @invalid=${this.#onInvalid} @valid=${this.#onValid}>
 				<div id="item">
-					${this.disabled || this.readonly ? nothing : html`<uui-icon name="icon-grip"></uui-icon>`}
+					${this.disabled || this.readonly ? nothing : html`<uui-icon name="icon-grip" class="handle"></uui-icon>`}
 					<div class="color-wrapper">
 						<uui-input
 							id="input"
@@ -248,6 +248,14 @@ export class UmbMultipleColorPickerItemInputElement extends UUIFormControlMixin(
 				padding: 0;
 				margin: 0;
 				position: absolute;
+			}
+
+			.handle {
+				cursor: grab;
+			}
+
+			.handle:active {
+				cursor: grabbing;
 			}
 		`,
 	];


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
As title says it add styling for drag handle and makes it consistent with other parts of backoffice UI.

<img width="2161" height="975" alt="image" src="https://github.com/user-attachments/assets/83aeb2bf-4948-4683-ab73-b294c8911701" />

