### PR TITLE
Collections: Sets the default name for the content collection workspace name to 'Child items' instead of 'Collection'

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/collection/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/collection/manifests.ts
@@ -28,7 +28,7 @@ export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> =
 		name: 'Content Workspace Collection View',
 		weight: 1000,
 		meta: {
-			label: 'Collection',
+			label: 'Child items',
 			pathname: 'collection',
 			icon: 'icon-grid',
 		},


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #20860 

### Description

* Create a first document type "Folder item"
* Create 2nd document type "Folder"
* Change structure of "Folder" document type to "Allow at root" and specify "Folder item" as Allowed child node types.
* Change presentation of "Folder" document type and create a custom list view for the "Collection" property
* On the custom list view, do not specify the "Workspace View name"

<img width="936" height="205" alt="515172539-c4c4d068-9fa1-4dc1-9cc8-f6a7f63a6a98" src="https://github.com/user-attachments/assets/02d79df7-0cce-4c2d-828f-00868b7f31c9" />

* Go and create a document of type "Folder" at the root
* Create one or more documents of type "Folder item"
* Navigate to the Folder content node and notice the Workspace View name is now "Child items" instead of "Collection"

<img width="1920" height="239" alt="image" src="https://github.com/user-attachments/assets/658c00f2-d99f-48c2-8f2b-58b04ee1b694" />




