### PR TITLE
Backoffice Login: Redact back-office PKCE codes from the server (V16)

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/UmbracoBuilderAuthExtensions.cs
@@ -128,6 +128,12 @@ public static class UmbracoBuilderAuthExtensions
                             .UseSingletonHandler<HideBackOfficeTokensHandler>()
                             .SetOrder(OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreHandlers.ProcessJsonResponse<OpenIddictServerEvents.ApplyTokenResponseContext>.Descriptor.Order - 1);
                     });
+                    options.AddEventHandler<OpenIddictServerEvents.ApplyAuthorizationResponseContext>(configuration =>
+                    {
+                        configuration
+                            .UseSingletonHandler<HideBackOfficeTokensHandler>()
+                            .SetOrder(OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreHandlers.Authentication.ProcessQueryResponse.Descriptor.Order - 1);
+                    });
                     options.AddEventHandler<OpenIddictServerEvents.ExtractTokenRequestContext>(configuration =>
                     {
                         configuration


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is #20847, cherry-picked for V16 where the cookie handling is optional.

### Testing

See #20847 for test info. Remember to enable cookies in tokens - see #20779 for configuration details.