### PR TITLE
Code Quality: Fix ASP0019 warnings by replacing `Headers.Add` with `Headers.Append`

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
@@ -99,8 +99,8 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
 
     private IActionResult RedirectTo(IApiContentRoute redirectRoute)
     {
-        Response.Headers.Add("Location-Start-Item-Path", redirectRoute.StartItem.Path);
-        Response.Headers.Add("Location-Start-Item-Id", redirectRoute.StartItem.Id.ToString("D"));
+        Response.Headers.Append("Location-Start-Item-Path", redirectRoute.StartItem.Path);
+        Response.Headers.Append("Location-Start-Item-Id", redirectRoute.StartItem.Id.ToString("D"));
         return RedirectPermanent(redirectRoute.Path);
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/Umbraco.Cms.Api.Delivery.csproj
+++ b/src/Umbraco.Cms.Api.Delivery/Umbraco.Cms.Api.Delivery.csproj
@@ -7,10 +7,9 @@
   <PropertyGroup>
     <!--
       TODO: Fix and remove overrides:
-      [ASP0019] use IHeaderDictionary.Append or the indexer to append or set headers
       [CS0618/CS0612] update obsolete references
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors),ASP0019,CS0618,CS0612</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors),CS0618,CS0612</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -56,7 +57,7 @@ public sealed class ModelBindingExceptionAttribute : TypeFilterAttribute
                 && (filterContext.Exception is ModelBindingException || filterContext.Exception is InvalidCastException)
                 && IsMessageAboutTheSameModelType(filterContext.Exception.Message))
             {
-                filterContext.HttpContext.Response.Headers.Add(HttpResponseHeader.RetryAfter.ToString(), "1");
+                filterContext.HttpContext.Response.Headers.Append(HttpResponseHeader.RetryAfter.ToString(), "1");
                 filterContext.Result = new RedirectResult(filterContext.HttpContext.Request.GetEncodedUrl(), false);
 
                 filterContext.ExceptionHandled = true;

--- a/src/Umbraco.Web.Common/Filters/UmbracoUserTimeoutFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/UmbracoUserTimeoutFilterAttribute.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Umbraco.Extensions;
@@ -28,7 +29,7 @@ public class UmbracoUserTimeoutFilterAttribute : TypeFilterAttribute
             }
 
             var remainingSeconds = context.HttpContext.User.GetRemainingAuthSeconds();
-            context.HttpContext.Response.Headers.Add(
+            context.HttpContext.Response.Headers.Append(
                 "X-Umb-User-Seconds",
                 remainingSeconds.ToString(CultureInfo.InvariantCulture));
         }

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -12,14 +12,13 @@
       [SA1117] params all on same line
       [SA1401] make fields private
       [SA1134] own line attributes
-      [ASP0019] use IHeaderDictionary.Append or the indexer to append or set headers
       [CS0618]/[SYSLIB0051] adjust obsolete references
       [IDE0040]/[SA1400] access modifiers
       [SA1405] Debug assert message text
       [CS0419]/[CS1574] cref ambiguities
       [SA1649] file name match type
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors),SA1117,SA1401,SA1134,ASP0019,CS0618,SYSLIB0051,IDE0040,SA1400,SA1405,CS0419,CS1574,SA1649</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors),SA1117,SA1401,SA1134,CS0618,SYSLIB0051,IDE0040,SA1400,SA1405,CS0419,CS1574,SA1649</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
+++ b/src/Umbraco.Web.Website/Middleware/BasicAuthenticationMiddleware.cs
@@ -106,7 +106,7 @@ public class BasicAuthenticationMiddleware : IMiddleware
         else
         {
             context.Response.StatusCode = 401;
-            context.Response.Headers.Add("WWW-Authenticate", "Basic realm=\"Umbraco login\"");
+            context.Response.Headers.Append("WWW-Authenticate", "Basic realm=\"Umbraco login\"");
         }
     }
 }

