### PR TITLE
Performance: Embed Store API in Manifests to lower number of network request

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/detail/manifests.ts
@@ -1,6 +1,7 @@
 import { UMB_CLIPBOARD_ENTRY_ENTITY_TYPE } from '../entity.js';
 import { UMB_CLIPBOARD_ENTRY_ITEM_REPOSITORY_ALIAS } from '../item/index.js';
 import { UMB_CLIPBOARD_ENTRY_DETAIL_REPOSITORY_ALIAS, UMB_CLIPBOARD_ENTRY_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbClipboardEntryDetailStore } from './clipboard-entry-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -13,7 +14,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_CLIPBOARD_ENTRY_DETAIL_STORE_ALIAS,
 		name: 'Clipboard Detail Store',
-		api: () => import('./clipboard-entry-detail.store.js'),
+		api: UmbClipboardEntryDetailStore,
 	},
 	{
 		type: 'entityAction',

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-entry/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_CLIPBOARD_ENTRY_ITEM_REPOSITORY_ALIAS, UMB_CLIPBOARD_ENTRY_ITEM_STORE_ALIAS } from './constants.js';
+import { UmbClipboardEntryItemStore } from './clipboard-entry-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_CLIPBOARD_ENTRY_ITEM_STORE_ALIAS,
 		name: 'Clipboard Entry Item Store',
-		api: () => import('./clipboard-entry-item.store.js'),
+		api: UmbClipboardEntryItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor-data-source/item/data/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor-data-source/item/data/manifests.ts
@@ -2,6 +2,7 @@ import {
 	UMB_PROPERTY_EDITOR_DATA_SOURCE_ITEM_REPOSITORY_ALIAS,
 	UMB_PROPERTY_EDITOR_DATA_SOURCE_ITEM_STORE_ALIAS,
 } from './constants.js';
+import { UmbPropertyEditorDataSourceItemStore } from './item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -14,6 +15,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_PROPERTY_EDITOR_DATA_SOURCE_ITEM_STORE_ALIAS,
 		name: 'Property Editor Data Source Item Store',
-		api: () => import('./item.store.js'),
+		api: UmbPropertyEditorDataSourceItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/manifests.ts
@@ -1,11 +1,12 @@
 import { UMB_TEMPORARY_FILE_CONFIG_STORE_ALIAS, UMB_TEMPORARY_FILE_REPOSITORY_ALIAS } from './constants.js';
+import { UmbTemporaryFileConfigStore } from './config.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'store',
 		alias: UMB_TEMPORARY_FILE_CONFIG_STORE_ALIAS,
 		name: 'Temporary File Config Store',
-		api: () => import('./config.store.js'),
+		api: UmbTemporaryFileConfigStore,
 	},
 	{
 		type: 'repository',

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DATA_TYPE_DETAIL_REPOSITORY_ALIAS, UMB_DATA_TYPE_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbDataTypeDetailStore } from './data-type-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DATA_TYPE_DETAIL_STORE_ALIAS,
 		name: 'Data Type Detail Store',
-		api: () => import('./data-type-detail.store.js'),
+		api: UmbDataTypeDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DATA_TYPE_ITEM_REPOSITORY_ALIAS, UMB_DATA_TYPE_STORE_ALIAS } from './constants.js';
+import { UmbDataTypeItemStore } from './data-type-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_DATA_TYPE_STORE_ALIAS,
 		name: 'Data Type Item Store',
-		api: () => import('./data-type-item.store.js'),
+		api: UmbDataTypeItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DATA_TYPE_FOLDER_REPOSITORY_ALIAS, UMB_DATA_TYPE_FOLDER_STORE_ALIAS } from './constants.js';
+import { UmbDataTypeFolderStore } from './data-type-folder.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DATA_TYPE_FOLDER_STORE_ALIAS,
 		name: 'Data Type Folder Store',
-		api: () => import('./data-type-folder.store.js'),
+		api: UmbDataTypeFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/manifests.ts
@@ -5,6 +5,7 @@ import {
 	UMB_DATA_TYPE_TREE_REPOSITORY_ALIAS,
 	UMB_DATA_TYPE_TREE_STORE_ALIAS,
 } from './constants.js';
+import { UmbDataTypeTreeStore } from './data-type-tree.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -17,7 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_DATA_TYPE_TREE_STORE_ALIAS,
 		name: 'Data Type Tree Store',
-		api: () => import('./data-type-tree.store.js'),
+		api: UmbDataTypeTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/repository/detail/manifests.ts
@@ -1,4 +1,6 @@
 import { UMB_DICTIONARY_DETAIL_REPOSITORY_ALIAS, UMB_DICTIONARY_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbDictionaryDetailStore } from './dictionary-detail.store.js';
+
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'repository',
@@ -10,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DICTIONARY_DETAIL_STORE_ALIAS,
 		name: 'Dictionary Detail Store',
-		api: () => import('./dictionary-detail.store.js'),
+		api: UmbDictionaryDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DICTIONARY_ITEM_REPOSITORY_ALIAS, UMB_DICTIONARY_STORE_ALIAS } from './constants.js';
+import { UmbDictionaryItemStore } from './dictionary-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_DICTIONARY_STORE_ALIAS,
 		name: 'Dictionary Item Store',
