### PR TITLE
Only register the Entity Data Picker when we have some registered Data Sources

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/entry-point.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/entry-point.ts
@@ -1,0 +1,22 @@
+import { manifests as entityDataPickerManifests } from './manifests.js';
+import type { UmbEntryPointOnInit } from '@umbraco-cms/backoffice/extension-api';
+import type { ManifestPropertyEditorDataSource } from '@umbraco-cms/backoffice/property-editor-data-source';
+
+export const onInit: UmbEntryPointOnInit = (host, extensionRegistry) => {
+	let initialized = false;
+
+	/* We register the Entity Data Picker only if any picker data sources have been registered. 
+  This prevents an unusable Property Editor UI from appearing in the list of Property Editors out of the box. 
+  We can remove this code when data sources become more common. */
+	extensionRegistry
+		.byTypeAndFilter<'propertyEditorDataSource', ManifestPropertyEditorDataSource>(
+			'propertyEditorDataSource',
+			(manifest) => manifest.dataSourceType === 'picker',
+		)
+		.subscribe((pickerPropertyEditorDataSource) => {
+			if (pickerPropertyEditorDataSource.length > 0 && !initialized) {
+				extensionRegistry.registerMany(entityDataPickerManifests);
+				initialized = true;
+			}
+		});
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entry-point.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entry-point.ts
@@ -1,2 +1,9 @@
+import { onInit as entityDataPickerOnInit } from './entity-data-picker/entry-point.js';
+import type { UmbEntryPointOnInit } from '@umbraco-cms/backoffice/extension-api';
 import './checkbox-list/components/index.js';
 import './content-picker/components/index.js';
+
+export const onInit: UmbEntryPointOnInit = (host, extensionRegistry) => {
+	// We do not have a package for the Entity Data Picker, so we proxy the init call here
+	entityDataPickerOnInit(host, extensionRegistry);
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/manifests.ts
@@ -25,7 +25,6 @@ import { manifests as textareaManifests } from './textarea/manifests.js';
 import { manifests as textBoxManifests } from './text-box/manifests.js';
 import { manifests as toggleManifests } from './toggle/manifests.js';
 import { manifests as contentPickerManifests } from './content-picker/manifests.js';
-import { manifests as entityDataPickerManifests } from './entity-data-picker/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	...checkboxListManifests,
@@ -46,7 +45,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 	...textBoxManifests,
 	...toggleManifests,
 	...contentPickerManifests,
-	...entityDataPickerManifests,
 	acceptedType,
 	colorEditor,
 	dimensions,


### PR DESCRIPTION
Introduces an entry point for the Entity Data Picker property editor that registers its manifests only if picker data sources are present, preventing an unusable UI from appearing by default.