### PR TITLE
Obsolete `GetAtRoot` on `DocumentCache`

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/DocumentCache.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DocumentCache.cs
@@ -42,6 +42,9 @@ public sealed class DocumentCache : IPublishedContentCache
 
     public IPublishedContent? GetById(Guid contentId) => GetByIdAsync(contentId).GetAwaiter().GetResult();
 
+    [Obsolete("This method is no longer used in Umbraco and is not defined on the interface. " +
+        "Any usage can be replaced with a call to IDocumentNavigationQueryService.TryGetRootKeys to retrieve the document keys, " +
+        "with each key passed to IPublishedContentCache.GetById to retrieve the IPublishedContent instances. Scheduled for removal in Umbraco 19.")]
     public IEnumerable<IPublishedContent> GetAtRoot(bool preview, string? culture = null)
     {
         if (_documentNavigationQueryService.TryGetRootKeys(out IEnumerable<Guid> rootKeys) is false)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditorTests.cs
@@ -8,7 +8,6 @@ using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Cms.Infrastructure.HybridCache;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -127,7 +126,6 @@ public class DateTimePropertyEditorTests : UmbracoIntegrationTest
 
         Assert.IsTrue(publishResult.Success);
 
-        var test = ((DocumentCache)PublishedContentCache).GetAtRoot(false);
         var publishedContent = await PublishedContentCache.GetByIdAsync(createContentResult.Result.Content.Key, false);
         Assert.IsNotNull(publishedContent);
 


### PR DESCRIPTION
This looks like an oversight from Umbraco 15, where we separated the concerns for navigation and content cache services.  The concrete `DocumentCache` still has a method to retrieve an `IPublishedContent` collection from the root.  But this is no longer defined on the interface nor is it used within Umbraco (apart from one instance in a test).

As `DocumentCache` is public we need to obsolete before removal, which I've done with a comment indicating removal in Umbraco 19.