### PR TITLE
Backoffice entity actions: prevent entity actions dropdown from closing on first click

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/global-components/entity-actions-dropdown/entity-actions-dropdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/global-components/entity-actions-dropdown/entity-actions-dropdown.element.ts
@@ -70,10 +70,13 @@ export class UmbEntityActionsDropdownElement extends UmbLitElement {
 			id="action-modal"
 			@click=${this.#onDropdownClick}
 			@opened=${this.#onDropdownOpened}
-			@focusout=${(e: FocusEvent) =>
-				!['umb-entity-action-list', 'uui-scroll-container'].includes(
-					(e.relatedTarget as HTMLElement)?.tagName.toLowerCase() || '',
-				) && this.#onActionExecuted()}
+			@focusout=${(e: FocusEvent) => {
+				const relatedTarget = e.relatedTarget as HTMLElement | null;
+				if (!relatedTarget) return;
+				const allowedTags = ['umb-entity-action-list', 'uui-scroll-container', 'uui-menu-item', 'umb-entity-action'];
+				if (allowedTags.includes(relatedTarget.tagName.toLowerCase())) return;
+				this.#onActionExecuted();
+			}}
 			.label=${this.label}
 			?compact=${this.compact}
 			hide-expand>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #21320

### Description

The actions menu (three dots) for Media Type items in Settings was closing instantly after opening on the first click. It only worked on the second click. This issue affected only Media Types, not Document Types or other entity types.

**Root cause:**
The `focus()` method in entity actions is async (awaits `updateComplete`). When the dropdown opens for the first time, a `focusout` event fires with `relatedTarget = null` before the async focus operation completes. The original handler treated null as "focus left the dropdown" and closed it immediately.

**Fix:**
- Added early return when `relatedTarget` is `null` to handle async focus transitions
- Added `uui-menu-item` and `umb-entity-action` to allowed focus target tags

**How to test:**
1. Go to Settings → Media Types
2. Click the ⋯ (three dots) action menu on any media type item
3. Verify the dropdown stays open on the **first** click
4. Verify clicking outside the dropdown still closes it properly

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234