### PR TITLE
Segments: Adds deprecation notices to `AllowNonExistingSegmentsCreation`

### DIFF
--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentConfigurationResponseModel.cs
@@ -8,5 +8,6 @@ public class DocumentConfigurationResponseModel
 
     public required bool AllowEditInvariantFromNonDefault { get; set; }
 
+    [Obsolete("This functionality will be moved to a client-side extension. Scheduled for removal in V19.")]
     public required bool AllowNonExistingSegmentsCreation { get; set; }
 }

--- a/src/Umbraco.Core/Configuration/Models/SegmentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SegmentSettings.cs
@@ -19,5 +19,6 @@ public class SegmentSettings
     /// <summary>
     ///     Gets or sets a value indicating whether the creation of non-existing segments is allowed.
     /// </summary>
+    [Obsolete("This functionality will be moved to a client-side extension. Scheduled for removal in V19.")]
     public bool AllowCreation { get; set; } = StaticAllowCreation;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -96,6 +96,15 @@ export class UmbDocumentWorkspaceContext
 			const allowSegmentCreation = config?.allowNonExistingSegmentsCreation ?? false;
 			const allowEditInvariantFromNonDefault = config?.allowEditInvariantFromNonDefault ?? true;
 
+			// Deprecation warning for allowNonExistingSegmentsCreation (default from server is true, so we warn on false)
+			if (!allowSegmentCreation) {
+				new UmbDeprecation({
+					deprecated: 'The "AllowNonExistingSegmentsCreation" setting is deprecated.',
+					removeInVersion: '19.0.0',
+					solution: 'This functionality will be moved to a client-side extension.',
+				}).warn();
+			}
+
 			this._variantOptionsFilter = (variantOption) => {
 				const isNotCreatedSegmentVariant = variantOption.segment && !variantOption.variant;
 


### PR DESCRIPTION
## Description

The `DocumentConfigurationResponseModel#AllowNonExistingSegmentsCreation` as well as the `SegmentSettings#AllowCreation` have been deprecated. They will be replaced by a yet non-existing client-side extension in V19.