### PR TITLE
Webhooks: Reverts nullability update to continue to allow derived classes to create null payloads

### DIFF
--- a/src/Umbraco.Core/Webhooks/WebhookEventBase.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventBase.cs
@@ -103,6 +103,6 @@ public abstract class WebhookEventBase<TNotification> : IWebhookEvent, INotifica
     /// </summary>
     /// <param name="notification"></param>
     /// <returns></returns>
-    public virtual object ConvertNotificationToRequestPayload(TNotification notification)
+    public virtual object? ConvertNotificationToRequestPayload(TNotification notification)
         => notification;
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses comment raised here: https://github.com/umbraco/Umbraco-CMS/pull/15927#issuecomment-3450135568 on https://github.com/umbraco/Umbraco-CMS/pull/15927

### Description
As noted in the linked comment, we don't need to prevent custom webhook implementations from providing null payloads if they want to.
