### PR TITLE
UX: Adjust box-sizing to ensure tree and workspace top borders are aligned

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/app-language-select/app-language-select.element.ts
@@ -234,6 +234,7 @@ export class UmbAppLanguageSelectElement extends UmbLitElement {
 				justify-content: space-between;
 				cursor: pointer;
 				font-family: inherit;
+				box-sizing: border-box;
 			}
 
 			#toggle:hover {


### PR DESCRIPTION
Fixes height difference between language-toggle and body-layout-header - both have the same height, but language-toggle's border-bottom was adding a pixel due to not using border-box sizing.

To test - visually verify that the two elements have the same height in v17 backoffice:

Before:
<img width="656" height="95" alt="image" src="https://github.com/user-attachments/assets/c8532a4d-7eb3-4e38-b5cc-bff137a6518d" />

After:
<img width="631" height="89" alt="image" src="https://github.com/user-attachments/assets/203cba31-0c2f-4fbc-be03-f6578498c50e" />

