### PR TITLE
News Dashboard: Replacing old hostname, with new custom one

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
@@ -46,7 +46,7 @@ public class NewsDashboardService : INewsDashboardService
     /// <inheritdoc />
     public async Task<NewsDashboardResponseModel> GetItemsAsync()
     {
-        const string BaseUrl = "https://umbraco-dashboard-news.euwest01.umbraco.io";
+        const string BaseUrl = "https://news-dashboard.umbraco.com";
         const string Path = "/api/News";
 
         var version = _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild();


### PR DESCRIPTION
### Description
Getting rid of the old default hostname given by Umbraco Cloud, to a new custom one.

<!-- Thanks for contributing to Umbraco CMS! -->
