### PR TITLE
Media types: Handle null configured file extensions when populating allowed media types (closes #20620)

### DIFF
--- a/src/Umbraco.Core/Services/ContentTypeEditing/MediaTypeEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/MediaTypeEditingService.cs
@@ -175,7 +175,7 @@ internal sealed class MediaTypeEditingService : ContentTypeEditingServiceBase<IM
                 continue;
             }
 
-            allowedFileExtensionsByMediaType[mediaType] = fileUploadConfiguration.FileExtensions ?? [];
+            allowedFileExtensionsByMediaType[mediaType] = fileUploadConfiguration.FileExtensions ?? []; // Although we never expect null here, legacy data type configuration did allow it.
         }
 
         return allowedFileExtensionsByMediaType;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20620

### Description
Seems with legacy data the configuration for `fileExtensions` under an upload field data type can be null, which we aren't expecting in backend code.  So this PR just defensively ensures we are working with an empty collection and never null.

### Testing
There's a method using uSync described in the linked issue, but I replicated the problem and verified the fix with the following:

- Modified the stored configuration for the Upload (Audio) data type with:

```
update umbracoDataType
set config = '{"fileExtensions": null}'
where nodeId = -101
```

- Restarted to clear caches
- Made a call to the following: `/umbraco/management/api/v1/item/media-type/allowed?fileExtension=mp3&skip=0&take=100`
    - Before this update the exception reported in the linked issue should be shown
    - After you should get back a collection of data types

- Reset my database with:

```
update umbracoDataType
set config = '{"fileExtensions":["mp3","weba","oga","opus"]}'
where nodeId = -101
```

### Release
On approval and merge this will go into 16.4.  Let me know if you are happy this goes into 17.0 which I would say is OK given we are in the beta period still.  Otherwise it'll be 17.0.
