### PR TITLE
Loadbalancing: Add Cache Sync service to allow us to roll forward isolated caches when backoffice is load balanced.

### DIFF
--- a/src/Umbraco.Core/Cache/ICacheSyncService.cs
+++ b/src/Umbraco.Core/Cache/ICacheSyncService.cs
@@ -1,8 +1,33 @@
 namespace Umbraco.Cms.Core.Cache;
 
+/// <summary>
+/// Provides cache synchronization capabilities for load-balanced Umbraco environments.
+/// </summary>
+/// <remarks>
+/// This service synchronizes isolated caches across servers in a load-balanced cluster by rolling forward
+/// out-of-date caches. It separates synchronization into two distinct operations: internal isolated caches
+/// (repositories and services) and published content caches, enabling selective cache refreshing.
+/// </remarks>
 public interface ICacheSyncService
 {
+    /// <summary>
+    /// Synchronizes all caches including both isolated caches and published content caches.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <remarks>
+    /// This method clears all isolated caches (repositories and services) and published content caches
+    /// (IPublishedContentCache, route caching, etc.) to ensure complete cache consistency across the cluster.
+    /// </remarks>
     void SyncAll(CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Synchronizes only isolated caches without affecting the published content cache layer.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <remarks>
+    /// This method clears only the isolated caches used by repositories and services, leaving the
+    /// published content cache layer intact. During synchronization, repositories reload data from
+    /// the database while temporarily bypassing version checking to prevent recursive sync attempts.
+    /// </remarks>
     void SyncInternal(CancellationToken cancellationToken);
 }

--- a/src/Umbraco.Core/Cache/ICacheSyncService.cs
+++ b/src/Umbraco.Core/Cache/ICacheSyncService.cs
@@ -1,0 +1,8 @@
+namespace Umbraco.Cms.Core.Cache;
+
+public interface ICacheSyncService
+{
+    void SyncAll(CancellationToken cancellationToken);
+
+    void SyncInternal(CancellationToken cancellationToken);
+}

--- a/src/Umbraco.Core/Cache/ICacheVersionAccessor.cs
+++ b/src/Umbraco.Core/Cache/ICacheVersionAccessor.cs
@@ -1,0 +1,24 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Cache;
+
+/// <summary>
+/// Provides access to repository cache version information with request-level caching.
+/// </summary>
+/// <remarks>
+/// This accessor retrieves cache version information from the database and caches it at the request level
+/// to minimize database queries. Cache versions are used to determine if cached repository data is still valid
+/// in distributed environments.
+/// </remarks>
+public interface ICacheVersionAccessor
+{
+
+    /// <summary>
+    /// Retrieves the cache version for the specified cache key.
+    /// </summary>
+    /// <param name="cacheKey">The unique identifier for the cache entry.</param>
+    /// <returns>
+    /// The cache version if found, or <see langword="null"/> if the version doesn't exist or the request is a client-side request.
+    /// </returns>
+    public Task<RepositoryCacheVersion?> GetAsync(string cacheKey);
+}

--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
@@ -21,4 +21,6 @@ public interface IRepositoryCacheVersionAccessor
     /// The cache version if found, or <see langword="null"/> if the version doesn't exist or the request is a client-side request.
     /// </returns>
     public Task<RepositoryCacheVersion?> GetAsync(string cacheKey);
+
+    public void CachesSynced();
 }

--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
@@ -22,5 +22,12 @@ public interface IRepositoryCacheVersionAccessor
     /// </returns>
     public Task<RepositoryCacheVersion?> GetAsync(string cacheKey);
 
+    /// <summary>
+    /// Notifies the accessor that caches have been synchronized.
+    /// </summary>
+    /// <remarks>
+    /// This method is called after cache synchronization to temporarily bypass version checking,
+    /// preventing recursive sync attempts while repositories reload data from the database.
+    /// </remarks>
     public void CachesSynced();
 }

--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Core.Cache;
 /// to minimize database queries. Cache versions are used to determine if cached repository data is still valid
 /// in distributed environments.
 /// </remarks>
-public interface ICacheVersionAccessor
+public interface IRepositoryCacheVersionAccessor
 {
 
     /// <summary>

--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
@@ -24,5 +24,5 @@ public interface IRepositoryCacheVersionService
     /// <summary>
     /// Registers that the cache has been synced with the database.
     /// </summary>
-    Task SetCachesSyncedAsync();
+    Task SetCachesSyncedAsync(); // TODO: Set caches synced when they are syncde
 }

--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionService.cs
@@ -24,5 +24,5 @@ public interface IRepositoryCacheVersionService
     /// <summary>
     /// Registers that the cache has been synced with the database.
     /// </summary>
-    Task SetCachesSyncedAsync(); // TODO: Set caches synced when they are syncde
+    Task SetCachesSyncedAsync();
 }

--- a/src/Umbraco.Core/Cache/Refreshers/IJsonCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/IJsonCacheRefresher.cs
@@ -10,4 +10,10 @@ public interface IJsonCacheRefresher : ICacheRefresher
     /// </summary>
     /// <param name="json"></param>
     void Refresh(string json);
+
+    /// <summary>
+    /// Refreshes internal (isolated) caches by a json payload.
+    /// </summary>
+    /// <param name="json">The json payload.</param>
+    void RefreshInternal(string json) => Refresh(json);
 }

--- a/src/Umbraco.Core/Cache/Refreshers/IPayloadCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/IPayloadCacheRefresher.cs
@@ -10,4 +10,6 @@ public interface IPayloadCacheRefresher<TPayload> : IJsonCacheRefresher
     /// </summary>
     /// <param name="payloads"></param>
     void Refresh(TPayload[] payloads);
+
+    void RefreshInternal(TPayload[] payloads) => Refresh(payloads);
 }

--- a/src/Umbraco.Core/Cache/Refreshers/IPayloadCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/IPayloadCacheRefresher.cs
@@ -11,5 +11,9 @@ public interface IPayloadCacheRefresher<TPayload> : IJsonCacheRefresher
     /// <param name="payloads"></param>
     void Refresh(TPayload[] payloads);
 
+    /// <summary>
+    /// Refreshes internal (isolated) caches by a payload.
+    /// </summary>
+    /// <param name="payloads">The payload.</param>
     void RefreshInternal(TPayload[] payloads) => Refresh(payloads);
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
@@ -120,7 +120,7 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
 
     #region Refresher
 
-    public override void Refresh(JsonPayload[] payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
         AppCaches.RuntimeCache.ClearOfType<PublicAccessEntry>();
         AppCaches.RuntimeCache.ClearByKey(CacheKeys.ContentRecycleBinCacheKey);
@@ -132,7 +132,6 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
         // If published elements become their own entities with relations, instead of just property data, we can revisit this.
         _cacheManager.ElementsCache.Clear();
 
-        var idsRemoved = new HashSet<int>();
         IAppPolicyCache isolatedCache = AppCaches.IsolatedCaches.GetOrCreate<IContent>();
 
         foreach (JsonPayload payload in payloads)
@@ -152,13 +151,22 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
                 var pathid = "," + payload.Id + ",";
                 isolatedCache.ClearOfType<IContent>((k, v) => v.Path?.Contains(pathid) ?? false);
             }
+        }
 
+        base.RefreshInternal(payloads);
+    }
+
+    public override void Refresh(JsonPayload[] payloads)
+    {
+        var idsRemoved = new HashSet<int>();
+
+        foreach (JsonPayload payload in payloads)
+        {
             // if the item is not a blueprint and is being completely removed, we need to refresh the domains cache if any domain was assigned to the content
             if (payload.Blueprint is false && payload.ChangeTypes.HasTypesAny(TreeChangeTypes.Remove))
             {
                 idsRemoved.Add(payload.Id);
             }
-
 
             HandleMemoryCache(payload);
             HandleRouting(payload);

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ContentTypeCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ContentTypeCacheRefresher.cs
@@ -76,7 +76,7 @@ public sealed class ContentTypeCacheRefresher : PayloadCacheRefresherBase<Conten
 
     #region Refresher
 
-    public override void Refresh(JsonPayload[] payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
         // TODO: refactor
         // we should NOT directly clear caches here, but instead ask whatever class
@@ -124,6 +124,11 @@ public sealed class ContentTypeCacheRefresher : PayloadCacheRefresherBase<Conten
             MemberCacheRefresher.RefreshMemberTypes(AppCaches);
         }
 
+        base.RefreshInternal(payloads);
+    }
+
+    public override void Refresh(JsonPayload[] payloads)
+    {
         _publishedContentTypeCache.ClearContentTypes(payloads.Select(x => x.Id));
         _publishedContentTypeFactory.NotifyDataTypeChanges();
         _publishedModelFactory.WithSafeLiveFactoryReset(() =>

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/DataTypeCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/DataTypeCacheRefresher.cs
@@ -72,7 +72,7 @@ public sealed class DataTypeCacheRefresher : PayloadCacheRefresherBase<DataTypeC
 
     #region Refresher
 
-    public override void Refresh(JsonPayload[] payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
         // we need to clear the ContentType runtime cache since that is what caches the
         // db data type to store the value against and anytime a datatype changes, this also might change
@@ -86,7 +86,6 @@ public sealed class DataTypeCacheRefresher : PayloadCacheRefresherBase<DataTypeC
 
         Attempt<IAppPolicyCache?> dataTypeCache = AppCaches.IsolatedCaches.Get<IDataType>();
 
-        List<IPublishedContentType> removedContentTypes = new();
         foreach (JsonPayload payload in payloads)
         {
             _idKeyMap.ClearCache(payload.Id);
@@ -95,7 +94,16 @@ public sealed class DataTypeCacheRefresher : PayloadCacheRefresherBase<DataTypeC
             {
                 dataTypeCache.Result?.Clear(RepositoryCacheKeys.GetKey<IDataType, int>(payload.Id));
             }
+        }
 
+        base.RefreshInternal(payloads);
+    }
+
+    public override void Refresh(JsonPayload[] payloads)
+    {
+        List<IPublishedContentType> removedContentTypes = new();
+        foreach (JsonPayload payload in payloads)
+        {
             removedContentTypes.AddRange(_publishedContentTypeCache.ClearByDataTypeId(payload.Id));
         }
 

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/DomainCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/DomainCacheRefresher.cs
@@ -51,7 +51,7 @@ public sealed class DomainCacheRefresher : PayloadCacheRefresherBase<DomainCache
 
     #region Refresher
 
-    public override void Refresh(JsonPayload[] payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
         ClearAllIsolatedCacheByEntityType<IDomain>();
 
@@ -61,8 +61,8 @@ public sealed class DomainCacheRefresher : PayloadCacheRefresherBase<DomainCache
 
         // notify
         _domainCacheService.Refresh(payloads);
-        // then trigger event
-        base.Refresh(payloads);
+
+        base.RefreshInternal(payloads);
     }
 
     // these events should never trigger

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/LanguageCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/LanguageCacheRefresher.cs
@@ -96,8 +96,9 @@ public sealed class LanguageCacheRefresher : PayloadCacheRefresherBase<LanguageC
 
     #region Refresher
 
-    public override void Refresh(JsonPayload[] payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
+        // Languages has no concept of "published" languages, so all caches are "internal"
         if (payloads.Length == 0)
         {
             return;
@@ -135,20 +136,9 @@ public sealed class LanguageCacheRefresher : PayloadCacheRefresherBase<LanguageC
             // clear all domain caches
             RefreshDomains();
             ContentCacheRefresher.RefreshContentTypes(AppCaches); // we need to evict all IContent items
-
-            // now refresh all nucache
-            ContentCacheRefresher.JsonPayload[] clearContentPayload = new[]
-            {
-                new ContentCacheRefresher.JsonPayload()
-                {
-                    ChangeTypes = TreeChangeTypes.RefreshAll
-                }
-            };
         }
-
-        // then trigger event
-        base.Refresh(payloads);
     }
+
 
     // these events should never trigger
     // everything should be PAYLOAD/JSON

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MediaCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MediaCacheRefresher.cs
@@ -128,7 +128,7 @@ public sealed class MediaCacheRefresher : PayloadCacheRefresherBase<MediaCacheRe
                 _idKeyMap.ClearCache(payload.Id);
             }
 
-            if (mediaCache.Success is false)
+            if (mediaCache.Success is false || mediaCache.Result is null)
             {
                 continue;
             }
@@ -136,14 +136,14 @@ public sealed class MediaCacheRefresher : PayloadCacheRefresherBase<MediaCacheRe
             // repository cache
             // it *was* done for each pathId but really that does not make sense
             // only need to do it for the current media
-            mediaCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMedia, int>(payload.Id));
-            mediaCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMedia, Guid?>(payload.Key));
+            mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia, int>(payload.Id));
+            mediaCache.Result.Clear(RepositoryCacheKeys.GetKey<IMedia, Guid?>(payload.Key));
 
             // remove those that are in the branch
             if (payload.ChangeTypes.HasTypesAny(TreeChangeTypes.RefreshBranch | TreeChangeTypes.Remove))
             {
                 var pathid = "," + payload.Id + ",";
-                mediaCache.Result?.ClearOfType<IMedia>((_, v) => v.Path?.Contains(pathid) ?? false);
+                mediaCache.Result.ClearOfType<IMedia>((_, v) => v.Path?.Contains(pathid) ?? false);
             }
         }
 
