### PR TITLE
Code Quality: Fix `SA1500`, `SA1111` and `SA1134` StyleCop warnings

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Services/Entities/UserStartNodeEntitiesService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Entities/UserStartNodeEntitiesService.cs
@@ -11,12 +11,21 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Api.Management.Services.Entities;
 
+/// <summary>
+/// Provides functionality for retrieving user start node entities with access information.
+/// </summary>
 public class UserStartNodeEntitiesService : IUserStartNodeEntitiesService
 {
     private readonly IEntityService _entityService;
     private readonly ICoreScopeProvider _scopeProvider;
     private readonly IIdKeyMap _idKeyMap;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserStartNodeEntitiesService"/> class.
+    /// </summary>
+    /// <param name="entityService">The entity service.</param>
+    /// <param name="scopeProvider">The core scope provider.</param>
+    /// <param name="idKeyMap">The ID to key mapping service.</param>
     public UserStartNodeEntitiesService(IEntityService entityService, ICoreScopeProvider scopeProvider, IIdKeyMap idKeyMap)
     {
         _entityService = entityService;
@@ -150,8 +159,7 @@ public class UserStartNodeEntitiesService : IUserStartNodeEntitiesService
         int after,
         Ordering ordering,
         out long totalBefore,
-        out long totalAfter
-        )
+        out long totalAfter)
     {
         Attempt<int> targetIdAttempt = _idKeyMap.GetIdForKey(targetKey, umbracoObjectType);
         if (targetIdAttempt.Success is false)

--- a/src/Umbraco.Core/Models/Membership/IUserGroup.cs
+++ b/src/Umbraco.Core/Models/Membership/IUserGroup.cs
@@ -4,12 +4,24 @@ using Umbraco.Cms.Core.Models.Membership.Permissions;
 
 namespace Umbraco.Cms.Core.Models.Membership;
 
+/// <summary>
+/// Represents a user group in Umbraco.
+/// </summary>
 public interface IUserGroup : IEntity, IRememberBeingDirty
 {
+    /// <summary>
+    /// Gets or sets the alias of the user group.
+    /// </summary>
     string Alias { get; set; }
 
+    /// <summary>
+    /// Gets or sets the starting content node ID for this user group.
+    /// </summary>
     int? StartContentId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the starting media node ID for this user group.
+    /// </summary>
     int? StartMediaId { get; set; }
 
     /// <summary>
@@ -22,8 +34,14 @@ public interface IUserGroup : IEntity, IRememberBeingDirty
     /// </summary>
     string? Name { get; set; }
 
+    /// <summary>
+    /// Gets or sets the description of the user group.
+    /// </summary>
+    /// <remarks>
     /// TODO (V18): Remove the default implementations.
-    string? Description {
+    /// </remarks>
+    string? Description
+    {
         get => null;
         set { }
     }
@@ -46,26 +64,57 @@ public interface IUserGroup : IEntity, IRememberBeingDirty
     /// </remarks>
     ISet<string> Permissions { get; set; }
 
+    /// <summary>
+    /// Gets or sets the granular permissions for this user group.
+    /// </summary>
     ISet<IGranularPermission> GranularPermissions { get; set; }
 
+    /// <summary>
+    /// Gets the collection of section aliases that this user group has access to.
+    /// </summary>
     IEnumerable<string> AllowedSections { get; }
 
+    /// <summary>
+    /// Removes access to a section for this user group.
+    /// </summary>
+    /// <param name="sectionAlias">The alias of the section to remove.</param>
     void RemoveAllowedSection(string sectionAlias);
 
+    /// <summary>
+    /// Adds access to a section for this user group.
+    /// </summary>
+    /// <param name="sectionAlias">The alias of the section to add.</param>
     void AddAllowedSection(string sectionAlias);
 
+    /// <summary>
+    /// Removes access to all sections for this user group.
+    /// </summary>
     void ClearAllowedSections();
 
+    /// <summary>
+    /// Gets the collection of language IDs that this user group has access to.
+    /// </summary>
     IEnumerable<int> AllowedLanguages => Enumerable.Empty<int>();
 
+    /// <summary>
+    /// Removes access to a language for this user group.
+    /// </summary>
+    /// <param name="languageId">The ID of the language to remove.</param>
     void RemoveAllowedLanguage(int languageId)
     {
     }
 
+    /// <summary>
+    /// Adds access to a language for this user group.
+    /// </summary>
+    /// <param name="languageId">The ID of the language to add.</param>
     void AddAllowedLanguage(int languageId)
     {
     }
 
+    /// <summary>
+    /// Removes access to all languages for this user group.
+    /// </summary>
     void ClearAllowedLanguages()
     {
     }

--- a/src/Umbraco.Core/Services/ContentValidationServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentValidationServiceBase.cs
@@ -52,13 +52,12 @@ internal abstract class ContentValidationServiceBase<TContentType>
 
         // We don't have managed segments, so we have to make do with the ones passed in the model.
         var segments =
-            new string?[] { null }
-                .Union(contentEditingModelBase.Variants
-                    .Where(variant => variant.Culture is null || cultures.Contains(variant.Culture))
-                    .DistinctBy(variant => variant.Segment).Select(variant => variant.Segment)
-                    .WhereNotNull()
-                )
-                .ToArray();
+        new string?[] { null }
+            .Union(contentEditingModelBase.Variants
+                .Where(variant => variant.Culture is null || cultures.Contains(variant.Culture))
+                .DistinctBy(variant => variant.Segment).Select(variant => variant.Segment)
+                .WhereNotNull())
+            .ToArray();
 
         foreach (IPropertyType propertyType in invariantPropertyTypes)
         {

--- a/src/Umbraco.Core/Services/PublishStatus/PublishStatusInitializationNotificationHandler.cs
+++ b/src/Umbraco.Core/Services/PublishStatus/PublishStatusInitializationNotificationHandler.cs
@@ -5,23 +5,28 @@ using Umbraco.Cms.Core.Notifications;
 namespace Umbraco.Cms.Core.Services.Navigation;
 
 /// <summary>
-///     Responsible for seeding the in-memory publish status cache at application's startup
-///     by loading all data from the database.
+/// Responsible for seeding the in-memory publish status cache at application's startup
+/// by loading all data from the database.
 /// </summary>
 public sealed class PublishStatusInitializationNotificationHandler : INotificationAsyncHandler<PostRuntimePremigrationsUpgradeNotification>
 {
     private readonly IRuntimeState _runtimeState;
     private readonly IPublishStatusManagementService _publishStatusManagementService;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublishStatusInitializationNotificationHandler"/> class.
+    /// </summary>
+    /// <param name="runtimeState">The runtime state.</param>
+    /// <param name="publishStatusManagementService">The publish status management service.</param>
     public PublishStatusInitializationNotificationHandler(
         IRuntimeState runtimeState,
-        IPublishStatusManagementService publishStatusManagementService
-        )
+        IPublishStatusManagementService publishStatusManagementService)
     {
         _runtimeState = runtimeState;
         _publishStatusManagementService = publishStatusManagementService;
     }
 
+    /// <inheritdoc />
     public async Task HandleAsync(PostRuntimePremigrationsUpgradeNotification notification, CancellationToken cancellationToken)
     {
         if(_runtimeState.Level < RuntimeLevel.Upgrade)

--- a/src/Umbraco.Core/Services/ServiceContext.cs
+++ b/src/Umbraco.Core/Services/ServiceContext.cs
@@ -1,4 +1,4 @@
-﻿namespace Umbraco.Cms.Core.Services;
+namespace Umbraco.Cms.Core.Services;
 
 /// <summary>
 ///     Represents the Umbraco Service context, which provides access to all services.
@@ -34,8 +34,35 @@ public class ServiceContext
     private readonly Lazy<IWebhookService>? _webhookService;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="ServiceContext" /> class with lazy services.
+    /// Initializes a new instance of the <see cref="ServiceContext" /> class with lazy services.
     /// </summary>
+    /// <param name="publicAccessService">The public access service.</param>
+    /// <param name="domainService">The domain service.</param>
+    /// <param name="auditService">The audit service.</param>
+    /// <param name="localizedTextService">The localized text service.</param>
+    /// <param name="tagService">The tag service.</param>
+    /// <param name="contentService">The content service.</param>
+    /// <param name="userService">The user service.</param>
+    /// <param name="memberService">The member service.</param>
+    /// <param name="mediaService">The media service.</param>
+    /// <param name="contentTypeService">The content type service.</param>
+    /// <param name="mediaTypeService">The media type service.</param>
+    /// <param name="dataTypeService">The data type service.</param>
+    /// <param name="fileService">The file service.</param>
+    /// <param name="localizationService">The localization service.</param>
+    /// <param name="packagingService">The packaging service.</param>
+    /// <param name="serverRegistrationService">The server registration service.</param>
+    /// <param name="entityService">The entity service.</param>
+    /// <param name="relationService">The relation service.</param>
+    /// <param name="memberTypeService">The member type service.</param>
+    /// <param name="memberGroupService">The member group service.</param>
+    /// <param name="notificationService">The notification service.</param>
+    /// <param name="externalLoginService">The external login service.</param>
+    /// <param name="redirectUrlService">The redirect URL service.</param>
+    /// <param name="consentService">The consent service.</param>
+    /// <param name="keyValueService">The key-value service.</param>
+    /// <param name="contentTypeBaseServiceProvider">The content type base service provider.</param>
+    /// <param name="webhookService">The webhook service.</param>
     public ServiceContext(
         Lazy<IPublicAccessService>? publicAccessService,
         Lazy<IDomainService>? domainService,
@@ -230,10 +257,38 @@ public class ServiceContext
     public IWebhookService? WebhookService => _webhookService?.Value;
 
     /// <summary>
-    ///     Creates a partial service context with only some services (for tests).
+    /// Creates a partial service context with only some services (for tests).
     /// </summary>
+    /// <param name="contentService">The content service.</param>
+    /// <param name="mediaService">The media service.</param>
+    /// <param name="contentTypeService">The content type service.</param>
+    /// <param name="mediaTypeService">The media type service.</param>
+    /// <param name="dataTypeService">The data type service.</param>
+    /// <param name="fileService">The file service.</param>
+    /// <param name="localizationService">The localization service.</param>
+    /// <param name="packagingService">The packaging service.</param>
+    /// <param name="entityService">The entity service.</param>
+    /// <param name="relationService">The relation service.</param>
+    /// <param name="memberGroupService">The member group service.</param>
+    /// <param name="memberTypeService">The member type service.</param>
+    /// <param name="memberService">The member service.</param>
+    /// <param name="userService">The user service.</param>
+    /// <param name="tagService">The tag service.</param>
+    /// <param name="notificationService">The notification service.</param>
+    /// <param name="localizedTextService">The localized text service.</param>
+    /// <param name="auditService">The audit service.</param>
+    /// <param name="domainService">The domain service.</param>
+    /// <param name="publicAccessService">The public access service.</param>
+    /// <param name="externalLoginService">The external login service.</param>
+    /// <param name="serverRegistrationService">The server registration service.</param>
+    /// <param name="redirectUrlService">The redirect URL service.</param>
+    /// <param name="consentService">The consent service.</param>
+    /// <param name="keyValueService">The key-value service.</param>
+    /// <param name="contentTypeBaseServiceProvider">The content type base service provider.</param>
+    /// <param name="webhookService">The webhook service.</param>
+    /// <returns>A new <see cref="ServiceContext"/> instance with the specified services.</returns>
     /// <remarks>
-    ///     <para>Using a true constructor for this confuses DI containers.</para>
+    /// <para>Using a true constructor for this confuses DI containers.</para>
     /// </remarks>
     public static ServiceContext CreatePartial(
         IContentService? contentService = null,
@@ -296,7 +351,6 @@ public class ServiceContext
             Lazy(consentService),
             Lazy(keyValueService),
             Lazy(contentTypeBaseServiceProvider),
-            Lazy(webhookService)
-            );
+            Lazy(webhookService));
     }
 }

--- a/src/Umbraco.Core/Webhooks/Events/User/AssignedUserGroupPermissionsWebhookEvent.cs
+++ b/src/Umbraco.Core/Webhooks/Events/User/AssignedUserGroupPermissionsWebhookEvent.cs
@@ -7,11 +7,22 @@ using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Core.Webhooks.Events;
 
+/// <summary>
+/// Webhook event that fires when user group permissions are assigned.
+/// </summary>
 [WebhookEvent("User Group Permissions Assigned")]
 public class AssignedUserGroupPermissionsWebhookEvent : WebhookEventBase<AssignedUserGroupPermissionsNotification>
 {
     private readonly IIdKeyMap _idKeyMap;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssignedUserGroupPermissionsWebhookEvent"/> class.
+    /// </summary>
+    /// <param name="webhookFiringService">The webhook firing service.</param>
+    /// <param name="webHookService">The webhook service.</param>
+    /// <param name="webhookSettings">The webhook settings.</param>
+    /// <param name="serverRoleAccessor">The server role accessor.</param>
+    /// <param name="idKeyMap">The ID to key mapping service.</param>
     public AssignedUserGroupPermissionsWebhookEvent(
         IWebhookFiringService webhookFiringService,
         IWebhookService webHookService,
@@ -23,11 +34,14 @@ public class AssignedUserGroupPermissionsWebhookEvent : WebhookEventBase<Assigne
         _idKeyMap = idKeyMap;
     }
 
+    /// <inheritdoc />
     public override string Alias => Constants.WebhookEvents.Aliases.AssignedUserGroupPermissions;
 
+    /// <inheritdoc />
     public override object ConvertNotificationToRequestPayload(AssignedUserGroupPermissionsNotification notification)
         => notification.EntityPermissions.Select(permission =>
-        new {
+        new
+        {
             UserId = _idKeyMap.GetKeyForId(permission.EntityId, UmbracoObjectTypes.Unknown).Result,
             UserGroupId = _idKeyMap.GetKeyForId(permission.UserGroupId, UmbracoObjectTypes.Unknown).Result,
         });

--- a/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsUserExtensions.cs
+++ b/src/Umbraco.Core/Webhooks/WebhookEventCollectionBuilderCmsUserExtensions.cs
@@ -46,7 +46,8 @@ public static class WebhookEventCollectionBuilderCmsUserExtensions
     /// The builder.
     /// </returns>
     public static WebhookEventCollectionBuilderCmsUser AddLogin(this WebhookEventCollectionBuilderCmsUser builder, WebhookPayloadType payloadType = WebhookPayloadType.Legacy)
-    {switch (payloadType)
+    {
+        switch (payloadType)
         {
             case WebhookPayloadType.Extended:
             case WebhookPayloadType.Minimal:

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeLogStatusCode.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_13_0_0/ChangeLogStatusCode.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Infrastructure.Persistence;
@@ -52,7 +52,8 @@ public class ChangeLogStatusCode : MigrationBase
         [PrimaryKeyColumn(AutoIncrement = true)]
         public int Id { get; set; }
 
-        [Column("webhookKey")] public Guid WebhookKey { get; set; }
+        [Column("webhookKey")]
+        public Guid WebhookKey { get; set; }
 
         [Column(Name = "key")]
         [NullSetting(NullSetting = NullSettings.NotNull)]

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/AddGuidsToUsers.cs
@@ -1,4 +1,4 @@
-﻿using NPoco;
+using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_14_0_0;
 using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
@@ -201,14 +201,17 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
         [Constraint(Default = "0")]
         public bool NoConsole { get; set; }
 
-        [Column("userName")] public string UserName { get; set; } = null!;
+        [Column("userName")]
+        public string UserName { get; set; } = null!;
 
         [Column("userLogin")]
         [Length(125)]
         [Index(IndexTypes.NonClustered)]
         public string? Login { get; set; }
 
-        [Column("userPassword")] [Length(500)] public string? Password { get; set; }
+        [Column("userPassword")]
+        [Length(500)]
+        public string? Password { get; set; }
 
         /// <summary>
         ///     This will represent a JSON structure of how the password has been created (i.e hash algorithm, iterations)
@@ -218,7 +221,8 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
         [Length(500)]
         public string? PasswordConfig { get; set; }
 
-        [Column("userEmail")] public string Email { get; set; } = null!;
+        [Column("userEmail")]
+        public string Email { get; set; } = null!;
 
         [Column("userLanguage")]
         [NullSetting(NullSetting = NullSettings.Null)]
@@ -320,14 +324,17 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
         [Constraint(Default = "0")]
         public bool NoConsole { get; set; }
 
-        [Column("userName")] public string UserName { get; set; } = null!;
+        [Column("userName")]
+        public string UserName { get; set; } = null!;
 
         [Column("userLogin")]
         [Length(125)]
         [Index(IndexTypes.NonClustered)]
         public string? Login { get; set; }
 
-        [Column("userPassword")] [Length(500)] public string? Password { get; set; }
+        [Column("userPassword")]
+        [Length(500)]
+        public string? Password { get; set; }
 
         /// <summary>
         ///     This will represent a JSON structure of how the password has been created (i.e hash algorithm, iterations)
@@ -337,7 +344,8 @@ internal class AddGuidsToUsers : UnscopedMigrationBase
         [Length(500)]
         public string? PasswordConfig { get; set; }
 
-        [Column("userEmail")] public string Email { get; set; } = null!;
+        [Column("userEmail")]
+        public string Email { get; set; } = null!;
 
         [Column("userLanguage")]
         [NullSetting(NullSetting = NullSettings.Null)]

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateTours.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/MigrateTours.cs
@@ -178,14 +178,17 @@ internal class MigrateTours : UnscopedMigrationBase
         [Constraint(Default = "0")]
         public bool NoConsole { get; set; }
 
-        [Column("userName")] public string UserName { get; set; } = null!;
+        [Column("userName")]
+        public string UserName { get; set; } = null!;
 
         [Column("userLogin")]
         [Length(125)]
         [Index(IndexTypes.NonClustered)]
         public string? Login { get; set; }
 
-        [Column("userPassword")] [Length(500)] public string? Password { get; set; }
+        [Column("userPassword")]
+        [Length(500)]
+        public string? Password { get; set; }
 
         /// <summary>
         ///     This will represent a JSON structure of how the password has been created (i.e hash algorithm, iterations)
@@ -195,7 +198,8 @@ internal class MigrateTours : UnscopedMigrationBase
         [Length(500)]
         public string? PasswordConfig { get; set; }
 
-        [Column("userEmail")] public string Email { get; set; } = null!;
+        [Column("userEmail")]
+        public string Email { get; set; } = null!;
 
         [Column("userLanguage")]
         [NullSetting(NullSetting = NullSettings.Null)]

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepositoryBase.cs
@@ -27,8 +27,13 @@ public abstract class EntityRepositoryBase<TId, TEntity> : RepositoryBase, IRead
     private IQuery<TEntity>? _hasIdQuery;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="EntityRepositoryBase{TId, TEntity}" /> class.
+    /// Initializes a new instance of the <see cref="EntityRepositoryBase{TId, TEntity}" /> class.
     /// </summary>
+    /// <param name="scopeAccessor">The scope accessor.</param>
+    /// <param name="appCaches">The application caches.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="repositoryCacheVersionService">The repository cache version service.</param>
+    /// <param name="cacheSyncService">The cache synchronization service.</param>
     protected EntityRepositoryBase(
         IScopeAccessor scopeAccessor,
         AppCaches appCaches,
@@ -228,8 +233,7 @@ public abstract class EntityRepositoryBase<TId, TEntity> : RepositoryBase, IRead
             ScopeAccessor,
             DefaultOptions,
             RepositoryCacheVersionService,
-            CacheSyncService
-            );
+            CacheSyncService);
 
     protected abstract TEntity? PerformGet(TId? id);
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RelationRepository.cs
@@ -432,7 +432,8 @@ internal sealed class RelationRepository : EntityRepositoryBase<int, IRelation>,
 
     protected override IEnumerable<string> GetDeleteClauses()
     {
-        var list = new List<string> {
+        var list = new List<string>
+        {
             $"DELETE FROM {QuoteTableName(Constants.DatabaseSchema.Tables.Relation)} WHERE id = @id"
         };
         return list;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
@@ -447,25 +447,35 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
 
         private sealed class UnionHelperDto
         {
-            [Column("id")] public int Id { get; set; }
+            [Column("id")]
+            public int Id { get; set; }
 
-            [Column("otherId")] public int OtherId { get; set; }
+            [Column("otherId")]
+            public int OtherId { get; set; }
 
-            [Column("key")] public Guid Key { get; set; }
+            [Column("key")]
+            public Guid Key { get; set; }
 
-            [Column("trashed")] public bool Trashed { get; set; }
+            [Column("trashed")]
+            public bool Trashed { get; set; }
 
-            [Column("nodeObjectType")] public Guid NodeObjectType { get; set; }
+            [Column("nodeObjectType")]
+            public Guid NodeObjectType { get; set; }
 
-            [Column("otherKey")] public Guid OtherKey { get; set; }
+            [Column("otherKey")]
+            public Guid OtherKey { get; set; }
 
-            [Column("alias")] public string? Alias { get; set; }
+            [Column("alias")]
+            public string? Alias { get; set; }
 
-            [Column("name")] public string? Name { get; set; }
+            [Column("name")]
+            public string? Name { get; set; }
 
-            [Column("isDependency")] public bool IsDependency { get; set; }
+            [Column("isDependency")]
+            public bool IsDependency { get; set; }
 
-            [Column("dual")] public bool Dual { get; set; }
+            [Column("dual")]
+            public bool Dual { get; set; }
         }
 
         private RelationItem MapDtoToEntity(RelationItemDto dto) =>

--- a/src/Umbraco.PublishedCache.HybridCache/Factories/CacheNodeFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/CacheNodeFactory.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
@@ -21,10 +21,9 @@ internal sealed class CacheNodeFactory : ICacheNodeFactory
 
         ContentData contentData = GetContentData(
             content,
-              GetPublishedValue(content, preview),
-              GetTemplateId(content, preview),
-              content.PublishCultureInfos!.Values.Select(x=>x.Culture).ToHashSet()
-            );
+            GetPublishedValue(content, preview),
+            GetTemplateId(content, preview),
+            content.PublishCultureInfos!.Values.Select(x => x.Culture).ToHashSet());
         return new ContentCacheNode
         {
             Id = content.Id,

--- a/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/ManagementApiTest.cs
@@ -207,6 +207,7 @@ public abstract class ManagementApiTest<T> : UmbracoTestServerTestBase
 
     private class TokenModel
     {
-        [JsonPropertyName("access_token")] public string AccessToken { get; set; }
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; set; }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoFetchTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/NPocoTests/NPocoFetchTests.cs
@@ -490,9 +490,11 @@ JOIN zbThingA3 a3x ON a2x.id=a3x.id
     [ExplicitColumns]
     public class Thing4Dto
     {
-        [Column("id")] public int Id { get; set; }
+        [Column("id")]
+        public int Id { get; set; }
 
-        [Column("name")] public string Name { get; set; }
+        [Column("name")]
+        public string Name { get; set; }
 
         // reference is required else FetchOneToMany aggregation does not happen
         // not sure ColumnName nor ReferenceMemberName make much sense here
@@ -505,9 +507,11 @@ JOIN zbThingA3 a3x ON a2x.id=a3x.id
     [ExplicitColumns]
     public class Thing5Dto
     {
-        [Column("id")] public int Id { get; set; }
+        [Column("id")]
+        public int Id { get; set; }
 
-        [Column("name")] public string Name { get; set; }
+        [Column("name")]
+        public string Name { get; set; }
 
         [Column("groupCount")]
         [ResultColumn] // not included in insert/update, not sql-generated
@@ -539,9 +543,11 @@ JOIN zbThingA3 a3x ON a2x.id=a3x.id
     [ExplicitColumns]
     public class ThingA2Dto
     {
-        [Column("id")] public int Id { get; set; }
+        [Column("id")]
+        public int Id { get; set; }
 
-        [Column("name")] public string Name { get; set; }
+        [Column("name")]
+        public string Name { get; set; }
 
         [ResultColumn]
         [Reference(ReferenceType.OneToOne)]
@@ -553,19 +559,24 @@ JOIN zbThingA3 a3x ON a2x.id=a3x.id
     [ExplicitColumns]
     public class ThingA3Dto
     {
-        [Column("id")] public int Id { get; set; }
+        [Column("id")]
+        public int Id { get; set; }
 
-        [Column("name")] public string Name { get; set; }
+        [Column("name")]
+        public string Name { get; set; }
     }
 
     [TableName("zbThingA12")]
     [ExplicitColumns]
     public class ThingA12Dto
     {
-        [Column("thing1id")] public int Thing1Id { get; set; }
+        [Column("thing1id")]
+        public int Thing1Id { get; set; }
 
-        [Column("thing2id")] public int Thing2Id { get; set; }
+        [Column("thing2id")]
+        public int Thing2Id { get; set; }
 
-        [Column("name")] public string Name { get; set; }
+        [Column("name")]
+        public string Name { get; set; }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Editing.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
@@ -43,44 +43,43 @@ internal partial class BlockListElementLevelVariationTests
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                ),
+                        null)),
                 (
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -203,44 +202,43 @@ internal partial class BlockListElementLevelVariationTests
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The second invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The second content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The second content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The second content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The second invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The second settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The second settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The second settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                ),
+                        null)),
                 (
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The second invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The second content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The second content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The second content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The second invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The second settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The second settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The second settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         var updateModel = new ContentUpdateModel
         {
@@ -335,44 +333,43 @@ internal partial class BlockListElementLevelVariationTests
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                ),
+                        null)),
                 (
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         content.Properties["blocks"]!.SetValue(JsonSerializer.Serialize(blockListValue));
         ContentService.Save(content);
@@ -497,44 +494,43 @@ internal partial class BlockListElementLevelVariationTests
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The second invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The second content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The second content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The second content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The second invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The second settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The second settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The second settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                ),
+                        null)),
                 (
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The second invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The second content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The second content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The second content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The second invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The second settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The second settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The second settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         var updateModel = new ContentUpdateModel
         {
@@ -627,13 +623,15 @@ internal partial class BlockListElementLevelVariationTests
                     firstContentElementKey,
                     firstSettingsElementKey,
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first content value in German", Culture = "de-DE" },
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in Danish", Culture = "da-DK" },
@@ -645,13 +643,15 @@ internal partial class BlockListElementLevelVariationTests
                     secondContentElementKey,
                     secondSettingsElementKey,
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first content value in German", Culture = "de-DE" },
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in Danish", Culture = "da-DK" },
@@ -673,7 +673,8 @@ internal partial class BlockListElementLevelVariationTests
                 Key = newContentElementKey,
                 ContentTypeAlias = elementType.Alias,
                 ContentTypeKey = elementType.Key,
-                Values = new List<BlockPropertyValue> {
+                Values = new List<BlockPropertyValue>
+                        {
                     new() { Alias = "invariantText", Value = "#new: The new invariant settings value" },
                     new() { Alias = "variantText", Value = "#new: The new settings value in English", Culture = "en-US" },
                     new() { Alias = "variantText", Value = "#new: The new settings value in Danish", Culture = "da-DK" },
@@ -784,13 +785,15 @@ internal partial class BlockListElementLevelVariationTests
                     firstContentElementKey,
                     firstSettingsElementKey,
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first content value in German", Culture = "de-DE" },
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in Danish", Culture = "da-DK" },
@@ -802,13 +805,15 @@ internal partial class BlockListElementLevelVariationTests
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first content value in German", Culture = "de-DE" },
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in Danish", Culture = "da-DK" },
@@ -830,7 +835,8 @@ internal partial class BlockListElementLevelVariationTests
                 Key = newContentElementKey,
                 ContentTypeAlias = elementType.Alias,
                 ContentTypeKey = elementType.Key,
-                Values = new List<BlockPropertyValue> {
+                Values = new List<BlockPropertyValue>
+                        {
                     new() { Alias = "invariantText", Value = "#new: The new invariant settings value" },
                     new() { Alias = "variantText", Value = "#new: The new settings value in English", Culture = "en-US" },
                     new() { Alias = "variantText", Value = "#new: The new settings value in Danish", Culture = "da-DK" },
@@ -901,44 +907,43 @@ internal partial class BlockListElementLevelVariationTests
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                ),
+                        null)),
                 (
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first content value in German", Culture = "de-DE" }
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in German", Culture = "de-DE" }
                         },
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         var serializedBlockListValue = JsonSerializer.Serialize(blockListValue);
         content.Properties["blocks"]!.SetValue(serializedBlockListValue);
@@ -1011,13 +1016,15 @@ internal partial class BlockListElementLevelVariationTests
                     firstContentElementKey,
                     firstSettingsElementKey,
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#1: The first content value in German", Culture = "de-DE" },
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The first settings value in Danish", Culture = "da-DK" },
@@ -1029,13 +1036,15 @@ internal partial class BlockListElementLevelVariationTests
                     secondContentElementKey,
                     secondSettingsElementKey,
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The first content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first content value in Danish", Culture = "da-DK" },
                             new() { Alias = "variantText", Value = "#2: The first content value in German", Culture = "de-DE" },
                         },
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The first invariant settings value" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The first settings value in Danish", Culture = "da-DK" },

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Indexing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Indexing.cs
@@ -149,32 +149,29 @@ internal partial class BlockListElementLevelVariationTests
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#1: The invariant content value" },
                             new() { Alias = "variantText", Value = "#1: The content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#1: The content value in Danish", Culture = "da-DK" }
                         },
                         [],
                         null,
-                        null
-                    )
-                ),
+                        null)),
                 (
                     Guid.NewGuid(),
                     Guid.NewGuid(),
                     new BlockProperty(
-                        new List<BlockPropertyValue> {
+                        new List<BlockPropertyValue>
+                        {
                             new() { Alias = "invariantText", Value = "#2: The invariant content value" },
                             new() { Alias = "variantText", Value = "#2: The content value in English", Culture = "en-US" },
                             new() { Alias = "variantText", Value = "#2: The content value in Danish", Culture = "da-DK" }
                         },
                         [],
                         null,
-                        null
-                    )
-                )
-            ]
-        );
+                        null))
+            ]);
 
         // only expose the first block in English and the second block in Danish (to make a difference between published and unpublished index values)
         blockListValue.Expose =

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueEditorReuseTests.cs
@@ -56,8 +56,7 @@ public class DataValueEditorReuseTests
                 Mock.Of<IPropertyValidationService>(),
                 blockVarianceHandler,
                 Mock.Of<ILanguageService>(),
