### PR TITLE
Collections: Add selection mode toggle in UmbTableElement update lifecycle

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -298,7 +298,7 @@ export class UmbTableElement extends UmbLitElement {
 		return html`
 			<uui-table-row
 				data-sortable-id=${item.id}
-				?selectable="${this.config.allowSelection && !this._sortable}"
+				?selectable=${this.config.allowSelection && !this._sortable}
 				?select-only=${this._selectionMode}
 				?selected=${this._isSelected(item.id)}
 				@selected=${() => this._selectRow(item.id)}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes https://github.com/umbraco/Umbraco.Forms.Issues/issues/1467

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

By default, when selecting row(s) in a table collection view, a `disable-child-interaction` attribute is added to individual cells, breaking interactivity with the table row. When 'Clear selection' is pressed in the actions, this attribute does not get removed because `table.element.ts` is not reacting to the `selection` property changing.

The attribute can however be removed by checking and unchecking the 'Select all' checkbox in the table view.

This PR watches for `updated` and sets the selection accordingly based on properties that have changed.

Before:

https://github.com/user-attachments/assets/a498f3e7-bdd9-4ff3-a01d-701204323310


After:

https://github.com/user-attachments/assets/a41a42dc-3e86-4303-87e8-fa385e68b5b2




<!-- Thanks for contributing to Umbraco CMS! -->
