### PR TITLE
Table Collection View: Update table view icon to 'icon-table'

### DIFF
--- a/src/Umbraco.Web.UI.Client/examples/collection/collection/table-view/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/examples/collection/collection/table-view/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 100,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		js: () => import('./table/clipboard-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/tree-item-children/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/tree-item-children/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 300,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/collection/views/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./table/dictionary-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 300,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/views/manifests.ts
@@ -28,7 +28,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 300,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/tree-item-children/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/tree-item-children/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 300,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/extension-insights/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/extension-insights/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./table/extension-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/language/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/collection/views/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		js: () => import('./table/language-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/tree-item-children/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/tree-item-children/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 300,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/views/manifests.ts
@@ -28,7 +28,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 200,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/tree-item-children/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/tree-item-children/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 300,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/views/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./table/member-group-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/tree-item-children/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/tree-item-children/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		weight: 300,
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./table/member-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/collection/views/manifests.ts
@@ -8,7 +8,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		js: () => import('./table/relation-type-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/collection/views/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		js: () => import('./user-group-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/collection/views/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		element: () => import('./table/user-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-delivery/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-delivery/collection/views/manifests.ts
@@ -8,7 +8,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		js: () => import('./table/webhook-delivery-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/collection/views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/collection/views/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		js: () => import('./table/webhook-table-collection-view.element.js'),
 		meta: {
 			label: 'Table',
-			icon: 'icon-list',
+			icon: 'icon-table',
 			pathName: 'table',
 		},
 		conditions: [


### PR DESCRIPTION
This PR prepares for the "Collection"-element in the Pickers feature and is made as a separate PR to keep the review scope as small as possible for the PR.

The PR replaces the 'icon-list' icon with 'icon-table' in all table view manifests across multiple packages to improve consistency and better visually represent the table view.

Currently, the icon is not visible in any place in the Backoffice because all the collections using a table view only have one registered view. For Document/Media the icon is overwritten by the Data Type configuration. The icon will become visible when we start to register additional collection views.


