### PR TITLE
Build Warnings: Suppress ASPDEPR003 warnings in DevelopmentMode.Backoffice

### DIFF
--- a/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/UmbracoRazorReferenceManager.cs
+++ b/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/UmbracoRazorReferenceManager.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Options;
 
+#pragma warning disable ASPDEPR003 // MvcRazorRuntimeCompilationOptions is obsolete - intentional use for development-mode runtime compilation
+
 namespace Umbraco.Cms.DevelopmentMode.Backoffice.InMemoryAuto;
 
 

--- a/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/UmbracoViewCompilerProvider.cs
+++ b/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/UmbracoViewCompilerProvider.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Exceptions;
 
+#pragma warning disable ASPDEPR003 // MvcRazorRuntimeCompilationOptions is obsolete - intentional use for development-mode runtime compilation
+
 namespace Umbraco.Cms.DevelopmentMode.Backoffice.InMemoryAuto;
 
 internal sealed class UmbracoViewCompilerProvider : IViewCompilerProvider


### PR DESCRIPTION
### Summary

Suppresses ASPDEPR003 warnings in the `Umbraco.Cms.DevelopmentMode.Backoffice` project by adding `#pragma warning disable` directives.

### Context

The ASPDEPR003 warning indicates that `MvcRazorRuntimeCompilationOptions` is obsolete because "Razor runtime compilation is obsolete and is not recommended for production scenarios. For development scenarios, use Hot Reload instead."

However, this warning is being raised in code that:
1. **Only runs in development mode** (`BackofficeDevelopment` runtime mode)
2. **Intentionally uses runtime compilation** to enable hot-reload of ModelsBuilder models
3. **Uses a clone-and-own approach** of ASP.NET Core internal APIs because no alternative APIs exist that support collectible `AssemblyLoadContext` (required for model unloading)

This is exactly the "development scenario" that Microsoft's deprecation message mentions - we're just using a more sophisticated approach than standard Hot Reload to support model regeneration.

### Changes

- Added `#pragma warning disable ASPDEPR003` to `UmbracoRazorReferenceManager.cs`
- Added `#pragma warning disable ASPDEPR003` to `UmbracoViewCompilerProvider.cs`
- Both include comments explaining the intentional use of the deprecated API

### Result

- **10 ASPDEPR003 warnings eliminated**
- No functional changes
- No breaking changes

### Testing

- [x] Solution builds successfully
- [x] No new warnings introduced
