### PR TITLE
Management API: Fixes the warning CS8524 and tidying up the "Set Status Redirect Url Management Controller"

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
@@ -34,7 +34,7 @@ public class SetStatusRedirectUrlManagementController : RedirectUrlManagementCon
     /// <summary>
     /// Sets the redirect URL tracking status.
     /// </summary>
-    /// <param name="cancellationToken">The cancellation token (currently unused, reserved for future use).</param>
+    /// <param name="cancellationToken">The cancellation token for the HTTP request.</param>
     /// <param name="status">The redirect status to set.</param>
     /// <returns>An OK result if successful.</returns>
     [HttpPost("status")]


### PR DESCRIPTION
I have added throwing an error in the switch statement if neither of the know Enums is submitted to the API, in theory this should never happen.

The other option would be to simply return false, but I think throwing the exception is better as it will alert whoever is calling the API that their call is invalid.

I also added XML documentation throughout the file.