### PR TITLE
News Dashboard: Adding functionality to overwrite the cache duration

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/DashboardBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/DashboardBuilderExtensions.cs
@@ -8,9 +8,10 @@ internal static class NewsDashboardBuilderExtensions
 {
     internal static IUmbracoBuilder AddNewsDashboard(this IUmbracoBuilder builder)
     {
-        builder.Services.AddSingleton<NewsDashboardOptions>();
+        builder.Services.AddSingleton<INewsCacheDurationProvider, NewsCacheDurationProvider>();
         builder.Services.AddSingleton<INewsDashboardService, NewsDashboardService>();
 
         return builder;
     }
 }
+

--- a/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/INewsCacheDurationProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/INewsCacheDurationProvider.cs
@@ -1,12 +1,12 @@
 namespace Umbraco.Cms.Api.Management.Services.NewsDashboard;
 
 /// <summary>
-/// Options for the news dashboard service.
+/// Cache duration provider for the news dashboard service.
 /// </summary>
-public class NewsDashboardOptions
+public interface INewsCacheDurationProvider
 {
     /// <summary>
     /// Gets the cache duration for news dashboard items.
     /// </summary>
-    public virtual TimeSpan CacheDuration => TimeSpan.FromMinutes(30);
+    TimeSpan CacheDuration { get; }
 }

--- a/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsCacheDurationProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsCacheDurationProvider.cs
@@ -1,0 +1,7 @@
+namespace Umbraco.Cms.Api.Management.Services.NewsDashboard;
+
+public class NewsCacheDurationProvider : INewsCacheDurationProvider
+{
+    /// <inheritdoc />
+    public TimeSpan CacheDuration => TimeSpan.FromMinutes(30);
+}

--- a/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
@@ -23,7 +23,7 @@ public class NewsDashboardService : INewsDashboardService
     private readonly ILogger<NewsDashboardService> _logger;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
     private readonly GlobalSettings _globalSettings;
-    private readonly NewsDashboardOptions _newsDashboardOptions;
+    private readonly INewsCacheDurationProvider _newsCacheDurationProvider;
 
     private static readonly HttpClient _httpClient = new();
 
@@ -37,7 +37,7 @@ public class NewsDashboardService : INewsDashboardService
         ILogger<NewsDashboardService> logger,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
         IOptions<GlobalSettings> globalSettings,
-        NewsDashboardOptions newsDashboardOptions)
+        INewsCacheDurationProvider newsCacheDurationProvider)
     {
         _appCaches = appCaches;
         _umbracoVersion = umbracoVersion;
@@ -45,7 +45,7 @@ public class NewsDashboardService : INewsDashboardService
         _logger = logger;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
         _globalSettings = globalSettings.Value;
-        _newsDashboardOptions = newsDashboardOptions;
+        _newsCacheDurationProvider = newsCacheDurationProvider;
     }
 
     [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19")]
@@ -63,7 +63,7 @@ public class NewsDashboardService : INewsDashboardService
         logger,
         backOfficeSecurityAccessor,
         globalSettings,
-        StaticServiceProvider.Instance.GetRequiredService<NewsDashboardOptions>())
+        StaticServiceProvider.Instance.GetRequiredService<INewsCacheDurationProvider>())
     {
     }
 
@@ -93,7 +93,7 @@ public class NewsDashboardService : INewsDashboardService
 
             if (TryMapModel(json, out NewsDashboardResponseModel? model))
             {
-                _appCaches.RuntimeCache.InsertCacheItem(CacheKey, () => model, _newsDashboardOptions.CacheDuration);
+                _appCaches.RuntimeCache.InsertCacheItem(CacheKey, () => model, _newsCacheDurationProvider.CacheDuration);
                 content = model;
             }
         }


### PR DESCRIPTION
### Description
This PR aims to add the ability to overwrite the cache duration, to increase or lower depending on what you want. Default is 30 minutes.


<!-- Thanks for contributing to Umbraco CMS! -->
