### PR TITLE
Media Picker: Always include folders when searching for media

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -37,12 +37,24 @@ public class SearchMediaItemController : MediaItemControllerBase
     [Obsolete("Use the non-obsolete constructor instead, will be removed in Umbraco 18.")]
     public SearchMediaItemController(
         IIndexedEntitySearchService indexedEntitySearchService,
+        IMediaPresentationFactory mediaPresentationFactory,
+        IDataTypeService dataTypeService)
+        : this(
+            indexedEntitySearchService,
+            mediaPresentationFactory,
+            dataTypeService,
+            StaticServiceProvider.Instance.GetRequiredService<IMediaTypeService>())
+    {
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead, will be removed in Umbraco 18.")]
+    public SearchMediaItemController(
+        IIndexedEntitySearchService indexedEntitySearchService,
         IMediaPresentationFactory mediaPresentationFactory)
         : this(
             indexedEntitySearchService,
             mediaPresentationFactory,
-            StaticServiceProvider.Instance.GetRequiredService<IDataTypeService>(),
-            StaticServiceProvider.Instance.GetRequiredService<IMediaTypeService>())
+            StaticServiceProvider.Instance.GetRequiredService<IDataTypeService>())
     {
     }
 
@@ -82,11 +94,12 @@ public class SearchMediaItemController : MediaItemControllerBase
         [FromQuery] IEnumerable<Guid>? allowedMediaTypes = null,
         Guid? dataTypeId = null)
     {
-        //We always want to include folders in the search results
-        if (allowedMediaTypes != null)
+        // We always want to include folders in the search results (aligns with behaviour in Umbraco 13, and allows folders
+        // to be selected to find the selectable items inside).
+        if (allowedMediaTypes is not null)
         {
             IMediaType? folderMediaType = _mediaTypeService.Get(Constants.Conventions.MediaTypes.Folder);
-            if (folderMediaType != null && !allowedMediaTypes.Contains(folderMediaType.Key))
+            if (folderMediaType is not null && allowedMediaTypes.Contains(folderMediaType.Key) is false)
             {
                 allowedMediaTypes = [..allowedMediaTypes, folderMediaType.Key];
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #21149 

### Description
This fixes #21149 by always including the folder media type when allowed media types are specified. This matches the behavior previously seen in v13.

I have chosen to do this in the `SearchMediaItemController`. This may not be the best place, if so feel free to suggest a better alternative and I'll update the PR accordingly. I did not want to actually modify the allowed media types in the picker, since we do not want the user to be able to select folders, only search for them.

To test, ensure you have few folders in the Media section. Without this PR, these folder will not show up in the search results in the Media Picker. With this PR, they will.
