### PR TITLE
Code clean-up: Fixes all SA1117 warnings and adding more XML documentation comments

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/BackOfficeAuthPolicyBuilderExtensions.cs
@@ -60,15 +60,25 @@ internal static class BackOfficeAuthPolicyBuilderExtensions
         AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessContentOrMedia, Constants.Applications.Content, Constants.Applications.Media);
         AddAllowedApplicationsPolicy(
             AuthorizationPolicies.SectionAccessForContentTree,
-            Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Users,
-            Constants.Applications.Settings, Constants.Applications.Packages, Constants.Applications.Members);
+            Constants.Applications.Content,
+            Constants.Applications.Media,
+            Constants.Applications.Users,
+            Constants.Applications.Settings,
+            Constants.Applications.Packages,
+            Constants.Applications.Members);
         AddAllowedApplicationsPolicy(
             AuthorizationPolicies.SectionAccessForMediaTree,
-            Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Users,
-            Constants.Applications.Settings, Constants.Applications.Packages, Constants.Applications.Members);
+            Constants.Applications.Content,
+            Constants.Applications.Media,
+            Constants.Applications.Users,
+            Constants.Applications.Settings,
+            Constants.Applications.Packages,
+            Constants.Applications.Members);
         AddAllowedApplicationsPolicy(
             AuthorizationPolicies.SectionAccessForMemberTree,
-            Constants.Applications.Content, Constants.Applications.Media, Constants.Applications.Members);
+            Constants.Applications.Content,
+            Constants.Applications.Media,
+            Constants.Applications.Members);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessMedia, Constants.Applications.Media);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessMembers, Constants.Applications.Members);
         AddAllowedApplicationsPolicy(AuthorizationPolicies.SectionAccessPackages, Constants.Applications.Packages);

--- a/src/Umbraco.Cms.Api.Management/Install/PostUnattendedInstallNotificationHandler.cs
+++ b/src/Umbraco.Cms.Api.Management/Install/PostUnattendedInstallNotificationHandler.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -19,7 +19,18 @@ public class PostUnattendedInstallNotificationHandler : INotificationAsyncHandle
     private readonly IUserService _userService;
     private readonly IMetricsConsentService _metricsConsentService;
 
-    public PostUnattendedInstallNotificationHandler(IOptions<UnattendedSettings> unattendedSettings, IUserService userService, IServiceScopeFactory serviceScopeFactory, IMetricsConsentService metricsConsentService)
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="PostUnattendedInstallNotificationHandler" /> class.
+    /// </summary>
+    /// <param name="unattendedSettings">The unattended settings.</param>
+    /// <param name="userService">The user service.</param>
+    /// <param name="serviceScopeFactory">The service scope factory.</param>
+    /// <param name="metricsConsentService">The metrics consent service.</param>
+    public PostUnattendedInstallNotificationHandler(
+        IOptions<UnattendedSettings> unattendedSettings,
+        IUserService userService,
+        IServiceScopeFactory serviceScopeFactory,
+        IMetricsConsentService metricsConsentService)
     {
         _unattendedSettings = unattendedSettings;
         _userService = userService;
@@ -95,7 +106,9 @@ public class PostUnattendedInstallNotificationHandler : INotificationAsyncHandle
         }
 
         IdentityResult resetResult =
-            await backOfficeUserManager.ChangePasswordWithResetAsync(membershipUser.Id, resetToken,
+            await backOfficeUserManager.ChangePasswordWithResetAsync(
+                membershipUser.Id,
+                resetToken,
                 unattendedPassword!.Trim());
         if (!resetResult.Succeeded)
         {

--- a/src/Umbraco.Cms.Api.Management/Middleware/UnhandledExceptionLoggerMiddleware.cs
+++ b/src/Umbraco.Cms.Api.Management/Middleware/UnhandledExceptionLoggerMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Logging;
 using Umbraco.Extensions;
@@ -30,7 +30,9 @@ public class UnhandledExceptionLoggerMiddleware : IMiddleware
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Unhandled controller exception occurred for request '{RequestUrl}'",
+                _logger.LogError(
+                    e,
+                    "Unhandled controller exception occurred for request '{RequestUrl}'",
                     context.Request.GetEncodedPathAndQuery());
                 // Throw the error again, just in case it gets handled
                 throw;

--- a/src/Umbraco.Cms.Api.Management/Security/Authorization/MustSatisfyRequirementAuthorizationHandler.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/Authorization/MustSatisfyRequirementAuthorizationHandler.cs
@@ -52,7 +52,9 @@ public abstract class MustSatisfyRequirementAuthorizationHandler<T, TResource> :
     where T : IAuthorizationRequirement
 {
     /// <inheritdoc />
-    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, T requirement,
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        T requirement,
         TResource resource)
     {
         var isAuth = await IsAuthorized(context, requirement, resource);

--- a/src/Umbraco.Core/Composing/TypeFinder.cs
+++ b/src/Umbraco.Core/Composing/TypeFinder.cs
@@ -115,7 +115,10 @@ public class TypeFinder : ITypeFinder
     {
         IEnumerable<Assembly> assemblyList = assemblies ?? AssembliesToScan;
 
-        return GetClassesWithBaseType(assignTypeFrom, assemblyList, onlyConcreteClasses,
+        return GetClassesWithBaseType(
+            assignTypeFrom,
+            assemblyList,
+            onlyConcreteClasses,
 
             // the additional filter will ensure that any found types also have the attribute applied.
             t => t.GetCustomAttributes(attributeType, false).Any());

--- a/src/Umbraco.Core/Models/CultureImpact.cs
+++ b/src/Umbraco.Core/Models/CultureImpact.cs
@@ -145,7 +145,9 @@ public sealed class CultureImpact
     /// <param name="savingCultures"></param>
     /// <param name="defaultCulture"></param>
     /// <returns></returns>
-    public static string? GetCultureForInvariantErrors(IContent? content, string?[] savingCultures,
+    public static string? GetCultureForInvariantErrors(
+        IContent? content,
+        string?[] savingCultures,
         string? defaultCulture)
     {
         if (content == null)

--- a/src/Umbraco.Core/Models/Membership/UserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/UserGroup.cs
@@ -53,13 +53,13 @@ public class UserGroup : EntityBase, IUserGroup, IReadOnlyUserGroup
     }
 
     /// <summary>
-    ///     Constructor to create an existing user group
+    ///     Constructor to create an existing user group.
     /// </summary>
-    /// <param name="userCount"></param>
-    /// <param name="alias"></param>
-    /// <param name="name"></param>
-    /// <param name="icon"></param>
-    /// <param name="shortStringHelper"></param>
+    /// <param name="shortStringHelper">The short string helper.</param>
+    /// <param name="userCount">The user count.</param>
+    /// <param name="alias">The alias.</param>
+    /// <param name="name">The name.</param>
+    /// <param name="icon">The icon.</param>
     public UserGroup(
         IShortStringHelper shortStringHelper,
         int userCount,
@@ -100,7 +100,8 @@ public class UserGroup : EntityBase, IUserGroup, IReadOnlyUserGroup
     {
         get => _alias;
         set => SetPropertyValueAndDetectChanges(
-            value.ToCleanString(_shortStringHelper, CleanStringType.Alias | CleanStringType.UmbracoCase), ref _alias!,
+            value.ToCleanString(_shortStringHelper, CleanStringType.Alias | CleanStringType.UmbracoCase),
+            ref _alias!,
             nameof(Alias));
     }
 

--- a/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/DefaultPropertyIndexValueFactory.cs
@@ -8,8 +8,14 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// </summary>
 public class DefaultPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
-    public IEnumerable<IndexValue> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
-        IEnumerable<string> availableCultures, IDictionary<Guid, IContentType> contentTypeDictionary)
+    /// <inheritdoc />
+    public IEnumerable<IndexValue> GetIndexValues(
+        IProperty property,
+        string? culture,
+        string? segment,
+        bool published,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypeDictionary)
         =>
         [
             new IndexValue

--- a/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/IDataEditor.cs
@@ -66,6 +66,17 @@ public interface IDataEditor : IDiscoverable
     /// <returns>The result of the merge operation.</returns>
     object? MergePartialPropertyValueForCulture(object? sourceValue, object? targetValue, string? culture) => sourceValue;
 
-    object? MergeVariantInvariantPropertyValue(object? sourceValue, object? targetValue,
-        bool canUpdateInvariantData, HashSet<string> allowedCultures) => sourceValue;
+    /// <summary>
+    ///     Merges variant and invariant property values.
+    /// </summary>
+    /// <param name="sourceValue">The source property value.</param>
+    /// <param name="targetValue">The target property value.</param>
+    /// <param name="canUpdateInvariantData">A value indicating whether invariant data can be updated.</param>
+    /// <param name="allowedCultures">The set of allowed cultures.</param>
+    /// <returns>The result of the merge operation.</returns>
+    object? MergeVariantInvariantPropertyValue(
+        object? sourceValue,
+        object? targetValue,
+        bool canUpdateInvariantData,
+        HashSet<string> allowedCultures) => sourceValue;
 }

--- a/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
+++ b/src/Umbraco.Core/PropertyEditors/NoopPropertyIndexValueFactory.cs
@@ -8,7 +8,12 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 public class NoopPropertyIndexValueFactory : IPropertyIndexValueFactory
 {
     /// <inheritdoc />
-    public IEnumerable<IndexValue> GetIndexValues(IProperty property, string? culture, string? segment, bool published,
-        IEnumerable<string> availableCultures, IDictionary<Guid, IContentType> contentTypeDictionary)
+    public IEnumerable<IndexValue> GetIndexValues(
+        IProperty property,
+        string? culture,
+        string? segment,
+        bool published,
+        IEnumerable<string> availableCultures,
+        IDictionary<Guid, IContentType> contentTypeDictionary)
         => [];
 }

--- a/src/Umbraco.Core/PropertyEditors/TextOnlyValueEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/TextOnlyValueEditor.cs
@@ -72,7 +72,11 @@ public class TextOnlyValueEditor : DataValueEditor
             _localizedTextService = localizedTextService;
         }
 
-        public IEnumerable<ValidationResult> Validate(object? value, string? valueType, object? dataTypeConfiguration,
+        /// <inheritdoc />
+        public IEnumerable<ValidationResult> Validate(
+            object? value,
+            string? valueType,
+            object? dataTypeConfiguration,
             PropertyValidationContext validationContext)
         {
             int? maxCharacters = dataTypeConfiguration switch

--- a/src/Umbraco.Core/Security/Authorization/ContentPermissionResource.cs
+++ b/src/Umbraco.Core/Security/Authorization/ContentPermissionResource.cs
@@ -25,7 +25,9 @@ public class ContentPermissionResource : IPermissionResource
     /// <param name="contentKey">The key of the content or null if root.</param>
     /// <param name="cultures">The cultures to validate</param>
     /// <returns>An instance of <see cref="ContentPermissionResource" />.</returns>
-    public static ContentPermissionResource WithKeys(string permissionToCheck, Guid? contentKey,
+    public static ContentPermissionResource WithKeys(
+        string permissionToCheck,
+        Guid? contentKey,
         IEnumerable<string> cultures) =>
         contentKey is null
             ? Root(permissionToCheck, cultures)
@@ -61,7 +63,9 @@ public class ContentPermissionResource : IPermissionResource
     /// <param name="contentKey">The key of the content.</param>
     /// <param name="cultures">The required culture access</param>
     /// <returns>An instance of <see cref="ContentPermissionResource" />.</returns>
-    public static ContentPermissionResource WithKeys(string permissionToCheck, Guid contentKey,
+    public static ContentPermissionResource WithKeys(
+        string permissionToCheck,
+        Guid contentKey,
         IEnumerable<string> cultures) => WithKeys(permissionToCheck, contentKey.Yield(), cultures);
 
     /// <summary>
@@ -80,7 +84,9 @@ public class ContentPermissionResource : IPermissionResource
     /// <param name="contentKeys">The keys of the contents.</param>
     /// <param name="cultures">The required culture access</param>
     /// <returns>An instance of <see cref="ContentPermissionResource" />.</returns>
-    public static ContentPermissionResource WithKeys(string permissionToCheck, IEnumerable<Guid> contentKeys,
+    public static ContentPermissionResource WithKeys(
+        string permissionToCheck,
+        IEnumerable<Guid> contentKeys,
         IEnumerable<string> cultures) =>
         new(
             contentKeys,
@@ -114,7 +120,12 @@ public class ContentPermissionResource : IPermissionResource
     /// <param name="cultures">The cultures to validate</param>
     /// <returns>An instance of <see cref="ContentPermissionResource" />.</returns>
     public static ContentPermissionResource Root(string permissionToCheck, IEnumerable<string> cultures) =>
-        new(Enumerable.Empty<Guid>(), new HashSet<string> { permissionToCheck }, true, false, null,
+        new(
+            Enumerable.Empty<Guid>(),
+            new HashSet<string> { permissionToCheck },
+            true,
+            false,
+            null,
             new HashSet<string>(cultures));
 
     /// <summary>
@@ -176,7 +187,9 @@ public class ContentPermissionResource : IPermissionResource
     /// <param name="parentKeyForBranch">The parent key of the branch.</param>
     /// <param name="culturesToCheck">The required cultures</param>
     /// <returns>An instance of <see cref="ContentPermissionResource" />.</returns>
-    public static ContentPermissionResource Branch(string permissionToCheck, Guid parentKeyForBranch,
+    public static ContentPermissionResource Branch(
+        string permissionToCheck,
+        Guid parentKeyForBranch,
         IEnumerable<string> culturesToCheck) =>
         new(
             Enumerable.Empty<Guid>(),
@@ -189,7 +202,8 @@ public class ContentPermissionResource : IPermissionResource
     private ContentPermissionResource(
         IEnumerable<Guid> contentKeys,
         ISet<string> permissionsToCheck,
-        bool checkRoot, bool checkRecycleBin,
+        bool checkRoot,
+        bool checkRecycleBin,
         Guid? parentKeyForBranch,
         ISet<string>? culturesToCheck)
     {

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -292,7 +292,9 @@ internal sealed class ContentEditingService
     public async Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid key, Guid? parentKey, bool relateToOriginal, bool includeDescendants, Guid userKey)
         => await HandleCopyAsync(key, parentKey, relateToOriginal, includeDescendants, userKey);
 
-    public async Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels,
+    public async Task<ContentEditingOperationStatus> SortAsync(
+        Guid? parentKey,
+        IEnumerable<SortingModel> sortingModels,
         Guid userKey)
         => await HandleSortAsync(parentKey, sortingModels, userKey);
 

--- a/src/Umbraco.Core/Services/IDataTypeService.cs
+++ b/src/Umbraco.Core/Services/IDataTypeService.cs
@@ -26,7 +26,10 @@ public interface IDataTypeService : IService
         => Task.FromResult(new PagedModel<RelationItemModel>());
 
     [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
-    Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(int parentId, Guid key, string name,
+    Attempt<OperationResult<OperationResultType, EntityContainer>?> CreateContainer(
+        int parentId,
+        Guid key,
+        string name,
         int userId = Constants.Security.SuperUserId);
 
     [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
@@ -51,7 +54,9 @@ public interface IDataTypeService : IService
     Attempt<OperationResult?> DeleteContainer(int containerId, int userId = Constants.Security.SuperUserId);
 
     [Obsolete("Please use IDataTypeContainerService for all data type container operations. Will be removed in V15.")]
-    Attempt<OperationResult<OperationResultType, EntityContainer>?> RenameContainer(int id, string name,
+    Attempt<OperationResult<OperationResultType, EntityContainer>?> RenameContainer(
+        int id,
+        string name,
         int userId = Constants.Security.SuperUserId);
 
     /// <summary>
@@ -210,7 +215,9 @@ public interface IDataTypeService : IService
         Copy(copying, containerId, Constants.Security.SuperUserId);
 
     [Obsolete("Please use CopyASync instead. Will be removed in V15")]
-    Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(IDataType copying, int containerId,
+    Attempt<OperationResult<MoveOperationStatusType, IDataType>?> Copy(
+        IDataType copying,
+        int containerId,
         int userId = Constants.Security.SuperUserId) => throw new NotImplementedException();
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/TempFileCleanupJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/TempFileCleanupJob.cs
@@ -64,7 +64,9 @@ public class TempFileCleanupJob : IRecurringBackgroundJob
             case CleanFolderResultStatus.FailedWithException:
                 foreach (CleanFolderResult.Error error in result.Errors!)
                 {
-                    _logger.LogError(error.Exception, "Could not delete temp file {FileName}",
+                    _logger.LogError(
+                        error.Exception,
+                        "Could not delete temp file {FileName}",
                         error.ErroringFile.FullName);
                 }
 

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -321,7 +321,8 @@ public static partial class UmbracoBuilderExtensions
                 default:
                     return new FileSystemMainDomLock(
                         loggerFactory.CreateLogger<FileSystemMainDomLock>(),
-                        mainDomKeyGenerator, hostingEnvironment,
+                        mainDomKeyGenerator,
+                        hostingEnvironment,
                         factory.GetRequiredService<IOptionsMonitor<GlobalSettings>>());
             }
         });

--- a/src/Umbraco.Infrastructure/Examine/ExamineUmbracoIndexingHandler.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineUmbracoIndexingHandler.cs
@@ -163,7 +163,10 @@ internal sealed class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
 
                     foreach (ISearchResult item in results)
                     {
-                        if (int.TryParse(item.Id, NumberStyles.Integer, CultureInfo.InvariantCulture,
+                        if (int.TryParse(
+                                item.Id,
+                                NumberStyles.Integer,
+                                CultureInfo.InvariantCulture,
                                 out var contentId))
                         {
                             DeleteIndexForEntity(contentId, false);
@@ -405,7 +408,9 @@ internal sealed class ExamineUmbracoIndexingHandler : IUmbracoIndexingHandler
             }
         }
 
-        public static void Execute(ExamineUmbracoIndexingHandler examineUmbracoIndexingHandler, int id,
+        public static void Execute(
+            ExamineUmbracoIndexingHandler examineUmbracoIndexingHandler,
+            int id,
             bool keepIfUnpublished)
         {
             foreach (IUmbracoIndex index in examineUmbracoIndexingHandler._examineManager.Indexes

--- a/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/ThreadAbortExceptionEnricher.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/ThreadAbortExceptionEnricher.cs
@@ -19,7 +19,8 @@ public class ThreadAbortExceptionEnricher : ILogEventEnricher
 
     public ThreadAbortExceptionEnricher(
         IOptionsMonitor<CoreDebugSettings> coreDebugSettings,
-        IHostingEnvironment hostingEnvironment, IMarchal marchal)
+        IHostingEnvironment hostingEnvironment,
+        IMarchal marchal)
     {
         _coreDebugSettings = coreDebugSettings.CurrentValue;
         _hostingEnvironment = hostingEnvironment;

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Alter/Table/AlterTableBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Alter/Table/AlterTableBuilder.cs
@@ -149,14 +149,17 @@ public class AlterTableBuilder : ExpressionBuilderBase<AlterTableExpression, IAl
         ForeignKey(string primaryTableName, string primaryColumnName) =>
         ForeignKey(null, null, primaryTableName, primaryColumnName);
 
-    public IAlterTableColumnOptionForeignKeyCascadeBuilder ForeignKey(string foreignKeyName, string primaryTableName,
+    public IAlterTableColumnOptionForeignKeyCascadeBuilder ForeignKey(
+        string foreignKeyName,
+        string primaryTableName,
         string primaryColumnName) =>
         ForeignKey(foreignKeyName, null, primaryTableName, primaryColumnName);
 
     public IAlterTableColumnOptionForeignKeyCascadeBuilder ForeignKey(
         string? foreignKeyName,
         string? primaryTableSchema,
-        string primaryTableName, string primaryColumnName)
+        string primaryTableName,
+        string primaryColumnName)
     {
         CurrentColumn.IsForeignKey = true;
 
@@ -188,14 +191,17 @@ public class AlterTableBuilder : ExpressionBuilderBase<AlterTableExpression, IAl
         string foreignTableName,
         string foreignColumnName) => ReferencedBy(null, null, foreignTableName, foreignColumnName);
 
-    public IAlterTableColumnOptionForeignKeyCascadeBuilder ReferencedBy(string foreignKeyName, string foreignTableName,
+    public IAlterTableColumnOptionForeignKeyCascadeBuilder ReferencedBy(
+        string foreignKeyName,
+        string foreignTableName,
         string foreignColumnName) =>
         ReferencedBy(foreignKeyName, null, foreignTableName, foreignColumnName);
 
     public IAlterTableColumnOptionForeignKeyCascadeBuilder ReferencedBy(
         string? foreignKeyName,
         string? foreignTableSchema,
-        string foreignTableName, string foreignColumnName)
+        string foreignTableName,
+        string foreignColumnName)
     {
         var fk = new CreateForeignKeyExpression(
             _context,

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Common/IColumnOptionBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Common/IColumnOptionBuilder.cs
@@ -32,7 +32,10 @@ public interface IColumnOptionBuilder<out TNext, out TNextFk> : IFluentBuilder
 
     TNextFk ForeignKey(string foreignKeyName, string primaryTableName, string primaryColumnName);
 
-    TNextFk ForeignKey(string foreignKeyName, string primaryTableSchema, string primaryTableName,
+    TNextFk ForeignKey(
+        string foreignKeyName,
+        string primaryTableSchema,
+        string primaryTableName,
         string primaryColumnName);
 
     TNextFk ForeignKey();
@@ -41,6 +44,9 @@ public interface IColumnOptionBuilder<out TNext, out TNextFk> : IFluentBuilder
 
     TNextFk ReferencedBy(string foreignKeyName, string foreignTableName, string foreignColumnName);
 
-    TNextFk ReferencedBy(string foreignKeyName, string foreignTableSchema, string foreignTableName,
+    TNextFk ReferencedBy(
+        string foreignKeyName,
+        string foreignTableSchema,
+        string foreignTableName,
         string foreignColumnName);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Create/Column/CreateColumnBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Create/Column/CreateColumnBuilder.cs
@@ -107,12 +107,17 @@ public class CreateColumnBuilder : ExpressionBuilderBase<CreateColumnExpression,
     public ICreateColumnOptionForeignKeyCascadeBuilder ForeignKey(string primaryTableName, string primaryColumnName) =>
         ForeignKey(null, null, primaryTableName, primaryColumnName);
 
-    public ICreateColumnOptionForeignKeyCascadeBuilder ForeignKey(string foreignKeyName, string primaryTableName,
+    public ICreateColumnOptionForeignKeyCascadeBuilder ForeignKey(
+        string foreignKeyName,
+        string primaryTableName,
         string primaryColumnName) =>
         ForeignKey(foreignKeyName, null, primaryTableName, primaryColumnName);
 
-    public ICreateColumnOptionForeignKeyCascadeBuilder ForeignKey(string? foreignKeyName, string? primaryTableSchema,
-        string primaryTableName, string primaryColumnName)
+    public ICreateColumnOptionForeignKeyCascadeBuilder ForeignKey(
+        string? foreignKeyName,
+        string? primaryTableSchema,
+        string primaryTableName,
+        string primaryColumnName)
     {
         Expression.Column.IsForeignKey = true;
 
@@ -144,12 +149,17 @@ public class CreateColumnBuilder : ExpressionBuilderBase<CreateColumnExpression,
         ReferencedBy(string foreignTableName, string foreignColumnName) =>
         ReferencedBy(null, null, foreignTableName, foreignColumnName);
 
-    public ICreateColumnOptionForeignKeyCascadeBuilder ReferencedBy(string foreignKeyName, string foreignTableName,
+    public ICreateColumnOptionForeignKeyCascadeBuilder ReferencedBy(
+        string foreignKeyName,
+        string foreignTableName,
         string foreignColumnName) =>
         ReferencedBy(foreignKeyName, null, foreignTableName, foreignColumnName);
 
-    public ICreateColumnOptionForeignKeyCascadeBuilder ReferencedBy(string? foreignKeyName, string? foreignTableSchema,
-        string foreignTableName, string foreignColumnName)
+    public ICreateColumnOptionForeignKeyCascadeBuilder ReferencedBy(
+        string? foreignKeyName,
+        string? foreignTableSchema,
+        string foreignTableName,
+        string foreignColumnName)
     {
         var fk = new CreateForeignKeyExpression(
             _context,

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Create/Table/CreateTableBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Create/Table/CreateTableBuilder.cs
@@ -160,7 +160,9 @@ public class CreateTableBuilder : ExpressionBuilderBase<CreateTableExpression, I
         string primaryColumnName) => ForeignKey(null, null, primaryTableName, primaryColumnName);
 
     /// <inheritdoc />
-    public ICreateTableColumnOptionForeignKeyCascadeBuilder ForeignKey(string foreignKeyName, string primaryTableName,
+    public ICreateTableColumnOptionForeignKeyCascadeBuilder ForeignKey(
+        string foreignKeyName,
+        string primaryTableName,
         string primaryColumnName) =>
         ForeignKey(foreignKeyName, null, primaryTableName, primaryColumnName);
 
@@ -168,7 +170,8 @@ public class CreateTableBuilder : ExpressionBuilderBase<CreateTableExpression, I
     public ICreateTableColumnOptionForeignKeyCascadeBuilder ForeignKey(
         string? foreignKeyName,
         string? primaryTableSchema,
-        string primaryTableName, string primaryColumnName)
+        string primaryTableName,
+        string primaryColumnName)
     {
         CurrentColumn.IsForeignKey = true;
 
@@ -204,7 +207,9 @@ public class CreateTableBuilder : ExpressionBuilderBase<CreateTableExpression, I
         string foreignColumnName) => ReferencedBy(null, null, foreignTableName, foreignColumnName);
 
     /// <inheritdoc />
-    public ICreateTableColumnOptionForeignKeyCascadeBuilder ReferencedBy(string foreignKeyName, string foreignTableName,
+    public ICreateTableColumnOptionForeignKeyCascadeBuilder ReferencedBy(
+        string foreignKeyName,
+        string foreignTableName,
         string foreignColumnName) =>
         ReferencedBy(foreignKeyName, null, foreignTableName, foreignColumnName);
 
@@ -212,7 +217,8 @@ public class CreateTableBuilder : ExpressionBuilderBase<CreateTableExpression, I
     public ICreateTableColumnOptionForeignKeyCascadeBuilder ReferencedBy(
         string? foreignKeyName,
         string? foreignTableSchema,
-        string foreignTableName, string foreignColumnName)
+        string foreignTableName,
+        string foreignColumnName)
     {
         var fk = new CreateForeignKeyExpression(
             _context,

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/DefaultConstraint/DeleteDefaultConstraintBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/DefaultConstraint/DeleteDefaultConstraintBuilder.cs
@@ -23,7 +23,9 @@ public class DeleteDefaultConstraintBuilder : ExpressionBuilderBase<DeleteDefaul
         Expression.ColumnName = columnName;
         Expression.HasDefaultConstraint = _context.SqlContext.SqlSyntax.TryGetDefaultConstraint(
             _context.Database,
-            Expression.TableName, columnName, out var constraintName);
+            Expression.TableName,
+            columnName,
+            out var constraintName);
         Expression.ConstraintName = constraintName ?? string.Empty;
 
         return new ExecutableBuilder(Expression);

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/Expressions/DeleteColumnExpression.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/Expressions/DeleteColumnExpression.cs
@@ -17,7 +17,9 @@ public class DeleteColumnExpression : MigrationExpressionBase
         var stmts = new StringBuilder();
         foreach (var columnName in ColumnNames)
         {
-            stmts.AppendFormat(SqlSyntax.DropColumn, SqlSyntax.GetQuotedTableName(TableName),
+            stmts.AppendFormat(
+                SqlSyntax.DropColumn,
+                SqlSyntax.GetQuotedTableName(TableName),
                 SqlSyntax.GetQuotedColumnName(columnName));
             AppendStatementSeparator(stmts);
         }

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -101,7 +101,17 @@ internal sealed class DatabaseDataCreator
     private readonly ILogger<DatabaseDataCreator> _logger;
     private readonly IUmbracoVersion _umbracoVersion;
 
-    public DatabaseDataCreator(IDatabase database, ILogger<DatabaseDataCreator> logger, IUmbracoVersion umbracoVersion,
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DatabaseDataCreator" /> class.
+    /// </summary>
+    /// <param name="database">The database.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="umbracoVersion">The Umbraco version.</param>
+    /// <param name="installDefaultDataSettings">The install default data settings.</param>
+    public DatabaseDataCreator(
+        IDatabase database,
+        ILogger<DatabaseDataCreator> logger,
+        IUmbracoVersion umbracoVersion,
         IOptionsMonitor<InstallDefaultDataSettings> installDefaultDataSettings)
     {
         _database = database;
@@ -267,7 +277,10 @@ internal sealed class DatabaseDataCreator
                 "id");
         }
 
-        _database.Insert(Constants.DatabaseSchema.Tables.Node, "id", false,
+        _database.Insert(
+            Constants.DatabaseSchema.Tables.Node,
+            "id",
+            false,
             new NodeDto
             {
                 NodeId = -1,
@@ -282,7 +295,10 @@ internal sealed class DatabaseDataCreator
                 NodeObjectType = Constants.ObjectTypes.SystemRoot,
                 CreateDate = DateTime.UtcNow,
             });
-        _database.Insert(Constants.DatabaseSchema.Tables.Node, "id", false,
+        _database.Insert(
+            Constants.DatabaseSchema.Tables.Node,
+            "id",
+            false,
             new NodeDto
             {
                 NodeId = Constants.System.RecycleBinContent,
@@ -297,7 +313,10 @@ internal sealed class DatabaseDataCreator
                 NodeObjectType = Constants.ObjectTypes.ContentRecycleBin,
                 CreateDate = DateTime.UtcNow,
             });
-        _database.Insert(Constants.DatabaseSchema.Tables.Node, "id", false,
+        _database.Insert(
+            Constants.DatabaseSchema.Tables.Node,
+            "id",
+            false,
             new NodeDto
             {
                 NodeId = Constants.System.RecycleBinMedia,
@@ -313,19 +332,45 @@ internal sealed class DatabaseDataCreator
                 CreateDate = DateTime.UtcNow,
             });
 
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelString, 35, Constants.DataTypes.Guids.LabelString,
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelString,
+            35,
+            Constants.DataTypes.Guids.LabelString,
             "Label (string)");
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelInt, 36, Constants.DataTypes.Guids.LabelInt, "Label (integer)");
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelBigint, 36, Constants.DataTypes.Guids.LabelBigInt,
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelInt,
+            36,
+            Constants.DataTypes.Guids.LabelInt,
+            "Label (integer)");
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelBigint,
+            36,
+            Constants.DataTypes.Guids.LabelBigInt,
             "Label (bigint)");
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelDateTime, 37, Constants.DataTypes.Guids.LabelDateTime,
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelDateTime,
+            37,
+            Constants.DataTypes.Guids.LabelDateTime,
             "Label (datetime)");
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelTime, 38, Constants.DataTypes.Guids.LabelTime, "Label (time)");
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelDecimal, 39, Constants.DataTypes.Guids.LabelDecimal,
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelTime,
+            38,
+            Constants.DataTypes.Guids.LabelTime,
+            "Label (time)");
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelDecimal,
+            39,
+            Constants.DataTypes.Guids.LabelDecimal,
             "Label (decimal)");
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelBytes, 40, Constants.DataTypes.Guids.LabelBytes,
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelBytes,
+            40,
+            Constants.DataTypes.Guids.LabelBytes,
             "Label (bytes)");
-        InsertDataTypeNodeDto(Constants.DataTypes.LabelPixels, 41, Constants.DataTypes.Guids.LabelPixels,
+        InsertDataTypeNodeDto(
+            Constants.DataTypes.LabelPixels,
+            41,
+            Constants.DataTypes.Guids.LabelPixels,
             "Label (pixels)");
 
         ConditionalInsert(
@@ -1090,7 +1135,10 @@ internal sealed class DatabaseDataCreator
         // Media types.
         if (_database.Exists<NodeDto>(1031))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 532,
@@ -1106,7 +1154,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1032))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 533,
@@ -1121,7 +1172,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1033))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 534,
@@ -1136,7 +1190,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1034))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 540,
@@ -1151,7 +1208,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1035))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 541,
@@ -1166,7 +1226,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1036))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 542,
@@ -1181,7 +1244,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1037))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 543,
@@ -1197,7 +1263,10 @@ internal sealed class DatabaseDataCreator
         // Member type.
         if (_database.Exists<NodeDto>(1044))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.ContentType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.ContentType,
+                "pk",
+                false,
                 new ContentTypeDto
                 {
                     PrimaryKey = 531,
@@ -1210,7 +1279,10 @@ internal sealed class DatabaseDataCreator
         }
     }
 
-    private void CreateUserData() => _database.Insert(Constants.DatabaseSchema.Tables.User, "id", false,
+    private void CreateUserData() => _database.Insert(
+        Constants.DatabaseSchema.Tables.User,
+        "id",
+        false,
         new UserDto
         {
             Id = Constants.Security.SuperUserId,
@@ -1355,7 +1427,10 @@ internal sealed class DatabaseDataCreator
         // Media property groups.
         if (_database.Exists<NodeDto>(1032))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyTypeGroup,
+                "id",
+                false,
                 new PropertyTypeGroupDto
                 {
                     Id = 3,
@@ -1369,7 +1444,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1033))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyTypeGroup,
+                "id",
+                false,
                 new PropertyTypeGroupDto
                 {
                     Id = 4,
@@ -1383,7 +1461,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1034))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyTypeGroup,
+                "id",
+                false,
                 new PropertyTypeGroupDto
                 {
                     Id = 52,
@@ -1397,7 +1478,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1035))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyTypeGroup,
+                "id",
+                false,
                 new PropertyTypeGroupDto
                 {
                     Id = 53,
@@ -1411,7 +1495,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1036))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyTypeGroup,
+                "id",
+                false,
                 new PropertyTypeGroupDto
                 {
                     Id = 54,
@@ -1425,7 +1512,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1037))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyTypeGroup,
+                "id",
+                false,
                 new PropertyTypeGroupDto
                 {
                     Id = 55,
@@ -1440,7 +1530,10 @@ internal sealed class DatabaseDataCreator
         // Membership property group.
         if (_database.Exists<NodeDto>(1044))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyTypeGroup, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyTypeGroup,
+                "id",
+                false,
                 new PropertyTypeGroupDto
                 {
                     Id = 11,
@@ -1461,7 +1554,10 @@ internal sealed class DatabaseDataCreator
         // Media property types.
         if (_database.Exists<PropertyTypeGroupDto>(3))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 6,
@@ -1477,7 +1573,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 7,
@@ -1493,7 +1592,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 8,
@@ -1509,7 +1611,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 9,
@@ -1525,7 +1630,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 10,
@@ -1545,7 +1653,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<PropertyTypeGroupDto>(4))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 24,
@@ -1561,7 +1672,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 25,
@@ -1577,7 +1691,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 26,
@@ -1597,7 +1714,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<PropertyTypeGroupDto>(52))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 40,
@@ -1613,7 +1733,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 41,
@@ -1629,7 +1752,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 42,
@@ -1649,7 +1775,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<PropertyTypeGroupDto>(53))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 43,
@@ -1665,7 +1794,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 44,
@@ -1681,7 +1813,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 45,
@@ -1701,7 +1836,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<PropertyTypeGroupDto>(54))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 46,
@@ -1717,7 +1855,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 47,
@@ -1733,7 +1874,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 48,
@@ -1753,7 +1897,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<PropertyTypeGroupDto>(55))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 49,
@@ -1769,7 +1916,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 50,
@@ -1785,7 +1935,10 @@ internal sealed class DatabaseDataCreator
                     Description = null,
                     Variations = (byte)ContentVariation.Nothing,
                 });
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 51,
@@ -1806,7 +1959,10 @@ internal sealed class DatabaseDataCreator
         // Membership property types.
         if (_database.Exists<PropertyTypeGroupDto>(11))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.PropertyType, "id", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.PropertyType,
+                "id",
+                false,
                 new PropertyTypeDto
                 {
                     Id = 28,
@@ -1894,14 +2050,20 @@ internal sealed class DatabaseDataCreator
             return;
         }
 
-        _database.Insert(Constants.DatabaseSchema.Tables.ContentChildType, "Id", false,
+        _database.Insert(
+            Constants.DatabaseSchema.Tables.ContentChildType,
+            "Id",
+            false,
             new ContentTypeAllowedContentTypeDto { Id = 1031, AllowedId = 1031 });
 
         for (var i = 1032; i <= 1037; i++)
         {
             if (_database.Exists<NodeDto>(i))
             {
-                _database.Insert(Constants.DatabaseSchema.Tables.ContentChildType, "Id", false,
+                _database.Insert(
+                    Constants.DatabaseSchema.Tables.ContentChildType,
+                    "Id",
+                    false,
                     new ContentTypeAllowedContentTypeDto { Id = 1031, AllowedId = i });
             }
         }
@@ -1937,7 +2099,10 @@ internal sealed class DatabaseDataCreator
         // of data types to create).
         if (_database.Exists<NodeDto>(Constants.DataTypes.Boolean))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.Boolean,
@@ -1949,7 +2114,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(-51))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = -51,
@@ -1977,7 +2145,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.Textbox))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.Textbox,
@@ -1989,7 +2160,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.Textarea))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.Textarea,
@@ -2001,7 +2175,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.Upload))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.Upload,
@@ -2011,26 +2188,61 @@ internal sealed class DatabaseDataCreator
                 });
         }
 
