### PR TITLE
Sync statuses order with selection changes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor-data-source/input/input-property-editor-data-source.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor-data-source/input/input-property-editor-data-source.element.ts
@@ -23,6 +23,16 @@ export class UmbInputPropertyEditorDataSourceElement extends UUIFormControlMixin
 		containerSelector: 'uui-ref-list',
 		onChange: ({ model }) => {
 			this.selection = model;
+
+			const statusesClone = this._statuses ? [...this._statuses] : [];
+
+			// reorder statuses to match the new order
+			statusesClone.sort((a, b) => {
+				return model.indexOf(a.unique) - model.indexOf(b.unique);
+			});
+
+			this._statuses = statusesClone;
+
 			this.dispatchEvent(new UmbChangeEvent());
 		},
 	});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -29,6 +29,16 @@ export class UmbInputDocumentElement extends UmbFormControlMixin<string | undefi
 		containerSelector: 'uui-ref-list',
 		onChange: ({ model }) => {
 			this.selection = model;
+
+			const statusesClone = this._statuses ? [...this._statuses] : [];
+
+			// reorder statuses to match the new order
+			statusesClone.sort((a, b) => {
+				return model.indexOf(a.unique) - model.indexOf(b.unique);
+			});
+
+			this._statuses = statusesClone;
+
 			this.dispatchEvent(new UmbChangeEvent());
 		},
 	});

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.ts
@@ -24,6 +24,16 @@ export class UmbInputEntityDataElement extends UmbFormControlMixin<string | unde
 		containerSelector: 'uui-ref-list',
 		onChange: ({ model }) => {
 			this.selection = model;
+
+			const statusesClone = this._statuses ? [...this._statuses] : [];
+
+			// reorder statuses to match the new order
+			statusesClone.sort((a, b) => {
+				return model.indexOf(a.unique) - model.indexOf(b.unique);
+			});
+
+			this._statuses = statusesClone;
+
 			this.dispatchEvent(new UmbChangeEvent());
 		},
 	});


### PR DESCRIPTION
Since we now iterate through the status array, the UI order is no longer synchronized with the order model. The PR ensures that the statuses array order is kept in sync with the sort model order.
