### PR TITLE
Fix: Stylesheet tree showing other filetypes than .css

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Services/FileSystem/FileSystemTreeServiceBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/FileSystem/FileSystemTreeServiceBase.cs
@@ -75,6 +75,7 @@ public abstract class FileSystemTreeServiceBase : IFileSystemTreeService
 
     public string[] GetFiles(string path) => FileSystem
         .GetFiles(path)
+        .Where(file => file.EndsWith(".css"))
         .OrderBy(file => file)
         .ToArray();
 


### PR DESCRIPTION
Closes #20518

### Description
Migrating from V13 to V17, created a .css.map file, that cannot be opened or edited from the backoffice.

The solution to this is to only show .css files in the backoffice tree, any other files will still exist on the filesystem. but wont be shown in the backoffice, since we only support editing of .css files.
