### PR TITLE
Packaging: Fixing bad serialization for data types in packages

### DIFF
--- a/src/Umbraco.Core/Services/EntityXmlSerializer.cs
+++ b/src/Umbraco.Core/Services/EntityXmlSerializer.cs
@@ -709,11 +709,13 @@ internal sealed class EntityXmlSerializer : IEntityXmlSerializer
         }
     }
 
+    /// <summary>
+    /// We have two properties containing configuration data:
+    /// 1. ConfigurationData - a dictionary that contains all the configuration data stored as key/value pairs.
+    /// 2. ConfigurationObject - a strongly typed object that represents the configuration data known to the server.
+    /// To fully be able to restore the package, we need to serialize the full ConfigurationData dictionary, not
+    /// just the configuration properties known to the server.
+    /// </summary>
     private string SerializeDataTypeConfiguration(IDataType dataType) =>
-        // We have two properties containing configuration data:
-        // 1. ConfigurationData - a dictionary that contains all the configuration data stored as key/value pairs.
-        // 2. ConfigurationObject - a strongly typed object that represents the configuration data known to the server.
-        // To fully be able to restore the package, we need to serialize the full ConfigurationData dictionary, not
-        // just the configuration properties known to the server.
         _configurationEditorJsonSerializer.Serialize(dataType.ConfigurationData);
 }


### PR DESCRIPTION
Messed my previous PR up a bit, so heres a new clean one.

Previous PR https://github.com/umbraco/Umbraco-CMS/pull/20969

Closing #20801 

### Description
An issue was raised, that pointed out that when creating and downloading a package from the backoffice. The blocklist data type did not contain any other properties on a block, other than 2 IDs. The missing property mentioned in the issue was the label, however i found that a bunch of other properties were missing as well.

The initial fix for this was to manually add these properties to the configuration classes of our property editors. However this could introduce difficulties in the long run, as we'd have to maintain these configurations and keep them up to date with the frontend.

The other fix was to change the serialization to serialize the `ConfigurationData` rather than the `ConfigurationObject`. With this change in place all properties should be included in the downloaded package.xml file that appears when downloading a newly created package.

### How do you test it?

Step by step:

1. Have a blocklist data type that has a block configured with some data, perhaps a label or so.
2. Create a package, and include this blocklist data type.
3. Download your package.
4. All configurations of the block should be present on the data type in the downloaded xml
5. Create a nuget package of this, as to be able to import it again
6. Add the package back into the original project
7. Ensure that all the properties are still in place
