### PR TITLE
Search: Preserve existing Examine FieldDefinitionCollection if it already exists

### DIFF
--- a/src/Umbraco.Examine.Lucene/DependencyInjection/ConfigureIndexOptions.cs
+++ b/src/Umbraco.Examine.Lucene/DependencyInjection/ConfigureIndexOptions.cs
@@ -10,7 +10,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 namespace Umbraco.Cms.Infrastructure.Examine.DependencyInjection;
 
 /// <summary>
-///     Configures the index options to construct the Examine indexes
+///     Configures the index options to construct the Examine indexes.
 /// </summary>
 public sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirectoryIndexOptions>
 {
@@ -18,6 +18,9 @@ public sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirecto
     private readonly IUmbracoIndexConfig _umbracoIndexConfig;
     private readonly IDeliveryApiContentIndexFieldDefinitionBuilder _deliveryApiContentIndexFieldDefinitionBuilder;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigureIndexOptions"/> class.
+    /// </summary>
     public ConfigureIndexOptions(
         IUmbracoIndexConfig umbracoIndexConfig,
         IOptions<IndexCreatorSettings> settings,
@@ -28,26 +31,26 @@ public sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirecto
         _deliveryApiContentIndexFieldDefinitionBuilder = deliveryApiContentIndexFieldDefinitionBuilder;
     }
 
+    /// <inheritdoc/>
     public void Configure(string? name, LuceneDirectoryIndexOptions options)
     {
+        // When creating FieldDefinitions with Umbraco defaults, pass in any already defined to avoid overwriting
+        // those added via a package or custom code.
         switch (name)
         {
             case Constants.UmbracoIndexes.InternalIndexName:
                 options.Analyzer = new CultureInvariantWhitespaceAnalyzer();
                 options.Validator = _umbracoIndexConfig.GetContentValueSetValidator();
-                // NOTE: we don't want to overwrite any already registered field definitions
                 options.FieldDefinitions = new UmbracoFieldDefinitionCollection(options.FieldDefinitions);
                 break;
             case Constants.UmbracoIndexes.ExternalIndexName:
                 options.Analyzer = new StandardAnalyzer(LuceneInfo.CurrentVersion);
                 options.Validator = _umbracoIndexConfig.GetPublishedContentValueSetValidator();
-                // NOTE: we don't want to overwrite any already registered field definitions
                 options.FieldDefinitions = new UmbracoFieldDefinitionCollection(options.FieldDefinitions);
                 break;
             case Constants.UmbracoIndexes.MembersIndexName:
                 options.Analyzer = new CultureInvariantWhitespaceAnalyzer();
                 options.Validator = _umbracoIndexConfig.GetMemberValueSetValidator();
-                // NOTE: we don't want to overwrite any already registered field definitions
                 options.FieldDefinitions = new UmbracoFieldDefinitionCollection(options.FieldDefinitions);
                 break;
             case Constants.UmbracoIndexes.DeliveryApiContentIndexName:
@@ -67,6 +70,7 @@ public sealed class ConfigureIndexOptions : IConfigureNamedOptions<LuceneDirecto
         }
     }
 
+    /// <inheritdoc/>
     public void Configure(LuceneDirectoryIndexOptions options)
         => throw new NotImplementedException("This is never called and is just part of the interface");
 }

--- a/src/Umbraco.Infrastructure/Examine/UmbracoFieldDefinitionCollection.cs
+++ b/src/Umbraco.Infrastructure/Examine/UmbracoFieldDefinitionCollection.cs
@@ -30,15 +30,24 @@ public class UmbracoFieldDefinitionCollection : FieldDefinitionCollection
         new(UmbracoExamineFieldNames.VariesByCultureFieldName, FieldDefinitionTypes.Raw),
     };
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoFieldDefinitionCollection"/> class containing
+    /// the default Umbraco field definitions.
+    /// </summary>
     public UmbracoFieldDefinitionCollection()
         : base(UmbracoIndexFieldDefinitions)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UmbracoFieldDefinitionCollection"/> class containing the containing