-        InsertDataTypeDto(Constants.DataTypes.LabelString, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Nvarchar", "{\"umbracoDataValueType\":\"STRING\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelInt, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Integer", "{\"umbracoDataValueType\":\"INT\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelBigint, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Nvarchar", "{\"umbracoDataValueType\":\"BIGINT\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelDateTime, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Date", "{\"umbracoDataValueType\":\"DATETIME\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelDecimal, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Decimal", "{\"umbracoDataValueType\":\"DECIMAL\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelTime, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Date", "{\"umbracoDataValueType\":\"TIME\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelBytes, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Nvarchar", "{\"umbracoDataValueType\":\"BIGINT\", \"labelTemplate\":\"{=value | bytes}\"}");
-        InsertDataTypeDto(Constants.DataTypes.LabelPixels, Constants.PropertyEditors.Aliases.Label,
-            "Umb.PropertyEditorUi.Label", "Integer", "{\"umbracoDataValueType\":\"INT\", \"labelTemplate\":\"{=value}px\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelString,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Nvarchar",
+            "{\"umbracoDataValueType\":\"STRING\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelInt,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Integer",
+            "{\"umbracoDataValueType\":\"INT\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelBigint,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Nvarchar",
+            "{\"umbracoDataValueType\":\"BIGINT\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelDateTime,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Date",
+            "{\"umbracoDataValueType\":\"DATETIME\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelDecimal,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Decimal",
+            "{\"umbracoDataValueType\":\"DECIMAL\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelTime,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Date",
+            "{\"umbracoDataValueType\":\"TIME\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelBytes,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Nvarchar",
+            "{\"umbracoDataValueType\":\"BIGINT\", \"labelTemplate\":\"{=value | bytes}\"}");
+        InsertDataTypeDto(
+            Constants.DataTypes.LabelPixels,
+            Constants.PropertyEditors.Aliases.Label,
+            "Umb.PropertyEditorUi.Label",
+            "Integer",
+            "{\"umbracoDataValueType\":\"INT\", \"labelTemplate\":\"{=value}px\"}");
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.DateTime))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.DateTime,
@@ -2043,7 +2255,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(-37))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = -37,
@@ -2053,12 +2268,19 @@ internal sealed class DatabaseDataCreator
                 });
         }
 
-        InsertDataTypeDto(Constants.DataTypes.DropDownSingle, Constants.PropertyEditors.Aliases.DropDownListFlexible,
-            "Umb.PropertyEditorUi.Dropdown", "Nvarchar", "{\"multiple\":false}");
+        InsertDataTypeDto(
+            Constants.DataTypes.DropDownSingle,
+            Constants.PropertyEditors.Aliases.DropDownListFlexible,
+            "Umb.PropertyEditorUi.Dropdown",
+            "Nvarchar",
+            "{\"multiple\":false}");
 
         if (_database.Exists<NodeDto>(-40))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = -40,
@@ -2070,7 +2292,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(-41))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = -41,
@@ -2081,12 +2306,19 @@ internal sealed class DatabaseDataCreator
                 });
         }
 
-        InsertDataTypeDto(Constants.DataTypes.DropDownMultiple, Constants.PropertyEditors.Aliases.DropDownListFlexible,
-            "Umb.PropertyEditorUi.Dropdown", "Nvarchar", "{\"multiple\":true}");
+        InsertDataTypeDto(
+            Constants.DataTypes.DropDownMultiple,
+            Constants.PropertyEditors.Aliases.DropDownListFlexible,
+            "Umb.PropertyEditorUi.Dropdown",
+            "Nvarchar",
+            "{\"multiple\":true}");
 
         if (_database.Exists<NodeDto>(-43))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = -43,
@@ -2114,7 +2346,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.ImageCropper))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.ImageCropper,
@@ -2182,7 +2417,10 @@ internal sealed class DatabaseDataCreator
         // New UDI pickers with newer Ids
         if (_database.Exists<NodeDto>(1046))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = 1046,
