### PR TITLE
Media: Fixes SQL error to ensure database relation between user group media start folder and deleted media item is removed (closes #20555)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -270,7 +270,7 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             "DELETE FROM " + Constants.DatabaseSchema.Tables.UserGroup2GranularPermission + " WHERE uniqueId IN (SELECT uniqueId FROM umbracoNode WHERE id = @id)",
             "DELETE FROM " + Constants.DatabaseSchema.Tables.UserStartNode + " WHERE startNode = @id",
             "UPDATE " + Constants.DatabaseSchema.Tables.UserGroup +
-            " SET startContentId = NULL WHERE startContentId = @id",
+            " SET startMediaId = NULL WHERE startMediaId = @id",
             "DELETE FROM " + Constants.DatabaseSchema.Tables.Relation + " WHERE parentId = @id",
             "DELETE FROM " + Constants.DatabaseSchema.Tables.Relation + " WHERE childId = @id",
             "DELETE FROM " + Constants.DatabaseSchema.Tables.TagRelationship + " WHERE nodeId = @id",


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20555

### Description
When deleting media, additional SQL DELETE statements are executed to remove or reset database relations.  For the deletion of media, the wrong field was referenced for the user group's start media folder.  This PR corrects that.

### Testing
See linked issue.
