### PR TITLE
Management API: Added trashed state so when requesting content from the recycle bin it will return trashed instead of draft or published state

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Content/DocumentVariantStateHelper.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Content/DocumentVariantStateHelper.cs
@@ -12,6 +12,7 @@ internal static class DocumentVariantStateHelper
             culture,
             content.Edited,
             content.Published,
+            content.Trashed,
             content.AvailableCultures,
             content.EditedCultures ?? Enumerable.Empty<string>(),
             content.PublishedCultures);
@@ -22,15 +23,21 @@ internal static class DocumentVariantStateHelper
             culture,
             content.Edited,
             content.Published,
+            content.Trashed,
             content.CultureNames.Keys,
             content.EditedCultures,
             content.PublishedCultures);
 
-    private static DocumentVariantState GetState(IEntity entity, string? culture, bool edited, bool published, IEnumerable<string> availableCultures, IEnumerable<string> editedCultures, IEnumerable<string> publishedCultures)
+    private static DocumentVariantState GetState(IEntity entity, string? culture, bool edited, bool published, bool trashed, IEnumerable<string> availableCultures, IEnumerable<string> editedCultures, IEnumerable<string> publishedCultures)
     {
         if (entity.Id <= 0 || (culture is not null && availableCultures.Contains(culture) is false))
         {
             return DocumentVariantState.NotCreated;
+        }
+
+        if (trashed)
+        {
+            return DocumentVariantState.Trashed;
         }
 
         var isDraft = published is false ||

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVariantState.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentVariantState.cs
@@ -24,4 +24,9 @@ public enum DocumentVariantState
     ///     The item is published and there are pending changes
     /// </summary>
     PublishedPendingChanges = 4,
+
+    /// <summary>
+    ///     The item is in the recycle bin
+    /// </summary>
+    Trashed = 5,
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Mapping/Content/DocumentVariantStateHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Mapping/Content/DocumentVariantStateHelperTests.cs
@@ -11,13 +11,14 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Mapping.Content
 [TestFixture]
 public class DocumentVariantStateHelperTests
 {
-    [TestCase(false, false, DocumentVariantState.Draft)]
-    [TestCase(false, true, DocumentVariantState.Published)]
-    [TestCase(true, false, DocumentVariantState.Draft)]
-    [TestCase(true, true, DocumentVariantState.PublishedPendingChanges)]
-    public void Culture_Invariant_Content_State(bool edited, bool published, DocumentVariantState expectedResult)
+    [TestCase(false, false, false, DocumentVariantState.Draft)]
+    [TestCase(false, true, false, DocumentVariantState.Published)]
+    [TestCase(true, false, false, DocumentVariantState.Draft)]
+    [TestCase(true, true, false, DocumentVariantState.PublishedPendingChanges)]
+    [TestCase(true, false, true, DocumentVariantState.Trashed)]
+    public void Culture_Invariant_Content_State(bool edited, bool published, bool trashed, DocumentVariantState expectedResult)
     {
-        var content = Mock.Of<IContent>(c => c.Id == 1 && c.Published == published && c.Edited == edited);
+        var content = Mock.Of<IContent>(c => c.Id == 1 && c.Published == published && c.Edited == edited && c.Trashed == trashed);
         Assert.AreEqual(expectedResult, DocumentVariantStateHelper.GetState(content, culture: null));
     }
 
@@ -31,11 +32,12 @@ public class DocumentVariantStateHelperTests
         Assert.AreEqual(DocumentVariantState.NotCreated, DocumentVariantStateHelper.GetState(content, culture: null));
     }
 
-    [TestCase(false, false, DocumentVariantState.Draft)]
-    [TestCase(false, true, DocumentVariantState.Published)]
-    [TestCase(true, false, DocumentVariantState.Draft)]
-    [TestCase(true, true, DocumentVariantState.PublishedPendingChanges)]
-    public void Culture_Variant_Content_Existing_Culture_State(bool edited, bool published, DocumentVariantState expectedResult)
+    [TestCase(false, false, false, DocumentVariantState.Draft)]
+    [TestCase(false, true, false, DocumentVariantState.Published)]
+    [TestCase(true, false, false, DocumentVariantState.Draft)]
+    [TestCase(true, true, false, DocumentVariantState.PublishedPendingChanges)]
+    [TestCase(true, false, true, DocumentVariantState.Trashed)]
+    public void Culture_Variant_Content_Existing_Culture_State(bool edited, bool published, bool trashed, DocumentVariantState expectedResult)
     {
         const string culture = "en";
         var content = Mock.Of<IContent>(c =>
@@ -43,7 +45,8 @@ public class DocumentVariantStateHelperTests
             && c.AvailableCultures == new[] { culture }
             && c.EditedCultures == (edited ? new[] { culture } : Enumerable.Empty<string>())
             && c.Published == published
-            && c.PublishedCultures == (published ? new[] { culture } : Enumerable.Empty<string>()));
+            && c.PublishedCultures == (published ? new[] { culture } : Enumerable.Empty<string>())
+            && c.Trashed == trashed);
         Assert.AreEqual(expectedResult, DocumentVariantStateHelper.GetState(content, culture));
     }
 
