### PR TITLE
Modal: Remove unused `uui-dialog` element in modal component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/modal.element.ts
@@ -10,7 +10,6 @@ import { UmbBasicState, type UmbObserverController } from '@umbraco-cms/backoffi
 import {
 	UUIModalCloseEvent,
 	type UUIModalElement,
-	type UUIDialogElement,
 	type UUIModalDialogElement,
 	type UUIModalSidebarElement,
 	type UUIModalSidebarSize,
@@ -127,8 +126,6 @@ export class UmbModalElement extends UmbLitElement {
 
 	#createDialogElement() {
 		const modalDialogElement = document.createElement('uui-modal-dialog');
-		const dialogElement: UUIDialogElement = document.createElement('uui-dialog');
-		modalDialogElement.appendChild(dialogElement);
 		return modalDialogElement;
 	}
 


### PR DESCRIPTION
## Summary

- Removes dead code that created an unnecessary `uui-dialog` element inside `uui-modal-dialog`
- Removes unused `UUIDialogElement` import
- Simplifies `#createDialogElement()` method to match `#createSidebarElement()` pattern

## Details

The `uui-modal-dialog` component already manages its own internal `<dialog>` element with a slot for content. Creating an additional `uui-dialog` element was redundant and never used - the `dialogElement` variable was only appended once and never referenced again.

This cleanup:
- Removes 3 lines of dead code
- Aligns the dialog implementation with the sidebar implementation pattern
- Follows the UUI library's intended architecture where modal containers handle their own internal structure

## Test plan

- [x] Verify modal dialogs still open and function correctly
- [x] Verify modal content is displayed properly
- [x] Verify modal close behavior works as expected
- [x] Check that no console errors occur when opening modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)