### PR TITLE
Content Sorting: increase modal size

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.token.ts
@@ -9,6 +9,6 @@ export const UMB_SORT_CHILDREN_OF_CONTENT_MODAL = new UmbModalToken<
 >(UMB_SORT_CHILDREN_OF_CONTENT_MODAL_ALIAS, {
 	modal: {
 		type: 'sidebar',
-		size: 'small',
+		size: 'medium',
 	},
 });


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/20821

### Prerequisites

This pr aims to resolve #20821. It increases the Modal size from `small` to `medium`.

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

I changed the size of the Modal here to medium:
src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.token.ts

It will look like this when you sort media with longer names:
<img width="775" height="850" alt="modalcontentsortsizemedium" src="https://github.com/user-attachments/assets/b497b200-0365-47f3-b150-5731e6d831c4" />

<!-- Thanks for contributing to Umbraco CMS! -->
