### PR TITLE
E2E: V16 QA Update acceptance tests to use refactored UI helpers 

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@umbraco/json-models-builders": "^2.0.40",
-        "@umbraco/playwright-testhelpers": "^16.1.0-beta.2",
+        "@umbraco/playwright-testhelpers": "^16.0.60",
         "camelize": "^1.0.0",
         "dotenv": "^16.3.1",
         "node-fetch": "^2.6.7"
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@umbraco/playwright-testhelpers": {
-      "version": "16.1.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-16.1.0-beta.2.tgz",
-      "integrity": "sha512-96k44PhFuR5Bwb6Cy2ZoJXqe7hRiri25xOPKktlIysopVgstC0H+VyV8SpnlLY3WbcCf/aTK/Uy8eamjQ0NKug==",
+      "version": "16.0.60",
+      "resolved": "https://registry.npmjs.org/@umbraco/playwright-testhelpers/-/playwright-testhelpers-16.0.60.tgz",
+      "integrity": "sha512-/6CS4YtsNN3vtahaG35xj5BNYlJMcIPKdiUBrmilWCYAFzxIT9u6EegWBtua46bQxcdeqQgUvIAghsNvDPEk1A==",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.40",

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@umbraco/json-models-builders": "^2.0.40",
-    "@umbraco/playwright-testhelpers": "^16.1.0-beta.2",
+    "@umbraco/playwright-testhelpers": "^16.0.60",
     "camelize": "^1.0.0",
     "dotenv": "^16.3.1",
     "node-fetch": "^2.6.7"


### PR DESCRIPTION
Since we had a significant refactoring of the UI test helpers to improve code maintainability, reduce duplication, and provide more consistent test behavior (refer the PR https://github.com/umbraco/Umbraco.Playwright.Testhelpers/pull/357), this PR will update acceptance tests to use refactored UI helpers.