### PR TITLE
Document Permissions: Export `UmbDocumentUserPermissionCondition` from package (closes #21199)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/conditions/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/conditions/index.ts
@@ -1,0 +1,1 @@
+export { UmbDocumentUserPermissionCondition } from './document-user-permission.condition.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/user-permissions/document/index.ts
@@ -1,1 +1,2 @@
+export * from './conditions/index.js';
 export * from './repository/index.js';


### PR DESCRIPTION
## Summary

Fixes #21199 

- Adds missing export for `UmbDocumentUserPermissionCondition` class from the documents package
- Extension developers can now import and use this condition in their extensions

## Changes

- Created `conditions/index.ts` to export the condition class
- Updated `document/index.ts` to re-export from conditions

**Note**: Constants and types were already exported via their respective chains (`constants.ts` and `types.ts`), only the class itself was missing.

## Import path

After this fix, extensions can import:

```typescript
import { UmbDocumentUserPermissionCondition } from '@umbraco-cms/backoffice/document';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)