### PR TITLE
Content Type Workspace: Fix navigation blocked after save (closes #21196)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
@@ -153,6 +153,7 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 		const data = await this.structure.reload();
 		if (data) {
 			this._data.setPersisted(data);
+			this._data.setCurrent(data);
 		}
 	}
 
@@ -172,7 +173,9 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 		try {
 			await this.structure.create(parent?.unique);
 
-			this._data.setPersisted(this.structure.getOwnerContentType());
+			const savedData = this.structure.getOwnerContentType();
+			this._data.setPersisted(savedData);
+			this._data.setCurrent(savedData);
 
 			const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
 			if (!eventContext) {
@@ -198,7 +201,9 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 		try {
 			await this.structure.save();
 
-			this._data.setPersisted(this.structure.getOwnerContentType());
+			const savedData = this.structure.getOwnerContentType();
+			this._data.setPersisted(savedData);
+			this._data.setCurrent(savedData);
 
 			const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
 			if (!eventContext) {


### PR DESCRIPTION
## Summary

Fixes #21196

After saving a content type (document type, media type, etc.), navigation was intermittently blocked with a "discard changes" modal appearing unexpectedly. The console showed warnings about changes being detected via JSON comparison.

**Root Cause**: In `content-type-workspace-context-base.ts`, the `_update()`, `_create()`, and `reload()` methods only called `_data.setPersisted()` but NOT `_data.setCurrent()`. An observer kept `current` in sync with `structure.ownerContentType`, but timing mismatches caused `persisted` and `current` to differ after save, triggering false dirty state detection.

**Fix**: Added `_data.setCurrent(savedData)` after `_data.setPersisted(savedData)` in all three methods to ensure both are synchronized immediately after save.

## Test plan

- [ ] Open Settings → Document Types
- [ ] Edit any document type (change name, add a property, etc.)
- [ ] Click Save
- [ ] After save completes, click on another section (Content, Media, etc.)
- [ ] **Expected**: Navigation works immediately without "discard changes" modal
- [ ] Repeat for Media Types and Member Types

🤖 Generated with [Claude Code](https://claude.com/claude-code)