### PR TITLE
Entity data picker: Hide tree root

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.context.ts
@@ -142,7 +142,7 @@ export class UmbEntityDataPickerInputContext extends UmbPickerInputContext<UmbIt
 				},
 				data: {
 					treeAlias: UMB_ENTITY_DATA_PICKER_TREE_ALIAS,
-					expandTreeRoot: true,
+					hideTreeRoot: true,
 					search: supportsSearch
 						? {
 								providerAlias: UMB_ENTITY_DATA_PICKER_SEARCH_PROVIDER_ALIAS,


### PR DESCRIPTION
By default, it shouldn't be possible to select a tree root when using the Entity Data Picker. We could consider making it configurable at some point if we are going to use it when moving/copying entities.