### PR TITLE
Long Running Operations: Ensure eager write lock

### DIFF
--- a/src/Umbraco.Core/Services/LongRunningOperationService.cs
+++ b/src/Umbraco.Core/Services/LongRunningOperationService.cs
@@ -128,7 +128,7 @@ internal class LongRunningOperationService : ILongRunningOperationService
             {
                 // Acquire a write lock to ensure that no other operations of the same type can be enqueued while this one is being processed.
                 // This is only needed if we do not allow multiple runs of the same type.
-                scope.WriteLock(Constants.Locks.LongRunningOperations);
+                scope.EagerWriteLock(Constants.Locks.LongRunningOperations);
                 if (await IsAlreadyRunning(type))
                 {
                     scope.Complete();


### PR DESCRIPTION
## Summary
- Use `EagerWriteLock` instead of `WriteLock` for long running operations lock acquisition

## Details
This change ensures proper lock acquisition timing when checking if a long running operation of the same type is already running. With the introduction of lazy locks in #21102, this lock needs to be explicitly eager to maintain the expected behavior.