### PR TITLE
Change ExamineIndexRebuilder to public access modifier

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
@@ -11,7 +11,7 @@ using Umbraco.Cms.Infrastructure.Models;
 
 namespace Umbraco.Cms.Infrastructure.Examine;
 
-internal class ExamineIndexRebuilder : IIndexRebuilder
+public class ExamineIndexRebuilder : IIndexRebuilder
 {
     private const string RebuildAllOperationTypeName = "RebuildAllExamineIndexes";
 


### PR DESCRIPTION
Without this being public it is not possible to override anything or resolve this internally without some ugly reflection being done at the composition layer. ExamineX has had to copy this internally to override some methods since index rebuilding should not be done for certain server roles. Similarly, for persisted indexes in managed search services like ExamineX with Azure or Elasticsearch, rebuilding on cold boot should not be done so this behavior needs to be overridden.