### PR TITLE
UFM: Resolves "missing filter" console warning

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/ufm-element-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/ufm-element-base.ts
@@ -36,6 +36,8 @@ export abstract class UmbUfmElementBase extends UmbLitElement {
 	}
 
 	override render() {
+		if (!this.isConnected) return;
+
 		let values = Array.isArray(this.value) ? this.value : [this.value];
 
 		if (this.#filterFuncArgs) {


### PR DESCRIPTION
### Description

When editing a Block entry (in a modal) that made use of a UFM Filter, e.g. `{umbValue: headline | uppercase}`, by closing the model, the would be a warning in the browser console, `UFM filters with aliases "uppercase" were not found.`. Even though the UFM filter does exist.

This is triggered when the UFM Component element has been disconnected from the DOM and still attempts to render, _(for some reason 🤷)_, meaning that the UFM context is no longer available to component and unable to find any filters.

The resolution is to check if the UFM Component is still connected to the DOM, if not then early exit from the method.