### PR TITLE
Tree: Fix race condition when loading tree with `hideTreeRoot` enabled

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.context.ts
@@ -155,7 +155,9 @@ export class UmbDefaultTreeContext<
 	 */
 	public loadNextItems = (): Promise<void> => this.#treeItemChildrenManager.loadNextChildren();
 
-	#debouncedLoadTree(reload = false) {
+	async #debouncedLoadTree(reload = false) {
+		await this.#init;
+
 		const hasStartNode = this.getStartNode();
 		const hideTreeRoot = this.getHideTreeRoot();
 		if (hasStartNode || hideTreeRoot) {


### PR DESCRIPTION
## Summary
- Fix race condition in `#debouncedLoadTree` that caused "repository is missing" error
- The method now awaits repository initialization before loading children when `hideTreeRoot` is enabled
- Fixes block thumbnail picker and other tree pickers using `hideTreeRoot: true`

## Root Cause
When `hideTreeRoot: true` was passed (e.g., Static File picker for block thumbnails), `#debouncedLoadTree` called `loadChildren()` before the repository was initialized via `UmbExtensionApiInitializer`.

## Test plan
- [ ] Open a Block List/Grid type configuration
- [ ] Click on the Thumbnail field to open the Static File picker
- [ ] Verify the tree loads without errors
- [ ] Verify other tree pickers (media, content, document types) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)