### PR TITLE
Property type: Vary in the same way as the owner Document Type

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-properties.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-properties.element.ts
@@ -231,7 +231,7 @@ export class UmbContentTypeDesignEditorPropertiesElement extends UmbLitElement {
 						this.#initResolver = undefined;
 						this.#initReject = undefined;
 					})
-					.catch((error) => {});
+					.catch(() => {});
 			}
 		});
 		this.observe(this.#propertyStructureHelper.propertyStructure, (propertyStructure) => {


### PR DESCRIPTION
Sets the Property Type to vary as its owner Document Type.

This aligns with v.13 UX, and is slightly UX breaking. Hence the targeting for v.17