### PR TITLE
Segments: Only validate segment values for cultures they are defined for (closes #21029)

### DIFF
--- a/src/Umbraco.Core/Models/ContentEditing/ContentEditingModelBase.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentEditingModelBase.cs
@@ -1,4 +1,4 @@
-namespace Umbraco.Cms.Core.Models.ContentEditing;
+﻿namespace Umbraco.Cms.Core.Models.ContentEditing;
 
 public abstract class ContentEditingModelBase
 {

--- a/src/Umbraco.Core/Services/ContentValidationService.cs
+++ b/src/Umbraco.Core/Services/ContentValidationService.cs
@@ -1,4 +1,4 @@
-using Umbraco.Cms.Core.Models;
+﻿using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 
 namespace Umbraco.Cms.Core.Services;

--- a/src/Umbraco.Core/Services/MediaValidationService.cs
+++ b/src/Umbraco.Core/Services/MediaValidationService.cs
@@ -1,4 +1,4 @@
-using Umbraco.Cms.Core.Models;
+﻿using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 
 namespace Umbraco.Cms.Core.Services;

--- a/src/Umbraco.Core/Services/MemberValidationService.cs
+++ b/src/Umbraco.Core/Services/MemberValidationService.cs
@@ -1,4 +1,4 @@
-using Umbraco.Cms.Core.Models;
+﻿using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 
 namespace Umbraco.Cms.Core.Services;


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/21029

### Description
This PR adds culture-aware segment validation to skip validating property values for segments not defined a culture.

See the linked issue for details of the concern and how to set up to test.

The issue comes as currently we don't look at what segments are defined when validating - we just take the aliases that come from the model.  A defined segment though can have one or more cultures defined for it.  If at least one culture is defined, the segment can be created only for those cultures.  And as such, we shouldn't validate segments that aren't creatable for a culture.

In the first version of this PR I've resolved this by injecting `ISegmentService` to determine this.

After discussion I've removed this.  We currently rely on the incoming model variants and properties to determine the segments, and we can do similar to find the segments along with the cultures they are associated with by looking at what culture and segment combinations are provided.

I've verified that this works for Save, Save and Publish and Publish operations on a document.

There's a small UI issue - that if tackled, should be handled in another PR - in that we still report publishing segments that aren't valid for a culture.

<img width="435" height="127" alt="image" src="https://github.com/user-attachments/assets/948aba51-4d6c-4fa6-9726-2e44a6d5a130" />

Which comes from this code in `UmbPublishDocumentEntityAction`.

```
// TODO: show correct variant names instead of variant strings [MR]
localize.list(documentVariants.map((v) => UmbVariantId.Create(v).toString() ?? v.name)),
```