### PR TITLE
Media Picker: Present root nodes for users with more than one media root node assigned (closes #20967)

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -879,13 +879,13 @@ public class EntityController : UmbracoAuthorizedJsonController
                 startNodeIds.Contains(Constants.System.Root) == false &&
                 ignoreUserStartNodes == false)
             {
-                var entitiesList = _entityService.GetAll(objectType.Value, startNodeIds).ToList();
-                var pagedEntities = entitiesList
+                var startNodeEntities = _entityService.GetAll(objectType.Value, startNodeIds).ToList();
+                IEnumerable<IEntitySlim> pagedStartNodeEntities = startNodeEntities
                     .Skip((pageNumber - 1) * pageSize)
                     .Take(pageSize);
-                return new PagedResult<EntityBasic>(entitiesList.Count, pageNumber, pageSize)
+                return new PagedResult<EntityBasic>(startNodeEntities.Count, pageNumber, pageSize)
                 {
-                    Items = pagedEntities
+                    Items = pagedStartNodeEntities
                         .Select(source => MapEntityBasic(source, culture))
                         .WhereNotNull(),
                 };


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/20967

### Description
This PR fixes an issue with the following setup:
- A user with more than one media root node assigned (either directly on the user account, or from being part of two groups that each have a different media root node assigned).
- Opening a media picker on a document would not present any nodes to pick from

It's reported as a regression but:
- I couldn't replicate the reported problem with a single media root node
- Looking at the code history, it seems this has been incorrect for a while in returning an empty collection.

### Testing
Follow steps in description above and verify the presentation and selection of items in the media picker.