@@ -152,7 +152,7 @@ public sealed class MediaCacheRefresher : PayloadCacheRefresherBase<MediaCacheRe
 
     public override void Refresh(JsonPayload[]? payloads)
     {
-        if (payloads == null)
+        if (payloads is null)
         {
             return;
         }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MediaCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MediaCacheRefresher.cs
@@ -108,13 +108,8 @@ public sealed class MediaCacheRefresher : PayloadCacheRefresherBase<MediaCacheRe
 
     #region Refresher
 
-    public override void Refresh(JsonPayload[]? payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
-        if (payloads == null)
-        {
-            return;
-        }
-
         // actions that always need to happen
         AppCaches.RuntimeCache.ClearByKey(CacheKeys.MediaRecycleBinCacheKey);
         Attempt<IAppPolicyCache?> mediaCache = AppCaches.IsolatedCaches.Get<IMedia>();
@@ -133,22 +128,37 @@ public sealed class MediaCacheRefresher : PayloadCacheRefresherBase<MediaCacheRe
                 _idKeyMap.ClearCache(payload.Id);
             }
 
-            if (mediaCache.Success)
+            if (mediaCache.Success is false)
             {
-                // repository cache
-                // it *was* done for each pathId but really that does not make sense
-                // only need to do it for the current media
-                mediaCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMedia, int>(payload.Id));
-                mediaCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMedia, Guid?>(payload.Key));
-
-                // remove those that are in the branch
-                if (payload.ChangeTypes.HasTypesAny(TreeChangeTypes.RefreshBranch | TreeChangeTypes.Remove))
-                {
-                    var pathid = "," + payload.Id + ",";
-                    mediaCache.Result?.ClearOfType<IMedia>((_, v) => v.Path?.Contains(pathid) ?? false);
-                }
+                continue;
             }
 
+            // repository cache
+            // it *was* done for each pathId but really that does not make sense
+            // only need to do it for the current media
+            mediaCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMedia, int>(payload.Id));
+            mediaCache.Result?.Clear(RepositoryCacheKeys.GetKey<IMedia, Guid?>(payload.Key));
+
+            // remove those that are in the branch
+            if (payload.ChangeTypes.HasTypesAny(TreeChangeTypes.RefreshBranch | TreeChangeTypes.Remove))
+            {
+                var pathid = "," + payload.Id + ",";
+                mediaCache.Result?.ClearOfType<IMedia>((_, v) => v.Path?.Contains(pathid) ?? false);
+            }
+        }
+
+        base.RefreshInternal(payloads);
+    }
+
+    public override void Refresh(JsonPayload[]? payloads)
+    {
+        if (payloads == null)
+        {
+            return;
+        }
+
+        foreach (JsonPayload payload in payloads)
+        {
             HandleMemoryCache(payload);
             HandleNavigation(payload);
         }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberCacheRefresher.cs
@@ -71,10 +71,10 @@ public sealed class MemberCacheRefresher : PayloadCacheRefresherBase<MemberCache
 
     public override string Name => "Member Cache Refresher";
 
-    public override void Refresh(JsonPayload[] payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
         ClearCache(payloads);
-        base.Refresh(payloads);
+        base.RefreshInternal(payloads);
     }
 
     public override void Refresh(int id)

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/MemberGroupCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/MemberGroupCacheRefresher.cs
@@ -41,10 +41,10 @@ public sealed class MemberGroupCacheRefresher : PayloadCacheRefresherBase<Member
 
     #region Refresher
 
-    public override void Refresh(string json)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
         ClearCache();
-        base.Refresh(json);
+        base.RefreshInternal(payloads);
     }
 
     public override void Refresh(int id)

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
@@ -32,10 +32,10 @@ public sealed class UserCacheRefresher : PayloadCacheRefresherBase<UserCacheRefr
         base.RefreshAll();
     }
 
-    public override void Refresh(JsonPayload[] payloads)
+    public override void RefreshInternal(JsonPayload[] payloads)
     {
         ClearCache(payloads);
-        base.Refresh(payloads);
+        base.RefreshInternal(payloads);
     }
 
     private void ClearCache(params JsonPayload[] payloads)

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ValueEditorCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ValueEditorCacheRefresher.cs
@@ -23,10 +23,11 @@ public sealed class ValueEditorCacheRefresher : PayloadCacheRefresherBase<DataTy
 
     public override string Name => "ValueEditorCacheRefresher";
 
-    public override void Refresh(DataTypeCacheRefresher.JsonPayload[] payloads)
+    public override void RefreshInternal(DataTypeCacheRefresher.JsonPayload[] payloads)
     {
         IEnumerable<int> ids = payloads.Select(x => x.Id);
         _valueEditorCache.ClearCache(ids);
+        base.RefreshInternal(payloads);
     }
 
     // these events should never trigger

--- a/src/Umbraco.Core/Cache/Refreshers/JsonCacheRefresherBase.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/JsonCacheRefresherBase.cs
@@ -33,6 +33,11 @@ public abstract class JsonCacheRefresherBase<TNotification, TJsonPayload> : Cach
     public virtual void Refresh(string json) =>
         OnCacheUpdated(NotificationFactory.Create<TNotification>(json, MessageType.RefreshByJson));
 
+    /// <inheritdoc />
+    public virtual void RefreshInternal(string json)
+    {
+    }
+
     #region Json
 
     /// <summary>

--- a/src/Umbraco.Core/Cache/Refreshers/PayloadCacheRefresherBase.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/PayloadCacheRefresherBase.cs
@@ -39,12 +39,26 @@ public abstract class
         }
     }
 
+    /// <inheritdoc />
+    public override void RefreshInternal(string json)
+    {
+        TPayload[]? payload = Deserialize(json);
+        if (payload is not null)
+        {
+            RefreshInternal(payload);
+        }
+    }
+
     /// <summary>
     ///     Refreshes as specified by a payload.
     /// </summary>
     /// <param name="payloads">The payload.</param>
     public virtual void Refresh(TPayload[] payloads) =>
         OnCacheUpdated(NotificationFactory.Create<TNotification>(payloads, MessageType.RefreshByPayload));
+
+    public virtual void RefreshInternal(TPayload[] payloads)
+    {
+    }
 
     #endregion
 }

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -111,6 +111,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
             _cacheVersions[version.Identifier] = Guid.Parse(version.Version);
         }
 
+        _repositoryCacheVersionAccessor.CachesSynced();
         scope.Complete();
     }
 

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -12,19 +12,19 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     private readonly ICoreScopeProvider _scopeProvider;
     private readonly IRepositoryCacheVersionRepository _repositoryCacheVersionRepository;
     private readonly ILogger<RepositoryCacheVersionService> _logger;
-    private readonly ICacheVersionAccessor _cacheVersionAccessor;
+    private readonly IRepositoryCacheVersionAccessor _repositoryCacheVersionAccessor;
     private readonly ConcurrentDictionary<string, Guid> _cacheVersions = new();
 
     public RepositoryCacheVersionService(
         ICoreScopeProvider scopeProvider,
         IRepositoryCacheVersionRepository repositoryCacheVersionRepository,
         ILogger<RepositoryCacheVersionService> logger,
-        ICacheVersionAccessor cacheVersionAccessor)
+        IRepositoryCacheVersionAccessor repositoryCacheVersionAccessor)
     {
         _scopeProvider = scopeProvider;
         _repositoryCacheVersionRepository = repositoryCacheVersionRepository;
         _logger = logger;
-        _cacheVersionAccessor = cacheVersionAccessor;
+        _repositoryCacheVersionAccessor = repositoryCacheVersionAccessor;
     }
 
     /// <inheritdoc />
@@ -38,7 +38,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
 
         var cacheKey = GetCacheKey<TEntity>();
 
-        RepositoryCacheVersion? databaseVersion = await _cacheVersionAccessor.GetAsync(cacheKey);
+        RepositoryCacheVersion? databaseVersion = await _repositoryCacheVersionAccessor.GetAsync(cacheKey);
 
         if (databaseVersion?.Version is null)
         {

--- a/src/Umbraco.Core/CacheSyncService.cs
+++ b/src/Umbraco.Core/CacheSyncService.cs
@@ -1,0 +1,36 @@
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Factories;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core;
+
+public class CacheSyncService : ICacheSyncService
+{
+    private readonly IMachineInfoFactory _machineInfoFactory;
+    private readonly CacheRefresherCollection _cacheRefreshers;
+    private readonly ICacheInstructionService _cacheInstructionService;
+
+    public CacheSyncService(
+        IMachineInfoFactory machineInfoFactory,
+        CacheRefresherCollection cacheRefreshers,
+        ICacheInstructionService cacheInstructionService)
+    {
+        _machineInfoFactory = machineInfoFactory;
+        _cacheRefreshers = cacheRefreshers;
+        _cacheInstructionService = cacheInstructionService;
+    }
+
+    /// <inheritdoc />
+    public void SyncAll(CancellationToken cancellationToken = default) =>
+        _cacheInstructionService.ProcessAllInstructions(
+            _cacheRefreshers,
+            cancellationToken,
+            _machineInfoFactory.GetLocalIdentity());
+
+    /// <inheritdoc />
+    public void SyncInternal(CancellationToken cancellationToken) =>
+        _cacheInstructionService.ProcessInternalInstructions(
+            _cacheRefreshers,
+            cancellationToken,
+            _machineInfoFactory.GetLocalIdentity());
+}

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -343,7 +343,8 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<ILocalizedTextService>(factory => new LocalizedTextService(
                 factory.GetRequiredService<Lazy<LocalizedTextServiceFileSources>>(),
                 factory.GetRequiredService<ILogger<LocalizedTextService>>()));
-            Services.AddUnique<IRepositoryCacheVersionService, RepositoryCacheVersionService>();
+            // Default to a NOOP repository cache version service
+            Services.AddUnique<IRepositoryCacheVersionService, SingleServerCacheVersionService>();
             Services.AddUnique<ILongRunningOperationService, LongRunningOperationService>();
             Services.AddUnique<ILastSyncedManager, LastSyncedManager>();
             Services.AddUnique<IMachineInfoFactory, MachineInfoFactory>();

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,0 +1,17 @@
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.DependencyInjection;
+
+public static partial class UmbracoBuilderExtensions
+{
+    /// <summary>
+    /// Adds the necessary components to support isolated caches in a load balanced environment.
+    /// </summary>
+    /// <remarks>This is require to load balance back office.</remarks>
+    public static IUmbracoBuilder LoadBalanceIsolatedCaches(this IUmbracoBuilder builder)
+    {
+        builder.Services.AddUnique<IRepositoryCacheVersionService, RepositoryCacheVersionService>();
+        return builder;
+    }
+}

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -8,7 +8,7 @@ public static partial class UmbracoBuilderExtensions
     /// <summary>
     /// Adds the necessary components to support isolated caches in a load balanced environment.
     /// </summary>
-    /// <remarks>This is require to load balance back office.</remarks>
+    /// <remarks>This is required to load balance back office.</remarks>
     public static IUmbracoBuilder LoadBalanceIsolatedCaches(this IUmbracoBuilder builder)
     {
         builder.Services.AddUnique<IRepositoryCacheVersionService, RepositoryCacheVersionService>();

--- a/src/Umbraco.Core/Factories/IMachineInfoFactory.cs
+++ b/src/Umbraco.Core/Factories/IMachineInfoFactory.cs
@@ -10,4 +10,21 @@ public interface IMachineInfoFactory
     /// </summary>
     /// <returns>A name of the host machine.</returns>
     public string GetMachineIdentifier();
+
+    /// <summary>
+    /// Gets the local identity for the executing AppDomain.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///         It is not only about the "server" (machine name and appDomainappId), but also about
+    ///         an AppDomain, within a Process, on that server - because two AppDomains running at the same
+    ///         time on the same server (eg during a restart) are, practically, a LB setup.
+    ///     </para>
+    ///     <para>
+    ///         Practically, all we really need is the guid, the other infos are here for information
+    ///         and debugging purposes.
+    ///     </para>
+    /// </remarks>
+    /// <returns></returns>
+    public string GetLocalIdentity();
 }

--- a/src/Umbraco.Core/Factories/MachineInfoFactory.cs
+++ b/src/Umbraco.Core/Factories/MachineInfoFactory.cs
@@ -1,8 +1,37 @@
-﻿namespace Umbraco.Cms.Core.Factories;
+﻿using System.Diagnostics;
+using Umbraco.Cms.Core.Hosting;
+
+namespace Umbraco.Cms.Core.Factories;
 
 internal sealed class MachineInfoFactory : IMachineInfoFactory
 {
+    private readonly IHostingEnvironment _hostingEnvironment;
+
+    public MachineInfoFactory(IHostingEnvironment hostingEnvironment)
+    {
+        _hostingEnvironment = hostingEnvironment;
+    }
 
     /// <inheritdoc />
     public string GetMachineIdentifier() => Environment.MachineName;
+
+    private string? _localIdentity;
+
+    /// <inheritdoc />
+    public string GetLocalIdentity()
+    {
+        if (_localIdentity is not null)
+        {
+            return _localIdentity;
+        }
+
+        using var process = Process.GetCurrentProcess();
+        _localIdentity = Environment.MachineName // eg DOMAIN\SERVER
+                         + "/" + _hostingEnvironment.ApplicationId // eg /LM/S3SVC/11/ROOT
+                         + " [P" + process.Id // eg 1234
+                         + "/D" + AppDomain.CurrentDomain.Id // eg 22
+                         + "] " + Guid.NewGuid().ToString("N").ToUpper(); // make it truly unique
+
+        return _localIdentity;
+    }
 }

--- a/src/Umbraco.Core/Sync/LastSyncedManager.cs
+++ b/src/Umbraco.Core/Sync/LastSyncedManager.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.Persistence.Repositories;
+﻿using System.ComponentModel;
+using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 
 namespace Umbraco.Cms.Core.Sync;
@@ -81,5 +82,13 @@ internal sealed class LastSyncedManager : ILastSyncedManager
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
         await _lastSyncedRepository.DeleteEntriesOlderThanAsync(date);
         scope.Complete();
+    }
+
+    // Used for testing purposes only
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal void ClearLocalCache()
+    {
+        _lastSyncedInternalId = null;
+        _lastSyncedExternalId = null;
     }
 }

