### PR TITLE
Umbraco Helper: Align `GetDictionaryValue` nullability with behaviour (closes #21145)

### DIFF
--- a/src/Umbraco.Core/Dictionary/ICultureDictionary.cs
+++ b/src/Umbraco.Core/Dictionary/ICultureDictionary.cs
@@ -3,26 +3,26 @@ using System.Globalization;
 namespace Umbraco.Cms.Core.Dictionary;
 
 /// <summary>
-///     Represents a dictionary based on a specific culture
+/// Represents a dictionary based on a specific culture.
 /// </summary>
 public interface ICultureDictionary
 {
     /// <summary>
-    ///     Returns the current culture
+    /// Gets the culture for the dictionary.
     /// </summary>
     CultureInfo Culture { get; }
 
     /// <summary>
-    ///     Returns the dictionary value based on the key supplied
+    /// Gets the value for a given key.
     /// </summary>
-    /// <param name="key"></param>
-    /// <returns></returns>
-    string? this[string key] { get; }
+    /// <param name="key">The key for the dictionary item.</param>
+    /// <returns>The value matching the provided key. If no value is found, an empty string is returned.</returns>
+    string this[string key] { get; }
 
     /// <summary>
-    ///     Returns the child dictionary entries for a given key
+    /// Returns the child dictionary entries for a given key.
     /// </summary>
-    /// <param name="key"></param>
-    /// <returns></returns>
+    /// <param name="key">The key for the dictionary item.</param>
+    /// <returns>The value matching the provided key. If no value is found, an empty dictionary is returned.</returns>
     IDictionary<string, string> GetChildren(string key);
 }

--- a/src/Umbraco.Web.Common/UmbracoHelper.cs
+++ b/src/Umbraco.Web.Common/UmbracoHelper.cs
@@ -105,8 +105,8 @@ public class UmbracoHelper
     ///     Returns the dictionary value for the key specified
     /// </summary>
     /// <param name="key">Key of dictionary item.</param>
-    /// <returns>The dictionary value, should one exist.</returns>
-    public string? GetDictionaryValue(string key) => GetDictionaryValue(key, Thread.CurrentThread.CurrentUICulture);
+    /// <returns>The dictionary value, should one exist. If not, an empty string is returned.</returns>
+    public string GetDictionaryValue(string key) => GetDictionaryValue(key, Thread.CurrentThread.CurrentUICulture);
 
 
     /// <summary>
@@ -114,8 +114,8 @@ public class UmbracoHelper
     /// </summary>
     /// <param name="key">Key of dictionary item.</param>
     /// <param name="specificCulture">the specific culture on which the result well be back upon</param>
-    /// <returns>The dictionary value, should one exist.</returns>
-    public string? GetDictionaryValue(string key, CultureInfo specificCulture)
+    /// <returns>The dictionary value, should one exist. If not, an empty string is returned.</returns>
+    public string GetDictionaryValue(string key, CultureInfo specificCulture)
     {
         ICultureDictionary cultureDictionary = GetCultureDictionary(specificCulture);
         return cultureDictionary[key];


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/21145 raised a concern about a change in behaviour of the `GetDictionaryValue` method, retuning empty string instead of null.  This doesn't seem to be the case and it's consistent going back to Umbraco 13.  However the signature suggests null can be returned, even though the implementation will never return null.

So to align behaviour with the signature I've changed the nullability such that it's clear a null string will never be returned.

## Change Summary
- Aligns the return type nullability of `ICultureDictionary` indexer and `UmbracoHelper.GetDictionaryValue` methods with actual behaviour
- The implementation already returns an empty string (never null) when no dictionary item is found, but the interface incorrectly declared `string?`
- Updated XML documentation to clarify the return behaviour

## Testing
Visual inspection should suffice here, but you can verify the method still works as expected using an existing and non-existing key:

```
<div>Exists: @Umbraco.GetDictionaryValue("exists")</div>
<div>Not Exists: @(Umbraco.GetDictionaryValue("notExists") == string.Empty ? "Empty String" : "Something else")</div>
```