### PR TITLE
Don't call generateAlias on #onAliasChange()

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
@@ -108,7 +108,7 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 
 	#onAliasChange() {
 		// TODO: Why can I not get the correct value via event? Is it an issue in uui library too?
-		const alias = generateAlias(this._aliasInput.value.toString());
+		const alias = this._aliasInput.value.toString();
 		this.updateValue({ alias });
 	}
 


### PR DESCRIPTION
Currently it's not possible to use characters like `_` and `-` in aliases due to this check - At least that is was @nul800sebastiaan told me 😇

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #20622

### Description
Removed the `generateAlias()` in the alias constant to ensure characters like `-` and `_` can again be used in document type/media type aliases.


---
_This item has been added to our backlog AB#61214_