### PR TITLE
Dependencies: Update dotnet sdk and node development dependency to latest secure version of current major (13)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.415",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src"
   },
   "engines": {
-    "node": ">=20.9",
+    "node": ">=20.19.4",
     "npm": ">=10.1"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

Following recent vulnerability reports in .NET SDKs and nodejs, this updates our **development dependencies** to the latest patch versions of the current major for Umbraco 13.

Note that this doesn't affect anyone running Umbraco.  They will need to ensure their hosting environments are updated, and this change won't force it.  But it ensures anyone contributing to Umbraco and building from source either locally or via a build agent will need to have a secure version of these dependencies available.

### Testing

Make sure you are running the necessary versions of dotnet (8.0.415) and node (>=20.19.4) and ensure you can still build the back-end and front-end of Umbraco.