### PR TITLE
Content Type Designer: Always register root route to support drag-and-drop into empty Generic tab.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -207,15 +207,16 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			});
 		}
 
+		routes.push({
+			path: 'root',
+			component: () => import('./content-type-design-editor-tab.element.js'),
+			setup: (component) => {
+				this.#currentTabComponent = component as UmbContentTypeDesignEditorTabElement;
+				this.#currentTabComponent.containerId = null;
+			},
+		});
+
 		if (this._hasRootGroups || this._tabs.length === 0) {
-			routes.push({
-				path: 'root',
-				component: () => import('./content-type-design-editor-tab.element.js'),
-				setup: (component) => {
-					this.#currentTabComponent = component as UmbContentTypeDesignEditorTabElement;
-					this.#currentTabComponent.containerId = null;
-				},
-			});
 			routes.push({
 				path: '',
 				pathMatch: 'full',


### PR DESCRIPTION
### Problem
Before, when the Generic (root) tab was empty and other tabs existed, the /root route wasn’t created.
Because of that, in reorder mode, dragging a group over the Generic tab tried to open /root, but since that route didn’t exist, a “Not found” message appeared and the drop didn’t work.

### Solution
Now, the root route (/root) is always created, even if the Generic tab isn’t visible or has no groups.
This makes sure the Generic tab is always ready to accept drops when sorting or moving groups between tabs.

### Changes
Updated the logic in `#createRoutes()` inside `umb-content-type-design-editor` to always register the /root route.

### How to test
1. Create a Document Type with one or more tabs.
2. Leave the Generic tab empty.
3. Enter Reorder mode:
    -The editor switches to the Generic tab view.
    -The drop area becomes available.
    -No “Not found” screen appears.
