### PR TITLE
UFM: Update contentName component to respect current backoffice culture.

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/content-name/content-name.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/content-name/content-name.element.ts
@@ -51,7 +51,7 @@ export class UmbUfmContentNameElement extends UmbUfmElementBase {
 			if (item.mediaKey) return UMB_MEDIA_ENTITY_TYPE;
 		}
 
-		return null;
+		return UMB_DOCUMENT_ENTITY_TYPE;
 	}
 
 	#getUniques(value: unknown) {


### PR DESCRIPTION
Fixed: https://github.com/umbraco/Umbraco-CMS/issues/20400

### Problem
The umbContentName component in Block List labels always displayed content names in the default language, regardless of the currently active backoffice culture.

### Solution
In `content-name.element.ts`, the code previously always accessed `variants[0].name`, which returned the first variant (typically the default language) regardless of the current backoffice culture. Now uses `UmbDocumentItemDataResolver` to get culture-aware content names for documents.

### How to test
1. Create a document with multiple language variants.
2. Add a Block List with {umbContentName: combiGift} in the label
3. Switch between languages in the backoffice
4. Verify the block label updates to show the correct language variant