### PR TITLE
fix: Update RenderNoContentController to use non-obsolete constructor

### DIFF
--- a/src/Umbraco.Web.UI/Composers/ControllersAsServicesComposer.cs
+++ b/src/Umbraco.Web.UI/Composers/ControllersAsServicesComposer.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Website.Controllers;
 using Umbraco.Extensions;
 using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
@@ -58,7 +58,7 @@ namespace Umbraco.Cms.Web.UI.Composers
                 builder.Services.TryAddTransient(controller, controller);
             }
 
-            builder.Services.AddUnique<RenderNoContentController>(x => new RenderNoContentController(x.GetRequiredService<IUmbracoContextAccessor>(), x.GetRequiredService<IHostingEnvironment>(), x.GetRequiredService<IOptionsSnapshot<GlobalSettings>>()));
+            builder.Services.AddUnique<RenderNoContentController>(x => new RenderNoContentController(x.GetRequiredService<IHostingEnvironment>(), x.GetRequiredService<IOptionsSnapshot<GlobalSettings>>(), x.GetRequiredService<IDocumentUrlService>()));
             return builder;
         }
     }


### PR DESCRIPTION
This PR fixes the build warnings showing for the **Umbraco.Web.UI** project.

- Replace obsolete constructor call that used IUmbracoContextAccessor
- Use new constructor with IDocumentUrlService instead
- Add using for Umbraco.Cms.Core.Services namespace
- Remove unused Umbraco.Cms.Core.Web namespace

The obsolete constructor was scheduled for removal in Umbraco 18. This is an internal change only - ControllersAsServicesComposer is not shipped with Umbraco.Templates package.

All unit tests pass 👍 