### PR TITLE
Document Recycle Bin: Remove non-relevant entity bulk actions (closes #20677)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+import { UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -15,6 +16,9 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: UMB_COLLECTION_ALIAS_CONDITION,
 				match: 'Umb.Collection.Document',
+			},
+			{
+				alias: UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-bulk-actions/duplicate-to/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-bulk-actions/duplicate-to/manifests.ts
@@ -4,6 +4,7 @@ import { UMB_DOCUMENT_TREE_ALIAS } from '../../tree/manifests.js';
 import { UMB_USER_PERMISSION_DOCUMENT_DUPLICATE } from '../../user-permissions/document/constants.js';
 import { UMB_BULK_DUPLICATE_DOCUMENT_REPOSITORY_ALIAS } from './repository/constants.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
+import { UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
 
 export const manifests: Array<UmbExtensionManifest> = [
@@ -26,6 +27,9 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: 'Umb.Condition.UserPermission.Document',
 				allOf: [UMB_USER_PERMISSION_DOCUMENT_DUPLICATE],
+			},
+			{
+				alias: UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-bulk-actions/move-to/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-bulk-actions/move-to/manifests.ts
@@ -1,3 +1,4 @@
+import { UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
 import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../../collection/constants.js';
 import { UMB_DOCUMENT_ENTITY_TYPE } from '../../entity.js';
 import { UMB_DOCUMENT_TREE_ALIAS } from '../../tree/manifests.js';
@@ -26,6 +27,9 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: 'Umb.Condition.UserPermission.Document',
 				allOf: [UMB_USER_PERMISSION_DOCUMENT_MOVE],
+			},
+			{
+				alias: UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/entity-bulk-action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/publish/entity-bulk-action/manifests.ts
@@ -2,6 +2,7 @@ import { UMB_DOCUMENT_ENTITY_TYPE } from '../../../entity.js';
 import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../../../collection/constants.js';
 import { UMB_USER_PERMISSION_DOCUMENT_PUBLISH } from '../../../user-permissions/document/constants.js';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+import { UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -24,6 +25,9 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: 'Umb.Condition.UserPermission.Document',
 				allOf: [UMB_USER_PERMISSION_DOCUMENT_PUBLISH],
+			},
+			{
+				alias: UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/entity-bulk-action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/unpublish/entity-bulk-action/manifests.ts
@@ -2,6 +2,7 @@ import { UMB_DOCUMENT_ENTITY_TYPE } from '../../../entity.js';
 import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../../../collection/constants.js';
 import { UMB_USER_PERMISSION_DOCUMENT_UNPUBLISH } from '../../../user-permissions/document/constants.js';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+import { UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -24,6 +25,9 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: 'Umb.Condition.UserPermission.Document',
 				allOf: [UMB_USER_PERMISSION_DOCUMENT_UNPUBLISH],
+			},
+			{
+				alias: UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/entity-action/bulk-trash/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/entity-action/bulk-trash/manifests.ts
@@ -6,6 +6,7 @@ import { UMB_DOCUMENT_REFERENCE_REPOSITORY_ALIAS } from '../../../reference/cons
 import { UMB_DOCUMENT_COLLECTION_ALIAS } from '../../../collection/constants.js';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
 import { UMB_ENTITY_BULK_ACTION_TRASH_WITH_RELATION_KIND } from '@umbraco-cms/backoffice/relations';
+import { UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -28,6 +29,9 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: 'Umb.Condition.UserPermission.Document',
 				allOf: [UMB_USER_PERMISSION_DOCUMENT_DELETE],
+			},
+			{
+				alias: UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
 			},
 		],
 	},


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/20677

Introduces the UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS to various document-related bulk action manifests, ensuring actions like duplicate, move, publish, unpublish, and trash are only available for entities that are not already in the recycle bin.



