### PR TITLE
Move/Duplicate: Add early validation for content type and structure constraints (closes #20451)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Server/ConfigurationServerController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Server/ConfigurationServerController.cs
@@ -2,11 +2,13 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Cms.Api.Management.ViewModels.Server;
 using Umbraco.Cms.Core.Configuration.Models;
-
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Hosting;
 namespace Umbraco.Cms.Api.Management.Controllers.Server;
 
 [ApiVersion("1.0")]
@@ -15,12 +17,21 @@ public class ConfigurationServerController : ServerControllerBase
     private readonly SecuritySettings _securitySettings;
     private readonly GlobalSettings _globalSettings;
     private readonly IBackOfficeExternalLoginProviders _externalLoginProviders;
+    private readonly IHostingEnvironment _hostingEnvironment;
 
-    public ConfigurationServerController(IOptions<SecuritySettings> securitySettings, IOptions<GlobalSettings> globalSettings, IBackOfficeExternalLoginProviders externalLoginProviders)
+    [ActivatorUtilitiesConstructor]
+    public ConfigurationServerController(IOptions<SecuritySettings> securitySettings, IOptions<GlobalSettings> globalSettings, IBackOfficeExternalLoginProviders externalLoginProviders, IHostingEnvironment hostingEnvironment)
     {
         _securitySettings = securitySettings.Value;
         _globalSettings = globalSettings.Value;
         _externalLoginProviders = externalLoginProviders;
+        _hostingEnvironment = hostingEnvironment;
+    }
+
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
+    public ConfigurationServerController(IOptions<SecuritySettings> securitySettings, IOptions<GlobalSettings> globalSettings, IBackOfficeExternalLoginProviders externalLoginProviders)
+        : this(securitySettings, globalSettings, externalLoginProviders, StaticServiceProvider.Instance.GetRequiredService<IHostingEnvironment>())
+    {
     }
 
     [AllowAnonymous]
@@ -34,6 +45,7 @@ public class ConfigurationServerController : ServerControllerBase
             AllowPasswordReset = _securitySettings.AllowPasswordReset,
             VersionCheckPeriod = _globalSettings.VersionCheckPeriod,
             AllowLocalLogin = _externalLoginProviders.HasDenyLocalLogin() is false,
+            UmbracoCssPath = _hostingEnvironment.ToAbsolute(_globalSettings.UmbracoCssPath),
         };
 
         return Task.FromResult<IActionResult>(Ok(responseModel));

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Server/ServerConfigurationResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Server/ServerConfigurationResponseModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Server;
+namespace Umbraco.Cms.Api.Management.ViewModels.Server;
 
 public class ServerConfigurationResponseModel
 {
@@ -7,4 +7,6 @@ public class ServerConfigurationResponseModel
     public int VersionCheckPeriod { get; set; }
 
     public bool AllowLocalLogin { get; set; }
+
+    public string UmbracoCssPath { get; set; } = string.Empty;
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -284,6 +284,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IDictionaryItemService, DictionaryItemService>();
             Services.AddUnique<IDataTypeContainerService, DataTypeContainerService>();
             Services.AddUnique<IContentTypeContainerService, ContentTypeContainerService>();
+            Services.AddUnique<IContentTypeSchemaService, ContentTypeSchemaService>();
             Services.AddUnique<IMediaTypeContainerService, MediaTypeContainerService>();
             Services.AddUnique<IContentBlueprintContainerService, ContentBlueprintContainerService>();
             Services.AddUnique<IIsoCodeValidator, IsoCodeValidator>();

--- a/src/Umbraco.Core/Models/ContentTypePropertySchemaInfo.cs
+++ b/src/Umbraco.Core/Models/ContentTypePropertySchemaInfo.cs
@@ -1,0 +1,27 @@
+namespace Umbraco.Cms.Core.Models;
+
+/// <summary>
+/// Represents the subset of content type property information that is needed for schema generation.
+/// </summary>
+public class ContentTypePropertySchemaInfo
+{
+    /// <summary>
+    /// Gets the property alias.
+    /// </summary>
+    public required string Alias { get; init; }
+
+    /// <summary>
+    /// Gets the property editor alias.
+    /// </summary>
+    public required string EditorAlias { get; init; }
+
+    /// <summary>
+    /// Gets the CLR type used to represent this property in the Delivery API.
+    /// </summary>
+    public required Type DeliveryApiClrType { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this property is inherited from a composition.
+    /// </summary>
+    public bool Inherited { get; init; }
+}

--- a/src/Umbraco.Core/Models/ContentTypeSchemaInfo.cs
+++ b/src/Umbraco.Core/Models/ContentTypeSchemaInfo.cs
@@ -1,0 +1,32 @@
+namespace Umbraco.Cms.Core.Models;
+
+/// <summary>
+/// Represents the subset of content type information that is needed for schema generation.
+/// </summary>
+public class ContentTypeSchemaInfo
+{
+    /// <summary>
+    /// Gets the content type alias.
+    /// </summary>
+    public required string Alias { get; init; }
+
+    /// <summary>
+    /// Gets the content type schema ID.
+    /// </summary>
+    public required string SchemaId { get; init; }
+
+    /// <summary>
+    /// Gets the schema IDs of the content type's compositions.
+    /// </summary>
+    public required IReadOnlyList<string> CompositionSchemaIds { get; init; }
+
+    /// <summary>
+    /// Gets the properties for this content type.
+    /// </summary>
+    public required IReadOnlyList<ContentTypePropertySchemaInfo> Properties { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the content type is an element type.
+    /// </summary>
+    public bool IsElement { get; init; }
+}

--- a/src/Umbraco.Core/Services/ContentTypeSchemaService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeSchemaService.cs
@@ -1,0 +1,87 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Services;
+
+/// <inheritdoc />
+internal sealed class ContentTypeSchemaService : IContentTypeSchemaService
+{
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IMediaTypeService _mediaTypeService;
+    private readonly IPublishedContentTypeCache _publishedContentTypeCache;
+    private readonly IShortStringHelper _shortStringHelper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContentTypeSchemaService"/> class.
+    /// </summary>
+    public ContentTypeSchemaService(
+        IContentTypeService contentTypeService,
+        IMediaTypeService mediaTypeService,
+        IPublishedContentTypeCache publishedContentTypeCache,
+        IShortStringHelper shortStringHelper)
+    {
+        _contentTypeService = contentTypeService;
+        _mediaTypeService = mediaTypeService;
+        _publishedContentTypeCache = publishedContentTypeCache;
+        _shortStringHelper = shortStringHelper;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<ContentTypeSchemaInfo> GetDocumentTypes()
+        => GetContentTypeSchemaInfos(PublishedItemType.Content, _contentTypeService.GetAll());
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<ContentTypeSchemaInfo> GetMediaTypes()
+        => GetContentTypeSchemaInfos(PublishedItemType.Media, _mediaTypeService.GetAll());
+
+    private List<ContentTypeSchemaInfo> GetContentTypeSchemaInfos(
+        PublishedItemType itemType,
+        IEnumerable<IContentTypeComposition> contentTypes)
+    {
+        List<ContentTypeSchemaInfo> result = [];
+
+        foreach (IContentTypeComposition contentType in contentTypes)
+        {
+            IPublishedContentType publishedContentType;
+            try
+            {
+                publishedContentType = _publishedContentTypeCache.Get(itemType, contentType.Alias);
+            }
+            catch
+            {
+                // Skip content types that fail to load from cache
+                continue;
+            }
+
+            HashSet<string> ownPropertyAliases = [.. contentType.PropertyTypes.Select(p => p.Alias)];
+
+            result.Add(
+                new ContentTypeSchemaInfo
+                {
+                    Alias = contentType.Alias,
+                    SchemaId = GetContentTypeSchemaId(contentType.Alias),
+                    CompositionSchemaIds = [.. publishedContentType.CompositionAliases.Select(GetContentTypeSchemaId)],
+                    Properties =
+                    [
+                        .. publishedContentType.PropertyTypes.Select(p => new ContentTypePropertySchemaInfo
+                        {
+                            Alias = p.Alias,
+                            EditorAlias = p.EditorAlias,
+                            DeliveryApiClrType = p.DeliveryApiModelClrType,
+                            Inherited = ownPropertyAliases.Contains(p.Alias) is false,
+                        })
+                    ],
+                    IsElement = publishedContentType.IsElement,
+                });
+        }
+
+        return result;
+    }
+
+    // Currently uses the same transformation as ModelsBuilder (UmbracoServices.GetClrName)
+    private string GetContentTypeSchemaId(string contentTypeAlias) =>
+        contentTypeAlias.ToCleanString(_shortStringHelper, CleanStringType.ConvertCase | CleanStringType.PascalCase);
+}

--- a/src/Umbraco.Core/Services/IContentTypeSchemaService.cs
+++ b/src/Umbraco.Core/Services/IContentTypeSchemaService.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Umbraco.Cms.Core.Services;
+
+/// <summary>
+/// Service to get content type schema information for schema generation.
+/// </summary>
+public interface IContentTypeSchemaService
+{
+    /// <summary>
+    /// Gets all available document types.
+    /// </summary>
+    /// <returns>A collection of document type schema information.</returns>
+    public IReadOnlyCollection<ContentTypeSchemaInfo> GetDocumentTypes();
+
+    /// <summary>
+    /// Gets all available media types.
+    /// </summary>
+    /// <returns>A collection of media type schema information.</returns>
+    public IReadOnlyCollection<ContentTypeSchemaInfo> GetMediaTypes();
+}

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -1,6 +1,7 @@
 using HtmlAgilityPack;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.PublishedCache;
@@ -143,12 +144,21 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
             mediaCache,
             href,
             type,
-            route =>
+            (route, content) =>
             {
+                attributes["destinationId"] = content.Key.ToString("D");
+                attributes["destinationType"] = content.ContentType.Alias;
+                attributes["linkType"] = nameof(LinkType.Content);
                 attributes["route"] = route;
                 attributes.Remove("href");
             },
-            url => attributes["href"] = url,
+            (url, media) =>
+            {
+                attributes["destinationId"] = media.Key.ToString("D");
+                attributes["destinationType"] = media.ContentType.Alias;
+                attributes["linkType"] = nameof(LinkType.Media);
+                attributes["href"] = url;
+            },
             () => attributes.Remove("href"));
     }
 

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Extensions;
 
@@ -58,17 +59,23 @@ internal sealed class ApiRichTextMarkupParser : ApiRichTextParserBase, IApiRichT
                     mediaCache,
                 link.GetAttributeValue("href", string.Empty),
                 link.GetAttributeValue("type", "unknown"),
-                route =>
+                (route, content) =>
                 {
                     link.SetAttributeValue("href", $"{route.Path}{route.QueryString}");
+                    link.SetAttributeValue("data-destination-id", content.Key.ToString("D"));
+                    link.SetAttributeValue("data-destination-type", content.ContentType.Alias);
                     link.SetAttributeValue("data-start-item-path", route.StartItem.Path);
                     link.SetAttributeValue("data-start-item-id", route.StartItem.Id.ToString("D"));
                     link.Attributes["type"]?.Remove();
+                    link.SetAttributeValue("data-link-type", nameof(LinkType.Content));
                 },
-                url =>
+                (url, media) =>
                 {
                     link.SetAttributeValue("href", url);
+                    link.SetAttributeValue("data-destination-id", media.Key.ToString("D"));
+                    link.SetAttributeValue("data-destination-type", media.ContentType.Alias);
                     link.Attributes["type"]?.Remove();
+                    link.SetAttributeValue("data-link-type", nameof(LinkType.Media));
                 },
                 () =>
                 {

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
@@ -21,7 +21,7 @@ internal abstract partial class ApiRichTextParserBase
         _apiMediaUrlProvider = apiMediaUrlProvider;
     }
 
-    protected void ReplaceLocalLinks(IPublishedContentCache contentCache, IPublishedMediaCache mediaCache, string href, string type, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl, Action handleInvalidLink)
+    protected void ReplaceLocalLinks(IPublishedContentCache contentCache, IPublishedMediaCache mediaCache, string href, string type, Action<IApiContentRoute, IPublishedContent> handleContentRoute, Action<string, IPublishedContent> handleMediaUrl, Action handleInvalidLink)
     {
         ReplaceStatus replaceAttempt = ReplaceLocalLink(contentCache, mediaCache, href, type, handleContentRoute, handleMediaUrl);
         if (replaceAttempt == ReplaceStatus.Success)
@@ -35,7 +35,7 @@ internal abstract partial class ApiRichTextParserBase
         }
     }
 
-    private ReplaceStatus ReplaceLocalLink(IPublishedContentCache contentCache, IPublishedMediaCache mediaCache, string href, string type, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl)
+    private ReplaceStatus ReplaceLocalLink(IPublishedContentCache contentCache, IPublishedMediaCache mediaCache, string href, string type, Action<IApiContentRoute, IPublishedContent> handleContentRoute, Action<string, IPublishedContent> handleMediaUrl)
     {
         Match match = LocalLinkRegex().Match(href);
         if (match.Success is false)
@@ -60,7 +60,7 @@ internal abstract partial class ApiRichTextParserBase
                 if (route != null)
                 {
                     route.QueryString = match.Groups["query"].Value.NullOrWhiteSpaceAsNull();
-                    handleContentRoute(route);
+                    handleContentRoute(route, content!);
                     return ReplaceStatus.Success;
                 }
 
@@ -69,7 +69,7 @@ internal abstract partial class ApiRichTextParserBase
                 IPublishedContent? media = mediaCache.GetById(guid);
                 if (media != null)
                 {
-                    handleMediaUrl(_apiMediaUrlProvider.GetUrl(media));
+                    handleMediaUrl(_apiMediaUrlProvider.GetUrl(media), media);
                     return ReplaceStatus.Success;
                 }
 
@@ -79,7 +79,7 @@ internal abstract partial class ApiRichTextParserBase
         return ReplaceStatus.InvalidEntityType;
     }
 
-    private ReplaceStatus ReplaceLegacyLocalLink(IPublishedContentCache contentCache, IPublishedMediaCache mediaCache, string href, Action<IApiContentRoute> handleContentRoute, Action<string> handleMediaUrl)
+    private ReplaceStatus ReplaceLegacyLocalLink(IPublishedContentCache contentCache, IPublishedMediaCache mediaCache, string href, Action<IApiContentRoute, IPublishedContent> handleContentRoute, Action<string, IPublishedContent> handleMediaUrl)
     {
         Match match = LegacyLocalLinkRegex().Match(href);
         if (match.Success is false)
@@ -108,7 +108,7 @@ internal abstract partial class ApiRichTextParserBase
                 if (route != null)
                 {
                     route.QueryString = match.Groups["query"].Value.NullOrWhiteSpaceAsNull();
-                    handleContentRoute(route);
+                    handleContentRoute(route, content!);
                     return ReplaceStatus.Success;
                 }
 
@@ -117,7 +117,7 @@ internal abstract partial class ApiRichTextParserBase
                 IPublishedContent? media = mediaCache.GetById(guidUdi.Guid);
                 if (media != null)
                 {
-                    handleMediaUrl(_apiMediaUrlProvider.GetUrl(media));
+                    handleMediaUrl(_apiMediaUrlProvider.GetUrl(media), media);
                     return ReplaceStatus.Success;
                 }
 

--- a/src/Umbraco.Web.UI.Client/examples/block-workspace-context/README.md
+++ b/src/Umbraco.Web.UI.Client/examples/block-workspace-context/README.md
@@ -1,0 +1,9 @@
+# Consuming Variant Context in a Block Workspace View Example
+This example demonstrates how to consume and display the contextual variant information (culture and segment) from the `UMB_VARIANT_CONTEXT` within a block workspace view extension.
+
+## What this example includes
+- **Workspace View** – A custom workspace view that reads the current variant context (culture and segment) and displays it to the user.
+
+## How it works
+The workspace view extension uses the `UMB_VARIANT_CONTEXT` context token to access the current variant's culture and segment. This allows the extension to react to changes in the variant context and display the relevant information.
+This pattern is useful for extension developers who need to make their workspace views aware of the current variant, enabling context-sensitive UI and logic.

--- a/src/Umbraco.Web.UI.Client/examples/block-workspace-context/block-workspace-view.ts
+++ b/src/Umbraco.Web.UI.Client/examples/block-workspace-context/block-workspace-view.ts
@@ -1,0 +1,50 @@
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { css, html, customElement, state, LitElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+import { UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
+import type { UmbWorkspaceViewElement } from '@umbraco-cms/backoffice/workspace';
+
+@customElement('example-block-workspace-view')
+export class ExampleBlockWorkspaceViewElement extends UmbElementMixin(LitElement) implements UmbWorkspaceViewElement {
+	@state()
+	private _culture?: string | null;
+	@state()
+	private _segment?: string | null;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_VARIANT_CONTEXT, (context) => {
+			this.observe(context?.displayVariantId, (variantId) => {
+				this._culture = variantId?.culture;
+				this._segment = variantId?.segment;
+			});
+		});
+	}
+
+	override render() {
+		return html`
+			<uui-box class="uui-text">
+				<p class="uui-lead">Current variant context culture: ${this._culture}, & segment of : ${this._segment}</p>
+			</uui-box>
+		`;
+	}
+
+	static override styles = [
+		UmbTextStyles,
+		css`
+			:host {
+				display: block;
+				padding: var(--uui-size-layout-1);
+			}
+		`,
+	];
+}
+
+export default ExampleBlockWorkspaceViewElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'example-block-workspace-view': ExampleBlockWorkspaceViewElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/examples/block-workspace-context/index.ts
+++ b/src/Umbraco.Web.UI.Client/examples/block-workspace-context/index.ts
@@ -1,0 +1,23 @@
+import { UMB_BLOCK_WORKSPACE_ALIAS } from '@umbraco-cms/backoffice/block';
+import { UMB_WORKSPACE_CONDITION_ALIAS } from '@umbraco-cms/backoffice/workspace';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'workspaceView',
+		name: 'Example Block Workspace View',
+		alias: 'example.workspaceView.block',
+		element: () => import('./block-workspace-view.js'),
+		weight: 900,
+		meta: {
+			label: 'Counter',
+			pathname: 'counter',
+			icon: 'icon-lab',
+		},
+		conditions: [
+			{
+				alias: UMB_WORKSPACE_CONDITION_ALIAS,
+				match: UMB_BLOCK_WORKSPACE_ALIAS,
+			},
+		],
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/server.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/server.handlers.ts
@@ -49,6 +49,7 @@ export const serverInformationHandlers = [
 				allowPasswordReset: true,
 				versionCheckPeriod: 7, // days
 				allowLocalLogin: true,
+				umbracoCssPath: '/css',
 			}),
 		);
 	}),

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-editor/property-editor-ui-block-grid.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-editor/property-editor-ui-block-grid.element.ts
@@ -12,13 +12,14 @@ import {
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
-import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbBlockTypeGroup } from '@umbraco-cms/backoffice/block-type';
 import type {
 	UmbPropertyEditorUiElement,
 	UmbPropertyEditorConfigCollection,
 } from '@umbraco-cms/backoffice/property-editor';