@@ -2194,7 +2432,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1047))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = 1047,
@@ -2206,7 +2447,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1050))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = 1050,
@@ -2218,7 +2462,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.UploadVideo))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.UploadVideo,
@@ -2232,7 +2479,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.UploadAudio))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.UploadAudio,
@@ -2246,7 +2496,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.UploadArticle))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.UploadArticle,
@@ -2260,7 +2513,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(Constants.DataTypes.UploadVectorGraphics))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = Constants.DataTypes.UploadVectorGraphics,
@@ -2273,7 +2529,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1051))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = 1051,
@@ -2286,7 +2545,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1052))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = 1052,
@@ -2299,7 +2561,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1053))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = 1053,
@@ -2313,7 +2578,10 @@ internal sealed class DatabaseDataCreator
 
         if (_database.Exists<NodeDto>(1054))
         {
-            _database.Insert(Constants.DatabaseSchema.Tables.DataType, "pk", false,
+            _database.Insert(
+                Constants.DatabaseSchema.Tables.DataType,
+                "pk",
+                false,
                 new DataTypeDto
                 {
                     NodeId = 1054,
@@ -2344,26 +2612,65 @@ internal sealed class DatabaseDataCreator
 
     private void CreateRelationTypeData()
     {
-        CreateRelationTypeData(1, Constants.Conventions.RelationTypes.RelateDocumentOnCopyAlias,
-            Constants.Conventions.RelationTypes.RelateDocumentOnCopyName, Constants.ObjectTypes.Document,
-            Constants.ObjectTypes.Document, true, false);
-        CreateRelationTypeData(2, Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias,
-            Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteName, Constants.ObjectTypes.Document,
-            Constants.ObjectTypes.Document, false, false);
-        CreateRelationTypeData(3, Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias,
-            Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteName, Constants.ObjectTypes.Media,
-            Constants.ObjectTypes.Media, false, false);
-        CreateRelationTypeData(4, Constants.Conventions.RelationTypes.RelatedMediaAlias,
-            Constants.Conventions.RelationTypes.RelatedMediaName, null, null, false, true);
-        CreateRelationTypeData(5, Constants.Conventions.RelationTypes.RelatedDocumentAlias,
-            Constants.Conventions.RelationTypes.RelatedDocumentName, null, null, false, true);
-        CreateRelationTypeData(6, Constants.Conventions.RelationTypes.RelatedMemberAlias,
-            Constants.Conventions.RelationTypes.RelatedMemberName, null, null, false, true);
+        CreateRelationTypeData(
+            1,
+            Constants.Conventions.RelationTypes.RelateDocumentOnCopyAlias,
+            Constants.Conventions.RelationTypes.RelateDocumentOnCopyName,
+            Constants.ObjectTypes.Document,
+            Constants.ObjectTypes.Document,
+            true,
+            false);
+        CreateRelationTypeData(
+            2,
+            Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias,
+            Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteName,
+            Constants.ObjectTypes.Document,
+            Constants.ObjectTypes.Document,
+            false,
+            false);
+        CreateRelationTypeData(
+            3,
+            Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias,
+            Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteName,
+            Constants.ObjectTypes.Media,
+            Constants.ObjectTypes.Media,
+            false,
+            false);
+        CreateRelationTypeData(
+            4,
+            Constants.Conventions.RelationTypes.RelatedMediaAlias,
+            Constants.Conventions.RelationTypes.RelatedMediaName,
+            null,
+            null,
+            false,
+            true);
+        CreateRelationTypeData(
+            5,
+            Constants.Conventions.RelationTypes.RelatedDocumentAlias,
+            Constants.Conventions.RelationTypes.RelatedDocumentName,
+            null,
+            null,
+            false,
+            true);
+        CreateRelationTypeData(
+            6,
+            Constants.Conventions.RelationTypes.RelatedMemberAlias,
+            Constants.Conventions.RelationTypes.RelatedMemberName,
+            null,
+            null,
+            false,
+            true);
 
     }
 
-    private void CreateRelationTypeData(int id, string alias, string name, Guid? parentObjectType,
-        Guid? childObjectType, bool dual, bool isDependency)
+    private void CreateRelationTypeData(
+        int id,
+        string alias,
+        string name,
+        Guid? parentObjectType,
+        Guid? childObjectType,
+        bool dual,
+        bool isDependency)
     {
         var relationType = new RelationTypeDto
         {
@@ -2387,7 +2694,10 @@ internal sealed class DatabaseDataCreator
         var stateValueKey = upgrader.StateValueKey;
         var finalState = upgrader.Plan.FinalState;
 
-        _database.Insert(Constants.DatabaseSchema.Tables.KeyValue, "key", false,
+        _database.Insert(
+            Constants.DatabaseSchema.Tables.KeyValue,
+            "key",
+            false,
             new KeyValueDto { Key = stateValueKey, Value = finalState, UpdateDate = DateTime.UtcNow });
 
 
@@ -2395,7 +2705,10 @@ internal sealed class DatabaseDataCreator
         stateValueKey = upgrader.StateValueKey;
         finalState = upgrader.Plan.FinalState;
 
-        _database.Insert(Constants.DatabaseSchema.Tables.KeyValue, "key", false,
+        _database.Insert(
+            Constants.DatabaseSchema.Tables.KeyValue,
+            "key",
+            false,
             new KeyValueDto { Key = stateValueKey, Value = finalState, UpdateDate = DateTime.UtcNow });
     }
 

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreator.cs
@@ -174,7 +174,8 @@ public class DatabaseSchemaCreator
         if (creatingNotification.Cancel == false)
         {
             var dataCreation = new DatabaseDataCreator(
-                _database, _loggerFactory.CreateLogger<DatabaseDataCreator>(),
+                _database,
+                _loggerFactory.CreateLogger<DatabaseDataCreator>(),
                 _umbracoVersion,
                 _installDefaultDataSettings);
             foreach (Type table in _orderedTables)

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreatorFactory.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseSchemaCreatorFactory.cs
@@ -32,6 +32,16 @@ public class DatabaseSchemaCreatorFactory
             _installDefaultDataSettings = installDefaultDataSettings;
         }
 
-    public DatabaseSchemaCreator Create(IUmbracoDatabase? database) => new DatabaseSchemaCreator(database, _logger,
-        _loggerFactory, _umbracoVersion, _eventAggregator, _installDefaultDataSettings);
+    /// <summary>
+    ///     Creates a new instance of <see cref="DatabaseSchemaCreator" />.
+    /// </summary>
+    /// <param name="database">The database.</param>
+    /// <returns>A new <see cref="DatabaseSchemaCreator" /> instance.</returns>
+    public DatabaseSchemaCreator Create(IUmbracoDatabase? database) => new DatabaseSchemaCreator(
+        database,
+        _logger,
+        _loggerFactory,
+        _umbracoVersion,
+        _eventAggregator,
+        _installDefaultDataSettings);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
@@ -122,7 +122,9 @@ public abstract class ConvertBlockEditorPropertiesBase : MigrationBase
                     "- starting property type {propertyTypeIndex}/{propertyTypeCount} : {propertyTypeName} (id: {propertyTypeId}, alias: {propertyTypeAlias})...",
                     propertyTypeIndex + 1,
                     propertyTypeCount,
-                    propertyType.Name, propertyType.Id, propertyType.Alias);
+                    propertyType.Name,
+                    propertyType.Id,
+                    propertyType.Alias);
                 IDataType dataType = _dataTypeService.GetAsync(propertyType.DataTypeKey).GetAwaiter().GetResult()
                                      ?? throw new InvalidOperationException("The data type could not be fetched.");
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
@@ -157,7 +157,9 @@ public class FixConvertLocalLinks : MigrationBase
                 progress++;
                 if (progress % 100 == 0)
                 {
-                    _logger.LogInformation("  - finíshed {progress} of {total} properties", progress,
+                    _logger.LogInformation(
+                        "  - finíshed {progress} of {total} properties",
+                        progress,
                         updateBatch.Count);
                 }
 
@@ -227,8 +229,11 @@ public class FixConvertLocalLinks : MigrationBase
         return true;
     }
 
-    private bool ProcessPropertyDataDto(PropertyDataDto propertyDataDto, IPropertyType propertyType,
-        IDictionary<int, ILanguage> languagesById, IDataValueEditor valueEditor)
+    private bool ProcessPropertyDataDto(
+        PropertyDataDto propertyDataDto,
+        IPropertyType propertyType,
+        IDictionary<int, ILanguage> languagesById,
+        IDataValueEditor valueEditor)
     {
         // NOTE: some old property data DTOs can have variance defined, even if the property type no longer varies
         var culture = propertyType.VariesByCulture()

--- a/src/Umbraco.Infrastructure/Models/PathValidationExtensions.cs
+++ b/src/Umbraco.Infrastructure/Models/PathValidationExtensions.cs
@@ -104,7 +104,9 @@ internal static class PathValidationExtensions
         {
             logger.LogWarning(
                 "The content item {EntityId} has an invalid path: {EntityPath} with parentID: {EntityParentId}",
-                entity.Id, entity.Path, entity.ParentId);
+                entity.Id,
+                entity.Path,
+                entity.ParentId);
             if (entity.ParentId == -1)
             {
                 entity.Path = string.Concat("-1,", entity.Id);

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/ModelsGenerator.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/ModelsGenerator.cs
@@ -13,8 +13,18 @@ public class ModelsGenerator : IModelsGenerator
     private readonly UmbracoServices _umbracoService;
     private ModelsBuilderSettings _config;
 
-    public ModelsGenerator(UmbracoServices umbracoService, IOptionsMonitor<ModelsBuilderSettings> config,
-        OutOfDateModelsStatus outOfDateModels, IHostEnvironment hostEnvironment)
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ModelsGenerator" /> class.
+    /// </summary>
+    /// <param name="umbracoService">The Umbraco services.</param>
+    /// <param name="config">The models builder configuration.</param>
+    /// <param name="outOfDateModels">The out of date models status.</param>
+    /// <param name="hostEnvironment">The host environment.</param>
+    public ModelsGenerator(
+        UmbracoServices umbracoService,
+        IOptionsMonitor<ModelsBuilderSettings> config,
+        OutOfDateModelsStatus outOfDateModels,
+        IHostEnvironment hostEnvironment)
     {
         _umbracoService = umbracoService;
         _config = config.CurrentValue;

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
@@ -311,7 +311,8 @@ public class TextBuilder : Builder
         // write the ctor
         sb.AppendFormat(
             "\n\n\t\t// ctor\n\t\tpublic {0}(IPublished{1} content, IPublishedValueFallback publishedValueFallback)\n\t\t\t: base(content, publishedValueFallback)\n\t\t{{\n\t\t\t_publishedValueFallback = publishedValueFallback;\n\t\t}}\n\n",
-            type.ClrName, type.IsElement ? "Element" : "Content");
+            type.ClrName,
+            type.IsElement ? "Element" : "Content");
 
         // write the properties
         sb.Append("\t\t// properties\n");
@@ -364,7 +365,9 @@ public class TextBuilder : Builder
 
             if (!string.IsNullOrWhiteSpace(property.Description))
             {
-                sb.AppendFormat("\t\t/// {0}: {1}\n", XmlCommentString(property.Name),
+                sb.AppendFormat(
+                    "\t\t/// {0}: {1}\n",
+                    XmlCommentString(property.Name),
                     XmlCommentString(property.Description));
             }
             else
@@ -443,7 +446,9 @@ public class TextBuilder : Builder
 
             if (!string.IsNullOrWhiteSpace(property.Description))
             {
-                sb.AppendFormat("\t\t/// {0}: {1}\n", XmlCommentString(property.Name),
+                sb.AppendFormat(
+                    "\t\t/// {0}: {1}\n",
+                    XmlCommentString(property.Name),
                     XmlCommentString(property.Description));
             }
             else
@@ -472,7 +477,8 @@ public class TextBuilder : Builder
             WriteClrType(sb, property.ClrTypeName);
             sb.AppendFormat(
                 " {0} => {1}(this, _publishedValueFallback);\n",
-                property.ClrName, MixinStaticGetterName(property.ClrName));
+                property.ClrName,
+                MixinStaticGetterName(property.ClrName));
         }
         else
         {
@@ -529,7 +535,8 @@ public class TextBuilder : Builder
         WriteClrType(sb, property.ClrTypeName);
         sb.AppendFormat(
             " {0}(I{1} that, IPublishedValueFallback publishedValueFallback) => that.Value",
-            mixinStaticGetterName, mixinClrName);
+            mixinStaticGetterName,
+            mixinClrName);
         if (property.ModelClrType != typeof(object))
         {
             sb.Append("<");

--- a/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
+++ b/src/Umbraco.Infrastructure/Packaging/PackageDataInstallation.cs
@@ -166,16 +166,22 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 {
                     Warnings = compiledPackage.Warnings,
                     DataTypesInstalled =
-                        ImportDataTypes(compiledPackage.DataTypes.ToList(), userId,
+                        ImportDataTypes(
+                            compiledPackage.DataTypes.ToList(),
+                            userId,
                             out IEnumerable<EntityContainer> dataTypeEntityContainersInstalled),
                     LanguagesInstalled = ImportLanguages(compiledPackage.Languages, userId),
                     DictionaryItemsInstalled = ImportDictionaryItems(compiledPackage.DictionaryItems, userId),
                     TemplatesInstalled = ImportTemplatesAsync(compiledPackage.Templates.ToList(), userId).GetAwaiter().GetResult(),
                     DocumentTypesInstalled =
-                        ImportDocumentTypes(compiledPackage.DocumentTypes, userId,
+                        ImportDocumentTypes(
+                            compiledPackage.DocumentTypes,
+                            userId,
                             out IEnumerable<EntityContainer> documentTypeEntityContainersInstalled),
                     MediaTypesInstalled =
-                        ImportMediaTypes(compiledPackage.MediaTypes, userId,
+                        ImportMediaTypes(
+                            compiledPackage.MediaTypes,
+                            userId,
                             out IEnumerable<EntityContainer> mediaTypeEntityContainersInstalled),
                     StylesheetsInstalled = ImportStylesheets(compiledPackage.Stylesheets, userId),
                     ScriptsInstalled = ImportScripts(compiledPackage.Scripts, userId),
@@ -192,10 +198,18 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 var importedDocTypes = installationSummary.DocumentTypesInstalled.ToDictionary(x => x.Alias, x => x);
                 var importedMediaTypes = installationSummary.MediaTypesInstalled.ToDictionary(x => x.Alias, x => x);
 
-                installationSummary.ContentInstalled = ImportContentBase(compiledPackage.Documents, importedDocTypes,
-                    userId, _contentTypeService, _contentService);
-                installationSummary.MediaInstalled = ImportContentBase(compiledPackage.Media, importedMediaTypes,
-                    userId, _mediaTypeService, _mediaService);
+                installationSummary.ContentInstalled = ImportContentBase(
+                    compiledPackage.Documents,
+                    importedDocTypes,
+                    userId,
+                    _contentTypeService,
+                    _contentService);
+                installationSummary.MediaInstalled = ImportContentBase(
+                    compiledPackage.Media,
+                    importedMediaTypes,
+                    userId,
+                    _mediaTypeService,
+                    _mediaService);
 
                 scope.Complete();
 
@@ -210,18 +224,30 @@ namespace Umbraco.Cms.Infrastructure.Packaging
 #pragma warning restore CS0618 // Type or member is obsolete
 
         [Obsolete("This method is not used in Umbraco outside of this class so will be made private in Umbraco 19.")]
-        public IReadOnlyList<IMediaType> ImportMediaTypes(IEnumerable<XElement> docTypeElements, int userId,
+        public IReadOnlyList<IMediaType> ImportMediaTypes(
+            IEnumerable<XElement> docTypeElements,
+            int userId,
             out IEnumerable<EntityContainer> entityContainersInstalled)
-            => ImportDocumentTypes(docTypeElements.ToList(), true, userId, _mediaTypeService,
+            => ImportDocumentTypes(
+                docTypeElements.ToList(),
+                true,
+                userId,
+                _mediaTypeService,
                 out entityContainersInstalled);
 
         /// <inheritdoc/>
         public IReadOnlyList<IMemberType> ImportMemberTypes(IEnumerable<XElement> docTypeElements, int userId)
             => ImportMemberTypes(docTypeElements, userId, out _);
 
-        private IReadOnlyList<IMemberType> ImportMemberTypes(IEnumerable<XElement> docTypeElements, int userId,
+        private IReadOnlyList<IMemberType> ImportMemberTypes(
+            IEnumerable<XElement> docTypeElements,
+            int userId,
             out IEnumerable<EntityContainer> entityContainersInstalled)
-            => ImportDocumentTypes(docTypeElements.ToList(), true, userId, _memberTypeService,
+            => ImportDocumentTypes(
+                docTypeElements.ToList(),
+                true,
+                userId,
+                _memberTypeService,
                 out entityContainersInstalled);
 
         #endregion
@@ -237,8 +263,13 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             where TContentBase : class, IContentBase
             where TContentTypeComposition : IContentTypeComposition
             => docs.SelectMany(x =>
-                ImportContentBase(x.XmlData.Elements().Where(doc => (string?)doc.Attribute("isDoc") == string.Empty), -1,
-                    importedDocumentTypes, userId, typeService, service)).ToList();
+                ImportContentBase(
+                    x.XmlData.Elements().Where(doc => (string?)doc.Attribute("isDoc") == string.Empty),
+                    -1,
+                    importedDocumentTypes,
+                    userId,
+                    typeService,
+                    service)).ToList();
 
         /// <summary>
         /// Imports and saves package xml as <see cref="IContent"/>
@@ -348,7 +379,12 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 }
 
                 // Create and add the child to the list
-                if (TryCreateContentFromXml(child, importedContentTypes[contentTypeAlias], parent, default, service,
+                if (TryCreateContentFromXml(
+                        child,
+                        importedContentTypes[contentTypeAlias],
+                        parent,
+                        default,
+                        service,
                         out TContentBase content))
                 {
                     list.Add(content);
@@ -358,7 +394,11 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 var grandChildren = child.Elements().Where(x => (string?)x.Attribute("isDoc") == string.Empty).ToList();
                 if (grandChildren.Any())
                 {
-                    list.AddRange(CreateContentFromXml(grandChildren, content, importedContentTypes, typeService,
+                    list.AddRange(CreateContentFromXml(
+                        grandChildren,
+                        content,
+                        importedContentTypes,
+                        typeService,
                         service));
                 }
             }
@@ -479,8 +519,15 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             return true;
         }
 
-        private TContentBase? CreateContent<TContentBase, TContentTypeComposition>(string name, TContentBase? parent,
-            int parentId, TContentTypeComposition contentType, Guid key, int level, int sortOrder, int? templateId)
+        private TContentBase? CreateContent<TContentBase, TContentTypeComposition>(
+            string name,
+            TContentBase? parent,
+            int parentId,
+            TContentTypeComposition contentType,
+            Guid key,
+            int level,
+            int sortOrder,
+            int? templateId)
             where TContentBase : class?, IContentBase
             where TContentTypeComposition : IContentTypeComposition
         {
@@ -560,9 +607,15 @@ namespace Umbraco.Cms.Infrastructure.Packaging
         /// <param name="userId">Optional id of the User performing the operation. Default is zero (admin).</param>
         /// <param name="entityContainersInstalled">Collection of entity containers installed by the package to be populated with those created in installing data types.</param>
         /// <returns>An enumerable list of generated ContentTypes</returns>
-        public IReadOnlyList<IContentType> ImportDocumentTypes(IEnumerable<XElement> docTypeElements, int userId,
+        public IReadOnlyList<IContentType> ImportDocumentTypes(
+            IEnumerable<XElement> docTypeElements,
+            int userId,
             out IEnumerable<EntityContainer> entityContainersInstalled)
-            => ImportDocumentTypes(docTypeElements.ToList(), true, userId, _contentTypeService,
+            => ImportDocumentTypes(
+                docTypeElements.ToList(),
+                true,
+                userId,
+                _contentTypeService,
                 out entityContainersInstalled);
 
         /// <summary>
@@ -588,7 +641,8 @@ namespace Umbraco.Cms.Infrastructure.Packaging
         /// <returns>An enumerable list of generated ContentTypes</returns>
         public IReadOnlyList<T> ImportDocumentTypes<T>(
             IReadOnlyCollection<XElement> unsortedDocumentTypes,
-            bool importStructure, int userId,
+            bool importStructure,
+            int userId,
             IContentTypeBaseService<T> service,
             out IEnumerable<EntityContainer> entityContainersInstalled)
             where T : class, IContentTypeComposition
@@ -633,7 +687,9 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                         }
                     }
 
-                    graph.AddItem(TopoGraph.CreateNode(infoElement!.Element("Alias")!.Value, elementCopy,
+                    graph.AddItem(TopoGraph.CreateNode(
+                        infoElement!.Element("Alias")!.Value,
+                        elementCopy,
                         dependencies.ToArray()));
                 }
             }
@@ -687,8 +743,11 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                         continue;
                     }
 
-                    T updated = UpdateContentTypesStructure(importedContentTypes[alias], structureElement,
-                        importedContentTypes, service);
+                    T updated = UpdateContentTypesStructure(
+                        importedContentTypes[alias],
+                        structureElement,
+                        importedContentTypes,
+                        service);
                     updatedContentTypes.Add(updated);
                 }
 
@@ -751,7 +810,9 @@ namespace Umbraco.Cms.Infrastructure.Packaging
 
                         if (tryCreateFolder == false)
                         {
-                            _logger.LogError(tryCreateFolder.Exception, "Could not create folder: {FolderName}",
+                            _logger.LogError(
+                                tryCreateFolder.Exception,
+                                "Could not create folder: {FolderName}",
                                 rootFolder);
                             throw tryCreateFolder.Exception!;
                         }
@@ -951,7 +1012,9 @@ namespace Umbraco.Cms.Infrastructure.Packaging
 
             if (contentType is IContentType contentTypex)
             {
-                UpdateContentTypesAllowedTemplates(contentTypex, infoElement.Element("AllowedTemplates"),
+                UpdateContentTypesAllowedTemplates(
+                    contentTypex,
+                    infoElement.Element("AllowedTemplates"),
                     defaultTemplateElement);
             }
 
@@ -999,7 +1062,9 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             }
         }
 
-        private void UpdateContentTypesAllowedTemplates(IContentType contentType, XElement? allowedTemplatesElement,
+        private void UpdateContentTypesAllowedTemplates(
+            IContentType contentType,
+            XElement? allowedTemplatesElement,
             XElement? defaultTemplateElement)
         {
             if (allowedTemplatesElement != null && allowedTemplatesElement.Elements("Template").Any())
@@ -1079,8 +1144,11 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                     propertyGroup.Type = type;
                 }
 
-                if (int.TryParse(propertyGroupElement.Element("SortOrder")?.Value, NumberStyles.Integer,
-                        CultureInfo.InvariantCulture, out var sortOrder))
+                if (int.TryParse(
+                        propertyGroupElement.Element("SortOrder")?.Value,
+                        NumberStyles.Integer,
+                        CultureInfo.InvariantCulture,
+                        out var sortOrder))
                 {
                     // Override the sort order with the imported value
                     propertyGroup.SortOrder = sortOrder;
@@ -1137,7 +1205,9 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                     // TODO: We should expose this to the UI during install!
                     _logger.LogWarning(
                         "Packager: Error handling creation of PropertyType '{PropertyType}'. Could not find DataTypeDefintion with unique id '{DataTypeDefinitionId}' nor one referencing the DataType with a property editor alias (or legacy control id) '{PropertyEditorAlias}'. Did the package creator forget to package up custom datatypes? This property will be converted to a label/readonly editor if one exists.",
-                        property.Element("Name")?.Value, dataTypeDefinitionId, property.Element("Type")?.Value.Trim());
+                        property.Element("Name")?.Value,
+                        dataTypeDefinitionId,
+                        property.Element("Type")?.Value.Trim());
 
                     //convert to a label!
                     dataTypeDefinition = _dataTypeService.GetByEditorAlias(Constants.PropertyEditors.Aliases.Label)?
@@ -1153,7 +1223,10 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 XElement? sortOrderElement = property.Element("SortOrder");
                 if (sortOrderElement != null)
                 {
-                    int.TryParse(sortOrderElement.Value, NumberStyles.Integer, CultureInfo.InvariantCulture,
+                    int.TryParse(
+                        sortOrderElement.Value,
+                        NumberStyles.Integer,
+                        CultureInfo.InvariantCulture,
                         out sortOrder);
                 }
 
@@ -1203,8 +1276,11 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             }
         }
 
-        private T UpdateContentTypesStructure<T>(T contentType, XElement structureElement,
-            IReadOnlyDictionary<string, T> importedContentTypes, IContentTypeBaseService<T> service)
+        private T UpdateContentTypesStructure<T>(
+            T contentType,
+            XElement structureElement,
+            IReadOnlyDictionary<string, T> importedContentTypes,
+            IContentTypeBaseService<T> service)
             where T : IContentTypeComposition
         {
             var allowedChildren = contentType.AllowedContentTypes?.ToList();
@@ -1220,7 +1296,8 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                 {
                     _logger.LogWarning(
                         "Packager: Error handling DocumentType structure. DocumentType with alias '{DoctypeAlias}' could not be found and was not added to the structure for '{DoctypeStructureAlias}'.",
-                        alias, contentType.Alias);
+                        alias,
+                        contentType.Alias);
                     continue;
                 }
 
@@ -1271,7 +1348,9 @@ namespace Umbraco.Cms.Infrastructure.Packaging
         /// <param name="userId">Optional id of the user</param>
         /// <param name="entityContainersInstalled">Collection of entity containers installed by the package to be populated with those created in installing data types.</param>
         /// <returns>An enumerable list of generated DataTypeDefinitions</returns>
-        public IReadOnlyList<IDataType> ImportDataTypes(IReadOnlyCollection<XElement> dataTypeElements, int userId,
+        public IReadOnlyList<IDataType> ImportDataTypes(
+            IReadOnlyCollection<XElement> dataTypeElements,
+            int userId,
             out IEnumerable<EntityContainer> entityContainersInstalled)
         {
             var dataTypes = new List<IDataType>();
@@ -1376,7 +1455,9 @@ namespace Umbraco.Cms.Infrastructure.Packaging
                         Attempt<OperationResult<OperationResultType, EntityContainer>?> tryCreateFolder = _dataTypeService.CreateContainer(-1, rootFolderKey, rootFolder);
                         if (tryCreateFolder == false)
                         {
-                            _logger.LogError(tryCreateFolder.Exception, "Could not create folder: {FolderName}",
+                            _logger.LogError(
+                                tryCreateFolder.Exception,
+                                "Could not create folder: {FolderName}",
                                 rootFolder);
                             throw tryCreateFolder.Exception!;
                         }
@@ -1486,12 +1567,17 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             _localizationService.Save(dictionaryItem, userId);
             items.Add(dictionaryItem);
 
-            items.AddRange(ImportDictionaryItems(dictionaryItemElement.Elements("DictionaryItem"), languages,
-                dictionaryItem.Key, userId));
+            items.AddRange(ImportDictionaryItems(
+                dictionaryItemElement.Elements("DictionaryItem"),
+                languages,
+                dictionaryItem.Key,
+                userId));
             return items;
         }
 
-        private IDictionaryItem UpdateDictionaryItem(IDictionaryItem dictionaryItem, XElement dictionaryItemElement,
+        private IDictionaryItem UpdateDictionaryItem(
+            IDictionaryItem dictionaryItem,
+            XElement dictionaryItemElement,
             List<ILanguage> languages)
         {
             var translations = dictionaryItem.Translations.ToList();
@@ -1505,8 +1591,12 @@ namespace Umbraco.Cms.Infrastructure.Packaging
             return dictionaryItem;
         }
 
-        private static DictionaryItem CreateNewDictionaryItem(Guid itemId, string itemName,
-            XElement dictionaryItemElement, List<ILanguage> languages, Guid? parentId)
+        private static DictionaryItem CreateNewDictionaryItem(
+            Guid itemId,
+            string itemName,
+            XElement dictionaryItemElement,
+            List<ILanguage> languages,
+            Guid? parentId)
         {
             DictionaryItem dictionaryItem = parentId.HasValue
                 ? new DictionaryItem(parentId.Value, itemName)

--- a/src/Umbraco.Infrastructure/Persistence/Factories/TemplateFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/TemplateFactory.cs
@@ -29,8 +29,11 @@ internal static class TemplateFactory
 
     #region Implementation of IEntityFactory<ITemplate,TemplateDto>
 
-    public static Template BuildEntity(IShortStringHelper shortStringHelper, TemplateDto dto,
-        IEnumerable<IUmbracoEntity> childDefinitions, Func<File, string?> getFileContent)
+    public static Template BuildEntity(
+        IShortStringHelper shortStringHelper,
+        TemplateDto dto,
+        IEnumerable<IUmbracoEntity> childDefinitions,
+        Func<File, string?> getFileContent)
     {
         var template = new Template(shortStringHelper, dto.NodeDto.Text, dto.Alias, getFileContent);
 

--- a/src/Umbraco.Infrastructure/Persistence/Factories/UserFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/UserFactory.cs
@@ -22,7 +22,13 @@ internal static class UserFactory
             key = dto.Id.ToGuid();
         }
 
-        var user = new User(globalSettings, dto.Id, dto.UserName, dto.Email, dto.Login, dto.Password,
+        var user = new User(
+            globalSettings,
+            dto.Id,
+            dto.UserName,
+            dto.Email,
+            dto.Login,
+            dto.Password,
             dto.PasswordConfig,
             dto.UserGroupDtos.Select(x => ToReadOnlyGroup(x, permissionMappers)).ToArray(),
             dto.UserStartNodeDtos.Where(x => x.StartNodeType == (int)UserStartNodeDto.StartNodeTypeValue.Content)

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -478,7 +478,9 @@ namespace Umbraco.Extensions
 
         }
 
-        public static Sql<ISqlContext> AndBy<TDto>(this Sql<ISqlContext> sql, string tableAlias,
+        public static Sql<ISqlContext> AndBy<TDto>(
+            this Sql<ISqlContext> sql,
+            string tableAlias,
             params Expression<Func<TDto, object?>>[] fields)
         {
             ISqlSyntaxProvider sqlSyntax = sql.SqlContext.SqlSyntax;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/AuditEntryRepository.cs
@@ -27,7 +27,8 @@ internal sealed class AuditEntryRepository : EntityRepositoryBase<int, IAuditEnt
     ///     Initializes a new instance of the <see cref="AuditEntryRepository" /> class.
     /// </summary>
     public AuditEntryRepository(
-        IRuntimeState runtimeState,IScopeAccessor scopeAccessor,
+        IRuntimeState runtimeState,
+        IScopeAccessor scopeAccessor,
         AppCaches cache,
         ILogger<AuditEntryRepository> logger,
         IRepositoryCacheVersionService repositoryCacheVersionService,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -171,7 +171,9 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
 
     protected abstract IEnumerable<TEntity>? GetAllWithFullCachePolicy();
 
-    protected virtual PropertyType CreatePropertyType(string propertyEditorAlias, ValueStorageType storageType,
+    protected virtual PropertyType CreatePropertyType(
+        string propertyEditorAlias,
+        ValueStorageType storageType,
         string propertyTypeAlias) =>
         new PropertyType(_shortStringHelper, propertyEditorAlias, storageType, propertyTypeAlias);
 
@@ -986,8 +988,12 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
             // now we need to insert names into these 2 tables based on the invariant data
 
             // insert rows into the versionCultureVariationDto table based on the data from contentVersionDto for the default lang
-            var cols = Sql().ColumnsForInsert<ContentVersionCultureVariationDto>(x => x.VersionId, x => x.Name,
-                x => x.UpdateUserId, x => x.UpdateDate, x => x.LanguageId);
+            var cols = Sql().ColumnsForInsert<ContentVersionCultureVariationDto>(
+                x => x.VersionId,
+                x => x.Name,
+                x => x.UpdateUserId,
+                x => x.UpdateDate,
+                x => x.LanguageId);
             Sql<ISqlContext> sqlSelect2 = Sql().Select<ContentVersionDto>(x => x.Id, x => x.Text, x => x.UserId, x => x.VersionDate)
                 .Append($", {defaultLanguageId}") // default language ID
                 .From<ContentVersionDto>()
@@ -999,8 +1005,13 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
             Database.Execute(sqlInsertContentVersion);
 
             // insert rows into the documentCultureVariation table
-            cols = Sql().ColumnsForInsert<DocumentCultureVariationDto>(x => x.NodeId, x => x.Edited, x => x.Published,
-                x => x.Name, x => x.Available, x => x.LanguageId);
+            cols = Sql().ColumnsForInsert<DocumentCultureVariationDto>(
+                x => x.NodeId,
+                x => x.Edited,
+                x => x.Published,
+                x => x.Name,
+                x => x.Available,
+                x => x.LanguageId);
             Sql<ISqlContext> sqlSelectDocument = Sql().Select<DocumentDto>(x => x.NodeId, x => x.Edited, x => x.Published)
                 .AndSelect<NodeDto>(x => x.Text)
                 .Append($", {SqlSyntax.ConvertIntegerToBoolean(1)}, {defaultLanguageId}") // make Available + default language ID
@@ -1078,7 +1089,8 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
             .LeftJoin<TagDto>("xtags")
             .On<TagDto, TagDto>(
                 (tag, xtag) => tag.Text == xtag.Text && tag.Group == xtag.Group &&
-                               xtag.LanguageId.SqlNullableEquals(targetLanguageId, -1), aliasRight: "xtags");
+                               xtag.LanguageId.SqlNullableEquals(targetLanguageId, -1),
+                aliasRight: "xtags");
 
         if (contentTypeIds != null)
         {
@@ -1112,7 +1124,8 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
             .InnerJoin<TagDto>("otag")
             .On<TagDto, TagDto>(
                 (tag, otag) => tag.Text == otag.Text && tag.Group == otag.Group &&
-                               otag.LanguageId.SqlNullableEquals(targetLanguageId, -1), aliasRight: "otag");
+                               otag.LanguageId.SqlNullableEquals(targetLanguageId, -1),
+                aliasRight: "otag");
 
         if (contentTypeIds != null)
         {
@@ -1175,8 +1188,11 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
     /// <param name="targetLanguageId">The target language (can be null ie invariant)</param>
     /// <param name="propertyTypeIds">The property type identifiers.</param>
     /// <param name="contentTypeIds">The content type identifiers.</param>
-    private void CopyPropertyData(int? sourceLanguageId, int? targetLanguageId,
-        IReadOnlyCollection<int> propertyTypeIds, IReadOnlyCollection<int>? contentTypeIds = null)
+    private void CopyPropertyData(
+        int? sourceLanguageId,
+        int? targetLanguageId,
+        IReadOnlyCollection<int> propertyTypeIds,
+        IReadOnlyCollection<int>? contentTypeIds = null)
     {
         // note: important to use SqlNullableEquals for nullable types, cannot directly compare language identifiers
         var whereInArgsCount = propertyTypeIds.Count + (contentTypeIds?.Count ?? 0);
@@ -1219,11 +1235,24 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
 
         // now insert all property data into the target language that exists under the source language
         var targetLanguageIdS = targetLanguageId.HasValue ? targetLanguageId.ToString() : "NULL";
-        var cols = Sql().ColumnsForInsert<PropertyDataDto>(x => x.VersionId, x => x.PropertyTypeId, x => x.Segment,
-            x => x.IntegerValue, x => x.DecimalValue, x => x.DateValue, x => x.VarcharValue, x => x.TextValue,
+        var cols = Sql().ColumnsForInsert<PropertyDataDto>(
+            x => x.VersionId,
+            x => x.PropertyTypeId,
+            x => x.Segment,
+            x => x.IntegerValue,
+            x => x.DecimalValue,
+            x => x.DateValue,
+            x => x.VarcharValue,
+            x => x.TextValue,
             x => x.LanguageId);
-        Sql<ISqlContext> sqlSelectData = Sql().Select<PropertyDataDto>(x => x.VersionId, x => x.PropertyTypeId,
-                x => x.Segment, x => x.IntegerValue, x => x.DecimalValue, x => x.DateValue, x => x.VarcharValue,
+        Sql<ISqlContext> sqlSelectData = Sql().Select<PropertyDataDto>(
+                x => x.VersionId,
+                x => x.PropertyTypeId,
+                x => x.Segment,
+                x => x.IntegerValue,
+                x => x.DecimalValue,
+                x => x.DateValue,
+                x => x.VarcharValue,
                 x => x.TextValue)
             .Append(", " + targetLanguageIdS) // default language ID
             .From<PropertyDataDto>();

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -185,7 +185,9 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
 
             // see notes in ApplyOrdering: the field MUST be selected + aliased
             sql = Sql(
-                InsertBefore(sql, "FROM",
+                InsertBefore(
+                    sql,
+                    "FROM",
                     ", " + SqlSyntax.GetFieldName<UserDto>(x => x.UserName, "updaterUser") + " AS ordering "),
                 sql.Arguments);
 
@@ -226,7 +228,9 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
 
             // see notes in ApplyOrdering: the field MUST be selected + aliased, and we cannot have
             // the whole CASE fragment in ORDER BY due to it not being detected by NPoco
-            var sqlText = InsertBefore(sql.SQL, "FROM",
+            var sqlText = InsertBefore(
+                sql.SQL,
+                "FROM",
 
                 // when invariant, ie 'variations' does not have the culture flag (value 1), it should be safe to simply use the published flag on umbracoDocument,
                 // otherwise check if there's a version culture variation for the lang, via ccv.id
@@ -432,7 +436,9 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
         }
     }
 
-    private void SetVariations(Content? content, IDictionary<int, List<ContentVariation>> contentVariations,
+    private void SetVariations(
+        Content? content,
+        IDictionary<int, List<ContentVariation>> contentVariations,
         IDictionary<int, List<DocumentVariation>> documentVariations)
     {
         if (content is null)
@@ -481,7 +487,9 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
         }
 
         IEnumerable<ContentVersionCultureVariationDto> dtos =
-            Database.FetchByGroups<ContentVersionCultureVariationDto, int>(versions, Constants.Sql.MaxParameterCount,
+            Database.FetchByGroups<ContentVersionCultureVariationDto, int>(
+                versions,
+                Constants.Sql.MaxParameterCount,
                 batch
                     => Sql()
                         .Select<ContentVersionCultureVariationDto>()
@@ -762,7 +770,10 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
             .LeftJoin<ContentVersionCultureVariationDto>(
                 nested => nested.InnerJoin<LanguageDto>("lang")
                 .On<ContentVersionCultureVariationDto, LanguageDto>(
-                        (ccv, lang) => ccv.LanguageId == lang.Id && lang.IsoCode == "[[[ISOCODE]]]", "ccv", "lang"), "ccv")
+                        (ccv, lang) => ccv.LanguageId == lang.Id && lang.IsoCode == "[[[ISOCODE]]]",
+                        "ccv",
+                        "lang"),
+                "ccv")
                 .On<ContentVersionDto, ContentVersionCultureVariationDto>(
                         (version, ccv) => version.Id == ccv.VersionId,
                     aliasRight: "ccv");
@@ -873,9 +884,12 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
 
         var pageIndex = skip / take;
 
-        return MapDtosToContent(Database.Page<DocumentDto>(pageIndex + 1, take, sql).Items, true,
+        return MapDtosToContent(
+            Database.Page<DocumentDto>(pageIndex + 1, take, sql).Items,
+            true,
             // load bare minimum, need variants though since this is used to rollback with variants
-            false, false);
+            false,
+            false);
     }
 
     public override IContent? GetVersion(int versionId)
@@ -1272,7 +1286,11 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
             var versionToDelete = publishing ? entity.PublishedVersionId : entity.VersionId;
 
             // insert property data
-            ReplacePropertyValues(entity, versionToDelete, publishing ? entity.PublishedVersionId : 0, out var edited,
+            ReplacePropertyValues(
+                entity,
+                versionToDelete,
+                publishing ? entity.PublishedVersionId : 0,
+                out var edited,
                 out HashSet<string>? editedCultures);
 
             // if !publishing, we may have a new name != current publish name,
@@ -1565,7 +1583,11 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
             }
         }
 
-        return GetPage<DocumentDto>(query, pageIndex, pageSize, out totalRecords,
+        return GetPage<DocumentDto>(
+            query,
+            pageIndex,
+            pageSize,
+            out totalRecords,
             x => MapDtosToContent(x),
             filterSql,
             ordering);
@@ -1988,7 +2010,9 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
             content.SetCultureName(uniqueName, cultureInfo.Culture);
             if (publishing && (content.PublishCultureInfos?.ContainsKey(cultureInfo.Culture) ?? false))
             {
-                content.SetPublishInfo(cultureInfo.Culture, uniqueName,
+                content.SetPublishInfo(
+                    cultureInfo.Culture,
+                    uniqueName,
                     DateTime.UtcNow); //TODO: This is weird, this call will have already been made in the SetCultureName
             }
         }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
@@ -128,10 +128,16 @@ internal class EntityContainerRepository : EntityRepositoryBase<int, EntityConta
             return null;
         }
 
-        var entity = new EntityContainer(nodeDto.NodeId, nodeDto.UniqueId,
-            nodeDto.ParentId, nodeDto.Path, nodeDto.Level, nodeDto.SortOrder,
+        var entity = new EntityContainer(
+            nodeDto.NodeId,
+            nodeDto.UniqueId,
+            nodeDto.ParentId,
+            nodeDto.Path,
+            nodeDto.Level,
+            nodeDto.SortOrder,
             containedObjectType,
-            nodeDto.Text, nodeDto.UserId ?? Constants.Security.UnknownUserId);
+            nodeDto.Text,
+            nodeDto.UserId ?? Constants.Security.UnknownUserId);
 
         // reset dirty initial properties (U4-1946)
         entity.ResetDirtyProperties(false);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
@@ -659,7 +659,11 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
             .OrderBy<LanguageDto>(x => x.Id);
 
     // gets the full sql for a given object type and a given unique id
-    private Sql<ISqlContext> GetFullSqlForEntityType(bool isContent, bool isMedia, bool isMember, Guid objectType,
+    private Sql<ISqlContext> GetFullSqlForEntityType(
+        bool isContent,
+        bool isMedia,
+        bool isMember,
+        Guid objectType,
         Guid uniqueId)
     {
         Sql<ISqlContext> sql = GetBaseWhere(isContent, isMedia, isMember, false, objectType, uniqueId);
@@ -667,7 +671,11 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     }
 
     // gets the full sql for a given object type and a given node id
-    private Sql<ISqlContext> GetFullSqlForEntityType(bool isContent, bool isMedia, bool isMember, Guid objectType,
+    private Sql<ISqlContext> GetFullSqlForEntityType(
+        bool isContent,
+        bool isMedia,
+        bool isMember,
+        Guid objectType,
         int nodeId)
     {
         Sql<ISqlContext> sql = GetBaseWhere(isContent, isMedia, isMember, false, objectType, nodeId);
@@ -675,7 +683,11 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     }
 
     // gets the full sql for a given object type, with a given filter
-    private Sql<ISqlContext> GetFullSqlForEntityType(bool isContent, bool isMedia, bool isMember, Guid objectType,
+    private Sql<ISqlContext> GetFullSqlForEntityType(
+        bool isContent,
+        bool isMedia,
+        bool isMember,
+        Guid objectType,
         Action<Sql<ISqlContext>>? filter)
     {
         Sql<ISqlContext> sql = GetBaseWhere(isContent, isMedia, isMember, false, filter, new[] { objectType });
@@ -722,9 +734,18 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
         else
         {
             sql
-                .Select<NodeDto>(x => x.NodeId, x => x.Trashed, x => x.ParentId, x => x.UserId, x => x.Level,
+                .Select<NodeDto>(
+                    x => x.NodeId,
+                    x => x.Trashed,
+                    x => x.ParentId,
+                    x => x.UserId,
+                    x => x.Level,
                     x => x.Path)
-                .AndSelect<NodeDto>(x => x.SortOrder, x => x.UniqueId, x => x.Text, x => x.NodeObjectType,
+                .AndSelect<NodeDto>(
+                    x => x.SortOrder,
+                    x => x.UniqueId,
+                    x => x.Text,
+                    x => x.NodeObjectType,
                     x => x.CreateDate);
 
             if (objectTypes.Length == 0)
@@ -810,8 +831,13 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
 
     // gets the base SELECT + FROM [+ filter] + WHERE sql
     // for a given object type, with a given filter
-    private Sql<ISqlContext> GetBaseWhere(bool isContent, bool isMedia, bool isMember, bool isCount,
-        Action<Sql<ISqlContext>>? filter, Guid[] objectTypes)
+    private Sql<ISqlContext> GetBaseWhere(
+        bool isContent,
+        bool isMedia,
+        bool isMember,
+        bool isCount,
+        Action<Sql<ISqlContext>>? filter,
+        Guid[] objectTypes)
     {
         Sql<ISqlContext> sql = GetBase(isContent, isMedia, isMember, filter, objectTypes, isCount);
         if (objectTypes.Length > 0)
@@ -842,21 +868,35 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
 
     // gets the base SELECT + FROM + WHERE sql
     // for a given object type and node id
-    private Sql<ISqlContext> GetBaseWhere(bool isContent, bool isMedia, bool isMember, bool isCount, Guid objectType,
+    private Sql<ISqlContext> GetBaseWhere(
+        bool isContent,
+        bool isMedia,
+        bool isMember,
+        bool isCount,
+        Guid objectType,
         int nodeId) =>
         GetBase(isContent, isMedia, isMember, null, isCount)
             .Where<NodeDto>(x => x.NodeId == nodeId && x.NodeObjectType == objectType);
 
     // gets the base SELECT + FROM + WHERE sql
     // for a given object type and unique id
-    private Sql<ISqlContext> GetBaseWhere(bool isContent, bool isMedia, bool isMember, bool isCount, Guid objectType,
+    private Sql<ISqlContext> GetBaseWhere(
+        bool isContent,
+        bool isMedia,
+        bool isMember,
+        bool isCount,
+        Guid objectType,
         Guid uniqueId) =>
         GetBase(isContent, isMedia, isMember, null, isCount)
             .Where<NodeDto>(x => x.UniqueId == uniqueId && x.NodeObjectType == objectType);
 
     // gets the GROUP BY / ORDER BY sql
     // required in order to count children
-    private Sql<ISqlContext> AddGroupBy(bool isContent, bool isMedia, bool isMember, Sql<ISqlContext> sql,
+    private Sql<ISqlContext> AddGroupBy(
+        bool isContent,
+        bool isMedia,
+        bool isMember,
+        Sql<ISqlContext> sql,
         bool defaultSort)
     {
         sql

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
@@ -43,7 +43,9 @@ public abstract class EntityRepositoryBase<TId, TEntity> : RepositoryBase, IRead
     }
 
     [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
-    protected EntityRepositoryBase(IScopeAccessor scopeAccessor, AppCaches appCaches,
+    protected EntityRepositoryBase(
+        IScopeAccessor scopeAccessor,
+        AppCaches appCaches,
         ILogger<EntityRepositoryBase<TId, TEntity>> logger)
         : this(
             scopeAccessor,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaRepository.cs
@@ -141,7 +141,11 @@ public class MediaRepository : ContentRepositoryBase<int, IMedia, MediaRepositor
             }
         }
 
-        return GetPage<ContentDto>(query, pageIndex, pageSize, out totalRecords,
+        return GetPage<ContentDto>(
+            query,
+            pageIndex,
+            pageSize,
+            out totalRecords,
             x => MapDtosToContent(x),
             filterSql,
             ordering);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -153,7 +153,9 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
 
     public override int RecycleBinId => throw new NotSupportedException();
 
-    public IEnumerable<IMember> FindMembersInRole(string roleName, string usernameToMatch,
+    public IEnumerable<IMember> FindMembersInRole(
+        string roleName,
+        string usernameToMatch,
         StringPropertyMatchType matchType = StringPropertyMatchType.StartsWith)
     {
         //get the group id
@@ -374,7 +376,11 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
             }
         }
 
-        return GetPage<MemberDto>(query, pageIndex, pageSize, out totalRecords,
+        return GetPage<MemberDto>(
+            query,
+            pageIndex,
+            pageSize,
+            out totalRecords,
             x => MapDtosToContent(x),
             filterSql,
             ordering);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -143,8 +143,11 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
     {
         Sql<ISqlContext> sql = GetBaseQuery(false)
             .Where(
-                string.Format("{0}.{1} LIKE @path", QuoteTableName("umbracoNode"),
-                    QuoteColumnName("path")), new { path = "%," + rootContentId + ",%" })
+                string.Format(
+                    "{0}.{1} LIKE @path",
+                    QuoteTableName("umbracoNode"),
+                    QuoteColumnName("path")),
+                new { path = "%," + rootContentId + ",%" })
             .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);
         Page<RedirectUrlDto> result = Database.Page<RedirectUrlDto>(pageIndex + 1, pageSize, sql);
         total = Convert.ToInt32(result.TotalItems);
@@ -157,7 +160,9 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
     {
         Sql<ISqlContext> sql = GetBaseQuery(false)
             .Where(
-                string.Format("{0}.{1} LIKE @url", QuoteTableName("umbracoRedirectUrl"),
+                string.Format(
+                    "{0}.{1} LIKE @url",
+                    QuoteTableName("umbracoRedirectUrl"),
                     QuoteColumnName("Url")),
                 new { url = "%" + searchTerm.Trim().ToLowerInvariant() + "%" })
             .OrderByDescending<RedirectUrlDto>(x => x.CreateDateUtc);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -47,7 +47,9 @@ internal sealed class TagRepository : EntityRepositoryBase<int, ITag>, ITagRepos
     {
         IEnumerable<TagDto> dtos = ids?.Length == 0
             ? Database.Fetch<TagDto>(Sql().Select<TagDto>().From<TagDto>())
-            : Database.FetchByGroups<TagDto, int>(ids!, Constants.Sql.MaxParameterCount,
+            : Database.FetchByGroups<TagDto, int>(
+                ids!,
+                Constants.Sql.MaxParameterCount,
                 batch => Sql().Select<TagDto>().From<TagDto>().WhereIn<TagDto>(x => x.Id, batch));
 
         return dtos.Select(TagFactory.BuildEntity).ToList();
@@ -331,7 +333,9 @@ ON (tagset.tag = {cmsTags}.tag AND tagset.{group} = {cmsTags}.{group} AND COALES
     }
 
     /// <inheritdoc />
-    public IEnumerable<TaggedEntity> GetTaggedEntitiesByTagGroup(TaggableObjectTypes objectType, string group,
+    public IEnumerable<TaggedEntity> GetTaggedEntitiesByTagGroup(
+        TaggableObjectTypes objectType,
+        string group,
         string? culture = null)
     {
         Sql<ISqlContext> sql = GetTaggedEntitiesSql(objectType, culture);
@@ -343,8 +347,11 @@ ON (tagset.tag = {cmsTags}.tag AND tagset.{group} = {cmsTags}.{group} AND COALES
     }
 
     /// <inheritdoc />
-    public IEnumerable<TaggedEntity> GetTaggedEntitiesByTag(TaggableObjectTypes objectType, string tag,
-        string? group = null, string? culture = null)
+    public IEnumerable<TaggedEntity> GetTaggedEntitiesByTag(
+        TaggableObjectTypes objectType,
+        string tag,
+        string? group = null,
+        string? culture = null)
     {
         Sql<ISqlContext> sql = GetTaggedEntitiesSql(objectType, culture);
 
@@ -365,10 +372,13 @@ ON (tagset.tag = {cmsTags}.tag AND tagset.{group} = {cmsTags}.{group} AND COALES
         Sql<ISqlContext> sql = Sql()
             .Select<TagRelationshipDto>(x => Alias(x.NodeId, "NodeId"))
             .AndSelect<PropertyTypeDto>(
-            x => Alias(x.Alias, "PropertyTypeAlias"),
+                x => Alias(x.Alias, "PropertyTypeAlias"),
                 x => Alias(x.Id, "PropertyTypeId"))
-            .AndSelect<TagDto>(x => Alias(x.Id, "TagId"), x => Alias(x.Text, "TagText"),
-                x => Alias(x.Group, "TagGroup"), x => Alias(x.LanguageId, "TagLanguage"))
+            .AndSelect<TagDto>(
+                x => Alias(x.Id, "TagId"),
+                x => Alias(x.Text, "TagText"),
+                x => Alias(x.Group, "TagGroup"),
+                x => Alias(x.LanguageId, "TagLanguage"))
             .From<TagDto>()
             .InnerJoin<TagRelationshipDto>().On<TagDto, TagRelationshipDto>((tag, rel) => tag.Id == rel.TagId)
             .InnerJoin<ContentDto>()
@@ -486,7 +496,10 @@ ON (tagset.tag = {cmsTags}.tag AND tagset.{group} = {cmsTags}.{group} AND COALES
     }
 
     /// <inheritdoc />
-    public IEnumerable<ITag> GetTagsForProperty(int contentId, string propertyTypeAlias, string? group = null,
+    public IEnumerable<ITag> GetTagsForProperty(
+        int contentId,
+        string propertyTypeAlias,
+        string? group = null,
         string? culture = null)
     {
         Sql<ISqlContext> sql = GetTagsSql(culture);
@@ -509,7 +522,10 @@ ON (tagset.tag = {cmsTags}.tag AND tagset.{group} = {cmsTags}.{group} AND COALES
     }
 
     /// <inheritdoc />
-    public IEnumerable<ITag> GetTagsForProperty(Guid contentId, string propertyTypeAlias, string? group = null,
+    public IEnumerable<ITag> GetTagsForProperty(
+        Guid contentId,
+        string propertyTypeAlias,
+        string? group = null,
         string? culture = null)
     {
         Sql<ISqlContext> sql = GetTagsSql(culture);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TemplateRepository.cs
@@ -134,7 +134,10 @@ internal sealed class TemplateRepository : EntityRepositoryBase<int, ITemplate>,
     /// <returns></returns>
     private ITemplate MapFromDto(TemplateDto dto, IUmbracoEntity[] axisDefinitions)
     {
-        Template template = TemplateFactory.BuildEntity(_shortStringHelper, dto, axisDefinitions,
+        Template template = TemplateFactory.BuildEntity(
+            _shortStringHelper,
+            dto,
+            axisDefinitions,
             file => GetFileContent((Template)file, false));
 
         if (dto.NodeDto.ParentId > 0)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -725,14 +725,20 @@ SELECT 4 AS {keyAlias}, COUNT(id) AS {valueAlias} FROM {userTableName}
 
         if (entity.IsPropertyDirty("StartContentIds"))
         {
-            AddingOrUpdateStartNodes(entity, Enumerable.Empty<UserStartNodeDto>(),
-                UserStartNodeDto.StartNodeTypeValue.Content, entity.StartContentIds);
+            AddingOrUpdateStartNodes(
+                entity,
+                Enumerable.Empty<UserStartNodeDto>(),
+                UserStartNodeDto.StartNodeTypeValue.Content,
+                entity.StartContentIds);
         }
 
         if (entity.IsPropertyDirty("StartMediaIds"))
         {
-            AddingOrUpdateStartNodes(entity, Enumerable.Empty<UserStartNodeDto>(),
-                UserStartNodeDto.StartNodeTypeValue.Media, entity.StartMediaIds);
+            AddingOrUpdateStartNodes(
+                entity,
+                Enumerable.Empty<UserStartNodeDto>(),
+                UserStartNodeDto.StartNodeTypeValue.Media,
+                entity.StartMediaIds);
         }
 
         if (entity.IsPropertyDirty("Groups"))
@@ -937,8 +943,11 @@ SELECT 4 AS {keyAlias}, COUNT(id) AS {valueAlias} FROM {userTableName}
         userGroupCache.Clear(cacheKey);
     }
 
-    private void AddingOrUpdateStartNodes(IEntity entity, IEnumerable<UserStartNodeDto> current,
-        UserStartNodeDto.StartNodeTypeValue startNodeType, int[]? entityStartIds)
+    private void AddingOrUpdateStartNodes(
+        IEntity entity,
+        IEnumerable<UserStartNodeDto> current,
+        UserStartNodeDto.StartNodeTypeValue startNodeType,
+        int[]? entityStartIds)
     {
         if (entityStartIds is null)
         {
@@ -1112,10 +1121,16 @@ SELECT 4 AS {keyAlias}, COUNT(id) AS {valueAlias} FROM {userTableName}
     ///     The query supplied will ONLY work with data specifically on the umbracoUser table because we are using NPoco paging
     ///     (SQL paging)
     /// </remarks>
-    public IEnumerable<IUser> GetPagedResultsByQuery(IQuery<IUser>? query, long pageIndex, int pageSize,
+    public IEnumerable<IUser> GetPagedResultsByQuery(
+        IQuery<IUser>? query,
+        long pageIndex,
+        int pageSize,
         out long totalRecords,
-        Expression<Func<IUser, object?>> orderBy, Direction orderDirection = Direction.Ascending,
-        string[]? includeUserGroups = null, string[]? excludeUserGroups = null, UserState[]? userState = null,
+        Expression<Func<IUser, object?>> orderBy,
+        Direction orderDirection = Direction.Ascending,
+        string[]? includeUserGroups = null,
+        string[]? excludeUserGroups = null,
+        UserState[]? userState = null,
         IQuery<IUser>? filter = null)
     {
         if (orderBy == null)
@@ -1306,7 +1321,9 @@ SELECT 4 AS {keyAlias}, COUNT(id) AS {valueAlias} FROM {userTableName}
         return sql;
     }
 
-    private Sql<ISqlContext> ApplySort(Sql<ISqlContext> sql, Expression<Func<IUser, object?>>? orderBy,
+    private Sql<ISqlContext> ApplySort(
+        Sql<ISqlContext> sql,
+        Expression<Func<IUser, object?>>? orderBy,
         Direction orderDirection)
     {
         if (orderBy == null)

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderExtensions.cs
@@ -46,5 +46,6 @@ internal static class SqlSyntaxProviderExtensions
                 : @"DELETE FROM {0} WHERE {1} NOT IN (SELECT {1} FROM ({2}) x)",
             sqlProvider.GetQuotedTableName(tableName),
             sqlProvider.GetQuotedColumnName(columnName),
-            subQuery.SQL), subQuery.Arguments);
+            subQuery.SQL),
+            subQuery.Arguments);
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyEditor.cs
@@ -113,7 +113,10 @@ public class ImageCropperPropertyEditor : DataEditor,
                     ? _jsonSerializer.Deserialize<ImageCropperValue>(stringValue)
                     : null) ?? new ImageCropperValue();
                 newValue.Src = _mediaFileManager.FileSystem.GetUrl(copyPath);
-                notification.Copy.SetValue(property.Alias,  _jsonSerializer.Serialize(newValue), propertyValue.Culture,
+                notification.Copy.SetValue(
+                    property.Alias,
+                    _jsonSerializer.Serialize(newValue),
+                    propertyValue.Culture,
                     propertyValue.Segment);
                 isUpdated = true;
             }
@@ -335,7 +338,8 @@ public class ImageCropperPropertyEditor : DataEditor,
                         // are fixing that anomaly here - does not make any sense at all but... bah...
                         property.SetValue(
                             _jsonSerializer.Serialize(new LightWeightImageCropperValue { Src = stringValue }),
-                            pvalue.Culture, pvalue.Segment);
+                            pvalue.Culture,
+                            pvalue.Segment);
                     }
 
                     if (source is null)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -57,8 +57,11 @@ public class ImageCropperValue :TemporaryFileUploadValueBase, IHtmlEncodedString
         {
             return new ImageUrlGenerationOptions(url)
             {
-                Crop = new ImageUrlGenerationOptions.CropCoordinates(crop.Coordinates.X1, crop.Coordinates.Y1,
-                    crop.Coordinates.X2, crop.Coordinates.Y2)
+                Crop = new ImageUrlGenerationOptions.CropCoordinates(
+                    crop.Coordinates.X1,
+                    crop.Coordinates.Y1,
+                    crop.Coordinates.X2,
+                    crop.Coordinates.Y2)
             };
         }
 
@@ -68,8 +71,12 @@ public class ImageCropperValue :TemporaryFileUploadValueBase, IHtmlEncodedString
     /// <summary>
     ///     Gets the value image URL for a specified crop.
     /// </summary>
-    public string? GetCropUrl(string alias, IImageUrlGenerator imageUrlGenerator, bool useCropDimensions = true,
-        bool useFocalPoint = false, string? cacheBusterValue = null)
+    public string? GetCropUrl(
+        string alias,
+        IImageUrlGenerator imageUrlGenerator,
+        bool useCropDimensions = true,
+        bool useFocalPoint = false,
+        string? cacheBusterValue = null)
     {
         ImageCropperCrop? crop = GetCrop(alias);
 
@@ -96,7 +103,10 @@ public class ImageCropperValue :TemporaryFileUploadValueBase, IHtmlEncodedString
     /// <summary>
     ///     Gets the value image URL for a specific width and height.
     /// </summary>
-    public string? GetCropUrl(int width, int height, IImageUrlGenerator imageUrlGenerator,
+    public string? GetCropUrl(
+        int width,
+        int height,
+        IImageUrlGenerator imageUrlGenerator,
         string? cacheBusterValue = null)
     {
         ImageUrlGenerationOptions options = GetCropBaseOptions(null, null, false);

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
@@ -45,11 +45,21 @@ public class RteBlockRenderingValueConverter : SimpleRichTextValueConverter, IDe
     private DeliveryApiSettings _deliveryApiSettings;
     private readonly IDisposable? _deliveryApiSettingsChangeSubscription;
 
-    public RteBlockRenderingValueConverter(HtmlLocalLinkParser linkParser, HtmlUrlParser urlParser, HtmlImageSourceParser imageSourceParser,
-        IApiRichTextElementParser apiRichTextElementParser, IApiRichTextMarkupParser apiRichTextMarkupParser,
-        IPartialViewBlockEngine partialViewBlockEngine, BlockEditorConverter blockEditorConverter, IJsonSerializer jsonSerializer,
-        IApiElementBuilder apiElementBuilder, RichTextBlockPropertyValueConstructorCache constructorCache, ILogger<RteBlockRenderingValueConverter> logger,
-        IVariationContextAccessor variationContextAccessor, BlockEditorVarianceHandler blockEditorVarianceHandler, IOptionsMonitor<DeliveryApiSettings> deliveryApiSettingsMonitor)
+    public RteBlockRenderingValueConverter(
+        HtmlLocalLinkParser linkParser,
+        HtmlUrlParser urlParser,
+        HtmlImageSourceParser imageSourceParser,
+        IApiRichTextElementParser apiRichTextElementParser,
+        IApiRichTextMarkupParser apiRichTextMarkupParser,
+        IPartialViewBlockEngine partialViewBlockEngine,
+        BlockEditorConverter blockEditorConverter,
+        IJsonSerializer jsonSerializer,
+        IApiElementBuilder apiElementBuilder,
+        RichTextBlockPropertyValueConstructorCache constructorCache,
+        ILogger<RteBlockRenderingValueConverter> logger,
+        IVariationContextAccessor variationContextAccessor,
+        BlockEditorVarianceHandler blockEditorVarianceHandler,
+        IOptionsMonitor<DeliveryApiSettings> deliveryApiSettingsMonitor)
     {
         _linkParser = linkParser;
         _urlParser = urlParser;
@@ -108,8 +118,12 @@ public class RteBlockRenderingValueConverter : SimpleRichTextValueConverter, IDe
         };
     }
 
-    public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType,
-        PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    public override object ConvertIntermediateToObject(
+        IPublishedElement owner,
+        IPublishedPropertyType propertyType,
+        PropertyCacheLevel referenceCacheLevel,
+        object? inter,
+        bool preview)
     {
         var converted = Convert(inter, preview);
 

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -245,24 +245,35 @@ public class PublishedContentQuery : IPublishedContentQuery
     #region Search
 
     /// <inheritdoc />
-    public IEnumerable<PublishedSearchResult> Search(string term, string culture = "*",
+    public IEnumerable<PublishedSearchResult> Search(
+        string term,
+        string culture = "*",
         string indexName = Constants.UmbracoIndexes.ExternalIndexName)
         => Search(term, 0, 0, out _, culture, indexName);
 
     /// <inheritdoc />
-    public IEnumerable<PublishedSearchResult> Search(string term, int skip, int take, out long totalRecords,
-        string culture = "*", string indexName = Constants.UmbracoIndexes.ExternalIndexName,
+    public IEnumerable<PublishedSearchResult> Search(
+        string term,
+        int skip,
+        int take,
+        out long totalRecords,
+        string culture = "*",
+        string indexName = Constants.UmbracoIndexes.ExternalIndexName,
         ISet<string>? loadedFields = null)
     {
         if (skip < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(skip), skip,
+            throw new ArgumentOutOfRangeException(
+                nameof(skip),
+                skip,
                 "The value must be greater than or equal to zero.");
         }
 
         if (take < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(take), take,
+            throw new ArgumentOutOfRangeException(
+                nameof(take),
+                take,
                 "The value must be greater than or equal to zero.");
         }
 
@@ -324,13 +335,17 @@ public class PublishedContentQuery : IPublishedContentQuery
     {
         if (skip < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(skip), skip,
+            throw new ArgumentOutOfRangeException(
+                nameof(skip),
+                skip,
                 "The value must be greater than or equal to zero.");
         }
 
         if (take < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(take), take,
+            throw new ArgumentOutOfRangeException(
+                nameof(take),
+                take,
                 "The value must be greater than or equal to zero.");
         }
 
@@ -381,7 +396,9 @@ public class PublishedContentQuery : IPublishedContentQuery
             }
 
             // Now the IPublishedContent returned will be contextualized to the culture specified and will be reset when the enumerator is disposed
-            return new CultureContextualSearchResultsEnumerator(_wrapped.GetEnumerator(), _variationContextAccessor,
+            return new CultureContextualSearchResultsEnumerator(
+                _wrapped.GetEnumerator(),
+                _variationContextAccessor,
                 originalContext);
         }
 

--- a/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
+++ b/src/Umbraco.Infrastructure/Runtime/FileSystemMainDomLock.cs
@@ -100,7 +100,10 @@ internal sealed class FileSystemMainDomLock : IMainDomLock
     public void Dispose() => Dispose(true);
 
     public void CreateLockReleaseSignalFile() =>
-        File.Open(_releaseSignalFilePath, FileMode.OpenOrCreate, FileAccess.ReadWrite,
+        File.Open(
+                _releaseSignalFilePath,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
                 FileShare.ReadWrite | FileShare.Delete)
             .Close();
 

--- a/src/Umbraco.Infrastructure/Search/IndexingNotificationHandler.ContentType.cs
+++ b/src/Umbraco.Infrastructure/Search/IndexingNotificationHandler.ContentType.cs
@@ -20,7 +20,9 @@ public sealed class ContentTypeIndexingNotificationHandler : INotificationHandle
 
     public ContentTypeIndexingNotificationHandler(
         IUmbracoIndexingHandler umbracoIndexingHandler,
-        IContentService contentService, IMemberService memberService, IMediaService mediaService,
+        IContentService contentService,
+        IMemberService memberService,
+        IMediaService mediaService,
         IMemberTypeService memberTypeService)
     {
         _umbracoIndexingHandler =
@@ -117,7 +119,11 @@ public sealed class ContentTypeIndexingNotificationHandler : INotificationHandle
             while (page * pageSize < total)
             {
                 IEnumerable<IMember> memberToRefresh = _memberService.GetAll(
-                    page * pageSize, pageSize, out total, "LoginName", Direction.Ascending,
+                    page * pageSize,
+                    pageSize,
+                    out total,
+                    "LoginName",
+                    Direction.Ascending,
                     memberType.Alias);
 
                 foreach (IMember c in memberToRefresh)
@@ -141,7 +147,10 @@ public sealed class ContentTypeIndexingNotificationHandler : INotificationHandle
 
                 // Re-index all content of these types
                 mediaTypeIds,
-                page++, pageSize, out total, null,
+                page++,
+                pageSize,
+                out total,
+                null,
                 Ordering.By("Path"));
 
             foreach (IMedia c in mediaToRefresh)
@@ -162,7 +171,10 @@ public sealed class ContentTypeIndexingNotificationHandler : INotificationHandle
 
                 // Re-index all content of these types
                 contentTypeIds,
-                page++, pageSize, out total, null,
+                page++,
+                pageSize,
+                out total,
+                null,
 
                 // order by shallowest to deepest, this allows us to check it's published state without checking every item
                 Ordering.By("Path"));

--- a/src/Umbraco.Infrastructure/Security/MemberRoleStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberRoleStore.cs
@@ -145,7 +145,9 @@ public class MemberRoleStore : IQueryableRoleStore<UmbracoIdentityRole>
     }
 
     /// <inheritdoc />
-    public Task SetRoleNameAsync(UmbracoIdentityRole role, string? roleName,
+    public Task SetRoleNameAsync(
+        UmbracoIdentityRole role,
+        string? roleName,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -167,7 +169,9 @@ public class MemberRoleStore : IQueryableRoleStore<UmbracoIdentityRole>
         => GetRoleNameAsync(role, cancellationToken);
 
     /// <inheritdoc />
-    public Task SetNormalizedRoleNameAsync(UmbracoIdentityRole role, string? normalizedName,
+    public Task SetNormalizedRoleNameAsync(
+        UmbracoIdentityRole role,
+        string? normalizedName,
         CancellationToken cancellationToken = default)
         => SetRoleNameAsync(role, normalizedName, cancellationToken);
 

--- a/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberUserStore.cs
@@ -387,7 +387,9 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
     }
 
     /// <inheritdoc />
-    public override Task AddLoginAsync(MemberIdentityUser user, UserLoginInfo login,
+    public override Task AddLoginAsync(
+        MemberIdentityUser user,
+        UserLoginInfo login,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -428,7 +430,10 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
     }
 
     /// <inheritdoc />
-    public override Task RemoveLoginAsync(MemberIdentityUser user, string loginProvider, string providerKey,
+    public override Task RemoveLoginAsync(
+        MemberIdentityUser user,
+        string loginProvider,
+        string providerKey,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -491,7 +496,9 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
     /// <summary>
     ///     Returns true if a user is in the role
     /// </summary>
-    public override Task<bool> IsInRoleAsync(MemberIdentityUser user, string roleName,
+    public override Task<bool> IsInRoleAsync(
+        MemberIdentityUser user,
+        string roleName,
         CancellationToken cancellationToken = default)
     {
         EnsureRoles(user);
@@ -658,7 +665,10 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
     ///     tracking ORMs like EFCore.
     /// </remarks>
     /// <inheritdoc />
-    public override Task<string?> GetTokenAsync(MemberIdentityUser user, string loginProvider, string name,
+    public override Task<string?> GetTokenAsync(
+        MemberIdentityUser user,
+        string loginProvider,
+        string name,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -697,7 +707,9 @@ public class MemberUserStore : UmbracoUserStore<MemberIdentityUser, UmbracoIdent
     }
 
     /// <inheritdoc />
-    protected override async Task<IdentityUserRole<string>?> FindUserRoleAsync(string userId, string roleId,
+    protected override async Task<IdentityUserRole<string>?> FindUserRoleAsync(
+        string userId,
+        string roleId,
         CancellationToken cancellationToken)
     {
         MemberIdentityUser? user = await FindUserAsync(userId, cancellationToken);

--- a/src/Umbraco.Infrastructure/Security/UmbracoIdentityUser.cs
+++ b/src/Umbraco.Infrastructure/Security/UmbracoIdentityUser.cs
@@ -115,7 +115,9 @@ public abstract class UmbracoIdentityUser : IdentityUser, IRememberBeingDirty
     public DateTime? LastPasswordChangeDate
     {
         get => _lastPasswordChangeDateUtc;
-        set => BeingDirty.SetPropertyValueAndDetectChanges(value, ref _lastPasswordChangeDateUtc,
+        set => BeingDirty.SetPropertyValueAndDetectChanges(
+            value,
+            ref _lastPasswordChangeDateUtc,
             nameof(LastPasswordChangeDate));
     }
 

--- a/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessenger.cs
@@ -123,8 +123,11 @@ public class BatchedDatabaseServerMessenger : DatabaseServerMessenger
     }
 
     /// <inheritdoc />
-    protected override void DeliverRemote(ICacheRefresher refresher, MessageType messageType,
-        IEnumerable<object>? ids = null, string? json = null)
+    protected override void DeliverRemote(
+        ICacheRefresher refresher,
+        MessageType messageType,
+        IEnumerable<object>? ids = null,
+        string? json = null)
     {
         var idsA = ids?.ToArray();
 

--- a/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/UrlHelperExtensions.cs
@@ -290,8 +290,12 @@ public static class UrlHelperExtensions
             throw new ArgumentException("Value can't be empty.", nameof(controllerName));
         }
 
-        var encryptedRoute = EncryptionHelper.CreateEncryptedRouteString(dataProtectionProvider, controllerName, action,
-            area, additionalRouteVals);
+        var encryptedRoute = EncryptionHelper.CreateEncryptedRouteString(
+            dataProtectionProvider,
+            controllerName,
+            action,
+            area,
+            additionalRouteVals);
 
         var result = umbracoContext.OriginalRequestUrl.AbsolutePath.EnsureEndsWith('?') + "ufprt=" + encryptedRoute;
         return result;

--- a/src/Umbraco.Web.Common/Security/MemberSecurityStampValidator.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSecurityStampValidator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
@@ -12,9 +12,16 @@ namespace Umbraco.Cms.Web.Common.Security;
 /// </summary>
 public class MemberSecurityStampValidator : SecurityStampValidator<MemberIdentityUser>
 {
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MemberSecurityStampValidator" /> class.
+    /// </summary>
+    /// <param name="options">The options.</param>
+    /// <param name="signInManager">The sign in manager.</param>
+    /// <param name="logger">The logger factory.</param>
     public MemberSecurityStampValidator(
         IOptions<MemberSecurityStampValidatorOptions> options,
-        MemberSignInManager signInManager, ILoggerFactory logger)
+        MemberSignInManager signInManager,
+        ILoggerFactory logger)
         : base(options, signInManager, logger)
     {
     }

--- a/tests/Umbraco.TestData/UmbracoTestDataController.cs
+++ b/tests/Umbraco.TestData/UmbracoTestDataController.cs
@@ -1,4 +1,4 @@
-﻿using Bogus;
+using Bogus;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
@@ -263,11 +263,16 @@ public class UmbracoTestDataController : SurfaceController
         docType.AddPropertyGroup("content", "Content");
         docType.AddPropertyType(
             new PropertyType(_shortStringHelper, Constants.PropertyEditors.Aliases.RichText, ValueStorageType.Ntext, "review")
-        {
-            Name = "Review",
-        }, "content");
-        docType.AddPropertyType(new PropertyType(_shortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext, "desc") { Name = "Description" }, "content");
-        docType.AddPropertyType(new PropertyType(_shortStringHelper, Constants.PropertyEditors.Aliases.MediaPicker3, ValueStorageType.Integer, "media") { Name = "Media" }, "content");
+            {
+                Name = "Review",
+            },
+            "content");
+        docType.AddPropertyType(
+            new PropertyType(_shortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext, "desc") { Name = "Description" },
+            "content");
+        docType.AddPropertyType(
+            new PropertyType(_shortStringHelper, Constants.PropertyEditors.Aliases.MediaPicker3, ValueStorageType.Integer, "media") { Name = "Media" },
+            "content");
 
 
         Services.ContentTypeService.Save(docType);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/ByKeyDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/ByKeyDocumentControllerTests.cs
@@ -27,8 +27,10 @@ public class ByKeyDocumentControllerTests : ManagementApiUserGroupTestBase<ByKey
         await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
 
         // Content Type
-        var contentType = ContentTypeBuilder.CreateTextPageContentType(defaultTemplateId: template.Id,
-            name: Guid.NewGuid().ToString(), alias: Guid.NewGuid().ToString());
+        var contentType = ContentTypeBuilder.CreateTextPageContentType(
+            defaultTemplateId: template.Id,
+            name: Guid.NewGuid().ToString(),
+            alias: Guid.NewGuid().ToString());
         contentType.AllowedAsRoot = true;
         await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
@@ -88,10 +88,12 @@ public abstract class ManagementApiTest<T> : UmbracoTestServerTestBase
                 }
 
                 return (user, password);
-            }, $"{username}:{isAdmin}");
+            },
+            $"{username}:{isAdmin}");
 
     protected async Task AuthenticateClientAsync(HttpClient client, string username, string password, Guid userGroupKey) =>
-        await AuthenticateClientAsync(client,
+        await AuthenticateClientAsync(
+            client,
             async userService =>
             {
                 IUser user;
@@ -116,7 +118,8 @@ public abstract class ManagementApiTest<T> : UmbracoTestServerTestBase
                 }
 
                 return (user, password);
-            }, $"{username}:{userGroupKey}");
+            },
+            $"{username}:{userGroupKey}");
 
     protected async Task AuthenticateClientAsync(HttpClient client, Func<IUserService, Task<(IUser User, string Password)>> createUser, string cacheKey = null)
     {

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiUserGroupTestBase.cs
@@ -57,7 +57,9 @@ public abstract class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T>
     public virtual async Task As_Editor_I_Have_Specified_Access()
     {
         var response = await AuthorizedRequest(Constants.Security.EditorGroupKey, "Editor");
-        Assert.AreEqual(EditorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode,
+        Assert.AreEqual(
+            EditorUserGroupAssertionModel.ExpectedStatusCode,
+            response.StatusCode,
             await response.Content.ReadAsStringAsync());
     }
 
@@ -66,7 +68,9 @@ public abstract class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T>
     public virtual async Task As_Sensitive_Data_I_Have_Specified_Access()
     {
         var response = await AuthorizedRequest(Constants.Security.SensitiveDataGroupKey, "SensitiveData");
-        Assert.AreEqual(SensitiveDataUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode,
+        Assert.AreEqual(
+            SensitiveDataUserGroupAssertionModel.ExpectedStatusCode,
+            response.StatusCode,
             await response.Content.ReadAsStringAsync());
     }
 
@@ -75,7 +79,9 @@ public abstract class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T>
     public virtual async Task As_Translator_I_Have_Specified_Access()
     {
         var response = await AuthorizedRequest(Constants.Security.TranslatorGroupKey, "Translator");
-        Assert.AreEqual(TranslatorUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode,
+        Assert.AreEqual(
+            TranslatorUserGroupAssertionModel.ExpectedStatusCode,
+            response.StatusCode,
             await response.Content.ReadAsStringAsync());
     }
 
@@ -84,7 +90,9 @@ public abstract class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T>
     public virtual async Task As_Writer_I_Have_Specified_Access()
     {
         var response = await AuthorizedRequest(Constants.Security.WriterGroupKey, "Writer");
-        Assert.AreEqual(WriterUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode,
+        Assert.AreEqual(
+            WriterUserGroupAssertionModel.ExpectedStatusCode,
+            response.StatusCode,
             await response.Content.ReadAsStringAsync());
     }
 
@@ -93,7 +101,9 @@ public abstract class ManagementApiUserGroupTestBase<T> : ManagementApiTest<T>
     public virtual async Task As_Unauthorized_I_Have_Specified_Access()
     {
         var response = await ClientRequest();
-        Assert.AreEqual(UnauthorizedUserGroupAssertionModel.ExpectedStatusCode, response.StatusCode,
+        Assert.AreEqual(
+            UnauthorizedUserGroupAssertionModel.ExpectedStatusCode,
+            response.StatusCode,
             await response.Content.ReadAsStringAsync());
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -255,7 +255,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
             if (i % 2 == 0)
             {
                 var contentSchedule =
-                    ContentScheduleCollection.CreateWithEntry(alternatingCulture, now.AddSeconds(5),
+                    ContentScheduleCollection.CreateWithEntry(
+                        alternatingCulture,
+                        now.AddSeconds(5),
                         null); // release in 5 seconds
                 var r = ContentService.Save(c, contentSchedule: contentSchedule);
                 Assert.IsTrue(r.Success, r.Result.ToString());
@@ -268,7 +270,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
                 var r = ContentService.Publish(c, c.AvailableCultures.ToArray());
 
                 var contentSchedule =
-                    ContentScheduleCollection.CreateWithEntry(alternatingCulture, null,
+                    ContentScheduleCollection.CreateWithEntry(
+                        alternatingCulture,
+                        null,
                         now.AddSeconds(5)); // expire in 5 seconds
                 ContentService.PersistContentSchedule(c, contentSchedule);
 
@@ -787,7 +791,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
     [LongRunning]
     public void Can_Publish_Culture_After_Last_Culture_Unpublished()
     {
-        var content = CreateEnglishAndFrenchDocument(out var langUk, out var langFr,
+        var content = CreateEnglishAndFrenchDocument(
+            out var langUk,
+            out var langFr,
             out var contentType);
 
         ContentService.Save(content);
@@ -827,7 +833,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
     [Test]
     public void Unpublish_All_Cultures_Has_Unpublished_State()
     {
-        var content = CreateEnglishAndFrenchDocument(out var langUk, out var langFr,
+        var content = CreateEnglishAndFrenchDocument(
+            out var langUk,
+            out var langFr,
             out var contentType);
 
         var saved = ContentService.Save(content);
@@ -916,7 +924,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
     [Test]
     public void Unpublishing_Already_Unpublished_Culture()
     {
-        var content = CreateEnglishAndFrenchDocument(out var langUk, out var langFr,
+        var content = CreateEnglishAndFrenchDocument(
+            out var langUk,
+            out var langFr,
             out var contentType);
 
         var saved = ContentService.Save(content);
@@ -954,7 +964,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
     [Test]
     public void Publishing_No_Cultures_Still_Saves()
     {
-        var content = CreateEnglishAndFrenchDocument(out var langUk, out var langFr,
+        var content = CreateEnglishAndFrenchDocument(
+            out var langUk,
+            out var langFr,
             out var contentType);
 
         var saved = ContentService.Save(content);
@@ -1238,8 +1250,8 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         ContentService.Save(content);
 
         Assert.Throws<ArgumentNullException>(() => ContentService.Publish(content, null!));
-        Assert.Throws<ArgumentException>(() => ContentService.Publish(content, new string[] { null }));
-        Assert.Throws<ArgumentException>(() => ContentService.Publish(content, new[] { "*", null }));
+        Assert.Throws<ArgumentException>(() => ContentService.Publish(content, new string[] { null! }));
+        Assert.Throws<ArgumentException>(() => ContentService.Publish(content, new[] { "*", null! }));
         Assert.Throws<ArgumentException>(() => ContentService.Publish(content, new[] { "en-US" }));
         Assert.Throws<ArgumentException>(() => ContentService.Publish(content, new[] { "en-US", "*" }));
     }
@@ -1250,8 +1262,11 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(contentType);
 
         var parentId = Textpage.Id;
@@ -1272,7 +1287,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
 
         // content cannot publish values because they are invalid
         var propertyValidationService = new PropertyValidationService(PropertyEditorCollection, DataTypeService, LocalizedTextService, ValueEditorCache, Mock.Of<ICultureDictionary>(), Mock.Of<ILanguageService>(), Mock.Of<IOptions<ContentSettings>>());
-        var isValid = propertyValidationService.IsPropertyDataValid(content, out var invalidProperties,
+        var isValid = propertyValidationService.IsPropertyDataValid(
+            content,
+            out var invalidProperties,
             CultureImpact.Invariant);
         Assert.IsFalse(isValid);
         Assert.IsNotEmpty(invalidProperties);
@@ -1392,7 +1409,10 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         Assert.IsTrue(parent.Published);
 
         var
-            children = ContentService.GetPagedChildren(parentId, 0, 500,
+            children = ContentService.GetPagedChildren(
+                parentId,
+                0,
+                500,
                 out var totalChildren); // we only want the first so page size, etc.. is abitrary
 
         // children are published including ... that was released 5 mins ago
@@ -2069,12 +2089,18 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         content1.PropertyValues(obj);
         content1.ResetDirtyProperties(false);
         ContentService.Save(content1);
-        Assert.IsTrue(ContentService.Publish(content1, content1.AvailableCultures.ToArray(), userId: -1).Success);
+        Assert.IsTrue(ContentService.Publish(
+            content1,
+            content1.AvailableCultures.ToArray(),
+            userId: -1).Success);
         var content2 = ContentBuilder.CreateBasicContent(contentType);
         content2.PropertyValues(obj);
         content2.ResetDirtyProperties(false);
         ContentService.Save(content2);
-        Assert.IsTrue(ContentService.Publish(content2, content2.AvailableCultures.ToArray(), userId: -1).Success);
+        Assert.IsTrue(ContentService.Publish(
+            content2,
+            content2.AvailableCultures.ToArray(),
+            userId: -1).Success);
 
         var editorGroup = await UserGroupService.GetAsync(Constants.Security.EditorGroupKey);
         editorGroup.StartContentId = content1.Id;
@@ -2084,11 +2110,19 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         admin.StartContentIds = new[] { content1.Id };
         UserService.Save(admin);
 
-        RelationService.Save(new RelationType("test", "test", false, Constants.ObjectTypes.Document,
-            Constants.ObjectTypes.Document, false));
+        RelationService.Save(new RelationType(
+            "test",
+            "test",
+            false,
+            Constants.ObjectTypes.Document,
+            Constants.ObjectTypes.Document,
+            false));
         Assert.IsNotNull(RelationService.Relate(content1, content2, "test"));
 
-        PublicAccessService.Save(new PublicAccessEntry(content1, content2, content2,
+        PublicAccessService.Save(new PublicAccessEntry(
+            content1,
+            content2,
+            content2,
             new List<PublicAccessRule> { new() { RuleType = "test", RuleValue = "test" } }));
         Assert.IsTrue(PublicAccessService.AddRule(content1, "test2", "test2").Success);
 
@@ -2257,13 +2291,19 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
         var contentType =
-            ContentTypeBuilder.CreateSimpleTagsContentType("umbTagsPage", "TagsPage",
+            ContentTypeBuilder.CreateSimpleTagsContentType(
+                "umbTagsPage",
+                "TagsPage",
                 defaultTemplateId: template.Id);
         contentType.Key = new Guid("78D96D30-1354-4A1E-8450-377764200C58");
         ContentTypeService.Save(contentType);
 
         var content = ContentBuilder.CreateSimpleContent(contentType, "Simple Tags Page");
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, propAlias,
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            propAlias,
             new[] { "hello", "world" });
         ContentService.Save(content);
 
@@ -2978,8 +3018,11 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
 
         var contentType = ContentTypeService.Get("umbTextpage");
         contentType.Variations = ContentVariation.Culture;
-        contentType.AddPropertyType(new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox,
-            ValueStorageType.Nvarchar, "prop")
+        contentType.AddPropertyType(new PropertyType(
+            ShortStringHelper,
+            Constants.PropertyEditors.Aliases.TextBox,
+            ValueStorageType.Nvarchar,
+            "prop")
         { Variations = ContentVariation.Culture });
         ContentTypeService.Save(contentType);
 
@@ -3168,8 +3211,13 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
     {
         foreach (var content in list)
         {
-            Console.WriteLine("[{0}] {1} {2} {3} {4}", content.Id, content.Name, content.GetCultureName("en-GB"),
-                content.GetCultureName("fr-FR"), content.GetCultureName("da-DK"));
+            Console.WriteLine(
+                "[{0}] {1} {2} {3} {4}",
+                content.Id,
+                content.Name,
+                content.GetCultureName("en-GB"),
+                content.GetCultureName("fr-FR"),
+                content.GetCultureName("da-DK"));
         }
 
         Console.WriteLine("-");
@@ -3202,8 +3250,11 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
 
         var contentType = ContentTypeService.Get("umbTextpage");
         contentType.Variations = ContentVariation.Culture;
-        contentType.AddPropertyType(new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox,
-            ValueStorageType.Nvarchar, "prop")
+        contentType.AddPropertyType(new PropertyType(
+            ShortStringHelper,
+            Constants.PropertyEditors.Aliases.TextBox,
+            ValueStorageType.Nvarchar,
+            "prop")
         { Variations = ContentVariation.Culture });
 
         // TODO: add test w/ an invariant prop
@@ -3244,15 +3295,31 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         Assert.IsNull(content2.GetPublishName(langUk.IsoCode));
 
         // only fr and uk have a name, and are available
-        AssertPerCulture(content, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // nothing has been published yet
-        AssertPerCulture(content, (x, c) => x.IsCulturePublished(c), (langFr, false), (langUk, false),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, false),
+            (langUk, false),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCulturePublished(c), (langFr, false), (langUk, false),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, false),
+            (langUk, false),
             (langDe, false));
 
         // not published => must be edited, if available
@@ -3285,26 +3352,56 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         Assert.AreEqual("value-uk1", content2.GetValue("prop", langUk.IsoCode, published: true));
 
         // no change
-        AssertPerCulture(content, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // fr and uk have been published now
-        AssertPerCulture(content, (x, c) => x.IsCulturePublished(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCulturePublished(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // fr and uk, published without changes, not edited
-        AssertPerCulture(content, (x, c) => x.IsCultureEdited(c), (langFr, false), (langUk, false),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureEdited(c),
+            (langFr, false),
+            (langUk, false),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureEdited(c), (langFr, false), (langUk, false),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureEdited(c),
+            (langFr, false),
+            (langUk, false),
             (langDe, false));
 
-        AssertPerCulture(content, (x, c) => x.GetPublishDate(c) == DateTime.MinValue, (langFr, false),
+        AssertPerCulture(
+            content,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+            (langFr, false),
             (langUk, false)); // DE would throw
-        AssertPerCulture(content2, (x, c) => x.GetPublishDate(c) == DateTime.MinValue, (langFr, false),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+            (langFr, false),
             (langUk, false)); // DE would throw
 
         // note that content and content2 culture published dates might be slightly different due to roundtrip to database
@@ -3346,24 +3443,46 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         Assert.AreEqual("value-uk1", content2.GetValue("prop", langUk.IsoCode, published: true));
 
         // no change
-        AssertPerCulture(content, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // no change
-        AssertPerCulture(content, (x, c) => x.IsCulturePublished(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCulturePublished(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // we have changed values so now fr and uk are edited
         AssertPerCulture(content, (x, c) => x.IsCultureEdited(c), (langFr, true), (langUk, true), (langDe, false));
         AssertPerCulture(content2, (x, c) => x.IsCultureEdited(c), (langFr, true), (langUk, true), (langDe, false));
 
-        AssertPerCulture(content, (x, c) => x.GetPublishDate(c) == DateTime.MinValue, (langFr, false),
+        AssertPerCulture(
+            content,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+            (langFr, false),
             (langUk, false)); // DE would throw
-        AssertPerCulture(content2, (x, c) => x.GetPublishDate(c) == DateTime.MinValue, (langFr, false),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+            (langFr, false),
             (langUk, false)); // DE would throw
 
         // Act
@@ -3392,24 +3511,44 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         Assert.IsTrue(content.IsCulturePublished(langUk.IsoCode));
 
         // no change
-        AssertPerCulture(content, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // fr is not published anymore
-        AssertPerCulture(content, (x, c) => x.IsCulturePublished(c), (langFr, false), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, false),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCulturePublished(c), (langFr, false), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, false),
+            (langUk, true),
             (langDe, false));
 
         // and so, fr has to be edited
         AssertPerCulture(content, (x, c) => x.IsCultureEdited(c), (langFr, true), (langUk, true), (langDe, false));
         AssertPerCulture(content2, (x, c) => x.IsCultureEdited(c), (langFr, true), (langUk, true), (langDe, false));
 
-        AssertPerCulture(content, (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+        AssertPerCulture(
+            content,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
             (langUk, false)); // FR, DE would throw
-        AssertPerCulture(content2, (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+        AssertPerCulture(
+            content2,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
             (langUk, false)); // FR, DE would throw
 
         // Act
@@ -3439,13 +3578,22 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         Assert.AreEqual("value-fr2", content2.GetValue("prop", langFr.IsoCode));
         Assert.AreEqual("value-uk2", content2.GetValue("prop", langUk.IsoCode));
         Assert.IsNull(content2.GetValue("prop", langFr.IsoCode, published: true));
-        Assert.AreEqual("value-uk1",
+        Assert.AreEqual(
+            "value-uk1",
             content2.GetValue("prop", langUk.IsoCode, published: true)); // has value, see note above
 
         // no change
-        AssertPerCulture(content, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // Everything should be unpublished
@@ -3465,25 +3613,54 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         content2 = ContentService.GetById(content.Id);
 
         // no change
-        AssertPerCulture(content, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureAvailable(c), (langFr, true), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureAvailable(c),
+            (langFr, true),
+            (langUk, true),
             (langDe, false));
 
         // no change
-        AssertPerCulture(content, (x, c) => x.IsCulturePublished(c), (langFr, false), (langUk, true),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, false),
+            (langUk, true),
             (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCulturePublished(c), (langFr, false), (langUk, true),
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCulturePublished(c),
+            (langFr, false),
+            (langUk, true),
             (langDe, false));
 
         // now, uk is no more edited
-        AssertPerCulture(content, (x, c) => x.IsCultureEdited(c), (langFr, true), (langUk, false), (langDe, false));
-        AssertPerCulture(content2, (x, c) => x.IsCultureEdited(c), (langFr, true), (langUk, false),
+        AssertPerCulture(
+            content,
+            (x, c) => x.IsCultureEdited(c),
+            (langFr, true),
+            (langUk, false),
+            (langDe, false));
+        AssertPerCulture(
+            content2,
+            (x, c) => x.IsCultureEdited(c),
+            (langFr, true),
+            (langUk, false),
             (langDe, false));
 
-        AssertPerCulture(content, (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+        AssertPerCulture(
+            content,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
             (langUk, false)); // FR, DE would throw
-        AssertPerCulture(content2, (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
+        AssertPerCulture(
+            content2,
+            (x, c) => x.GetPublishDate(c) == DateTime.MinValue,
             (langUk, false)); // FR, DE would throw
 
         // Act
@@ -3572,13 +3749,17 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         Assert.AreEqual(langEn.IsoCode, content.PublishedCultures.First());
     }
 
-    private void AssertPerCulture<T>(IContent item, Func<IContent, string, T> getter,
+    private void AssertPerCulture<T>(
+        IContent item,
+        Func<IContent, string, T> getter,
         params (ILanguage Language, bool Result)[] testCases)
     {
         foreach (var testCase in testCases)
         {
             var value = getter(item, testCase.Language.IsoCode);
-            Assert.AreEqual(testCase.Result, value,
+            Assert.AreEqual(
+                testCase.Result,
+                value,
                 $"Expected {testCase.Result} and got {value} for culture {testCase.Language.IsoCode}.");
         }
     }
@@ -3609,7 +3790,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         var list = new List<IContent>();
         for (var i = 0; i < depth; i++)
         {
-            var c = ContentBuilder.CreateSimpleContent(contentType, "Hierarchy Simple Text Subpage " + i,
+            var c = ContentBuilder.CreateSimpleContent(
+                contentType,
+                "Hierarchy Simple Text Subpage " + i,
                 content);
             list.Add(c);
 
@@ -3619,7 +3802,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         return list;
     }
 
-    private void CreateEnglishAndFrenchDocumentType(out Language langUk, out Language langFr,
+    private void CreateEnglishAndFrenchDocumentType(
+        out Language langUk,
+        out Language langFr,
         out ContentType contentType)
     {
         langUk = (Language)new LanguageBuilder()
@@ -3637,7 +3822,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         ContentTypeService.Save(contentType);
     }
 
-    private IContent CreateEnglishAndFrenchDocument(out Language langUk, out Language langFr,
+    private IContent CreateEnglishAndFrenchDocument(
+        out Language langUk,
+        out Language langFr,
         out ContentType contentType)
     {
         CreateEnglishAndFrenchDocumentType(out langUk, out langFr, out contentType);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Publishing.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -48,13 +48,19 @@ internal partial class BlockListElementLevelVariationTests
             },
             true);
 
-        AssertPropertyValues("en-US",
-            "The first invariant content value", "The first content value in English",
-            "The first invariant settings value", "The first settings value in English");
+        AssertPropertyValues(
+            "en-US",
+            "The first invariant content value",
+            "The first content value in English",
+            "The first invariant settings value",
+            "The first settings value in English");
 
-        AssertPropertyValues("da-DK",
-            "The first invariant content value", "The first content value in Danish",
-            "The first invariant settings value", "The first settings value in Danish");
+        AssertPropertyValues(
+            "da-DK",
+            "The first invariant content value",
+            "The first content value in Danish",
+            "The first invariant settings value",
+            "The first settings value in Danish");
 
         var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
         blockListValue.ContentData[0].Values[0].Value = "The second invariant content value";
@@ -68,23 +74,35 @@ internal partial class BlockListElementLevelVariationTests
         ContentService.Save(content);
         PublishContent(content, contentType, ["en-US"]);
 
-        AssertPropertyValues("en-US",
-            "The second invariant content value", "The second content value in English",
-            "The second invariant settings value", "The second settings value in English");
+        AssertPropertyValues(
+            "en-US",
+            "The second invariant content value",
+            "The second content value in English",
+            "The second invariant settings value",
+            "The second settings value in English");
 
-        AssertPropertyValues("da-DK",
-            "The second invariant content value", "The first content value in Danish",
-            "The second invariant settings value", "The first settings value in Danish");
+        AssertPropertyValues(
+            "da-DK",
+            "The second invariant content value",
+            "The first content value in Danish",
+            "The second invariant settings value",
+            "The first settings value in Danish");
 
         PublishContent(content, contentType, ["da-DK"]);
 
-        AssertPropertyValues("da-DK",
-            "The second invariant content value", "The second content value in Danish",
-            "The second invariant settings value", "The second settings value in Danish");
+        AssertPropertyValues(
+            "da-DK",
+            "The second invariant content value",
+            "The second content value in Danish",
+            "The second invariant settings value",
+            "The second settings value in Danish");
 
-        void AssertPropertyValues(string culture,
-            string expectedInvariantContentValue, string expectedVariantContentValue,
-            string expectedInvariantSettingsValue, string expectedVariantSettingsValue)
+        void AssertPropertyValues(
+            string culture,
+            string expectedInvariantContentValue,
+            string expectedVariantContentValue,
+            string expectedInvariantSettingsValue,
+            string expectedVariantSettingsValue)
         {
             SetVariationContext(culture, null);
             var publishedContent = GetPublishedContent(content.Key);
@@ -151,13 +169,19 @@ internal partial class BlockListElementLevelVariationTests
             },
             true);
 
-        AssertPropertyValues("en-US",
-            "English invariantText content value", "English variantText content value",
-            "English invariantText settings value", "English variantText settings value");
+        AssertPropertyValues(
+            "en-US",
+            "English invariantText content value",
+            "English variantText content value",
+            "English invariantText settings value",
+            "English variantText settings value");
 
-        AssertPropertyValues("da-DK",
-            "Danish invariantText content value", "Danish variantText content value",
-            "Danish invariantText settings value", "Danish variantText settings value");
+        AssertPropertyValues(
+            "da-DK",
+            "Danish invariantText content value",
+            "Danish variantText content value",
+            "Danish invariantText settings value",
+            "Danish variantText settings value");
 
         var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue("en-US")!);
         blockListValue.ContentData[0].Values[0].Value = "English invariantText content value (updated)";
@@ -176,23 +200,35 @@ internal partial class BlockListElementLevelVariationTests
         ContentService.Save(content);
         PublishContent(content, contentType, ["en-US"]);
 
-        AssertPropertyValues("en-US",
-            "English invariantText content value (updated)", "English variantText content value (updated)",
-            "English invariantText settings value (updated)", "English variantText settings value (updated)");
+        AssertPropertyValues(
+            "en-US",
+            "English invariantText content value (updated)",
+            "English variantText content value (updated)",
+            "English invariantText settings value (updated)",
+            "English variantText settings value (updated)");
 
-        AssertPropertyValues("da-DK",
-            "Danish invariantText content value", "Danish variantText content value",
-            "Danish invariantText settings value", "Danish variantText settings value");
+        AssertPropertyValues(
+            "da-DK",
+            "Danish invariantText content value",
+            "Danish variantText content value",
+            "Danish invariantText settings value",
+            "Danish variantText settings value");
 
         PublishContent(content, contentType, ["da-DK"]);
 
-        AssertPropertyValues("da-DK",
-            "Danish invariantText content value (updated)", "Danish variantText content value (updated)",
-            "Danish invariantText settings value (updated)", "Danish variantText settings value (updated)");
+        AssertPropertyValues(
+            "da-DK",
+            "Danish invariantText content value (updated)",
+            "Danish variantText content value (updated)",
+            "Danish invariantText settings value (updated)",
+            "Danish variantText settings value (updated)");
 
-        void AssertPropertyValues(string culture,
-            string expectedInvariantContentValue, string expectedVariantContentValue,
-            string expectedInvariantSettingsValue, string expectedVariantSettingsValue)
+        void AssertPropertyValues(
+            string culture,
+            string expectedInvariantContentValue,
+            string expectedVariantContentValue,
+            string expectedInvariantSettingsValue,
+            string expectedVariantSettingsValue)
         {
             SetVariationContext(culture, null);
             var publishedContent = GetPublishedContent(content.Key);
@@ -681,23 +717,41 @@ internal partial class BlockListElementLevelVariationTests
             [],
             true);
 
-        AssertPropertyValues("en-US", null,
-            "The first invariant content value", "The first content value in English");
+        AssertPropertyValues(
+            "en-US",
+            null,
+            "The first invariant content value",
+            "The first content value in English");
 
-        AssertPropertyValues("en-US", "s1",
-            "The first invariant content value", "The first content value in English (Segment 1)");
+        AssertPropertyValues(
+            "en-US",
+            "s1",
+            "The first invariant content value",
+            "The first content value in English (Segment 1)");
 
-        AssertPropertyValues("en-US", "s2",
-            "The first invariant content value", "The first content value in English (Segment 2)");
+        AssertPropertyValues(
+            "en-US",
+            "s2",
+            "The first invariant content value",
+            "The first content value in English (Segment 2)");
 
-        AssertPropertyValues("da-DK", null,
-            "The first invariant content value", "The first content value in Danish");
+        AssertPropertyValues(
+            "da-DK",
+            null,
+            "The first invariant content value",
+            "The first content value in Danish");
 
-        AssertPropertyValues("da-DK", "s1",
-            "The first invariant content value", "The first content value in Danish (Segment 1)");
+        AssertPropertyValues(
+            "da-DK",
+            "s1",
+            "The first invariant content value",
+            "The first content value in Danish (Segment 1)");
 
-        AssertPropertyValues("da-DK", "s2",
-            "The first invariant content value", "The first content value in Danish (Segment 2)");
+        AssertPropertyValues(
+            "da-DK",
+            "s2",
+            "The first invariant content value",
+            "The first content value in Danish (Segment 2)");
 
         var blockListValue = JsonSerializer.Deserialize<BlockListValue>((string)content.Properties["blocks"]!.GetValue()!);
         blockListValue.ContentData[0].Values[0].Value = "The second invariant content value";
@@ -712,36 +766,67 @@ internal partial class BlockListElementLevelVariationTests
         ContentService.Save(content);
         PublishContent(content, contentType, ["en-US"]);
 
-        AssertPropertyValues("en-US", null,
-            "The second invariant content value", "The second content value in English");
+        AssertPropertyValues(
+            "en-US",
+            null,
+            "The second invariant content value",
+            "The second content value in English");
 
-        AssertPropertyValues("en-US", "s1",
-            "The second invariant content value", "The second content value in English (Segment 1)");
+        AssertPropertyValues(
+            "en-US",
+            "s1",
+            "The second invariant content value",
+            "The second content value in English (Segment 1)");
 
-        AssertPropertyValues("en-US", "s2",
-            "The second invariant content value", "The second content value in English (Segment 2)");
+        AssertPropertyValues(
+            "en-US",
+            "s2",
+            "The second invariant content value",
+            "The second content value in English (Segment 2)");
 
-        AssertPropertyValues("da-DK", null,
-            "The second invariant content value", "The first content value in Danish");
+        AssertPropertyValues(
+            "da-DK",
+            null,
+            "The second invariant content value",
+            "The first content value in Danish");
 
-        AssertPropertyValues("da-DK", "s1",
-            "The second invariant content value", "The first content value in Danish (Segment 1)");
+        AssertPropertyValues(
+            "da-DK",
+            "s1",
+            "The second invariant content value",
+            "The first content value in Danish (Segment 1)");
 
-        AssertPropertyValues("da-DK", "s2",
-            "The second invariant content value", "The first content value in Danish (Segment 2)");
+        AssertPropertyValues(
+            "da-DK",
+            "s2",
+            "The second invariant content value",
+            "The first content value in Danish (Segment 2)");
 
         PublishContent(content, contentType, ["da-DK"]);
 
-        AssertPropertyValues("da-DK", null,
-            "The second invariant content value", "The second content value in Danish");
+        AssertPropertyValues(
+            "da-DK",
+            null,
+            "The second invariant content value",
+            "The second content value in Danish");
 
-        AssertPropertyValues("da-DK", "s1",
-            "The second invariant content value", "The second content value in Danish (Segment 1)");
+        AssertPropertyValues(
+            "da-DK",
+            "s1",
+            "The second invariant content value",
+            "The second content value in Danish (Segment 1)");
 
-        AssertPropertyValues("da-DK", "s2",
-            "The second invariant content value", "The second content value in Danish (Segment 2)");
+        AssertPropertyValues(
+            "da-DK",
+            "s2",
+            "The second invariant content value",
+            "The second content value in Danish (Segment 2)");
 
-        void AssertPropertyValues(string culture, string? segment, string expectedInvariantContentValue, string expectedVariantContentValue)
+        void AssertPropertyValues(
+            string culture,
+            string? segment,
+            string expectedInvariantContentValue,
+            string expectedVariantContentValue)
         {
             SetVariationContext(culture, segment);
             var publishedContent = GetPublishedContent(content.Key);
@@ -1570,11 +1655,8 @@ internal partial class BlockListElementLevelVariationTests
                             new() { Alias = "variantText", Value = "Valid value in Danish", Culture = "da-DK" },
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -1613,11 +1695,8 @@ internal partial class BlockListElementLevelVariationTests
                             new() { Alias = "variantText", Value = "Valid value in Danish", Culture = "da-DK" },
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -1656,11 +1735,8 @@ internal partial class BlockListElementLevelVariationTests
                             new() { Alias = "variantText", Value = "Valid value in Danish", Culture = "da-DK" },
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -1700,11 +1776,8 @@ internal partial class BlockListElementLevelVariationTests
                             new() { Alias = "variantText", Value = "Valid value in Danish", Culture = "da-DK" },
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -1745,11 +1818,8 @@ internal partial class BlockListElementLevelVariationTests
                             new() { Alias = "variantText", Value = "Valid value in Danish", Culture = "da-DK" },
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -1793,11 +1863,8 @@ internal partial class BlockListElementLevelVariationTests
                             new() { Alias = "variantText", Value = $"{(invalidSettingsValue ? "Invalid" : "Valid")} settings value in Danish", Culture = "da-DK" },
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -1841,11 +1908,8 @@ internal partial class BlockListElementLevelVariationTests
                             new() { Alias = "variantText", Value = "Valid settings value in English", Culture = "en-US" },
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         // make sure all blocks are exposed
         blockListValue.Expose =
@@ -1973,19 +2037,28 @@ internal partial class BlockListElementLevelVariationTests
             },
             true);
 
-        AssertPropertyValuesWithFallback("en-US",
-            "English invariantText content value", "English variantText content value",
-            "English invariantText settings value", "English variantText settings value");
+        AssertPropertyValuesWithFallback(
+            "en-US",
+            "English invariantText content value",
+            "English variantText content value",
+            "English invariantText settings value",
+            "English variantText settings value");
 
         AssetEmptyPropertyValues("da-DK");
 
-        AssertPropertyValuesWithFallback("da-DK",
-            "English invariantText content value", "English variantText content value",
-            "English invariantText settings value", "English variantText settings value");
+        AssertPropertyValuesWithFallback(
+            "da-DK",
+            "English invariantText content value",
+            "English variantText content value",
+            "English invariantText settings value",
+            "English variantText settings value");
 
-        void AssertPropertyValuesWithFallback(string culture,
-            string expectedInvariantContentValue, string expectedVariantContentValue,
-            string expectedInvariantSettingsValue, string expectedVariantSettingsValue)
+        void AssertPropertyValuesWithFallback(
+            string culture,
+            string expectedInvariantContentValue,
+            string expectedVariantContentValue,
+            string expectedInvariantSettingsValue,
+            string expectedVariantSettingsValue)
         {
             SetVariationContext(culture, null);
             var publishedContent = GetPublishedContent(content.Key);
@@ -2221,8 +2294,7 @@ internal partial class BlockListElementLevelVariationTests
                     new() { Alias = "variantText", Value = "The original invariant value for settings" },
                 },
                 null,
-                null)
-        );
+                null));
 
         blockListValue.Expose =
         [

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ConsentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ConsentServiceTests.cs
@@ -72,7 +72,11 @@ internal sealed class ConsentServiceTests : UmbracoIntegrationTest
         Assert.IsTrue(consents.Any(x => x.Source == "user/1236"));
 
         // can revoke
-        consent = ConsentService.RegisterConsent("user/1234", "app1", "do-something", ConsentState.Revoked,
+        consent = ConsentService.RegisterConsent(
+            "user/1234",
+            "app1",
+            "do-something",
+            ConsentState.Revoked,
             "no comment");
 
         consents = ConsentService.LookupConsent("user/1234", "app1", "do-something").ToArray();
@@ -100,8 +104,12 @@ internal sealed class ConsentServiceTests : UmbracoIntegrationTest
 
         // cannot be stupid
         Assert.Throws<ArgumentException>(() =>
-            ConsentService.RegisterConsent("user/1234", "app1", "do-something",
-                ConsentState.Granted | ConsentState.Revoked, "no comment"));
+            ConsentService.RegisterConsent(
+                "user/1234",
+                "app1",
+                "do-something",
+                ConsentState.Granted | ConsentState.Revoked,
+                "no comment"));
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Publish.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Publish.cs
@@ -115,9 +115,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
 
-        var result = await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
 
         Assert.IsTrue(result.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.Success, result.Status);
@@ -142,9 +146,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
 
-        var publishResult = await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        var publishResult = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
 
         Assert.IsTrue(publishResult.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.Success, publishResult.Status);
@@ -162,8 +170,10 @@ public partial class ContentPublishingServiceTests
         content = ContentService.GetById(content.Key)!;
         Assert.AreEqual(0, content.PublishedCultures.Count());
 
-        publishResult = await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        publishResult = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [new CulturePublishScheduleModel { Culture = langDa.IsoCode }],
+            Constants.Security.SuperUserKey);
         Assert.IsTrue(publishResult.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.Success, publishResult.Status);
 
@@ -325,9 +335,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
 
-        var result = await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.Success, result.Status);
 
@@ -362,9 +376,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("invariantValue", "Invariant value");
         ContentService.Save(content);
 
-        var result = await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = "en-US" },
-            new CulturePublishScheduleModel { Culture = "da-DK" }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = "en-US" },
+                new CulturePublishScheduleModel { Culture = "da-DK" }
+            ],
+            Constants.Security.SuperUserKey);
 
         Assert.IsTrue(result.Success);
 
@@ -374,7 +392,10 @@ public partial class ContentPublishingServiceTests
         content.SetValue("invariantValue", null);
         ContentService.Save(content);
 
-        result = await ContentPublishingService.PublishAsync(content.Key, culturesToRepublish.Select(culture => new CulturePublishScheduleModel { Culture = culture }).ToArray(), Constants.Security.SuperUserKey);
+        result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            culturesToRepublish.Select(culture => new CulturePublishScheduleModel { Culture = culture }).ToArray(),
+            Constants.Security.SuperUserKey);
 
         content = ContentService.GetById(content.Key)!;
 
@@ -485,9 +506,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", null, culture: langDa.IsoCode);
         ContentService.Save(content);
 
-        var result = await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.ContentInvalid, result.Status);
 
@@ -509,8 +534,10 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
 
-        var result = await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [new CulturePublishScheduleModel { Culture = langDa.IsoCode }],
+            Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.MandatoryCultureMissing, result.Status);
@@ -698,7 +725,10 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
 
-        var result = await ContentPublishingService.PublishAsync(content.Key, [new CulturePublishScheduleModel { Culture = cultureCode }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [new CulturePublishScheduleModel { Culture = cultureCode }],
+            Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.InvalidCulture, result.Status);
@@ -719,7 +749,10 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
 
-        var result = await ContentPublishingService.PublishAsync(content.Key, [new CulturePublishScheduleModel { Culture = cultureCode }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            content.Key,
+            [new CulturePublishScheduleModel { Culture = cultureCode }],
+            Constants.Security.SuperUserKey);
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentPublishingOperationStatus.InvalidCulture, result.Status);
@@ -728,7 +761,10 @@ public partial class ContentPublishingServiceTests
     [Test]
     public async Task Can_Publish_Invariant_Content_With_Cultures_Provided_If_The_Default_Culture_Is_Exclusively_Provided()
     {
-        var result = await ContentPublishingService.PublishAsync(Textpage.Key, [new CulturePublishScheduleModel { Culture = "en-US" }], Constants.Security.SuperUserKey);
+        var result = await ContentPublishingService.PublishAsync(
+            Textpage.Key,
+            [new CulturePublishScheduleModel { Culture = "en-US" }],
+            Constants.Security.SuperUserKey);
         Assert.IsTrue(result.Success);
     }
 
@@ -736,9 +772,11 @@ public partial class ContentPublishingServiceTests
     public async Task Can_Publish_Invariant_Content_With_Cultures_Provided_If_The_Default_Culture_Is_Provided_With_Other_Cultures()
     {
         var result = await ContentPublishingService.PublishAsync(
-            Textpage.Key, [
-            new CulturePublishScheduleModel { Culture = "en-US" },
-            new CulturePublishScheduleModel { Culture = "da-DK" }],
+            Textpage.Key,
+            [
+                new CulturePublishScheduleModel { Culture = "en-US" },
+                new CulturePublishScheduleModel { Culture = "da-DK" }
+            ],
             Constants.Security.SuperUserKey);
 
         Assert.IsTrue(result.Success);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Unpublish.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Unpublish.cs
@@ -148,9 +148,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "EN title", culture: langEn.IsoCode);
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
-        await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
         VerifyIsPublished(content.Key);
 
         var result = await ContentPublishingService.UnpublishAsync(content.Key, new HashSet<string> { langEn.IsoCode }, Constants.Security.SuperUserKey);
@@ -176,9 +180,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "EN title", culture: langEn.IsoCode);
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
-        await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
         VerifyIsPublished(content.Key);
 
         var result = await ContentPublishingService.UnpublishAsync(content.Key, new HashSet<string>(){"*"}, Constants.Security.SuperUserKey);
@@ -203,9 +211,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "EN title", culture: langEn.IsoCode);
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
-        await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
         VerifyIsPublished(content.Key);
 
         var result = await ContentPublishingService.UnpublishAsync(content.Key, new HashSet<string>() { langEn.IsoCode, langDa.IsoCode }, Constants.Security.SuperUserKey);
@@ -306,9 +318,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "EN title", culture: langEn.IsoCode);
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
-        await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
         VerifyIsPublished(content.Key);
 
         content = ContentService.GetById(content.Key)!;
@@ -350,9 +366,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "EN title", culture: langEn.IsoCode);
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
-        await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }], Constants.Security.SuperUserKey);
+        await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
         VerifyIsPublished(content.Key);
 
         var result = await ContentPublishingService.UnpublishAsync(content.Key, new HashSet<string>() { cultureCode }, Constants.Security.SuperUserKey);
@@ -378,10 +398,13 @@ public partial class ContentPublishingServiceTests
         content.SetValue("title", "EN title", culture: langEn.IsoCode);
         content.SetValue("title", "DA title", culture: langDa.IsoCode);
         ContentService.Save(content);
-        await ContentPublishingService.PublishAsync(content.Key, [
-            new CulturePublishScheduleModel { Culture = langEn.IsoCode },
-            new CulturePublishScheduleModel { Culture = langDa.IsoCode }
-        ], Constants.Security.SuperUserKey);
+        await ContentPublishingService.PublishAsync(
+            content.Key,
+            [
+                new CulturePublishScheduleModel { Culture = langEn.IsoCode },
+                new CulturePublishScheduleModel { Culture = langDa.IsoCode }
+            ],
+            Constants.Security.SuperUserKey);
 
         VerifyIsPublished(content.Key);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePublishBranchTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServicePublishBranchTests.cs
@@ -14,7 +14,9 @@ using Umbraco.Cms.Tests.Integration.Testing;
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
 [TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, PublishedRepositoryEvents = true,
+[UmbracoTest(
+    Database = UmbracoTestOptions.Database.NewSchemaPerTest,
+    PublishedRepositoryEvents = true,
     WithApplication = true)]
 internal sealed class ContentServicePublishBranchTests : UmbracoIntegrationTest
 {
@@ -621,7 +623,10 @@ internal sealed class ContentServicePublishBranchTests : UmbracoIntegrationTest
             Variations = ContentVariation.Nothing
         };
         iContentType.AddPropertyType(
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Nvarchar,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Nvarchar,
                 "ip")
             { Variations = ContentVariation.Nothing });
         ContentTypeService.Save(iContentType);
@@ -633,11 +638,17 @@ internal sealed class ContentServicePublishBranchTests : UmbracoIntegrationTest
             Variations = ContentVariation.Culture
         };
         vContentType.AddPropertyType(
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Nvarchar,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Nvarchar,
                 "ip")
             { Variations = ContentVariation.Nothing });
         vContentType.AddPropertyType(
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Nvarchar,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Nvarchar,
                 "vp")
             { Variations = ContentVariation.Culture });
         ContentTypeService.Save(vContentType);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTagsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTagsTests.cs
@@ -56,13 +56,20 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         IContent content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "another", "one" });
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
@@ -100,18 +107,31 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType, ContentVariation.Culture);
         ContentTypeService.Save(contentType);
 
         IContent content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
         content1.SetCultureName("name-fr", "fr-FR");
         content1.SetCultureName("name-en", "en-US");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "some", "tags", "plus" }, culture: "fr-FR");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "another", "one" }, culture: "en-US");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "some", "tags", "plus" },
+            culture: "fr-FR");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "another", "one" },
+            culture: "en-US");
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
@@ -156,13 +176,20 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         var propertyType = CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         IContent content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "another", "one" });
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
@@ -236,18 +263,31 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType, ContentVariation.Culture);
         ContentTypeService.Save(contentType);
 
         IContent content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
         content1.SetCultureName("name-fr", "fr-FR");
         content1.SetCultureName("name-en", "en-US");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "some", "tags", "plus" }, culture: "fr-FR");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "another", "one" }, culture: "en-US");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "some", "tags", "plus" },
+            culture: "fr-FR");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "another", "one" },
+            culture: "en-US");
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
@@ -296,28 +336,51 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         var propertyType = CreateAndAddTagsPropertyType(contentType, ContentVariation.Culture);
         ContentTypeService.Save(contentType);
 
         IContent content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
         content1.SetCultureName("name-fr", "fr-FR");
         content1.SetCultureName("name-en", "en-US");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "some", "tags", "plus" }, culture: "fr-FR");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "another", "one" }, culture: "en-US");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "some", "tags", "plus" },
+            culture: "fr-FR");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "another", "one" },
+            culture: "en-US");
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
         IContent content2 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 2");
         content2.SetCultureName("name-fr", "fr-FR");
         content2.SetCultureName("name-en", "en-US");
-        content2.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "some", "tags", "plus" }, culture: "fr-FR");
-        content2.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "another", "one" }, culture: "en-US");
+        content2.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "some", "tags", "plus" },
+            culture: "fr-FR");
+        content2.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "another", "one" },
+            culture: "en-US");
         ContentService.Save(content2);
         ContentService.Publish(content2, content2.AvailableCultures.ToArray());
 
@@ -343,18 +406,31 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         var propertyType = CreateAndAddTagsPropertyType(contentType, ContentVariation.Culture);
         ContentTypeService.Save(contentType);
 
         IContent content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
         content1.SetCultureName("name-fr", "fr-FR");
         content1.SetCultureName("name-en", "en-US");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "some", "tags", "plus" }, culture: "fr-FR");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            new[] { "hello", "world", "another", "one" }, culture: "en-US");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "some", "tags", "plus" },
+            culture: "fr-FR");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "hello", "world", "another", "one" },
+            culture: "en-US");
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
@@ -406,18 +482,31 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         var propertyType = CreateAndAddTagsPropertyType(contentType, ContentVariation.Culture);
         ContentTypeService.Save(contentType);
 
         IContent content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
         content1.SetCultureName("name-fr", "fr-FR");
         content1.SetCultureName("name-en", "en-US");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            frValue, culture: "fr-FR");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
-            enValue, culture: "en-US");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            frValue,
+            culture: "fr-FR");
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            enValue,
+            culture: "en-US");
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
@@ -438,19 +527,30 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         var content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags", "plus" });
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
         var content2 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 2");
-        content2.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content2.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content2);
         ContentService.Publish(content2, content2.AvailableCultures.ToArray());
@@ -470,19 +570,30 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         var content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags", "bam" });
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
         var content2 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 2");
-        content2.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content2.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content2);
         ContentService.Publish(content2, content2.AvailableCultures.ToArray());
@@ -504,19 +615,30 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         var content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags", "plus" });
         ContentService.Save(content1);
         ContentService.Publish(content1, Array.Empty<string>());
 
         var content2 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 2", content1.Id);
-        content2.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content2.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content2);
         ContentService.Publish(content2, Array.Empty<string>());
@@ -581,19 +703,30 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         var content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags", "bam" });
         ContentService.Save(content1);
         ContentService.Publish(content1, content1.AvailableCultures.ToArray());
 
         var content2 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 2");
-        content2.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content2.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content2);
         ContentService.Publish(content2, content2.AvailableCultures.ToArray());
@@ -609,19 +742,30 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         var content1 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags", "bam" });
         ContentService.Save(content1);
         ContentService.Publish(content1, Array.Empty<string>());
 
         var content2 = ContentBuilder.CreateSimpleContent(contentType, "Tagged content 2", content1);
-        content2.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content2.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content2);
         ContentService.Publish(content2, Array.Empty<string>());
@@ -664,20 +808,31 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
         contentType.AllowedContentTypes =
             new[] { new ContentTypeSort(contentType.Key, 0, contentType.Alias) };
 
         var content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content);
 
         var child1 = ContentBuilder.CreateSimpleContent(contentType, "child 1 content", content.Id);
-        child1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        child1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello1", "world1", "some1" });
         ContentService.Save(child1);
 
@@ -716,20 +871,32 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         FileService.SaveTemplate(template);
 
         // create content type with a tag property
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         // create a content with tags and publish
         var content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content);
         ContentService.Publish(content, content.AvailableCultures.ToArray());
 
         // edit tags and save
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags", new[] { "another", "world" },
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "another", "world" },
             true);
         ContentService.Save(content);
 
@@ -754,15 +921,22 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         FileService.SaveTemplate(template);
 
         // Arrange
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
 
         var content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
 
         // Act
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content);
         ContentService.Publish(content, Array.Empty<string>());
@@ -787,18 +961,30 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         FileService.SaveTemplate(template);
 
         // Arrange
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
         var content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content);
         ContentService.Publish(content, Array.Empty<string>());
 
         // Act
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags", new[] { "another", "world" },
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
+            new[] { "another", "world" },
             true);
         ContentService.Save(content);
         ContentService.Publish(content, Array.Empty<string>());
@@ -823,12 +1009,19 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         FileService.SaveTemplate(template);
 
         // Arrange
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
         ContentTypeService.Save(contentType);
         var content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello", "world", "some", "tags" });
         ContentService.Save(content);
         ContentService.Publish(content, Array.Empty<string>());
@@ -868,14 +1061,21 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
 
         ContentTypeService.Save(contentType);
 
         IContent content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello,world,tags", "new" });
 
         ContentService.Save(content);
@@ -912,14 +1112,21 @@ internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
-            mandatoryProperties: true, defaultTemplateId: template.Id);
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "umbMandatory",
+            "Mandatory Doc Type",
+            mandatoryProperties: true,
+            defaultTemplateId: template.Id);
         CreateAndAddTagsPropertyType(contentType);
 
         ContentTypeService.Save(contentType);
 
         IContent content = ContentBuilder.CreateSimpleContent(contentType, "Tagged content");
-        content.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "hello,world,tags", "new" });
 
         ContentService.Save(content);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceTests.cs
@@ -383,15 +383,24 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         };
 
         contentType.AddPropertyType(
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             { Name = "Title", Description = string.Empty, Mandatory = false, DataTypeId = -88 });
         contentType.AddPropertyType(
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.RichText, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.RichText,
+                ValueStorageType.Ntext,
                 "bodyText")
             { Name = "Body Text", Description = string.Empty, Mandatory = false, DataTypeId = -87 });
         contentType.AddPropertyType(
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             { Name = "Author", Description = "Name of the author", Mandatory = false, DataTypeId = -88 });
 
@@ -418,16 +427,28 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var global = ContentTypeBuilder.CreateSimpleContentType("global", "Global", defaultTemplateId: template.Id);
         ContentTypeService.Save(global);
 
-        var components = ContentTypeBuilder.CreateSimpleContentType("components", "Components", global,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var components = ContentTypeBuilder.CreateSimpleContentType(
+            "components",
+            "Components",
+            global,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(components);
 
-        var component = ContentTypeBuilder.CreateSimpleContentType("component", "Component", components,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var component = ContentTypeBuilder.CreateSimpleContentType(
+            "component",
+            "Component",
+            components,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(component);
 
-        var category = ContentTypeBuilder.CreateSimpleContentType("category", "Category", global,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var category = ContentTypeBuilder.CreateSimpleContentType(
+            "category",
+            "Category",
+            global,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(category);
 
         var success = category.AddContentType(component);
@@ -441,12 +462,20 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var contentType = ContentTypeBuilder.CreateSimpleContentType("page", "Page", randomizeAliases: true,
+        var contentType = ContentTypeBuilder.CreateSimpleContentType(
+            "page",
+            "Page",
+            randomizeAliases: true,
             defaultTemplateId: template.Id);
         ContentTypeService.Save(contentType);
 
-        var childContentType = ContentTypeBuilder.CreateSimpleContentType("childPage", "Child Page", contentType,
-            randomizeAliases: true, propertyGroupAlias: "childContent", propertyGroupName: "Child Content",
+        var childContentType = ContentTypeBuilder.CreateSimpleContentType(
+            "childPage",
+            "Child Page",
+            contentType,
+            randomizeAliases: true,
+            propertyGroupAlias: "childContent",
+            propertyGroupName: "Child Content",
             defaultTemplateId: template.Id);
         ContentTypeService.Save(childContentType);
         var content = ContentService.Create("Page 1", -1, childContentType.Alias);
@@ -618,7 +647,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
         var simpleContentType =
-            ContentTypeBuilder.CreateSimpleContentType("category", "Category", metaContentType,
+            ContentTypeBuilder.CreateSimpleContentType(
+                "category",
+                "Category",
+                metaContentType,
                 defaultTemplateId: template.Id) as IContentType;
         ContentTypeService.Save(simpleContentType);
         var categoryId = simpleContentType.Id;
@@ -660,12 +692,19 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var parentContentType1 =
             ContentTypeBuilder.CreateSimpleContentType("parent1", "Parent1", defaultTemplateId: template.Id);
         ContentTypeService.Save(parentContentType1);
-        var parentContentType2 = ContentTypeBuilder.CreateSimpleContentType("parent2", "Parent2",
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var parentContentType2 = ContentTypeBuilder.CreateSimpleContentType(
+            "parent2",
+            "Parent2",
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(parentContentType2);
 
-        var simpleContentType = ContentTypeBuilder.CreateSimpleContentType("category", "Category", parentContentType1,
-            randomizeAliases: true, defaultTemplateId: template.Id) as IContentType;
+        var simpleContentType = ContentTypeBuilder.CreateSimpleContentType(
+            "category",
+            "Category",
+            parentContentType1,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id) as IContentType;
         ContentTypeService.Save(simpleContentType);
 
         // Act
@@ -695,9 +734,11 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         Assert.AreNotEqual(clonedContentType.Key, originalContentType.Key);
         Assert.AreNotEqual(clonedContentType.Path, originalContentType.Path);
 
-        Assert.AreNotEqual(clonedContentType.PropertyTypes.First(x => x.Alias.StartsWith("title")).Id,
+        Assert.AreNotEqual(
+            clonedContentType.PropertyTypes.First(x => x.Alias.StartsWith("title")).Id,
             originalContentType.PropertyTypes.First(x => x.Alias.StartsWith("title")).Id);
-        Assert.AreNotEqual(clonedContentType.PropertyGroups.First(x => x.Name.StartsWith("Content")).Id,
+        Assert.AreNotEqual(
+            clonedContentType.PropertyGroups.First(x => x.Name.StartsWith("Content")).Id,
             originalContentType.PropertyGroups.First(x => x.Name.StartsWith("Content")).Id);
     }
 
@@ -711,7 +752,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var simpleContentType = ContentTypeBuilder.CreateSimpleContentType("category", "Category", metaContentType,
+        var simpleContentType = ContentTypeBuilder.CreateSimpleContentType(
+            "category",
+            "Category",
+            metaContentType,
             defaultTemplateId: template.Id);
         ContentTypeService.Save(simpleContentType);
         var categoryId = simpleContentType.Id;
@@ -750,9 +794,11 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         Assert.AreNotEqual(cloned.Key, original.Key);
         Assert.AreNotEqual(cloned.Path, original.Path);
         Assert.AreNotEqual(cloned.SortOrder, original.SortOrder);
-        Assert.AreNotEqual(cloned.PropertyTypes.First(x => x.Alias.Equals("title")).Id,
+        Assert.AreNotEqual(
+            cloned.PropertyTypes.First(x => x.Alias.Equals("title")).Id,
             original.PropertyTypes.First(x => x.Alias.Equals("title")).Id);
-        Assert.AreNotEqual(cloned.PropertyGroups.First(x => x.Name.Equals("Content")).Id,
+        Assert.AreNotEqual(
+            cloned.PropertyGroups.First(x => x.Name.Equals("Content")).Id,
             original.PropertyGroups.First(x => x.Name.Equals("Content")).Id);
     }
 
@@ -766,12 +812,19 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var parentContentType1 =
             ContentTypeBuilder.CreateSimpleContentType("parent1", "Parent1", defaultTemplateId: template.Id);
         ContentTypeService.Save(parentContentType1);
-        var parentContentType2 = ContentTypeBuilder.CreateSimpleContentType("parent2", "Parent2",
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var parentContentType2 = ContentTypeBuilder.CreateSimpleContentType(
+            "parent2",
+            "Parent2",
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(parentContentType2);
 
-        var simpleContentType = ContentTypeBuilder.CreateSimpleContentType("category", "Category", parentContentType1,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var simpleContentType = ContentTypeBuilder.CreateSimpleContentType(
+            "category",
+            "Category",
+            parentContentType1,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(simpleContentType);
 
         // Act
@@ -796,9 +849,11 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         Assert.AreNotEqual(clonedContentType.Key, originalContentType.Key);
         Assert.AreNotEqual(clonedContentType.Path, originalContentType.Path);
 
-        Assert.AreNotEqual(clonedContentType.PropertyTypes.First(x => x.Alias.StartsWith("title")).Id,
+        Assert.AreNotEqual(
+            clonedContentType.PropertyTypes.First(x => x.Alias.StartsWith("title")).Id,
             originalContentType.PropertyTypes.First(x => x.Alias.StartsWith("title")).Id);
-        Assert.AreNotEqual(clonedContentType.PropertyGroups.First(x => x.Name.StartsWith("Content")).Id,
+        Assert.AreNotEqual(
+            clonedContentType.PropertyGroups.First(x => x.Name.StartsWith("Content")).Id,
             originalContentType.PropertyGroups.First(x => x.Name.StartsWith("Content")).Id);
     }
 
@@ -813,8 +868,12 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         var parent = ContentTypeBuilder.CreateSimpleContentType(defaultTemplateId: template.Id);
         ContentTypeService.Save(parent);
-        var child = ContentTypeBuilder.CreateSimpleContentType("simpleChildPage", "Simple Child Page", parent,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var child = ContentTypeBuilder.CreateSimpleContentType(
+            "simpleChildPage",
+            "Simple Child Page",
+            parent,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(child);
         var composition = ContentTypeBuilder.CreateMetaContentType();
         ContentTypeService.Save(composition);
@@ -825,7 +884,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var duplicatePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -849,14 +911,24 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var basePage = ContentTypeBuilder.CreateSimpleContentType("basePage", "Base Page", randomizeAliases: true,
+        var basePage = ContentTypeBuilder.CreateSimpleContentType(
+            "basePage",
+            "Base Page",
+            randomizeAliases: true,
             defaultTemplateId: template.Id);
         ContentTypeService.Save(basePage);
-        var contentPage = ContentTypeBuilder.CreateSimpleContentType("contentPage", "Content Page", basePage,
+        var contentPage = ContentTypeBuilder.CreateSimpleContentType(
+            "contentPage",
+            "Content Page",
+            basePage,
             defaultTemplateId: template.Id);
         ContentTypeService.Save(contentPage);
-        var advancedPage = ContentTypeBuilder.CreateSimpleContentType("advancedPage", "Advanced Page", contentPage,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var advancedPage = ContentTypeBuilder.CreateSimpleContentType(
+            "advancedPage",
+            "Advanced Page",
+            contentPage,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(advancedPage);
 
         var metaComposition = ContentTypeBuilder.CreateMetaContentType();
@@ -871,7 +943,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var duplicatePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -930,7 +1005,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -943,7 +1021,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(basePage);
 
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -960,7 +1041,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // NOTE: It should not be possible to Save 'BasePage' with the Title PropertyType added
         var titlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -1023,7 +1107,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -1036,7 +1123,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(basePage);
 
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1049,7 +1139,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(contentPage);
 
         var subtitlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "subtitle")
             {
                 Name = "Subtitle",
@@ -1062,7 +1155,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(advancedPage);
 
         var titlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -1127,7 +1223,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -1140,7 +1239,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(basePage);
 
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1153,7 +1255,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(contentPage);
 
         var subtitlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "subtitle")
             {
                 Name = "Subtitle",
@@ -1166,7 +1271,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(advancedPage);
 
         var titlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -1192,7 +1300,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         Assert.That(metaCompositionAdded, Is.True);
 
         var testPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "test")
             {
                 Name = "Test",
@@ -1218,15 +1329,28 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
 
-        var page = ContentTypeBuilder.CreateSimpleContentType("page", "Page", randomizeAliases: true,
+        var page = ContentTypeBuilder.CreateSimpleContentType(
+            "page",
+            "Page",
+            randomizeAliases: true,
             defaultTemplateId: template.Id);
         ContentTypeService.Save(page);
-        var contentPage = ContentTypeBuilder.CreateSimpleContentType("contentPage", "Content Page", page,
-            randomizeAliases: true, propertyGroupAlias: "content2", propertyGroupName: "Content_",
+        var contentPage = ContentTypeBuilder.CreateSimpleContentType(
+            "contentPage",
+            "Content Page",
+            page,
+            randomizeAliases: true,
+            propertyGroupAlias: "content2",
+            propertyGroupName: "Content_",
             defaultTemplateId: template.Id);
         ContentTypeService.Save(contentPage);
-        var advancedPage = ContentTypeBuilder.CreateSimpleContentType("advancedPage", "Advanced Page", contentPage,
-            randomizeAliases: true, propertyGroupAlias: "details", propertyGroupName: "Details",
+        var advancedPage = ContentTypeBuilder.CreateSimpleContentType(
+            "advancedPage",
+            "Advanced Page",
+            contentPage,
+            randomizeAliases: true,
+            propertyGroupAlias: "details",
+            propertyGroupName: "Details",
             defaultTemplateId: template.Id);
         ContentTypeService.Save(advancedPage);
 
@@ -1235,7 +1359,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var subtitlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "subtitle")
             {
                 Name = "Subtitle",
@@ -1245,7 +1372,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1293,7 +1423,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var titlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -1304,7 +1437,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
             };
         var titleAdded = basePage.AddPropertyType(titlePropertyType, "content", "Content");
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -1315,7 +1451,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
             };
         var bodyTextAdded = contentPage.AddPropertyType(bodyTextPropertyType, "content", "Content");
         var subtitlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "subtitle")
             {
                 Name = "Subtitle",
@@ -1326,7 +1465,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
             };
         var subtitleAdded = contentPage.AddPropertyType(subtitlePropertyType, "content", "Content");
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1369,14 +1511,25 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         // Arrange
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
-        var basePage = ContentTypeBuilder.CreateSimpleContentType("basePage", "Base Page", randomizeAliases: true,
+        var basePage = ContentTypeBuilder.CreateSimpleContentType(
+            "basePage",
+            "Base Page",
+            randomizeAliases: true,
             defaultTemplateId: template.Id);
         ContentTypeService.Save(basePage);
-        var contentPage = ContentTypeBuilder.CreateSimpleContentType("contentPage", "Content Page", basePage,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var contentPage = ContentTypeBuilder.CreateSimpleContentType(
+            "contentPage",
+            "Content Page",
+            basePage,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(contentPage);
-        var advancedPage = ContentTypeBuilder.CreateSimpleContentType("advancedPage", "Advanced Page", contentPage,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var advancedPage = ContentTypeBuilder.CreateSimpleContentType(
+            "advancedPage",
+            "Advanced Page",
+            contentPage,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(advancedPage);
 
         var metaComposition = ContentTypeBuilder.CreateMetaContentType();
@@ -1393,7 +1546,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var propertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -1421,8 +1577,12 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         // create 'page' content type with a 'Content_' group
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
-        var page = ContentTypeBuilder.CreateSimpleContentType("page", "Page", propertyGroupAlias: "content2",
-            propertyGroupName: "Content_", defaultTemplateId: template.Id);
+        var page = ContentTypeBuilder.CreateSimpleContentType(
+            "page",
+            "Page",
+            propertyGroupAlias: "content2",
+            propertyGroupName: "Content_",
+            defaultTemplateId: template.Id);
         Assert.AreEqual(1, page.PropertyGroups.Count);
         Assert.AreEqual("Content_", page.PropertyGroups.First().Name);
         Assert.AreEqual(3, page.PropertyTypes.Count());
@@ -1432,8 +1592,12 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(page);
 
         // create 'contentPage' content type as a child of 'page'
-        var contentPage = ContentTypeBuilder.CreateSimpleContentType("contentPage", "Content Page", page,
-            randomizeAliases: true, defaultTemplateId: template.Id);
+        var contentPage = ContentTypeBuilder.CreateSimpleContentType(
+            "contentPage",
+            "Content Page",
+            page,
+            randomizeAliases: true,
+            defaultTemplateId: template.Id);
         Assert.AreEqual(1, page.PropertyGroups.Count);
         Assert.AreEqual("Content_", page.PropertyGroups.First().Name);
         Assert.AreEqual(3, contentPage.PropertyTypes.Count());
@@ -1459,7 +1623,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // add property 'prop1' to 'contentPage' group 'Content_'
         var prop1 =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "testTextbox")
             {
                 Name = "Test Textbox",
@@ -1473,7 +1640,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // add property 'prop2' to 'contentPage' group 'Content'
         var prop2 =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "anotherTextbox")
             {
                 Name = "Another Test Textbox",
@@ -1516,15 +1686,30 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         // Arrange
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
-        var page = ContentTypeBuilder.CreateSimpleContentType("page", "Page", randomizeAliases: true,
-            propertyGroupAlias: "content2", propertyGroupName: "Content_", defaultTemplateId: template.Id);
+        var page = ContentTypeBuilder.CreateSimpleContentType(
+            "page",
+            "Page",
+            randomizeAliases: true,
+            propertyGroupAlias: "content2",
+            propertyGroupName: "Content_",
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(page);
-        var contentPage = ContentTypeBuilder.CreateSimpleContentType("contentPage", "Content Page", page,
-            randomizeAliases: true, propertyGroupAlias: "contentx", propertyGroupName: "Contentx",
+        var contentPage = ContentTypeBuilder.CreateSimpleContentType(
+            "contentPage",
+            "Content Page",
+            page,
+            randomizeAliases: true,
+            propertyGroupAlias: "contentx",
+            propertyGroupName: "Contentx",
             defaultTemplateId: template.Id);
         ContentTypeService.Save(contentPage);
-        var advancedPage = ContentTypeBuilder.CreateSimpleContentType("advancedPage", "Advanced Page", contentPage,
-            randomizeAliases: true, propertyGroupAlias: "contenty", propertyGroupName: "Contenty",
+        var advancedPage = ContentTypeBuilder.CreateSimpleContentType(
+            "advancedPage",
+            "Advanced Page",
+            contentPage,
+            randomizeAliases: true,
+            propertyGroupAlias: "contenty",
+            propertyGroupName: "Contenty",
             defaultTemplateId: template.Id);
         ContentTypeService.Save(advancedPage);
 
@@ -1535,7 +1720,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -1545,7 +1733,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var subtitlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "subtitle")
             {
                 Name = "Subtitle",
@@ -1555,15 +1746,22 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var bodyTextAdded =
-            contentPage.AddPropertyType(bodyTextPropertyType, "content2",
+            contentPage.AddPropertyType(
+                bodyTextPropertyType,
+                "content2",
                 "Content_"); // Will be added to the parent tab
         var subtitleAdded =
-            contentPage.AddPropertyType(subtitlePropertyType, "content",
+            contentPage.AddPropertyType(
+                subtitlePropertyType,
+                "content",
                 "Content"); // Will be added to the "Content Meta" composition
         ContentTypeService.Save(contentPage);
 
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1573,7 +1771,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var descriptionPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "description")
             {
                 Name = "Description",
@@ -1583,7 +1784,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var keywordsPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "keywords")
             {
                 Name = "Keywords",
@@ -1593,13 +1797,19 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var authorAdded =
-            advancedPage.AddPropertyType(authorPropertyType, "content2",
+            advancedPage.AddPropertyType(
+                authorPropertyType,
+                "content2",
                 "Content_"); // Will be added to an ancestor tab
         var descriptionAdded =
-            advancedPage.AddPropertyType(descriptionPropertyType, "contentx",
+            advancedPage.AddPropertyType(
+                descriptionPropertyType,
+                "contentx",
                 "Contentx"); // Will be added to a parent tab
         var keywordsAdded =
-            advancedPage.AddPropertyType(keywordsPropertyType, "content",
+            advancedPage.AddPropertyType(
+                keywordsPropertyType,
+                "content",
                 "Content"); // Will be added to the "Content Meta" composition
         ContentTypeService.Save(advancedPage);
 
@@ -1642,11 +1852,21 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         // Arrange
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
-        var page = ContentTypeBuilder.CreateSimpleContentType("page", "Page", randomizeAliases: true,
-            propertyGroupAlias: "content2", propertyGroupName: "Content_", defaultTemplateId: template.Id);
+        var page = ContentTypeBuilder.CreateSimpleContentType(
+            "page",
+            "Page",
+            randomizeAliases: true,
+            propertyGroupAlias: "content2",
+            propertyGroupName: "Content_",
+            defaultTemplateId: template.Id);
         ContentTypeService.Save(page);
-        var contentPage = ContentTypeBuilder.CreateSimpleContentType("contentPage", "Content Page", page,
-            randomizeAliases: true, propertyGroupAlias: "content", propertyGroupName: "Content",
+        var contentPage = ContentTypeBuilder.CreateSimpleContentType(
+            "contentPage",
+            "Content Page",
+            page,
+            randomizeAliases: true,
+            propertyGroupAlias: "content",
+            propertyGroupName: "Content",
             defaultTemplateId: template.Id);
         ContentTypeService.Save(contentPage);
 
@@ -1655,7 +1875,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -1665,7 +1888,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var subtitlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "subtitle")
             {
                 Name = "Subtitle",
@@ -1675,7 +1901,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
                 DataTypeId = -88
             };
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1731,7 +1960,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -1744,7 +1976,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(basePage);
 
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1783,7 +2018,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(basePage);
 
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1795,7 +2033,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         Assert.IsTrue(basePage.AddPropertyType(authorPropertyType, "content", "Content"));
 
         var titlePropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "title")
             {
                 Name = "Title",
@@ -1845,7 +2086,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Act
         var authorPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "author")
             {
                 Name = "Author",
@@ -1858,7 +2102,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         ContentTypeService.Save(contentPage);
 
         var bodyTextPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext,
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext,
                 "bodyText")
             {
                 Name = "Body Text",
@@ -1889,7 +2136,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
 
         // Ensure that adding a new PropertyType to the "Content"-tab also adds it to the right group
         var descriptionPropertyType =
-            new PropertyType(ShortStringHelper, Constants.PropertyEditors.Aliases.TextBox, ValueStorageType.Ntext)
+            new PropertyType(
+                ShortStringHelper,
+                Constants.PropertyEditors.Aliases.TextBox,
+                ValueStorageType.Ntext)
             {
                 Alias = "description",
                 Name = "Description",
@@ -1937,29 +2187,41 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
             ContentVariation.Culture; // with a variant property
         ContentTypeService.Save(typeA);
 
-        var typeB = ContentTypeBuilder.CreateSimpleContentType("b", "B", typeA, randomizeAliases: true,
+        var typeB = ContentTypeBuilder.CreateSimpleContentType(
+            "b",
+            "B",
+            typeA,
+            randomizeAliases: true,
             defaultTemplateId: template.Id);
         typeB.Variations = ContentVariation.Nothing; // make it invariant
         ContentTypeService.Save(typeB);
 
-        var typeC = ContentTypeBuilder.CreateSimpleContentType("c", "C", typeA, randomizeAliases: true,
+        var typeC = ContentTypeBuilder.CreateSimpleContentType(
+            "c",
+            "C",
+            typeA,
+            randomizeAliases: true,
             defaultTemplateId: template.Id);
         typeC.Variations = ContentVariation.Culture; // make it variant
         ContentTypeService.Save(typeC);
 
         // property is variant on A
         var test = ContentTypeService.Get(typeA.Id);
-        Assert.AreEqual(ContentVariation.Culture,
+        Assert.AreEqual(
+            ContentVariation.Culture,
             test.CompositionPropertyTypes.First(x => x.Alias.InvariantEquals("title")).Variations);
-        Assert.AreEqual(ContentVariation.Culture,
+        Assert.AreEqual(
+            ContentVariation.Culture,
             test.CompositionPropertyGroups.Last().PropertyTypes.First(x => x.Alias.InvariantEquals("title"))
                 .Variations);
 
         // but not on B
         test = ContentTypeService.Get(typeB.Id);
-        Assert.AreEqual(ContentVariation.Nothing,
+        Assert.AreEqual(
+            ContentVariation.Nothing,
             test.CompositionPropertyTypes.First(x => x.Alias.InvariantEquals("title")).Variations);
-        Assert.AreEqual(ContentVariation.Nothing,
+        Assert.AreEqual(
+            ContentVariation.Nothing,
             test.CompositionPropertyGroups.Last().PropertyTypes.First(x => x.Alias.InvariantEquals("title"))
                 .Variations);
 
@@ -2192,7 +2454,11 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
             Trashed = false
         };
 
-        var propertyType = new PropertyType(ShortStringHelper, "test", ValueStorageType.Ntext, "bannerName")
+        var propertyType = new PropertyType(
+            ShortStringHelper,
+            "test",
+            ValueStorageType.Ntext,
+            "bannerName")
         {
             Name = "Banner Name",
             Description = string.Empty,
@@ -2239,7 +2505,10 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
     {
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
-        return ContentTypeBuilder.CreateSimpleContentType("homepage", "Homepage", parent,
+        return ContentTypeBuilder.CreateSimpleContentType(
+            "homepage",
+            "Homepage",
+            parent,
             defaultTemplateId: template.Id);
     }
 
@@ -2248,7 +2517,9 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
         // create the master type
         var template = TemplateBuilder.CreateTextPageTemplate();
         FileService.SaveTemplate(template);
-        var masterContentType = ContentTypeBuilder.CreateSimpleContentType("masterContentType", "MasterContentType",
+        var masterContentType = ContentTypeBuilder.CreateSimpleContentType(
+            "masterContentType",
+            "MasterContentType",
             defaultTemplateId: template.Id);
         masterContentType.Key = new Guid("C00CA18E-5A9D-483B-A371-EECE0D89B4AE");
         ContentTypeService.Save(masterContentType);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceVariantsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceVariantsTests.cs
@@ -847,9 +847,13 @@ internal sealed class ContentTypeServiceVariantsTests : UmbracoIntegrationTest
         Assert.IsFalse(document.IsCultureEdited("fr"));
         Assert.IsFalse(document.Edited);
 
-        document.SetValue("value1", "v1en",
+        document.SetValue(
+            "value1",
+            "v1en",
             "en"); // change the property culture value, so now this culture will be edited
-        document.SetValue("value1", "v1fr",
+        document.SetValue(
+            "value1",
+            "v1fr",
             "fr"); // change the property culture value, so now this culture will be edited
         ContentService.Save(document);
 
@@ -893,9 +897,13 @@ internal sealed class ContentTypeServiceVariantsTests : UmbracoIntegrationTest
         Assert.AreEqual("doc1fr", document.GetCultureName("fr"));
         Assert.IsNull(document.GetValue("value1", "en")); // The values are there but the business logic returns null
         Assert.IsNull(document.GetValue("value1", "fr")); // The values are there but the business logic returns null
-        Assert.IsNull(document.GetValue("value1", "en",
+        Assert.IsNull(document.GetValue(
+            "value1",
+            "en",
             published: true)); // The values are there but the business logic returns null
-        Assert.IsNull(document.GetValue("value1", "fr",
+        Assert.IsNull(document.GetValue(
+            "value1",
+            "fr",
             published: true)); // The values are there but the business logic returns null
         Assert.AreEqual("v1inv", document.GetValue("value1"));
         Assert.AreEqual("v1inv", document.GetValue("value1", published: true));
@@ -1025,7 +1033,9 @@ internal sealed class ContentTypeServiceVariantsTests : UmbracoIntegrationTest
             document.GetValue("value1")); // The variant property value gets copied over to the invariant
         Assert.AreEqual("v1en2", document.GetValue("value1", published: true));
         Assert.IsNull(document.GetValue("value1", "fr")); // The values are there but the business logic returns null
-        Assert.IsNull(document.GetValue("value1", "fr",
+        Assert.IsNull(document.GetValue(
+            "value1",
+            "fr",
             published: true)); // The values are there but the business logic returns null
         Assert.IsFalse(
             document.IsCultureEdited("en")); // The variant published AND edited values are copied over to the invariant

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentVersionCleanupServiceTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentVersionCleanupServiceTest.cs
@@ -93,7 +93,10 @@ internal class ContentVersionCleanupServiceTest : UmbracoIntegrationTest
         }
     }
 
-    private void InsertCleanupPolicy(IContentType contentType, int daysToKeepAll, int daysToRollupAll,
+    private void InsertCleanupPolicy(
+        IContentType contentType,
+        int daysToKeepAll,
+        int daysToRollupAll,
         bool preventCleanup = false)
     {
         using (var scope = ScopeProvider.CreateScope(autoComplete: true))

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
@@ -239,7 +239,10 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
         var tokens = ExternalLoginService.GetExternalLoginTokens(user.Key).OrderBy(x => x.LoginProvider).ToList();
 
         tokens.RemoveAt(0); // remove the first one
-        tokens.Add(new IdentityUserToken(externalLogins[1].LoginProvider, "hello2b", "world2b",
+        tokens.Add(new IdentityUserToken(
+            externalLogins[1].LoginProvider,
+            "hello2b",
+            "world2b",
             user.Id.ToString())); // add a new one
         tokens[0].Value = "abcd123"; // update
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
@@ -72,7 +72,9 @@ internal sealed class MediaServiceTests : UmbracoIntegrationTest
             // get the event arg type
             var eventArgType = e.EventHandlerType.GenericTypeArguments[1];
 
-            var found = EventNameExtractor.FindEvent(typeof(MediaService), eventArgType,
+            var found = EventNameExtractor.FindEvent(
+                typeof(MediaService),
+                eventArgType,
                 EventNameExtractor.MatchIngNames);
             if (!found.Success && found.Result.Error == EventNameExtractorError.Ambiguous)
             {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
@@ -17,7 +17,9 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
 [TestFixture]
 [Category("Slow")]
-[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, PublishedRepositoryEvents = true,
+[UmbracoTest(
+    Database = UmbracoTestOptions.Database.NewSchemaPerTest,
+    PublishedRepositoryEvents = true,
     WithApplication = true)]
 internal sealed class MemberServiceTests : UmbracoIntegrationTest
 {
@@ -464,7 +466,10 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
     [TestCase("MyTestRole1", "test", StringPropertyMatchType.Exact, 0)]
     [TestCase("MyTestRole1", "st2", StringPropertyMatchType.EndsWith, 1)]
     [TestCase("MyTestRole1", "test%", StringPropertyMatchType.Wildcard, 3)]
-    public void Find_Members_In_Role(string roleName1, string usernameToMatch, StringPropertyMatchType matchType,
+    public void Find_Members_In_Role(
+        string roleName1,
+        string usernameToMatch,
+        StringPropertyMatchType matchType,
         int resultCount)
     {
         IMemberType memberType = MemberTypeBuilder.CreateSimpleMemberType();
@@ -749,7 +754,14 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
         var members = MemberBuilder.CreateMultipleSimpleMembers(memberType, 10);
         MemberService.Save(members);
 
-        var found = MemberService.GetAll(0, 2, out var totalRecs, "username", Direction.Ascending, true, null,
+        var found = MemberService.GetAll(
+            0,
+            2,
+            out var totalRecs,
+            "username",
+            Direction.Ascending,
+            true,
+            null,
             "Member No-");
 
         Assert.AreEqual(2, found.Count());
@@ -843,7 +855,11 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
         var customMember = MemberBuilder.CreateSimpleMember(memberType, "hello", "hello@test.com", "hello", "hello");
         MemberService.Save(customMember);
 
-        var found = MemberService.FindByEmail("hello@test.com", 0, 100, out var totalRecs,
+        var found = MemberService.FindByEmail(
+            "hello@test.com",
+            0,
+            100,
+            out var totalRecs,
             StringPropertyMatchType.Exact);
 
         Assert.AreEqual(1, found.Count());
@@ -997,7 +1013,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Number",
                 DataTypeId =
                     -51 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
         var members =
             MemberBuilder.CreateMultipleSimpleMembers(memberType, 10, (i, member) => member.SetValue("number", i));
@@ -1027,7 +1045,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Number",
                 DataTypeId =
                     -51 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
         var members =
             MemberBuilder.CreateMultipleSimpleMembers(memberType, 10, (i, member) => member.SetValue("number", i));
@@ -1057,7 +1077,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Number",
                 DataTypeId =
                     -51 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
         var members =
             MemberBuilder.CreateMultipleSimpleMembers(memberType, 10, (i, member) => member.SetValue("number", i));
@@ -1087,7 +1109,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Number",
                 DataTypeId =
                     -51 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
         var members =
             MemberBuilder.CreateMultipleSimpleMembers(memberType, 10, (i, member) => member.SetValue("number", i));
@@ -1117,7 +1141,9 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Number",
                 DataTypeId =
                     -51 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
         var members =
             MemberBuilder.CreateMultipleSimpleMembers(memberType, 10, (i, member) => member.SetValue("number", i));
@@ -1147,9 +1173,13 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Date",
                 DataTypeId =
                     -36 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
-        var members = MemberBuilder.CreateMultipleSimpleMembers(memberType, 10,
+        var members = MemberBuilder.CreateMultipleSimpleMembers(
+            memberType,
+            10,
             (i, member) => member.SetValue("date", new DateTime(2013, 12, 20, 1, i, 0)));
         MemberService.Save(members);
 
@@ -1177,9 +1207,13 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Date",
                 DataTypeId =
                     -36 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
-        var members = MemberBuilder.CreateMultipleSimpleMembers(memberType, 10,
+        var members = MemberBuilder.CreateMultipleSimpleMembers(
+            memberType,
+            10,
             (i, member) => member.SetValue("date", new DateTime(2013, 12, 20, 1, i, 0)));
         MemberService.Save(members);
 
@@ -1207,9 +1241,13 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Date",
                 DataTypeId =
                     -36 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
-        var members = MemberBuilder.CreateMultipleSimpleMembers(memberType, 10,
+        var members = MemberBuilder.CreateMultipleSimpleMembers(
+            memberType,
+            10,
             (i, member) => member.SetValue("date", new DateTime(2013, 12, 20, 1, i, 0)));
         MemberService.Save(members);
 
@@ -1237,9 +1275,13 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Date",
                 DataTypeId =
                     -36 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
-        var members = MemberBuilder.CreateMultipleSimpleMembers(memberType, 10,
+        var members = MemberBuilder.CreateMultipleSimpleMembers(
+            memberType,
+            10,
             (i, member) => member.SetValue("date", new DateTime(2013, 12, 20, 1, i, 0)));
         MemberService.Save(members);
 
@@ -1267,9 +1309,13 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
                 Name = "Date",
                 DataTypeId =
                     -36 // NOTE: This is what really determines the db type - the above definition doesn't really do anything
-            }, "content", "Content");
+            },
+            "content",
+            "Content");
         MemberTypeService.Save(memberType);
-        var members = MemberBuilder.CreateMultipleSimpleMembers(memberType, 10,
+        var members = MemberBuilder.CreateMultipleSimpleMembers(
+            memberType,
+            10,
             (i, member) => member.SetValue("date", new DateTime(2013, 12, 20, 1, i, 0)));
         MemberService.Save(members);
 
@@ -1377,8 +1423,11 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
         var username = Path.GetRandomFileName();
 
         // Act
-        var member = MemberService.CreateMemberWithIdentity(username, $"{username}@domain.email",
-            Path.GetFileNameWithoutExtension(username), memberType);
+        var member = MemberService.CreateMemberWithIdentity(
+            username,
+            $"{username}@domain.email",
+            Path.GetFileNameWithoutExtension(username),
+            memberType);
         var found = MemberService.GetById(member.Id);
 
         // Assert

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberTypeServiceTests.cs
@@ -13,7 +13,9 @@ using Umbraco.Cms.Tests.Integration.Testing;
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
 [TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, PublishedRepositoryEvents = true,
+[UmbracoTest(
+    Database = UmbracoTestOptions.Database.NewSchemaPerTest,
+    PublishedRepositoryEvents = true,
     WithApplication = true)]
 internal sealed class MemberTypeServiceTests : UmbracoIntegrationTest
 {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RelationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/RelationServiceTests.cs
@@ -162,8 +162,13 @@ internal sealed class RelationServiceTests : UmbracoIntegrationTest
     public void Can_Create_RelationType_Without_Name()
     {
         var rs = RelationService;
-        IRelationType rt = new RelationType("Test", "repeatedEventOccurence", false, Constants.ObjectTypes.Document,
-            Constants.ObjectTypes.Media, false);
+        IRelationType rt = new RelationType(
+            "Test",
+            "repeatedEventOccurence",
+            false,
+            Constants.ObjectTypes.Document,
+            Constants.ObjectTypes.Media,
+            false);
 
         Assert.DoesNotThrow(() => rs.Save(rt));
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TagServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TagServiceTests.cs
@@ -29,7 +29,9 @@ internal sealed class TagServiceTests : UmbracoIntegrationTest
         FileService.SaveTemplate(template); // else, FK violation on contentType!
 
         _contentType =
-            ContentTypeBuilder.CreateSimpleContentType("umbMandatory", "Mandatory Doc Type",
+            ContentTypeBuilder.CreateSimpleContentType(
+                "umbMandatory",
+                "Mandatory Doc Type",
                 defaultTemplateId: template.Id);
         _contentType.PropertyGroups.First().PropertyTypes.Add(
             new PropertyType(ShortStringHelper, "test", ValueStorageType.Ntext, "tags")
@@ -59,7 +61,11 @@ internal sealed class TagServiceTests : UmbracoIntegrationTest
     public void TagApiConsistencyTest()
     {
         IContent content1 = ContentBuilder.CreateSimpleContent(_contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "cow", "pig", "goat" });
         ContentService.Save(content1);
         ContentService.Publish(content1, Array.Empty<string>());
@@ -101,7 +107,11 @@ internal sealed class TagServiceTests : UmbracoIntegrationTest
     public void TagList_Contains_NodeCount()
     {
         var content1 = ContentBuilder.CreateSimpleContent(_contentType, "Tagged content 1");
-        content1.AssignTags(PropertyEditorCollection, DataTypeService, Serializer, "tags",
+        content1.AssignTags(
+            PropertyEditorCollection,
+            DataTypeService,
+            Serializer,
+            "tags",
             new[] { "cow", "pig", "goat" });
         ContentService.Save(content1);
         ContentService.Publish(content1, Array.Empty<string>());

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.cs
@@ -667,7 +667,12 @@ internal sealed class UserServiceTests : UmbracoIntegrationTest
 
         UserService.Save(users);
 
-        var found = UserService.GetAll(0, 2, out long totalRecs, "username", Direction.Ascending,
+        var found = UserService.GetAll(
+            0,
+            2,
+            out long totalRecs,
+            "username",
+            Direction.Ascending,
             includeUserGroups: new[] { userGroup.Alias });
 
         Assert.AreEqual(2, found.Count());
@@ -697,8 +702,14 @@ internal sealed class UserServiceTests : UmbracoIntegrationTest
 
         UserService.Save(users);
 
-        var found = UserService.GetAll(0, 2, out long totalRecs, "username", Direction.Ascending,
-            userGroups: new[] { userGroup.Alias }, filter: "blah");
+        var found = UserService.GetAll(
+            0,
+            2,
+            out long totalRecs,
+            "username",
+            Direction.Ascending,
+            userGroups: new[] { userGroup.Alias },
+            filter: "blah");
 
         Assert.AreEqual(2, found.Count());
         Assert.AreEqual(2, totalRecs);

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheAncestryVariantTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheAncestryVariantTests.cs
@@ -140,8 +140,12 @@ internal sealed class DocumentHybridCacheAncestryVariantTests : UmbracoIntegrati
         await LanguageService.CreateAsync(language, Constants.Security.SuperUserKey);
 
         var contentTypeCreateModel = ContentTypeEditingBuilder.CreateContentTypeWithTwoPropertiesOneVariantAndOneInvariant(
-            "cultureVariationTest", "Culture Variation Test", _variantTitleAlias, _variantTitleName,
-            _invariantTitleAlias, _invariantTitleName);
+            "cultureVariationTest",
+            "Culture Variation Test",
+            _variantTitleAlias,
+            _variantTitleName,
+            _invariantTitleAlias,
+            _invariantTitleName);
         contentTypeCreateModel.AllowedAsRoot = true;
         var contentTypeAttempt = await ContentTypeEditingService.CreateAsync(contentTypeCreateModel, Constants.Security.SuperUserKey);
         if (contentTypeAttempt.Success is false)

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCachePropertyTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCachePropertyTest.cs
@@ -110,8 +110,11 @@ internal sealed class DocumentHybridCachePropertyTest : UmbracoIntegrationTest
         var pickerContentType = ContentTypeEditingBuilder.CreateContentTypeWithContentPicker(templateKey: templateKey);
         await ContentTypeEditingService.CreateAsync(pickerContentType, Constants.Security.SuperUserKey);
 
-        var createOtherModel = ContentEditingBuilder.CreateContentWithOneInvariantProperty(pickerContentType.Key.Value,
-            "Test Create", "contentPicker", textPageKey);
+        var createOtherModel = ContentEditingBuilder.CreateContentWithOneInvariantProperty(
+            pickerContentType.Key.Value,
+            "Test Create",
+            "contentPicker",
+            textPageKey);
         var result = await ContentEditingService.CreateAsync(createOtherModel, Constants.Security.SuperUserKey);
 
         Assert.IsTrue(result.Success);
@@ -132,7 +135,12 @@ internal sealed class DocumentHybridCachePropertyTest : UmbracoIntegrationTest
         await ContentTypeEditingService.CreateAsync(textContentType, Constants.Security.SuperUserKey);
 
         var contentCreateModel = ContentEditingBuilder.CreateContentWithTwoInvariantProperties(
-            textContentType.Key.Value, "Root Create", "title", "The title value", "bodyText", "The body text",
+            textContentType.Key.Value,
+            "Root Create",
+            "title",
+            "The title value",
+            "bodyText",
+            "The body text",
             Constants.System.RootKey);
 
         var createResult = await ContentEditingService.CreateAsync(contentCreateModel, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheScopeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheScopeTests.cs
@@ -111,10 +111,13 @@ internal sealed class DocumentHybridCacheScopeTests : UmbracoIntegrationTestWith
             Textpage.Key = key;
             var result = await ContentEditingService.CreateAsync(Textpage, Constants.Security.SuperUserKey);
             Assert.IsTrue(result);
-            var publishResult = await ContentPublishingService.PublishAsync(Textpage.Key.Value, new List<CulturePublishScheduleModel>
-            {
-                new() { Culture = "*" },
-            }, Constants.Security.SuperUserKey);
+            var publishResult = await ContentPublishingService.PublishAsync(
+                Textpage.Key.Value,
+                new List<CulturePublishScheduleModel>
+                {
+                    new() { Culture = "*" },
+                },
+                Constants.Security.SuperUserKey);
             Assert.IsTrue(publishResult.Success);
 
             scope.Complete();

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVariantsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVariantsTests.cs
@@ -128,8 +128,12 @@ internal sealed class DocumentHybridCacheVariantsTests : UmbracoIntegrationTest
         await LanguageService.CreateAsync(language, Constants.Security.SuperUserKey);
 
         var contentType = ContentTypeEditingBuilder.CreateContentTypeWithTwoPropertiesOneVariantAndOneInvariant(
-            "cultureVariationTest", "Culture Variation Test", _variantTitleAlias, _variantTitleName,
-            _invariantTitleAlias, _invariantTitleName);
+            "cultureVariationTest",
+            "Culture Variation Test",
+            _variantTitleAlias,
+            _variantTitleName,
+            _invariantTitleAlias,
+            _invariantTitleName);
         var contentTypeAttempt = await ContentTypeEditingService.CreateAsync(contentType, Constants.Security.SuperUserKey);
         if (!contentTypeAttempt.Success)
         {
@@ -137,8 +141,12 @@ internal sealed class DocumentHybridCacheVariantsTests : UmbracoIntegrationTest
         }
 
         var rootContentCreateModel =
-            ContentEditingBuilder.CreateContentWithTwoVariantProperties(contentTypeAttempt.Result.Key, "en-US", "da-DK",
-                _variantTitleAlias, _variantTitleName);
+            ContentEditingBuilder.CreateContentWithTwoVariantProperties(
+                contentTypeAttempt.Result.Key,
+                "en-US",
+                "da-DK",
+                _variantTitleAlias,
+                _variantTitleName);
         var result = await ContentEditingService.CreateAsync(rootContentCreateModel, Constants.Security.SuperUserKey);
         VariantPage = result.Result.Content;
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/BackOfficeExternalLoginServiceTests.UnLinkLoginAsync.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/BackOfficeExternalLoginServiceTests.UnLinkLoginAsync.cs
@@ -85,7 +85,9 @@ public partial class BackOfficeExternalLoginServiceTests
                 ? null
                 : () =>
                 {
-                    var mock = new BackOfficeIdentityUser(Mock.Of<GlobalSettings>(), -1,
+                    var mock = new BackOfficeIdentityUser(
+                        Mock.Of<GlobalSettings>(),
+                        -1,
                         Enumerable.Empty<IReadOnlyUserGroup>());
                     mock.Key = userId.Value;
                     mock.SetLoginsCallback(new Lazy<IEnumerable<IIdentityUserLogin>?>(() =>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
@@ -19,7 +19,8 @@ public class ContentPickerValueConverterTests : PropertyValueConverterTests
             new ApiContentBuilder(
                 nameProvider ?? new ApiContentNameProvider(),
                 CreateContentRouteBuilder(ApiContentPathProvider, CreateGlobalSettings()),
-                CreateOutputExpansionStrategyAccessor(), CreateVariationContextAccessor()));
+                CreateOutputExpansionStrategyAccessor(),
+                CreateVariationContextAccessor()));
 
     [Test]
     public void ContentPickerValueConverter_BuildsDeliveryApiOutput()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PropertyEditorValueConverterTests.cs
@@ -95,8 +95,14 @@ public class PropertyEditorValueConverterTests
             .Returns(new PublishedDataType(123, "test", "test", new Lazy<object>(() => new DropDownFlexibleConfiguration { Multiple = true })));
 
         var publishedPropType = new PublishedPropertyType(
-            new PublishedContentType(Guid.NewGuid(), 1234, "test", PublishedItemType.Content,
-                Enumerable.Empty<string>(), Enumerable.Empty<PublishedPropertyType>(), ContentVariation.Nothing),
+            new PublishedContentType(
+                Guid.NewGuid(),
+                1234,
+                "test",
+                PublishedItemType.Content,
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<PublishedPropertyType>(),
+                ContentVariation.Nothing),
             new PropertyType(Mock.Of<IShortStringHelper>(), "test", ValueStorageType.Nvarchar) { DataTypeId = 123 },
             new PropertyValueConverterCollection(() => Enumerable.Empty<IPropertyValueConverter>()),
             Mock.Of<IPublishedModelFactory>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyIndexValueFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/RichTextPropertyIndexValueFactoryTests.cs
@@ -61,7 +61,9 @@ public class RichTextPropertyIndexValueFactoryTests
 
         // create a mock property with the rich text value
         var property = Mock.Of<IProperty>(p => p.Alias == alias
-                                               && (string)p.GetValue(It.IsAny<string>(), It.IsAny<string>(),
+                                               && (string)p.GetValue(
+                                                   It.IsAny<string>(),
+                                                   It.IsAny<string>(),
                                                    It.IsAny<bool>()) == testContent);
 
         // get the index value for the property

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Scoping/ScopedNotificationPublisherTests.cs
@@ -91,7 +91,8 @@ public class ScopedNotificationPublisherTests
 
         return new ScopeProvider(
             new AmbientScopeStack(),
-                new AmbientScopeContextStack(),Mock.Of<IDistributedLockingMechanismFactory>(),
+            new AmbientScopeContextStack(),
+            Mock.Of<IDistributedLockingMechanismFactory>(),
             Mock.Of<IUmbracoDatabaseFactory>(),
             fileSystems,
             new TestOptionsMonitor<CoreDebugSettings>(new CoreDebugSettings()),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserGroupServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/UserGroupServiceTests.cs
@@ -123,8 +123,12 @@ public class UserGroupServiceTests
             {
                 persistedUserGroup
             });
-        var updatingUserGroup = new UserGroup(Mock.Of<IShortStringHelper>(), 0, persistedUserGroup.Alias + "updated",
-            persistedUserGroup.Name + "updated", null)
+        var updatingUserGroup = new UserGroup(
+            Mock.Of<IShortStringHelper>(),
+            0,
+            persistedUserGroup.Alias + "updated",
+            persistedUserGroup.Name + "updated",
+            null)
         {
             Key = persistedUserGroup.Key,
             Id = persistedUserGroup.Id

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackOffice/BackOfficeClaimsPrincipalFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackOffice/BackOfficeClaimsPrincipalFactoryTests.cs
@@ -68,7 +68,8 @@ public class BackOfficeClaimsPrincipalFactoryTests
     public void Ctor_When_Options_Value_Is_Null_Expect_ArgumentException()
         => Assert.Throws<ArgumentException>(() => new BackOfficeClaimsPrincipalFactory(
             GetMockedUserManager().Object,
-            new OptionsWrapper<BackOfficeIdentityOptions>(null), new OptionsWrapper<BackOfficeAuthenticationTypeSettings>(new BackOfficeAuthenticationTypeSettings())));
+            new OptionsWrapper<BackOfficeIdentityOptions>(null),
+            new OptionsWrapper<BackOfficeAuthenticationTypeSettings>(new BackOfficeAuthenticationTypeSettings())));
 
     [Test]
     public void CreateAsync_When_User_Is_Null_Expect_ArgumentNullException()
@@ -159,5 +160,6 @@ public class BackOfficeClaimsPrincipalFactoryTests
 
     private BackOfficeClaimsPrincipalFactory CreateSut() => new(
         _mockUserManager.Object,
-        new OptionsWrapper<BackOfficeIdentityOptions>(new BackOfficeIdentityOptions()), new OptionsWrapper<BackOfficeAuthenticationTypeSettings>(new BackOfficeAuthenticationTypeSettings()));
+        new OptionsWrapper<BackOfficeIdentityOptions>(new BackOfficeIdentityOptions()),
+        new OptionsWrapper<BackOfficeAuthenticationTypeSettings>(new BackOfficeAuthenticationTypeSettings()));
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberPasswordHasherTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberPasswordHasherTests.cs
@@ -15,8 +15,13 @@ public class MemberPasswordHasherTests
     [Test]
     [TestCase(
         "Password123!",
-        "AQAAAAIAAYagAAAAEJBorDjt+UEvw55UJVsbgAS6T2IGao+2XpCBbO3EKZoAMzoN+CNOpPdu1c0qrFcJVw==", null,  ExpectedResult = PasswordVerificationResult.Success, Description = "AspNetCoreIdentityPasswordHash: Correct password")]
-        [TestCase("Password123!", "AQAAAAEAACcQAAAAEGF/tTVoL6ef3bQPZFYfbgKFu1CDQIAMgyY1N4EDt9jqdG/hsOX93X1U6LNvlIQ3mw==",
+        "AQAAAAIAAYagAAAAEJBorDjt+UEvw55UJVsbgAS6T2IGao+2XpCBbO3EKZoAMzoN+CNOpPdu1c0qrFcJVw==",
+        null,
+        ExpectedResult = PasswordVerificationResult.Success,
+        Description = "AspNetCoreIdentityPasswordHash: Correct password")]
+    [TestCase(
+        "Password123!",
+        "AQAAAAEAACcQAAAAEGF/tTVoL6ef3bQPZFYfbgKFu1CDQIAMgyY1N4EDt9jqdG/hsOX93X1U6LNvlIQ3mw==",
         null,
         ExpectedResult = PasswordVerificationResult.SuccessRehashNeeded,
         Description = "GivenALegacyAspNetCoreIdentityPasswordHash: Correct password")]


### PR DESCRIPTION
This commit fixes around 1,000 build warnings related to SA1117, this warning is related to ensuring each parameter passed into a function is on a new line OR all on one line.

I have also added XML code comments to any public function within these files and fixed some that had invalid / old comments.

Everything still works, all unit tests pass.