### PR TITLE
Backoffice Performance: Use import maps to save requests

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-item/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-item/index.ts
@@ -5,3 +5,5 @@ export * from './utils.js';
 export type { UmbItemModel } from './types.js';
 
 export type { UmbItemDataResolver, UmbItemDataResolverConstructor } from './data-resolver/types.js';
+
+import './global-components.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entry-point.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entry-point.ts
@@ -19,7 +19,7 @@ import '@umbraco-cms/backoffice/menu';
 import '@umbraco-cms/backoffice/property-action';
 import '@umbraco-cms/backoffice/property-editor-data-source';
 import '@umbraco-cms/backoffice/property-sort-mode';
-import './entity-item/global-components.js';
+import '@umbraco-cms/backoffice/entity-item';
 
 export const onInit: UmbEntryPointOnInit = (host, extensionRegistry) => {
 	new UmbExtensionsApiInitializer(host, extensionRegistry, 'globalContext', [host]);


### PR DESCRIPTION
A small optimization to use the import maps in the core entry point file, which saves 4 initial requests. I know not much, but its something.