### PR TITLE
Property Editors: Add mandatory support to Number Range (Refactor).

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-number-range/input-number-range.element.ts
@@ -1,6 +1,6 @@
 import { css, customElement, html, ifDefined, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
-import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
 import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
@@ -36,6 +36,8 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 
 	@property({ type: Boolean })
 	required = false;
+	@property({ type: String })
+	requiredMessage = UMB_VALIDATION_EMPTY_LOCALIZATION_KEY;
 
 	@state()
 	private _maxValue?: number;
@@ -94,6 +96,12 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 		super();
 
 		this.addValidator(
+			'valueMissing',
+			() => this.requiredMessage,
+			() => this.required && (this._minValue == null || this._maxValue == null),
+		);
+
+		this.addValidator(
 			'patternMismatch',
 			() => {
 				return '#validation_rangeExceeds';
@@ -101,12 +109,6 @@ export class UmbInputNumberRangeElement extends UmbFormControlMixin(UmbLitElemen
 			() => {
 				return this._minValue !== undefined && this._maxValue !== undefined ? this._minValue > this._maxValue : false;
 			},
-		);
-
-		this.addValidator(
-			'valueMissing',
-			() => '#validation_fieldIsMandatory',
-			() => this.required && (this._minValue == null || this._maxValue == null),
 		);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/property-editor-ui-number-range.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/property-editor-ui-number-range.element.ts
@@ -1,6 +1,6 @@
 import type { UmbInputNumberRangeElement } from '@umbraco-cms/backoffice/components';
 import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
-import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbNumberRangeValueType } from '@umbraco-cms/backoffice/models';
@@ -28,6 +28,8 @@ export class UmbPropertyEditorUINumberRangeElement
 
 	@property({ type: Boolean })
 	mandatory = false;
+	@property({ type: String })
+	mandatoryMessage = UMB_VALIDATION_EMPTY_LOCALIZATION_KEY;
 
 	@property({ type: Object })
 	public override set value(value: UmbNumberRangeValueType | undefined) {
@@ -65,6 +67,7 @@ export class UmbPropertyEditorUINumberRangeElement
 				.minValue=${this._minValue}
 				.maxValue=${this._maxValue}
 				?required=${this.mandatory}
+				.requiredMessage=${this.mandatoryMessage}
 				.validationRange=${this._validationRange}
 				@change=${this.#onChange}>
 			</umb-input-number-range>


### PR DESCRIPTION
### Summary
Added support for the Mandatory setting in the Number Range property editor and removed the initial value assignment.

### Changes

- Removed default initialization of value.
- Implemented mandatory → forwards required to inner inputs.
- Added valueMissing check in <umb-input-number-range> to handle required fields.
