### PR TITLE
Added a migration to remove the property regex validation length limit (v16 backport)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -130,5 +130,8 @@ public class UmbracoPlan : MigrationPlan
 
         // To 16.4.0
         To<V_16_4_0.CreateMissingTabs>("{6A7D3B80-8B64-4E41-A7C0-02EC39336E97}");
+
+        // To 16.5.0
+        To<V_16_5_0.ChangeValidationRegExpToNvarcharMax>("{0C555A5F-8D7D-4B22-BA11-7C74A7A41964}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_5_0/ChangeValidationRegExpToNvarcharMax.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_16_5_0/ChangeValidationRegExpToNvarcharMax.cs
@@ -1,0 +1,44 @@
+using NPoco;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_16_5_0;
+
+public class ChangeValidationRegExpToNvarcharMax : MigrationBase
+{
+    public ChangeValidationRegExpToNvarcharMax(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        // SQLite doesn't need this - text is already unlimited
+        if (DatabaseType == DatabaseType.SQLite)
+        {
+            return;
+        }
+
+        // Check if the column is already nvarchar(max) (CHARACTER_MAXIMUM_LENGTH = -1)
+        // Skip migration if already migrated to prevent re-running
+        var maxLength = Database.ExecuteScalar<int?>(
+            @"SELECT CHARACTER_MAXIMUM_LENGTH
+              FROM INFORMATION_SCHEMA.COLUMNS
+              WHERE TABLE_NAME = @0
+              AND COLUMN_NAME = @1
+              AND TABLE_SCHEMA = SCHEMA_NAME()",
+            Constants.DatabaseSchema.Tables.PropertyType,
+            "validationRegExp");
+
+        // -1 means nvarchar(max) - already migrated
+        if (maxLength == -1)
+        {
+            return;
+        }
+
+        Alter.Table(Constants.DatabaseSchema.Tables.PropertyType)
+            .AlterColumn("validationRegExp")
+            .AsCustom("nvarchar(max)")
+            .Nullable()
+            .Do();
+    }
+}


### PR DESCRIPTION
V16 version of #21175

I made and am targeting the release branch to not accidently put a migration in a patch version if it were to come out before then.