### PR TITLE
Sidebar: Make scale grab-area smaller

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/split-panel/split-panel.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/split-panel/split-panel.element.ts
@@ -270,7 +270,7 @@ export class UmbSplitPanelElement extends UmbLitElement {
 			--umb-split-panel-initial-position: 50%;
 			--umb-split-panel-start-min-width: 0;
 			--umb-split-panel-end-min-width: 0;
-			--umb-split-panel-divider-touch-area-width: 20px;
+			--umb-split-panel-divider-touch-area-width: 12px;
 			--umb-split-panel-divider-width: 1px;
 			--umb-split-panel-divider-color: transparent;
 			--umb-split-panel-slot-overflow: hidden;
@@ -297,10 +297,9 @@ export class UmbSplitPanelElement extends UmbLitElement {
 		#divider-touch-area {
 			position: absolute;
 			top: 0;
-			left: 5px;
+			left: -1px;
 			height: 100%;
 			width: var(--umb-split-panel-divider-touch-area-width);
-			transform: translateX(-50%);
 			cursor: col-resize;
 		}
 		/* Do we want a line that shows the divider? */


### PR DESCRIPTION
Makes the area for dragging the sidebar width smaller to avoid collision with the scrollbar inside the sidebar and as well prevent unwished grab inside main view.
So it now becomes 8px smaller(only 12px to grab) and does not overlap the scrollbar, which I think is more appropriate.