### PR TITLE
Slider property editor: Fix for preset value handling of `enableRange`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/slider-property-value-preset.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/slider-property-value-preset.ts
@@ -6,16 +6,16 @@ export class UmbSliderPropertyValuePreset
 	implements UmbPropertyValuePreset<UmbSliderPropertyEditorUiValue, UmbPropertyEditorConfig>
 {
 	async processValue(value: undefined | UmbSliderPropertyEditorUiValue, config: UmbPropertyEditorConfig) {
-		const enableRange = Boolean(config.find((x) => x.alias === 'enableRange') ?? false);
+		const enableRange = Boolean(config.find((x) => x.alias === 'enableRange')?.value ?? false);
 
 		/*
-		const min = Number(config.find((x) => x.alias === 'minVal') ?? 0);
-		const max = Number(config.find((x) => x.alias === 'maxVal') ?? 100);
+		const min = Number(config.find((x) => x.alias === 'minVal')?.value ?? 0);
+		const max = Number(config.find((x) => x.alias === 'maxVal')?.value ?? 100);
 		const minVerified = isNaN(min) ? undefined : min;
 		const maxVerified = isNaN(max) ? undefined : max;
 		*/
 
-		const step = (config.find((x) => x.alias === 'step') as number | undefined) ?? 0;
+		const step = Number(config.find((x) => x.alias === 'step')?.value ?? 0);
 		const stepVerified = step > 0 ? step : 1;
 
 		const initValueMin = Number(config.find((x) => x.alias === 'initVal1')?.value) || 0;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco-CMS/issues/20771

### Description
This fixes an issue where a slider data type would incorrectly give validation errors when publishing a content node. The value presets of the slider do not correctly handle the _enableRange_ setting which caused it to be always true if the _enabledRange_ property is in the configuration, regardless of it's value.

The _steps_ setting was also incorrectly handled (it would always be 1), although that impact is extremely limited because it's only used in a fallback scenario.

I think that the steps to reproduce are clear in the associated issue, otherwise I'm happy to provide more details.