### PR TITLE
Routing: Prioritize domain-specific redirects over path-only redirects (closes #21314)

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByRedirectUrlTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/ContentFinderByRedirectUrlTests.cs
@@ -154,6 +154,106 @@ public class ContentFinderByRedirectUrlTests
         return publishedRequestBuilder;
     }
 
+    [Test]
+    public async Task Domain_Specific_Redirect_Takes_Priority_Over_Path_Only_Redirect()
+    {
+        const string FullPath = "/en/old-page-path";
+        const string DomainRelativePath = "/old-page-path";
+        const int PathOnlyRedirectContentId = 9999;
+        const string PathOnlyRedirectNewPath = "/wrong-new-path";
+        const string DomainRedirectNewPath = "/correct-new-path";
+
+        var domainPrefixedOldPath = $"{DomainContentId}{DomainRelativePath}";
+
+        var mockRedirectUrlService = new Mock<IRedirectUrlService>();
+        mockRedirectUrlService
+            .Setup(x => x.GetMostRecentRedirectUrlAsync(It.Is<string>(y => y == domainPrefixedOldPath), It.IsAny<string>()))
+            .ReturnsAsync(new RedirectUrl { ContentId = ContentId });
+        mockRedirectUrlService
+            .Setup(x => x.GetMostRecentRedirectUrlAsync(It.Is<string>(y => y == FullPath), It.IsAny<string>()))
+            .ReturnsAsync(new RedirectUrl { ContentId = PathOnlyRedirectContentId });
+
+        var mockDomainContent = new Mock<IPublishedContent>();
+        mockDomainContent.SetupGet(x => x.Id).Returns(ContentId);
+        mockDomainContent.SetupGet(x => x.ContentType.ItemType).Returns(PublishedItemType.Content);
+
+        var mockPathOnlyContent = new Mock<IPublishedContent>();
+        mockPathOnlyContent.SetupGet(x => x.Id).Returns(PathOnlyRedirectContentId);
+        mockPathOnlyContent.SetupGet(x => x.ContentType.ItemType).Returns(PublishedItemType.Content);
+
+        var mockUmbracoContext = new Mock<IUmbracoContext>();
+        mockUmbracoContext
+            .Setup(x => x.Content.GetById(It.Is<int>(y => y == ContentId)))
+            .Returns(mockDomainContent.Object);
+        mockUmbracoContext
+            .Setup(x => x.Content.GetById(It.Is<int>(y => y == PathOnlyRedirectContentId)))
+            .Returns(mockPathOnlyContent.Object);
+
+        var mockUmbracoContextAccessor = new Mock<IUmbracoContextAccessor>();
+        var umbracoContext = mockUmbracoContext.Object;
+        mockUmbracoContextAccessor
+            .Setup(x => x.TryGetUmbracoContext(out umbracoContext))
+            .Returns(true);
+
+        var mockPublishedUrlProvider = new Mock<IPublishedUrlProvider>();
+        mockPublishedUrlProvider
+            .Setup(x => x.GetUrl(It.Is<IPublishedContent>(y => y.Id == ContentId), It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
+            .Returns(DomainRedirectNewPath);
+        mockPublishedUrlProvider
+            .Setup(x => x.GetUrl(It.Is<IPublishedContent>(y => y.Id == PathOnlyRedirectContentId), It.IsAny<UrlMode>(), It.IsAny<string?>(), It.IsAny<Uri?>()))
+            .Returns(PathOnlyRedirectNewPath);
+
+        var sut = CreateContentFinder(mockRedirectUrlService, mockUmbracoContextAccessor, mockPublishedUrlProvider);
+        var publishedRequestBuilder = CreatePublishedRequestBuilder(FullPath, withDomain: true);
+
+        var result = await sut.TryFindContent(publishedRequestBuilder);
+
+        Assert.That(result, Is.True);
+        Assert.That((HttpStatusCode)publishedRequestBuilder.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Moved));
+        mockRedirectUrlService.Verify(
+            x => x.GetMostRecentRedirectUrlAsync(domainPrefixedOldPath, It.IsAny<string>()),
+            Times.Once);
+        mockRedirectUrlService.Verify(
+            x => x.GetMostRecentRedirectUrlAsync(FullPath, It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Falls_Back_To_Path_Only_Redirect_When_No_Domain_Specific_Exists()
+    {
+        const string FullPath = "/en/old-page-path";
+        const string DomainRelativePath = "/old-page-path";
+        const string NewPath = "/new-page-path";
+
+        var domainPrefixedOldPath = $"{DomainContentId}{DomainRelativePath}";
+
+        var mockRedirectUrlService = new Mock<IRedirectUrlService>();
+        mockRedirectUrlService
+            .Setup(x => x.GetMostRecentRedirectUrlAsync(It.Is<string>(y => y == domainPrefixedOldPath), It.IsAny<string>()))
+            .ReturnsAsync((IRedirectUrl?)null);
+        mockRedirectUrlService
+            .Setup(x => x.GetMostRecentRedirectUrlAsync(It.Is<string>(y => y == FullPath), It.IsAny<string>()))
+            .ReturnsAsync(new RedirectUrl { ContentId = ContentId });
+
+        var mockContent = CreateMockPublishedContent();
+        var mockUmbracoContextAccessor = CreateMockUmbracoContextAccessor(mockContent);
+        var mockPublishedUrlProvider = CreateMockPublishedUrlProvider(NewPath);
+
+        var sut = CreateContentFinder(mockRedirectUrlService, mockUmbracoContextAccessor, mockPublishedUrlProvider);
+        var publishedRequestBuilder = CreatePublishedRequestBuilder(FullPath, withDomain: true);
+
+        var result = await sut.TryFindContent(publishedRequestBuilder);
+
+        Assert.That(result, Is.True);
+        Assert.That((HttpStatusCode)publishedRequestBuilder.ResponseStatusCode, Is.EqualTo(HttpStatusCode.Moved));
+        mockRedirectUrlService.Verify(
+            x => x.GetMostRecentRedirectUrlAsync(domainPrefixedOldPath, It.IsAny<string>()),
+            Times.Once);
+        mockRedirectUrlService.Verify(
+            x => x.GetMostRecentRedirectUrlAsync(FullPath, It.IsAny<string>()),
+            Times.Once);
+    }
+
     private static void AssertRedirectResult(PublishedRequestBuilder publishedRequestBuilder, bool result)
     {
         Assert.AreEqual(true, result);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #21314

### Description

In multi-site Umbraco setups, URL redirects were being applied across site boundaries. A URL requested on one domain (e.g., `localhost`) was being redirected to a page on another domain (e.g., `test.localhost`), even though the redirect was created for a different site.

**Root cause:** The redirect lookup logic checked path-only redirects before domain-specific redirects. This meant a redirect stored without a domain prefix would match requests from any domain.

**Fix:** Changed the lookup order in both `ContentFinderByRedirectUrl` and `RequestRedirectService` to:
1. First check for domain-specific redirect (e.g., `{domainContentId}/page`)
2. Fall back to path-only redirect only if no domain-specific match is found

**How to test:**
1. Set up multi-site Umbraco with two domains (e.g., `localhost` and `test.localhost`)
2. Create a page `page2` on Site2 (test.localhost)
3. Rename the page to `page2-redirect` to create a redirect from the old URL
4. Request `localhost/page2` → should return 404
5. Request `test.localhost/page2` → should redirect to `test.localhost/page2-redirect`

**Unit tests added:**
- `Domain_Specific_Redirect_Takes_Priority_Over_Path_Only_Redirect`
- `Falls_Back_To_Path_Only_Redirect_When_No_Domain_Specific_Exists`

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=207491815