-		api: () => import('./dictionary-item.store.js'),
+		api: UmbDictionaryItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/tree/manifests.ts
@@ -4,6 +4,7 @@ import {
 	UMB_DICTIONARY_TREE_REPOSITORY_ALIAS,
 	UMB_DICTIONARY_TREE_STORE_ALIAS,
 } from './constants.js';
+import { UmbDictionaryTreeStore } from './dictionary-tree.store.js';
 import { manifests as reloadTreeItemChildrenManifests } from './reload-tree-item-children/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
@@ -17,7 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_DICTIONARY_TREE_STORE_ALIAS,
 		name: 'Dictionary Tree Store',
-		api: () => import('./dictionary-tree.store.js'),
+		api: UmbDictionaryTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/detail/manifests.ts
@@ -2,6 +2,7 @@ import {
 	UMB_DOCUMENT_BLUEPRINT_DETAIL_REPOSITORY_ALIAS,
 	UMB_DOCUMENT_BLUEPRINT_DETAIL_STORE_ALIAS,
 } from './constants.js';
+import { UmbDocumentBlueprintDetailStore } from './document-blueprint-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -14,6 +15,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DOCUMENT_BLUEPRINT_DETAIL_STORE_ALIAS,
 		name: 'Document Blueprint Detail Store',
-		api: () => import('./document-blueprint-detail.store.js'),
+		api: UmbDocumentBlueprintDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DOCUMENT_BLUEPRINT_ITEM_REPOSITORY_ALIAS, UMB_DOCUMENT_BLUEPRINT_STORE_ALIAS } from './constants.js';
+import { UmbDocumentBlueprintItemStore } from './document-blueprint-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_DOCUMENT_BLUEPRINT_STORE_ALIAS,
 		name: 'Document Blueprint Item Store',
-		api: () => import('./document-blueprint-item.store.js'),
+		api: UmbDocumentBlueprintItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/repository/manifests.ts
@@ -2,6 +2,7 @@ import {
 	UMB_DOCUMENT_BLUEPRINT_FOLDER_REPOSITORY_ALIAS,
 	UMB_DOCUMENT_BLUEPRINT_FOLDER_STORE_ALIAS,
 } from './constants.js';
+import { UmbDocumentBlueprintFolderStore } from './document-blueprint-folder.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -14,6 +15,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DOCUMENT_BLUEPRINT_FOLDER_STORE_ALIAS,
 		name: 'Document Blueprint Folder Store',
-		api: () => import('./document-blueprint-folder.store.js'),
+		api: UmbDocumentBlueprintFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/manifests.ts
@@ -8,6 +8,7 @@ import {
 	UMB_DOCUMENT_BLUEPRINT_TREE_REPOSITORY_ALIAS,
 	UMB_DOCUMENT_BLUEPRINT_TREE_STORE_ALIAS,
 } from './constants.js';
+import { UmbDocumentBlueprintTreeStore } from './document-blueprint-tree.store.js';
 import { manifests as folderManifests } from './folder/manifests.js';
 import { manifests as reloadManifests } from './reload-tree-item-children/manifests.js';
 
@@ -22,7 +23,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_DOCUMENT_BLUEPRINT_TREE_STORE_ALIAS,
 		name: 'Document Blueprint Tree Store',
-		api: () => import('./document-blueprint-tree.store.js'),
+		api: UmbDocumentBlueprintTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DOCUMENT_TYPE_DETAIL_REPOSITORY_ALIAS, UMB_DOCUMENT_TYPE_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbDocumentTypeDetailStore } from './document-type-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DOCUMENT_TYPE_DETAIL_STORE_ALIAS,
 		name: 'Document Type Store',
-		api: () => import('./document-type-detail.store.js'),
+		api: UmbDocumentTypeDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DOCUMENT_TYPE_ITEM_REPOSITORY_ALIAS, UMB_DOCUMENT_TYPE_ITEM_STORE_ALIAS } from './constants.js';
+import { UmbDocumentTypeItemStore } from './document-type-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_DOCUMENT_TYPE_ITEM_STORE_ALIAS,
 		name: 'Document Type Item Store',
-		api: () => import('./document-type-item.store.js'),
+		api: UmbDocumentTypeItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DOCUMENT_TYPE_FOLDER_REPOSITORY_ALIAS, UMB_DOCUMENT_TYPE_FOLDER_STORE_ALIAS } from './constants.js';
+import { UmbDocumentTypeFolderStore } from './document-type-folder.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DOCUMENT_TYPE_FOLDER_STORE_ALIAS,
 		name: 'Document Type Folder Store',
-		api: () => import('./document-type-folder.store.js'),
+		api: UmbDocumentTypeFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/manifests.ts
@@ -8,6 +8,7 @@ import {
 	UMB_DOCUMENT_TYPE_FOLDER_WORKSPACE_ALIAS,
 	UMB_DOCUMENT_TYPE_TREE_ITEM_CHILDREN_COLLECTION_ALIAS,
 } from './constants.js';
