### PR TITLE
Document Recycle Bin: Fix missing item name when restoring

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.token.ts
@@ -1,4 +1,5 @@
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
+import type { UmbItemDataResolverConstructor } from '@umbraco-cms/backoffice/entity-item';
 import type { UmbPickerModalData, UmbPickerModalValue } from '@umbraco-cms/backoffice/modal';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
@@ -7,6 +8,7 @@ export interface UmbRestoreFromRecycleBinModalData {
 	entityType: string;
 	recycleBinRepositoryAlias: string;
 	itemRepositoryAlias: string;
+	itemDataResolver?: UmbItemDataResolverConstructor;
 	pickerModal: UmbModalToken<UmbPickerModalData<any>, UmbPickerModalValue> | string;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/restore-from-recycle-bin.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/restore-from-recycle-bin.action.ts
@@ -24,6 +24,7 @@ export class UmbRestoreFromRecycleBinEntityAction extends UmbEntityActionBase<Me
 				entityType: this.args.entityType,
 				recycleBinRepositoryAlias: this.args.meta.recycleBinRepositoryAlias,
 				itemRepositoryAlias: this.args.meta.itemRepositoryAlias,
+				itemDataResolver: this.args.meta.itemDataResolver,
 				pickerModal: this.args.meta.pickerModal,
 			},
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/types.ts
@@ -1,4 +1,5 @@
 import type { ManifestEntityAction, MetaEntityActionDefaultKind } from '@umbraco-cms/backoffice/entity-action';
+import type { UmbItemDataResolverConstructor } from '@umbraco-cms/backoffice/entity-item';
 import type { UmbModalToken, UmbPickerModalData, UmbPickerModalValue } from '@umbraco-cms/backoffice/modal';
 
 export interface ManifestEntityActionRestoreFromRecycleBinKind
@@ -10,6 +11,7 @@ export interface ManifestEntityActionRestoreFromRecycleBinKind
 export interface MetaEntityActionRestoreFromRecycleBinKind extends MetaEntityActionDefaultKind {
 	recycleBinRepositoryAlias: string;
 	itemRepositoryAlias: string;
+	itemDataResolver?: UmbItemDataResolverConstructor;
 	pickerModal: UmbModalToken<UmbPickerModalData<any>, UmbPickerModalValue> | string;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/entity-action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/entity-action/manifests.ts
@@ -46,6 +46,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		forEntityTypes: [UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
 			itemRepositoryAlias: UMB_DOCUMENT_ITEM_REPOSITORY_ALIAS,
+			itemDataResolver: UmbDocumentItemDataResolver,
 			recycleBinRepositoryAlias: UMB_DOCUMENT_RECYCLE_BIN_REPOSITORY_ALIAS,
 			pickerModal: UMB_DOCUMENT_PICKER_MODAL,
 		},


### PR DESCRIPTION
Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20520

We no longer set a name in the Document Model because we need to retrieve the name from a specific variant. This caused the name to disappear in the generic "Restore from Recycle Bin"-modal.

This PR adds the option to pass an `ItemDataResolver`, which determines the correct variant name, to the generic modal.