@@ -63,13 +66,14 @@ public class DocumentVariantStateHelperTests
         Assert.AreEqual(DocumentVariantState.NotCreated, DocumentVariantStateHelper.GetState(content, "dk"));
     }
 
-    [TestCase(false, false, DocumentVariantState.Draft)]
-    [TestCase(false, true, DocumentVariantState.Published)]
-    [TestCase(true, false, DocumentVariantState.Draft)]
-    [TestCase(true, true, DocumentVariantState.PublishedPendingChanges)]
-    public void Culture_Invariant_DocumentEntitySlim_State(bool edited, bool published, DocumentVariantState expectedResult)
+    [TestCase(false, false, false, DocumentVariantState.Draft)]
+    [TestCase(false, true, false, DocumentVariantState.Published)]
+    [TestCase(true, false, false, DocumentVariantState.Draft)]
+    [TestCase(true, true, false, DocumentVariantState.PublishedPendingChanges)]
+    [TestCase(true, false, true, DocumentVariantState.Trashed)]
+    public void Culture_Invariant_DocumentEntitySlim_State(bool edited, bool published, bool trashed, DocumentVariantState expectedResult)
     {
-        var entity = Mock.Of<IDocumentEntitySlim>(c => c.Id == 1 && c.Published == published && c.Edited == edited && c.CultureNames == new Dictionary<string, string>());
+        var entity = Mock.Of<IDocumentEntitySlim>(c => c.Id == 1 && c.Published == published && c.Edited == edited && c.CultureNames == new Dictionary<string, string>() && c.Trashed == trashed);
         Assert.AreEqual(expectedResult, DocumentVariantStateHelper.GetState(entity, culture: null));
     }
 
@@ -83,11 +87,12 @@ public class DocumentVariantStateHelperTests
         Assert.AreEqual(DocumentVariantState.NotCreated, DocumentVariantStateHelper.GetState(entity, culture: null));
     }
 
-    [TestCase(false, false, DocumentVariantState.Draft)]
-    [TestCase(false, true, DocumentVariantState.Published)]
-    [TestCase(true, false, DocumentVariantState.Draft)]
-    [TestCase(true, true, DocumentVariantState.PublishedPendingChanges)]
-    public void Culture_Variant_DocumentEntitySlim_Existing_Culture_State(bool edited, bool published, DocumentVariantState expectedResult)
+    [TestCase(false, false, false, DocumentVariantState.Draft)]
+    [TestCase(false, true, false, DocumentVariantState.Published)]
+    [TestCase(true, false, false, DocumentVariantState.Draft)]
+    [TestCase(true, true, false, DocumentVariantState.PublishedPendingChanges)]
+    [TestCase(true, false, true, DocumentVariantState.Trashed)]
+    public void Culture_Variant_DocumentEntitySlim_Existing_Culture_State(bool edited, bool published, bool trashed, DocumentVariantState expectedResult)
     {
         const string culture = "en";
         var entity = Mock.Of<IDocumentEntitySlim>(c =>
@@ -95,7 +100,8 @@ public class DocumentVariantStateHelperTests
             && c.CultureNames == new Dictionary<string, string> { { culture, "value does not matter" } }
             && c.EditedCultures == (edited ? new[] { culture } : Enumerable.Empty<string>())
             && c.Published == published
-            && c.PublishedCultures == (published ? new[] { culture } : Enumerable.Empty<string>()));
+            && c.PublishedCultures == (published ? new[] { culture } : Enumerable.Empty<string>())
+            && c.Trashed == trashed);
         Assert.AreEqual(expectedResult, DocumentVariantStateHelper.GetState(entity, culture));
     }
 


### PR DESCRIPTION
### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I added the value of "Trashed" to the document variant state. Before, when requesting a document by its key via the Management API, it returned the state of "Published" while the document was in the recycle bin. Now it will return "Trashed" instead.

I updated the unit tests here as well to test the behaviour:
`DocumentVariantStateHelperTests`


<!-- Thanks for contributing to Umbraco CMS! -->