+import { UmbDocumentTypeTreeStore } from './document-type.tree.store.js';
 import { manifests as folderManifests } from './folder/manifests.js';
 import { manifests as treeItemChildrenManifests } from './tree-item-children/manifests.js';
 import { UMB_WORKSPACE_CONDITION_ALIAS } from '@umbraco-cms/backoffice/workspace';
@@ -23,7 +24,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_DOCUMENT_TYPE_TREE_STORE_ALIAS,
 		name: 'Document Type Tree Store',
-		api: () => import('./document-type.tree.store.js'),
+		api: UmbDocumentTypeTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DOCUMENT_ITEM_REPOSITORY_ALIAS, UMB_DOCUMENT_STORE_ALIAS } from './constants.js';
+import { UmbDocumentItemStore } from './document-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_DOCUMENT_STORE_ALIAS,
 		name: 'Document Item Store',
-		api: () => import('./document-item.store.js'),
+		api: UmbDocumentItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/data/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/data/manifests.ts
@@ -2,6 +2,7 @@ import {
 	UMB_DOCUMENT_RECYCLE_BIN_TREE_REPOSITORY_ALIAS,
 	UMB_DOCUMENT_RECYCLE_BIN_TREE_STORE_ALIAS,
 } from '../constants.js';
+import { UmbDocumentRecycleBinTreeStore } from './document-recycle-bin-tree.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -14,6 +15,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_DOCUMENT_RECYCLE_BIN_TREE_STORE_ALIAS,
 		name: 'Document Recycle Bin Tree Store',
-		api: () => import('./document-recycle-bin-tree.store.js'),
+		api: UmbDocumentRecycleBinTreeStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DOCUMENT_DETAIL_REPOSITORY_ALIAS, UMB_DOCUMENT_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbDocumentDetailStore } from './document-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_DOCUMENT_DETAIL_STORE_ALIAS,
 		name: 'Document Detail Store',
-		api: () => import('./document-detail.store.js'),
+		api: UmbDocumentDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_ROOT_ENTITY_TYPE } from '../entity.js';
 import { manifests as reloadTreeItemChildrenManifests } from './reload-tree-item-children/manifests.js';
