### PR TITLE
Make data source field mandatory, when supported, in data type details

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/views/details/data-type-details-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/views/details/data-type-details-workspace-view.element.ts
@@ -109,13 +109,19 @@ export class UmbDataTypeDetailsWorkspaceViewEditElement extends UmbLitElement im
 		if (!this._supportsDataSource) return nothing;
 
 		return html`
-			<umb-property-layout label="Data Source">
+			<umb-property-layout label="Data Source" mandatory>
 				<umb-input-property-editor-data-source
 					.value=${this._propertyEditorDataSourceAlias || ''}
 					.dataSourceTypes=${this._supportedDataSourceTypes}
 					slot="editor"
 					max="1"
-					@change=${this.#onDataSourceChange}></umb-input-property-editor-data-source>
+					@change=${this.#onDataSourceChange}
+					required
+					${umbBindToValidation(
+						this,
+						'$.editorDataSourceAlias',
+						this._propertyEditorDataSourceAlias,
+					)}></umb-input-property-editor-data-source>
 			</umb-property-layout>
 		`;
 	}


### PR DESCRIPTION
When a Property Editor UI that supports Data Sources is selected, the data source becomes mandatory. This PR introduces client-side validation to provide feedback.