### PR TITLE
Integration Tests: Use empty temp folder for legacy lang config when using integration tests outside core (closes #20888)

### DIFF
--- a/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/tests/Umbraco.Tests.Integration/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -125,6 +125,10 @@ public static class UmbracoBuilderExtensions
 
                 if (!currFolder.Exists)
                 {
+                    // When Umbraco.Integration.Tests is installed in a "consumer" Umbraco site, the src/tests path might not be there.
+                    // This replaces the folder reference with an empty folder under temp
+                    // such that the LocalizedTextServiceFileSources don't blow up from directory not found,
+                    // or reading random xml files from the base temp folder.
                     var tempPath = Path.GetTempPath();
                     currFolder = new DirectoryInfo(Path.GetFullPath("Umbraco.Integration.Tests.Fake.SrcRoot", tempPath));
                     currFolder.Create();


### PR DESCRIPTION
Fixes problem where consumers of Umbraco.Cms.Integration.Tests may get invalid localization xml from random xml files in the base temp folder. See #20888.

### Prerequisites

There's an existing issue for this PR, and this fixes #20888

I've executed the `Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services.LocalizationServiceTests` fixture and it's all green.  
I've used the "updated" method in our own tests by calling `services.AddUnique(GetLocalizedTextService)` in `CustomTestSetup` and it no longer brings in the random xml files from my base temp folder.

### Description

Removes unused "mainLangFolder" and replaces currFolder with an empty folder under temp when used outside Umbraco core source. 