--- a/src/Umbraco.Core/Sync/LastSyncedManager.cs
+++ b/src/Umbraco.Core/Sync/LastSyncedManager.cs
@@ -8,6 +8,8 @@ internal sealed class LastSyncedManager : ILastSyncedManager
 {
     private readonly ILastSyncedRepository _lastSyncedRepository;
     private readonly ICoreScopeProvider _coreScopeProvider;
+    private int? _lastSyncedInternalId;
+    private int? _lastSyncedExternalId;
 
     public LastSyncedManager(ILastSyncedRepository lastSyncedRepository, ICoreScopeProvider coreScopeProvider)
     {
@@ -18,21 +20,31 @@ internal sealed class LastSyncedManager : ILastSyncedManager
     /// <inheritdoc/>
     public async Task<int?> GetLastSyncedInternalAsync()
     {
+        if (_lastSyncedInternalId is not null)
+        {
+            return _lastSyncedInternalId;
+        }
+
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        int? internalId = await _lastSyncedRepository.GetInternalIdAsync();
+        _lastSyncedInternalId = await _lastSyncedRepository.GetInternalIdAsync();
         scope.Complete();
 
-        return internalId;
+        return _lastSyncedInternalId;
     }
 
     /// <inheritdoc/>
     public async Task<int?> GetLastSyncedExternalAsync()
     {
+        if (_lastSyncedExternalId is not null)
+        {
+            return _lastSyncedExternalId;
+        }
+
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        int? externalId = await _lastSyncedRepository.GetExternalIdAsync();
+        _lastSyncedExternalId = await _lastSyncedRepository.GetExternalIdAsync();
         scope.Complete();
 
-        return externalId;
+        return _lastSyncedExternalId;
     }
 
     /// <inheritdoc/>
@@ -45,6 +57,7 @@ internal sealed class LastSyncedManager : ILastSyncedManager
 
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
         await _lastSyncedRepository.SaveInternalIdAsync(id);
+        _lastSyncedInternalId = id;
         scope.Complete();
     }
 
@@ -58,6 +71,7 @@ internal sealed class LastSyncedManager : ILastSyncedManager
 
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
         await _lastSyncedRepository.SaveExternalIdAsync(id);
+        _lastSyncedExternalId = id;
         scope.Complete();
     }
 

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJob.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Sync;
@@ -37,6 +39,21 @@ public class CacheInstructionsPruningJob : IRecurringBackgroundJob
         _timeProvider = timeProvider;
         Period = globalSettings.Value.DatabaseServerMessenger.TimeBetweenPruneOperations;
         _lastSyncedManager = lastSyncedManager;
+    }
+
+    [Obsolete("Use the constructor with ILastSyncedManager parameter instead. Scheduled for removal in Umbraco 18.")]
+    public CacheInstructionsPruningJob(
+        IOptions<GlobalSettings> globalSettings,
+        ICacheInstructionRepository cacheInstructionRepository,
+        ICoreScopeProvider scopeProvider,
+        TimeProvider timeProvider)
+        : this(
+            globalSettings,
+            cacheInstructionRepository,
+            scopeProvider,
+            timeProvider,
+            StaticServiceProvider.Instance.GetRequiredService<ILastSyncedManager>())
+    {
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/DefaultRepositoryCachePolicy.cs
@@ -30,8 +30,9 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
         IAppPolicyCache cache,
         IScopeAccessor scopeAccessor,
         RepositoryCachePolicyOptions options,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(cache, scopeAccessor, repositoryCacheVersionService) =>
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(cache, scopeAccessor, repositoryCacheVersionService, cacheSyncService) =>
         _options = options ?? throw new ArgumentNullException(nameof(options));
 
     [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
@@ -43,7 +44,8 @@ public class DefaultRepositoryCachePolicy<TEntity, TId> : RepositoryCachePolicyB
             cache,
             scopeAccessor,
             options,
-            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>(),
+            StaticServiceProvider.Instance.GetRequiredService<ICacheSyncService>())
     {
     }
 

--- a/src/Umbraco.Infrastructure/Cache/FullDataSetRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/FullDataSetRepositoryCachePolicy.cs
@@ -28,8 +28,8 @@ internal sealed class FullDataSetRepositoryCachePolicy<TEntity, TId> : Repositor
     private readonly Func<TEntity, TId> _entityGetId;
     private readonly bool _expires;
 
-    public FullDataSetRepositoryCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, Func<TEntity, TId> entityGetId, bool expires)
-        : base(cache, scopeAccessor)
+    public FullDataSetRepositoryCachePolicy(IAppPolicyCache cache, IScopeAccessor scopeAccessor, IRepositoryCacheVersionService repositoryCacheVersionService, ICacheSyncService cacheSyncService, Func<TEntity, TId> entityGetId, bool expires)
+        : base(cache, scopeAccessor, repositoryCacheVersionService, cacheSyncService)
     {
         _entityGetId = entityGetId;
         _expires = expires;

--- a/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/MemberRepositoryUsernameCachePolicy.cs
@@ -1,4 +1,6 @@
 ﻿using System.Runtime.Versioning;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Extensions;
@@ -11,12 +13,14 @@ public class MemberRepositoryUsernameCachePolicy : DefaultRepositoryCachePolicy<
         IAppPolicyCache cache,
         IScopeAccessor scopeAccessor,
         RepositoryCachePolicyOptions options,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             cache,
             scopeAccessor,
             options,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 
@@ -25,7 +29,12 @@ public class MemberRepositoryUsernameCachePolicy : DefaultRepositoryCachePolicy<
         IAppPolicyCache cache,
         IScopeAccessor scopeAccessor,
         RepositoryCachePolicyOptions options)
-        : base(cache, scopeAccessor, options)
+        : this(
+            cache,
+            scopeAccessor,
+            options,
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>(),
+            StaticServiceProvider.Instance.GetRequiredService<ICacheSyncService>())
     {
     }
 

--- a/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/SingleItemsOnlyRepositoryCachePolicy.cs
@@ -27,8 +27,14 @@ internal sealed class SingleItemsOnlyRepositoryCachePolicy<TEntity, TId> : Defau
         IAppPolicyCache cache,
         IScopeAccessor scopeAccessor,
         RepositoryCachePolicyOptions options,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(cache, scopeAccessor, options,  repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            cache,
+            scopeAccessor,
+            options,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 
@@ -38,7 +44,8 @@ internal sealed class SingleItemsOnlyRepositoryCachePolicy<TEntity, TId> : Defau
             cache,
             scopeAccessor,
             options,
-            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>(),
+            StaticServiceProvider.Instance.GetRequiredService<ICacheSyncService>())
     {
     }
 

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Services.cs
@@ -45,6 +45,7 @@ public static partial class UmbracoBuilderExtensions
 
         builder.Services.AddUnique<IAuditService, AuditService>();
         builder.Services.AddUnique<ICacheInstructionService, CacheInstructionService>();
+        builder.Services.AddUnique<ICacheSyncService, CacheSyncService>();
         builder.Services.AddUnique<IBasicAuthService, BasicAuthService>();
         builder.Services.AddUnique<IDataTypeService, DataTypeService>();
         builder.Services.AddUnique<IPackagingService, PackagingService>();

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
@@ -25,12 +25,14 @@ internal sealed class AuditEntryRepository : EntityRepositoryBase<int, IAuditEnt
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<AuditEntryRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
             logger,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditRepository.cs
@@ -17,12 +17,14 @@ internal sealed class AuditRepository : EntityRepositoryBase<int, IAuditItem>, I
     public AuditRepository(
         IScopeAccessor scopeAccessor,
         ILogger<AuditRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             AppCaches.NoCache,
             logger,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ConsentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ConsentRepository.cs
@@ -24,12 +24,14 @@ internal sealed class ConsentRepository : EntityRepositoryBase<int, IConsent>, I
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<ConsentRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
             logger,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -51,8 +51,14 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             DataValueReferenceFactoryCollection dataValueReferenceFactories,
             IDataTypeService dataTypeService,
             IEventAggregator eventAggregator,
-            IRepositoryCacheVersionService repositoryCacheVersionService)
-            : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+            IRepositoryCacheVersionService repositoryCacheVersionService,
+            ICacheSyncService cacheSyncService)
+            : base(
+                scopeAccessor,
+                cache,
+                logger,
+                repositoryCacheVersionService,
+                cacheSyncService)
         {
             DataTypeService = dataTypeService;
             LanguageRepository = languageRepository;
@@ -86,7 +92,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
                 dataValueReferenceFactories,
                 dataTypeService,
                 eventAggregator,
-                StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+                StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>(),
+                StaticServiceProvider.Instance.GetRequiredService<ICacheSyncService>())
         {
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -20,6 +20,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// </summary>
 internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContentType>, IContentTypeRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     public ContentTypeRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
@@ -41,6 +44,8 @@ internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContent
             idKeyMap,
             cacheSyncService)
     {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     protected override bool SupportsPublishing => ContentType.SupportsPublishingConst;
@@ -103,7 +108,7 @@ internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContent
     }
 
     protected override IRepositoryCachePolicy<IContentType, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<IContentType, int>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, /*expires:*/ true);
+        new FullDataSetRepositoryCachePolicy<IContentType, int>(GlobalIsolatedCache, ScopeAccessor, _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ true);
 
     // every GetExists method goes cachePolicy.GetSomething which in turns goes PerformGetAll,
     // since this is a FullDataSet policy - and everything is cached

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -28,7 +28,8 @@ internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContent
         ILanguageRepository languageRepository,
         IShortStringHelper shortStringHelper,
         IRepositoryCacheVersionService repositoryCacheVersionService,
-        IIdKeyMap idKeyMap)
+        IIdKeyMap idKeyMap,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
@@ -37,7 +38,8 @@ internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContent
             languageRepository,
             shortStringHelper,
             repositoryCacheVersionService,
-            idKeyMap)
+            idKeyMap,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -39,8 +39,14 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
         ILanguageRepository languageRepository,
         IShortStringHelper shortStringHelper,
         IRepositoryCacheVersionService repositoryCacheVersionService,
-        IIdKeyMap idKeyMap)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IIdKeyMap idKeyMap,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         _shortStringHelper = shortStringHelper;
         CommonRepository = commonRepository;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeContainerRepository.cs
@@ -12,8 +12,15 @@ internal sealed class DataTypeContainerRepository : EntityContainerRepository, I
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<DataTypeContainerRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DataTypeContainer, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            Constants.ObjectTypes.DataTypeContainer,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DataTypeRepository.cs
@@ -37,12 +37,14 @@ internal sealed class DataTypeRepository : EntityRepositoryBase<int, IDataType>,
         ILogger<DataTypeRepository> logger,
         ILoggerFactory loggerFactory,
         IConfigurationEditorJsonSerializer serializer,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
             logger,
-            repositoryCacheVersionService
+            repositoryCacheVersionService,
+            cacheSyncService
             )
     {
         _editors = editors;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -24,6 +24,7 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILanguageRepository _languageRepository;
     private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
 
     public DictionaryRepository(
         IScopeAccessor scopeAccessor,
@@ -31,12 +32,14 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
         ILogger<DictionaryRepository> logger,
         ILoggerFactory loggerFactory,
         ILanguageRepository languageRepository,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(scopeAccessor, cache, logger)
     {
         _loggerFactory = loggerFactory;
         _languageRepository = languageRepository;
         _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     public IDictionaryItem? Get(Guid uniqueId)
@@ -46,7 +49,8 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             ScopeAccessor,
             AppCaches,
             _loggerFactory.CreateLogger<DictionaryByUniqueIdRepository>(),
-            _repositoryCacheVersionService);
+            _repositoryCacheVersionService,
+            _cacheSyncService);
         return uniqueIdRepo.Get(uniqueId);
     }
 
@@ -57,7 +61,8 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             ScopeAccessor,
             AppCaches,
             _loggerFactory.CreateLogger<DictionaryByUniqueIdRepository>(),
-            _repositoryCacheVersionService);
+            _repositoryCacheVersionService,
+            _cacheSyncService);
         return uniqueIdRepo.GetMany(uniqueIds);
     }
 
@@ -68,7 +73,8 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             ScopeAccessor,
             AppCaches,
             _loggerFactory.CreateLogger<DictionaryByKeyRepository>(),
-            _repositoryCacheVersionService);
+            _repositoryCacheVersionService,
+            _cacheSyncService);
         return keyRepo.Get(key);
     }
 
@@ -79,7 +85,8 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             ScopeAccessor,
             AppCaches,
             _loggerFactory.CreateLogger<DictionaryByKeyRepository>(),
-            _repositoryCacheVersionService);
+            _repositoryCacheVersionService,
+            _cacheSyncService);
         return keyRepo.GetMany(keys);
     }
 
@@ -150,7 +157,12 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             GetAllCacheAllowZeroCount = true
         };
 
-        return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, int>(GlobalIsolatedCache, ScopeAccessor, options, _repositoryCacheVersionService);
+        return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, int>(
+            GlobalIsolatedCache,
+            ScopeAccessor,
+            options,
+            _repositoryCacheVersionService,
+            _cacheSyncService);
     }
 
     private static IDictionaryItem ConvertFromDto(DictionaryDto dto, IDictionary<int, ILanguage> languagesById)
@@ -210,6 +222,7 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
     {
         private readonly DictionaryRepository _dictionaryRepository;
         private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+        private readonly ICacheSyncService _cacheSyncService;
         private readonly IDictionary<int, ILanguage> _languagesById;
 
         public DictionaryByUniqueIdRepository(
@@ -217,11 +230,18 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             IScopeAccessor scopeAccessor,
             AppCaches cache,
             ILogger<DictionaryByUniqueIdRepository> logger,
-            IRepositoryCacheVersionService repositoryCacheVersionService)
-            : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+            IRepositoryCacheVersionService repositoryCacheVersionService,
+            ICacheSyncService cacheSyncService)
+            : base(
+                scopeAccessor,
+                cache,
+                logger,
+                repositoryCacheVersionService,
+                cacheSyncService)
         {
             _dictionaryRepository = dictionaryRepository;
             _repositoryCacheVersionService = repositoryCacheVersionService;
+            _cacheSyncService = cacheSyncService;
             _languagesById = dictionaryRepository.GetLanguagesById();
         }
 
@@ -250,7 +270,12 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
                 GetAllCacheAllowZeroCount = true
             };
 
