### PR TITLE
Webhooks: Register OutputExpansionStrategy for webhooks if Delivery API is not enabled (closes #20272 for 13)

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Rendering/RequestContextOutputExpansionStrategyV2.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Rendering/RequestContextOutputExpansionStrategyV2.cs
@@ -1,61 +1,23 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.DeliveryApi;
-using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Extensions;
+using Umbraco.Cms.Web.Common.Rendering;
 
 namespace Umbraco.Cms.Api.Delivery.Rendering;
 
-internal sealed class RequestContextOutputExpansionStrategyV2 : IOutputExpansionStrategy
+internal sealed class RequestContextOutputExpansionStrategyV2 : ElementOnlyOutputExpansionStrategy, IOutputExpansionStrategy
 {
-    private const string All = "$all";
-    private const string None = "";
-    private const string ExpandParameterName = "expand";
-    private const string FieldsParameterName = "fields";
-
-    private readonly IApiPropertyRenderer _propertyRenderer;
     private readonly ILogger<RequestContextOutputExpansionStrategyV2> _logger;
-
-    private readonly Stack<Node?> _expandProperties;
-    private readonly Stack<Node?> _includeProperties;
 
     public RequestContextOutputExpansionStrategyV2(
         IHttpContextAccessor httpContextAccessor,
         IApiPropertyRenderer propertyRenderer,
         ILogger<RequestContextOutputExpansionStrategyV2> logger)
+        : base(propertyRenderer)
     {
-        _propertyRenderer = propertyRenderer;
         _logger = logger;
-        _expandProperties = new Stack<Node?>();
-        _includeProperties = new Stack<Node?>();
-
         InitializeExpandAndInclude(httpContextAccessor);
     }
-
-    public IDictionary<string, object?> MapContentProperties(IPublishedContent content)
-        => content.ItemType == PublishedItemType.Content
-            ? MapProperties(content.Properties)
-            : throw new ArgumentException($"Invalid item type. This method can only be used with item type {nameof(PublishedItemType.Content)}, got: {content.ItemType}");
-
-    public IDictionary<string, object?> MapMediaProperties(IPublishedContent media, bool skipUmbracoProperties = true)
-    {
-        if (media.ItemType != PublishedItemType.Media)
-        {
-            throw new ArgumentException($"Invalid item type. This method can only be used with item type {PublishedItemType.Media}, got: {media.ItemType}");
-        }
-
-        IPublishedProperty[] properties = media
-            .Properties
-            .Where(p => skipUmbracoProperties is false || p.Alias.StartsWith("umbraco") is false)
-            .ToArray();
-
-        return properties.Any()
-            ? MapProperties(properties)
-            : new Dictionary<string, object?>();
-    }
-
-    public IDictionary<string, object?> MapElementProperties(IPublishedElement element)
-        => MapProperties(element.Properties, true);
 
     private void InitializeExpandAndInclude(IHttpContextAccessor httpContextAccessor)
     {
@@ -66,7 +28,7 @@ internal sealed class RequestContextOutputExpansionStrategyV2 : IOutputExpansion
 
         try
         {
-            _expandProperties.Push(Node.Parse(toExpand));
+            ExpandProperties.Push(Node.Parse(toExpand));
         }
         catch (ArgumentException ex)
         {
@@ -76,110 +38,12 @@ internal sealed class RequestContextOutputExpansionStrategyV2 : IOutputExpansion
 
         try
         {
-            _includeProperties.Push(Node.Parse(toInclude));
+            IncludeProperties.Push(Node.Parse(toInclude));
         }
         catch (ArgumentException ex)
         {
             _logger.LogError(ex, $"Could not parse the '{FieldsParameterName}' parameter. See exception for details.");
             throw new ArgumentException($"Could not parse the '{FieldsParameterName}' parameter: {ex.Message}");
-        }
-    }
-
-    private IDictionary<string, object?> MapProperties(IEnumerable<IPublishedProperty> properties, bool forceExpandProperties = false)
-    {
-        Node? currentExpandProperties = _expandProperties.Peek();
-        if (_expandProperties.Count > 1 && currentExpandProperties is null && forceExpandProperties is false)
-        {
-            return new Dictionary<string, object?>();
-        }
-
-        Node? currentIncludeProperties = _includeProperties.Peek();
-        var result = new Dictionary<string, object?>();
-        foreach (IPublishedProperty property in properties)
-        {
-            Node? nextIncludeProperties = GetNextProperties(currentIncludeProperties, property.Alias);
-            if (currentIncludeProperties is not null && currentIncludeProperties.Items.Any() && nextIncludeProperties is null)
-            {
-                continue;
-            }
-
-            Node? nextExpandProperties = GetNextProperties(currentExpandProperties, property.Alias);
-
-            _includeProperties.Push(nextIncludeProperties);
-            _expandProperties.Push(nextExpandProperties);
-
-            result[property.Alias] = GetPropertyValue(property);
-
-            _expandProperties.Pop();
-            _includeProperties.Pop();
-        }
-
-        return result;
-    }
-
-    private Node? GetNextProperties(Node? currentProperties, string propertyAlias)
-        => currentProperties?.Items.FirstOrDefault(i => i.Key == All)
-           ?? currentProperties?.Items.FirstOrDefault(i => i.Key == "properties")?.Items.FirstOrDefault(i => i.Key == All || i.Key == propertyAlias);
-
-    private object? GetPropertyValue(IPublishedProperty property)
-        => _propertyRenderer.GetPropertyValue(property, _expandProperties.Peek() is not null);
-
-    private class Node
-    {
-        public string Key { get; private set; } = string.Empty;
-
-        public List<Node> Items { get; } = new();
-
-        public static Node Parse(string value)
-        {
-            // verify that there are as many start brackets as there are end brackets
-            if (value.CountOccurrences("[") != value.CountOccurrences("]"))
-            {
-                throw new ArgumentException("Value did not contain an equal number of start and end brackets");
-            }
-
-            // verify that the value does not start with a start bracket
-            if (value.StartsWith("["))
-            {
-                throw new ArgumentException("Value cannot start with a bracket");
-            }
-
-            // verify that there are no empty brackets
-            if (value.Contains("[]"))
-            {
-                throw new ArgumentException("Value cannot contain empty brackets");
-            }
-
-            var stack = new Stack<Node>();
-            var root = new Node { Key = "root" };
-            stack.Push(root);
-
-            var currentNode = new Node();
-            root.Items.Add(currentNode);
-
-            foreach (char c in value)
-            {
-                switch (c)
-                {
-                    case '[': // Start a new node, child of the current node
-                        stack.Push(currentNode);
-                        currentNode = new Node();
-                        stack.Peek().Items.Add(currentNode);
-                        break;
-                    case ',': // Start a new node, but at the same level of the current node
-                        currentNode = new Node();
-                        stack.Peek().Items.Add(currentNode);
-                        break;
-                    case ']': // Back to parent of the current node
-                        currentNode = stack.Pop();
-                        break;
-                    default: // Add char to current node key
-                        currentNode.Key += c;
-                        break;
-                }
-            }
-
-            return root;
         }
     }
 }

--- a/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.BackOffice/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
@@ -21,6 +22,8 @@ using Umbraco.Cms.Web.BackOffice.Security;
 using Umbraco.Cms.Web.BackOffice.Services;
 using Umbraco.Cms.Web.BackOffice.SignalR;
 using Umbraco.Cms.Web.BackOffice.Trees;
+using Umbraco.Cms.Web.Common.Accessors;
+using Umbraco.Cms.Web.Common.Rendering;
 
 namespace Umbraco.Extensions;
 
@@ -121,6 +124,9 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddSingleton<UnhandledExceptionLoggerMiddleware>();
         builder.Services.AddTransient<BlockGridSampleHelper>();
         builder.Services.AddUnique<IWebhookPresentationFactory, WebhookPresentationFactory>();
+        // deliveryApi will overwrite these more basic ones.
+        builder.Services.AddScoped<IOutputExpansionStrategy, ElementOnlyOutputExpansionStrategy>();
+        builder.Services.AddSingleton<IOutputExpansionStrategyAccessor, RequestContextOutputExpansionStrategyAccessor>();
 
         return builder;
     }

--- a/src/Umbraco.Web.Common/Accessors/RequestContextOutputExpansionStrategyAccessor.cs
+++ b/src/Umbraco.Web.Common/Accessors/RequestContextOutputExpansionStrategyAccessor.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Http;
+using Umbraco.Cms.Core.DeliveryApi;
+
+namespace Umbraco.Cms.Web.Common.Accessors;
+
+public sealed class RequestContextOutputExpansionStrategyAccessor : RequestContextServiceAccessorBase<IOutputExpansionStrategy>, IOutputExpansionStrategyAccessor
+{
+    public RequestContextOutputExpansionStrategyAccessor(IHttpContextAccessor httpContextAccessor)
+        : base(httpContextAccessor)
+    {
+    }
+}

--- a/src/Umbraco.Web.Common/Accessors/RequestContextServiceAccessorBase.cs
+++ b/src/Umbraco.Web.Common/Accessors/RequestContextServiceAccessorBase.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Umbraco.Cms.Web.Common.Accessors;
+
+public abstract class RequestContextServiceAccessorBase<T>
+    where T : class
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    protected RequestContextServiceAccessorBase(IHttpContextAccessor httpContextAccessor)
+        => _httpContextAccessor = httpContextAccessor;
+
+    public bool TryGetValue([NotNullWhen(true)] out T? requestStartNodeService)
+    {
+        requestStartNodeService = _httpContextAccessor.HttpContext?.RequestServices.GetService<T>();
+        return requestStartNodeService is not null;
+    }
+}

