### PR TITLE
Decimal property editor: Flexibly parse decimal value with different separators (closes #20823)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalPropertyEditor.cs
@@ -138,7 +138,7 @@ public class DecimalPropertyEditor : DataEditor
                     return double.TryParse(formattableValue.ToString(null, CultureInfo.InvariantCulture), NumberStyles.Any, CultureInfo.InvariantCulture, out parsedDecimalValue);
                 }
 
-                return double.TryParse(value.ToString(), CultureInfo.CurrentCulture, out parsedDecimalValue);
+                return double.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.CurrentCulture, out parsedDecimalValue);
             }
         }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DecimalPropertyValueEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DecimalPropertyValueEditorTests.cs
@@ -161,7 +161,7 @@ public class DecimalPropertyValueEditorTests
             Assert.AreEqual(1, result.Count());
 
             var validationResult = result.First();
-            Assert.AreEqual(validationResult.ErrorMessage, "validation_outOfRangeMaximum");
+            Assert.AreEqual("validation_outOfRangeMaximum", validationResult.ErrorMessage);
         }
     }
 
@@ -181,7 +181,7 @@ public class DecimalPropertyValueEditorTests
             Assert.AreEqual(1, result.Count());
 
             var validationResult = result.First();
-            Assert.AreEqual(validationResult.ErrorMessage, "validation_outOfRangeMaximum");
+            Assert.AreEqual("validation_outOfRangeMaximum", validationResult.ErrorMessage);
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20823

### Description
This linked issue shows a server-side error message that appears to come about when there's a difference in decimal separators between the client and the server.  I was able to replicate this via a failing unit test, that parses when the code from this PR is applied.

### Testing
Verify min/max validation with the decimal property editor.
