### PR TITLE
Multi-node picker: Validate content type when filter is configured but object type is not (closes #21338)

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiNodeTreePickerPropertyEditor.cs
@@ -3,8 +3,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Nodes;
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
@@ -348,18 +346,21 @@ public class MultiNodeTreePickerPropertyEditor : DataEditor
 
                 Guid[] allowedTypes = configuration?.Filter?.Split(Constants.CharArrays.Comma, StringSplitOptions.RemoveEmptyEntries).Select(Guid.Parse).ToArray() ?? [];
 
-                // We can't validate if there is no object type, and we don't need to if there's no filter.
-                if (entityReferences is null || allowedTypes.Length == 0 || configuration?.TreeSource?.ObjectType is null)
+                // Don't need to validate if there's no filter.
+                if (entityReferences is null || allowedTypes.Length == 0)
                 {
                     return validationResults;
                 }
+
+                // If no object type is specified, it's considered as document.
+                var objectType = configuration?.TreeSource?.ObjectType ?? DocumentObjectType;
 
                 using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
 
                 Guid?[] uniqueContentTypeKeys = entityReferences
                     .Select(x => x.Unique)
                     .Distinct()
-                    .Select(x => GetContent(configuration.TreeSource.ObjectType, x))
+                    .Select(x => GetContent(objectType, x))
                     .Select(x => x?.ContentType.Key)
                     .Distinct()
                     .ToArray();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiNodeTreePickerValidationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/MultiNodeTreePickerValidationTests.cs
@@ -135,10 +135,11 @@ public class MultiNodeTreePickerValidationTests
     [TestCase(false, false, true, MultiNodeTreePickerPropertyEditor.MultiNodeTreePickerPropertyValueEditor.DocumentObjectType)]
     [TestCase(false, false, true, MultiNodeTreePickerPropertyEditor.MultiNodeTreePickerPropertyValueEditor.MediaObjectType)]
     [TestCase(false, false, true, MultiNodeTreePickerPropertyEditor.MultiNodeTreePickerPropertyValueEditor.MemberObjectType)]
+    [TestCase(false, true, false, null)] // Null object type should be treated as being for document.
     [TestCase(false, true, false, MultiNodeTreePickerPropertyEditor.MultiNodeTreePickerPropertyValueEditor.DocumentObjectType)]
     [TestCase(false, true, false, MultiNodeTreePickerPropertyEditor.MultiNodeTreePickerPropertyValueEditor.MediaObjectType)]
     [TestCase(false, true, false, MultiNodeTreePickerPropertyEditor.MultiNodeTreePickerPropertyValueEditor.MemberObjectType)]
-    public void Validates_Allowed_Type(bool shouldSucceed, bool hasAllowedType, bool findsContent, string objectType)
+    public void Validates_Allowed_Type(bool shouldSucceed, bool hasAllowedType, bool findsContent, string? objectType)
     {
         var (valueEditor, _, contentService, mediaService, memberService) = CreateValueEditor();
 
@@ -170,7 +171,6 @@ public class MultiNodeTreePickerValidationTests
 
         var result = valueEditor.Validate(value, false, null, PropertyValidationContext.Empty());
         TestShouldSucceed(shouldSucceed, result);
-
     }
 
     private static (MultiNodeTreePickerPropertyEditor.MultiNodeTreePickerPropertyValueEditor ValueEditor,


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/21338 reports an issue where a content picker fails to validate for allowed types.  I found it happens as we have a short-circuit when the object type - document, media or member - isn't defined.  That makes sense, as we need to know that to know what type the defined GUIDs for the allow types represent, in order to look them up using the appropriate service.

I can see it happens from the front-end if you don't touch the "Node type" drop-down list.  It'll then be submitted as null when the data type is saved, and so no object type is recorded.  It only saves if you touch the drop-down list, e.g. set it to "media".

So whilst perhaps this could be fixed on the front-end, ensuring an object type is provided, we can safely assume that "no object type" = "no selection of object type in the backoffice" = " document by default".  And as we'll have data types saved already like this, it's better to make that deduction on the server.

## Change Summary
- Fixes issue where the Multi Node Tree Picker's content type validation was skipped when allowed types (`Filter`) were configured but the object type (document/media/member) was not specified.
- When no object type is specified, it now defaults to "document" instead of skipping validation entirely.
- Added a unit test to verify the new behaviour

## Testing

See steps to reproduce on the linked issue.