### PR TITLE
Block Entry Context: Update the settingsPropertyValueByAlias to observe settings.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -239,7 +239,7 @@ export abstract class UmbBlockEntryContext<
 		await this.#settingsStructurePromise;
 		return mergeObservables(
 			[
-				this.#content.asObservablePart((data) => data?.values?.filter((x) => x?.alias === propertyAlias)),
+				this.#settings.asObservablePart((data) => data?.values?.filter((x) => x?.alias === propertyAlias)),
 				await this.propertyVariantId(this.#settingsStructure!, propertyAlias),
 			],
 			([propertyValues, propertyVariantId]) => {


### PR DESCRIPTION
Fixed https://github.com/umbraco/Umbraco-CMS/issues/19895

### Problem
Calling settingsPropertyValueByAlias("alias") was always retrieving undefined. That was because the method was observing the `#content` instead of the `#settings`. 

### How to test(two ways)

1. Create a custom UFM element
2. Create a custom view(Using the Examples Project):
- Run the examples project for block custom view
- In the block-custom-view.js file, add the following code inside the constructor:
```
   this.consumeContext(UMB_BLOCK_ENTRY_CONTEXT, async (context) => {
       // Test observing a specific settings property by alias
       this.observe(
           await context?.settingsPropertyValueByAlias('yourSettingsPropertyAlias'),
           (value) => {
               console.log('Settings value by alias:', value);
           },
           'observeSettings'
       );
   });
```
- Configure the block you want to use.
- Go to content section and edit your block.
- Open the console and you should see the value display

### Note
You don't really need to observe through the context just to access settings data. The easier way is using property decorators directly:`@property({ attribute: false }) settings?: UmbBlockDataType;` This gets you straight to the settings without all the context setup. 
An example here: [Block Custom View docs](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-types/block-custom-view).

That said, developers might still want to use the context-based approach with settingsPropertyValueByAlias() for different reasons, or it just makes more sense for what they're building. Either way, the API should do what it says. This fix ensures that if you decide to go down the context path, observing settings by alias will actually work properly.