### PR TITLE
Auth: Cleans up stale or completed auth details from storage

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/external/openid/src/redirect_based_handler.ts
+++ b/src/Umbraco.Web.UI.Client/src/external/openid/src/redirect_based_handler.ts
@@ -82,7 +82,7 @@ export class RedirectRequestHandler extends AuthorizationRequestHandler {
 	 * This scans localStorage for any keys matching the appauth patterns and removes them,
 	 * including the authorization request handle key.
 	 */
-	protected cleanupStaleAuthorizationData(): Promise<void> {
+	public cleanupStaleAuthorizationData(): Promise<void> {
 		// Check if we're in a browser environment with localStorage
 		if (typeof window === 'undefined' || !window.localStorage) {
 			return Promise.resolve();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth-flow.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth-flow.ts
@@ -247,6 +247,10 @@ export class UmbAuthFlow {
 
 		// clear the internal state
 		this.#tokenResponse.setValue(undefined);
+
+		// Also cleanup any OAuth/PKCE artifacts that may still be in localStorage
+		// This is a defense-in-depth measure during logout
+		await this.#authorizationHandler.cleanupStaleAuthorizationData();
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces improvements to the handling and cleanup of stale OAuth/PKCE authorization data in localStorage, enhancing both security and reliability of the authentication flow. The main changes include a new method to comprehensively clean up authorization artifacts, its integration into both the authorization response and logout processes, and improved handling of mismatched requests.

**Authorization Data Cleanup Enhancements:**

* Added a new method `cleanupStaleAuthorizationData` to `RedirectRequestHandler` that scans localStorage for all appauth-related keys and removes them, ensuring no stale authorization requests or configurations persist.
* Updated the authorization response completion logic to call `cleanupStaleAuthorizationData` instead of removing only the current request's keys, ensuring all stale entries are cleared after a successful authorization.
* Modified the mismatched request handling to invoke `cleanupStaleAuthorizationData`, preventing leftover PKCE data even when requests fail to match.

**Logout Process Improvements:**

* Enhanced the `UmbAuthFlow` logout method to call `cleanupStaleAuthorizationData` after clearing the token response, providing defense-in-depth against lingering OAuth/PKCE artifacts in localStorage.

## How to test
1. Check your DevTools - you probably have some stale states lying around in Local Storage, if not, run the script down below in the console to generate test markers
2. Log out and back in again
3. Verify that all states are gone (including the just-generated one)

**Script to generate test data**

_(Paste into console)_

```js
localStorage.setItem('TEST123ABC_appauth_authorization_request', JSON.stringify({
  response_type: 'code',
  client_id: 'umbraco-back-office',
  redirect_uri: 'http://localhost:5173',
  scope: 'offline_access',
  state: 'fake_state_12345',
  extras: {
    code_challenge: 'fake_challenge_value_for_testing',
    code_challenge_method: 'S256'
  },
  internal: {
    code_verifier: 'fake_verifier_value_for_testing'
  }
}));

localStorage.setItem('TEST123ABC_appauth_authorization_service_configuration', JSON.stringify({
  authorization_endpoint: 'http://localhost:5173/umbraco/management/api/v1/security/back-office/authorize',
  token_endpoint: 'http://localhost:5173/umbraco/management/api/v1/security/back-office/token'
}));

console.log('Added stale test entries. Check localStorage to verify.');js
```