### PR TITLE
Gitignore: Exclude acceptance test results from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ tools/docfx/
 /tests/Umbraco.Tests.Integration/Views/
 /tests/Umbraco.Tests.UnitTests/[Uu]mbraco/[Dd]ata/TEMP/
 /BenchmarkDotNet.Artifacts/
+playwright-report
+trace.zip
+/tests/Umbraco.Tests.AcceptanceTest/results
 
 # Ignore auto-generated schema
 /src/Umbraco.Cms.Targets/tasks/
@@ -108,6 +111,3 @@ tools/docfx/
 /tests/Umbraco.Tests.Integration/appsettings-schema.*.json
 /tests/Umbraco.Tests.Integration/umbraco-package-schema.json
 /src/Umbraco.Cms/appsettings-schema.json
-playwright-report
-trace.zip
-/tests/Umbraco.Tests.AcceptanceTest/results


### PR DESCRIPTION
### Prerequisites

I think the results folder should be ignored. This is important for locally executed acceptance tests.
