### PR TITLE
Media Picker Fixed folder navigation when returning from an empty folder (closes #20975)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -595,6 +595,9 @@ angular.module("umbraco")
 
             function syncPagination(opts, data) {
                 var d = data || {};
+                if (d.pageNumber > 0) {
+                    opts.pageNumber = d.pageNumber;
+                }
                 opts.pageNumber = d.pageNumber;
                 if (d.pageSize > 0) {
                     opts.pageSize = d.pageSize;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20975

### Description
This PR fixes the regression described in the linked issue.

### Testing
To replicate the original issue:
- Create a media structure where you have a folder without any items in it.
- Create a media picker on a document that allows navigation into that folder
- Using the picker, navigate into the folder and click the "Media" root of the breadcrumb to reveal the error.

<img width="800" src="https://github.com/user-attachments/assets/d5d8af1b-bc78-4173-8ae8-6e82b452f8a2" />

With this PR in place you should navigate back to the root without error.

