### PR TITLE
Tests: Fix CS4014 warnings - add missing await operators

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LanguageRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LanguageRepositoryTest.cs
@@ -23,7 +23,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
 internal sealed class LanguageRepositoryTest : UmbracoIntegrationTest
 {
     [SetUp]
-    public void SetUp() => CreateTestData();
+    public async Task SetUp() => await CreateTestData();
 
     [Test]
     public void Can_Perform_Get_On_LanguageRepository()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LongRunningOperationRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LongRunningOperationRepositoryTests.cs
@@ -142,7 +142,7 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
         await CreateTestData(repository);
 
         var testOperation = _operations[1];
-        repository.UpdateStatusAsync(testOperation.Operation.Id, LongRunningOperationStatus.Failed, DateTimeOffset.UtcNow);
+        await repository.UpdateStatusAsync(testOperation.Operation.Id, LongRunningOperationStatus.Failed, DateTimeOffset.UtcNow);
 
         var result = await repository.GetAsync(testOperation.Operation.Id);
         Assert.IsNotNull(result);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Validation.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Validation.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.ContentEditing;
@@ -351,11 +351,11 @@ internal partial class BlockListElementLevelVariationTests
     [Test]
     [ConfigureBuilder(ActionName = nameof(ConfigureAllowEditInvariantFromNonDefaultTrue))]
     public async Task Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only_With_AllowEditInvariantFromNonDefault()
-        => Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(true);
+        => await Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(true);
 
     [Test]
     public async Task Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only_Without_AllowEditInvariantFromNonDefault()
-        => Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(false);
+        => await Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(false);
 
     private async Task Can_Validate_Missing_Properties_Nested_Blocks_Specific_Culture_Only(bool expectedInvariantValidationErrors)
     {


### PR DESCRIPTION
## Summary
- Fixed 4 CS4014 compiler warnings for unawaited async calls in test files
- These warnings indicate potential bugs where async operations complete after test assertions

## Changes
| File | Issue | Fix |
|------|-------|-----|
| `LanguageRepositoryTest.cs` | `SetUp()` called async `CreateTestData()` without await | Changed to `async Task SetUp()` with `await` |
| `LongRunningOperationRepositoryTests.cs` | `UpdateStatusAsync()` not awaited | Added `await` |
| `BlockListElementLevelVariationTests.Validation.cs` | Two test methods didn't await async calls | Added `await` (×2) |

## Why This Matters
Unawaited async calls in tests can cause:
- Race conditions between test setup and assertions
- Swallowed exceptions that should fail the test
- Unpredictable/flaky test behavior

## Test Plan
- [x] Build succeeds with 0 errors
- [x] No CS4014 warnings remaining
- [x] Unit tests pass (3678 passed, 0 failed)
- [ ] Integration tests (CI will run)