### PR TITLE
Package section: use command icon for migrations, remove prop

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view-item.element.ts
@@ -31,9 +31,6 @@ export class UmbInstalledPackagesSectionViewItemElement extends UmbLitElement {
 	@property({ type: Boolean, attribute: false })
 	hasPendingMigrations = false;
 
-	@property({ attribute: 'custom-icon' })
-	customIcon?: string;
-
 	@state()
 	private _migrationButtonState?: UUIButtonState;
 
@@ -123,7 +120,7 @@ export class UmbInstalledPackagesSectionViewItemElement extends UmbLitElement {
 						version="${ifDefined(this.version ?? undefined)}"
 						@open=${this.#onConfigure}
 						?readonly="${!this._packageView}">
-						${this.customIcon ? html`<umb-icon slot="icon" name=${this.customIcon}></umb-icon>` : nothing}
+						<umb-icon slot="icon" name="icon-command"></umb-icon>
 						<div slot="tag">
 							${this.hasPendingMigrations
 								? html`<uui-button

--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/installed/installed-packages-section-view.element.ts
@@ -98,7 +98,6 @@ export class UmbInstalledPackagesSectionViewElement extends UmbLitElement implem
 						(item) => item.name,
 						(item) => html`
 							<umb-installed-packages-section-view-item
-								custom-icon="icon-sync"
 								.name=${item.name}
 								.version=${item.version}
 								.hasPendingMigrations=${item.hasPendingMigrations}>


### PR DESCRIPTION
Remove the property to set migration icon, changes icon from 'refresh' to Command.

This one:
<img width="70" height="50" alt="image" src="https://github.com/user-attachments/assets/c17600cd-2585-482c-b88f-26c8ef2157f1" />
