### PR TITLE
Document Editing: Fix property variation change breaking document save via Infinite Editing (closes #21195)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -178,6 +178,12 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 	#saveModalToken?: UmbModalToken<UmbContentVariantPickerData<VariantOptionModelType>, UmbContentVariantPickerValue>;
 	#contentTypePropertyName: string;
 
+	/**
+	 * Cache of property variation settings to detect changes when structure is updated.
+	 * Used to trigger value migration when properties change from invariant to variant or vice versa.
+	 */
+	#propertyVariationCache = new Map<string, { variesByCulture: boolean; variesBySegment: boolean }>();
+
 	constructor(
 		host: UmbControllerHost,
 		args: UmbContentDetailWorkspaceContextArgs<
@@ -375,6 +381,16 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			this.structure.contentTypeDataTypeUniques,
 			(dataTypeUniques: Array<string>) => {
 				this.#dataTypeItemManager.setUniques(dataTypeUniques);
+			},
+			null,
+		);
+
+		// Observe property variation changes to trigger value migration when properties change
+		// from invariant to variant (or vice versa) via Infinite Editing
+		this.observe(
+			this.structure.contentTypeProperties,
+			(properties: Array<UmbPropertyTypeModel>) => {
+				this.#handlePropertyVariationChanges(properties);
 			},
 			null,
 		);
@@ -1092,6 +1108,67 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		host: UmbControllerHost,
 		variantId: UmbVariantId,
 	): UmbContentPropertyDatasetContext<DetailModelType, ContentTypeDetailModelType, VariantModelType>;
