### PR TITLE
Add support for custom query strings in Umbraco URL redirects

### DIFF
--- a/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoUrlResult.cs
+++ b/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoUrlResult.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Umbraco.Cms.Core.Web;
@@ -15,11 +16,21 @@ namespace Umbraco.Cms.Web.Website.ActionResults;
 public class RedirectToUmbracoUrlResult : IKeepTempDataResult
 {
     private readonly IUmbracoContext _umbracoContext;
+    private readonly QueryString _queryString;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="RedirectToUmbracoUrlResult" /> class.
     /// </summary>
     public RedirectToUmbracoUrlResult(IUmbracoContext umbracoContext) => _umbracoContext = umbracoContext;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="RedirectToUmbracoUrlResult" /> class.
+    /// </summary>
+    public RedirectToUmbracoUrlResult(IUmbracoContext umbracoContext, QueryString queryString)
+    {
+        _umbracoContext = umbracoContext;
+        _queryString = queryString;
+    }
 
     /// <inheritdoc />
     public Task ExecuteResultAsync(ActionContext context)
@@ -30,6 +41,11 @@ public class RedirectToUmbracoUrlResult : IKeepTempDataResult
         }
 
         var destinationUrl = _umbracoContext.OriginalRequestUrl.PathAndQuery;
+
+        if (_queryString.HasValue)
+        {
+            destinationUrl = _umbracoContext.OriginalRequestUrl.AbsolutePath + _queryString.ToUriComponent();
+        }
 
         context.HttpContext.Response.Redirect(destinationUrl);
 

--- a/src/Umbraco.Web.Website/Controllers/SurfaceController.cs
+++ b/src/Umbraco.Web.Website/Controllers/SurfaceController.cs
@@ -102,6 +102,12 @@ public abstract class SurfaceController : PluginController
         => new(UmbracoContext);
 
     /// <summary>
+    ///     Redirects to the currently rendered Umbraco URL and passes provided querystring
+    /// </summary>
+    protected RedirectToUmbracoUrlResult RedirectToCurrentUmbracoUrl(QueryString queryString)
+        => new(UmbracoContext, queryString);
+
+    /// <summary>
     ///     Returns the currently rendered Umbraco page
     /// </summary>
     protected UmbracoPageResult CurrentUmbracoPage()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
This PR adds the ability to pass a `QueryString` value into `RedirectToCurrentUmbracoUrl()`. This will form part of a fix for Umbraco Forms so that forms posting back to virtual pages can be redirected correctly whilst respecting a custom `IContentFinder`.

Information on how to test can be found at: https://github.com/rickbutterfield/UmbracoVirtualRedirectsTest/
There is more information/discussion on this issue: https://github.com/umbraco/Umbraco.Forms.Issues/issues/1456

The same code works in v16/dev and should be able to be cherry picked.

<!-- Thanks for contributing to Umbraco CMS! -->