### PR TITLE
Media: Picker Modal types export (Fixes #21265)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
@@ -2,7 +2,7 @@ export * from './audit-log/index.js';
 export * from './components/index.js';
 export * from './constants.js';
 export * from './dropzone/index.js';
-export { UMB_IMAGE_CROPPER_EDITOR_MODAL, UMB_MEDIA_PICKER_MODAL } from './modals/index.js';
+export * from './modals/index.js';
 export * from './recycle-bin/index.js';
 export * from './reference/index.js';
 export * from './repository/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/image-cropper-editor/image-cropper-editor-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/image-cropper-editor/image-cropper-editor-modal.element.ts
@@ -15,6 +15,7 @@ import { UMB_MODAL_MANAGER_CONTEXT, UmbModalBaseElement } from '@umbraco-cms/bac
 import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/workspace';
 import type { UmbModalManagerContext } from '@umbraco-cms/backoffice/modal';
 
+import './components/index.js';
 import '../../components/input-upload-field/file-upload-preview.element.js';
 
 @customElement('umb-image-cropper-editor-modal')

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/image-cropper-editor/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/image-cropper-editor/index.ts
@@ -1,3 +1,1 @@
-export * from './components/index.js';
-export * from './image-cropper-editor-modal.element.js';
 export * from './image-cropper-editor-modal.token.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-caption-alt-text/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-caption-alt-text/index.ts
@@ -1,1 +1,1 @@
-export * from './media-caption-alt-text-modal.element.js';
+export * from './media-caption-alt-text-modal.token.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/index.ts
@@ -1,4 +1,2 @@
-export * from './components/index.js';
-export * from './media-picker-modal.element.js';
 export * from './media-picker-modal.token.js';
 export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -30,6 +30,7 @@ import type { UmbInteractionMemoryModel } from '@umbraco-cms/backoffice/interact
 import type { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
 import type { UUIInputEvent, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 
+import './components/index.js';
 import '@umbraco-cms/backoffice/imaging';
 
 const root: UmbMediaPathModel = { name: 'Media', unique: null, entityType: UMB_MEDIA_ROOT_ENTITY_TYPE };


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/21265

This is just a suggestion, it needs to be reviewed carefully.

A concern could be, what if someone used the Element export. On the otherside, we should not export the elements of things that goes into a manifest.