### PR TITLE
Content picker: Allow selections on a content picker on a read-only document to be opened (closes #20816)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/contentpicker/contentpicker.html
@@ -13,7 +13,7 @@
                               description="node.url"
                               sortable="!sortableOptions.disabled"
                               allow-remove="allowRemove"
-                              allow-open="model.config.showOpenButton && allowOpen && !dialogEditor && !readonly"
+                              allow-open="model.config.showOpenButton && allowOpen && !dialogEditor"
                               on-remove="remove($index)"
                               on-open="openEditor(node)">
             </umb-node-preview>


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20816

### Description
There's no reason a user with only permissions to browse a node shouldn't be able to open the selections on a content picker, so this update allows it.

<img width="709" height="267" alt="image" src="https://github.com/user-attachments/assets/b6cb0a45-91be-4085-ac3f-4b684f73ba2a" />

### Testing
With a user that only has "Browse" permissions for a document that has a content picker on it, verify that the "Open" button is available next to the selected items.