### PR TITLE
Hybrid Cache: Clear published content cache on content type change

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -347,7 +347,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
         // Clear the entire published content cache.
         // It doesn't seem feasible to be smarter about this, as a changed content type could be used for a document,
-        // an elements within the document, an ancestor or a composition.
+        // elements within the document, an ancestor or composition.
         _publishedContentCache.Clear();
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -294,7 +294,7 @@ internal sealed class MediaCacheService : IMediaCacheService
 
         // Clear the entire published content cache.
         // It doesn't seem feasible to be smarter about this, as a changed content type could be used for a media item,
-        // an elements within the media item, an ancestor, or a composition.
+        // elements within the media item, an ancestor, or a composition.
         _publishedContentCache.Clear();
     }
 


### PR DESCRIPTION
## Issue
I found this issue when testing the results of performance improvements for save of content types in #21207, but as it's a clear regression in 17 we should look to review and release it earlier.

To reproduce:

- Have a rendered document using `InMemoryAuto` for models builder.
- Save the document type the document is based on on the backoffice.
- Refresh the rendered page and note a null reference exception error.
- Clearing the memory cache or database cache doesn't help, it's only a restart that allows the page to render correctly again,

## Cause
- The root cause is that the `_publishedContentCache` (introduced in #20681) caches `IPublishedContent` objects which hold references to `IPublishedContentType`. When a content type is modified, these cached objects become stale.
- The fix clears the entire `_publishedContentCache` at the end of the `Rebuild` method in both `DocumentCacheService` and `MediaCacheService`

## Technical Details
The `_publishedContentCache` is a `ConcurrentDictionary<string, IPublishedContent>` that caches fully-constructed `IPublishedContent` objects for performance. However, these objects contain references to their `IPublishedContentType`, which becomes stale when the content type is modified.

A filtered/targeted clear approach was attempted but has inherent race conditions due to the non-atomic check-then-act pattern. I was also concerned that content types can be used in various places in a document (elements, compositions etc.).  So the atomic `Clear()` looks to be the only reliable solution.

## Test plan
- [X] Save a document type that has existing documents
- [X] Verify documents based on that type render correctly without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code) with human updates.