### PR TITLE
Templates: Retain layout from file when loading template (closes #20524)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
@@ -102,7 +102,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 	}
 
 	#resetMasterTemplate() {
-		this.#templateWorkspaceContext?.setMasterTemplate(null);
+		this.#templateWorkspaceContext?.setMasterTemplate(null, true);
 	}
 
 	#openMasterTemplatePicker() {
@@ -121,7 +121,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 			?.onSubmit()
 			.then((value) => {
 				if (!value?.selection) return;
-				this.#templateWorkspaceContext?.setMasterTemplate(value.selection[0] ?? null);
+				this.#templateWorkspaceContext?.setMasterTemplate(value.selection[0] ?? null, true);
 			})
 			.catch(() => undefined);
 	}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20524

### Description

This was raised as a migration error, but it's not really - more a difference in how the 13 and 17 backoffice handles loading templates.

We have the concept of a "master template", i.e. a layout, which can be set via the UI when creating templates.  If creating one at the root `Layout = null;` will be set.  If creating under another template, something like `Layout = "Layout.cshtml";` will.

The problem is that's not the only way to create a layout relationship with a template - you can just do it in the Razor code itself.  So even if a template doesn't have a parent, it can still have something like `Layout = "Layout.cshtml";` in the code.

Currently when a template loads, whether or not a parent exists is used to amend the code to set the layout to `null` or the master template as appropriate.  So in the situation where a layout is set in code in a template at the root, `Layout = null;` will be written into the markup.  When this happens you can see the file on disk is still correct with `Layout = "Layout.cshtml";`, and the template editor is dirty as you'll see a "Discard changes" message pop up if you try to navigate away.

This PR fixes this by not attempting to amend the Razor code on load - it'll now always keep whatever is on disk.  Only when creating a template, or in setting a master template via the backoffice UI, will it continue to write the `Layout` setting in the template file.

### Testing

- Create two templates at the root. 
- Set one to be the layout of the other by changing `Layout = null;` to e.g. `Layout = "MyLayout.cshtml";` in the .cshtml file.
- Load the template in the backoffice.
- Before this PR you'll see `Layout = null;` presented in the backoffice UI, whilst the file on disk is unchanged.
- After this PR this change won't be made.
- Verify that creating a template, at the root and under the parent, and using the backoffice UI picker interface to set and remove a master template, all correctly still modify the Razor code's `Layout` property.

### Release

Merging this will include it for 17.0, but we could likely cherry-pick back to `main` for 16.4 too.