### PR TITLE
Models Builder: Make Models Builder better at not performing "rude edits"

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ModelsBuilderSettings.cs
@@ -17,6 +17,7 @@ public class ModelsBuilderSettings
     internal const bool StaticAcceptUnsafeModelsDirectory = false;
     internal const int StaticDebugLevel = 0;
     internal const bool StaticIncludeVersionNumberInGeneratedModels = true;
+    internal const bool StaticGenerateVirtualProperties = true;
     private bool _flagOutOfDateModels = true;
 
     /// <summary>
@@ -77,4 +78,13 @@ public class ModelsBuilderSettings
     /// </remarks>
     [DefaultValue(StaticIncludeVersionNumberInGeneratedModels)]
     public bool IncludeVersionNumberInGeneratedModels { get; set; } = StaticIncludeVersionNumberInGeneratedModels;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether to mark all properties in the generated models as virtual.
+    /// </summary>
+    /// <remarks>
+    ///     Virtual properties will not work with Hot Reload when running dotnet watch.
+    /// </remarks>
+    [DefaultValue(StaticGenerateVirtualProperties)]
+    public bool GenerateVirtualProperties { get; set; } = StaticGenerateVirtualProperties;
 }

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
@@ -384,7 +384,11 @@ public class TextBuilder : Builder
 
         sb.AppendFormat("\t\t[ImplementPropertyType(\"{0}\")]\n", property.Alias);
 
-        sb.Append("\t\tpublic virtual ");
+        sb.Append("\t\tpublic ");
+        if (Config.GenerateVirtualProperties)
+        {
+            sb.Append("virtual ");
+        }
         WriteClrType(sb, property.ClrTypeName);
 
         sb.AppendFormat(
@@ -460,7 +464,11 @@ public class TextBuilder : Builder
 
         if (mixinStatic)
         {
-            sb.Append("\t\tpublic virtual ");
+            sb.Append("\t\tpublic ");
+            if (Config.GenerateVirtualProperties)
+            {
+                sb.Append("virtual ");
+            }
             WriteClrType(sb, property.ClrTypeName);
             sb.AppendFormat(
                 " {0} => {1}(this, _publishedValueFallback);\n",
@@ -468,7 +476,11 @@ public class TextBuilder : Builder
         }
         else
         {
-            sb.Append("\t\tpublic virtual ");
+            sb.Append("\t\tpublic ");
+            if (Config.GenerateVirtualProperties)
+            {
+                sb.Append("virtual ");
+            }
             WriteClrType(sb, property.ClrTypeName);
             sb.AppendFormat(
                 " {0} => this.Value",


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

In an effort to make Umbraco support 🔥 [Hot Reload](https://learn.microsoft.com/en-us/aspnet/core/test/hot-reload), the Models Builder models generation needs to change a little:

1. It must not delete and recreate files. This constitutes a "rude edit" towards Hot Reload, which in turn requires an application restart.
2. It must not generate `virtual` properties, as adding `virtual` members is an [unsupported edit](https://learn.microsoft.com/en-us/visualstudio/debugger/supported-code-changes-csharp#unsupported-changes-to-code) for Hot Reload.

The first change is relatively simple; I have made Models Builder a bit more conscious about file deletions.

The second is harder. Models Builder has generated `virtual` properties ~~since forever~~ for the past five years, so simply removing that would be quite the breaking change.

To work around this, I have introduced a new configuration option in the [Models Builder settings](https://docs.umbraco.com/umbraco-cms/reference/configuration/modelsbuildersettings). It's called `GenerateVirtualProperties` , and it's a boolean which defaults to `true` to retain backwards compatibility by default.

### Considerations

Adding yet another configuration option is not ideal. We have plenty of those 🙈 

On the flip side, Umbraco is by default configured to generate in-memory models and use Razor Runtime Compilation, so one needs to jump through a fair few hoops to get to a point where Hot Reload can be used (see #20187 for details). An extra configuration is probably not the worst that can happen.

### Testing this PR

It is likely best to test this PR using the NuGet packages generated by the build server.

Start by setting up a site without Razor Runtime Compilation (again, see #20187 for details), and configure Models Builder to:

- Use the `SourceCodeManual` mode.
- Generate non-virtual properties (`GenerateVirtualProperties` set to `false`).

Start the site with `dotnet run` and build up a basic setup for testing - just a few pages and a template.

Now restart the site using `dotnet watch`, and verify that Hot Reload allows for:

- Adding new properties to a doctype and subsequently rendering them in the template.
- Making other rendering changes to the template (i.e. changing the rendering of an existing property).

Please note that you're likely to encounter [this issue](https://developercommunity.visualstudio.com/t/Hot-Reload:-Token-id-is-not-valid-in-t/10973525) while testing. That's a problem with the .NET 10 runtime, not an Umbraco specific problem. If you run into that issue, you need to restart the site to continue testing.
