### PR TITLE
Members: Fix `IMemberService.GetByKeysAsync()`

### DIFF
--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -548,7 +548,8 @@ namespace Umbraco.Cms.Core.Services
         {
             using ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true);
             scope.ReadLock(Constants.Locks.MemberTree);
-            IQuery<IMember> query = Query<IMember>().Where(x => ids.Contains(x.Key));
+            List<Guid> idsAsList = [.. ids];
+            IQuery<IMember> query = Query<IMember>().Where(x => idsAsList.Contains(x.Key));
             return Task.FromResult(_memberRepository.Get(query));
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
@@ -1435,4 +1435,25 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
         Assert.IsNotNull(found, "Verifying the created member instance has been retrieved");
         Assert.IsTrue(found?.Name == member?.Name, "Verifying the retrieved member instance has the expected name");
     }
+
+    [Test]
+    public async Task Can_Get_Multiple_By_Key()
+    {
+        var memberType = MemberTypeService.Get("member");
+        IMember memberA = new Member("aname", "a@email", "ausername", "arawpassword", memberType, true);
+        MemberService.Save(memberA);
+
+        IMember memberB = new Member("bname", "b@email", "busername", "brawpassword", memberType, true);
+        MemberService.Save(memberB);
+
+        IMember memberC = new Member("cname", "c@email", "cusername", "crawpassword", memberType, true);
+        MemberService.Save(memberC);
+
+        var members = (await MemberService.GetByKeysAsync(memberA.Key, memberB.Key, memberC.Key)).ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(3, members.Length);
+            CollectionAssert.AreEquivalent(new [] { memberA.Key, memberB.Key, memberC.Key }, members.Select(m => m.Key).ToArray());
+        });
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR amends `IMemberService.GetByKeysAsync()` to follow the pattern introduced in #20184 (following changes in  .NET 10).

Without this PR, the methods throws `System.ArgumentOutOfRangeException : Specified argument was out of the range of valid values. (Parameter 'No logic supported for op_Implicit')`.

With this PR, the method works as expected.

### Testing this PR

Visual inspection is sufficient here. I have included an integration test to prove the method works.