### PR TITLE
Tests: Fix intermittent failure in `RecycleBinMediaProtectionHelperTests`

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/RecycleBinMediaProtectionHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/RecycleBinMediaProtectionHelperTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Data;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -18,7 +19,7 @@ public class RecycleBinMediaProtectionHelperTests
     public void DeleteContainedFilesWithProtection_WithTrashedMedia_DeletesFilesWithSuffix()
     {
         // Arrange
-        var deletedFiles = new List<string>();
+        var deletedFiles = new ConcurrentBag<string>();
         var fileSystemMock = new Mock<IFileSystem>();
         fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
         fileSystemMock
@@ -38,14 +39,14 @@ public class RecycleBinMediaProtectionHelperTests
 
         // Assert
         Assert.That(deletedFiles, Has.Count.EqualTo(1));
-        Assert.That(deletedFiles[0], Is.EqualTo("media/test/image.deleted.jpg"));
+        Assert.That(deletedFiles.Single(), Is.EqualTo("media/test/image.deleted.jpg"));
     }
 
     [Test]
     public void DeleteContainedFilesWithProtection_WithNonTrashedMedia_DeletesFilesWithoutSuffix()
     {
         // Arrange
-        var deletedFiles = new List<string>();
+        var deletedFiles = new ConcurrentBag<string>();
         var fileSystemMock = new Mock<IFileSystem>();
         fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
         fileSystemMock
@@ -65,14 +66,14 @@ public class RecycleBinMediaProtectionHelperTests
 
         // Assert
         Assert.That(deletedFiles, Has.Count.EqualTo(1));
-        Assert.That(deletedFiles[0], Is.EqualTo("media/test/image.jpg"));
+        Assert.That(deletedFiles.Single(), Is.EqualTo("media/test/image.jpg"));
     }
 
     [Test]
     public void DeleteContainedFilesWithProtection_WithTrashedAndNonTrashedMedia_DeletesBothCorrectly()
     {
         // Arrange
-        var deletedFiles = new List<string>();
+        var deletedFiles = new ConcurrentBag<string>();
         var fileSystemMock = new Mock<IFileSystem>();
         fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
         fileSystemMock
@@ -130,7 +131,7 @@ public class RecycleBinMediaProtectionHelperTests
     public void DeleteContainedFilesWithProtection_WithMultipleFiles_DeletesAllWithCorrectSuffix()
     {
         // Arrange
-        var deletedFiles = new List<string>();
+        var deletedFiles = new ConcurrentBag<string>();
         var fileSystemMock = new Mock<IFileSystem>();
         fileSystemMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
         fileSystemMock


### PR DESCRIPTION
## Description
I noticed we were getting intermittent, cross-platform failures on some unit tests I recently added.  I don't see a problem locally, but following some analysis, the problem looks to be the tests using a non-thread safe collection, but the code under test does some parallel processing (when deleting files).

So this PR updates to use a thread-safe collection for tracking test actions.

## Change Details
- Fixed intermittent test failure in `DeleteContainedFilesWithProtection_WithMultipleFiles_DeletesAllWithCorrectSuffix`
- The `MediaFileManager.DeleteMediaFiles` method uses `Parallel.ForEach` with up to 20 threads
- Tests were using `List<string>` to capture deleted files, which is not thread-safe
- Changed to `ConcurrentBag<string>` to ensure thread-safe collection access

## Testing
Verify these tests no longer fails intermittently on the cross-platform build pipeline
