### PR TITLE
Hybrid cache performance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,6 +43,7 @@
   <ItemGroup>
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageVersion Include="AsyncKeyedLock" Version="7.1.7" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
     <PackageVersion Include="Examine" Version="3.7.1" />
     <PackageVersion Include="Examine.Core" Version="3.7.1" />

--- a/src/Umbraco.PublishedCache.HybridCache/Umbraco.PublishedCache.HybridCache.csproj
+++ b/src/Umbraco.PublishedCache.HybridCache/Umbraco.PublishedCache.HybridCache.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
     <PackageReference Include="MessagePack" />
     <PackageReference Include="K4os.Compression.LZ4" />


### PR DESCRIPTION
This PR replaces the locking mechanism with the battle-tested AsyncKeyedLock library (disclaimer: I am the author of this library).

The locking mechanism here reduces allocations (due to pooling of objects) and avoids the existing double-check of the dictionary (which is technically a race condition because if the reference matches inside the finally, there is no guarantee that by the time it's removed that another thread hasn't obtained the lock).