### PR TITLE
Don't use non-generic ILogger as a fallback in BlockEditorPropertyValueEditor

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyValueEditor.cs
@@ -51,7 +51,7 @@ public abstract class BlockEditorPropertyValueEditor<TValue, TLayout> : BlockVal
               languageService,
               ioHelper,
               attribute,
-              StaticServiceProvider.Instance.GetRequiredService<ILogger>())
+              StaticServiceProvider.Instance.GetRequiredService<ILogger<BlockEditorPropertyValueEditor<TValue, TLayout>>>())
     {
     }
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

[Fixes #20531 ](https://github.com/umbraco/Umbraco-CMS/issues/20531)

### Description
Changes the fallback to obtain an ILogger typed to the current class
