### PR TITLE
Localization: Supply the display name to the localization key for the `alt` and `title` attributes of the 2FA QR code image

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/components/mfa-provider-default.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/components/mfa-provider-default.element.ts
@@ -101,8 +101,8 @@ export class UmbMfaProviderDefaultElement extends UmbLitElement implements UmbMf
 									<img
 										id="qrCode"
 										.src=${this._qrCodeSetupImageUrl}
-										alt=${this.localize.term('user_2faQrCodeAlt')}
-										title=${this.localize.term('user_2faQrCodeTitle')}
+										alt=${this.localize.term('user_2faQrCodeAlt', this.displayName)}
+										title=${this.localize.term('user_2faQrCodeTitle', this.displayName)}
 										loading="eager" />
 								</div>
 								<uui-form-layout-item class="text-center">


### PR DESCRIPTION
## Fix
A very simple fix to supply the display name to the localization key for the 2FA QR Code Image

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
The quickest way to test is to install 2FA package into the Umbraco site. Saves you setting up a MFA provider and the extension manifest yourself

`dotnet add package Umbraco.Community.User2FA --version 1.0.2`

### Before
<img width="1397" height="1044" alt="image" src="https://github.com/user-attachments/assets/62c66897-e29d-4ab5-bd95-ce5c831e3e40" />


### After
<img width="1397" height="1044" alt="image" src="https://github.com/user-attachments/assets/465331cd-f474-4234-96c6-d5d98b4e4b9e" />




<!-- Thanks for contributing to Umbraco CMS! -->
