### PR TITLE
Manifests: Fix misnaming and mis-registering of the document validation manifest (closes #21128)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/manifests.ts
@@ -1,3 +1,4 @@
 import { manifests as detailManifests } from './detail/manifests.js';
+import { manifests as validationManifests } from './validation/manifests.js';
 
-export const manifests: Array<UmbExtensionManifest> = [...detailManifests];
+export const manifests: Array<UmbExtensionManifest> = [...detailManifests, ...validationManifests];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/validation/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/validation/constants.ts
@@ -1,1 +1,1 @@
-export const UMB_MEDIA_VALIDATION_REPOSITORY_ALIAS = 'Umb.Repository.Document.Validation';
+export const UMB_MEDIA_VALIDATION_REPOSITORY_ALIAS = 'Umb.Repository.Media.Validation';


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

Fixes: https://github.com/umbraco/Umbraco-CMS/issues/21128

### Description
This was clearly a copy/paste error, but was confused that it didn't log a warning at runtime, as normally that's what you see if you try to register a manifest with a duplicate alias.

The reason was that the document validation repository wasn't being registered.

So this PR fixes both issues.

### Testing
Tricky, as I'm not sure what problem in reality this missed registration actually caused!  Document validation appears to work correctly both before and after this change.