+import { UmbDocumentTreeStore } from './document-tree.store.js';
 
 export const UMB_DOCUMENT_TREE_REPOSITORY_ALIAS = 'Umb.Repository.Document.Tree';
 /**
@@ -19,7 +20,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_DOCUMENT_TREE_STORE_ALIAS,
 		name: 'Document Tree Store',
-		api: () => import('./document-tree.store.js'),
+		api: UmbDocumentTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_DOCUMENT_URL_REPOSITORY_ALIAS, UMB_DOCUMENT_URL_STORE_ALIAS } from './constants.js';
+import { UmbDocumentUrlStore } from './document-url.store.js';
 import type { ManifestItemStore, ManifestRepository } from '@umbraco-cms/backoffice/extension-registry';
 
 const urlRepository: ManifestRepository = {
@@ -12,7 +13,7 @@ const urlStore: ManifestItemStore = {
 	type: 'itemStore',
 	alias: UMB_DOCUMENT_URL_STORE_ALIAS,
 	name: 'Document Url Store',
-	api: () => import('./document-url.store.js'),
+	api: UmbDocumentUrlStore,
 };
 
 export const manifests = [urlRepository, urlStore];

--- a/src/Umbraco.Web.UI.Client/src/packages/language/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_LANGUAGE_DETAIL_REPOSITORY_ALIAS, UMB_LANGUAGE_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbLanguageDetailStore } from './language-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_LANGUAGE_DETAIL_STORE_ALIAS,
 		name: 'Language Detail Store',
-		api: () => import('./language-detail.store.js'),
+		api: UmbLanguageDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/language/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_LANGUAGE_ITEM_REPOSITORY_ALIAS, UMB_LANGUAGE_STORE_ALIAS } from './constants.js';
+import { UmbLanguageItemStore } from './language-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_LANGUAGE_STORE_ALIAS,
 		name: 'Language Item Store',
-		api: () => import('./language-item.store.js'),
+		api: UmbLanguageItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/imaging/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/imaging/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_IMAGING_REPOSITORY_ALIAS, UMB_IMAGING_STORE_ALIAS } from './constants.js';
+import { UmbImagingStore } from './imaging.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_IMAGING_STORE_ALIAS,
 		name: 'Imaging Store',
-		api: () => import('./imaging.store.js'),
+		api: UmbImagingStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEDIA_TYPE_DETAIL_REPOSITORY_ALIAS, UMB_MEDIA_TYPE_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbMediaTypeDetailStore } from './media-type-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_MEDIA_TYPE_DETAIL_STORE_ALIAS,
 		name: 'Media Type Store',
-		api: () => import('./media-type-detail.store.js'),
+		api: UmbMediaTypeDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEDIA_TYPE_ITEM_REPOSITORY_ALIAS, UMB_MEDIA_TYPE_ITEM_STORE_ALIAS } from './constants.js';
+import { UmbMediaTypeItemStore } from './media-type-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_MEDIA_TYPE_ITEM_STORE_ALIAS,
 		name: 'Media Type Item Store',
-		api: () => import('./media-type-item.store.js'),
+		api: UmbMediaTypeItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEDIA_TYPE_FOLDER_REPOSITORY_ALIAS, UMB_MEDIA_TYPE_FOLDER_STORE_ALIAS } from './constants.js';
+import { UmbMediaTypeFolderStore } from './media-type-folder.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_MEDIA_TYPE_FOLDER_STORE_ALIAS,
 		name: 'Media Type Folder Store',
-		api: () => import('./media-type-folder.store.js'),
+		api: UmbMediaTypeFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/manifests.ts
@@ -8,6 +8,7 @@ import {
 	UMB_MEDIA_TYPE_TREE_REPOSITORY_ALIAS,
 	UMB_MEDIA_TYPE_TREE_STORE_ALIAS,
 } from './constants.js';
+import { UmbMediaTypeTreeStore } from './media-type-tree.store.js';
 import { manifests as folderManifests } from './folder/manifests.js';
 import { manifests as treeItemChildrenManifest } from './tree-item-children/manifests.js';
 
@@ -22,7 +23,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_MEDIA_TYPE_TREE_STORE_ALIAS,
 		name: 'Media Type Tree Store',
-		api: () => import('./media-type-tree.store.js'),
+		api: UmbMediaTypeTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/manifests.ts
@@ -5,6 +5,7 @@ import {
 	UMB_MEDIA_RECYCLE_BIN_TREE_REPOSITORY_ALIAS,
 	UMB_MEDIA_RECYCLE_BIN_TREE_STORE_ALIAS,
 } from './constants.js';
+import { UmbMediaRecycleBinTreeStore } from './media-recycle-bin-tree.store.js';
 import { manifests as reloadTreeItemChildrenManifests } from './reload-tree-item-children/manifests.js';
 import { manifests as treeItemChildrenManifests } from './tree-item-children/manifests.js';
 
@@ -19,7 +20,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_MEDIA_RECYCLE_BIN_TREE_STORE_ALIAS,
 		name: 'Media Recycle Bin Tree Store',
-		api: () => import('./media-recycle-bin-tree.store.js'),
+		api: UmbMediaRecycleBinTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/detail/manifests.ts
@@ -1,4 +1,6 @@
 import { UMB_MEDIA_DETAIL_REPOSITORY_ALIAS, UMB_MEDIA_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbMediaDetailStore } from './media-detail.store.js';
+
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'repository',
@@ -10,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_MEDIA_DETAIL_STORE_ALIAS,
 		name: 'Media Detail Store',
-		api: () => import('./media-detail.store.js'),
+		api: UmbMediaDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEDIA_ITEM_REPOSITORY_ALIAS, UMB_MEDIA_STORE_ALIAS } from './constants.js';
+import { UmbMediaItemStore } from './media-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_MEDIA_STORE_ALIAS,
 		name: 'Media Item Store',
-		api: () => import('./media-item.store.js'),
+		api: UmbMediaItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_MEDIA_ENTITY_TYPE, UMB_MEDIA_ROOT_ENTITY_TYPE } from '../entity.js';
 import { UMB_MEDIA_TREE_ALIAS, UMB_MEDIA_TREE_REPOSITORY_ALIAS, UMB_MEDIA_TREE_STORE_ALIAS } from './constants.js';
+import { UmbMediaTreeStore } from './media-tree.store.js';
 import { manifests as reloadTreeItemChildrenManifests } from './reload-tree-item-children/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
@@ -13,7 +14,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_MEDIA_TREE_STORE_ALIAS,
 		name: 'Media Tree Store',
-		api: () => import('./media-tree.store.js'),
+		api: UmbMediaTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/url/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/url/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEDIA_URL_REPOSITORY_ALIAS, UMB_MEDIA_URL_STORE_ALIAS } from './constants.js';
+import { UmbMediaUrlStore } from './media-url.store.js';
 import type { ManifestItemStore, ManifestRepository } from '@umbraco-cms/backoffice/extension-registry';
 
 const urlRepository: ManifestRepository = {
@@ -12,7 +13,7 @@ const urlStore: ManifestItemStore = {
 	type: 'itemStore',
 	alias: UMB_MEDIA_URL_STORE_ALIAS,
 	name: 'Media Url Store',
-	api: () => import('./media-url.store.js'),
+	api: UmbMediaUrlStore,
 };
 
 export const manifests = [urlRepository, urlStore];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEMBER_GROUP_DETAIL_REPOSITORY_ALIAS, UMB_MEMBER_GROUP_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbMemberGroupDetailStore } from './member-group-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_MEMBER_GROUP_DETAIL_STORE_ALIAS,
 		name: 'Member Group Detail Store',
-		api: () => import('./member-group-detail.store.js'),
+		api: UmbMemberGroupDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEMBER_GROUP_ITEM_REPOSITORY_ALIAS, UMB_MEMBER_GROUP_STORE_ALIAS } from './constants.js';
+import { UmbMemberGroupItemStore } from './member-group-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_MEMBER_GROUP_STORE_ALIAS,
 		name: 'Member Group Item Store',
-		api: () => import('./member-group-item.store.js'),
+		api: UmbMemberGroupItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/repository/detail/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbMemberTypeDetailStore } from './member-type-detail.store.js';
+
 export const UMB_MEMBER_TYPE_DETAIL_REPOSITORY_ALIAS = 'Umb.Repository.MemberType.Detail';
 export const UMB_MEMBER_TYPE_DETAIL_STORE_ALIAS = 'Umb.Store.MemberType.Detail';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_MEMBER_TYPE_DETAIL_STORE_ALIAS,
 		name: 'Member Type Detail Store',
-		api: () => import('./member-type-detail.store.js'),
+		api: UmbMemberTypeDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/repository/item/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbMemberTypeItemStore } from './member-type-item.store.js';
+
 export const UMB_MEMBER_TYPE_ITEM_REPOSITORY_ALIAS = 'Umb.Repository.MemberTypeItem';
 export const UMB_MEMBER_TYPE_STORE_ALIAS = 'Umb.Store.MemberTypeItem';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_MEMBER_TYPE_STORE_ALIAS,
 		name: 'Member Type Item Store',
-		api: () => import('./member-type-item.store.js'),
+		api: UmbMemberTypeItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_MEMBER_TYPE_FOLDER_REPOSITORY_ALIAS, UMB_MEMBER_TYPE_FOLDER_STORE_ALIAS } from './constants.js';
+import { UmbMemberTypeFolderStore } from './member-type-folder.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_MEMBER_TYPE_FOLDER_STORE_ALIAS,
 		name: 'Member Type Folder Store',
-		api: () => import('./member-type-folder.store.js'),
+		api: UmbMemberTypeFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/manifests.ts
@@ -4,6 +4,7 @@ import {
 	UMB_MEMBER_TYPE_TREE_REPOSITORY_ALIAS,
 	UMB_MEMBER_TYPE_TREE_STORE_ALIAS,
 } from './constants.js';
+import { UmbMemberTypeTreeStore } from './member-type-tree.store.js';
 import { manifests as folderManifests } from './folder/manifests.js';
 import { manifests as treeItemChildrenManifests } from './tree-item-children/manifests.js';
 
@@ -18,7 +19,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_MEMBER_TYPE_TREE_STORE_ALIAS,
 		name: 'Member Type Tree Store',
-		api: () => import('./member-type-tree.store.js'),
+		api: UmbMemberTypeTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/item/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/item/repository/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbMemberItemStore } from './member-item.store.js';
+
 export const UMB_MEMBER_ITEM_REPOSITORY_ALIAS = 'Umb.Repository.MemberItem';
 export const UMB_MEMBER_STORE_ALIAS = 'Umb.Store.MemberItem';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_MEMBER_STORE_ALIAS,
 		name: 'Member Item Store',
-		api: () => import('./member-item.store.js'),
+		api: UmbMemberItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbMemberDetailStore } from './member-detail.store.js';
+
 export const UMB_MEMBER_DETAIL_REPOSITORY_ALIAS = 'Umb.Repository.Member.Detail';
 export const UMB_MEMBER_DETAIL_STORE_ALIAS = 'Umb.Store.Member.Detail';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_MEMBER_DETAIL_STORE_ALIAS,
 		name: 'Member Detail Store',
-		api: () => import('./member-detail.store.js'),
+		api: UmbMemberDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_PACKAGE_REPOSITORY_ALIAS, UMB_PACKAGE_STORE_ALIAS } from './constants.js';
+import { UmbPackageStore } from './package.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_PACKAGE_STORE_ALIAS,
 		name: 'Package Store',
-		api: () => import('./package.store.js'),
+		api: UmbPackageStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/repository/detail/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbRelationTypeDetailStore } from './relation-type-detail.store.js';
+
 export const UMB_RELATION_TYPE_DETAIL_REPOSITORY_ALIAS = 'Umb.Repository.RelationType.Detail';
 export const UMB_RELATION_TYPE_DETAIL_STORE_ALIAS = 'Umb.Store.RelationType.Detail';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_RELATION_TYPE_DETAIL_STORE_ALIAS,
 		name: 'Relation Type Detail Store',
-		api: () => import('./relation-type-detail.store.js'),
+		api: UmbRelationTypeDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_STATIC_FILE_ITEM_REPOSITORY_ALIAS, UMB_STATIC_FILE_STORE_ALIAS } from './constants.js';
+import { UmbStaticFileItemStore } from './static-file-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_STATIC_FILE_STORE_ALIAS,
 		name: 'Static File Item Store',
-		api: () => import('./static-file-item.store.js'),
+		api: UmbStaticFileItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/tree/manifests.ts
@@ -7,6 +7,7 @@ import {
 	UMB_STATIC_FILE_TREE_REPOSITORY_ALIAS,
 	UMB_STATIC_FILE_TREE_STORE_ALIAS,
 } from './constants.js';
+import { UmbStaticFileTreeStore } from './static-file-tree.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -19,7 +20,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_STATIC_FILE_TREE_STORE_ALIAS,
 		name: 'Static File Tree Store',
-		api: () => import('./static-file-tree.store.js'),
+		api: UmbStaticFileTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_TAG_REPOSITORY_ALIAS, UMB_TAG_STORE_ALIAS } from './constants.js';
+import { UmbTagStore } from './tag.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_TAG_STORE_ALIAS,
 		name: 'Tags Store',
-		api: () => import('./tag.store.js'),
+		api: UmbTagStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/repository/item/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbPartialViewItemStore } from './partial-view-item.store.js';
+
 export const UMB_PARTIAL_VIEW_ITEM_REPOSITORY_ALIAS = 'Umb.Repository.PartialView.Item';
 export const UMB_PARTIAL_VIEW_ITEM_STORE_ALIAS = 'Umb.ItemStore.PartialView';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: 'Umb.ItemStore.PartialView',
 		name: 'Partial View Item Store',
-		api: () => import('./partial-view-item.store.js'),
+		api: UmbPartialViewItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { manifests as itemManifests } from './item/manifests.js';
+import { UmbPartialViewDetailStore } from './partial-view-detail.store.js';
 
 export const UMB_PARTIAL_VIEW_DETAIL_REPOSITORY_ALIAS = 'Umb.Repository.PartialView.Detail';
 export const UMB_PARTIAL_VIEW_DETAIL_STORE_ALIAS = 'Umb.Store.PartialView.Detail';
@@ -14,7 +15,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_PARTIAL_VIEW_DETAIL_STORE_ALIAS,
 		name: 'Partial View Detail Store',
-		api: () => import('./partial-view-detail.store.js'),
+		api: UmbPartialViewDetailStore,
 	},
 	...itemManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/repository/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbPartialViewFolderStore } from './partial-view-folder.store.js';
+
 export const UMB_PARTIAL_VIEW_FOLDER_REPOSITORY_ALIAS = 'Umb.Repository.PartialView.Folder';
 export const UMB_PARTIAL_VIEW_FOLDER_STORE_ALIAS = 'Umb.Store.PartialView.Folder';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_PARTIAL_VIEW_FOLDER_STORE_ALIAS,
 		name: 'Partial View Folder Store',
-		api: () => import('./partial-view-folder.store.js'),
+		api: UmbPartialViewFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/manifests.ts
@@ -5,6 +5,7 @@ import {
 } from '../entity.js';
 import { manifests as folderManifests } from './folder/manifests.js';
 import { manifests as reloadTreeItemChildrenManifest } from './reload-tree-item-children/manifests.js';
+import { UmbPartialViewTreeStore } from './partial-view-tree.store.js';
 
 export const UMB_PARTIAL_VIEW_TREE_REPOSITORY_ALIAS = 'Umb.Repository.PartialView.Tree';
 /**
@@ -24,7 +25,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_PARTIAL_VIEW_TREE_STORE_ALIAS,
 		name: 'Partial View Tree Store',
-		api: () => import('./partial-view-tree.store.js'),
+		api: UmbPartialViewTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_SCRIPT_ITEM_REPOSITORY_ALIAS } from './constants.js';
+import { UmbScriptItemStore } from './script-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: 'Umb.ItemStore.Script',
 		name: 'Script Item Store',
-		api: () => import('./script-item.store.js'),
+		api: UmbScriptItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/repository/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_SCRIPT_DETAIL_REPOSITORY_ALIAS, UMB_SCRIPT_DETAIL_STORE_ALIAS } from './constants.js';
 import { manifests as itemManifests } from './item/manifests.js';
+import { UmbScriptDetailStore } from './script-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -12,7 +13,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_SCRIPT_DETAIL_STORE_ALIAS,
 		name: 'Script Detail Store',
-		api: () => import('./script-detail.store.js'),
+		api: UmbScriptDetailStore,
 	},
 	...itemManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_SCRIPT_FOLDER_REPOSITORY_ALIAS, UMB_SCRIPT_FOLDER_STORE_ALIAS } from './constants.js';
+import { UmbScriptFolderStore } from './script-folder.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_SCRIPT_FOLDER_STORE_ALIAS,
 		name: 'Script Folder Store',
-		api: () => import('./script-folder.store.js'),
+		api: UmbScriptFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/manifests.ts
@@ -1,6 +1,7 @@
 import { UMB_SCRIPT_ENTITY_TYPE, UMB_SCRIPT_FOLDER_ENTITY_TYPE, UMB_SCRIPT_ROOT_ENTITY_TYPE } from '../entity.js';
 import { manifests as folderManifests } from './folder/manifests.js';
 import { manifests as reloadTreeItemChildrenManifest } from './reload-tree-item-children/manifests.js';
+import { UmbScriptTreeStore } from './script-tree.store.js';
 
 export const UMB_SCRIPT_TREE_REPOSITORY_ALIAS = 'Umb.Repository.Script.Tree';
 /**
@@ -20,7 +21,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_SCRIPT_TREE_STORE_ALIAS,
 		name: 'Script Tree Store',
-		api: () => import('./script-tree.store.js'),
+		api: UmbScriptTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/repository/item/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbStylesheetItemStore } from './stylesheet-item.store.js';
+
 export const UMB_STYLESHEET_ITEM_REPOSITORY_ALIAS = 'Umb.Repository.Stylesheet.Item';
 export const UMB_STYLESHEET_ITEM_STORE_ALIAS = 'Umb.ItemStore.Stylesheet';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: 'Umb.ItemStore.Stylesheet',
 		name: 'Stylesheet Item Store',
-		api: () => import('./stylesheet-item.store.js'),
+		api: UmbStylesheetItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { manifests as itemManifests } from './item/manifests.js';
+import { UmbStylesheetDetailStore } from './stylesheet-detail.store.js';
 
 export const UMB_STYLESHEET_DETAIL_REPOSITORY_ALIAS = 'Umb.Repository.Stylesheet.Detail';
 export const UMB_STYLESHEET_DETAIL_STORE_ALIAS = 'Umb.Store.Stylesheet.Detail';
@@ -14,7 +15,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_STYLESHEET_DETAIL_STORE_ALIAS,
 		name: 'Stylesheet Detail Store',
-		api: () => import('./stylesheet-detail.store.js'),
+		api: UmbStylesheetDetailStore,
 	},
 	...itemManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/repository/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_STYLESHEET_FOLDER_REPOSITORY_ALIAS, UMB_STYLESHEET_FOLDER_STORE_ALIAS } from './constants.js';
+import { UmbStylesheetFolderStore } from './stylesheet-folder.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_STYLESHEET_FOLDER_STORE_ALIAS,
 		name: 'Stylesheet Folder Store',
-		api: () => import('./stylesheet-folder.store.js'),
+		api: UmbStylesheetFolderStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/manifests.ts
@@ -5,6 +5,7 @@ import {
 } from '../entity.js';
 import { manifests as folderManifests } from './folder/manifests.js';
 import { manifests as reloadTreeItemChildrenManifest } from './reload-tree-item-children/manifests.js';
+import { UmbStylesheetTreeStore } from './stylesheet-tree.store.js';
 
 export const UMB_STYLESHEET_TREE_ALIAS = 'Umb.Tree.Stylesheet';
 export const UMB_STYLESHEET_TREE_REPOSITORY_ALIAS = 'Umb.Repository.StylesheetTree';
@@ -24,7 +25,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_STYLESHEET_TREE_STORE_ALIAS,
 		name: 'Stylesheet Tree Store',
-		api: () => import('./stylesheet-tree.store.js'),
+		api: UmbStylesheetTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbTemplateDetailStore } from './template-detail.store.js';
+
 export const UMB_TEMPLATE_DETAIL_REPOSITORY_ALIAS = 'Umb.Repository.Template.Detail';
 export const UMB_TEMPLATE_DETAIL_STORE_ALIAS = 'Umb.Store.Template.Detail';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_TEMPLATE_DETAIL_STORE_ALIAS,
 		name: 'Template Detail Store',
-		api: () => import('./template-detail.store.js'),
+		api: UmbTemplateDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/item/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbTemplateItemStore } from './template-item.store.js';
+
 export const UMB_TEMPLATE_ITEM_REPOSITORY_ALIAS = 'Umb.Repository.TemplateItem';
 export const UMB_TEMPLATE_STORE_ALIAS = 'Umb.Store.TemplateItem';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_TEMPLATE_STORE_ALIAS,
 		name: 'Template Item Store',
-		api: () => import('./template-item.store.js'),
+		api: UmbTemplateItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_TEMPLATE_ENTITY_TYPE, UMB_TEMPLATE_ROOT_ENTITY_TYPE } from '../entity.js';
 import { manifests as reloadTreeItemChildrenManifest } from './reload-tree-item-children/manifests.js';
+import { UmbTemplateTreeStore } from './template-tree.store.js';
 
 export const UMB_TEMPLATE_TREE_REPOSITORY_ALIAS = 'Umb.Repository.Template.Tree';
 /**
@@ -19,7 +20,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'treeStore',
 		alias: UMB_TEMPLATE_TREE_STORE_ALIAS,
 		name: 'Template Tree Store',
-		api: () => import('./template-tree.store.js'),
+		api: UmbTemplateTreeStore,
 	},
 	{
 		type: 'tree',

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbCurrentUserHistoryStore } from './current-user-history.store.js';
+
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'userProfileApp',
@@ -14,6 +16,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: 'Umb.Store.CurrentUser.History',
 		name: 'Current User History Store',
-		api: () => import('./current-user-history.store.js'),
+		api: UmbCurrentUserHistoryStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/manifests.ts
@@ -4,6 +4,8 @@ import {
 	UMB_CURRENT_USER_CONFIG_REPOSITORY_ALIAS,
 	UMB_CURRENT_USER_CONFIG_STORE_ALIAS,
 } from './constants.js';
+import { UmbCurrentUserStore } from './current-user.store.js';
+import { UmbCurrentUserConfigStore } from './current-user-config.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -16,13 +18,13 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_CURRENT_USER_STORE_ALIAS,
 		name: 'Current User Store',
-		api: () => import('./current-user.store.js'),
+		api: UmbCurrentUserStore,
 	},
 	{
 		type: 'store',
 		alias: UMB_CURRENT_USER_CONFIG_STORE_ALIAS,
 		name: 'Current User Config Store',
-		api: () => import('./current-user-config.store.js'),
+		api: UmbCurrentUserConfigStore,
 	},
 	{
 		type: 'repository',

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_USER_GROUP_DETAIL_REPOSITORY_ALIAS, UMB_USER_GROUP_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbUserGroupDetailStore } from './user-group-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_USER_GROUP_DETAIL_STORE_ALIAS,
 		name: 'User Group Detail Store',
-		api: () => import('./user-group-detail.store.js'),
+		api: UmbUserGroupDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_USER_GROUP_ITEM_REPOSITORY_ALIAS, UMB_USER_GROUP_STORE_ALIAS } from './constants.js';
+import { UmbUserGroupItemStore } from './user-group-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_USER_GROUP_STORE_ALIAS,
 		name: 'User Group Item Store',
-		api: () => import('./user-group-item.store.js'),
+		api: UmbUserGroupItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/manifests.ts
@@ -1,11 +1,12 @@
 import { UMB_USER_CONFIG_REPOSITORY_ALIAS, UMB_USER_CONFIG_STORE_ALIAS } from './constants.js';
+import { UmbUserConfigStore } from './user-config.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
 		type: 'store',
 		alias: UMB_USER_CONFIG_STORE_ALIAS,
 		name: 'User Config Store',
-		api: () => import('./user-config.store.js'),
+		api: UmbUserConfigStore,
 	},
 	{
 		type: 'repository',

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/detail/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_USER_DETAIL_REPOSITORY_ALIAS, UMB_USER_DETAIL_STORE_ALIAS } from './constants.js';
+import { UmbUserDetailStore } from './user-detail.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_USER_DETAIL_STORE_ALIAS,
 		name: 'User Detail Store',
-		api: () => import('./user-detail.store.js'),
+		api: UmbUserDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/item/manifests.ts
@@ -1,4 +1,5 @@
 import { UMB_USER_ITEM_REPOSITORY_ALIAS, UMB_USER_ITEM_STORE_ALIAS } from './constants.js';
+import { UmbUserItemStore } from './user-item.store.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -11,6 +12,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_USER_ITEM_STORE_ALIAS,
 		name: 'User Item Store',
-		api: () => import('./user-item.store.js'),
+		api: UmbUserItemStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-event/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-event/repository/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbWebhookEventStore } from './webhook-event.store.js';
+
 export const UMB_WEBHOOK_EVENT_REPOSITORY_ALIAS = 'Umb.Repository.Webhook.Event';
 export const UMB_WEBHOOK_EVENT_STORE_ALIAS = 'Umb.Store.Webhook.Event';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_WEBHOOK_EVENT_STORE_ALIAS,
 		name: 'Webhook Event Store',
-		api: () => import('./webhook-event.store.js'),
+		api: UmbWebhookEventStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/detail/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/detail/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbWebhookDetailStore } from './webhook-detail.store.js';
+
 export const UMB_WEBHOOK_DETAIL_REPOSITORY_ALIAS = 'Umb.Repository.Webhook.Detail';
 export const UMB_WEBHOOK_DETAIL_STORE_ALIAS = 'Umb.Store.Webhook.Detail';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'store',
 		alias: UMB_WEBHOOK_DETAIL_STORE_ALIAS,
 		name: 'Webhook Detail Store',
-		api: () => import('./webhook-detail.store.js'),
+		api: UmbWebhookDetailStore,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/item/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/item/manifests.ts
@@ -1,3 +1,5 @@
+import { UmbWebhookItemStore } from './webhook-item.store.js';
+
 export const UMB_WEBHOOK_ITEM_REPOSITORY_ALIAS = 'Umb.Repository.WebhookItem';
 export const UMB_WEBHOOK_STORE_ALIAS = 'Umb.Store.WebhookItem';
 
@@ -12,6 +14,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'itemStore',
 		alias: UMB_WEBHOOK_STORE_ALIAS,
 		name: 'Webhook Item Store',
-		api: () => import('./webhook-item.store.js'),
+		api: UmbWebhookItemStore,
 	},
 ];


### PR DESCRIPTION
This PR updates all store-related Manifest registrations to use direct class references instead of lazy loading via dynamic imports. This removes unnecessary network requests on application startup for store classes, as these are Global Context anyway.

**Result**:
The number of network requests was reduced by 73 requests.

**Changes**

Updated the `api` property in manifest registrations from:
```typescript
api: () => import('./some-store.js')
```

To:
```typescript
api: SomeStoreClass
```

**Affected Manifest Types**
| Type | Count |
|------|-------|
| `store` | 37 |
| `itemStore` | 25 |
| `treeStore` | 15 |
| **Total** | 77