### PR TITLE
Indexing: Gracefully handle element property variance changes at index time

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactoryBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyIndexValueFactoryBase.cs
@@ -219,10 +219,19 @@ internal abstract class BlockValuePropertyIndexValueFactoryBase<TSerialized> : J
                     continue;
                 }
 
+                var propertyCulture = rawPropertyData.Culture ?? culture;
+
+                if (propertyType.VariesByCulture() is false && propertyCulture is not null)
+                {
+                    // culture variance mismatch - the stored property value varies by culture, but the element property
+                    // does not. this is likely due to element (or element property) variation changes since last edit.
+                    // we'll ignore this to avoid polluting the indexes with cross-variant values, as the same property
+                    // might have a value in multiple languages.
+                    continue;
+                }
+
                 IProperty subProperty = new Property(propertyType);
                 IEnumerable<IndexValue> indexValues = null!;
-
-                var propertyCulture = rawPropertyData.Culture ?? culture;
 
                 if (propertyType.VariesByCulture() && propertyCulture is null)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is very much related to #21121, but aims to fix indexing for already "polluted" published values.

In essence, the Examine indexing has a hard time handling culture variance changes for element properties when indexing for block level variance. Specifically, when a property changes from culture _variant_ to culture _invariant_, exceptions are thrown and the indexing fails:

<img width="1090" height="366" alt="image" src="https://github.com/user-attachments/assets/4d903078-70e2-44f2-9fdf-c391aa57d9c9" />

This happens in a background job, and while the site seemingly continues to run, the logs fill up with error messages, and of course the index is not updated either:

<img width="1380" height="241" alt="image" src="https://github.com/user-attachments/assets/665e93e2-e120-4adf-9824-b487e665ca9c" />

This PR adds a safeguard for this variance change. To air on the side of caution, the indexer explicitly discards property values stored as culture variant, if they are supposed to be indexed as culture invariant. This way we avoid potentially multiple property values for different cultures being indexes as invariant.

**Note:** The opposite change in element level property variance (from culture _invariant_ to culture _variant_) is already handled gracefully by the indexer. In this case, the values stored as culture invariant will be propagated across all available cultures.

### Testing this PR

If #21121 is merged before this one, it is likely somewhat hard to test this. But the issue can certainly be reproduced on v17.0.x like this:

1. Define multiple languages.
2. Create an element type that varies by culture, and add a text property which also varies by culture.
3. Create a block list data type using this element type.
4. Create a document type that varies by culture, and add the block list as a property that does _not_ vary by culture (thus obtaining block level variance).
5. Create a document of the document type and add a block to the default language variant. Remember to add a value to the element text property.
6. Save and publish the document.
7. Change the element type text property to become _invariant_.
8. Repoen the document and save it.
9. The exception is thrown at index time.

Thus, the fix should be testable by using a v17.0.x DB with this setup to test.