+    /// the default Umbraco field definitions, augmented or overridden by the provided definitions.
+    /// </summary>
+    /// <param name="definitions">Existing collection of field definitions.</param>
     public UmbracoFieldDefinitionCollection(FieldDefinitionCollection definitions)
         : base(UmbracoIndexFieldDefinitions)
     {
-        foreach (var definition in definitions)
+        foreach (FieldDefinition definition in definitions)
         {
             AddOrUpdate(definition);
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoFieldDefinitionCollectionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/UmbracoFieldDefinitionCollectionTests.cs
@@ -1,0 +1,75 @@
+using Examine;
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Examine;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine;
+
+[TestFixture]
+internal class UmbracoFieldDefinitionCollectionTests
+{
+    [Test]
+    public void Create_Contains_Expected_Fields()
+    {
+        var collection = new UmbracoFieldDefinitionCollection();
+        AssertDefaultField(collection);
+    }
+
+    [Test]
+    public void Create_New_Contains_Expected_Fields()
+    {
+        var collection = new UmbracoFieldDefinitionCollection();
+        collection.AddOrUpdate(new FieldDefinition("customField", "string"));
+        var collectionCount = collection.Count;
+
+        collection = new UmbracoFieldDefinitionCollection();
+        Assert.AreEqual(collectionCount - 1, collection.Count);
+        AssertDefaultField(collection);
+        AssertCustomField(collection, expectExists: false);
+    }
+
+    [Test]
+    public void Create_With_Existing_Contains_Expected_Fields()
+    {
+        var collection = new UmbracoFieldDefinitionCollection();
+        collection.AddOrUpdate(new FieldDefinition("customField", "string"));
+        var collectionCount = collection.Count;
+
+        collection = new UmbracoFieldDefinitionCollection(collection);
+        Assert.AreEqual(collectionCount, collection.Count);
+        AssertDefaultField(collection);
+        AssertCustomField(collection, expectExists: true);
+    }
+
+    [Test]
+    public void Create_With_Existing_Retains_Override_Of_DefaultField()
+    {
+        var collection = new UmbracoFieldDefinitionCollection();
+        collection.AddOrUpdate(new FieldDefinition("parentID", "string"));
+
+        collection = new UmbracoFieldDefinitionCollection(collection);
+        AssertDefaultField(collection, "string");
+    }
+
+    private static void AssertDefaultField(UmbracoFieldDefinitionCollection collection, string expectedType = "int")
+    {
+        var field = collection.SingleOrDefault(x => x.Name == "parentID");
+        Assert.IsNotNull(field);
+        Assert.AreEqual("parentID", field.Name);
+        Assert.AreEqual(expectedType, field.Type);
+    }
+
+    private static void AssertCustomField(UmbracoFieldDefinitionCollection collection, bool expectExists)
+    {
+        var field = collection.SingleOrDefault(x => x.Name == "customField");
+        if (expectExists is false)
+        {
+            Assert.IsNull(field.Name);
+            Assert.IsNull(field.Type);
+            return;
+        }
+
+        Assert.IsNotNull(field);
+        Assert.AreEqual("customField", field.Name);
+        Assert.AreEqual("string", field.Type);
+    }
+}


### PR DESCRIPTION
As discussed on #20267 v16 introduced a behavioural breaking change whereby Umbraco's own Examine index configuration now happens at an undetermined point in the startup lifecycle, compared with previously running as part of the core Umbraco boot steps.

This can cause issues when trying to customise the Examine index, e.g. setting field types, as you don't know whether your code is going to run before or after Umbraco's.

I explained a bit more about how this came to be [here](https://github.com/umbraco/Umbraco-CMS/issues/20267#issuecomment-3426875421):

> This was caused by https://github.com/umbraco/Umbraco-CMS/pull/18988 - where the registration of Examine (and therefore Umbraco's own configuration of `LuceneDirectoryIndexOptions`) was moved from happening inside `builder.AddBackOffice()` to a composer. This meant it went from being (almost) guaranteed to run first, as `AddBackOffice` is called first from `Program.cs`, to an unknown order.
> 
> Other than the `[ComposeBefore]` / `[ComposeAfter]` attributes I can't see a way of forcing Umbraco's Examine composer to run before any user registered ones...

The solution is of course to add decorate your `IComposer` with `[ComposeAfter(typeof(AddExamineComposer))]` as per the docs - but this has been problematic for me in my [Search Extensions](https://github.com/callumbwhyte/umbraco-search-extensions) package where I am multi-targeting 🙈 and can't reliably target this change to V16+ as V15 also uses .NET 9 where `AddExamineComposer` does not exist...

After digging into things I found the real issue is Umbraco assumes it's okay to set the `FieldDefinitions` property during configuration, without consideration for if this has already been set. The fix is simple: when Umbraco's configuration code runs, ensure any existing config is applied too. I have added an overload to `UmbracoFieldDefinitionCollection` that takes an existing `FieldDefinitionCollection` and tries to add each existing definition to the `UmbracoFieldDefinitionCollection`. Examine sets this property to an empty collection on initialisation ([here](https://github.com/Shazwazza/Examine/blob/support/3.x/src/Examine.Core/IndexOptions.cs#L5)) anyway so it should always be set.

I believe it would be good to get this fix into both V16 and V17 to prevent confusion as others have been experiencing!