### PR TITLE
Detail Request Manager: Use tryExecute for delete API call to enable error notifications

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/detail/detail-data.request-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/detail/detail-data.request-manager.ts
@@ -125,7 +125,7 @@ export class UmbManagementApiDetailDataRequestManager<
 	}
 
 	async delete(id: string): Promise<UmbApiWithErrorResponse> {
-		const { error } = await this.#delete(id);
+		const { error } = await tryExecute(this, this.#delete(id));
 
 		// Only update the cache when we are connected to the server events
 		if (this.#isConnectedToServerEvents && !error) {


### PR DESCRIPTION
Replaced direct use of 'await' with 'tryExecute' to improve error handling in the 'delete' method of 'UmbManagementApiDetailDataRequestManager.'

How to test:
* Delete one of the protected Data Types, e.g., Label (datetime). It should now display an error notification when the server responds with an error.