### PR TITLE
Mobile navigation: enable horizontal scroll on small screens

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -319,7 +319,7 @@ export class UmbAppElement extends UmbLitElement {
 	static override styles = css`
 		:host {
 			overflow: hidden;
-			min-width: 800px;
+			min-width: 920px;
 		}
 
 		:host,


### PR DESCRIPTION
Enable sideways/horizontal scroll on small screens by enforing a width of 920px.

<img width="830" height="830" alt="image" src="https://github.com/user-attachments/assets/5943d3e0-6a6f-4e87-ba3f-a59d089d4e3a" />
