### PR TITLE
Content Types: Prevent creation of document type with an alias that case insensitively matches an existing alias (closes #20467)

### DIFF
--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentTypeEditing;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Core.Strings;
@@ -407,7 +407,7 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
     }
 
     // This this method gets aliases across documents, members, and media, so it covers it all
-    private bool ContentTypeAliasIsInUse(string alias) => _contentTypeService.GetAllContentTypeAliases().Contains(alias);
+    private bool ContentTypeAliasIsInUse(string alias) => _contentTypeService.GetAllContentTypeAliases().InvariantContains(alias);
 
     private bool ContentTypeAliasCanBeUsedFor(string alias, Guid key)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Create.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Create.cs
@@ -861,14 +861,15 @@ internal sealed partial class ContentTypeEditingServiceTests
         Assert.AreEqual(ContentTypeOperationStatus.InvalidAlias, result.Status);
     }
 
-    [Test]
-    public async Task Cannot_Use_Existing_Alias()
+    [TestCase("test")] // Matches alias case sensitively.
+    [TestCase("Test")] // Matches alias case insensitively.
+    public async Task Cannot_Use_Existing_Alias(string newAlias)
     {
         var createModel = ContentTypeCreateModel("Test", "test");
         var result = await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
         Assert.IsTrue(result.Success);
 
-        createModel = ContentTypeCreateModel("Test 2", "test");
+        createModel = ContentTypeCreateModel("Test 2", newAlias);
         result = await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentTypeOperationStatus.DuplicateAlias, result.Status);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20467

### Description
Models builder requires unique aliases for content types, otherwise the exception shown in the linked issue is thrown.  We do have a check for this, but it only matches case sensitively.  In the specific example in the linked issue "folder" doesn't match with the existing "Folder", which is then allowed to be created.

### Testing

- Attempt to create a document type with an alias - e.g. "folder" - that matches with an existing content type alias but differs in case.
- Verify a validation error is displayed and the content type cannot be saved.