### PR TITLE
Delivery API: Provided culture to the `ApiContentRouteBuilder`, fixing issue with route path on preview requests for language variant content (closes #20366)

### DIFF
--- a/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentBuilderBase.cs
@@ -45,7 +45,7 @@ public abstract class ApiContentBuilderBase<T>
 
     public virtual T? Build(IPublishedContent content)
     {
-        IApiContentRoute? route = ApiContentRouteBuilder.Build(content);
+        IApiContentRoute? route = ApiContentRouteBuilder.Build(content, VariationContextAccessor.VariationContext?.Culture);
         if (route is null)
         {
             return default;


### PR DESCRIPTION
### Prerequisites



If there's an existing issue for this PR then this fixes [#20366](https://github.com/umbraco/Umbraco-CMS/issues/20366)

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

Made sure that the language variant culture was passed along when building the content route. This ensures that the drafted content for that specific culture will return a preview path as expected.

To test it, follow the reproduction steps in the issue.


<!-- Thanks for contributing to Umbraco CMS! -->
