### PR TITLE
Content Type Designer: make inherited property appear more like the local, to take less focus

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -165,8 +165,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 		} else {
 			return html`
 				<div id="header">
-					<p>${this.property.name}</p>
-					<p><i>${this.property.alias}</i></p>
+					<p>${this.localize.string(this.property.name)}<i>${this.property.alias}</i></p>
 					<p>${this.property.description}</p>
 				</div>
 				<div id="editor">
@@ -429,6 +428,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 
 			#header i {
 				opacity: 0.55;
+				float: right;
 			}
 
 			#header umb-input-with-alias {


### PR DESCRIPTION
Remove bold style from inherited properties so they look more like the local ones. To prevent the inherited once taking too much attention.

And made the property names localize, so they appear like in the Content Workspace.
Also, makes the alias be right-aligned to visually appear in the same spot as locals.
<img width="519" height="674" alt="image" src="https://github.com/user-attachments/assets/403d452c-1a47-4db0-a8ba-a197b75a9119" />


(Also, we will properly remove bold from property labels in general in next mayor as well, so leading the way...)