### PR TITLE
Collections: fix `create` action causing full page navigation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/action/create/collection-create-action.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/action/create/collection-create-action.element.ts
@@ -33,12 +33,12 @@ export class UmbCollectionCreateActionButtonElement extends UmbLitElement {
 	}
 
 	async #onClick(event: Event, controller: UmbExtensionApiInitializer<ManifestType>, href?: string) {
-		event.stopPropagation();
-
 		// skip if href is defined
 		if (href) {
 			return;
 		}
+
+		event.stopPropagation();
 
 		if (!controller.api) throw new Error('No API found');
 		await controller.api.execute().catch(() => {});


### PR DESCRIPTION
When a `create` `collectionAction` had an `href`, clicking it would trigger a full browser navigation instead of using `history.pushState()` for routing. This was caused by `event.stopPropagation()` being called before the early return when an `href` was present, preventing the global `ensureAnchorHistory()` listener from intercepting the click event.

The fix moves `stopPropagation()` to only execute when the click is being handled via `execute()` (no `href`), allowing `href`-based navigation to bubble up.

Before:

https://github.com/user-attachments/assets/6b60fa99-fe1f-4565-bad6-388af16ad30e

After:

https://github.com/user-attachments/assets/c52b2850-3ed7-4616-b6a7-1a995bc2431e

