### PR TITLE
Migrations: Set a long timeout by default on the migration of system dates (closes #21013)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/MigrateSystemDatesToUtc.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/MigrateSystemDatesToUtc.cs
@@ -96,6 +96,14 @@ public class MigrateSystemDatesToUtc : UnscopedMigrationBase
         using IScope scope = _scopeProvider.CreateScope();
         using IDisposable notificationSuppression = scope.Notifications.Suppress();
 
+        // Ensure we have a long command timeout as this migration can take a while on large tables within the database.
+        // If the command timeout is already longer, applied via the connection string with "Connect Timeout={timeout}" we leave it as is.
+        const int CommandTimeoutInSeconds = 300;
+        if (scope.Database.CommandTimeout < CommandTimeoutInSeconds)
+        {
+            scope.Database.CommandTimeout = CommandTimeoutInSeconds;
+        }
+
         MigrateDateColumn(scope, "cmsMember", "emailConfirmedDate", timeZone);
         MigrateDateColumn(scope, "cmsMember", "lastLoginDate", timeZone);
         MigrateDateColumn(scope, "cmsMember", "lastLockoutDate", timeZone);


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses https://github.com/umbraco/Umbraco-CMS/issues/21013

### Description
Although as noted in the discussion on the linked issue we can resolve this by configuring a command timeout in the connection string, it makes sense to use a long one by default for these migration queries.

So this PR will set a timeout of 5 minutes unless a longer one is already configured.

### Testing
Use a SQL update like the following to re-run the migration and verify with a breakpoint that the `CommandTimeout` is set as expected.

```
update umbracoKeyValue
set value = '{EB1E50B7-CD5E-4B6B-B307-36237DD2C506}'
where [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
```

If set in the connection string to a value longer than 300 seconds, e.g. with the following, then the configured value should be kept:

```
"umbracoDbDSN": "Server=.\\SQLEXPRESS;Database=UmbracoCms17;Integrated Security=true;TrustServerCertificate=true;Connect Timeout=500"
```
