### PR TITLE
Performance: Use request cache for `ContentSourceDto` retrieval

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
@@ -16,7 +16,13 @@ internal interface IDatabaseCacheRepository
     /// <summary>
     /// Gets a single cache node for a document key and preview status.
     /// </summary>
+    [Obsolete("Please use the method overload takng all parameters. Scheduled for removal in Umbraco 19.")]
     Task<ContentCacheNode?> GetContentSourceAsync(Guid key, bool preview = false);
+
+    /// <summary>
+    /// Gets a single cache node for a document key and preview status.
+    /// </summary>
+    Task<ContentCacheNode?> GetContentSourceAsync(Guid key, bool preview = false, bool useCache = false);
 
     /// <summary>
     /// Gets a collection of cache nodes for a collection of document keys.
@@ -27,7 +33,7 @@ internal interface IDatabaseCacheRepository
         var contentCacheNodes = new List<ContentCacheNode>();
         foreach (Guid key in keys)
         {
-            ContentCacheNode? contentSource = await GetContentSourceAsync(key, preview);
+            ContentCacheNode? contentSource = await GetContentSourceAsync(key, preview, false);
             if (contentSource is not null)
             {
                 contentCacheNodes.Add(contentSource);

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
@@ -14,7 +14,7 @@ internal interface IDatabaseCacheRepository
     Task DeleteContentItemAsync(int id);
 
     /// <summary>
-    /// Gets a single cache node for a document key.
+    /// Gets a single cache node for a document key and preview status.
     /// </summary>
     Task<ContentCacheNode?> GetContentSourceAsync(Guid key, bool preview = false);
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -121,7 +121,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             async cancel =>
             {
                 using ICoreScope scope = _scopeProvider.CreateCoreScope();
-                ContentCacheNode? contentCacheNode = await _databaseCacheRepository.GetContentSourceAsync(key, preview);
+                ContentCacheNode? contentCacheNode = await _databaseCacheRepository.GetContentSourceAsync(key, preview, false);
 
                 // If we can resolve the content cache node, we still need to check if the ancestor path is published.
                 // This does cost some performance, but it's necessary to ensure that the content is actually published.
@@ -180,13 +180,13 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
         scope.ReadLock(Constants.Locks.ContentTree);
 
-        ContentCacheNode? draftNode = await _databaseCacheRepository.GetContentSourceAsync(key, true);
+        ContentCacheNode? draftNode = await _databaseCacheRepository.GetContentSourceAsync(key, true, false);
         if (draftNode is not null)
         {
             await _hybridCache.SetAsync(GetCacheKey(draftNode.Key, true), draftNode, GetEntryOptions(draftNode.Key, true), GenerateTags(key));
         }
 
-        ContentCacheNode? publishedNode = await _databaseCacheRepository.GetContentSourceAsync(key, false);
+        ContentCacheNode? publishedNode = await _databaseCacheRepository.GetContentSourceAsync(key, false, true);
         if (publishedNode is not null && _publishStatusQueryService.HasPublishedAncestorPath(publishedNode.Key))
         {
             var cacheKey = GetCacheKey(publishedNode.Key, false);

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
@@ -77,12 +77,12 @@ internal sealed class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithC
             IsDraft = false,
         };
 
-        _mockDatabaseCacheRepository.Setup(r => r.GetContentSourceAsync(It.IsAny<Guid>(), true))
+        _mockDatabaseCacheRepository.Setup(r => r.GetContentSourceAsync(It.IsAny<Guid>(), true, It.IsAny<bool>()))
             .ReturnsAsync(draftTestCacheNode);
         _mockDatabaseCacheRepository.Setup(r => r.GetContentSourcesAsync(It.IsAny<IEnumerable<Guid>>(), true))
             .ReturnsAsync([draftTestCacheNode]);
 
-        _mockDatabaseCacheRepository.Setup(r => r.GetContentSourceAsync(It.IsAny<Guid>(), false))
+        _mockDatabaseCacheRepository.Setup(r => r.GetContentSourceAsync(It.IsAny<Guid>(), false, It.IsAny<bool>()))
             .ReturnsAsync(publishedTestCacheNode);
         _mockDatabaseCacheRepository.Setup(r => r.GetContentSourcesAsync(It.IsAny<IEnumerable<Guid>>(), false))
             .ReturnsAsync([publishedTestCacheNode]);
@@ -148,7 +148,7 @@ internal sealed class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithC
         var textPage2 = await _mockedCache.GetByIdAsync(Textpage.Key, true);
         AssertTextPage(textPage);
         AssertTextPage(textPage2);
-        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
+        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     [Test]
@@ -160,7 +160,7 @@ internal sealed class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithC
         var textPage2 = await _mockedCache.GetByIdAsync(Textpage.Id, true);
         AssertTextPage(textPage);
         AssertTextPage(textPage2);
-        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
+        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     [Test]
@@ -219,7 +219,7 @@ internal sealed class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithC
         var textPage = await _mockedCache.GetByIdAsync(Textpage.Id, true);
         AssertTextPage(textPage);
 
-        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
+        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     [Test]
@@ -232,7 +232,7 @@ internal sealed class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithC
         var textPage = await _mockedCache.GetByIdAsync(Textpage.Key, true);
         AssertTextPage(textPage);
 
-        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Exactly(1));
+        _mockDatabaseCacheRepository.Verify(x => x.GetContentSourceAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Exactly(1));
     }
 
     private void AssertTextPage(IPublishedContent textPage)


### PR DESCRIPTION
### Description
It was noted that `GetContentSourceAsync` is called more than once during save and publish operations, and that we go to the database both for published and draft content even though the data returned is the same.  This PR adds a request cache around this, ensuring we only request the underlying DTO once, and then create the `ContentCacheNode` as appropriate from that.

Not super-happy with the implementation here - it seemed I either needed to pass a parameter indicating whether to use the cache, or have the repository expose the `ContentSourceDto` so the service can decide whether to re-get it or not.  Neither felt very nice, but I've gone with the former.  Maybe reviewers have a better approach here.

### Change Summary
- Adds request-level caching for `ContentSourceDto` lookups in `DatabaseCacheRepository` to avoid redundant database queries within the same HTTP request
- Refactors `GetContentSourceAsync` by extracting `GetContentSourceDto` (with caching) and `CreateContentCacheNode` methods
- Updates XML documentation to clarify the `preview` parameter

### Testing
Via a breakpoint you can verify that during a save and publish operation, only the first request for a content cache node hits the database.