### PR TITLE
Accessibility: Adding a label attribute for `<uui-button>` in news dashboard

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/umbraco-news/components/umb-news-card.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/umbraco-news/components/umb-news-card.element.ts
@@ -36,9 +36,12 @@ export class UmbNewsCardElement extends UmbLitElement {
 				${this.item.body ? html`<div class="card-text">${unsafeHTML(this.item.body)}</div>` : nothing}
 				${!isLastRow && this.item.url
 					? html`<div class="card-actions">
-							<uui-button look="outline" href=${this.item.url} target="_blank" rel="noopener">
-								${this.item.buttonText || 'Open'}
-							</uui-button>
+							<uui-button
+								look="outline"
+								href=${this.item.url}
+								target="_blank"
+								rel="noopener"
+								label=${this.item.buttonText || 'Open'}></uui-button>
 						</div>`
 					: nothing}
 			</div>


### PR DESCRIPTION
The uui-button was missing the label attribute inside the umb-news-card element

Also removed the uui-button text since it is not needed when a label attribute is present. 