-            return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, Guid>(GlobalIsolatedCache, ScopeAccessor, options, _repositoryCacheVersionService);
+            return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, Guid>(
+                GlobalIsolatedCache,
+                ScopeAccessor,
+                options,
+                _repositoryCacheVersionService,
+                _cacheSyncService);
         }
 
         protected override IEnumerable<IDictionaryItem> PerformGetAll(params Guid[]? ids)
@@ -271,6 +296,7 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
     {
         private readonly DictionaryRepository _dictionaryRepository;
         private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+        private readonly ICacheSyncService _cacheSyncService;
         private readonly IDictionary<int, ILanguage> _languagesById;
 
         public DictionaryByKeyRepository(
@@ -278,11 +304,18 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             IScopeAccessor scopeAccessor,
             AppCaches cache,
             ILogger<DictionaryByKeyRepository> logger,
-            IRepositoryCacheVersionService repositoryCacheVersionService)
-            : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+            IRepositoryCacheVersionService repositoryCacheVersionService,
+            ICacheSyncService cacheSyncService)
+            : base(
+                scopeAccessor,
+                cache,
+                logger,
+                repositoryCacheVersionService,
+                cacheSyncService)
         {
             _dictionaryRepository = dictionaryRepository;
             _repositoryCacheVersionService = repositoryCacheVersionService;
+            _cacheSyncService = cacheSyncService;
             _languagesById = dictionaryRepository.GetLanguagesById();
         }
 
@@ -313,7 +346,12 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
                 GetAllCacheAllowZeroCount = true
             };
 
-            return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, string>(GlobalIsolatedCache, ScopeAccessor, options, _repositoryCacheVersionService);
+            return new SingleItemsOnlyRepositoryCachePolicy<IDictionaryItem, string>(
+                GlobalIsolatedCache,
+                ScopeAccessor,
+                options,
+                _repositoryCacheVersionService,
+                _cacheSyncService);
         }
 
         protected override IEnumerable<IDictionaryItem> PerformGetAll(params string[]? ids)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentBlueprintContainerRepository.cs
@@ -11,8 +11,16 @@ internal sealed class DocumentBlueprintContainerRepository : EntityContainerRepo
     public DocumentBlueprintContainerRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
-        ILogger<DocumentBlueprintContainerRepository> logger, IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, Constants.ObjectTypes.DocumentBlueprintContainer, repositoryCacheVersionService)
+        ILogger<DocumentBlueprintContainerRepository> logger,
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            Constants.ObjectTypes.DocumentBlueprintContainer,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentTypeContainerRepository.cs
@@ -12,13 +12,15 @@ internal sealed class DocumentTypeContainerRepository : EntityContainerRepositor
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<DocumentTypeContainerRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
             logger,
             Constants.ObjectTypes.DocumentTypeContainer,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
@@ -19,8 +19,14 @@ internal sealed class DomainRepository : EntityRepositoryBase<int, IDomain>, IDo
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<DomainRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     { }
 
     public IDomain? GetByName(string domainName)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DomainRepository.cs
@@ -15,6 +15,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal sealed class DomainRepository : EntityRepositoryBase<int, IDomain>, IDomainRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     public DomainRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
@@ -27,7 +30,10 @@ internal sealed class DomainRepository : EntityRepositoryBase<int, IDomain>, IDo
             logger,
             repositoryCacheVersionService,
             cacheSyncService)
-    { }
+    {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
+    }
 
     public IDomain? GetByName(string domainName)
         => GetMany().FirstOrDefault(x => x.DomainName.InvariantEquals(domainName));
@@ -42,7 +48,7 @@ internal sealed class DomainRepository : EntityRepositoryBase<int, IDomain>, IDo
         => GetMany().Where(x => x.RootContentId == contentId).Where(x => includeWildcards || x.IsWildcard == false);
 
     protected override IRepositoryCachePolicy<IDomain, int> CreateCachePolicy()
-        => new FullDataSetRepositoryCachePolicy<IDomain, int>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, false);
+        => new FullDataSetRepositoryCachePolicy<IDomain, int>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, false);
 
     protected override IDomain? PerformGet(int id)
         // Use the underlying GetAll which will force cache all domains

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
@@ -21,8 +21,14 @@ internal class EntityContainerRepository : EntityRepositoryBase<int, EntityConta
         AppCaches cache,
         ILogger<EntityContainerRepository> logger,
         Guid containerObjectType,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         Guid[] allowedContainers =
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ExternalLoginRepository.cs
@@ -20,8 +20,14 @@ internal sealed class ExternalLoginRepository : EntityRepositoryBase<int, IIdent
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<ExternalLoginRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger,  repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
     /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/KeyValueRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/KeyValueRepository.cs
@@ -17,8 +17,14 @@ internal sealed class KeyValueRepository : EntityRepositoryBase<string, IKeyValu
     public KeyValueRepository(
         IScopeAccessor scopeAccessor,
         ILogger<KeyValueRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, AppCaches.NoCache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            AppCaches.NoCache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -28,8 +28,14 @@ internal sealed class LanguageRepository : EntityRepositoryBase<int, ILanguage>,
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<LanguageRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger,  repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LanguageRepository.cs
@@ -18,6 +18,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// </summary>
 internal sealed class LanguageRepository : EntityRepositoryBase<int, ILanguage>, ILanguageRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     // We need to lock this dictionary every time we do an operation on it as the languageRepository is registered as a unique implementation
     // It is used to quickly get isoCodes by Id, or the reverse by avoiding (deep)cloning dtos
     // It is rebuild on PerformGetAll
@@ -37,6 +40,8 @@ internal sealed class LanguageRepository : EntityRepositoryBase<int, ILanguage>,
             repositoryCacheVersionService,
             cacheSyncService)
     {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     private FullDataSetRepositoryCachePolicy<ILanguage, int>? TypedCachePolicy =>
@@ -137,7 +142,7 @@ internal sealed class LanguageRepository : EntityRepositoryBase<int, ILanguage>,
     public int? GetDefaultId() => GetDefault().Id;
 
     protected override IRepositoryCachePolicy<ILanguage, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<ILanguage, int>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, /*expires:*/ false);
+        new FullDataSetRepositoryCachePolicy<ILanguage, int>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ false);
 
     protected ILanguage ConvertFromDto(LanguageDto dto)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
@@ -18,8 +18,15 @@ internal sealed class LogViewerQueryRepository : EntityRepositoryBase<int, ILogV
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<LogViewerQueryRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService
+            )
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
@@ -14,6 +14,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal sealed class LogViewerQueryRepository : EntityRepositoryBase<int, ILogViewerQuery>, ILogViewerQueryRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     public LogViewerQueryRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
@@ -28,6 +31,8 @@ internal sealed class LogViewerQueryRepository : EntityRepositoryBase<int, ILogV
             cacheSyncService
             )
     {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     public ILogViewerQuery? GetByName(string name) =>
@@ -36,7 +41,7 @@ internal sealed class LogViewerQueryRepository : EntityRepositoryBase<int, ILogV
         GetMany().FirstOrDefault(x => x.Name == name);
 
     protected override IRepositoryCachePolicy<ILogViewerQuery, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<ILogViewerQuery, int>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, /*expires:*/ false);
+        new FullDataSetRepositoryCachePolicy<ILogViewerQuery, int>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ false);
 
     protected override IEnumerable<ILogViewerQuery> PerformGetAll(params int[]? ids)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Infrastructure.Persistence.Factories;
 using Umbraco.Cms.Infrastructure.Persistence.Querying;
@@ -51,7 +52,8 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
         IDataTypeService dataTypeService,
         IJsonSerializer serializer,
         IEventAggregator eventAggregator,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
@@ -63,7 +65,8 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             dataValueReferenceFactories,
             dataTypeService,
             eventAggregator,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         _cache = cache;
         _mediaTypeRepository = mediaTypeRepository ?? throw new ArgumentNullException(nameof(mediaTypeRepository));
@@ -75,7 +78,8 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             scopeAccessor,
             cache,
             loggerFactory.CreateLogger<MediaByGuidReadRepository>(),
-            repositoryCacheVersionService);
+            repositoryCacheVersionService,
+            cacheSyncService);
     }
 
     [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
@@ -110,7 +114,8 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             dataTypeService,
             serializer,
             eventAggregator,
-            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>()
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>(),
+            StaticServiceProvider.Instance.GetRequiredService<ICacheSyncService>()
             )
     {
     }
@@ -582,8 +587,14 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             IScopeAccessor scopeAccessor,
             AppCaches cache,
             ILogger<MediaByGuidReadRepository> logger,
-            IRepositoryCacheVersionService repositoryCacheVersionService)
-            : base(scopeAccessor, cache, logger,  repositoryCacheVersionService) =>
+            IRepositoryCacheVersionService repositoryCacheVersionService,
+            ICacheSyncService cacheSyncService)
+            : base(
+                scopeAccessor,
+                cache,
+                logger,
+                repositoryCacheVersionService,
+                cacheSyncService) =>
             _outerRepo = outerRepo;
 
         protected override IMedia? PerformGet(Guid id)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeContainerRepository.cs
@@ -12,13 +12,15 @@ internal sealed class MediaTypeContainerRepository : EntityContainerRepository, 
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<MediaTypeContainerRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
             logger,
             Constants.ObjectTypes.MediaTypeContainer,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -19,6 +19,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// </summary>
 internal sealed class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType>, IMediaTypeRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     public MediaTypeRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
@@ -40,6 +43,8 @@ internal sealed class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType
             idKeyMap,
             cacheSyncService)
     {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     protected override bool SupportsPublishing => MediaType.SupportsPublishingConst;
@@ -47,7 +52,7 @@ internal sealed class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType
     protected override Guid NodeObjectTypeId => Constants.ObjectTypes.MediaType;
 
     protected override IRepositoryCachePolicy<IMediaType, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<IMediaType, int>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, /*expires:*/ true);
+        new FullDataSetRepositoryCachePolicy<IMediaType, int>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ true);
 
     // every GetExists method goes cachePolicy.GetSomething which in turns goes PerformGetAll,
     // since this is a FullDataSet policy - and everything is cached

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -27,7 +27,8 @@ internal sealed class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType
         ILanguageRepository languageRepository,
         IShortStringHelper shortStringHelper,
         IRepositoryCacheVersionService repositoryCacheVersionService,
-        IIdKeyMap idKeyMap)
+        IIdKeyMap idKeyMap,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
@@ -36,7 +37,8 @@ internal sealed class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType
             languageRepository,
             shortStringHelper,
             repositoryCacheVersionService,
-            idKeyMap)
+            idKeyMap,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberGroupRepository.cs
@@ -24,8 +24,14 @@ internal sealed class MemberGroupRepository : EntityRepositoryBase<int, IMemberG
         AppCaches cache,
         ILogger<MemberGroupRepository> logger,
         IEventMessagesFactory eventMessagesFactory,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService) =>
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService) =>
         _eventMessagesFactory = eventMessagesFactory;
 
     protected Guid NodeObjectTypeId => Constants.ObjectTypes.MemberGroup;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -59,7 +59,8 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
         IJsonSerializer serializer,
         IEventAggregator eventAggregator,
         IOptions<MemberPasswordConfigurationSettings> passwordConfiguration,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
@@ -71,7 +72,8 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
             dataValueReferenceFactories,
             dataTypeService,
             eventAggregator,
-            repositoryCacheVersionService)
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         _memberTypeRepository =
             memberTypeRepository ?? throw new ArgumentNullException(nameof(memberTypeRepository));
@@ -81,7 +83,7 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
         _memberGroupRepository = memberGroupRepository;
         _passwordConfiguration = passwordConfiguration.Value;
         _memberByUsernameCachePolicy =
-            new MemberRepositoryUsernameCachePolicy(GlobalIsolatedCache, ScopeAccessor, DefaultOptions, repositoryCacheVersionService);
+            new MemberRepositoryUsernameCachePolicy(GlobalIsolatedCache, ScopeAccessor, DefaultOptions, repositoryCacheVersionService, cacheSyncService);
     }
 
     [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
@@ -119,7 +121,8 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
             serializer,
             eventAggregator,
             passwordConfiguration,
-            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>(),
+            StaticServiceProvider.Instance.GetRequiredService<ICacheSyncService>())
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -21,6 +21,8 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberType>, IMemberTypeRepository
 {
     private readonly IShortStringHelper _shortStringHelper;
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
 
     public MemberTypeRepository(
         IScopeAccessor scopeAccessor,
@@ -41,15 +43,19 @@ internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberTy
             shortStringHelper,
             repositoryCacheVersionService,
             idKeyMap,
-            cacheSyncService) =>
+            cacheSyncService)
+    {
         _shortStringHelper = shortStringHelper;
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
+    }
 
     protected override bool SupportsPublishing => MemberType.SupportsPublishingConst;
 
     protected override Guid NodeObjectTypeId => Constants.ObjectTypes.MemberType;
 
     protected override IRepositoryCachePolicy<IMemberType, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<IMemberType, int>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, /*expires:*/ true);
+        new FullDataSetRepositoryCachePolicy<IMemberType, int>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ true);
 
     // every GetExists method goes cachePolicy.GetSomething which in turns goes PerformGetAll,
     // since this is a FullDataSet policy - and everything is cached

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -30,7 +30,8 @@ internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberTy
         ILanguageRepository languageRepository,
         IShortStringHelper shortStringHelper,
         IRepositoryCacheVersionService repositoryCacheVersionService,
-        IIdKeyMap idKeyMap)
+        IIdKeyMap idKeyMap,
+        ICacheSyncService cacheSyncService)
         : base(
             scopeAccessor,
             cache,
@@ -39,7 +40,8 @@ internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberTy
             languageRepository,
             shortStringHelper,
             repositoryCacheVersionService,
-            idKeyMap) =>
+            idKeyMap,
+            cacheSyncService) =>
         _shortStringHelper = shortStringHelper;
 
     protected override bool SupportsPublishing => MemberType.SupportsPublishingConst;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PermissionRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PermissionRepository.cs
