### PR TITLE
Back-office auth: Calculate token cookie names at request time (Closes #21050)

### DIFF
--- a/src/Umbraco.Cms.Api.Common/DependencyInjection/HideBackOfficeTokensHandler.cs
+++ b/src/Umbraco.Cms.Api.Common/DependencyInjection/HideBackOfficeTokensHandler.cs
@@ -155,8 +155,7 @@ internal sealed class HideBackOfficeTokensHandler
             return ValueTask.CompletedTask;
         }
 
-        HttpContext httpContext = GetHttpContext();
-        if (TryGetCookie(httpContext, AccessTokenCookieName, out var accessToken))
+        if (TryGetCookie(GetHttpContext(), AccessTokenCookieName, out var accessToken))
         {
             context.AccessToken = accessToken;
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/21050

### Description

The `__Host-` cookie prefix enforces secure cookies at browser level, which causes cookies to be rejected when running over HTTP in local development environments even when `UseHttps` is set to false.

With this PR, cookie names are now calculated per-request based on both the `UseHttps` setting and whether the current request is over HTTPS, matching the logic used for the Secure cookie option.

### Testing this PR

1. If `UseHttps` is set to `true`, it should be possible to log into the backoffice over HTTPS.
2. If `UseHttps` is set to `false`, it should be possible to log into the backoffice over both HTTPS and HTTP.

Also verify that the resulting cookie name prefixes (for `umbAccessToken` and `umbRefreshToken`) follow these rules:

| `UseHttps` | Request is HTTPS | Cookie name prefix          |
|----------|-----------------|-----------------------|
| `true`     | Any             | `__Host-` |
| `false`    | Yes            | `__Host-` |
| `false`    | No           | (none)        |
