### PR TITLE
Icon picker: Better title for icon colors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -1017,6 +1017,7 @@ export default {
 		text: 'Sort',
 		yellow: 'Gul',
 		white: 'Hvid',
+		grey: 'Grå',
 	},
 	shortcuts: {
 		addGroup: 'Tilføj fane',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -914,6 +914,7 @@ export default {
 		text: 'Schwarz',
 		yellow: 'Gelb',
 		white: 'Weiß',
+		grey: 'Grau',
 	},
 	shortcuts: {
 		addTab: 'Tab hinzufügen',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en-us.ts
@@ -35,6 +35,9 @@ export default {
 		showLabelDescription:
 			'Stores colors as a JSON object containing both the color hex string and label, rather than just the hex string.',
 	},
+	colors: {
+		grey: 'Gray',
+	},
 	create: {
 		folderDescription: 'Used to organize items and other folders. Keep items structured and easy to access.',
 	},

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1024,6 +1024,7 @@ export default {
 		text: 'Black',
 		yellow: 'Yellow',
 		white: 'White',
+		grey: 'Grey',
 	},
 	shortcuts: {
 		addGroup: 'Add group',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
@@ -850,7 +850,18 @@ export default {
 		avatar: 'Avatar per',
 	},
 	colors: {
+		black: 'Nero',
 		blue: 'Blu',
+		brown: 'Marrone',
+		cyan: 'Ciano',
+		green: 'Verde',
+		lightBlue: 'Azzurro',
+		pink: 'Rosa',
+		red: 'Rosso',
+		text: 'Nero',
+		yellow: 'Giallo',
+		white: 'Bianco',
+		grey: 'Grigio',
 	},
 	shortcuts: {
 		addGroup: 'Aggiungi gruppo',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icon-picker-modal/icon-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/icon-registry/icon-picker-modal/icon-picker-modal.element.ts
@@ -1,7 +1,6 @@
 import type { UmbIconDefinition } from '../types.js';
 import { UMB_ICON_REGISTRY_CONTEXT } from '../icon-registry.context-token.js';
 import type { UmbIconPickerModalData, UmbIconPickerModalValue } from './icon-picker-modal.token.js';
-import { toCamelCase } from '../to-camel-case/index.js';
 import {
 	css,
 	customElement,
@@ -17,6 +16,7 @@ import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UUIColorSwatchesEvent } from '@umbraco-cms/backoffice/external/uui';
+import { toCamelCase } from '@umbraco-cms/backoffice/utils';
 
 @customElement('umb-icon-picker-modal')
 export class UmbIconPickerModalElement extends UmbModalBaseElement<UmbIconPickerModalData, UmbIconPickerModalValue> {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
This improves the titles for icon colors - especially the title for `text` color, which isn't meaningful although the alias makes sense in code.

<img width="796" height="453" alt="image" src="https://github.com/user-attachments/assets/3d6f7b8d-29a2-4408-abde-d3e5bb8b311a" />
