### PR TITLE
Dependencies: Update Microsoft packages to 10.0.1 and pin vulnerable transitive dependencies (closes #21122)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,9 +80,11 @@
   <!-- Transitive pinned versions (only required because our direct dependencies have vulnerable versions of transitive dependencies) -->
   <ItemGroup>
     <!-- Dazinator.Extensions.FileProviders references vulnerable versions of the following: -->
+    <!-- TODO (V18): Remove these pinned dependencies when the Dazinator.Extensions.FileProviders dependency is removed. -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <!-- Markdown references vulnerable version of the following: -->
+    <!-- TODO (V19): Remove these pinned dependencies when the Markdown dependency is removed. -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description
Although I can't see evidence for this myself - e.g. via `dotnet list package --include-transitive --vulnerable` or through Visual Studio tools - it can be reported that some of our transitive dependencies have security vulnerabilities.  See https://github.com/umbraco/Umbraco-CMS/issues/21122.

We removed some direct dependencies we listed for Umbraco 17 in https://github.com/umbraco/Umbraco-CMS/issues/20385, but seems we should have kept them.  So I've added them back in this PR.

I've also taken the opportunity to bump Microsoft's 10.0.0 dependencies to the latest patch of 10.0.1.

### Change Summary
- Enables `CentralPackageTransitivePinningEnabled` in `Directory.Packages.props` to allow pinning transitive dependency versions
- Updates Microsoft packages from 10.0.0 to 10.0.1 patch versions (security and bug fixes)
- Adds explicit version pins for transitive dependencies with known vulnerabilities:
  - `System.Net.Http` 4.3.4 (via Dazinator.Extensions.FileProviders)
  - `System.Private.Uri` 4.3.2 (via Dazinator.Extensions.FileProviders)
  - `System.Text.RegularExpressions` 4.3.1 (via Markdown)
