### PR TITLE
Block Type Card: make actions stand clear from thumbnail/color

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-type/components/input-block-type/input-block-type.element.ts
@@ -204,27 +204,15 @@ export class UmbInputBlockTypeElement<
 				opacity: 0.5;
 			}
 
+			uui-action-bar {
+				--uui-button-background-color: var(--uui-color-surface);
+				--uui-button-background-color-hover: var(--uui-color-surface);
+			}
+
 			#add-button {
 				text-align: center;
 				min-height: 150px;
 				height: 100%;
-			}
-
-			uui-icon {
-				display: block;
-				margin: 0 auto;
-			}
-
-			uui-input {
-				border: none;
-				margin: var(--uui-size-space-6) 0 var(--uui-size-space-4);
-			}
-
-			uui-input:hover uui-button {
-				opacity: 1;
-			}
-			uui-input uui-button {
-				opacity: 0;
 			}
 		`,
 	];


### PR DESCRIPTION
Gives a background color to actions, same approach as on Content Type Designer Properties.

<img width="698" height="571" alt="image" src="https://github.com/user-attachments/assets/575b294c-e87a-421a-9946-f8a9a22a3b98" />

And then removes some unused CSS