+import { UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
 
 // TODO: consider moving the components to the property editor folder as they are only used here
 import '../../local-components.js';
@@ -232,8 +233,14 @@ export class UmbPropertyEditorUIBlockGridElement
 			);
 		});
 
-		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (context) => {
-			this.#managerContext.setVariantId(context?.getVariantId());
+		this.consumeContext(UMB_VARIANT_CONTEXT, async (context) => {
+			this.observe(
+				context?.displayVariantId,
+				(variantId) => {
+					this.#managerContext.setVariantId(variantId);
+				},
+				'observeContextualVariantId',
+			);
 		});
 
 		this.observe(this.#managerContext.isSortMode, (isSortMode) => (this._isSortMode = isSortMode ?? false));

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -14,7 +14,7 @@ import {
 import { jsonStringComparison, observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { umbDestroyOnDisconnect, UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
-import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
 import type { UmbBlockLayoutBaseModel } from '@umbraco-cms/backoffice/block';
 import type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/block-type';
@@ -25,6 +25,7 @@ import type {
 	UmbPropertyEditorUiElement,
 } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbSorterConfig } from '@umbraco-cms/backoffice/sorter';
+import { UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
 
 import '../../components/block-list-entry/index.js';
 
@@ -248,8 +249,14 @@ export class UmbPropertyEditorUIBlockListElement
 			null,
 		);
 
-		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, async (context) => {
-			this.#managerContext.setVariantId(context?.getVariantId());
+		this.consumeContext(UMB_VARIANT_CONTEXT, async (context) => {
+			this.observe(
+				context?.displayVariantId,
+				(variantId) => {
+					this.#managerContext.setVariantId(variantId);
+				},
+				'observeContextualVariantId',
+			);
 		});
 
 		this.observe(this.#managerContext.isSortMode, (isSortMode) => (this._isSortMode = isSortMode ?? false));

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/property-editor-ui-block-single.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/property-editor-ui-block-single.element.ts
@@ -26,7 +26,7 @@ import type { UmbBlockLayoutBaseModel } from '@umbraco-cms/backoffice/block';
 import type { UmbBlockTypeBaseModel } from '@umbraco-cms/backoffice/block-type';
 
 import '../../components/block-single-entry/index.js';
-import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import {
 	extractJsonQueryProps,
 	UMB_VALIDATION_EMPTY_LOCALIZATION_KEY,
@@ -36,6 +36,7 @@ import {
 import { jsonStringComparison, observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { debounceTime } from '@umbraco-cms/backoffice/external/rxjs';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
+import { UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
 
 const SORTER_CONFIG: UmbSorterConfig<UmbBlockSingleLayoutModel, UmbBlockSingleEntryElement> = {
 	getUniqueOfElement: (element) => {
@@ -244,8 +245,14 @@ export class UmbPropertyEditorUIBlockSingleElement
 			null,
 		);
 
-		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, async (context) => {
-			this.#managerContext.setVariantId(context?.getVariantId());
+		this.consumeContext(UMB_VARIANT_CONTEXT, async (context) => {
+			this.observe(
+				context?.displayVariantId,
+				(variantId) => {
+					this.#managerContext.setVariantId(variantId);
+				},
+				'observeContextualVariantId',
+			);
 		});
 
 		this.addValidator(

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -714,7 +714,7 @@ export abstract class UmbBlockEntryContext<
 		this.observe(
 			this._manager?.hasExposeOf(this.#contentKey, variantId),
 			(hasExpose) => {
-				this.#hasExpose.setValue(hasExpose);
+				this.#hasExpose.setValue(hasExpose ?? false);
 			},
 			'observeExpose',
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-manager.context.ts
@@ -243,20 +243,57 @@ export abstract class UmbBlockManagerContext<
 	settingsOf(key: string) {
 		return this.#settings.asObservablePart((source) => source.find((x) => x.key === key));
 	}
+
 	currentExposeOf(contentKey: string) {
-		const variantId = this.getVariantId();
-		if (!variantId) return;
 		return mergeObservables(
 			[this.#exposes.asObservablePart((source) => source.filter((x) => x.contentKey === contentKey)), this.variantId],
-			([exposes, variantId]) => (variantId ? exposes.find((x) => variantId.compare(x)) : undefined),
+			([exposes, variantId]) => {
+				if (!variantId) {
+					return undefined;
+				}
+
+				const contentTypeKey = this.getContentTypeKeyOfContentKey(contentKey);
+				if (!contentTypeKey) {
+					return false;
+				}
+				const contentStructure = this.getStructure(contentTypeKey);
+				if (!contentStructure) {
+					throw new Error(`Cannot lookup expose of block, missing content structure for ${contentTypeKey}`);
+				}
+
+				const varyByCulture = contentStructure.getVariesByCulture();
+				const varyBySegment = contentStructure.getVariesBySegment();
+				const blockVariantId = variantId.toVariant(varyByCulture, varyBySegment);
+
+				return exposes.find((x) => blockVariantId.compare(x));
+			},
 		);
 	}
 
 	hasExposeOf(contentKey: string, variantId: UmbVariantId) {
 		if (!variantId) return;
-		return this.#exposes.asObservablePart((source) =>
-			source.some((x) => x.contentKey === contentKey && variantId.compare(x)),
-		);
+
+		const contentTypeKey = this.getContentTypeKeyOfContentKey(contentKey);
+		if (!contentTypeKey) {
+			// Not created yet and therefor not exposed.
+			// (This currently does not give any trouble,
+			// but this is not returning a observable,
+			// meaning one trying to observe this would
+			// not be updated when it is exposed. But it
+			// is not a problem currently. [NL])
+			return;
+		}
+		const contentStructure = this.getStructure(contentTypeKey);
+		if (!contentStructure) {
+			throw new Error(`Cannot lookup expose of block, missing content structure for ${contentTypeKey}`);
+		}
+		const varyByCulture = contentStructure.getVariesByCulture();
+		const varyBySegment = contentStructure.getVariesBySegment();
+		const blockVariantId = variantId.toVariant(varyByCulture, varyBySegment);
+
+		return this.#exposes.asObservablePart((exposes) => {
+			return exposes.some((x) => x.contentKey === contentKey && blockVariantId.compare(x));
+		});
 	}
 
 	getBlockTypeOf(contentTypeKey: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -188,7 +188,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 				this.observe(
 					manager.hasExposeOf(contentKey, variantId),
 					(exposed) => {
-						this.#exposed.setValue(exposed);
+						this.#exposed.setValue(exposed ?? false);
 					},
 					'observeHasExpose',
 				);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
@@ -2321,6 +2321,7 @@ export type ServerConfigurationResponseModel = {
     allowPasswordReset: boolean;
     versionCheckPeriod: number;
     allowLocalLogin: boolean;
+    umbracoCssPath: string;
 };
 
 export type ServerInformationResponseModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/server-connection.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/server-connection.ts
@@ -1,7 +1,7 @@
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { RuntimeLevelModel, ServerService } from '@umbraco-cms/backoffice/external/backend-api';
-import { UmbBooleanState, UmbNumberState } from '@umbraco-cms/backoffice/observable-api';
+import { UmbBooleanState, UmbNumberState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
 
 export class UmbServerConnection extends UmbControllerBase {
@@ -19,6 +19,9 @@ export class UmbServerConnection extends UmbControllerBase {
 
 	#allowPasswordReset = new UmbBooleanState(false);
 	allowPasswordReset = this.#allowPasswordReset.asObservable();
+
+	#umbracoCssPath = new UmbStringState(undefined);
+	umbracoCssPath = this.#umbracoCssPath.asObservable();
 
 	constructor(host: UmbControllerHost, serverUrl: string) {
 		super(host);
@@ -86,5 +89,6 @@ export class UmbServerConnection extends UmbControllerBase {
 		this.#versionCheckPeriod.setValue(data?.versionCheckPeriod);
 		this.#allowLocalLogin.setValue(data?.allowLocalLogin ?? false);
 		this.#allowPasswordReset.setValue(data?.allowPasswordReset ?? false);
+		this.#umbracoCssPath.setValue(data?.umbracoCssPath);
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/context/variant.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/context/variant.context.ts
@@ -2,7 +2,12 @@ import { UmbVariantId } from '../variant-id.class.js';
 import { UMB_VARIANT_CONTEXT } from './variant.context.token.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
-import { mergeObservables, UmbClassState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
+import {
+	createObservablePart,
+	mergeObservables,
+	UmbClassState,
+	UmbStringState,
+} from '@umbraco-cms/backoffice/observable-api';
 
 /**
  * A context for the current variant state.
@@ -11,20 +16,40 @@ import { mergeObservables, UmbClassState, UmbStringState } from '@umbraco-cms/ba
  * @implements {UmbVariantContext}
  */
 export class UmbVariantContext extends UmbContextBase {
+	// Local variant ID:
 	#variantId = new UmbClassState<UmbVariantId | undefined>(undefined);
 	public readonly variantId = this.#variantId.asObservable();
 	public readonly culture = this.#variantId.asObservablePart((x) => x?.culture);
 	public readonly segment = this.#variantId.asObservablePart((x) => x?.segment);
+
+	// The inherited variant ID is the inherited variant ID from parent contexts, only set when inherited: [NL]
+	#inheritedVariantId = new UmbClassState<UmbVariantId | undefined>(undefined);
+	// The display variant ID observables, this is based on the inherited variantID and adapted with the local variant ID: [NL]
+	public readonly displayVariantId = mergeObservables(
+		[this.#inheritedVariantId.asObservable(), this.variantId],
+		([contextual, local]) => {
+			// If no context, then provide the local: [NL]
+			if (!contextual) return local;
+			// If a context, then adjust with the local variant ID specifics. (But only for defined cultures or segments) [NL]
+			let variantId = contextual.clone();
+			if (!local) return variantId;
+			if (!local.isCultureInvariant()) {
+				variantId = variantId.toCulture(local.culture);
+			}
+			if (!local.isSegmentInvariant()) {
+				variantId = variantId.toSegment(local.segment);
+			}
+			return variantId;
+		},
+	);
+	public readonly displayCulture = createObservablePart(this.displayVariantId, (x) => x?.culture);
+	public readonly displaySegment = createObservablePart(this.displayVariantId, (x) => x?.segment);
 
 	#fallbackCulture = new UmbStringState<string | null | undefined>(undefined);
 	public fallbackCulture = this.#fallbackCulture.asObservable();
 
 	#appCulture = new UmbStringState<string | null | undefined>(undefined);
 	public appCulture = this.#appCulture.asObservable();
-
-	public readonly displayCulture = mergeObservables([this.culture, this.appCulture], ([culture, appCulture]) => {
-		return culture ?? appCulture;
-	});
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_VARIANT_CONTEXT);
@@ -37,6 +62,14 @@ export class UmbVariantContext extends UmbContextBase {
 	 */
 	inherit(): UmbVariantContext {
 		this.consumeContext(UMB_VARIANT_CONTEXT, (context) => {
+			this.observe(
+				context?.displayVariantId,
+				(contextualVariantId) => {
+					this.#inheritedVariantId.setValue(contextualVariantId);
+				},
+				'observeContextualVariantId',
+			);
+
 			this.observe(
 				context?.fallbackCulture,
 				(fallbackCulture) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/variant/variant-id.class.ts
@@ -71,7 +71,7 @@ export class UmbVariantId {
 	}
 
 	public clone(): UmbVariantId {
-		return new UmbVariantId(null, this.segment);
+		return new UmbVariantId(this.culture, this.segment);
 	}
 
 	public toObject(): UmbObjectWithVariantProperties {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -447,6 +447,8 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		css`
 			:host {
 				position: relative;
+				display: block;
+				width: 100%;
 			}
 			.container {
 				display: grid;

--- a/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/rte/components/rte-base.element.ts
@@ -10,9 +10,9 @@ import {
 	UMB_VALIDATION_EMPTY_LOCALIZATION_KEY,
 } from '@umbraco-cms/backoffice/validation';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { UMB_VARIANT_CONTEXT, UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UMB_CONTENT_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content';
-import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
 import type { StyleInfo } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbBlockDataModel } from '@umbraco-cms/backoffice/block';
 import type { UmbBlockRteLayoutModel, UmbBlockRteTypeModel } from '@umbraco-cms/backoffice/block-rte';
@@ -192,8 +192,14 @@ export abstract class UmbPropertyEditorUiRteElementBase
 			this.#gotPropertyContext(context);
 		});
 
-		this.consumeContext(UMB_PROPERTY_DATASET_CONTEXT, (context) => {
-			this.#managerContext.setVariantId(context?.getVariantId());
+		this.consumeContext(UMB_VARIANT_CONTEXT, async (context) => {
+			this.observe(
+				context?.displayVariantId,
+				(variantId) => {
+					this.#managerContext.setVariantId(variantId);
+				},
+				'observeContextualVariantId',
+			);
 		});
 
 		this.observe(

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/contexts/tiptap-rte.context.ts
@@ -1,13 +1,25 @@
 import type { Editor } from '../externals.js';
 import { UMB_TIPTAP_RTE_CONTEXT } from './tiptap-rte.context-token.js';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import { UmbStringState } from '@umbraco-cms/backoffice/observable-api';
+import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbTiptapRteContext extends UmbContextBase {
 	#editor?: Editor;
 
+	#stylesheetRootPath = new UmbStringState(undefined);
+	stylesheetRootPath = this.#stylesheetRootPath.asObservable();
+
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_TIPTAP_RTE_CONTEXT);
+
+		this.consumeContext(UMB_SERVER_CONTEXT, (serverContext) => {
+			const serverConnection = serverContext?.getServerConnection();
+			this.observe(serverConnection?.umbracoCssPath, (umbracoCssPath) => {
+				this.#stylesheetRootPath.setValue(umbracoCssPath);
+			});
+		});
 	}
 
 	public getEditor(): Editor | undefined {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeSchemaServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeSchemaServiceTests.cs
@@ -1,0 +1,79 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models.DeliveryApi;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class ContentTypeSchemaServiceTests : UmbracoIntegrationTestWithContentEditing
+{
+    // Required to register IPublishedContentTypeCache (even though it uses in-memory cache, not HybridCache)
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+        => builder.AddUmbracoHybridCache();
+
+    private IContentTypeSchemaService ContentTypeSchemaService =>
+        GetRequiredService<IContentTypeSchemaService>();
+
+    private IContentTypeService ContentTypeService =>
+        GetRequiredService<IContentTypeService>();
+
+    private IMediaTypeService MediaTypeService =>
+        GetRequiredService<IMediaTypeService>();
+
+    [Test]
+    public void Can_Get_DocumentTypes()
+    {
+        // Act
+        var result = ContentTypeSchemaService.GetDocumentTypes();
+
+        // Assert - count should match the content type service
+        Assert.That(result, Has.Count.EqualTo(ContentTypeService.Count()));
+
+        var contentTypeSchema = result.FirstOrDefault(ct => ct.Alias == ContentType.Alias);
+        Assert.That(contentTypeSchema, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(contentTypeSchema!.Alias, Is.EqualTo("umbTextpage"));
+            Assert.That(contentTypeSchema.SchemaId, Is.EqualTo("UmbTextpage"));
+            Assert.That(contentTypeSchema.Properties, Has.Count.EqualTo(1));
+        });
+
+        // Verify property details - the base class creates a "title" property
+        var titleProperty = contentTypeSchema!.Properties.First();
+        Assert.Multiple(() =>
+        {
+            Assert.That(titleProperty.Alias, Is.EqualTo("title"));
+            Assert.That(titleProperty.EditorAlias, Is.EqualTo("Umbraco.TextArea"));
+            Assert.That(titleProperty.Inherited, Is.False);
+            Assert.That(titleProperty.DeliveryApiClrType, Is.EqualTo(typeof(string)));
+        });
+    }
+
+    [Test]
+    public void Can_Get_MediaTypes()
+    {
+        // Act
+        var result = ContentTypeSchemaService.GetMediaTypes();
+
+        // Assert - count should match the media type service
+        Assert.That(result, Has.Count.EqualTo(MediaTypeService.Count()));
+
+        // Built-in Image media type should be present with its properties
+        var imageSchema = result.FirstOrDefault(mt => mt.Alias == "Image");
+        Assert.That(imageSchema, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(imageSchema!.SchemaId, Is.EqualTo("Image"));
+            Assert.That(imageSchema.Properties, Is.Not.Empty);
+        });
+
+        // Verify the umbracoFile property exists on Image
+        var umbracoFileProperty = imageSchema!.Properties.FirstOrDefault(p => p.Alias == "umbracoFile");
+        Assert.That(umbracoFileProperty, Is.Not.Null);
+        Assert.That(umbracoFileProperty!.EditorAlias, Is.EqualTo("Umbraco.ImageCropper"));
+        Assert.That(umbracoFileProperty.DeliveryApiClrType, Is.EqualTo(typeof(ApiImageCropperValue)));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentTypeSchemaServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentTypeSchemaServiceTests.cs
@@ -1,0 +1,181 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Tests.UnitTests.Umbraco.Core.ShortStringHelper;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
+
+[TestFixture]
+public class ContentTypeSchemaServiceTests
+{
+    private Mock<IContentTypeService> _contentTypeServiceMock = null!;
+    private Mock<IMediaTypeService> _mediaTypeServiceMock = null!;
+    private Mock<IPublishedContentTypeCache> _publishedContentTypeCacheMock = null!;
+    private ContentTypeSchemaService _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _contentTypeServiceMock = new Mock<IContentTypeService>();
+        _mediaTypeServiceMock = new Mock<IMediaTypeService>();
+        _publishedContentTypeCacheMock = new Mock<IPublishedContentTypeCache>();
+
+        _sut = new ContentTypeSchemaService(
+            _contentTypeServiceMock.Object,
+            _mediaTypeServiceMock.Object,
+            _publishedContentTypeCacheMock.Object,
+            new DefaultShortStringHelper(new DefaultShortStringHelperConfig()));
+    }
+
+    [Test]
+    public void GetDocumentTypes_SkipsContentTypesWhenCacheThrows()
+    {
+        // Arrange
+        var cachedType = Mock.Of<IContentType>(x => x.Alias == "cachedType" && x.PropertyTypes == Array.Empty<IPropertyType>());
+        var uncachedType = Mock.Of<IContentType>(x => x.Alias == "uncachedType");
+
+        _contentTypeServiceMock.Setup(x => x.GetAll()).Returns([cachedType, uncachedType]);
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Content, "cachedType"))
+            .Returns(Mock.Of<IPublishedContentType>(x =>
+                x.Alias == "cachedType" &&
+                x.IsElement == false &&
+                x.CompositionAliases == new HashSet<string>() &&
+                x.PropertyTypes == Array.Empty<IPublishedPropertyType>()));
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Content, "uncachedType"))
+            .Throws<Exception>();
+
+        // Act
+        var result = _sut.GetDocumentTypes();
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result.First().Alias, Is.EqualTo("cachedType"));
+        Assert.That(result.First().SchemaId, Is.EqualTo("Cachedtype"));
+    }
+
+    [Test]
+    public void GetDocumentTypes_CorrectlyIdentifiesInheritedProperties()
+    {
+        // Arrange
+        var contentType = Mock.Of<IContentType>(x =>
+            x.Alias == "composedType" &&
+            x.PropertyTypes == new[] { Mock.Of<IPropertyType>(p => p.Alias == "ownProperty") });
+
+        var publishedContentType = Mock.Of<IPublishedContentType>(x =>
+            x.Alias == "composedType" &&
+            x.IsElement == false &&
+            x.CompositionAliases == new HashSet<string> { "baseComposition" } &&
+            x.PropertyTypes == new[]
+            {
+                Mock.Of<IPublishedPropertyType>(p => p.Alias == "ownProperty" && p.EditorAlias == "test" && p.DeliveryApiModelClrType == typeof(string)),
+                Mock.Of<IPublishedPropertyType>(p => p.Alias == "inheritedProperty" && p.EditorAlias == "test" && p.DeliveryApiModelClrType == typeof(string)),
+            });
+
+        _contentTypeServiceMock.Setup(x => x.GetAll()).Returns([contentType]);
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Content, "composedType")).Returns(publishedContentType);
+
+        // Act
+        var result = _sut.GetDocumentTypes();
+
+        // Assert
+        var props = result.First().Properties;
+        Assert.That(props.First(p => p.Alias == "ownProperty").Inherited, Is.False);
+        Assert.That(props.First(p => p.Alias == "inheritedProperty").Inherited, Is.True);
+    }
+
+    [Test]
+    public void GetDocumentTypes_IncludesCompositionSchemaIds()
+    {
+        // Arrange
+        var contentType = Mock.Of<IContentType>(x => x.Alias == "articlePage" && x.PropertyTypes == Array.Empty<IPropertyType>());
+        var publishedContentType = Mock.Of<IPublishedContentType>(x =>
+            x.Alias == "articlePage" &&
+            x.IsElement == false &&
+            x.CompositionAliases == new HashSet<string> { "basePage", "seoComposition" } &&
+            x.PropertyTypes == Array.Empty<IPublishedPropertyType>());
+
+        _contentTypeServiceMock.Setup(x => x.GetAll()).Returns([contentType]);
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Content, "articlePage")).Returns(publishedContentType);
+
+        // Act
+        var result = _sut.GetDocumentTypes();
+
+        // Assert
+        var schema = result.First();
+        Assert.That(schema.SchemaId, Is.EqualTo("Articlepage"));
+        Assert.That(schema.CompositionSchemaIds, Is.EquivalentTo(new[] { "Basepage", "Seocomposition" }));
+    }
+
+    [Test]
+    public void GetDocumentTypes_ReturnsEmptyCollectionWhenNoContentTypes()
+    {
+        // Arrange
+        _contentTypeServiceMock.Setup(x => x.GetAll()).Returns(Array.Empty<IContentType>());
+
+        // Act
+        var result = _sut.GetDocumentTypes();
+
+        // Assert
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GetDocumentTypes_CorrectlySetsIsElementProperty()
+    {
+        // Arrange
+        var documentType = Mock.Of<IContentType>(x => x.Alias == "documentType" && x.PropertyTypes == Array.Empty<IPropertyType>());
+        var elementType = Mock.Of<IContentType>(x => x.Alias == "elementType" && x.PropertyTypes == Array.Empty<IPropertyType>());
+
+        _contentTypeServiceMock.Setup(x => x.GetAll()).Returns([documentType, elementType]);
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Content, "documentType"))
+            .Returns(Mock.Of<IPublishedContentType>(x =>
+                x.Alias == "documentType" &&
+                x.IsElement == false &&
+                x.CompositionAliases == new HashSet<string>() &&
+                x.PropertyTypes == Array.Empty<IPublishedPropertyType>()));
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Content, "elementType"))
+            .Returns(Mock.Of<IPublishedContentType>(x =>
+                x.Alias == "elementType" &&
+                x.IsElement == true &&
+                x.CompositionAliases == new HashSet<string>() &&
+                x.PropertyTypes == Array.Empty<IPublishedPropertyType>()));
+
+        // Act
+        var result = _sut.GetDocumentTypes();
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result.First(x => x.Alias == "documentType").IsElement, Is.False);
+        Assert.That(result.First(x => x.Alias == "elementType").IsElement, Is.True);
+    }
+
+    [Test]
+    public void GetMediaTypes_SkipsMediaTypesWhenCacheThrows()
+    {
+        // Arrange
+        var cachedType = Mock.Of<IMediaType>(x => x.Alias == "cachedType" && x.PropertyTypes == Array.Empty<IPropertyType>());
+        var uncachedType = Mock.Of<IMediaType>(x => x.Alias == "uncachedType");
+
+        _mediaTypeServiceMock.Setup(x => x.GetAll()).Returns([cachedType, uncachedType]);
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Media, "cachedType"))
+            .Returns(Mock.Of<IPublishedContentType>(x =>
+                x.Alias == "cachedType" &&
+                x.IsElement == false &&
+                x.CompositionAliases == new HashSet<string>() &&
+                x.PropertyTypes == Array.Empty<IPublishedPropertyType>()));
+        _publishedContentTypeCacheMock.Setup(x => x.Get(PublishedItemType.Media, "uncachedType"))
+            .Throws<Exception>();
+
+        // Act
+        var result = _sut.GetMediaTypes();
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result.First().Alias, Is.EqualTo("cachedType"));
+        Assert.That(result.First().SchemaId, Is.EqualTo("Cachedtype"));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.DeliveryApi;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -22,6 +23,7 @@ public class ApiRichTextMarkupParserTests
         var key1 = Guid.Parse("a1c5d649977f4ea59b1cb26055f3eed3");
         var data1 = new MockData()
             .WithKey(key1)
+            .WithContentTypeAlias("someAlias")
             .WithRoutePath("/inline/")
             .WithRouteStartPath("inline");
 
@@ -36,7 +38,7 @@ public class ApiRichTextMarkupParserTests
             "<p><a href=\"/{localLink:umb://document/a1c5d649977f4ea59b1cb26055f3eed3}\" title=\"Inline\">link </a>to another page</p>";
 
         var expectedOutput =
-            "<p><a href=\"/inline/\" title=\"Inline\" data-start-item-path=\"inline\" data-start-item-id=\"a1c5d649-977f-4ea5-9b1c-b26055f3eed3\">link </a>to another page</p>";
+            $"<p><a href=\"/inline/\" title=\"Inline\" data-destination-id=\"{key1:D}\" data-destination-type=\"someAlias\" data-start-item-path=\"inline\" data-start-item-id=\"a1c5d649-977f-4ea5-9b1c-b26055f3eed3\" data-link-type=\"{LinkType.Content}\">link </a>to another page</p>";
 
         var parsedHtml = parser.Parse(legacyHtml);
 
@@ -49,12 +51,14 @@ public class ApiRichTextMarkupParserTests
         var key1 = Guid.Parse("eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f");
         var data1 = new MockData()
             .WithKey(key1)
+            .WithContentTypeAlias("someAlias")
             .WithRoutePath("/self/")
             .WithRouteStartPath("self");
 
         var key2 = Guid.Parse("cc143afe-4cbf-46e5-b399-c9f451384373");
         var data2 = new MockData()
             .WithKey(key2)
+            .WithContentTypeAlias("someAliasTwo")
             .WithRoutePath("/other/")
             .WithRouteStartPath("other");
 
@@ -71,8 +75,8 @@ public class ApiRichTextMarkupParserTests
 <p>and to the <a type=""document"" href=""/{localLink:cc143afe-4cbf-46e5-b399-c9f451384373}"" title=""other page"">other page</a></p>";
 
         var expectedOutput =
-            @"<p>Rich text outside of the blocks with a link to <a href=""/self/"" title=""itself"" data-start-item-path=""self"" data-start-item-id=""eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f"">itself</a><br><br></p>
-<p>and to the <a href=""/other/"" title=""other page"" data-start-item-path=""other"" data-start-item-id=""cc143afe-4cbf-46e5-b399-c9f451384373"">other page</a></p>";
+            $@"<p>Rich text outside of the blocks with a link to <a href=""/self/"" title=""itself"" data-destination-id=""{key1:D}"" data-destination-type=""someAlias"" data-start-item-path=""self"" data-start-item-id=""eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f"" data-link-type=""{LinkType.Content}"">itself</a><br><br></p>
+<p>and to the <a href=""/other/"" title=""other page"" data-destination-id=""{key2:D}"" data-destination-type=""someAliasTwo"" data-start-item-path=""other"" data-start-item-id=""cc143afe-4cbf-46e5-b399-c9f451384373"" data-link-type=""{LinkType.Content}"">other page</a></p>";
 
         var parsedHtml = parser.Parse(html);
 
@@ -88,12 +92,14 @@ public class ApiRichTextMarkupParserTests
         var key1 = Guid.Parse("eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f");
         var data1 = new MockData()
             .WithKey(key1)
+            .WithContentTypeAlias("someAlias")
             .WithRoutePath($"/self/{postfix}")
             .WithRouteStartPath("self");
 
         var key2 = Guid.Parse("cc143afe-4cbf-46e5-b399-c9f451384373");
         var data2 = new MockData()
             .WithKey(key2)
+            .WithContentTypeAlias("someAliasTwo")
             .WithRoutePath($"/other/{postfix}")
             .WithRouteStartPath("other");
 
@@ -110,8 +116,8 @@ public class ApiRichTextMarkupParserTests
 <p>and to the <a type=""document"" href=""/{{localLink:cc143afe-4cbf-46e5-b399-c9f451384373}}{postfix}"" title=""other page"">other page</a></p>";
 
         var expectedOutput =
-            $@"<p>Rich text outside of the blocks with a link to <a href=""/self/{postfix}"" title=""itself"" data-start-item-path=""self"" data-start-item-id=""eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f"">itself</a><br><br></p>
-<p>and to the <a href=""/other/{postfix}"" title=""other page"" data-start-item-path=""other"" data-start-item-id=""cc143afe-4cbf-46e5-b399-c9f451384373"">other page</a></p>";
+            $@"<p>Rich text outside of the blocks with a link to <a href=""/self/{postfix}"" title=""itself"" data-destination-id=""{key1:D}"" data-destination-type=""someAlias"" data-start-item-path=""self"" data-start-item-id=""eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f"" data-link-type=""{LinkType.Content}"">itself</a><br><br></p>
+<p>and to the <a href=""/other/{postfix}"" title=""other page"" data-destination-id=""{key2:D}"" data-destination-type=""someAliasTwo"" data-start-item-path=""other"" data-start-item-id=""cc143afe-4cbf-46e5-b399-c9f451384373"" data-link-type=""{LinkType.Content}"">other page</a></p>";
 
         var parsedHtml = parser.Parse(html);
 
@@ -195,6 +201,12 @@ public class ApiRichTextMarkupParserTests
         {
             _publishedContentMock.SetupGet(i => i.Key).Returns(key);
             _apiContentStartItem.SetupGet(rsi => rsi.Id).Returns(key);
+            return this;
+        }
+
+        public MockData WithContentTypeAlias(string alias)
+        {
+            _publishedContentMock.SetupGet(x => x.ContentType.Alias).Returns(alias);
             return this;
         }
 


### PR DESCRIPTION
## Summary

Closes #20451

This PR implements early validation for Move and Duplicate operations in the backoffice, providing immediate feedback to users when selecting invalid destinations.

### Addressing #20451 - Different Approach

The original issue suggested that invalid destinations should not be selectable at all. We took a **lazy validation approach** instead, for good reasons:

**Why not pre-disable all invalid items?**
- Would require fetching allowed children for every visible tree item upfront
- Expensive API calls that scale poorly with large content trees
- Slows down modal opening significantly

**Our approach: Validate on selection**
- Items are validated when selected (lazy/on-demand)
- Invalid selections show an error message immediately
- After a content type is found invalid, **all items of that type become disabled** (progressive learning)
- Descendants and self are disabled upfront (cheap to compute from tree data)

This gives users immediate feedback without the performance cost of pre-computing all valid destinations.

### Features Added

- **Content type validation**: Validates that the source item's type is allowed as a child of the destination. Shows error and disables invalid destinations.
- **Descendant prevention (Move only)**: Prevents moving items to their own descendants.
- **Same-parent prevention (Move only)**: Prevents selecting the current parent (no-op).
- **Dynamic disabling**: Invalid destination types become greyed out after first validation failure.
- **Improved modal UX**: Item name in headline, error messages in footer with proper styling.

## Screenshots

### Move Modal - Initial State
Shows item name in headline ("Select where **Home** should be moved to below"):

<img width="1200" alt="01-move-modal-initial" src="https://github.com/user-attachments/assets/e6966a64-a9e5-44e4-909d-fc2ec0de65c2" />

### Move Modal - Descendants Disabled
All descendants of the source item are automatically disabled (greyed out):
<img width="1200" alt="02-move-descendants-disabled" src="https://github.com/user-attachments/assets/4c6c7b76-9afb-43e7-9de8-18ff197e52f9" />

### Move Modal - Content Type Error
Error shown when selecting a destination that doesn't allow the source's document type:
<img width="1200" alt="03-move-content-type-error" src="https://github.com/user-attachments/assets/b0bbfe4c-6f2f-421b-bfa8-f49739032968" />

### Move Modal - Valid Selection
Submit button enabled when a valid destination is selected:
<img width="1200" alt="04-move-valid-selection" src="https://github.com/user-attachments/assets/42ef47c9-3bc7-4078-84c6-96a66a37e88a" />

### Duplicate Modal - Content Type Error
Same validation for duplicate operations:
<img width="1200" alt="06-duplicate-content-type-error" src="https://github.com/user-attachments/assets/363c8428-238b-475e-a897-dbd2c1bc410e" />

## Design Notes

### Why similar modal code is intentional

The modals for different entity types (documents, media, etc.) have similar but separate implementations. This follows Umbraco's package architecture:

1. **Independence** - Each package owns its implementations, so changes to the document modal don't risk breaking media or other entity types
2. **Extensibility** - Entity-specific features can be added without affecting others (e.g., documents have "relate to original" and "include descendants" options that don't apply to media)
3. **Avoiding premature abstraction** - A shared base class would couple entity types that may diverge in the future

The validation logic (e.g., `onTreeSelectionChange`) is similar across modals but not identical, and the cost of maintaining a few similar methods is lower than the coupling a shared abstraction would introduce.

### Why duplicating to descendants is allowed

Unlike move operations, duplicating a document to one of its descendants is intentionally allowed - it creates a copy without circular reference issues.

## Test Plan

- [ ] **Move document**: Right-click → Move to → verify descendants are disabled, invalid types show error, valid selection enables button
- [ ] **Duplicate document**: Right-click → Duplicate to → verify content type validation works (descendants ARE allowed for copy)
- [ ] **Bulk move/duplicate**: Select multiple items → verify "X items" in headline, validation works for all selected items
- [ ] **Media move**: Same validation flow works for media items

🤖 Generated with [Claude Code](https://claude.com/claude-code)