### PR TITLE
Migrations: Use reliable GUID to check for existence of data type when creating (closes #20592)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_3_0/MigrateMediaTypeLabelProperties.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_3_0/MigrateMediaTypeLabelProperties.cs
@@ -144,7 +144,7 @@ public class MigrateMediaTypeLabelProperties : AsyncMigrationBase
     private bool NodeExists(Guid uniqueId)
     {
         Sql<ISqlContext> sql = Database.SqlContext.Sql()
-            .Select<NodeDto>()
+            .Select<NodeDto>(x => x.NodeId)
             .From<NodeDto>()
             .Where<NodeDto>(x => x.UniqueId == uniqueId);
         return Database.FirstOrDefault<NodeDto>(sql) is not null;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses : https://github.com/umbraco/Umbraco-CMS/issues/20592

### Description
This PR updates the check on whether a data type already exists before creating in a migration to use the GUID rather than the integer ID.  In Cloud, with Deploy, there'll be the change of a restored environment creating the data types from the `.uda` files with a different ID than the one we expect when they are created on new installs or migrations - which then causes a bug as per the linked issue when the migration attempts to create them again.

I've resolved this by using the GUID which will be the same across all environments and installations.

### Testing
You can test the migration by rolling back a current database to an earlier state with the following SQL, such that on start up the migration will run again - this will confirm that the creation is skipped still if the data types already exist.

```
update umbracoKeyValue
set value = '{A917FCBC-C378-4A08-A36C-220C581A6581}'
where [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
```

