### PR TITLE
Block Catalogue: Localizes block-type name/description before render (closes #20890)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/modals/block-catalogue/block-catalogue-modal.element.ts
@@ -104,7 +104,11 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 
 		const lookup = items.reduce(
 			(acc, item) => {
-				acc[item.unique] = item;
+				acc[item.unique] = {
+					...item,
+					name: this.localize.string(item.name),
+					description: this.localize.string(item.description),
+				};
 				return acc;
 			},
 			{} as { [key: string]: UmbDocumentTypeItemModel },
@@ -244,8 +248,8 @@ export class UmbBlockCatalogueModalElement extends UmbModalBaseElement<
 		return html`
 			<uui-card-block-type
 				href=${ifDefined(href)}
-				name=${this.localize.string(block.name)}
-				description=${this.localize.string(block.description)}
+				name=${block.name}
+				description=${ifDefined(block.description)}
 				.background=${block.backgroundColor}
 				@open=${() => this.#chooseBlock(block.contentElementTypeKey)}>
 				${when(


### PR DESCRIPTION
### Description

Fixes #20890

The filtering used on the Block Catalogue queries against the block-type data, meaning when localizations are used for a block-type's name and description, these are localized as render time (in the block-card display), and not in the data (source).

This PR moves the localization to when the block-types are first observed and processed (into groups). This means that the Block Catalogue filtering with query against the localized strings.