### PR TITLE
Header: Adjusted button focus border color contrast

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-header.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-header.element.ts
@@ -20,6 +20,7 @@ export class UmbBackofficeHeaderElement extends UmbLitElement {
 			}
 
 			#appHeader {
+				--uui-focus-outline-color: var(--uui-color-header-contrast-emphasis);
 				background-color: var(--umb-header-background-color, var(--uui-color-header-surface));
 				display: flex;
 				align-items: center;


### PR DESCRIPTION
Made use of the uui-button outline overwrite to change the focus border color to be the contrast color of the header to have an easier way to see where your current tab focus is.