### PR TITLE
Block editors: Localization schema elements such as property names in clipboard view (#20756)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.context.ts
@@ -20,6 +20,7 @@ import { UmbBlockEntryContext } from '@umbraco-cms/backoffice/block';
 import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UMB_CLIPBOARD_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/clipboard';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 export class UmbBlockGridEntryContext
 	extends UmbBlockEntryContext<
@@ -58,6 +59,8 @@ export class UmbBlockGridEntryContext
 	public getRelevantColumnSpanOptions() {
 		return this.#relevantColumnSpanOptions.getValue();
 	}
+
+	#localize = new UmbLocalizationController(this);
 
 	#canScale = new UmbBooleanState(false);
 	readonly canScale = this.#canScale.asObservable();
@@ -297,8 +300,8 @@ export class UmbBlockGridEntryContext
 			throw new Error('No clipboard context found');
 		}
 
-		const workspaceName = propertyDatasetContext?.getName();
-		const propertyLabel = propertyContext?.getLabel();
+		const workspaceName = this.#localize.string(propertyDatasetContext?.getName());
+		const propertyLabel = this.#localize.string(propertyContext?.getLabel());
 		const blockLabel = this.getName();
 
 		const entryName = workspaceName

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
@@ -307,8 +307,8 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 			throw new Error('Could not get required contexts to copy.');
 		}
 
-		const workspaceName = propertyDatasetContext?.getName();
-		const propertyLabel = propertyContext?.getLabel();
+		const workspaceName = this.localize.string(propertyDatasetContext?.getName());
+		const propertyLabel = this.localize.string(propertyContext?.getLabel());
 		const blockLabel = this.#context.getName();
 
 		const entryName = workspaceName


### PR DESCRIPTION
### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

This PR fixes for issue https://github.com/umbraco/Umbraco-CMS/issues/20756

I added localize when getting the name of the copyToClipboard action for both Block Grid and Block List
<!-- Thanks for contributing to Umbraco CMS! -->
