### PR TITLE
Content types: Allow adding composition with clashing property alias when property is being removed (closes #21298)

### DIFF
--- a/src/Umbraco.Core/Models/ContentTypeCompositionBase.cs
+++ b/src/Umbraco.Core/Models/ContentTypeCompositionBase.cs
@@ -122,11 +122,6 @@ public abstract class ContentTypeCompositionBase : ContentTypeBase, IContentType
     /// <inheritdoc />
     public bool AddContentType(IContentTypeComposition contentType, string[] removedPropertyTypeAliases)
     {
-        if (contentType is null)
-        {
-            return false;
-        }
-
         if (contentType.ContentTypeComposition.Any(x => x.CompositionAliases().Any(ContentTypeCompositionExists)))
         {
             return false;

--- a/src/Umbraco.Core/Models/ContentTypeCompositionBase.cs
+++ b/src/Umbraco.Core/Models/ContentTypeCompositionBase.cs
@@ -119,7 +119,6 @@ public abstract class ContentTypeCompositionBase : ContentTypeBase, IContentType
         return AddContentType(contentType, []);
     }
 
-
     /// <inheritdoc />
     public bool AddContentType(IContentTypeComposition contentType, string[] removedPropertyTypeAliases)
     {

--- a/src/Umbraco.Core/Models/IContentTypeComposition.cs
+++ b/src/Umbraco.Core/Models/IContentTypeComposition.cs
@@ -39,10 +39,15 @@ public interface IContentTypeComposition : IContentTypeBase
     /// </summary>
     /// <param name="contentType"><see cref="IContentType" /> to add</param>
     /// <param name="removedPropertyTypeAliases">
-    /// Aliases of property types that are to be removed in the current update operation.
-    /// It's OK if the composition has property type aliases that clash with these.
+    /// Aliases of property types that are being removed from the current content type in this update operation.
+    /// The composition is allowed to have properties with these aliases since they won't conflict.
     /// </param>
     /// <returns>True if ContentType was added, otherwise returns False</returns>
+    /// <remarks>
+    ///     The default implementation of this overload ignores <paramref name="removedPropertyTypeAliases" />
+    ///     and simply calls <see cref="AddContentType(IContentTypeComposition?)" />. Implementations that need to
+    ///     respect removed property type aliases must override this method.
+    /// </remarks>
     // TODO (V18): Remove the default implementation.
     bool AddContentType(IContentTypeComposition contentType, string[] removedPropertyTypeAliases) => AddContentType(contentType);
 

--- a/src/Umbraco.Core/Models/IContentTypeComposition.cs
+++ b/src/Umbraco.Core/Models/IContentTypeComposition.cs
@@ -31,7 +31,20 @@ public interface IContentTypeComposition : IContentTypeBase
     /// </summary>
     /// <param name="contentType"><see cref="IContentType" /> to add</param>
     /// <returns>True if ContentType was added, otherwise returns False</returns>
+    // TODO (V18): Update nullability so only a non-null contentType can be passed.
     bool AddContentType(IContentTypeComposition? contentType);
+
+    /// <summary>
+    ///     Adds a new ContentType to the list of composite ContentTypes
+    /// </summary>
+    /// <param name="contentType"><see cref="IContentType" /> to add</param>
+    /// <param name="removedPropertyTypeAliases">
+    /// Aliases of property types that are to be removed in the current update operation.
+    /// It's OK if the composition has property type aliases that clash with these.
+    /// </param>
+    /// <returns>True if ContentType was added, otherwise returns False</returns>
+    // TODO (V18): Remove the default implementation.
+    bool AddContentType(IContentTypeComposition contentType, string[] removedPropertyTypeAliases) => AddContentType(contentType);
 
     /// <summary>
     ///     Removes a ContentType with the supplied alias from the list of composite ContentTypes


### PR DESCRIPTION
## Description
When updating a content type to add a composition and remove a property at the same time, if the composition has a property with the same alias as the one being removed, this is rejected with an `InvalidCompositionException` - as raised in https://github.com/umbraco/Umbraco-CMS/issues/21298.

Having checked Umbraco 13, this wasn't the case there.  You could carry out this operation.  Data loss will occur - as the property is not the same given it has a new ID and isn't stored by alias.  This is the case in 13 and in 17.

This PR allows the operation to succeed by passing the removed property aliases to `AddContentType`, which excludes them from the conflict check

## Change Summary

- Added new overload `IContentTypeComposition.AddContentType(IContentTypeComposition contentType, string[] removedPropertyTypeAliases)` .
- Updated `ContentTypeCompositionBase.AddContentType` to accept removed property aliases and exclude them from conflict detection.
- Updated `ContentTypeEditingServiceBase.UpdateCompositions` to calculate removed property aliases and pass them when adding compositions.
- Added integration tests to verify the behaviour.

## Testing
Integration tests `Cannot_Add_Composition_With_Conflicting_Property_Type_Alias` and `Can_Add_Composition_With_Conflicting_Property_Type_Alias_When_Alias_Is_Being_Removed` test verify the behaviour.

Manual testing steps:

- Create a document type with a property.
- Create a second document type with a property with the same alias.
- Create a document based on the document type and populate the property.
- Edit the second document type, remove the property defined on the type and add the first document type as a composition.
- Save the document type and note the operation now succeeds without error.
- Note that the document's property data is lost, but that the document is editable as expected.