-                Mock.Of<IIOHelper>()
-                ));
+                Mock.Of<IIOHelper>()));
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceBaseTests.cs
@@ -897,8 +897,7 @@ public class ContentNavigationServiceBaseTests
     [TestCase("E48DD82A-7059-418E-9B82-CDD5205796CF", new string[0])] // Root
     [TestCase("C6173927-0C59-4778-825D-D7B9F45D8DDE", new[] { "E48DD82A-7059-418E-9B82-CDD5205796CF" })] // Child 1
     [TestCase("E856AC03-C23E-4F63-9AA9-681B42A58573", new[] { "C6173927-0C59-4778-825D-D7B9F45D8DDE", "E48DD82A-7059-418E-9B82-CDD5205796CF" })] // Grandchild 1
-    [TestCase("56E29EA9-E224-4210-A59F-7C2C5C0C5CC7", new[] { "D63C1621-C74A-4106-8587-817DEE5FB732", "60E0E5C4-084E-4144-A560-7393BEAD2E96", "E48DD82A-7059-418E-9B82-CDD5205796CF",
-        })] // Great-grandchild 1
+    [TestCase("56E29EA9-E224-4210-A59F-7C2C5C0C5CC7", new[] { "D63C1621-C74A-4106-8587-817DEE5FB732", "60E0E5C4-084E-4144-A560-7393BEAD2E96", "E48DD82A-7059-418E-9B82-CDD5205796CF" })] // Great-grandchild 1
     public void Can_Get_Ancestors_From_Existing_Content_Key_In_Correct_Order_Of_Creation(Guid childKey, string[] ancestors)
     {
         // Arrange


### PR DESCRIPTION
Fixed 194 StyleCop analyzer warnings across the codebase:

- SA1500: Move opening braces to their own line for multi-line statements (80 warnings)
- SA1111: Move closing parenthesis to same line as last parameter (50 warnings)
- SA1134: Place each attribute on its own line (64 warnings)

Also added XML documentation to any public APIs within the edited files.
