### PR TITLE
TextBox: Fix max length validation message showing wrong exceeded count (closes #21198)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/property-editor-ui-text-box.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/property-editor-ui-text-box.element.ts
@@ -81,7 +81,8 @@ export class UmbPropertyEditorUITextBoxElement
 	}
 
 	#getMaxLengthMessage(max: number, current: number) {
-		return this.localize.term('textbox_characters_exceed', max, current);
+		const exceeded = current - max;
+		return this.localize.term('textbox_characters_exceed', max, exceeded);
 	}
 
 	#onInput(e: InputEvent) {


### PR DESCRIPTION
## Summary

Fixes #21198

The TextBox max length validation message was displaying the total character count instead of how many characters exceeded the limit.

**Example with max length = 4:**
- User enters "12345" (5 characters)
- **Before (wrong)**: "Maximum 4 characters, 5 too many"
- **After (correct)**: "Maximum 4 characters, 1 too many"

**Root Cause**: The `#getMaxLengthMessage()` callback passed `current` (total length) directly to the localization term instead of calculating `exceeded = current - max`.

**Note**: This was a regression introduced in PR #20886. The TextArea component had the correct calculation, but TextBox did not.

## Test plan

- [ ] Create a document type with a TextBox property that has max length = 4
- [ ] Create content using this document type
- [ ] Enter more than 4 characters in the text box (e.g., "12345")
- [ ] **Expected**: Validation message shows "Maximum 4 characters, 1 too many"
- [ ] **Not**: "Maximum 4 characters, 5 too many"

🤖 Generated with [Claude Code](https://claude.com/claude-code)