### PR TITLE
Docs: Add branch naming convention details to CLAUDE.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This guide describes each step to make your first contribution:
 
    Create a new branch based on `main` and name it after the issue you're fixing. For example: `v15/bugfix/18132-rte-tinymce-onchange-value-check`.
 
-   Please follow this format for branches: `v{major}/{feature|bugfix|task}/{issue}-{description}`.
+   Please follow this format for branches: `v{major}/{feature|bugfix|task|qa|improvement}/{issue}-{description}`.
 
    This is a development branch for the particular issue you're working on, in this case, a bug-fix for issue number `18132` that affects Umbraco v.15.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Web.UI → Web.Common → Infrastructure → Core
 - **Main branch**: `main` (protected)
 - **Branch naming convention**: `v<version>/<type>/<description>`
 
-**Format**: `v{major-version}/{type}/{snake-case-description}`
+**Format**: `v{major-version}/{type}/{kebab-case-description}`
 
 **Version**: Read from `version.json` in the repository root. Use the major version number (e.g., `v17` for version 17.x.x).
 
@@ -157,11 +157,11 @@ Web.UI → Web.Common → Infrastructure → Core
 | `improvement` | Update to something that already exists but isn't broken (UI finessing, refactoring) |
 | `task` | Update that doesn't directly impact product behavior (dependency updates, build pipeline) |
 
-**Description**: A short, snake_case description (a few words).
+**Description**: A short, kebab-case description (a few words). This should be prefixed with the GitHub issue number if the update is related to resolving a tracked issue.
 
 **Examples**:
 ```
-v17/bugfix/correct-display-of-pending-migrations
+v17/bugfix/12345-correct-display-of-pending-migrations
 v17/feature/add-webhook-support
 v17/improvement/optimize-content-cache
 v17/qa/add-media-service-tests


### PR DESCRIPTION
## Description

I noticed a few branches being created on PRs that didn't match what we have internally documented, which I'm guessing are coming about from use of Claude to create the branch.  To maximise the chance of this using a conventional branch name, I've made these updates to the memory files.

- Adds explicit branch naming convention documentation to CLAUDE.md
- Documents the `v<version>/<type>/<description>` format with version sourced from `version.json`
- Provides a table of branch types (feature, bugfix, qa, improvement, task) with use cases
- Includes examples for each branch type
