### PR TITLE
Use dependency track devops task

### DIFF
--- a/build/templates/dependency-track.yml
+++ b/build/templates/dependency-track.yml
@@ -13,12 +13,12 @@ jobs:
     - checkout: none
 
     - bash: |
-        project_id=$(curl --no-progress-meter -H "X-Api-Key: $(DT_API_KEY)" "$(DT_API_URL)/v1/project/lookup?name=${{ parameters.projectName }}&version=${{ parameters.umbracoVersion }}" | jq -r '.uuid')
+        project_id=$(curl --no-progress-meter -H "X-Api-Key: $(DT_API_KEY)" "$(DT_API_URI)/api/v1/project/lookup?name=${{ parameters.projectName }}&version=${{ parameters.umbracoVersion }}" | jq -r '.uuid')
         if [ "$project_id" != "null" ] && [ -n "$project_id" ]; then
           echo "Project '${{ parameters.projectName }}' with version '${{ parameters.umbracoVersion }}' already exists (ID: $project_id)."
         else
           project_id=$(curl --no-progress-meter \
-            -X PUT "$(DT_API_URL)/v1/project" \
+            -X PUT "$(DT_API_URI)/api/v1/project" \
             -H "X-Api-Key: $(DT_API_KEY)" \
             -H "Content-Type: application/json" \
             -d '{"name": "${{ parameters.projectName }}", "version": "${{ parameters.umbracoVersion }}", "collectionLogic": "AGGREGATE_DIRECT_CHILDREN"}' \
@@ -44,7 +44,7 @@ jobs:
 
       - task: upload-bom-dtrack@1
         inputs:
-          dtrackURI: $(DT_API_URL)
+          dtrackURI: $(DT_API_URI)
           dtrackAPIKey: $(DT_API_KEY)
           dtrackProjAutoCreate: true
           dtrackProjName: '${{ parameters.projectName }}-${{ project.name }}'


### PR DESCRIPTION
This pull request replaces the Dependency Track build pipeline BOM upload script with the Azure DevOps task.
The additional calls done to the Dependency Track API do not have corresponding tasks, and therefore need to remain as is.