### PR TITLE
Repositories: v13 UserService.GetAllInGroup fix

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -376,11 +376,11 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
 
         // get users2groups
 
-        List<User2UserGroupDto>? user2Groups = Database.FetchByGroups<User2UserGroupDto, int>(userIds, Constants.Sql.MaxParameterCount, ints =>
+        var user2Groups = Database.FetchByGroups<User2UserGroupDto, int>(userIds, Constants.Sql.MaxParameterCount, ints =>
         {
             return SqlContext.Sql()
-            .Select<User2UserGroupDto>()
-            .From<User2UserGroupDto>()
+                .Select<User2UserGroupDto>()
+                .From<User2UserGroupDto>()
                 .WhereIn<User2UserGroupDto>(x => x.UserId, ints);
         }).ToList();
         var groupIds = user2Groups.Select(x => x.UserGroupId).ToList();
@@ -424,14 +424,13 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
 
         // get start nodes
 
-        List<UserStartNodeDto>? startNodes = Database.FetchByGroups<UserStartNodeDto, int>(userIds, Constants.Sql.MaxParameterCount, ints =>
+        var startNodes = Database.FetchByGroups<UserStartNodeDto, int>(userIds, Constants.Sql.MaxParameterCount, ints =>
         {
             return SqlContext.Sql()
-            .Select<UserStartNodeDto>()
-            .From<UserStartNodeDto>()
+                .Select<UserStartNodeDto>()
+                .From<UserStartNodeDto>()
                 .WhereIn<UserStartNodeDto>(x => x.UserId, ints);
         }).ToList();
-
 
         // get groups2languages
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -372,15 +372,17 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
 
         List<int> userIds = dtos.Count == 1 ? new List<int> {dtos[0].Id} : dtos.Select(x => x.Id).ToList();
         Dictionary<int, UserDto>? xUsers = dtos.Count == 1 ? null : dtos.ToDictionary(x => x.Id, x => x);
+        Sql<ISqlContext> sql;
 
         // get users2groups
 
-        Sql<ISqlContext> sql = SqlContext.Sql()
+        List<User2UserGroupDto>? user2Groups = Database.FetchByGroups<User2UserGroupDto, int>(userIds, Constants.Sql.MaxParameterCount, ints =>
+        {
+            return SqlContext.Sql()
             .Select<User2UserGroupDto>()
             .From<User2UserGroupDto>()
-            .WhereIn<User2UserGroupDto>(x => x.UserId, userIds);
-
-        List<User2UserGroupDto>? user2Groups = Database.Fetch<User2UserGroupDto>(sql);
+                .WhereIn<User2UserGroupDto>(x => x.UserId, ints);
+        }).ToList();
         var groupIds = user2Groups.Select(x => x.UserGroupId).ToList();
 
         // get groups
@@ -422,12 +424,14 @@ SELECT 4 AS [Key], COUNT(id) AS [Value] FROM umbracoUser WHERE userDisabled = 0 
 
         // get start nodes
 
-        sql = SqlContext.Sql()
+        List<UserStartNodeDto>? startNodes = Database.FetchByGroups<UserStartNodeDto, int>(userIds, Constants.Sql.MaxParameterCount, ints =>
+        {
+            return SqlContext.Sql()
             .Select<UserStartNodeDto>()
             .From<UserStartNodeDto>()
-            .WhereIn<UserStartNodeDto>(x => x.UserId, userIds);
+                .WhereIn<UserStartNodeDto>(x => x.UserId, ints);
+        }).ToList();
 
-        List<UserStartNodeDto>? startNodes = Database.Fetch<UserStartNodeDto>(sql);
 
         // get groups2languages
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below
Fixes issue #18420 for **v13**

### Description
- Issue is fixed in v16.4/17 but still persists in v13 as referenced in original issue https://github.com/umbraco/Umbraco-CMS/issues/18420#issuecomment-3380349524
- Applied FetchByGroups() extension method like before to batch queries

### Steps to reproduce
- Clone and deploy from v13 branch
- Have/create 6000+ users
- Add them all to the same group
- Call userService.GetAllInGroup( groupId ) manually in code to see exception (I quickly created a new Controller endpoint and manually called it from Postman)
<img width="489" height="390" alt="image" src="https://github.com/user-attachments/assets/233679fa-e255-4b2c-8c9b-dd6670744330" />

### Before
<img width="1689" height="616" alt="image" src="https://github.com/user-attachments/assets/5d01fc02-8201-4381-b41c-fb4134e12a42" />

### After
<img width="780" height="580" alt="image" src="https://github.com/user-attachments/assets/957e203b-a05d-4d91-b139-131f07fd6d79" />