### PR TITLE
Routing: Added method to `IDocumentUrlService` for retrieving document key from URI (closes #20666)

### DIFF
--- a/src/Umbraco.Core/Routing/DomainUtilities.cs
+++ b/src/Umbraco.Core/Routing/DomainUtilities.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services.Navigation;

--- a/src/Umbraco.Core/Services/IDocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/IDocumentUrlService.cs
@@ -1,5 +1,4 @@
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Routing;
 
 namespace Umbraco.Cms.Core.Services;
 
@@ -63,6 +62,14 @@ public interface IDocumentUrlService
     /// </summary>
     /// <param name="documentKeys">The collection of document keys.</param>
     Task DeleteUrlsFromCacheAsync(IEnumerable<Guid> documentKeys);
+
+    /// <summary>
+    /// Gets a document key by <see cref="Uri" />.
+    /// </summary>
+    /// <param name="uri">The uniform resource identifier.</param>
+    /// <param name="isDraft">Whether to get the url of the draft or published document.</param>
+    /// <returns>The document key, or null if not found.</returns>
+    Guid? GetDocumentKeyByUri(Uri uri, bool isDraft) => throw new NotImplementedException(); // TODO (V19): Remove default implementation.
 
     /// <summary>
     /// Gets a document key by route.

--- a/tests/Umbraco.Tests.Common/Builders/TemplateBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/TemplateBuilder.cs
@@ -129,9 +129,9 @@ public class TemplateBuilder
         return template;
     }
 
-    public static Template CreateTextPageTemplate(string alias = "textPage") =>
+    public static Template CreateTextPageTemplate(string alias = "textPage", string name = "Text page") =>
         (Template)new TemplateBuilder()
             .WithAlias(alias)
-            .WithName("Text page")
+            .WithName(name)
             .Build();
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -1,11 +1,13 @@
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping;
@@ -22,6 +24,8 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
     protected IDocumentUrlService DocumentUrlService => GetRequiredService<IDocumentUrlService>();
 
     protected ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    protected IDomainService DomainService => GetRequiredService<IDomainService>();
 
     protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
@@ -148,6 +152,64 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
         Assert.IsNull(actual);
     }
 
+    [TestCase("/", ExpectedResult = TextpageKey)]
+    [TestCase("/text-page-1", ExpectedResult = SubPageKey)]
+    public string? GetDocumentKeyByUri_Without_Domains_Returns_Expected_DocumentKey(string path)
+    {
+        ContentService.PublishBranch(Textpage, PublishBranchFilter.IncludeUnpublished, ["*"]);
+
+        var uri = new Uri("http://example.com" + path);
+        return DocumentUrlService.GetDocumentKeyByUri(uri, false)?.ToString()?.ToUpper();
+    }
+
+    private const string VariantRootPageKey = "1D3283C7-64FD-4F4D-A741-442BDA487B71";
+    private const string VariantChildPageKey = "1D3283C7-64FD-4F4D-A741-442BDA487B72";
+
+    [TestCase("/", "/en", "http://example.com/en/", ExpectedResult = VariantRootPageKey)]
+    [TestCase("/child-page", "/en", "http://example.com/en/", ExpectedResult = VariantChildPageKey)]
+    [TestCase("/", "example.com", "http://example.com/", ExpectedResult = VariantRootPageKey)]
+    [TestCase("/child-page", "example.com", "http://example.com/", ExpectedResult = VariantChildPageKey)]
+    public async Task<string?> GetDocumentKeyByUri_With_Domains_Returns_Expected_DocumentKey(string path, string domain, string rootUrl)
+    {
+        var template = TemplateBuilder.CreateTextPageTemplate("variantPageTemplate", "Variant Page Template");
+        FileService.SaveTemplate(template);
+
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("variantPage")
+            .WithName("Variant Page")
+            .WithContentVariation(ContentVariation.Culture)
+            .WithAllowAsRoot(true)
+            .WithDefaultTemplateId(template.Id)
+            .Build();
+        ContentTypeService.Save(contentType);
+
+        var rootPage = new ContentBuilder()
+            .WithKey(Guid.Parse(VariantRootPageKey))
+            .WithContentType(contentType)
+            .WithCultureName("en-US", $"Root Page")
+            .Build();
+        var childPage = new ContentBuilder()
+            .WithKey(Guid.Parse(VariantChildPageKey))
+            .WithContentType(contentType)
+            .WithCultureName("en-US", $"Child Page")
+            .WithParent(rootPage)
+            .Build();
+        ContentService.Save(rootPage, -1);
+        ContentService.Save(childPage, -1);
+        ContentService.PublishBranch(rootPage, PublishBranchFilter.IncludeUnpublished, ["*"]);
+
+        var updateDomainResult = await DomainService.UpdateDomainsAsync(
+            rootPage.Key,
+            new DomainsUpdateModel
+            {
+                Domains = [new DomainModel { DomainName = domain, IsoCode = "en-US" }],
+            });
+        Assert.IsTrue(updateDomainResult.Success);
+
+        var uri = new Uri(rootUrl + path);
+        return DocumentUrlService.GetDocumentKeyByUri(uri, false)?.ToString()?.ToUpper();
+    }
+
     [TestCase("/", "en-US", true, ExpectedResult = TextpageKey)]
     [TestCase("/text-page-1", "en-US", true, ExpectedResult = SubPageKey)]
     [TestCase("/text-page-1-custom", "en-US", true, ExpectedResult = SubPageKey)] // Uses the segment registered by the custom IIUrlSegmentProvider that allows for more than one segment per document.
