### PR TITLE
Added a migration to remove the property regex validation length limit

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -144,6 +144,9 @@ public class UmbracoPlan : MigrationPlan
         // To 17.0.1
         To<V_17_0_1.EnsureUmbracoPropertyDataColumnCasing>("{BE5CA411-E12D-4455-A59E-F12A669E5363}");
 
+        // To 17.1.0
+        To<V_17_1_0.ChangeValidationRegExpToNvarcharMax>("{1CE2E78B-E736-45D8-97A2-CE3EF2F31BCD}");
+
         // To 18.0.0
         // TODO (V18): Enable on 18 branch
         //// To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_1_0/ChangeValidationRegExpToNvarcharMax.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_1_0/ChangeValidationRegExpToNvarcharMax.cs
@@ -1,0 +1,44 @@
+using Umbraco.Cms.Core;
+using NPoco;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_1_0;
+
+public class ChangeValidationRegExpToNvarcharMax : MigrationBase
+{
+    public ChangeValidationRegExpToNvarcharMax(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        // SQLite doesn't need this - text is already unlimited
+        if (DatabaseType == DatabaseType.SQLite)
+        {
+            return;
+        }
+
+        // Check if column is already nvarchar(max) (CHARACTER_MAXIMUM_LENGTH = -1)
+        // Skip migration if already migrated to prevent re-running
+        var maxLength = Database.ExecuteScalar<int?>(
+            @"SELECT CHARACTER_MAXIMUM_LENGTH
+              FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_NAME = @0
+              AND COLUMN_NAME = @1
+              AND TABLE_SCHEMA = SCHEMA_NAME()",
+            Constants.DatabaseSchema.Tables.PropertyType,
+            "validationRegExp");
+
+        // -1 means nvarchar(max) - already migrated
+        if (maxLength == -1)
+        {
+            return;
+        }
+
+        Alter.Table(Constants.DatabaseSchema.Tables.PropertyType)
+            .AlterColumn("validationRegExp")
+            .AsCustom("nvarchar(max)")
+            .Nullable()
+            .Do();
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/PropertyTypeDto.cs
@@ -54,6 +54,7 @@ internal class PropertyTypeDto
 
     [Column("validationRegExp")]
     [NullSetting(NullSetting = NullSettings.Null)]
+    [SpecialDbType(SpecialDbTypes.NVARCHARMAX)]
     public string? ValidationRegExp { get; set; }
 
     [Column("validationRegExpMessage")]


### PR DESCRIPTION
### Prerequisites

Fixes #16368

### Description
Removes the limit on regex validation length in sql databases instead of limiting the regex in the frontend as this is not enforcable for other clients and it doesn't make sense to have an arbitrary max length. With this increase in length the chance of very complex and processing heavy regexes comes in to play for production ready (sql server) implementations but I consider this to be like other choices we have made regarding implementation complexity => with greater power comes great responsibility.

Sibling PR's for older versions will follow shortly.
The migration is done in an idempotent way as to not interfere with specific upgrade paths.