### PR TITLE
Rendering: Explicitly contextualize variation context for language fallback (closes #20350)

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -1932,4 +1932,95 @@ internal partial class BlockListElementLevelVariationTests
             Assert.AreEqual(expectedPickedContent.Key, actualPickedPublishedContent.Key);
         }
     }
+
+    [TestCase(ContentVariation.Culture, false)]
+    [TestCase(ContentVariation.Culture, true)]
+    [TestCase(ContentVariation.Nothing, false)]
+    [TestCase(ContentVariation.Nothing, true)]
+    public async Task Can_Perform_Language_Fallback(ContentVariation elementTypeVariation, bool performFallbackToDefaultLanguage)
+    {
+        var daDkLanguage = await LanguageService.GetAsync("da-DK");
+        Assert.IsNotNull(daDkLanguage);
+        daDkLanguage.FallbackIsoCode = "en-US";
+        var saveLanguageResult = await LanguageService.UpdateAsync(daDkLanguage, Constants.Security.SuperUserKey);
+        Assert.IsTrue(saveLanguageResult.Success);
+
+        daDkLanguage = await LanguageService.GetAsync("da-DK");
+        Assert.AreEqual("en-US", daDkLanguage?.FallbackIsoCode);
+
+        var elementType = CreateElementType(elementTypeVariation);
+        var blockListDataType = await CreateBlockListDataType(elementType);
+        var contentType = CreateContentType(ContentVariation.Culture, blockListDataType, ContentVariation.Culture);
+
+        var content = CreateContent(
+            contentType,
+            elementType,
+            new []
+            {
+                new BlockProperty(
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "English invariantText content value" },
+                        new() { Alias = "variantText", Value = "English variantText content value" }
+                    },
+                    new List<BlockPropertyValue>
+                    {
+                        new() { Alias = "invariantText", Value = "English invariantText settings value" },
+                        new() { Alias = "variantText", Value = "English variantText settings value" }
+                    },
+                    "en-US",
+                    null)
+            },
+            true);
+
+        AssertPropertyValuesWithFallback("en-US",
+            "English invariantText content value", "English variantText content value",
+            "English invariantText settings value", "English variantText settings value");
+
+        AssetEmptyPropertyValues("da-DK");
+
+        AssertPropertyValuesWithFallback("da-DK",
+            "English invariantText content value", "English variantText content value",
+            "English invariantText settings value", "English variantText settings value");
+
+        void AssertPropertyValuesWithFallback(string culture,
+            string expectedInvariantContentValue, string expectedVariantContentValue,
+            string expectedInvariantSettingsValue, string expectedVariantSettingsValue)
+        {
+            SetVariationContext(culture, null);
+            var publishedContent = GetPublishedContent(content.Key);
+
+            var fallback = performFallbackToDefaultLanguage ? Fallback.ToDefaultLanguage : Fallback.ToLanguage;
+
+            var publishedValueFallback = GetRequiredService<IPublishedValueFallback>();
+            var value = publishedContent.Value<BlockListModel>(publishedValueFallback, "blocks", fallback: fallback);
+            Assert.IsNotNull(value);
+            Assert.AreEqual(1, value.Count);
+
+            var blockListItem = value.First();
+            Assert.AreEqual(2, blockListItem.Content.Properties.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedInvariantContentValue, blockListItem.Content.Value<string>("invariantText"));
+                Assert.AreEqual(expectedVariantContentValue, blockListItem.Content.Value<string>("variantText"));
+            });
+
+            Assert.AreEqual(2, blockListItem.Settings.Properties.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedInvariantSettingsValue, blockListItem.Settings.Value<string>("invariantText"));
+                Assert.AreEqual(expectedVariantSettingsValue, blockListItem.Settings.Value<string>("variantText"));
+            });
+        }
+
+        void AssetEmptyPropertyValues(string culture)
+        {
+            SetVariationContext(culture, null);
+            var publishedContent = GetPublishedContent(content.Key);
+
+            var value = publishedContent.Value<BlockListModel>("blocks");
+            Assert.NotNull(value);
+            Assert.IsEmpty(value);
+        }
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #20350

### Description

This PR addresses a regression for rendering block editor properties using language fallback under certain circumstances.

The essence is: If element types are set to vary by culture, and the containing block editor property also varies by culture, language fallback does not work. See the linked issue for additional details.

The root cause of this regression is that we do not contextualize the current rendering when performing language fallback. This means that the property value converters will continue to resolve the current rendering context as being for the requested language, rather than the active fallback language.

Following an internal discussion, we have deemed this to be wrongful behavior. This PR therefore explicitly contextualizes the fallback language (culture) before attempting to get a value for the fallback language, and reverts the contextualization after the value has been retrieved.

### Testing this PR

1. Set up at least one extra language, and configure it with fallback to the default language.
2. Setup host header mappings that allow rendering both languages - e.g. "/en" for en-US and "/xx" for the second language.
3. Create an element type that is set to vary by culture.
4. Create a block list data type using this element type.
5. Create a document type _with a template_, and configure it as vary by culture. It should contain two properties, both of which should vary by culture:
    - A "title" property of type text string.
    - A "blocks" property of the block list data type created above. 
6. Create and publish a document of this document type in both languages, but _only_ with values filled out for the default language.

Using the template below, verify that fallback works for the second language.

Now fill out values in the second language, republish the document, and verify that no fallback is performed.

#### Template for testing

```cshtml
@using Umbraco.Cms.Core.Models.Blocks
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
    Layout = null;
}
<html>
<body>
<h1>@Model.Name</h1>
<fieldset>
    <legend>Title</legend>
    <ul>
        <li>Without fallback: <strong>@(Model.Value<string>("title"))</strong></li>
        <li>Without configured language fallback: <strong>@(Model.Value<string>("title", fallback: Fallback.ToLanguage))</strong></li>
        <li>Without default language fallback: <strong>@(Model.Value<string>("title", fallback: Fallback.ToDefaultLanguage))</strong></li>
    </ul>
</fieldset>
<fieldset>
    <legend>Blocks</legend>
    <ul>
        <li>Without fallback: <strong>@(Model.Value<BlockListModel>("blocks")?.Count ?? 0) blocks</strong></li>
        <li>Without configured language fallback: <strong>@(Model.Value<BlockListModel>("blocks", fallback: Fallback.ToLanguage)?.Count ?? 0) blocks</strong></li>
        <li>Without default language fallback: <strong>@(Model.Value<BlockListModel>("blocks", fallback: Fallback.ToDefaultLanguage)?.Count ?? 0) blocks</strong></li>
    </ul>
</fieldset>
</body>
</html>
```