### PR TITLE
Migrations: Handles rich text blocks created with TinyMCE in convert local links migration and refreshes internal datatype cache following migration requiring cache rebuild (closes #20885)

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/RichTextBlockValue.cs
+++ b/src/Umbraco.Core/Models/Blocks/RichTextBlockValue.cs
@@ -23,4 +23,11 @@ public class RichTextBlockValue : BlockValue<RichTextBlockLayoutItem>
     /// <inheritdoc />
     [JsonIgnore]
     public override string PropertyEditorAlias => Constants.PropertyEditors.Aliases.RichText;
+
+    /// <inheritdoc />
+#pragma warning disable CS0672 // Member overrides obsolete member
+#pragma warning disable CS0618 // Type or member is obsolete
+    public override bool SupportsBlockLayoutAlias(string alias) => base.SupportsBlockLayoutAlias(alias) || alias.Equals("Umbraco.TinyMCE");
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0672 // Member overrides obsolete member
 }

--- a/src/Umbraco.Core/Models/PublishedContent/IPublishedContentTypeFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/IPublishedContentTypeFactory.cs
@@ -54,6 +54,12 @@ public interface IPublishedContentTypeFactory
     PublishedDataType GetDataType(int id);
 
     /// <summary>
+    ///     Clears the internal data type cache.
+    /// </summary>
+    void ClearDataTypeCache()
+    { }
+
+    /// <summary>
     ///     Notifies the factory of datatype changes.
     /// </summary>
     /// <remarks>

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentTypeFactory.cs
@@ -66,6 +66,22 @@ public class PublishedContentTypeFactory : IPublishedContentTypeFactory
     }
 
     /// <inheritdoc />
+    public void ClearDataTypeCache()
+    {
+        if (_publishedDataTypes is null)
+        {
+            // Not initialized yet, so skip and avoid lock
+            return;
+        }
+
+        lock (_publishedDataTypesLocker)
+        {
+            // Clear cache (and let it lazy initialize again later)
+            _publishedDataTypes = null;
+        }
+    }
+
+    /// <inheritdoc />
     public void NotifyDataTypeChanges(params int[] ids)
     {
         if (_publishedDataTypes is null)

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
@@ -47,9 +49,12 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
     private readonly DistributedCache _distributedCache;
     private readonly IScopeAccessor _scopeAccessor;
     private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IPublishedContentTypeFactory _publishedContentTypeFactory;
+
     private bool _rebuildCache;
     private bool _invalidateBackofficeUserAccess;
 
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
     public MigrationPlanExecutor(
         ICoreScopeProvider scopeProvider,
         IScopeAccessor scopeAccessor,
@@ -61,6 +66,33 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
         IKeyValueService keyValueService,
         IServiceScopeFactory serviceScopeFactory,
         AppCaches appCaches)
+        : this(
+            scopeProvider,
+            scopeAccessor,
+            loggerFactory,
+            migrationBuilder,
+            databaseFactory,
+            databaseCacheRebuilder,
+            distributedCache,
+            keyValueService,
+            serviceScopeFactory,
+            appCaches,
+            StaticServiceProvider.Instance.GetRequiredService<IPublishedContentTypeFactory>())
+    {
+    }
+
+    public MigrationPlanExecutor(
+        ICoreScopeProvider scopeProvider,
+        IScopeAccessor scopeAccessor,
+        ILoggerFactory loggerFactory,
+        IMigrationBuilder migrationBuilder,
+        IUmbracoDatabaseFactory databaseFactory,
+        IDatabaseCacheRebuilder databaseCacheRebuilder,
+        DistributedCache distributedCache,
+        IKeyValueService keyValueService,
+        IServiceScopeFactory serviceScopeFactory,
+        AppCaches appCaches,
+        IPublishedContentTypeFactory publishedContentTypeFactory)
     {
         _scopeProvider = scopeProvider;
         _scopeAccessor = scopeAccessor;
@@ -72,6 +104,7 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
         _serviceScopeFactory = serviceScopeFactory;
         _appCaches = appCaches;
         _distributedCache = distributedCache;
+        _publishedContentTypeFactory = publishedContentTypeFactory;
         _logger = _loggerFactory.CreateLogger<MigrationPlanExecutor>();
     }
 
@@ -269,6 +302,7 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
         _appCaches.IsolatedCaches.ClearAllCaches();
         await _databaseCacheRebuilder.RebuildAsync(false);
         _distributedCache.RefreshAllPublishedSnapshot();
+        _publishedContentTypeFactory.ClearDataTypeCache();
     }
 
     private async Task RevokeBackofficeTokens()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/AdvancedMigrationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/AdvancedMigrationTests.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
@@ -38,6 +39,7 @@ internal sealed class AdvancedMigrationTests : UmbracoIntegrationTest
     private IServiceScopeFactory ServiceScopeFactory => GetRequiredService<IServiceScopeFactory>();
     private DistributedCache DistributedCache => GetRequiredService<DistributedCache>();
     private IDatabaseCacheRebuilder DatabaseCacheRebuilder => GetRequiredService<IDatabaseCacheRebuilder>();