@@ -30,8 +30,14 @@ internal sealed class PermissionRepository<TEntity> : EntityRepositoryBase<int, 
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<PermissionRepository<TEntity>> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
@@ -15,6 +15,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 internal sealed class PublicAccessRepository : EntityRepositoryBase<Guid, PublicAccessEntry>, IPublicAccessRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     public PublicAccessRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
@@ -28,10 +31,12 @@ internal sealed class PublicAccessRepository : EntityRepositoryBase<Guid, Public
             repositoryCacheVersionService,
             cacheSyncService)
     {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     protected override IRepositoryCachePolicy<PublicAccessEntry, Guid> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<PublicAccessEntry, Guid>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, /*expires:*/ false);
+        new FullDataSetRepositoryCachePolicy<PublicAccessEntry, Guid>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ false);
 
     protected override PublicAccessEntry? PerformGet(Guid id) =>
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublicAccessRepository.cs
@@ -19,8 +19,14 @@ internal sealed class PublicAccessRepository : EntityRepositoryBase<Guid, Public
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<PublicAccessRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -18,8 +18,14 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<RedirectUrlRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -31,8 +31,14 @@ internal sealed class RelationRepository : EntityRepositoryBase<int, IRelation>,
         ILogger<RelationRepository> logger,
         IRelationTypeRepository relationTypeRepository,
         IEntityRepositoryExtended entityRepository,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, AppCaches.NoCache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            AppCaches.NoCache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         _relationTypeRepository = relationTypeRepository;
         _entityRepository = entityRepository;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationTypeRepository.cs
@@ -19,6 +19,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// </summary>
 internal sealed class RelationTypeRepository : EntityRepositoryBase<int, IRelationType>, IRelationTypeRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     public RelationTypeRepository(
         IScopeAccessor scopeAccessor,
         AppCaches cache,
@@ -32,10 +35,12 @@ internal sealed class RelationTypeRepository : EntityRepositoryBase<int, IRelati
             repositoryCacheVersionService,
             cacheSyncService)
     {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     protected override IRepositoryCachePolicy<IRelationType, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<IRelationType, int>(GlobalIsolatedCache, ScopeAccessor, GetEntityId, /*expires:*/ true);
+        new FullDataSetRepositoryCachePolicy<IRelationType, int>(GlobalIsolatedCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ true);
 
     private static void CheckNullObjectTypeValues(IRelationType entity)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationTypeRepository.cs
@@ -23,8 +23,14 @@ internal sealed class RelationTypeRepository : EntityRepositoryBase<int, IRelati
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<RelationTypeRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
@@ -17,8 +17,14 @@ internal sealed class ServerRegistrationRepository : EntityRepositoryBase<int, I
     public ServerRegistrationRepository(
         IScopeAccessor scopeAccessor,
         ILogger<ServerRegistrationRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, AppCaches.NoCache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            AppCaches.NoCache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRegistrationRepository.cs
@@ -14,6 +14,9 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 internal sealed class ServerRegistrationRepository : EntityRepositoryBase<int, IServerRegistration>,
     IServerRegistrationRepository
 {
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
+
     public ServerRegistrationRepository(
         IScopeAccessor scopeAccessor,
         ILogger<ServerRegistrationRepository> logger,
@@ -26,6 +29,8 @@ internal sealed class ServerRegistrationRepository : EntityRepositoryBase<int, I
             repositoryCacheVersionService,
             cacheSyncService)
     {
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     public void ClearCache() => CachePolicy.ClearAll();
@@ -52,7 +57,7 @@ internal sealed class ServerRegistrationRepository : EntityRepositoryBase<int, I
         // note: this means that the ServerRegistrationRepository does *not* implement scoped cache,
         // and this is because the repository is special and should not participate in scopes
         // (cleanup in v8)
-        new FullDataSetRepositoryCachePolicy<IServerRegistration, int>(AppCaches.RuntimeCache, ScopeAccessor, GetEntityId, /*expires:*/ false);
+        new FullDataSetRepositoryCachePolicy<IServerRegistration, int>(AppCaches.RuntimeCache, ScopeAccessor,  _repositoryCacheVersionService, _cacheSyncService, GetEntityId, /*expires:*/ false);
 
     protected override int PerformCount(IQuery<IServerRegistration>? query) =>
         throw new NotSupportedException("This repository does not support this method.");

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimpleGetRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimpleGetRepository.cs
@@ -22,8 +22,14 @@ internal abstract class SimpleGetRepository<TId, TEntity, TDto> : EntityReposito
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<SimpleGetRepository<TId, TEntity, TDto>> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -21,8 +21,14 @@ internal sealed class TagRepository : EntityRepositoryBase<int, ITag>, ITagRepos
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<TagRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -37,8 +37,14 @@ internal sealed class TemplateRepository : EntityRepositoryBase<int, ITemplate>,
         IShortStringHelper shortStringHelper,
         IViewHelper viewHelper,
         IOptionsMonitor<RuntimeSettings> runtimeSettings,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         _shortStringHelper = shortStringHelper;
         _viewsFileSystem = fileSystems.MvcViewsFileSystem;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -28,6 +28,8 @@ internal sealed class TemplateRepository : EntityRepositoryBase<int, ITemplate>,
     private readonly IFileSystem? _viewsFileSystem;
     private readonly IViewHelper _viewHelper;
     private readonly IOptionsMonitor<RuntimeSettings> _runtimeSettings;
+    private readonly IRepositoryCacheVersionService _repositoryCacheVersionService;
+    private readonly ICacheSyncService _cacheSyncService;
 
     public TemplateRepository(
         IScopeAccessor scopeAccessor,
@@ -50,6 +52,8 @@ internal sealed class TemplateRepository : EntityRepositoryBase<int, ITemplate>,
         _viewsFileSystem = fileSystems.MvcViewsFileSystem;
         _viewHelper = viewHelper;
         _runtimeSettings = runtimeSettings;
+        _repositoryCacheVersionService = repositoryCacheVersionService;
+        _cacheSyncService = cacheSyncService;
     }
 
     public Stream GetFileContentStream(string filepath)
@@ -92,8 +96,13 @@ internal sealed class TemplateRepository : EntityRepositoryBase<int, ITemplate>,
     }
 
     protected override IRepositoryCachePolicy<ITemplate, int> CreateCachePolicy() =>
-        new FullDataSetRepositoryCachePolicy<ITemplate, int>(GlobalIsolatedCache, ScopeAccessor,
-            GetEntityId, /*expires:*/ false);
+        new FullDataSetRepositoryCachePolicy<ITemplate, int>(
+            GlobalIsolatedCache,
+            ScopeAccessor,
+            _repositoryCacheVersionService,
+            _cacheSyncService,
+            GetEntityId,
+            /*expires:*/ false);
 
     private IEnumerable<IUmbracoEntity> GetAxisDefinitions(params TemplateDto[] templates)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TwoFactorLoginRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TwoFactorLoginRepository.cs
@@ -18,8 +18,14 @@ internal sealed class TwoFactorLoginRepository : EntityRepositoryBase<int, ITwoF
         IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<TwoFactorLoginRepository> logger,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, cache, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            cache,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserGroupRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserGroupRepository.cs
@@ -38,8 +38,14 @@ public class UserGroupRepository : EntityRepositoryBase<int, IUserGroup>, IUserG
         ILoggerFactory loggerFactory,
         IShortStringHelper shortStringHelper,
         IEnumerable<IPermissionMapper> permissionMappers,
-        IRepositoryCacheVersionService repositoryCacheVersionService)
-        : base(scopeAccessor, appCaches, logger, repositoryCacheVersionService)
+        IRepositoryCacheVersionService repositoryCacheVersionService,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            appCaches,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         _shortStringHelper = shortStringHelper;
         _userGroupWithUsersRepository = new UserGroupWithUsersRepository(
@@ -47,12 +53,14 @@ public class UserGroupRepository : EntityRepositoryBase<int, IUserGroup>, IUserG
             scopeAccessor,
             appCaches,
             loggerFactory.CreateLogger<UserGroupWithUsersRepository>(),
-            repositoryCacheVersionService);
+            repositoryCacheVersionService,
+            cacheSyncService);
         _permissionRepository = new PermissionRepository<IContent>(
             scopeAccessor,
             appCaches,
             loggerFactory.CreateLogger<PermissionRepository<IContent>>(),
-            repositoryCacheVersionService);
+            repositoryCacheVersionService,
+            cacheSyncService);
         _permissionMappers = permissionMappers.ToDictionary(x => x.Context);
     }
 
@@ -71,7 +79,8 @@ public class UserGroupRepository : EntityRepositoryBase<int, IUserGroup>, IUserG
             loggerFactory,
             shortStringHelper,
             permissionMappers,
-            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>())
+            StaticServiceProvider.Instance.GetRequiredService<IRepositoryCacheVersionService>(),
+            StaticServiceProvider.Instance.GetRequiredService<ICacheSyncService>())
     {
     }
 
@@ -241,12 +250,14 @@ public class UserGroupRepository : EntityRepositoryBase<int, IUserGroup>, IUserG
             IScopeAccessor scopeAccessor,
             AppCaches cache,
             ILogger<UserGroupWithUsersRepository> logger,
-            IRepositoryCacheVersionService repositoryCacheVersionService)
+            IRepositoryCacheVersionService repositoryCacheVersionService,
+            ICacheSyncService cacheSyncService)
             : base(
                 scopeAccessor,
                 cache,
                 logger,
-                repositoryCacheVersionService) =>
+                repositoryCacheVersionService,
+                cacheSyncService) =>
             _userGroupRepo = userGroupRepo;
 
         protected override void PersistNewItem(UserGroupWithUsers entity)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -71,8 +71,14 @@ internal sealed class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserR
         IJsonSerializer jsonSerializer,
         IRuntimeState runtimeState,
         IRepositoryCacheVersionService repositoryCacheVersionService,
