### PR TITLE
Added direct dependency to secure version of Microsoft.Build.Tasks.Core in Umbraco.Web.UI

### DIFF
--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,6 +26,11 @@
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.0-rc.2.25502.107" />
+    <!--
+    Added the following direct dependency due to Microsoft.EntityFrameworkCore.Design having a dependency on an insecure version.
+    Review for removal when Microsoft.EntityFrameworkCore.Design is updated to a newer version.
+    -->
+    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="17.14.28" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We don't ship this project, so it's not important publicly, but there's a security warning now on the version of `Microsoft.Build.Tasks.Core` that is brought in by the latest `Microsoft.EntityFrameworkCore.Design`.  Taking a direct dependency resolves that, and it can likely be removed again once `Microsoft.EntityFrameworkCore.Design` is updated, which we'll need to do again before release.