### PR TITLE
Block list: ensure block items stay top-aligned when sorting

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -441,6 +441,7 @@ export class UmbPropertyEditorUIBlockListElement
 		css`
 			:host {
 				display: grid;
+				align-content: start;
 				gap: 1px;
 			}
 			> div {


### PR DESCRIPTION
When sorting Blocks in Block List Editor, with Inline editing mode. then when sorting a block that is expanded, then the Blocks will appear divided over the available height.  (because the sorter locks the heigh for consistency when dragging).

This makes sure the items stay top aligned to avoid this wierdness.