--- a/src/Umbraco.Web.Common/Rendering/ElementOnlyOutputExpansionStrategy.cs
+++ b/src/Umbraco.Web.Common/Rendering/ElementOnlyOutputExpansionStrategy.cs
@@ -1,0 +1,148 @@
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Web.Common.Rendering;
+
+public class ElementOnlyOutputExpansionStrategy : IOutputExpansionStrategy
+{
+    protected const string All = "$all";
+    protected const string None = "";
+    protected const string ExpandParameterName = "expand";
+    protected const string FieldsParameterName = "fields";
+
+    private readonly IApiPropertyRenderer _propertyRenderer;
+
+    protected Stack<Node?> ExpandProperties { get; } = new();
+
+    protected Stack<Node?> IncludeProperties { get; } = new();
+
+    public ElementOnlyOutputExpansionStrategy(
+        IApiPropertyRenderer propertyRenderer)
+    {
+        _propertyRenderer = propertyRenderer;
+    }
+
+    public virtual IDictionary<string, object?> MapContentProperties(IPublishedContent content)
+        => content.ItemType == PublishedItemType.Content
+            ? MapProperties(content.Properties)
+            : throw new ArgumentException($"Invalid item type. This method can only be used with item type {nameof(PublishedItemType.Content)}, got: {content.ItemType}");
+
+    public virtual IDictionary<string, object?> MapMediaProperties(IPublishedContent media, bool skipUmbracoProperties = true)
+    {
+        if (media.ItemType != PublishedItemType.Media)
+        {
+            throw new ArgumentException($"Invalid item type. This method can only be used with item type {PublishedItemType.Media}, got: {media.ItemType}");
+        }
+
+        IPublishedProperty[] properties = media
+            .Properties
+            .Where(p => skipUmbracoProperties is false || p.Alias.StartsWith("umbraco") is false)
+            .ToArray();
+
+        return properties.Any()
+            ? MapProperties(properties)
+            : new Dictionary<string, object?>();
+    }
+
+    public virtual IDictionary<string, object?> MapElementProperties(IPublishedElement element)
+        => MapProperties(element.Properties, true);
+
+    private IDictionary<string, object?> MapProperties(IEnumerable<IPublishedProperty> properties, bool forceExpandProperties = false)
+    {
+        Node? currentExpandProperties = ExpandProperties.Count > 0 ? ExpandProperties.Peek() : null;
+        if (ExpandProperties.Count > 1 && currentExpandProperties is null && forceExpandProperties is false)
+        {
+            return new Dictionary<string, object?>();
+        }
+
+        Node? currentIncludeProperties = IncludeProperties.Count > 0 ? IncludeProperties.Peek() : null;
+        var result = new Dictionary<string, object?>();
+        foreach (IPublishedProperty property in properties)
+        {
+            Node? nextIncludeProperties = GetNextProperties(currentIncludeProperties, property.Alias);
+            if (currentIncludeProperties is not null && currentIncludeProperties.Items.Any() && nextIncludeProperties is null)
+            {
+                continue;
+            }
+
+            Node? nextExpandProperties = GetNextProperties(currentExpandProperties, property.Alias);
+
+            IncludeProperties.Push(nextIncludeProperties);
+            ExpandProperties.Push(nextExpandProperties);
+
+            result[property.Alias] = GetPropertyValue(property);
+
+            ExpandProperties.Pop();
+            IncludeProperties.Pop();
+        }
+
+        return result;
+    }
+
+    private Node? GetNextProperties(Node? currentProperties, string propertyAlias)
+        => currentProperties?.Items.FirstOrDefault(i => i.Key == All)
+           ?? currentProperties?.Items.FirstOrDefault(i => i.Key == "properties")?.Items.FirstOrDefault(i => i.Key == All || i.Key == propertyAlias);
+
+    private object? GetPropertyValue(IPublishedProperty property)
+        => _propertyRenderer.GetPropertyValue(property, ExpandProperties.Peek() is not null);
+
+    protected sealed class Node
+    {
+        public string Key { get; private set; } = string.Empty;
+
+        public List<Node> Items { get; } = new();
+
+        public static Node Parse(string value)
+        {
+            // verify that there are as many start brackets as there are end brackets
+            if (value.CountOccurrences("[") != value.CountOccurrences("]"))
+            {
+                throw new ArgumentException("Value did not contain an equal number of start and end brackets");
+            }
+
+            // verify that the value does not start with a start bracket
+            if (value.StartsWith("["))
+            {
+                throw new ArgumentException("Value cannot start with a bracket");
+            }
+
+            // verify that there are no empty brackets
+            if (value.Contains("[]"))
+            {
+                throw new ArgumentException("Value cannot contain empty brackets");
+            }
+
+            var stack = new Stack<Node>();
+            var root = new Node { Key = "root" };
+            stack.Push(root);
+
+            var currentNode = new Node();
+            root.Items.Add(currentNode);
+
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    case '[': // Start a new node, child of the current node
+                        stack.Push(currentNode);
+                        currentNode = new Node();
+                        stack.Peek().Items.Add(currentNode);
+                        break;
+                    case ',': // Start a new node, but at the same level of the current node
+                        currentNode = new Node();
+                        stack.Peek().Items.Add(currentNode);
+                        break;
+                    case ']': // Back to parent of the current node
+                        currentNode = stack.Pop();
+                        break;
+                    default: // Add char to current node key
+                        currentNode.Key += c;
+                        break;
+                }
+            }
+
+            return root;
+        }
+    }
+}


### PR DESCRIPTION
V13 implementation off #20559
### Prerequisites

Fixes #20272 for v13

### Description
See details of #20559
Since there is no api.common yet in v13 and both backoffice and api delivery already have a dependency on web.common, I decided to put the common pieces there.