--- a/src/Umbraco.Web.Website/Umbraco.Web.Website.csproj
+++ b/src/Umbraco.Web.Website/Umbraco.Web.Website.csproj
@@ -9,13 +9,12 @@
   <PropertyGroup>
     <!--
       TODO: Fix and remove overrides:
-      [ASP0019] use IHeaderDictionary.Append or the indexer to append or set headers
       [CS0618] handle member obsolete appropriately
       [SA1401] make fields private
       [SA1649] update file name
       [IDE1006] fix naming rule violation
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors),ASP0019,CS0618,SA1401,SA1649,IDE1006</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors),CS0618,SA1401,SA1649,IDE1006</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -17,7 +17,6 @@
       [SA1401] fields must be private
       [SA1405] debug message text
       [IDE0060] remove parameter
-      [ASP0019] header append
       [CS0114] inherited member
       [CS0661]/[CS0659] adjust overrides
       [CS0414] unassigned field
@@ -25,7 +24,7 @@
       [CS0612] obsolete
       [IDE1006] fix naming rule violation
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors),SYSLIB0013,CS0618,CS1998,SA1117,CS0067,CA1822,CA1416,IDE0028,SA1401,SA1405,IDE0060,ASP0019,CS0114,CS0661,CS0659,CS0414,CS0252,CS0612,IDE1006</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors),SYSLIB0013,CS0618,CS1998,SA1117,CS0067,CA1822,CA1416,IDE0028,SA1401,SA1405,IDE0060,CS0114,CS0661,CS0659,CS0414,CS0252,CS0612,IDE1006</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpContextExtensionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpContextExtensionTests.cs
@@ -29,7 +29,7 @@ public class HttpContextExtensionTests
 
         var httpContext = new DefaultHttpContext();
         var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{testUsername}:{testPassword}"));
-        httpContext.Request.Headers.Add("Authorization", $"Basic {credentials}");
+        httpContext.Request.Headers.Append("Authorization", $"Basic {credentials}");
 
         var result = httpContext.TryGetBasicAuthCredentials(out var username, out var password);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/HttpQueryStringModelBinderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/HttpQueryStringModelBinderTests.cs
@@ -74,7 +74,7 @@ public class HttpQueryStringModelBinderTests
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Request.QueryString = new QueryString(querystring);
-        httpContext.Request.Headers.Add("X-UMB-CULTURE", new StringValues("en-gb"));
+        httpContext.Request.Headers.Append("X-UMB-CULTURE", new StringValues("en-gb"));
         var routeData = new RouteData();
         var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
         var metadataProvider = new EmptyModelMetadataProvider();


### PR DESCRIPTION
This PR resolves all ASP0019 analyzer warnings by replacing IHeaderDictionary.Add() calls with IHeaderDictionary.Append().
## Why this change?
The Add() method throws an ArgumentException if a header with the same key already exists. The analyzer recommends using Append() which safely adds header values without throwing, or the indexer for replacement semantics.

## What changed?

### Source files (4 files, 5 calls):

- BasicAuthenticationMiddleware.cs - WWW-Authenticate header
- UmbracoUserTimeoutFilterAttribute.cs - X-Umb-User-Seconds header
- ModelBindingExceptionAttribute.cs - Retry-After header
- ByRouteContentApiController.cs - Location-Start-Item-Path and Location-Start-Item-Id headers

### Test files (2 files, 2 calls):

- HttpQueryStringModelBinderTests.cs - X-UMB-CULTURE header
- HttpContextExtensionTests.cs - Authorization header

### Removed ASP0019 suppressions from:

- Umbraco.Web.Common.csproj
- Umbraco.Web.Website.csproj
- Umbraco.Cms.Api.Delivery.csproj
- Umbraco.Tests.UnitTests.csproj

## Notes

- Added using Microsoft.AspNetCore.Http; to two files that needed the Append extension method
- No behavioral change - Append() has the same effect as Add() when the header doesn't already exist
- Build passes with zero ASP0019 warnings