### PR TITLE
Block Grid: Add more spacing in combobox group header

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/block-grid-area-type-permission.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/block-grid-area-type-permission.element.ts
@@ -247,7 +247,7 @@ export class UmbPropertyEditorUIBlockGridAreaTypePermissionElement
 			}
 
 			uui-combobox strong {
-				padding: 0 var(--uui-size-space-1);
+				padding: var(--uui-size-space-2);
 			}
 
 			uui-combobox-list-option {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Follow-up on https://github.com/umbraco/Umbraco-CMS/pull/20364 adding a bit more spacing in combobox group header.

**Before**

<img width="499" height="250" alt="image" src="https://github.com/user-attachments/assets/f6c82906-ae2d-405c-b4fd-1d30edc1006d" />


**After**

<img width="503" height="276" alt="image" src="https://github.com/user-attachments/assets/f6df0b3c-7cc5-4cb6-a7c1-e31d1bc0c630" />
