### PR TITLE
Nightly E2E test pipeline: QA Run E2E tests on v17/dev and enable the different setting app tests by default

### DIFF
--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -10,6 +10,7 @@ schedules:
       include:
         - v15/dev
         - main
+        - v17/dev
 
 parameters:
   - name: skipIntegrationTests
@@ -20,7 +21,7 @@ parameters:
   - name: differentAppSettingsAcceptanceTests
     displayName: Run acceptance tests with different app settings
     type: boolean
-    default: false
+    default: true
 
   - name: skipDefaultConfigAcceptanceTests
     displayName: Skip tests with DefaultConfig


### PR DESCRIPTION
This PR updates the YAML configuration to run E2E tests against the v17/dev branch and include acceptance tests for different setting apps by default, since they are stable and quick to run.