### PR TITLE
Members: Fix `EntityContainer.GetUdi()` for member type containers

### DIFF
--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -64,6 +64,10 @@ public static class UdiGetterExtensions
         {
             entityType = Constants.UdiEntityType.DataTypeContainer;
         }
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentBlueprint)
+        {
+            entityType = Constants.UdiEntityType.DocumentBlueprintContainer;
+        }
         else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentType)
         {
             entityType = Constants.UdiEntityType.DocumentTypeContainer;
@@ -72,9 +76,9 @@ public static class UdiGetterExtensions
         {
             entityType = Constants.UdiEntityType.MediaTypeContainer;
         }
-        else if (entity.ContainedObjectType == Constants.ObjectTypes.DocumentBlueprint)
+        else if (entity.ContainedObjectType == Constants.ObjectTypes.MemberType)
         {
-            entityType = Constants.UdiEntityType.DocumentBlueprintContainer;
+            entityType = Constants.UdiEntityType.MemberTypeContainer;
         }
         else
         {

--- a/src/Umbraco.Core/Models/EntityContainer.cs
+++ b/src/Umbraco.Core/Models/EntityContainer.cs
@@ -10,10 +10,10 @@ public sealed class EntityContainer : TreeEntityBase, IUmbracoEntity
     private static readonly Dictionary<Guid, Guid> ObjectTypeMap = new()
     {
         { Constants.ObjectTypes.DataType, Constants.ObjectTypes.DataTypeContainer },
+        { Constants.ObjectTypes.DocumentBlueprint, Constants.ObjectTypes.DocumentBlueprintContainer },
         { Constants.ObjectTypes.DocumentType, Constants.ObjectTypes.DocumentTypeContainer },
         { Constants.ObjectTypes.MediaType, Constants.ObjectTypes.MediaTypeContainer },
         { Constants.ObjectTypes.MemberType, Constants.ObjectTypes.MemberTypeContainer },
-        { Constants.ObjectTypes.DocumentBlueprint, Constants.ObjectTypes.DocumentBlueprintContainer },
     };
 
     /// <summary>
@@ -83,7 +83,7 @@ public sealed class EntityContainer : TreeEntityBase, IUmbracoEntity
     public static Guid GetContainedObjectType(Guid containerObjectType)
     {
         Guid contained = ObjectTypeMap.FirstOrDefault(x => x.Value == containerObjectType).Key;
-        if (contained == null)
+        if (contained == default)
         {
             throw new ArgumentException("Not a container object type.", nameof(containerObjectType));
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
@@ -16,9 +16,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
 public class UdiGetterExtensionsTests
 {
     [TestCase(Constants.ObjectTypes.Strings.DataType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://data-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.DocumentBlueprint, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-blueprint-container/6ad82c70685c4e049b36d81bd779d16f")]
     [TestCase(Constants.ObjectTypes.Strings.DocumentType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-type-container/6ad82c70685c4e049b36d81bd779d16f")]
     [TestCase(Constants.ObjectTypes.Strings.MediaType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media-type-container/6ad82c70685c4e049b36d81bd779d16f")]
-    [TestCase(Constants.ObjectTypes.Strings.DocumentBlueprint, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-blueprint-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.MemberType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member-type-container/6ad82c70685c4e049b36d81bd779d16f")]
     public void GetUdiForEntityContainer(Guid containedObjectType, Guid key, string expected)
     {
         EntityContainer entity = new EntityContainer(containedObjectType)


### PR DESCRIPTION
Besides the preparations done in https://github.com/umbraco/Umbraco-CMS/pull/20715 to support member type containers, I encountered an issue in 17.0.0-rc2 while trying to add initial support in Deploy.

Within Deploy, notification handlers are registered for all entity container operations (e.g. `EntityContainerSavedNotification`) to ensure schema/UDA files and signatures are updated. However, this caused the following exception:
```
NotSupportedException: Contained object type 9b5416fb-e72f-45a9-a07b-5a9a2709ce43 is not supported.
   at Umbraco.Cms.Infrastructure.Scoping.Scope.TryFinally(Action[] actions)
   at Umbraco.Cms.Infrastructure.Scoping.Scope.Dispose()
   at Umbraco.Cms.Core.Services.EntityTypeContainerService`2.SaveAsync(EntityContainer container, Guid userKey, Func`1 operationValidation, AuditType auditType)
   at Umbraco.Cms.Core.Services.EntityTypeContainerService`2.SaveAsync(EntityContainer container, Guid userKey, Func`1 operationValidation, AuditType auditType)
   at Umbraco.Cms.Core.Services.EntityTypeContainerService`2.CreateAsync(Nullable`1 key, String name, Nullable`1 parentKey, Guid userKey)
   at Umbraco.Cms.Api.Management.Controllers.FolderManagementControllerBase`1.CreateFolderAsync[TCreatedActionController](CreateFolderRequestModel createFolderRequestModel, Expression`1 createdAction)
   at Umbraco.Cms.Api.Management.Controllers.MemberType.Folder.CreateMemberTypeFolderController.Create(CancellationToken cancellationToken, CreateFolderRequestModel createFolderRequestModel)
...
```

Although not obvious from the stack trace, searching for the error message highlighted the `EntityContainer.GetUdi()` extension method not yet updated to support this new object type. And Deploy uses UDIs when updating the schema/signatures, so it makes sense that this only occurred when its installed.

Besides adding the missing member type, I've ordered them alphabetically now and updated the test to ensure the correct UDI is returned.