### PR TITLE
Picker: introduce conditions to check if an extension is or is not in a picker

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_IS_NOT_PICKER_CONDITION_ALIAS = 'Umb.Condition.IsNotPicker';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition-config.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition-config.ts
@@ -1,0 +1,12 @@
+import type { UMB_IS_NOT_PICKER_CONDITION_ALIAS } from './constants.js';
+import type { UmbConditionConfigBase } from '@umbraco-cms/backoffice/extension-api';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbIsNotPickerConditionConfig
+	extends UmbConditionConfigBase<typeof UMB_IS_NOT_PICKER_CONDITION_ALIAS> {}
+
+declare global {
+	interface UmbExtensionConditionConfigMap {
+		UmbIsNotPickerConditionConfig: UmbIsNotPickerConditionConfig;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition.manifest.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition.manifest.ts
@@ -1,0 +1,10 @@
+import { UMB_IS_NOT_PICKER_CONDITION_ALIAS } from './constants.js';
+import { UmbIsNotPickerCondition } from './is-not-picker.condition.js';
+import type { ManifestCondition } from '@umbraco-cms/backoffice/extension-api';
+
+export const manifest: ManifestCondition = {
+	type: 'condition',
+	name: 'Is Not Picker Condition',
+	alias: UMB_IS_NOT_PICKER_CONDITION_ALIAS,
+	api: UmbIsNotPickerCondition,
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition.test.ts
@@ -1,0 +1,82 @@
+import { expect } from '@open-wc/testing';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbIsNotPickerCondition } from './is-not-picker.condition.js';
+import { UMB_IS_NOT_PICKER_CONDITION_ALIAS } from './constants.js';
+import { UmbPickerContext } from '../../picker.context.js';
+
+@customElement('test-controller-host-not-in-picker')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+@customElement('test-controller-host-with-picker-context-not-in-picker')
+class UmbTestControllerHostWithPickerContextElement extends UmbControllerHostElementMixin(HTMLElement) {
+	pickerContext = new UmbPickerContext(this);
+}
+
+describe('UmbIsNotPickerCondition', () => {
+	describe('without picker context', () => {
+		let hostElement: UmbTestControllerHostElement;
+		let condition: UmbIsNotPickerCondition;
+
+		beforeEach(async () => {
+			hostElement = new UmbTestControllerHostElement();
+			document.body.appendChild(hostElement);
+		});
+
+		afterEach(() => {
+			document.body.innerHTML = '';
+		});
+
+		it('should return true when not inside a picker context', async () => {
+			condition = new UmbIsNotPickerCondition(hostElement, {
+				host: hostElement,
+				config: {
+					alias: UMB_IS_NOT_PICKER_CONDITION_ALIAS,
+				},
+				onChange: () => {},
+			});
+
+			// Wait for context consumption to settle
+			await new Promise((resolve) => requestAnimationFrame(resolve));
+
+			// The condition defaults to true and should remain true since no picker context exists
+			expect(condition.permitted).to.be.true;
+			condition.destroy();
+		});
+	});
+
+	describe('with picker context', () => {
+		let hostElement: UmbTestControllerHostWithPickerContextElement;
+		let condition: UmbIsNotPickerCondition | undefined;
+
+		beforeEach(async () => {
+			hostElement = new UmbTestControllerHostWithPickerContextElement();
+			document.body.appendChild(hostElement);
+		});
+
+		afterEach(() => {
+			document.body.innerHTML = '';
+		});
+
+		it('should return false when inside a picker context', (done) => {
+			let resolved = false;
+			condition = new UmbIsNotPickerCondition(hostElement, {
+				host: hostElement,
+				config: {
+					alias: UMB_IS_NOT_PICKER_CONDITION_ALIAS,
+				},
+				onChange: () => {
+					// Skip if already resolved or if condition is not yet assigned (during constructor)
+					if (resolved || !condition) return;
+					// Only check when permitted becomes false (context was found)
+					if (condition.permitted === false) {
+						resolved = true;
+						expect(condition.permitted).to.be.false;
+						condition.destroy();
+						done();
+					}
+				},
+			});
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-not-picker/is-not-picker.condition.ts
@@ -1,0 +1,23 @@
+import { UMB_PICKER_CONTEXT } from '../../picker.context.token.js';
+import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type {
+	UmbConditionConfigBase,
+	UmbConditionControllerArguments,
+	UmbExtensionCondition,
+} from '@umbraco-cms/backoffice/extension-api';
+
+export class UmbIsNotPickerCondition extends UmbConditionBase<UmbConditionConfigBase> implements UmbExtensionCondition {
+	constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<UmbConditionConfigBase>) {
+		super(host, args);
+
+		// Default: assume NOT in picker context (permitted = true)
+		this.permitted = true;
+
+		this.consumeContext(UMB_PICKER_CONTEXT, (context) => {
+			this.permitted = context === undefined;
+		});
+	}
+}
+
+export { UmbIsNotPickerCondition as api };

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_IS_PICKER_CONDITION_ALIAS = 'Umb.Condition.IsPicker';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition-config.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition-config.ts
@@ -1,0 +1,12 @@
+import type { UMB_IS_PICKER_CONDITION_ALIAS } from './constants.js';
+import type { UmbConditionConfigBase } from '@umbraco-cms/backoffice/extension-api';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UmbIsPickerConditionConfig
+	extends UmbConditionConfigBase<typeof UMB_IS_PICKER_CONDITION_ALIAS> {}
+
+declare global {
+	interface UmbExtensionConditionConfigMap {
+		UmbIsPickerConditionConfig: UmbIsPickerConditionConfig;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition.manifest.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition.manifest.ts
@@ -1,0 +1,10 @@
+import { UMB_IS_PICKER_CONDITION_ALIAS } from './constants.js';
+import { UmbIsPickerCondition } from './is-picker.condition.js';
+import type { ManifestCondition } from '@umbraco-cms/backoffice/extension-api';
+
+export const manifest: ManifestCondition = {
+	type: 'condition',
+	name: 'Is Picker Condition',
+	alias: UMB_IS_PICKER_CONDITION_ALIAS,
+	api: UmbIsPickerCondition,
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition.test.ts
@@ -1,0 +1,77 @@
+import { expect } from '@open-wc/testing';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbIsPickerCondition } from './is-picker.condition.js';
+import { UMB_IS_PICKER_CONDITION_ALIAS } from './constants.js';
+import { UmbPickerContext } from '../../picker.context.js';
+
+@customElement('test-controller-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+@customElement('test-controller-host-with-picker-context')
+class UmbTestControllerHostWithPickerContextElement extends UmbControllerHostElementMixin(HTMLElement) {
+	pickerContext = new UmbPickerContext(this);
+}
+
+describe('UmbIsPickerCondition', () => {
+	describe('without picker context', () => {
+		let hostElement: UmbTestControllerHostElement;
+		let condition: UmbIsPickerCondition;
+
+		beforeEach(async () => {
+			hostElement = new UmbTestControllerHostElement();
+			document.body.appendChild(hostElement);
+		});
+
+		afterEach(() => {
+			document.body.innerHTML = '';
+		});
+
+		it('should return false when not inside a picker context', async () => {
+			condition = new UmbIsPickerCondition(hostElement, {
+				host: hostElement,
+				config: {
+					alias: UMB_IS_PICKER_CONDITION_ALIAS,
+				},
+				onChange: () => {},
+			});
+
+			// Wait for context consumption to settle
+			await new Promise((resolve) => requestAnimationFrame(resolve));
+
+			expect(condition.permitted).to.be.false;
+			condition.destroy();
+		});
+	});
+
+	describe('with picker context', () => {
+		let hostElement: UmbTestControllerHostWithPickerContextElement;
+		let condition: UmbIsPickerCondition;
+
+		beforeEach(async () => {
+			hostElement = new UmbTestControllerHostWithPickerContextElement();
+			document.body.appendChild(hostElement);
+		});
+
+		afterEach(() => {
+			document.body.innerHTML = '';
+		});
+
+		it('should return true when inside a picker context', (done) => {
+			let resolved = false;
+			condition = new UmbIsPickerCondition(hostElement, {
+				host: hostElement,
+				config: {
+					alias: UMB_IS_PICKER_CONDITION_ALIAS,
+				},
+				onChange: () => {
+					if (resolved) return;
+					resolved = true;
+					expect(condition.permitted).to.be.true;
+					condition.destroy();
+					done();
+				},
+			});
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/is-picker/is-picker.condition.ts
@@ -1,0 +1,23 @@
+import { UMB_PICKER_CONTEXT } from '../../picker.context.token.js';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type {
+	UmbConditionConfigBase,
+	UmbConditionControllerArguments,
+	UmbExtensionCondition,
+} from '@umbraco-cms/backoffice/extension-api';
+import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
+
+export class UmbIsPickerCondition
+	extends UmbConditionBase<UmbConditionConfigBase>
+	implements UmbExtensionCondition
+{
+	constructor(host: UmbControllerHost, args: UmbConditionControllerArguments<UmbConditionConfigBase>) {
+		super(host, args);
+
+		this.consumeContext(UMB_PICKER_CONTEXT, (context) => {
+			this.permitted = context !== undefined;
+		});
+	}
+}
+
+export { UmbIsPickerCondition as api };

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/manifests.ts
@@ -1,0 +1,4 @@
+import { manifest as isPickerManifest } from './is-picker/is-picker.condition.manifest.js';
+import { manifest as isNotPickerManifest } from './is-not-picker/is-not-picker.condition.manifest.js';
+
+export const manifests = [isPickerManifest, isNotPickerManifest];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/conditions/types.ts
@@ -1,0 +1,2 @@
+export type * from './is-picker/is-picker.condition-config.js';
+export type * from './is-not-picker/is-not-picker.condition-config.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/constants.ts
@@ -1,2 +1,4 @@
 export { UMB_PICKER_CONTEXT } from './picker.context.token.js';
+export * from './conditions/is-picker/constants.js';
+export * from './conditions/is-not-picker/constants.js';
 export * from './search/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/index.ts
@@ -4,3 +4,4 @@ export * from './picker.context.js';
 export * from './picker.context.token.js';
 export * from './search/index.js';
 export type * from './types.js';
+export type * from './conditions/types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/manifests.ts
@@ -1,4 +1,8 @@
+import { manifests as conditionManifests } from './conditions/manifests.js';
 import { manifests as searchManifests } from './search/manifests.js';
 import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
-export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [...searchManifests];
+export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> = [
+	...conditionManifests,
+	...searchManifests,
+];


### PR DESCRIPTION
This PR is made in preparation for "Collection"-elements inside a picker.

This PR introduces two new conditions to check if an extension is in a Picker or if an extension is NOT in a picker. This is useful for collection actions, entity bulk actions, or entity actions that should not be available in a Picker.

Usage:

**Manifest**
```typescript
{
 ...
 conditions: [
    {
      alias: UMB_IS_NOT_PICKER_CONDITION_ALIAS,
    }
  ]
}
```