+
+	/**
+	 * Handles property variation changes when the document type is updated via Infinite Editing.
+	 * When a property's variation setting changes (e.g., from shared/invariant to variant or vice versa),
+	 * this method reloads the document to get properly migrated values from the server.
+	 */
+	#handlePropertyVariationChanges(properties: Array<UmbPropertyTypeModel>): void {
+		// Skip if no current data or if this is initial load
+		const currentData = this._data.getCurrent();
+		if (!currentData || this.#propertyVariationCache.size === 0) {
+			// Initial load - just populate the cache
+			for (const property of properties) {
+				this.#propertyVariationCache.set(property.alias, {
+					variesByCulture: property.variesByCulture,
+					variesBySegment: property.variesBySegment,
+				});
+			}
+			return;
+		}
+
+		// Check for variation setting changes
+		let hasChanges = false;
+		for (const property of properties) {
+			const cached = this.#propertyVariationCache.get(property.alias);
+			if (cached) {
+				if (
+					cached.variesByCulture !== property.variesByCulture ||
+					cached.variesBySegment !== property.variesBySegment
+				) {
+					hasChanges = true;
+				}
+			}
+			// Update cache
+			this.#propertyVariationCache.set(property.alias, {
+				variesByCulture: property.variesByCulture,
+				variesBySegment: property.variesBySegment,
+			});
+		}
+
+		// If variation settings changed, reload to get properly migrated values
+		if (hasChanges) {
+			this.reload();
+		}
+	}
+
+	/**
+	 * Override reload to process incoming data through the value migration pipeline.
+	 * This ensures property values are properly transformed when variation settings change.
+	 */
+	public override async reload(): Promise<void> {
+		const unique = this.getUnique();
+		if (!unique) throw new Error('Unique is not set');
+		const { data } = await this._detailRepository!.requestByUnique(unique);
+
+		if (data) {
+			// Process the data through _processIncomingData to handle value migration
+			const processedData = await this._processIncomingData(data);
+			this._data.setPersisted(processedData);
+			this._data.setCurrent(processedData);
+		}
+	}
 
 	public override destroy(): void {
 		this.structure.destroy();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.test.ts
@@ -230,5 +230,91 @@ describe('UmbPropertyValuePresetVariantBuilderController', () => {
 			expect(result[5]?.culture).to.be.equal('cultureB');
 			expect(result[5]?.segment).to.be.equal('segmentB');
 		});
+
+		it('migrates invariant value to variant when variation changes', async () => {
+			const ctrlHost = new UmbTestControllerHostElement();
+			const ctrl = new UmbPropertyValuePresetVariantBuilderController(ctrlHost);
+			ctrl.setCultures(['en-US', 'da-DK']);
+
+			// Set existing values as invariant (culture: null) - simulating before variation change
+			ctrl.setValues([
+				{
+					alias: 'test',
+					value: 'invariant value',
+					culture: null,
+					segment: null,
+					editorAlias: 'test-editor-schema',
+				},
+			]);
+
+			// Property now varies by culture (after variation change)
+			const propertyTypes: Array<UmbPropertyTypePresetModel | UmbPropertyTypePresetWithSchemaAliasModel> = [
+				{
+					alias: 'test',
+					propertyEditorUiAlias: 'test-editor-ui',
+					propertyEditorSchemaAlias: 'test-editor-schema',
+					config: [],
+					typeArgs: { variesByCulture: true },
+				},
+			];
+
+			const result = await ctrl.create(propertyTypes, {
+				entityType: 'test',
+				entityUnique: 'some-unique',
+			});
+
+			// Both culture variants should inherit the invariant value
+			// Note: When a value exists, the preset API preserves it without modification
+			expect(result.length).to.be.equal(2);
+			expect(result[0]?.value).to.be.equal('invariant value');
+			expect(result[0]?.culture).to.be.equal('en-US');
+			expect(result[1]?.value).to.be.equal('invariant value');
+			expect(result[1]?.culture).to.be.equal('da-DK');
+		});
+
+		it('migrates variant value to invariant when variation changes', async () => {
+			const ctrlHost = new UmbTestControllerHostElement();
+			const ctrl = new UmbPropertyValuePresetVariantBuilderController(ctrlHost);
+
+			// Set existing values as variant (culture-specific) - simulating before variation change
+			ctrl.setValues([
+				{
+					alias: 'test',
+					value: 'en-US value',
+					culture: 'en-US',
+					segment: null,
+					editorAlias: 'test-editor-schema',
+				},
+				{
+					alias: 'test',
+					value: 'da-DK value',
+					culture: 'da-DK',
+					segment: null,
+					editorAlias: 'test-editor-schema',
+				},
+			]);
+
+			// Property is now invariant (after variation change)
+			const propertyTypes: Array<UmbPropertyTypePresetModel | UmbPropertyTypePresetWithSchemaAliasModel> = [
+				{
+					alias: 'test',
+					propertyEditorUiAlias: 'test-editor-ui',
+					propertyEditorSchemaAlias: 'test-editor-schema',
+					config: [],
+					typeArgs: { variesByCulture: false },
+				},
+			];
+
+			const result = await ctrl.create(propertyTypes, {
+				entityType: 'test',
+				entityUnique: 'some-unique',
+			});
+
+			// Invariant value should use first culture-specific value found
+			// Note: When a value exists, the preset API preserves it without modification
+			expect(result.length).to.be.equal(1);
+			expect(result[0]?.value).to.be.equal('en-US value');
+			expect(result[0]?.culture).to.be.null;
+		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.ts
@@ -101,8 +101,51 @@ export class UmbPropertyValuePresetVariantBuilderController extends UmbPropertyV
 		const variantId = new UmbVariantId(culture, segment);
 		const args: Partial<UmbPropertyValuePresetApiCallArgs> = {
 			variantId,
-			value: this._existingValues?.find((x) => x.alias === alias && variantId.compare(x))?.value,
+			value: this.#findExistingValue(alias, variantId),
 		};
 		return args;
+	}
+
+	/**
+	 * Finds an existing value for a property, with fallback logic for variation setting changes.
+	 * When a property changes from invariant to variant (or vice versa), the existing values
+	 * may have a different culture/segment than what we're looking for. This method handles
+	 * value migration by trying fallback lookups.
+	 */
+	#findExistingValue(alias: string, variantId: UmbVariantId): unknown {
+		if (!this._existingValues) return undefined;
+
+		// First, try exact match (same alias + same culture/segment)
+		const exactMatch = this._existingValues.find((x) => x.alias === alias && variantId.compare(x));
+		if (exactMatch) {
+			return exactMatch.value;
+		}
+
+		// No exact match - try fallback for variation setting changes
+		// Get all values for this property alias
+		const valuesForAlias = this._existingValues.filter((x) => x.alias === alias);
+		if (valuesForAlias.length === 0) {
+			return undefined;
+		}
+
+		// Fallback 1: If looking for a culture-specific value, try to use the invariant value
+		// This handles: invariant → variant migration
+		if (variantId.culture !== null) {
+			const invariantValue = valuesForAlias.find((x) => x.culture === null && x.segment === variantId.segment);
+			if (invariantValue) {
+				return invariantValue.value;
+			}
+		}
+
+		// Fallback 2: If looking for an invariant value, try to use the first culture-specific value
+		// This handles: variant → invariant migration
+		if (variantId.culture === null) {
+			const anyVariantValue = valuesForAlias.find((x) => x.culture !== null && x.segment === variantId.segment);
+			if (anyVariantValue) {
+				return anyVariantValue.value;
+			}
+		}
+
+		return undefined;
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes issue where changing a property's variation setting (Shared/Invariant ↔ Variant) via Infinite Editing caused document save to fail with 404 error
- Adds value migration fallback logic to find values when culture/segment doesn't match exactly
- Overrides `reload()` to process incoming data through `_processIncomingData()` for proper value transformation

Fixes #21195

## Root Cause
When a property's variation setting was changed via Infinite Editing, the document's values in memory still had the old culture/segment format. The base class `reload()` method was fetching raw data without processing it through `_processIncomingData()`, which contains the value migration logic.

## Changes
1. **`property-value-preset-variant-builder.controller.ts`**: Added `#findExistingValue()` method with fallback logic:
   - Handles invariant → variant migration (uses null-culture value for all variants)
   - Handles variant → invariant migration (uses first culture value for invariant)

2. **`content-detail-workspace-base.ts`**: 
   - Added property variation cache and observer to detect changes
   - Override `reload()` to call `_processIncomingData()` for proper value transformation

## Test plan
- [x] Unit tests pass (8 tests in variant builder controller)
- [x] Manual testing: Change property from Shared to Variant → Save document works
- [x] Manual testing: Change property from Variant to Shared → Save document works
- [x] Values are preserved during variation changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)