### PR TITLE
Block Grid: Add a bit more spacing and align button in block grid areas config

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/block-grid-area-config-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/block-grid-area-config-entry.element.ts
@@ -123,7 +123,6 @@ export class UmbBlockGridAreaConfigEntryElement extends UmbLitElement implements
 			.alias {
 				padding: var(--uui-size-space-4);
 			}
-			
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/block-grid-area-config-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area-config-entry/block-grid-area-config-entry.element.ts
@@ -73,7 +73,7 @@ export class UmbBlockGridAreaConfigEntryElement extends UmbLitElement implements
 	#renderBlock() {
 		return this._key
 			? html`
-					<span>${this._alias}</span>
+					<span class="alias">${this._alias}</span>
 					<uui-action-bar>
 						<uui-button label="edit" compact href=${this.workspacePath + 'edit/' + this._key}>
 							<uui-icon name="icon-edit"></uui-icon>
@@ -110,15 +110,20 @@ export class UmbBlockGridAreaConfigEntryElement extends UmbLitElement implements
 				background-color: var(--uui-color-disabled-standalone);
 			}
 
+			:host([drag-placeholder]) {
+				opacity: 0.2;
+			}
+
 			uui-action-bar {
 				position: absolute;
 				top: var(--uui-size-2);
 				right: var(--uui-size-2);
 			}
 
-			:host([drag-placeholder]) {
-				opacity: 0.2;
+			.alias {
+				padding: var(--uui-size-space-4);
 			}
+			
 		`,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/property-editor-ui-block-grid-areas-config.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/property-editor-ui-block-grid-areas-config.element.ts
@@ -159,6 +159,12 @@ export class UmbPropertyEditorUIBlockGridAreasConfigElement
 
 	static override styles = [
 		css`
+			:host {
+				display: flex;
+				flex-direction: column;
+				gap: var(--uui-size-2);
+			}
+
 			.umb-block-grid__area {
 				cursor: move;
 			}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
A bit more spacing and alignment in block grid areas config.

**Before**

<img width="1200" height="417" alt="image" src="https://github.com/user-attachments/assets/665ac846-05cf-458b-a32f-f37a5f4cf7a5" />


**After**

<img width="1200" height="437" alt="image" src="https://github.com/user-attachments/assets/34cdb4fc-b711-41fe-aaab-e99da5255a1b" />
