### PR TITLE
Media picker: Fix image selection after upload when media picker presents multiple pages (closes #21115)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -376,8 +376,9 @@ angular.module("umbraco")
                     if (vm.searchOptions.totalPages > 1) {
                         vm.searchOptions.pageNumber = vm.searchOptions.totalPages;
                         return getChildren($scope.currentFolder.id);
+                    } else {
+                        return Promise.resolve();
                     }
-
                 }).then(function () {
 
                     // Select the newly uploaded items.


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/21115

### Description
This PR fixes a regression introduced in https://github.com/umbraco/Umbraco-CMS/pull/20202 that prevented correct automatic selection of an uploaded image when there were more images to display than a single page.

After the upload completes, the code now checks if there are multiple pages and if so, navigates to the last page and selects the newly uploaded image(s) from there.

### Testing
To test this fix:

- Have a media folder with > 100 items (or temporarily lower the page size configured in `mediapicker.controller.js`, line 87.
- Upload a media file to the folder.
- Verify that the last page of media items is displayed and the uploaded item is now automatically selected.
