### PR TITLE
Back Office: Fixes link to workspace root from breadcrumb trail (closes: #20455)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-menu-breadcrumb/workspace-menu-breadcrumb.element.ts
@@ -78,7 +78,13 @@ export class UmbWorkspaceBreadcrumbElement extends UmbLitElement {
 
 	#getHref(structureItem: UmbStructureItemModel) {
 		if (structureItem.isFolder) return undefined;
-		return `section/${this.#sectionContext?.getPathname()}/workspace/${structureItem.entityType}/edit/${structureItem.unique}`;
+
+		let href = `section/${this.#sectionContext?.getPathname()}`;
+		if (structureItem.unique) {
+			href += `/workspace/${structureItem.entityType}/edit/${structureItem.unique}`;
+		}
+
+		return href;
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-breadcrumb/workspace-variant-menu-breadcrumb/workspace-variant-menu-breadcrumb.element.ts
@@ -115,8 +115,13 @@ export class UmbWorkspaceVariantMenuBreadcrumbElement extends UmbLitElement {
 
 	#getHref(structureItem: any) {
 		if (structureItem.isFolder) return undefined;
-		const workspaceBasePath = `section/${this.#sectionContext?.getPathname()}/workspace/${structureItem.entityType}/edit`;
-		return `${workspaceBasePath}/${structureItem.unique}/${this._workspaceActiveVariantId?.toCultureString()}`;
+
+		let href = `section/${this.#sectionContext?.getPathname()}`;
+		if (structureItem.unique) {
+			href += `/workspace/${structureItem.entityType}/edit/${structureItem.unique}/${this._workspaceActiveVariantId?.toCultureString()}`;
+		}
+
+		return href;
 	}
 
 	override render() {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

https://github.com/umbraco/Umbraco-CMS/issues/20455

### Description
Currently the initial item in the content and media breadcrumb trial isn't correct and doesn't take you to the content or media root when you click on it.

<img width="375" height="45" alt="image" src="https://github.com/user-attachments/assets/dd330b09-1757-4853-9675-820f07fcd2eb" />

With this update the link is correct such that it does.

### Testing
Click on "Content" or "Media" in the breadcrumb trial shown when on a document or media item and check you end up at the expected root page.