### PR TITLE
Update nightly build to include 16 as 17 is now main

### DIFF
--- a/build/nightly-build-trigger.yml
+++ b/build/nightly-build-trigger.yml
@@ -9,7 +9,7 @@ schedules:
   branches:
     include:
     - v13/dev
-    - v17/dev
+    - v16/dev
     - main
 
 steps:


### PR DESCRIPTION
Since we switched v17/dev to main, we need to manually include v16 in the nightly builds.
