### PR TITLE
User Workspace: localize password mismatch feedback

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/views/member/member-workspace-view-member.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/views/member/member-workspace-view-member.element.ts
@@ -65,7 +65,7 @@ export class UmbMemberWorkspaceViewMemberElement extends UmbLitElement implement
 		)?.value;
 
 		if (newPassword !== confirmPassword) {
-			this._newPasswordError = 'Passwords do not match';
+			this._newPasswordError = this.localize.term('user_passwordMismatch');
 			return;
 		}
 


### PR DESCRIPTION
Update to use a localized message when user passwords mismatch
<img width="565" height="431" alt="image" src="https://github.com/user-attachments/assets/6d6f70c1-9ed2-4937-b19e-9371c8aa4697" />
