### PR TITLE
Icon Picker: Fit icons scroll container to modal height

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icon-picker-modal/icon-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icon-picker-modal/icon-picker-modal.element.ts
@@ -194,7 +194,7 @@ export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPicker
 				gap: 10px;
 				height: 100%;
 				align-items: flex-start;
-				overflow-y: auto;
+				overflow-y: scroll;
 				max-height: 100%;
 				min-height: 0;
 				padding: 2px;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
When search result in a few icons, the scroll container doesn't fill height of modal content:

<img width="2560" height="849" alt="image" src="https://github.com/user-attachments/assets/10fb2a99-f406-4de1-b0f9-558cb8cfd2e7" />

Fit scroll container to height and align icons to top combined with CSS grid auto rows:
https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows

<img width="2560" height="849" alt="image" src="https://github.com/user-attachments/assets/3dd2bf0a-ffcd-4179-b57d-c3e2f85ef909" />

<img width="2560" height="849" alt="image" src="https://github.com/user-attachments/assets/1159e737-a44f-4c4f-b7a7-47eafa90c750" />
