### PR TITLE
Performance: Only flush ID/Key map in `ContentCacheRefresher` on content deletion

### DIFF
--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
@@ -499,12 +499,12 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
     public class JsonPayload
     {
         /// <summary>
-        /// Gets the unique identifier for the entity.
+        /// Gets the unique integer identifier for the entity.
         /// </summary>
         public int Id { get; init; }
 
         /// <summary>
-        /// Gets the unique identifier associated with the entity, or null if no key is assigned.
+        /// Gets the unique GUID key associated with the entity, or null if no key is assigned.
         /// </summary>
         public Guid? Key { get; init; }
 


### PR DESCRIPTION
### Description
Currently the `ContentCacheRefresher` explicitly flushes the `IIdKeyMap` for all content changes. This only needs doing when content is deleted (`TreeChangeType.Remove`).  This PR makes only this behavioural change.

Other updates are code clean-up and code quality warning resolution.

## Summary
- Only flushes the ID/Key map when content is actually deleted (`TreeChangeTypes.Remove`), avoiding unnecessary cache invalidation on publish/unpublish/refresh operations
- Extracts `HandleIdKeyMap` and `HandleDomainCache` methods for better code organization
- Makes `IsBranchUnpublished` static since it doesn't use instance members
- Adds XML documentation comments to the class, constructor, methods, and `JsonPayload` properties
- Resolves code style warnings (capitalization, punctuation in comments)

### Testing
Via a breakpoint, verify that the `IIdKeyMap` is not cleared in content save and publish operations.