### PR TITLE
Preview: Add `allow-forms` to iframe sandbox attributes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/preview/preview.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/preview/preview.element.ts
@@ -65,7 +65,7 @@ export class UmbPreviewElement extends UmbLitElement {
 						src=${this._previewUrl}
 						title="Page preview"
 						@load=${this.#onIFrameLoad}
-						sandbox="allow-scripts allow-same-origin"></iframe>
+						sandbox="allow-scripts allow-same-origin allow-forms"></iframe>
 				</div>
 			</div>
 			<div id="menu">


### PR DESCRIPTION
### Description 

When viewing a page in Preview mode and attempting to submit a form (either a standard form `POST` or Umbraco Forms), an error occurs in the browser console and the form is not submitted:

`Blocked form submission to '/form-submission-endpoint' because the form's frame is sandboxed and the 'allow-forms' permission is not set.`

<img width="1909" height="742" alt="image" src="https://github.com/user-attachments/assets/db2f21f2-5482-43a4-b6ca-5c8a31a799e7" />  

Umbraco Forms allows content editors to "Save and preview" forms from the backoffice, and we are aware of users that do test their forms this way.

This PR resolves that issue by adding the `allow-forms` value to the preview iframe's `sandbox` attribute.

### Testing
This can be replicated on a blank install of CMS with the Starter Kit (both in 16.3.4 and 17.0.0-rc1)

```
dotnet new install Umbraco.Templates@16.3.4
dotnet new umbraco --name TestProject
cd .\TestProject\
dotnet add package Umbraco.TheStarterKit --version 16.0.0
dotnet run
```

Once Umbraco is installed and running:
- navigate to the Contact page in the backoffice
- press the "Save and preview" button
- On the loaded Contact page preview, open the dev tools
- Fill out the form and attempt to submit it

Observe that the error listed above shows in the dev tools console.