-        IEnumerable<IPermissionMapper> permissionMappers)
-        : base(scopeAccessor, appCaches, logger, repositoryCacheVersionService)
+        IEnumerable<IPermissionMapper> permissionMappers,
+        ICacheSyncService cacheSyncService)
+        : base(
+            scopeAccessor,
+            appCaches,
+            logger,
+            repositoryCacheVersionService,
+            cacheSyncService)
     {
         _mapperCollection = mapperCollection ?? throw new ArgumentNullException(nameof(mapperCollection));
         _globalSettings = globalSettings.Value ?? throw new ArgumentNullException(nameof(globalSettings));

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -171,10 +171,10 @@ namespace Umbraco.Cms
             {
                 lock (_syncLock)
                 {
-                    _repositoryCacheVersionService.SetCachesSyncedAsync();
                     using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<CacheInstructionService>("Syncing from database..."))
                     using (ICoreScope scope = ScopeProvider.CreateCoreScope())
                     {
+                        _repositoryCacheVersionService.SetCachesSyncedAsync();
                         var lastId = _lastSyncedManager.GetLastSyncedExternalAsync().GetAwaiter().GetResult() ?? 0;
                         var numberOfInstructionsProcessed = ProcessDatabaseInstructions(cacheRefreshers, cancellationToken, localIdentity, ref lastId);
 
@@ -201,13 +201,13 @@ namespace Umbraco.Cms
                     using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<CacheInstructionService>("Syncing from database..."))
                     using (ICoreScope scope = ScopeProvider.CreateCoreScope())
                     {
+                        _repositoryCacheVersionService.SetCachesSyncedAsync();
                         var lastId = _lastSyncedManager.GetLastSyncedInternalAsync().GetAwaiter().GetResult() ?? 0;
                         var numberOfInstructionsProcessed = ProcessDatabaseInstructions(cacheRefreshers, cancellationToken, localIdentity, ref lastId);
 
                         if (numberOfInstructionsProcessed > 0)
                         {
                             _lastSyncedManager.SaveLastSyncedInternalAsync(lastId).GetAwaiter().GetResult();
-                            _repositoryCacheVersionService.SetCachesSyncedAsync();
                         }
 
                         scope.Complete();

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -171,6 +171,7 @@ namespace Umbraco.Cms
             {
                 lock (_syncLock)
                 {
+                    _repositoryCacheVersionService.SetCachesSyncedAsync();
                     using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<CacheInstructionService>("Syncing from database..."))
                     using (ICoreScope scope = ScopeProvider.CreateCoreScope())
                     {
@@ -181,7 +182,6 @@ namespace Umbraco.Cms
                         {
                             _lastSyncedManager.SaveLastSyncedExternalAsync(lastId).GetAwaiter().GetResult();
                             _lastSyncedManager.SaveLastSyncedInternalAsync(lastId).GetAwaiter().GetResult();
-                            _repositoryCacheVersionService.SetCachesSyncedAsync();
                         }
 
                         scope.Complete();

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Models;
@@ -26,11 +28,10 @@ namespace Umbraco.Cms
             private readonly ICacheInstructionRepository _cacheInstructionRepository;
             private readonly GlobalSettings _globalSettings;
             private readonly ILogger<CacheInstructionService> _logger;
+            private readonly ILastSyncedManager _lastSyncedManager;
             private readonly IProfilingLogger _profilingLogger;
 
-            /// <summary>
-            ///     Initializes a new instance of the <see cref="CacheInstructionService" /> class.
-            /// </summary>
+            [Obsolete("Use the overload that requires ILastSyncedManager. Scheduled for removal in V18.")]
             public CacheInstructionService(
                 ICoreScopeProvider provider,
                 ILoggerFactory loggerFactory,
@@ -39,11 +40,33 @@ namespace Umbraco.Cms
                 IProfilingLogger profilingLogger,
                 ILogger<CacheInstructionService> logger,
                 IOptions<GlobalSettings> globalSettings)
+                 : this(
+                     provider,
+                     loggerFactory,
+                     eventMessagesFactory,
+                     cacheInstructionRepository,
+                     profilingLogger,
+                     logger,
+                     globalSettings,
+                     StaticServiceProvider.Instance.GetRequiredService<ILastSyncedManager>())
+            {
+            }
+
+            public CacheInstructionService(
+                ICoreScopeProvider provider,
+                ILoggerFactory loggerFactory,
+                IEventMessagesFactory eventMessagesFactory,
+                ICacheInstructionRepository cacheInstructionRepository,
+                IProfilingLogger profilingLogger,
+                ILogger<CacheInstructionService> logger,
+                IOptions<GlobalSettings> globalSettings,
+                ILastSyncedManager lastSyncedManager)
                 : base(provider, loggerFactory, eventMessagesFactory)
             {
                 _cacheInstructionRepository = cacheInstructionRepository;
                 _profilingLogger = profilingLogger;
                 _logger = logger;
+                _lastSyncedManager = lastSyncedManager;
                 _globalSettings = globalSettings.Value;
             }
 
@@ -119,7 +142,7 @@ namespace Umbraco.Cms
                 }
             }
 
-            /// <inheritdoc />
+            [Obsolete("Use non obsolete version instead, scheduled for removal in V18.")]
             public ProcessInstructionsResult ProcessInstructions(
                 CacheRefresherCollection cacheRefreshers,
                 CancellationToken cancellationToken,
@@ -136,15 +159,51 @@ namespace Umbraco.Cms
             }
 
             /// <inheritdoc />
-            [Obsolete("Use the non-obsolete overload. Scheduled for removal in V17.")]
-            public ProcessInstructionsResult ProcessInstructions(
+            public ProcessInstructionsResult ProcessAllInstructions(
                 CacheRefresherCollection cacheRefreshers,
-                ServerRole serverRole,
                 CancellationToken cancellationToken,
-                string localIdentity,
-                DateTime lastPruned,
-                int lastId) =>
-                ProcessInstructions(cacheRefreshers, cancellationToken, localIdentity, lastId);
+                string localIdentity)
+            {
+                // TODO: Add Locking
+                using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<CacheInstructionService>("Syncing from database..."))
+                using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+                {
+                    var lastId = _lastSyncedManager.GetLastSyncedExternalAsync().GetAwaiter().GetResult() ?? 0;
+                    var numberOfInstructionsProcessed = ProcessDatabaseInstructions(cacheRefreshers, cancellationToken, localIdentity, ref lastId);
+
+                    if (numberOfInstructionsProcessed > 0)
+                    {
+                        _lastSyncedManager.SaveLastSyncedExternalAsync(lastId).GetAwaiter().GetResult();
+                        _lastSyncedManager.SaveLastSyncedInternalAsync(lastId).GetAwaiter().GetResult();
+                    }
+
+                    scope.Complete();
+                    return ProcessInstructionsResult.AsCompleted(numberOfInstructionsProcessed, lastId);
+                }
+            }
+
+            /// <inheritdoc />
+            public ProcessInstructionsResult ProcessInternalInstructions(
+                CacheRefresherCollection cacheRefreshers,
+                CancellationToken cancellationToken,
+                string localIdentity)
+            {
+                // TODO: Add Locking
+                using (!_profilingLogger.IsEnabled(Core.Logging.LogLevel.Debug) ? null : _profilingLogger.DebugDuration<CacheInstructionService>("Syncing from database..."))
+                using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+                {
+                    var lastId = _lastSyncedManager.GetLastSyncedInternalAsync().GetAwaiter().GetResult() ?? 0;
+                    var numberOfInstructionsProcessed = ProcessDatabaseInstructions(cacheRefreshers, cancellationToken, localIdentity, ref lastId);
+
+                    if (numberOfInstructionsProcessed > 0)
+                    {
+                        _lastSyncedManager.SaveLastSyncedInternalAsync(lastId).GetAwaiter().GetResult();
+                    }
+
+                    scope.Complete();
+                    return ProcessInstructionsResult.AsCompleted(numberOfInstructionsProcessed, lastId);
+                }
+            }
 
             private CacheInstruction CreateCacheInstruction(IEnumerable<RefreshInstruction> instructions, string localIdentity)
                 => new(

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -439,6 +439,7 @@ namespace Umbraco.Cms
                 IJsonCacheRefresher refresher = GetJsonRefresher(cacheRefreshers, uniqueIdentifier);
                 if (jsonPayload is not null)
                 {
+                    refresher.RefreshInternal(jsonPayload);
                     refresher.Refresh(jsonPayload);
                 }
             }

--- a/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
@@ -1,7 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Factories;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Runtime;
 using Umbraco.Cms.Core.Serialization;
@@ -18,9 +21,35 @@ public class BatchedDatabaseServerMessenger : DatabaseServerMessenger
 {
     private readonly IRequestCache _requestCache;
 
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="BatchedDatabaseServerMessenger" /> class.
-    /// </summary>
+    public BatchedDatabaseServerMessenger(
+        IMainDom mainDom,
+        CacheRefresherCollection cacheRefreshers,
+        ILogger<BatchedDatabaseServerMessenger> logger,
+        ISyncBootStateAccessor syncBootStateAccessor,
+        IHostingEnvironment hostingEnvironment,
+        ICacheInstructionService cacheInstructionService,
+        IJsonSerializer jsonSerializer,
+        IRequestCache requestCache,
+        ILastSyncedManager lastSyncedManager,
+        IOptionsMonitor<GlobalSettings> globalSettings,
+        IMachineInfoFactory machineInfoFactory)
+        : base(
+            mainDom,
+            cacheRefreshers,
+            logger,
+            true,
+            syncBootStateAccessor,
+            hostingEnvironment,
+            cacheInstructionService,
+            jsonSerializer,
+            globalSettings,
+            lastSyncedManager,
+            machineInfoFactory)
+    {
+        _requestCache = requestCache;
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in V18.")]
     public BatchedDatabaseServerMessenger(
         IMainDom mainDom,
         CacheRefresherCollection cacheRefreshers,
@@ -32,19 +61,19 @@ public class BatchedDatabaseServerMessenger : DatabaseServerMessenger
         IRequestCache requestCache,
         LastSyncedFileManager lastSyncedFileManager,
         IOptionsMonitor<GlobalSettings> globalSettings)
-        : base(
+        : this(
             mainDom,
             cacheRefreshers,
             logger,
-            true,
             syncBootStateAccessor,
             hostingEnvironment,
             cacheInstructionService,
             jsonSerializer,
-            lastSyncedFileManager,
-            globalSettings)
+            requestCache,
+            StaticServiceProvider.Instance.GetRequiredService<ILastSyncedManager>(),
+            globalSettings,
+            StaticServiceProvider.Instance.GetRequiredService<IMachineInfoFactory>())
     {
-        _requestCache = requestCache;
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -129,6 +129,7 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
         _lastSyncedManager = lastSyncedManager;
 
         globalSettings.OnChange(x => GlobalSettings = x);
+        // TODO: Use IMachineInfoFactory instead
         using (var process = Process.GetCurrentProcess())
         {
             // See notes on _localIdentity

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -202,17 +202,10 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
 
         try
         {
-            var lastSyncId = _lastSyncedManager.GetLastSyncedExternalAsync().GetAwaiter().GetResult() ?? -1;
-            ProcessInstructionsResult result = CacheInstructionService.ProcessInstructions(
+            CacheInstructionService.ProcessAllInstructions(
                 _cacheRefreshers,
                 _cancellationToken,
-                LocalIdentity,
-                lastSyncId);
-
-            if (result.LastId > 0)
-            {
-                _lastSyncedManager.SaveLastSyncedExternalAsync(result.LastId).GetAwaiter().GetResult();
-            }
+                LocalIdentity);
         }
         finally
         {

--- a/src/Umbraco.Infrastructure/Sync/ServerMessengerBase.cs
+++ b/src/Umbraco.Infrastructure/Sync/ServerMessengerBase.cs
@@ -206,6 +206,7 @@ public abstract class ServerMessengerBase : IServerMessenger
             throw new InvalidOperationException("The cache refresher " + refresher.GetType() + " is not of type " + typeof(IPayloadCacheRefresher<TPayload>));
         }
 
+        payloadRefresher.RefreshInternal(payload);
         payloadRefresher.Refresh(payload);
     }
 
@@ -265,6 +266,7 @@ public abstract class ServerMessengerBase : IServerMessenger
 
                 if (json is not null)
                 {
+                    jsonRefresher.RefreshInternal(json);
                     jsonRefresher.Refresh(json);
                 }
 

--- a/src/Umbraco.Web.Common/Cache/CacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/CacheVersionAccessor.cs
@@ -1,0 +1,79 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Web.Common.Cache;
+
+public class CacheVersionAccessor : ICacheVersionAccessor
+{
+    private readonly IRequestCache _requestCache;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IRepositoryCacheVersionRepository _repositoryCacheVersionRepository;
+    private readonly ICoreScopeProvider _coreScopeProvider;
+    private readonly ILogger<CacheVersionAccessor> _logger;
+
+    public CacheVersionAccessor(
+        IRequestCache requestCache,
+        IHttpContextAccessor httpContextAccessor,
+        IRepositoryCacheVersionRepository repositoryCacheVersionRepository,
+        ICoreScopeProvider coreScopeProvider,
+        ILogger<CacheVersionAccessor> logger)
+    {
+        _requestCache = requestCache;
+        _httpContextAccessor = httpContextAccessor;
+        _repositoryCacheVersionRepository = repositoryCacheVersionRepository;
+        _coreScopeProvider = coreScopeProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Retrieves the cache version for the specified cache key.
+    /// </summary>
+    /// <param name="cacheKey">The unique identifier for the cache entry.</param>
+    /// <returns>
+    /// The cache version if found, or <see langword="null"/> if the version doesn't exist or the request is a client-side request.
+    /// </returns>
+    /// <remarks>
+    /// This method implements a two-tier caching strategy:
+    /// <list type="number">
+    /// <item>First checks the request cache to avoid database queries within the same request.</item>
+    /// <item>If not found in request cache, queries the database and caches the result for subsequent calls.</item>
+    /// </list>
+    /// Client-side requests always return <see langword="null"/>
+    /// to avoid unnecessary cache version lookups.
+    /// </remarks>
+    public async Task<RepositoryCacheVersion?> GetAsync(string cacheKey)
+    {
+        HttpContext? httpcontext = _httpContextAccessor.HttpContext;
+        if (httpcontext is not null && httpcontext.Request.IsClientSideRequest())
+        {
+            _logger.LogDebug("Client side request detected, skipping cache version retrieval for key {CacheKey}", cacheKey);
+            // We don't want to try and fetch version for client side requests, always assume we're in sync.
+            return null;
+        }
+
+        RepositoryCacheVersion? requestCachedVersion = _requestCache.GetCacheItem<RepositoryCacheVersion>(cacheKey);
+        if (requestCachedVersion is not null)
+        {
+            _logger.LogDebug("Cache version for key {CacheKey} found in request cache", cacheKey);
+            return requestCachedVersion;
+        }
+
+        using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
+        scope.ReadLock(Core.Constants.Locks.CacheVersion);
+
+        RepositoryCacheVersion? databaseVersion = await _repositoryCacheVersionRepository.GetAsync(cacheKey);
+
+        if (databaseVersion is null)
+        {
+            return databaseVersion;
+        }
+
+        _requestCache.Set(cacheKey, databaseVersion);
+        return databaseVersion;
+    }
+}

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -49,7 +49,7 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
     public async Task<RepositoryCacheVersion?> GetAsync(string cacheKey)
     {
         HttpContext? httpcontext = _httpContextAccessor.HttpContext;
-        if (httpcontext?.RequestServices is not null && httpcontext.Request.IsClientSideRequest())
+        if (httpcontext?.RequestServices is not null && httpcontext.Request.IsBackOfficeRequest() is false)
         {
             _logger.LogDebug("Client side request detected, skipping cache version retrieval for key {CacheKey}", cacheKey);
             // We don't want to try and fetch version for client side requests, always assume we're in sync.

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -8,20 +8,20 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.Cache;
 
-public class CacheVersionAccessor : ICacheVersionAccessor
+public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
 {
     private readonly IRequestCache _requestCache;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IRepositoryCacheVersionRepository _repositoryCacheVersionRepository;
     private readonly ICoreScopeProvider _coreScopeProvider;
-    private readonly ILogger<CacheVersionAccessor> _logger;
+    private readonly ILogger<RepositoryCacheVersionAccessor> _logger;
 
-    public CacheVersionAccessor(
+    public RepositoryCacheVersionAccessor(
         IRequestCache requestCache,
         IHttpContextAccessor httpContextAccessor,
         IRepositoryCacheVersionRepository repositoryCacheVersionRepository,
         ICoreScopeProvider coreScopeProvider,
-        ILogger<CacheVersionAccessor> logger)
+        ILogger<RepositoryCacheVersionAccessor> logger)
     {
         _requestCache = requestCache;
         _httpContextAccessor = httpContextAccessor;
@@ -49,7 +49,7 @@ public class CacheVersionAccessor : ICacheVersionAccessor
     public async Task<RepositoryCacheVersion?> GetAsync(string cacheKey)
     {
         HttpContext? httpcontext = _httpContextAccessor.HttpContext;
-        if (httpcontext is not null && httpcontext.Request.IsClientSideRequest())
+        if (httpcontext?.RequestServices is not null && httpcontext.Request.IsClientSideRequest())
         {
             _logger.LogDebug("Client side request detected, skipping cache version retrieval for key {CacheKey}", cacheKey);
             // We don't want to try and fetch version for client side requests, always assume we're in sync.

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -76,4 +76,6 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         _requestCache.Set(cacheKey, databaseVersion);
         return databaseVersion;
     }
+
+    public void CachesSynced() => _requestCache.ClearOfType<RepositoryCacheVersion>();
 }

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -46,6 +46,7 @@ using Umbraco.Cms.Web.Common;
 using Umbraco.Cms.Web.Common.ApplicationModels;
 using Umbraco.Cms.Web.Common.AspNetCore;
 using Umbraco.Cms.Web.Common.Blocks;
+using Umbraco.Cms.Web.Common.Cache;
 using Umbraco.Cms.Web.Common.Configuration;
 using Umbraco.Cms.Web.Common.Controllers;
 using Umbraco.Cms.Web.Common.DependencyInjection;
@@ -104,6 +105,7 @@ public static partial class UmbracoBuilderExtensions
         // is just based on AsyncLocal, see https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http/src/HttpContextAccessor.cs
         IHttpContextAccessor httpContextAccessor = new HttpContextAccessor();
         services.AddSingleton(httpContextAccessor);
+        services.AddUnique<ICacheVersionAccessor, CacheVersionAccessor>();
 
         var requestCache = new HttpContextRequestAppCache(httpContextAccessor);
         var appCaches = AppCaches.Create(requestCache);

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -105,7 +105,7 @@ public static partial class UmbracoBuilderExtensions
         // is just based on AsyncLocal, see https://github.com/dotnet/aspnetcore/blob/main/src/Http/Http/src/HttpContextAccessor.cs
         IHttpContextAccessor httpContextAccessor = new HttpContextAccessor();
         services.AddSingleton(httpContextAccessor);
-        services.AddUnique<ICacheVersionAccessor, CacheVersionAccessor>();
+        services.AddUnique<IRepositoryCacheVersionAccessor, RepositoryCacheVersionAccessor>();
 
         var requestCache = new HttpContextRequestAppCache(httpContextAccessor);
         var appCaches = AppCaches.Create(requestCache);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/DistributedCacheRefresherTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/DistributedCacheRefresherTests.cs
@@ -25,6 +25,7 @@ internal sealed class DistributedCacheRefresherTests : UmbracoIntegrationTest
         var cacheKey = "test";
         PopulateCache("test");
 
+        ContentCacheRefresher.RefreshInternal([new ContentCacheRefresher.JsonPayload()]);
         ContentCacheRefresher.Refresh([new ContentCacheRefresher.JsonPayload()]);
 
         Assert.IsNull(ElementsCache.Get(cacheKey));
@@ -36,6 +37,7 @@ internal sealed class DistributedCacheRefresherTests : UmbracoIntegrationTest
         var cacheKey = "test";
         PopulateCache("test");
 
+        MediaCacheRefresher.RefreshInternal([new MediaCacheRefresher.JsonPayload(1, Guid.NewGuid(), TreeChangeTypes.RefreshAll)]);
         MediaCacheRefresher.Refresh([new MediaCacheRefresher.JsonPayload(1, Guid.NewGuid(), TreeChangeTypes.RefreshAll)]);
 
         Assert.IsNull(ElementsCache.Get(cacheKey));

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRequestTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRequestTestBase.cs
@@ -89,5 +89,13 @@ public abstract class ApiContentRequestTestBase : UmbracoIntegrationTest
     }
 
     protected void RefreshContentCache()
-        => Services.GetRequiredService<ContentCacheRefresher>().Refresh([new ContentCacheRefresher.JsonPayload { ChangeTypes = TreeChangeTypes.RefreshAll }]);
+    {
+        var refresher = Services.GetRequiredService<ContentCacheRefresher>();
+        ContentCacheRefresher.JsonPayload[] payloads =
+        [
+            new() { ChangeTypes = TreeChangeTypes.RefreshAll }
+        ];
+        refresher.RefreshInternal(payloads);
+        refresher.Refresh(payloads);
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentResponseBuilderTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentResponseBuilderTests.cs
@@ -99,5 +99,14 @@ public class ApiContentResponseBuilderTests : UmbracoIntegrationTest
     }
 
     private void RefreshContentCache()
-        => GetRequiredService<ContentCacheRefresher>().Refresh([new ContentCacheRefresher.JsonPayload { ChangeTypes = TreeChangeTypes.RefreshAll }]);
+    {
+        var refresher = GetRequiredService<ContentCacheRefresher>();
+        ContentCacheRefresher.JsonPayload[] payloads =
+        [
+            new() { ChangeTypes = TreeChangeTypes.RefreshAll }
+        ];
+
+        refresher.RefreshInternal(payloads);
+        refresher.Refresh(payloads);
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
@@ -18,6 +18,8 @@ internal sealed class RepositoryCacheVersionServiceTests : UmbracoIntegrationTes
 
     private ICoreScopeProvider CoreScopeProvider => GetRequiredService<ICoreScopeProvider>();
 
+    protected override void CustomTestSetup(IUmbracoBuilder builder) => builder.LoadBalanceIsolatedCaches();
+
     [Test]
     public async Task Cache_Is_Initially_Synced()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/AuditRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/AuditRepositoryTest.cs
@@ -36,7 +36,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = ScopeProvider.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
             repo.Save(new AuditItem(-1, AuditType.System, -1, UmbracoObjectTypes.Document.GetName(), "This is a System audit trail"));
 
             var dtos = ScopeAccessor.AmbientScope.Database.Fetch<LogDto>("WHERE id > -1");
@@ -84,7 +84,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -97,7 +97,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             var page = repo.GetPagedResultsByQuery(sp.CreateQuery<IAuditItem>(), 0, 10, out var total, Direction.Descending, null, null);
 
@@ -112,7 +112,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -125,7 +125,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             var query = sp.CreateQuery<IAuditItem>().Where(x => x.UserId == -1);
 
@@ -161,7 +161,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -174,7 +174,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             var page = repo.GetPagedResultsByQuery(
                     sp.CreateQuery<IAuditItem>(),
@@ -198,7 +198,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
         var sp = ScopeProvider;
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             for (var i = 0; i < 100; i++)
             {
@@ -211,7 +211,7 @@ internal sealed class AuditRepositoryTest : UmbracoIntegrationTest
 
         using (var scope = sp.CreateScope())
         {
-            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new AuditRepository((IScopeAccessor)sp, _logger, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             var page = repo.GetPagedResultsByQuery(
                     sp.CreateQuery<IAuditItem>(),

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
@@ -90,7 +90,8 @@ internal sealed class ContentTypeRepositoryTest : UmbracoIntegrationTest
                 ShortStringHelper,
                 Mock.Of<IViewHelper>(),
                 runtimeSettingsMock.Object,
-                Mock.Of<IRepositoryCacheVersionService>());
+                Mock.Of<IRepositoryCacheVersionService>(),
+                Mock.Of<ICacheSyncService>());
             var repository = ContentTypeRepository;
             Template[] templates =
             {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -103,7 +103,7 @@ internal sealed class DocumentRepositoryTest : UmbracoIntegrationTest
 
         var ctRepository = CreateRepository(scopeAccessor, out contentTypeRepository, out TemplateRepository tr);
         var editors = new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
-        dtdRepository = new DataTypeRepository(scopeAccessor, appCaches, editors, LoggerFactory.CreateLogger<DataTypeRepository>(), LoggerFactory, ConfigurationEditorJsonSerializer, Mock.Of<IRepositoryCacheVersionService>());
+        dtdRepository = new DataTypeRepository(scopeAccessor, appCaches, editors, LoggerFactory.CreateLogger<DataTypeRepository>(), LoggerFactory, ConfigurationEditorJsonSerializer, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         return ctRepository;
     }
 
@@ -117,16 +117,16 @@ internal sealed class DocumentRepositoryTest : UmbracoIntegrationTest
         var runtimeSettingsMock = new Mock<IOptionsMonitor<RuntimeSettings>>();
         runtimeSettingsMock.Setup(x => x.CurrentValue).Returns(new RuntimeSettings());
 
-        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object,  Mock.Of<IRepositoryCacheVersionService>());
-        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object,  Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
+        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         var commonRepository =
             new ContentTypeCommonRepository(scopeAccessor, templateRepository, appCaches, ShortStringHelper);
         var languageRepository =
-            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
-        contentTypeRepository = new ContentTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap);
-        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
+        contentTypeRepository = new ContentTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>());
+        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
-        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
+        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         var propertyEditors =
             new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
         var dataValueReferences =

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DomainRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DomainRepositoryTest.cs
@@ -33,7 +33,7 @@ internal sealed class DomainRepositoryTest : UmbracoIntegrationTest
     {
         var accessor = (IScopeAccessor)provider;
         var domainRepository =
-            new DomainRepository(accessor, AppCaches.NoCache, LoggerFactory.CreateLogger<DomainRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            new DomainRepository(accessor, AppCaches.NoCache, LoggerFactory.CreateLogger<DomainRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         return domainRepository;
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/KeyValueRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/KeyValueRepositoryTests.cs
@@ -66,5 +66,5 @@ internal sealed class KeyValueRepositoryTests : UmbracoIntegrationTest
     }
 
     private IKeyValueRepository CreateRepository(ICoreScopeProvider provider) =>
-        new KeyValueRepository((IScopeAccessor)provider, LoggerFactory.CreateLogger<KeyValueRepository>(),  Mock.Of<IRepositoryCacheVersionService>());
+        new KeyValueRepository((IScopeAccessor)provider, LoggerFactory.CreateLogger<KeyValueRepository>(),  Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LanguageRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LanguageRepositoryTest.cs
@@ -366,7 +366,7 @@ internal sealed class LanguageRepositoryTest : UmbracoIntegrationTest
         }
     }
 
-    private LanguageRepository CreateRepository(IScopeProvider provider) => new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+    private LanguageRepository CreateRepository(IScopeProvider provider) => new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
     private async Task CreateTestData()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
@@ -51,16 +51,15 @@ internal sealed class MediaRepositoryTest : UmbracoIntegrationTest
     {
         appCaches ??= AppCaches.NoCache;
         var scopeAccessor = (IScopeAccessor)provider;
-        var globalSettings = new GlobalSettings();
         var commonRepository =
             new ContentTypeCommonRepository(scopeAccessor, TemplateRepository, appCaches, ShortStringHelper);
         var languageRepository =
-            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
-        mediaTypeRepository = new MediaTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap);
-        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
-        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            new LanguageRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
+        mediaTypeRepository = new MediaTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>());
+        var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
+        var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
-        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
+        var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         var propertyEditors =
             new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
         var mediaUrlGenerators = new MediaUrlGeneratorCollection(() => Enumerable.Empty<IMediaUrlGenerator>());
@@ -82,7 +81,8 @@ internal sealed class MediaRepositoryTest : UmbracoIntegrationTest
             DataTypeService,
             JsonSerializer,
             Mock.Of<IEventAggregator>(),
-            Mock.Of<IRepositoryCacheVersionService>());
+            Mock.Of<IRepositoryCacheVersionService>(),
+            Mock.Of<ICacheSyncService>());
         return repository;
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaTypeRepositoryTest.cs
@@ -413,8 +413,8 @@ internal sealed class MediaTypeRepositoryTest : UmbracoIntegrationTest
     }
 
     private MediaTypeRepository CreateRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<MediaTypeRepository>(), CommonRepository, LanguageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap);
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<MediaTypeRepository>(), CommonRepository, LanguageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>());
 
     private EntityContainerRepository CreateContainerRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<EntityContainerRepository>(), Constants.ObjectTypes.MediaTypeContainer, Mock.Of<IRepositoryCacheVersionService>());
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<EntityContainerRepository>(), Constants.ObjectTypes.MediaTypeContainer, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MemberTypeRepositoryTest.cs
@@ -27,7 +27,7 @@ internal sealed class MemberTypeRepositoryTest : UmbracoIntegrationTest
     {
         var commonRepository = GetRequiredService<IContentTypeCommonRepository>();
         var languageRepository = GetRequiredService<ILanguageRepository>();
-        return new MemberTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap);
+        return new MemberTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, Mock.Of<ILogger<MemberTypeRepository>>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>());
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/PublicAccessRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/PublicAccessRepositoryTest.cs
@@ -35,7 +35,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -57,7 +57,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         using (var scope = provider.CreateScope())
         {
             ScopeAccessor.AmbientScope.Database.AsUmbracoDatabase().EnableSqlTrace = true;
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -91,7 +91,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         using (var scope = provider.CreateScope())
         {
             ScopeAccessor.AmbientScope.Database.AsUmbracoDatabase().EnableSqlTrace = true;
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             PublicAccessRule[] rules =
             {
@@ -125,7 +125,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -154,7 +154,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(),Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(),Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             PublicAccessRule[] rules = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry = new PublicAccessEntry(content[0], content[1], content[2], rules);
@@ -175,7 +175,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             var allEntries = new List<PublicAccessEntry>();
             for (var i = 0; i < 10; i++)
@@ -235,7 +235,7 @@ internal sealed class PublicAccessRepositoryTest : UmbracoIntegrationTest
         var provider = ScopeProvider;
         using (var scope = provider.CreateScope())
         {
-            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(),  Mock.Of<IRepositoryCacheVersionService>());
+            var repo = new PublicAccessRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<PublicAccessRepository>(),  Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             PublicAccessRule[] rules1 = { new PublicAccessRule { RuleValue = "test", RuleType = "RoleName" } };
             var entry1 = new PublicAccessEntry(content[0], content[1], content[2], rules1);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RedirectUrlRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RedirectUrlRepositoryTests.cs
@@ -237,7 +237,7 @@ internal sealed class RedirectUrlRepositoryTests : UmbracoIntegrationTest
     }
 
     private IRedirectUrlRepository CreateRepository(IScopeProvider provider) =>
-        new RedirectUrlRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<RedirectUrlRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        new RedirectUrlRepository((IScopeAccessor)provider, AppCaches, LoggerFactory.CreateLogger<RedirectUrlRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
     private IContent _textpage;
     private IContent _subpage;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationRepositoryTest.cs
@@ -574,9 +574,9 @@ internal sealed class RelationRepositoryTest : UmbracoIntegrationTest
         using (var scope = ScopeProvider.CreateScope())
         {
             var accessor = (IScopeAccessor)ScopeProvider;
-            var relationTypeRepository = new RelationTypeRepository(accessor, AppCaches.Disabled, Mock.Of<ILogger<RelationTypeRepository>>(), Mock.Of<IRepositoryCacheVersionService>());
+            var relationTypeRepository = new RelationTypeRepository(accessor, AppCaches.Disabled, Mock.Of<ILogger<RelationTypeRepository>>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
             var entityRepository = new EntityRepository(accessor, AppCaches.Disabled);
-            var relationRepository = new RelationRepository(accessor, Mock.Of<ILogger<RelationRepository>>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
+            var relationRepository = new RelationRepository(accessor, Mock.Of<ILogger<RelationRepository>>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             relationTypeRepository.Save(_relateContent);
             relationTypeRepository.Save(_relateContentType);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RelationTypeRepositoryTest.cs
@@ -24,7 +24,7 @@ internal sealed class RelationTypeRepositoryTest : UmbracoIntegrationTest
     public void SetUp() => CreateTestData();
 
     private RelationTypeRepository CreateRepository(ICoreScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
     [Test]
     public void Can_Perform_Add_On_RelationTypeRepository()
@@ -241,7 +241,7 @@ internal sealed class RelationTypeRepositoryTest : UmbracoIntegrationTest
         ICoreScopeProvider provider = ScopeProvider;
         using (var scope = provider.CreateCoreScope())
         {
-            var repository = new RelationTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var repository = new RelationTypeRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
             repository.Save(relateContent); // Id 2
             repository.Save(relateContentType); // Id 3

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ServerRegistrationRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ServerRegistrationRepositoryTest.cs
@@ -29,7 +29,7 @@ internal sealed class ServerRegistrationRepositoryTest : UmbracoIntegrationTest
     private AppCaches _appCaches;
 
     private ServerRegistrationRepository CreateRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, LoggerFactory.CreateLogger<ServerRegistrationRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        new((IScopeAccessor)provider, LoggerFactory.CreateLogger<ServerRegistrationRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
     [Test]
     public void Cannot_Add_Duplicate_Server_Identities()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TagRepositoryTest.cs
@@ -1141,5 +1141,5 @@ internal sealed class TagRepositoryTest : UmbracoIntegrationTest
     }
 
     private TagRepository CreateRepository(IScopeProvider provider) =>
-        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+        new((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -63,7 +63,7 @@ internal sealed class TemplateRepositoryTest : UmbracoIntegrationTest
     private IOptionsMonitor<RuntimeSettings> RuntimeSettings => GetRequiredService<IOptionsMonitor<RuntimeSettings>>();
 
     private ITemplateRepository CreateRepository(IScopeProvider provider) =>
-        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, ShortStringHelper, ViewHelper, RuntimeSettings, Mock.Of<IRepositoryCacheVersionService>());
+        new TemplateRepository((IScopeAccessor)provider, AppCaches.Disabled, LoggerFactory.CreateLogger<TemplateRepository>(), FileSystems, ShortStringHelper, ViewHelper, RuntimeSettings, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
     [Test]
     public void Can_Instantiate_Repository()
@@ -262,14 +262,14 @@ internal sealed class TemplateRepositoryTest : UmbracoIntegrationTest
             var templateRepository = CreateRepository(provider);
             var globalSettings = new GlobalSettings();
             var serializer = new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory());
-            var tagRepository = new TagRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var tagRepository = new TagRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
             var commonRepository =
                 new ContentTypeCommonRepository(scopeAccessor, templateRepository, AppCaches, ShortStringHelper);
-            var languageRepository = new LanguageRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>());
-            var contentTypeRepository = new ContentTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap);
-            var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>());
+            var languageRepository = new LanguageRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
+            var contentTypeRepository = new ContentTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>());
+            var relationTypeRepository = new RelationTypeRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
             var entityRepository = new EntityRepository(scopeAccessor, AppCaches.Disabled);
-            var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>());
+            var relationRepository = new RelationRepository(scopeAccessor, LoggerFactory.CreateLogger<RelationRepository>(), relationTypeRepository, entityRepository, Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
             var propertyEditors =
                 new PropertyEditorCollection(new DataEditorCollection(() => Enumerable.Empty<IDataEditor>()));
             var dataValueReferences =

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/UserRepositoryTest.cs
@@ -58,7 +58,8 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
             new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory()),
             mockRuntimeState.Object,
             Mock.Of<IRepositoryCacheVersionService>(),
-            PermissionMappers);
+            PermissionMappers,
+            Mock.Of<ICacheSyncService>());
         return repository;
     }
 
@@ -166,7 +167,8 @@ internal sealed class UserRepositoryTest : UmbracoIntegrationTest
                 new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory()),
                 mockRuntimeState.Object,
                 Mock.Of<IRepositoryCacheVersionService>(),
-                PermissionMappers);
+                PermissionMappers,
+                Mock.Of<ICacheSyncService>());
 
             repository2.Delete(user);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RedirectUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RedirectUrlServiceTests.cs
@@ -42,7 +42,8 @@ internal sealed class RedirectUrlServiceTests : UmbracoIntegrationTestWithConten
                 (IScopeAccessor)ScopeProvider,
                 AppCaches.Disabled,
                 Mock.Of<ILogger<RedirectUrlRepository>>(),
-                Mock.Of<IRepositoryCacheVersionService>());
+                Mock.Of<IRepositoryCacheVersionService>(),
+                Mock.Of<ICacheSyncService>());
             var rootContent = ContentService.GetRootContent().First();
             var subPages = ContentService.GetPagedChildren(rootContent.Id, 0, 3, out _).ToList();
             _firstSubPage = subPages[0];

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DefaultCachePolicyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/DefaultCachePolicyTests.cs
@@ -36,7 +36,7 @@ public class DefaultCachePolicyTests
             .Callback(() => isCached = true);
 
         var defaultPolicy =
-            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>());
 
         var unused = defaultPolicy.Get(1, id => new AuditItem(1, AuditType.Copy, 123, "test", "blah"), o => null);
         Assert.IsTrue(isCached);
