### PR TITLE
Block List: Remove bold label from inline editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
@@ -289,10 +289,6 @@ export class UmbInlineListBlockElement extends UmbLitElement {
 				padding-left: var(--uui-size-2, 6px);
 			}
 
-			#name {
-				font-weight: 700;
-			}
-
 			uui-tag {
 				margin-left: 0.5em;
 				margin-bottom: -0.3em;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/20404

### Description
Removing bold from block list inline editing to align with when line inline editing and also aligns with block grid labels.

**Before**

<img width="2173" height="1046" alt="image" src="https://github.com/user-attachments/assets/a2f5c24e-4259-4047-9da2-6d484617869c" />


**After**

<img width="2172" height="1050" alt="image" src="https://github.com/user-attachments/assets/502df817-441a-43ea-9216-580f466c6125" />
