### PR TITLE
Dependencies: Update node development dependency to latest secure version of current major (17) 

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -64,8 +64,8 @@
 				"web-component-analyzer": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=22",
-				"npm": ">=10.9"
+				"node": ">=22.17.1",
+				"npm": ">=10.9.2"
 			}
 		},
 		"node_modules/@adobe/css-tools": {

--- a/src/Umbraco.Web.UI.Client/package.json
+++ b/src/Umbraco.Web.UI.Client/package.json
@@ -214,8 +214,8 @@
 		"generate:ui-api-docs": "npm run generate:check-const-test && typedoc --options typedoc.config.js"
 	},
 	"engines": {
-		"node": ">=22",
-		"npm": ">=10.9"
+		"node": ">=22.17.1",
+		"npm": ">=10.9.2"
 	},
 	"dependencies": {
 		"element-internals-polyfill": "^3.0.2"


### PR DESCRIPTION
### Description

Following recent vulnerability reports in nodejs, this updates our **development dependencies** to the latest patch versions of the current major for Umbraco 17.

Note that this doesn't affect anyone running Umbraco.  They will need to ensure their hosting environments are updated, and this change won't force it.  But it ensures anyone contributing to Umbraco and building from source either locally or via a build agent will need to have a secure version of these dependencies available.

### Testing

Make sure you are running the necessary versions of dotnet (10.0-rc2) and node (>=22.17.1) and ensure you can still build the back-end and front-end of Umbraco.