@@ -49,7 +49,7 @@ public class DefaultCachePolicyTests
         cache.Setup(x => x.Get(It.IsAny<string>())).Returns(new AuditItem(1, AuditType.Copy, 123, "test", "blah"));
 
         var defaultPolicy =
-            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>());
 
         var found = defaultPolicy.Get(1, id => null, ids => null);
         Assert.IsNotNull(found);
@@ -65,7 +65,7 @@ public class DefaultCachePolicyTests
         cache.Setup(x => x.SearchByKey(It.IsAny<string>())).Returns(new AuditItem[] { });
 
         var defaultPolicy =
-            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>());
 
         var unused = defaultPolicy.GetAll(
             new object[] { },
@@ -89,7 +89,7 @@ public class DefaultCachePolicyTests
         });
 
         var defaultPolicy =
-            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>());
 
         var found = defaultPolicy.GetAll(new object[] { }, ids => new[] { (AuditItem)null });
         Assert.AreEqual(2, found.Length);
@@ -104,7 +104,7 @@ public class DefaultCachePolicyTests
             .Callback(() => cacheCleared = true);
 
         var defaultPolicy =
-            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>());
         try
         {
             defaultPolicy.Update(new AuditItem(1, AuditType.Copy, 123, "test", "blah"), item => throw new Exception("blah!"));
@@ -128,7 +128,7 @@ public class DefaultCachePolicyTests
             .Callback(() => cacheCleared = true);
 
         var defaultPolicy =
-            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions());
+            new DefaultRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>());
         try
         {
             defaultPolicy.Delete(new AuditItem(1, AuditType.Copy, 123, "test", "blah"), item => throw new Exception("blah!"));

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/FullDataSetCachePolicyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/FullDataSetCachePolicyTests.cs
@@ -45,7 +45,7 @@ public class FullDataSetCachePolicyTests
             .Callback(() => isCached = true);
 
         var policy =
-            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
 
         var unused = policy.Get(1, id => new AuditItem(1, AuditType.Copy, 123, "test", "blah"), ids => getAll);
         Assert.IsTrue(isCached);
@@ -63,7 +63,7 @@ public class FullDataSetCachePolicyTests
         cache.Setup(x => x.Get(It.IsAny<string>())).Returns(new AuditItem(1, AuditType.Copy, 123, "test", "blah"));
 
         var defaultPolicy =
-            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
 
         var found = defaultPolicy.Get(1, id => null, ids => getAll);
         Assert.IsNotNull(found);
@@ -92,7 +92,7 @@ public class FullDataSetCachePolicyTests
             .Returns(() => cached.Any() ? new DeepCloneableList<AuditItem>(ListCloneBehavior.CloneOnce) : null);
 
         var policy =
-            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
 
         var found = policy.GetAll(new object[] { }, ids => getAll);
 
@@ -100,7 +100,7 @@ public class FullDataSetCachePolicyTests
         Assert.IsNotNull(list);
 
         // Do it again, ensure that its coming from the cache!
-        policy = new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+        policy = new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
 
         found = policy.GetAll(new object[] { }, ids => getAll);
 
@@ -131,7 +131,7 @@ public class FullDataSetCachePolicyTests
         cache.Setup(x => x.Get(It.IsAny<string>())).Returns(new AuditItem[] { });
 
         var defaultPolicy =
-            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
 
         var found = defaultPolicy.GetAll(new object[] { }, ids => getAll);
 
@@ -154,7 +154,7 @@ public class FullDataSetCachePolicyTests
             });
 
         var defaultPolicy =
