### PR TITLE
Delivery API: Missing Member Open API security scheme references

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Configuration/ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions.cs
@@ -47,9 +47,7 @@ public class ConfigureUmbracoMemberAuthenticationDeliveryApiSwaggerGenOptions : 
                 return;
             }
 
-            swaggerDoc.Components ??= new OpenApiComponents();
-            swaggerDoc.Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
-            swaggerDoc.Components.SecuritySchemes.Add(
+            swaggerDoc.AddComponent(
                 AuthSchemeName,
                 new OpenApiSecurityScheme
                 {


### PR DESCRIPTION
Fixes security requirements being serialized as empty objects in the OpenAPI document by using the document's `AddComponent` method instead of directly manipulating the SecuritySchemes dictionary.