### PR TITLE
Export UmbMediaPickerModalData and UmbMediaPickerModalValue types

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
@@ -2,7 +2,12 @@ export * from './audit-log/index.js';
 export * from './components/index.js';
 export * from './constants.js';
 export * from './dropzone/index.js';
-export { UMB_IMAGE_CROPPER_EDITOR_MODAL, UMB_MEDIA_PICKER_MODAL } from './modals/index.js';
+export {
+	UMB_IMAGE_CROPPER_EDITOR_MODAL,
+	UMB_MEDIA_PICKER_MODAL,
+	type UmbMediaPickerModalData,
+	type UmbMediaPickerModalValue,
+} from './modals/index.js';
 export * from './recycle-bin/index.js';
 export * from './reference/index.js';
 export * from './repository/index.js';


### PR DESCRIPTION
Fixes #21265

This change exports the media picker modal types (UmbMediaPickerModalData and UmbMediaPickerModalValue) from the @umbraco-cms/backoffice/media package, making them available for use in external code, consistent with how other packages like @umbraco-cms/backoffice/static-file and @umbraco-cms/backoffice/embedded-media export their modal types.

Changed the specific export statement to use export * from './modals/index.js' instead of selectively exporting only the modal token constants.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
