### PR TITLE
Translation: Localization of property labels

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -2546,6 +2546,8 @@ export default {
 		pickSpecificAllowance: 'Tilføj gruppe eller blok',
 		allowanceMinimum: 'Sæt minimum krav',
 		allowanceMaximum: 'Sæt maksimum krav',
+		rangeAllowed: 'Antal blokke',
+		specifiedAllowance: 'Tilladte bloktyper',
 		block: 'Blok',
 		tabBlock: 'Blok',
 		tabBlockTypeSettings: 'Indstillinger',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2681,6 +2681,8 @@ export default {
 		pickSpecificAllowance: 'Pick group or Block',
 		allowanceMinimum: 'Set a minimum requirement',
 		allowanceMaximum: 'Set a maximum requirement',
+		rangeAllowed: 'Number of blocks',
+		specifiedAllowance: 'Allowed block types',
 		block: 'Block',
 		tabBlock: 'Block',
 		tabBlockTypeSettings: 'Settings',

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/views/settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/workspace/views/settings.element.ts
@@ -58,7 +58,7 @@ export class UmbBlockGridAreaTypeWorkspaceViewSettingsElement extends UmbLitElem
 					property-editor-ui-alias="Umb.PropertyEditorUi.TextBox"></umb-property>
 			</uui-box>
 			<uui-box headline=${'Validation'}>
-				<umb-property-layout label=${'rangeAllowed'}>
+				<umb-property-layout label=${this.localize.term('blockEditor_rangeAllowed')}>
 					<umb-input-number-range
 						slot="editor"
 						.minValue=${this._minValue}
@@ -68,7 +68,7 @@ export class UmbBlockGridAreaTypeWorkspaceViewSettingsElement extends UmbLitElem
 				</umb-property-layout>
 
 				<umb-property
-					label=${'specifiedAllowance'}
+					label=${this.localize.term('blockEditor_specifiedAllowance')}
 					alias="specifiedAllowance"
 					property-editor-ui-alias="Umb.PropertyEditorUi.BlockGridAreaTypePermission"></umb-property>
 			</uui-box>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed a few labels which seems to render just the keys/aliases.