### PR TITLE
Continue work of this PR

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -523,8 +523,10 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 	 * @memberof UmbContentDetailWorkspaceContextBase
 	 */
 	public name(variantId?: UmbVariantId): Observable<string> {
+		// Fallback to invariant variant:
+		variantId ??= UmbVariantId.CreateInvariant();
 		return this._data.createObservablePartOfCurrent(
-			(data) => data?.variants?.find((x) => variantId?.compare(x))?.name ?? '',
+			(data) => data?.variants?.find((x) => variantId.compare(x))?.name ?? '',
 		);
 	}
 


### PR DESCRIPTION
<p><span style="">The Fix I(Niels) did here is not the right solution <a href="https://github.com/umbraco/Umbraco-CMS/issues/20759">https://github.com/umbraco/Umbraco-CMS/issues/20759</a><br><br style="box-sizing:border-box;"><span style="display:inline !important;">The `name` observer, the result of the method, should get the name of the first active variant. Making it reactive to the active variant, meaning variant-ID cannot be resolved in the method, but as part of the observable.<br></span><br>As well getName, should get the active (most left) variant and gives the name of that.<br><br>There might be an architectural challenge in this as the awareness of active variants is located in the Split View Context. — Please avoid spaghetti relations between these, maybe it not posible to make it happen without a mess, then we should back out and look for other sensible solutions.<br><br></span> </p>