-            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
 
         var found = defaultPolicy.GetAll(new object[] { }, ids => getAll);
         Assert.AreEqual(2, found.Length);
@@ -175,7 +175,7 @@ public class FullDataSetCachePolicyTests
             .Callback(() => cacheCleared = true);
 
         var defaultPolicy =
-            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
         try
         {
             defaultPolicy.Update(new AuditItem(1, AuditType.Copy, 123, "test", "blah"), item => throw new Exception("blah!"));
@@ -205,7 +205,7 @@ public class FullDataSetCachePolicyTests
             .Callback(() => cacheCleared = true);
 
         var defaultPolicy =
-            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, item => item.Id, false);
+            new FullDataSetRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new SingleServerCacheVersionService(), Mock.Of<ICacheSyncService>(), item => item.Id, false);
         try
         {
             defaultPolicy.Delete(new AuditItem(1, AuditType.Copy, 123, "test", "blah"), item => throw new Exception("blah!"));

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/SingleItemsOnlyCachePolicyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/SingleItemsOnlyCachePolicyTests.cs
@@ -36,7 +36,7 @@ public class SingleItemsOnlyCachePolicyTests
             .Callback((string cacheKey, Func<object> o, TimeSpan? t, bool b) => cached.Add(cacheKey));
         cache.Setup(x => x.SearchByKey(It.IsAny<string>())).Returns(new AuditItem[] { });
 
-        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), Mock.Of<IRepositoryCacheVersionService>());
+        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
         var unused = defaultPolicy.GetAll(
             new object[] { },
@@ -57,7 +57,7 @@ public class SingleItemsOnlyCachePolicyTests
         cache.Setup(x => x.Insert(It.IsAny<string>(), It.IsAny<Func<object>>(), It.IsAny<TimeSpan?>(), It.IsAny<bool>()))
             .Callback(() => isCached = true);
 
-        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), Mock.Of<IRepositoryCacheVersionService>());
+        var defaultPolicy = new SingleItemsOnlyRepositoryCachePolicy<AuditItem, object>(cache.Object, DefaultAccessor, new RepositoryCachePolicyOptions(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
 
         var unused = defaultPolicy.Get(1, id => new AuditItem(1, AuditType.Copy, 123, "test", "blah"), ids => null);
         Assert.IsTrue(isCached);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/CacheInstructionsPruningJobTests.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.BackgroundJobs.Jobs;
@@ -68,7 +69,7 @@ public class CacheInstructionsPruningJobTests
             .Setup(g => g.Value)
             .Returns(globalSettings);
 
-        return new CacheInstructionsPruningJob(_globalSettingsMock.Object, _cacheInstructionRepositoryMock.Object, _scopeProviderMock.Object, _timeProviderMock.Object);
+        return new CacheInstructionsPruningJob(_globalSettingsMock.Object, _cacheInstructionRepositoryMock.Object, _scopeProviderMock.Object, _timeProviderMock.Object, Mock.Of<ILastSyncedManager>());
     }
 
     private void SetupScopeProviderMock() =>


### PR DESCRIPTION
## Cache Sync Service for Load-Balanced Isolated Caches

### Overview
Builds on `load-balancing-isolated-caches` by introducing `ICacheSyncService`, which enables isolated caches to roll forward when detected as out of date in load-balanced environments.

### Key Changes

#### Cache Refresher Refactoring
Split cache refresher logic into two methods:
- **`RefreshInternal`**: Clears all isolated caches (repositories, services)
- **`Refresh`**: Clears published content caches (`IPublishedContentCache`, route caching, etc.)

This separation enables isolated caches to be synchronized separately from the published content cache layer.

#### DatabaseServerMessenger Responsibility Changes
Moved several responsibilities out of `DatabaseServerMessenger` to support the new sync architecture:
- **Last sync ID management**: Now handled by `ICacheSyncService` since sync state is managed centrally
- **Local identity generation**: Exposed outside `DatabaseServerMessenger` as it's needed by other components

#### RepositoryCacheVersionAccessor
Added a new accessor layer between the database and `RepositoryCacheVersionService` with two key purposes:

1. **Request-level caching**: Cache versions are now cached per request to avoid excessive database checks (e.g., user repository can be accessed 7+ times per request)
2. **Performance optimization**: Cache version checks are disabled outside the backoffice since isolated cache synchronization is only relevant for backoffice operations, eliminating unnecessary performance overhead on public-facing website requests

#### Critical Synchronization Caveat
During cache synchronization, repositories are used to reload data. To prevent recursive sync attempts:
- Repositories must be marked as synced **before** beginning the sync process
- A read lock is acquired on the cache version table during sync to prevent other servers from registering changes mid-sync
- Request cache is cleared during synchronization to ensure fresh data

### Opt-in Architecture
These changes are **only relevant for sites with load-balanced backoffice environments**. By default:
- `SingleServerCacheVersionService` is used (a no-op implementation)
- This PR has no effect on single-server or non-load-balanced deployments

To enable isolated cache synchronization in load-balanced environments, use the new `LoadBalanceIsolatedCaches()` extension method on `IUmbracoBuilder`.

### Usage
```csharp
builder.LoadBalanceIsolatedCaches();
```

---