+    private IPublishedContentTypeFactory PublishedContentTypeFactory => GetRequiredService<IPublishedContentTypeFactory>();
     private IMigrationPlanExecutor MigrationPlanExecutor => new MigrationPlanExecutor(
         CoreScopeProvider,
         ScopeAccessor,
@@ -48,7 +50,8 @@ internal sealed class AdvancedMigrationTests : UmbracoIntegrationTest
         DistributedCache,
         Mock.Of<IKeyValueService>(),
         ServiceScopeFactory,
-        AppCaches.NoCache);
+        AppCaches.NoCache,
+        PublishedContentTypeFactory);
 
     [Test]
     public async Task CreateTableOfTDtoAsync()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyEditorHelperTests.cs
@@ -110,15 +110,16 @@ public class RichTextPropertyEditorHelperTests
         Assert.IsNull(value.Blocks);
     }
 
-    [Test]
-    public void Can_Parse_Blocks_With_Both_Content_And_Settings()
+    [TestCase(Constants.PropertyEditors.Aliases.RichText)]
+    [TestCase("Umbraco.TinyMCE")]
+    public void Can_Parse_Blocks_With_Both_Content_And_Settings(string propertyEditorAlias)
     {
-        const string input = """
+        string input = """
                              {
                               "markup": "<p>this is some markup</p><umb-rte-block data-content-key=\"36cc710a-d8a6-45d0-a07f-7bbd8742cf02\"><!--Umbraco-Block--></umb-rte-block>",
                               "blocks": {
                                   "layout": {
-                                      "Umbraco.RichText": [{
+                                      "[PropertyEditorAlias]": [{
                                               "contentKey": "36cc710a-d8a6-45d0-a07f-7bbd8742cf02",
                                               "settingsKey": "d2eeef66-4111-42f4-a164-7a523eaffbc2"
                                           }
@@ -143,6 +144,7 @@ public class RichTextPropertyEditorHelperTests
                                 }
                              }
                              """;
+        input = input.Replace("[PropertyEditorAlias]", propertyEditorAlias);
 
         var result = RichTextPropertyEditorHelper.TryParseRichTextEditorValue(input, JsonSerializer(), Logger(), out RichTextEditorValue? value);
         Assert.IsTrue(result);
@@ -180,6 +182,12 @@ public class RichTextPropertyEditorHelperTests
             Assert.AreEqual("settingsPropertyAlias", settingsProperties.First().Alias);
             Assert.AreEqual("A settings property value", settingsProperties.First().Value);
         });
+
+        Assert.IsTrue(value.Blocks.Layout.ContainsKey(Constants.PropertyEditors.Aliases.RichText));
+        var layout = value.Blocks.Layout[Constants.PropertyEditors.Aliases.RichText];
+        Assert.AreEqual(1, layout.Count());
+        Assert.AreEqual(Guid.Parse("36cc710a-d8a6-45d0-a07f-7bbd8742cf02"), layout.First().ContentKey);
+        Assert.AreEqual(Guid.Parse("d2eeef66-4111-42f4-a164-7a523eaffbc2"), layout.First().SettingsKey);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationPlanTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/MigrationPlanTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
@@ -85,7 +86,8 @@ public class MigrationPlanTests
             distributedCache,
             Mock.Of<IKeyValueService>(),
             Mock.Of<IServiceScopeFactory>(),
-            appCaches);
+            appCaches,
+            Mock.Of<IPublishedContentTypeFactory>());
 
         var plan = new MigrationPlan("default")
             .From(string.Empty)


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/20885

### Description
This PR contains two updates to address issues found in testing the database provided illustrating the problem encountered in the linked issue.

The most important is the report of block data from blocks in the RTE being removed after the upgrade.  I tracked this down to the `ConvertLocalLinks` migration, which requires serializing the rich text content.  As in the 13 the layout values key is `"Umbraco.TinyMCE"` rather than `"Umbraco.RichText"`, these are omitted, and an empty block value is returned.  I've resolved that by supporting this key as well, such that the existing values will be read.

The second fix is that I noticed that after the migration, when accessing certain content, an error of being unable to find a data type by Id is thrown.  This was referring to one of the data types added in a migration - the "Label (pixels)" one.  Although we clear caches after the migration completes, there's an internal cache of datatypes in `PublishedContentTypeFactory` that isn't cleared.  So I've added a means of doing that and executed it along with the other post-migration cache invalidations.

#### Point to note

In testing this I've also seen that the markup will get encoded via this `ConvertLocalLinks` migration, so starting from:

```
{"markup":"<p>Two weeks ago, I had the absolute pleasure of speaking at ...
```

We end up with:

```
{"markup":"\u003Cp\u003ETwo weeks ago, I had the absolute pleasure of speaking at ...
```

It doesn't seem to cause any issues, but wanted to flag in case this jumps out as a concern.

### Testing
I've been working with a customer database that I could share, but I would expect this would be an issue you could see if you follow these steps:

- With Umbraco 13, create a content item that contains a rich text property, with a populated block along with the markup.
- Attach the database to the latest code from `main` or `release/16.4` and I'd expect you would see the block information lost after Umbraco starts and the migration completes.
- Repeating with the code from this PR should show the block data retained.