@@ -160,7 +222,7 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
     [TestCase("/text-page-2", "en-US", false, ExpectedResult = null)]
     [TestCase("/text-page-2-custom", "en-US", false, ExpectedResult = SubPage2Key)] // Uses the segment registered by the custom IIUrlSegmentProvider that does not allow for more than one segment per document.
     [TestCase("/text-page-3", "en-US", false, ExpectedResult = SubPage3Key)]
-    public string? GetDocumentKeyByRoute_Returns_Expected_Route(string route, string isoCode, bool loadDraft)
+    public string? GetDocumentKeyByRoute_Returns_Expected_DocumentKey(string route, string isoCode, bool loadDraft)
     {
         if (loadDraft is false)
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/20666

### Description
This PR looks to provide a solution to the concern raised in the linked issue that it's not so easy with the `IDocumentUrlService` to get a document's key from it's path when domains are involved.

See the discussion https://github.com/umbraco/Umbraco-CMS/issues/20666#issuecomment-3454907661 and https://github.com/umbraco/Umbraco-CMS/issues/20666#issuecomment-3455238044 for why that's currently the case and a suggestion to resolve, which is what I've done in this PR.

`IDocumentUrlService` now has a `GetDocumentKeyByUri` (to go with the existing `GetDocumentKeyByRoute`) that can be called providing a `Uri`.  The domain will be parsed as is done during routing to then be able to delegate to `GetDocumentKeyByRoute`.

### Testing

The following code for a document with or without domains associated should now successfully retrieve the document's key.

```
@using Microsoft.AspNetCore.Http.Extensions
@using Umbraco.Cms.Core.Services
@using Umbraco.Cms.Web.Common.PublishedModels;
@inject IDocumentUrlService DocumentUrlService
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
	Layout = null;
}

@{
    var currentRequest = Context.Request;
    var currentUri = new Uri(currentRequest.GetDisplayUrl());
}
<p>Current path: @currentRequest.Path</p>
<p>Found page guid: @DocumentUrlService.GetDocumentKeyByRoute(currentRequest.Path, null, null, false)</p>
<p>Current URL: @currentUri</p>
<p>Found page guid: @DocumentUrlService.GetDocumentKeyByUri(currentUri, false)</p>
```

Integration tests have also been added to verify the functionality.