### PR TITLE
UX: Center align log type in media history view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/audit-log/info-app/media-history-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/audit-log/info-app/media-history-workspace-info-app.element.ts
@@ -173,6 +173,7 @@ export class UmbMediaHistoryWorkspaceInfoAppElement extends UmbLitElement {
 			}
 
 			.log-type uui-tag {
+				justify-self: center;
 				height: fit-content;
 				margin-top: auto;
 				margin-bottom: auto;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
I noticed media log type is stretched, because of flexbox, but not center aligned (or auto margin) like log type in content.
Much of this is redundant (and perhaps added to member as well) and maybe useful for Forms and Commerce?

`<umb-history-item>` should maybe have an `user` property and a `tag/badge` - or slots for these?

Or create a `umb-log-type` component to avoid this part to be redundant:

```
<span class="log-type">
	<uui-tag look=${style.look} color=${style.color}>
		${this.localize.term(text.label, item.parameters)}
	</uui-tag>
	${this.localize.term(text.desc, item.parameters)}
</span>
```
```
.log-type {
    display: grid;
    grid-template-columns: var(--uui-size-40) auto;
    gap: var(--uui-size-layout-1);
}

.log-type uui-tag {
    justify-self: center;
    height: fit-content;
    margin-top: auto;
    margin-bottom: auto;
}
```

<img width="1778" height="661" alt="image" src="https://github.com/user-attachments/assets/b5167e86-586e-49c1-86ab-54ba92252c6d" />

**Before**

<img width="535" height="133" alt="image" src="https://github.com/user-attachments/assets/4c43ef15-d3cb-4cf8-91eb-cc5be6175e74" />

**After**

<img width="548" height="133" alt="image" src="https://github.com/user-attachments/assets/c3c57d0c-a42c-4507-851d-65d708f989ce" />
