### PR TITLE
Public Access: Ensure state when re-opening protection modal

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-public-access/modal/public-access-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-public-access/modal/public-access-modal.element.ts
@@ -41,6 +41,7 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 	override firstUpdated() {
 		this.#unique = this.data?.unique;
 		this.#getDocumentName();
+		this.#getPublicAccessModel();
 	}
 
 	async #getDocumentName() {
@@ -51,14 +52,13 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 		const item = data[0];
 		//TODO How do we ensure we get the correct variant?
 		this._documentName = item.variants[0]?.name;
-
-		if (item.isProtected) {
-			this.#getPublicAccessModel();
-		}
 	}
 
 	async #getPublicAccessModel() {
 		if (!this.#unique) return;
+
+		// Always fetch public access state directly from the API to avoid race conditions
+		// where a requested item's isProtected flag might be stale after saving.
 		const { data } = await this.#publicAccessRepository.read(this.#unique);
 
 		if (!data) return;


### PR DESCRIPTION
### Prerequisites

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/21237

### Description

I could replicate the situation described in the linked issue - where a node with protection added, when re-edited would not sure the configured protection, rather then empty form for adding protection.  When submitting this would cause an error as the configuration was looking to be added to an already protected node.

It wasn't manifest 100% of the time - refreshing would clear it, and sometimes I didn't see the issue.

The problem looks to be relying on the `isProtected` flag retrieved when requesting items from the server.  These are cached client-side I understand, so seems there can be a timing issue where the stale value is read before the server has cleared it's caches fully.

To avoid this I've removed the check on `isProtected` and instead call the server directly to check if protection exists.  This response then determines whether or not the "add protection" or "edit/remove protection" functionality is shown.

### Testing

To test:
- Add public access protection to a document.
- Immediately reopen the protection modal.
- Verify the modal shows the options for edit/remove, not adding.
- Remove protection and verify the modal shows the UI for adding protection when re-opening.