### PR TITLE
Keyboard navigation: Return to opening element after modal close

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/controller/open-modal.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/controller/open-modal.controller.ts
@@ -21,9 +21,7 @@ export class UmbOpenModalController extends UmbControllerBase {
 
 		const modalContext = modalManagerContext.open(this, modalAlias, args);
 
-		return await modalContext.onSubmit().finally(() => {
-			this.destroy();
-		});
+		return await modalContext.onSubmit();
 	}
 }
 


### PR DESCRIPTION
Removed the detroy from the modelContext.
It being destroyed prevented the uui-button from getting into focus again after closing the modal.

This affected the umb-input-document-type element.