### PR TITLE
Notifications: Populate `IncludeDescendants` on `ContentPublishedNotification` when publishing branch

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2199,7 +2199,7 @@ public class ContentService : RepositoryService, IContentService
                     variesByCulture ? culturesPublished.IsCollectionEmpty() ? null : culturesPublished : ["*"],
                     null,
                     eventMessages));
-            scope.Notifications.Publish(new ContentPublishedNotification(publishedDocuments, eventMessages).WithState(notificationState));
+            scope.Notifications.Publish(new ContentPublishedNotification(publishedDocuments, eventMessages, true).WithState(notificationState));
 
             scope.Complete();
         }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Resolves: https://github.com/umbraco/Umbraco-CMS/issues/20575

### Description
This looks a fairly straightforward oversight and fix - we have `IncludeDescendants` on `ContentPublishedNotification` but aren't currently populating it when publishing a branch as the wrong constructor is being called.

### Testing
Can use the following notification handler and composer for testing.

```
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI.Custom;

internal class MyContentPublishedNotificationHandler : INotificationAsyncHandler<ContentPublishedNotification>
{
    private readonly ILogger<MyContentPublishedNotificationHandler> _logger;

    public MyContentPublishedNotificationHandler(ILogger<MyContentPublishedNotificationHandler> logger) => _logger = logger;

    public Task HandleAsync(ContentPublishedNotification notification, CancellationToken cancellationToken)
    {
        _logger.LogInformation($"PublishWithDescendants: {notification.IncludeDescendants}");
        return Task.CompletedTask;
    }
}
```

```
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI.Custom;

public class TestComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationAsyncHandler<ContentPublishedNotification, MyContentPublishedNotificationHandler>();
    }
}
```
