### PR TITLE
Examine Management: Allow selection of all available fields in Examine search results, and fix layout issue when not all records have all fields (closes #20878 and #20879)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/search/examine-management-dashboard/views/section-view-examine-searchers.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/search/examine-management-dashboard/views/section-view-examine-searchers.ts
@@ -99,7 +99,7 @@ export class UmbDashboardExamineSearcherElement extends UmbLitElement {
 	private _updateFieldFilter() {
 		const documentFields: ExposedSearchResultField[] = [];
 
-		this._searchResults?.map((doc) => {
+		this._searchResults?.forEach((doc) => {
 			const document = doc.fields?.filter((field) => {
 				return field.name?.toUpperCase() !== 'NODENAME';
 			});
@@ -289,7 +289,7 @@ export class UmbDashboardExamineSearcherElement extends UmbLitElement {
 	renderBodyCells(cellData: UmbSearchFieldPresentationModel[]) {
 		return html`${this._exposedFields?.map((slot) => {
 			if (slot.exposed) {
-				const field = cellData.find((field) => field.name == slot.name);
+				const field = cellData.find((field) => field.name === slot.name);
 				if (field) {
 					return html`<uui-table-cell clip-text>${field.values}</uui-table-cell>`;
 				}


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20878 and https://github.com/umbraco/Umbraco-CMS/issues/20879

### Description
This PR addresses two issues found on the Examine Management search results feature:

- You previously couldn't select all fields that were available in the record set.  If a field was available in some records but not others, it could be omitted from the fields available to select.
- When rendering the records, if a field selected for display didn't exist for some records, no cell would be written, leading to an odd layout where other records did have the field, with missing cell borders.

### Testing
Create a document type with some properties and create a few content items using that type.
Add a new property and populate it on only a subset of content items.
Verify that in the Examine searcher you can select all fields for view.
Verify the layout looks as expected when the field is available only some of the records.

To find all content for a given document type, use `__NodeTypeAlias:{docTypeAlias}` as the search term, e.g. `__NodeTypeAlias:person`.