### PR TITLE
Blocks: localize group headline

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-tab.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-tab.element.ts
@@ -91,7 +91,7 @@ export class UmbBlockWorkspaceViewEditTabElement extends UmbLitElement {
 						this._groups,
 						(group) => group.key,
 						(group) =>
-							html`<uui-box .headline=${this.localize.string(group.name) ?? ''}>${this.renderGroup(group)}</uui-box>`,
+							html`<uui-box .headline=${this.localize.string(group.name)}>${this.renderGroup(group)}</uui-box>`,
 					)}
 		`;
 	}


### PR DESCRIPTION
Localize block group headline, for some reason, this has been an oversight.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/21082