### PR TITLE
Hybrid cache: Check for `ContentCacheNode` instead of object on exists for hybrid cache to ensure correct deserialization (closes #20352)

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Extensions/HybridCacheExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Extensions/HybridCacheExtensions.cs
@@ -17,9 +17,9 @@ internal static class HybridCacheExtensions
     /// Hat-tip: https://github.com/dotnet/aspnetcore/discussions/57191
     /// Will never add or alter the state of any items in the cache.
     /// </remarks>
-    public static async Task<bool> ExistsAsync(this Microsoft.Extensions.Caching.Hybrid.HybridCache cache, string key)
+    public static async Task<bool> ExistsAsync<T>(this Microsoft.Extensions.Caching.Hybrid.HybridCache cache, string key)
     {
-        (bool exists, _) = await TryGetValueAsync<object>(cache, key);
+        (bool exists, _) = await TryGetValueAsync<T>(cache, key);
         return exists;
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -205,7 +205,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
                 var cacheKey = GetCacheKey(key, false);
 
-                var existsInCache = await _hybridCache.ExistsAsync(cacheKey);
+                var existsInCache = await _hybridCache.ExistsAsync<ContentCacheNode>(cacheKey);
                 if (existsInCache is false)
                 {
                     uncachedKeys.Add(key);
@@ -278,7 +278,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             return false;
         }
 
-        return await _hybridCache.ExistsAsync(GetCacheKey(keyAttempt.Result, preview));
+        return await _hybridCache.ExistsAsync<ContentCacheNode>(GetCacheKey(keyAttempt.Result, preview));
     }
 
     public async Task RefreshContentAsync(IContent content)

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -133,7 +133,7 @@ internal sealed class MediaCacheService : IMediaCacheService
             return false;
         }
 
-        return await _hybridCache.ExistsAsync($"{keyAttempt.Result}");
+        return await _hybridCache.ExistsAsync<ContentCacheNode>($"{keyAttempt.Result}");
     }
 
     public async Task RefreshMediaAsync(IMedia media)
@@ -170,7 +170,7 @@ internal sealed class MediaCacheService : IMediaCacheService
 
                 var cacheKey = GetCacheKey(key, false);
 
-                var existsInCache = await _hybridCache.ExistsAsync(cacheKey);
+                var existsInCache = await _hybridCache.ExistsAsync<ContentCacheNode>(cacheKey);
                 if (existsInCache is false)
                 {
                     uncachedKeys.Add(key);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/Extensions/HybridCacheExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/Extensions/HybridCacheExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Caching.Hybrid;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.HybridCache;
 using Umbraco.Cms.Infrastructure.HybridCache.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.PublishedCache.HybridCache.Extensions;
@@ -27,20 +28,20 @@ public class HybridCacheExtensionsTests
     {
         // Arrange
         string key = "test-key";
-        var expectedValue = "test-value";
+        var expectedValue = new ContentCacheNode { Id = 1234 };
 
         _cacheMock
             .Setup(cache => cache.GetOrCreateAsync(
                 key,
                 null!,
-                It.IsAny<Func<object, CancellationToken, ValueTask<object>>>(),
+                It.IsAny<Func<object, CancellationToken, ValueTask<ContentCacheNode>>>(),
                 It.IsAny<HybridCacheEntryOptions>(),
                 null,
                 CancellationToken.None))
             .ReturnsAsync(expectedValue);
 
         // Act
-        var exists = await HybridCacheExtensions.ExistsAsync(_cacheMock.Object, key);
+        var exists = await HybridCacheExtensions.ExistsAsync<ContentCacheNode>(_cacheMock.Object, key);
 
         // Assert
         Assert.IsTrue(exists);
@@ -56,14 +57,14 @@ public class HybridCacheExtensionsTests
             .Setup(cache => cache.GetOrCreateAsync(
                 key,
                 null!,
-                It.IsAny<Func<object, CancellationToken, ValueTask<object>>>(),
+                It.IsAny<Func<object, CancellationToken, ValueTask<ContentCacheNode>>>(),
                 It.IsAny<HybridCacheEntryOptions>(),
                 null,
                 CancellationToken.None))
             .Returns((
                 string key,
                 object? state,
-                Func<object, CancellationToken, ValueTask<object>> factory,
+                Func<object, CancellationToken, ValueTask<ContentCacheNode>> factory,
                 HybridCacheEntryOptions? options,
                 IEnumerable<string>? tags,
                 CancellationToken token) =>
@@ -72,7 +73,7 @@ public class HybridCacheExtensionsTests
             });
 
         // Act
-        var exists = await HybridCacheExtensions.ExistsAsync(_cacheMock.Object, key);
+        var exists = await HybridCacheExtensions.ExistsAsync<ContentCacheNode>(_cacheMock.Object, key);
 
         // Assert
         Assert.IsFalse(exists);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco-CMS/issues/20352 caused by a regression introduced by https://github.com/umbraco/Umbraco-CMS/pull/19890.

### Description
Although the reported issue related to Redis, this is visible with any L2 cache other than a memory cache where deserialization is required.

The problem comes about because we are using `object` to verify the existence of something in the cache, rather than the actual object `ContentCacheNode` we always store, which has configured serialization rules.  As such the deserialization is using the default JSON serializer, which fails as we aren't stored cached values as JSON.

### Testing

Set up SQL L2 cache, which if running from source, is done by:

- Add the following to `Directory.Packages.props`:

```
<ItemGroup>
  <PackageVersion Include="Microsoft.Extensions.Caching.SqlServer" Version="9.0.9" />
</ItemGroup>
```

- Add the following to `Umbraco.Web.UI.csproj`:

```
<ItemGroup>
  <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" />
</ItemGroup>
```

- Add the following to `Program.cs`, just before `WebApplication app = builder.Build();`:

```
builder.Services.AddDistributedSqlServerCache(options =>
{
    options.ConnectionString = builder.Configuration.GetConnectionString("SqlDistributedCache");
    options.SchemaName = "dbo";
    options.TableName = "TestCache";
});
```

- Create a SQL Server database
- Populate the database with:

```
dotnet tool install --global dotnet-sql-cache
dotnet sql-cache create "Server=.\SQLEXPRESS;Database=MyDatabase;Integrated Security=true;TrustServerCertificate=true;" dbo TestCache
```

- Add the following connection string to `appSettings.json`:

```
"SqlDistributedCache": "Server=.\\SQLEXPRESS;Database=UmbracoCms16HybridCache;Integrated Security=true;TrustServerCertificate=true;"
```

Now verify the issue resolution with:

- Start up Umbraco using code from `main`.  The first time it'll be fine, as the table is empty and will be populated.
- Verify via `select * from TestCache`
- Stop and start Umbraco again.  You should now hit the error:

```
An error occurred starting the application
System.AggregateException: One or more errors occurred. (One or more errors occurred. ('0x92' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.))
```

- Check out the code in this branch and empty the table with `truncate table TestCache`
- Repeat starting up Umbraco twice.  This time there should be no error on the second restart.


