### PR TITLE
Logging: Resolves all CA2017 warnings and improves message clarity

### DIFF
--- a/src/Umbraco.Core/Models/Member.cs
+++ b/src/Umbraco.Core/Models/Member.cs
@@ -513,8 +513,8 @@ public class Member : ContentBase, IMember
         {
             StaticApplicationLogging.Logger.LogWarning(
                 "Trying to access the '{PropertyName}' property on '{MemberType}' " +
-                "but the {PropertyAlias} property does not exist on the member type so a default value is returned. " +
-                "Ensure that you have a property type with alias:  {PropertyAlias} configured on your member type in order to use the '{PropertyName}' property on the model correctly.",
+                "but the property type with alias '{PropertyAlias}' does not exist on the member type. " +
+                "A default value is returned. Ensure this property type is configured on your member type.",
                 logPropertyName,
                 typeof(Member),
                 logPropertyAlias);

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlanExecutor.cs
@@ -320,7 +320,7 @@ public class MigrationPlanExecutor : IMigrationPlanExecutor
         var backOfficeClientId = await openIddictApplicationManager.GetIdAsync(backOfficeClient);
         if (backOfficeClientId is null)
         {
-            _logger.LogWarning("Could not extract the clientId from the openIddict backofficelient Application. Canceling token revocation. Users might have to manually log out to get proper access to the backoffice", Constants.OAuthClientIds.BackOffice);
+            _logger.LogWarning("Could not extract the clientId from the openIddict backoffice client Application for {BackOfficeClientId}. Canceling token revocation. Users might have to manually log out to get proper access to the backoffice", Constants.OAuthClientIds.BackOffice);
             return;
         }
 

--- a/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/AutoModelsNotificationHandler.cs
@@ -122,7 +122,7 @@ public sealed class AutoModelsNotificationHandler : INotificationHandler<Umbraco
             catch (Exception e)
             {
                 _mbErrors.Report("Failed to build Live models.", e);
-                _logger.LogError("Failed to generate models.", e);
+                _logger.LogError(e, "Failed to generate models.");
             }
         }
         else


### PR DESCRIPTION
- Refines a warning when a property type alias is missing, clarifying that a default value is returned.
- Improves backoffice token revocation log by including contextual client id for easier troubleshooting.
- Corrects model generation error logging by passing the exception as the first argument for consistency.