### PR TITLE
Templates: Rename Master Template to Layout throughout codebase

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/TemplateControllerBase.cs
@@ -30,17 +30,17 @@ public class TemplateControllerBase : ManagementApiControllerBase
                 .WithTitle("Duplicate alias")
                 .WithDetail("A template with that alias already exists.")
                 .Build()),
-            TemplateOperationStatus.CircularMasterTemplateReference => BadRequest(problemDetailsBuilder
-                .WithTitle("Invalid master template")
-                .WithDetail("The master template referenced in the template leads to a circular reference.")
+            TemplateOperationStatus.CircularLayoutReference => BadRequest(problemDetailsBuilder
+                .WithTitle("Invalid layout")
+                .WithDetail("The layout referenced in the template leads to a circular reference.")
                 .Build()),
-            TemplateOperationStatus.MasterTemplateNotFound => BadRequest(problemDetailsBuilder
-                .WithTitle("Master template not found")
-                .WithDetail("The master template referenced in the template was not found.")
+            TemplateOperationStatus.LayoutNotFound => BadRequest(problemDetailsBuilder
+                .WithTitle("Layout not found")
+                .WithDetail("The layout referenced in the template was not found.")
                 .Build()),
-            TemplateOperationStatus.MasterTemplateCannotBeDeleted => BadRequest(problemDetailsBuilder
-                .WithTitle("Master template cannot be deleted")
-                .WithDetail("The master templates cannot be deleted. Please ensure the template is not a master template before you delete.")
+            TemplateOperationStatus.LayoutCannotBeDeleted => BadRequest(problemDetailsBuilder
+                .WithTitle("Layout cannot be deleted")
+                .WithDetail("The layout cannot be deleted. Please ensure the template is not used as a layout before you delete.")
                 .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown template operation status.")

--- a/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
@@ -29,10 +29,10 @@ public class TemplatePresentationFactory : ITemplatePresentationFactory
             Content = template.Content
         };
 
-        if (template.MasterTemplateAlias is not null)
+        if (template.LayoutAlias is not null)
         {
-            ITemplate? parentTemplate = await _templateService.GetAsync(template.MasterTemplateAlias);
-            responseModel.MasterTemplate = ReferenceByIdModel.ReferenceOrNull(parentTemplate?.Key);
+            ITemplate? parentTemplate = await _templateService.GetAsync(template.LayoutAlias);
+            responseModel.Layout = ReferenceByIdModel.ReferenceOrNull(parentTemplate?.Key);
         }
 
         return responseModel;

--- a/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Template/TemplateViewModelMapDefinition.cs
@@ -18,7 +18,8 @@ public class TemplateViewModelMapDefinition : IMapDefinition
     }
 
     // Umbraco.Code.MapAll -Id -Key -CreateDate -UpdateDate -DeleteDate
-    // Umbraco.Code.MapAll -Path -VirtualPath -MasterTemplateId -IsMasterTemplate
+    // Umbraco.Code.MapAll -Path -VirtualPath -LayoutId -IsLayout -LayoutAlias
+    // Umbraco.Code.MapAll -MasterTemplateId -IsMasterTemplate -MasterTemplateAlias
     private void Map(UpdateTemplateRequestModel source, ITemplate target, MapperContext context)
     {
         target.Name = source.Name;

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -47824,7 +47824,7 @@
             "type": "string",
             "format": "uuid"
           },
-          "masterTemplate": {
+          "layout": {
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ReferenceByIdModel"

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/TemplateResponseModel.cs
@@ -1,8 +1,21 @@
-﻿namespace Umbraco.Cms.Api.Management.ViewModels.Template;
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Template;
 
 public class TemplateResponseModel : TemplateModelBase
 {
     public Guid Id { get; set; }
 
-    public ReferenceByIdModel? MasterTemplate { get; set; }
+    /// <summary>
+    ///     Gets or sets the layout (parent template) reference.
+    /// </summary>
+    public ReferenceByIdModel? Layout { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the master template reference.
+    /// </summary>
+    [JsonIgnore]
+    [Obsolete("Use Layout instead. This will be removed in Umbraco 19.")]
+    public ReferenceByIdModel? MasterTemplate { get => Layout; set => Layout = value; }
 }

--- a/src/Umbraco.Core/IO/ViewHelper.cs
+++ b/src/Umbraco.Core/IO/ViewHelper.cs
@@ -107,7 +107,7 @@ public class ViewHelper : IViewHelper
 
         if (string.IsNullOrEmpty(design))
         {
-            design = _defaultViewContentProvider.GetDefaultFileContent(template.MasterTemplateAlias);
+            design = _defaultViewContentProvider.GetDefaultFileContent(template.LayoutAlias);
         }
 
         return design;

--- a/src/Umbraco.Core/Models/ITemplate.cs
+++ b/src/Umbraco.Core/Models/ITemplate.cs
@@ -18,17 +18,36 @@ public interface ITemplate : IFile
     /// <summary>
     ///     Returns true if the template is used as a layout for other templates (i.e. it has 'children')
     /// </summary>
-    bool IsMasterTemplate { get; set; }
+    bool IsLayout { get; set; }
 
     /// <summary>
-    ///     returns the master template alias
+    ///     Returns true if the template is used as a layout for other templates (i.e. it has 'children')
     /// </summary>
-    string? MasterTemplateAlias { get; }
+    [Obsolete("Use IsLayout instead. This will be removed in Umbraco 19.")]
+    bool IsMasterTemplate { get => IsLayout; set => IsLayout = value; }
 
     /// <summary>
-    ///     Set the mastertemplate
+    ///     Returns the layout alias (the parent template this template inherits from)
     /// </summary>
-    /// <param name="masterTemplate"></param>
-    [Obsolete("MasterTemplate is now calculated from the content. This will be removed in Umbraco 15.")]
-    void SetMasterTemplate(ITemplate? masterTemplate);
+    string? LayoutAlias { get; }
+
+    /// <summary>
+    ///     Returns the master template alias
+    /// </summary>
+    [Obsolete("Use LayoutAlias instead. This will be removed in Umbraco 19.")]
+    string? MasterTemplateAlias => LayoutAlias;
+
+    /// <summary>
+    ///     Set the layout template
+    /// </summary>
+    /// <param name="layout">The layout template</param>
+    [Obsolete("Layout is now calculated from the content. This will be removed in Umbraco 19.")]
+    void SetLayout(ITemplate? layout);
+
+    /// <summary>
+    ///     Set the master template
+    /// </summary>
+    /// <param name="masterTemplate">The master template</param>
+    [Obsolete("Use SetLayout instead. This will be removed in Umbraco 19.")]
+    void SetMasterTemplate(ITemplate? masterTemplate) => SetLayout(masterTemplate);
 }

--- a/src/Umbraco.Core/Models/Template.cs
+++ b/src/Umbraco.Core/Models/Template.cs
@@ -13,8 +13,8 @@ public class Template : File, ITemplate
 {
     private readonly IShortStringHelper _shortStringHelper;
     private string _alias;
-    private string? _masterTemplateAlias;
-    private Lazy<int>? _masterTemplateId;
+    private string? _layoutAlias;
+    private Lazy<int>? _layoutId;
     private string? _name;
 
     public Template(IShortStringHelper shortStringHelper, string? name, string? alias)
@@ -28,20 +28,20 @@ public class Template : File, ITemplate
         _shortStringHelper = shortStringHelper;
         _name = name;
         _alias = alias?.ToCleanString(shortStringHelper, CleanStringType.UnderscoreAlias) ?? string.Empty;
-        _masterTemplateId = new Lazy<int>(() => -1);
+        _layoutId = new Lazy<int>(() => -1);
     }
 
     [DataMember]
-    public Lazy<int>? MasterTemplateId
+    public Lazy<int>? LayoutId
     {
-        get => _masterTemplateId;
-        set => SetPropertyValueAndDetectChanges(value, ref _masterTemplateId, nameof(MasterTemplateId));
+        get => _layoutId;
+        set => SetPropertyValueAndDetectChanges(value, ref _layoutId, nameof(LayoutId));
     }
 
-    public string? MasterTemplateAlias
+    public string? LayoutAlias
     {
-        get => _masterTemplateAlias;
-        set => SetPropertyValueAndDetectChanges(value, ref _masterTemplateAlias, nameof(MasterTemplateAlias));
+        get => _layoutAlias;
+        set => SetPropertyValueAndDetectChanges(value, ref _layoutAlias, nameof(LayoutAlias));
     }
 
     [DataMember]
@@ -62,21 +62,33 @@ public class Template : File, ITemplate
     /// <summary>
     ///     Returns true if the template is used as a layout for other templates (i.e. it has 'children')
     /// </summary>
-    public bool IsMasterTemplate { get; set; }
+    public bool IsLayout { get; set; }
 
-    // FIXME: moving forward the master template is calculated from the actual template content; figure out how to get rid of this method, or at least *only* use it from TemplateService
-    [Obsolete("MasterTemplate is now calculated from the content. This will be removed in Umbraco 15.")]
-    public void SetMasterTemplate(ITemplate? masterTemplate)
+    /// <summary>
+    ///     Returns the master template alias (the parent template this template inherits from)
+    /// </summary>
+    [Obsolete("Use LayoutAlias instead. This will be removed in Umbraco 19.")]
+    public string? MasterTemplateAlias { get => LayoutAlias; set => LayoutAlias = value; }
+
+    /// <summary>
+    ///     Returns the Id of the master template
+    /// </summary>
+    [Obsolete("Use LayoutId instead. This will be removed in Umbraco 19.")]
+    public Lazy<int>? MasterTemplateId { get => LayoutId; set => LayoutId = value; }
+
+    // FIXME: moving forward the layout is calculated from the actual template content; figure out how to get rid of this method, or at least *only* use it from TemplateService
+    [Obsolete("Layout is now calculated from the content. This will be removed in Umbraco 19.")]
+    public void SetLayout(ITemplate? layout)
     {
-        if (masterTemplate == null)
+        if (layout == null)
         {
-            MasterTemplateId = new Lazy<int>(() => -1);
-            MasterTemplateAlias = null;
+            LayoutId = new Lazy<int>(() => -1);
+            LayoutAlias = null;
         }
         else
         {
-            MasterTemplateId = new Lazy<int>(() => masterTemplate.Id);
-            MasterTemplateAlias = masterTemplate.Alias;
+            LayoutId = new Lazy<int>(() => layout.Id);
+            LayoutAlias = layout.Alias;
         }
     }
 

--- a/src/Umbraco.Core/Persistence/Repositories/ITemplateRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/ITemplateRepository.cs
@@ -8,7 +8,7 @@ public interface ITemplateRepository : IReadWriteQueryRepository<int, ITemplate>
 
     IEnumerable<ITemplate> GetAll(params string[] aliases);
 
-    IEnumerable<ITemplate> GetChildren(int masterTemplateId);
+    IEnumerable<ITemplate> GetChildren(int layoutId);
 
-    IEnumerable<ITemplate> GetDescendants(int masterTemplateId);
+    IEnumerable<ITemplate> GetDescendants(int layoutId);
 }

--- a/src/Umbraco.Core/Services/ITemplateContentParserService.cs
+++ b/src/Umbraco.Core/Services/ITemplateContentParserService.cs
@@ -1,6 +1,21 @@
-﻿namespace Umbraco.Cms.Core.Services;
+﻿using System;
+
+namespace Umbraco.Cms.Core.Services;
 
 public interface ITemplateContentParserService
 {
-    string? MasterTemplateAlias(string? viewContent);
+    /// <summary>
+    ///     Parses the view content and extracts the layout alias from the Layout directive
+    /// </summary>
+    /// <param name="viewContent">The content of the Razor view</param>
+    /// <returns>The layout alias if found, otherwise null</returns>
+    string? LayoutAlias(string? viewContent);
+
+    /// <summary>
+    ///     Parses the view content and extracts the master template alias from the Layout directive
+    /// </summary>
+    /// <param name="viewContent">The content of the Razor view</param>
+    /// <returns>The master template alias if found, otherwise null</returns>
+    [Obsolete("Use LayoutAlias instead. This will be removed in Umbraco 19.")]
+    string? MasterTemplateAlias(string? viewContent) => LayoutAlias(viewContent);
 }

--- a/src/Umbraco.Core/Services/ITemplateService.cs
+++ b/src/Umbraco.Core/Services/ITemplateService.cs
@@ -18,10 +18,11 @@ public interface ITemplateService : IService
     Task<IEnumerable<ITemplate>> GetAllAsync(Guid[] keys);
 
     /// <summary>
-    ///     Gets a list of all <see cref="ITemplate" /> objects
+    ///     Gets a list of all <see cref="ITemplate" /> objects that use the specified layout
     /// </summary>
+    /// <param name="layoutId">The ID of the layout template</param>
     /// <returns>An enumerable list of <see cref="ITemplate" /> objects</returns>
-    Task<IEnumerable<ITemplate>> GetChildrenAsync(int masterTemplateId);
+    Task<IEnumerable<ITemplate>> GetChildrenAsync(int layoutId);
 
     /// <summary>
     ///     Gets a <see cref="ITemplate" /> object by its alias.
@@ -45,11 +46,11 @@ public interface ITemplateService : IService
     Task<ITemplate?> GetAsync(Guid id);
 
     /// <summary>
-    ///     Gets the template descendants
+    ///     Gets the template descendants (all templates that inherit from the specified layout)
     /// </summary>
-    /// <param name="masterTemplateId"></param>
-    /// <returns></returns>
-    Task<IEnumerable<ITemplate>> GetDescendantsAsync(int masterTemplateId);
+    /// <param name="layoutId">The ID of the layout template</param>
+    /// <returns>An enumerable list of descending templates</returns>
+    Task<IEnumerable<ITemplate>> GetDescendantsAsync(int layoutId);
 
     /// <summary>
     ///     Updates a <see cref="ITemplate" />

--- a/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/TemplateOperationStatus.cs
@@ -1,4 +1,6 @@
-﻿namespace Umbraco.Cms.Core.Services.OperationStatus;
+﻿using System;
+
+namespace Umbraco.Cms.Core.Services.OperationStatus;
 
 public enum TemplateOperationStatus
 {
@@ -7,7 +9,25 @@ public enum TemplateOperationStatus
     InvalidAlias,
     DuplicateAlias,
     TemplateNotFound,
-    MasterTemplateNotFound,
-    CircularMasterTemplateReference,
-    MasterTemplateCannotBeDeleted,
+    LayoutNotFound,
+    CircularLayoutReference,
+    LayoutCannotBeDeleted,
+
+    /// <summary>
+    ///     The master template was not found
+    /// </summary>
+    [Obsolete("Use LayoutNotFound instead. This will be removed in Umbraco 19.")]
+    MasterTemplateNotFound = LayoutNotFound,
+
+    /// <summary>
+    ///     A circular master template reference was detected
+    /// </summary>
+    [Obsolete("Use CircularLayoutReference instead. This will be removed in Umbraco 19.")]
+    CircularMasterTemplateReference = CircularLayoutReference,
+
+    /// <summary>
+    ///     The master template cannot be deleted
+    /// </summary>
+    [Obsolete("Use LayoutCannotBeDeleted instead. This will be removed in Umbraco 19.")]
+    MasterTemplateCannotBeDeleted = LayoutCannotBeDeleted,
 }

--- a/src/Umbraco.Core/Services/TemplateContentParserService.cs
+++ b/src/Umbraco.Core/Services/TemplateContentParserService.cs
@@ -1,11 +1,13 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services;
 
 public partial class TemplateContentParserService : ITemplateContentParserService
 {
-    public string? MasterTemplateAlias(string? viewContent)
+    /// <inheritdoc />
+    public string? LayoutAlias(string? viewContent)
     {
         if (viewContent.IsNullOrWhiteSpace())
         {

--- a/src/Umbraco.Infrastructure/Persistence/Factories/TemplateFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/TemplateFactory.cs
@@ -17,7 +17,7 @@ internal static class TemplateFactory
             NodeId = entity.Id,
             Level = 1,
             NodeObjectType = nodeObjectTypeId,
-            ParentId = entity.MasterTemplateId?.Value ?? 0,
+            ParentId = entity.LayoutId?.Value ?? 0,
             Path = entity.Path,
             Text = entity.Name,
             Trashed = false,
@@ -46,11 +46,11 @@ internal static class TemplateFactory
             template.Key = dto.NodeDto.UniqueId;
             template.Path = dto.NodeDto.Path;
 
-            template.IsMasterTemplate = childDefinitions.Any(x => x.ParentId == dto.NodeId);
+            template.IsLayout = childDefinitions.Any(x => x.ParentId == dto.NodeId);
 
             if (dto.NodeDto.ParentId > 0)
             {
-                template.MasterTemplateId = new Lazy<int>(() => dto.NodeDto.ParentId);
+                template.LayoutId = new Lazy<int>(() => dto.NodeDto.ParentId);
             }
 
             // reset dirty initial properties (U4-1946)
@@ -67,9 +67,9 @@ internal static class TemplateFactory
     {
         var dto = new TemplateDto {Alias = entity.Alias, NodeDto = BuildNodeDto(entity, nodeObjectTypeId)};
 
-        if (entity.MasterTemplateId != null && entity.MasterTemplateId.Value > 0)
+        if (entity.LayoutId != null && entity.LayoutId.Value > 0)
         {
-            dto.NodeDto.ParentId = entity.MasterTemplateId.Value;
+            dto.NodeDto.ParentId = entity.LayoutId.Value;
         }
 
         if (entity.HasIdentity)

--- a/src/Umbraco.Infrastructure/Persistence/Mappers/TemplateMapper.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Mappers/TemplateMapper.cs
@@ -19,7 +19,7 @@ public sealed class TemplateMapper : BaseMapper
     protected override void DefineMaps()
     {
         DefineMap<Template, TemplateDto>(nameof(Template.Id), nameof(TemplateDto.NodeId));
-        DefineMap<Template, NodeDto>(nameof(Template.MasterTemplateId), nameof(NodeDto.ParentId));
+        DefineMap<Template, NodeDto>(nameof(Template.LayoutId), nameof(NodeDto.ParentId));
         DefineMap<Template, NodeDto>(nameof(Template.Key), nameof(NodeDto.UniqueId));
         DefineMap<Template, TemplateDto>(nameof(Template.Alias), nameof(TemplateDto.Alias));
     }

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1632,8 +1632,13 @@ export default {
 		insertPartialView: 'Partial view',
 		insertPartialViewDesc:
 			"A partial view is a separate template file which can be rendered inside another template, it's great for reusing markup or for separating complex templates into separate files.",
+		layout: 'Layout',
+		/** @deprecated Use  instead. Will be removed in Umbraco 19. */
+		/** @deprecated Use layout instead. Will be removed in Umbraco 19. */
 		mastertemplate: 'Master template',
 		quickGuide: 'Quick guide to template tags',
+		noLayout: 'No layout',
+		/** @deprecated Use noLayout instead. Will be removed in Umbraco 19. */
 		noMaster: 'No master',
 		renderBody: 'Render child template',
 		renderBodyDesc: 'Renders the contents of a child template, by inserting a <code>@RenderBody()</code> placeholder.',

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/template/template.data.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/template/template.data.ts
@@ -44,7 +44,7 @@ export const data: Array<UmbMockTemplateModel> = [
 	{
 		id: '9a84c0b3-03b4-4dd4-84ac-706740ac0f72',
 		parent: { id: '9a84c0b3-03b4-4dd4-84ac-706740ac0f71' },
-		masterTemplate: { id: '9a84c0b3-03b4-4dd4-84ac-706740ac0f71' },
+		layout: { id: '9a84c0b3-03b4-4dd4-84ac-706740ac0f71' },
 		name: 'Child',
 		hasChildren: false,
 		alias: 'Test',
@@ -55,10 +55,10 @@ export const data: Array<UmbMockTemplateModel> = [
 	{
 		id: '9a84c0b3-03b4-4dd4-84ac-706740acwerer0f72',
 		parent: { id: '9a84c0b3-03b4-4dd4-84ac-706740ac0f71' },
-		name: 'Has Master Template',
-		masterTemplate: { id: '9a84c0b3-03b4-4dd4-84ac-706740ac0f71' },
+		name: 'Has Layout',
+		layout: { id: '9a84c0b3-03b4-4dd4-84ac-706740ac0f71' },
 		hasChildren: false,
-		alias: 'hasMasterTemplate',
+		alias: 'hasLayout',
 		flags: [],
 		content:
 			'@using Umbraco.Cms.Web.Common.PublishedModels;\n@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.Test>\r\n@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;\r\n@{\r\n\tLayout = "Test.cshtml";\r\n}',
@@ -74,11 +74,11 @@ export const data: Array<UmbMockTemplateModel> = [
 	},
 ];
 
-export const createTemplateScaffold = (masterTemplateAlias: string) => {
+export const createTemplateScaffold = (layoutAlias: string) => {
 	return `@using Umbraco.Cms.Web.Common.PublishedModels;
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
 @{
-	Layout = ${masterTemplateAlias};
+	Layout = ${layoutAlias};
 }`;
 };
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
@@ -2539,7 +2539,7 @@ export type TemplateResponseModel = {
     alias: string;
     content?: string | null;
     id: string;
-    masterTemplate?: ReferenceByIdModel | null;
+    layout?: ReferenceByIdModel | null;
 };
 
 export type TemporaryFileConfigurationResponseModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/repository/detail/template-detail.server.data-source.ts
@@ -43,7 +43,7 @@ export class UmbTemplateServerDataSource implements UmbDetailDataSource<UmbTempl
 			name: '',
 			alias: '',
 			content: scaffold,
-			masterTemplate: preset.masterTemplate ?? null,
+			layout: preset.layout ?? null,
 			...preset,
 		};
 
@@ -72,7 +72,7 @@ export class UmbTemplateServerDataSource implements UmbDetailDataSource<UmbTempl
 			name: data.name,
 			content: data.content || null,
 			alias: data.alias,
-			masterTemplate: data.masterTemplate ? { unique: data.masterTemplate.id } : null,
+			layout: data.layout ? { unique: data.layout.id } : null,
 		};
 
 		return { data: template };

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/types.ts
@@ -6,5 +6,5 @@ export interface UmbTemplateDetailModel {
 	name: string;
 	alias: string;
 	content: string | null;
-	masterTemplate: { unique: string } | null;
+	layout: { unique: string } | null;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
@@ -29,7 +29,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 	private _alias?: string = '';
 
 	@state()
-	private _masterTemplateName?: string | null = null;
+	private _layoutName?: string | null = null;
 
 	@query('umb-code-editor')
 	private _codeEditor?: UmbCodeEditorElement;
@@ -37,7 +37,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 	#templateWorkspaceContext?: typeof UMB_TEMPLATE_WORKSPACE_CONTEXT.TYPE;
 	#isNew = false;
 
-	#masterTemplateUnique: string | null = null;
+	#layoutUnique: string | null = null;
 
 	constructor() {
 		super();
@@ -60,9 +60,9 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 				this._content = content;
 			});
 
-			this.observe(this.#templateWorkspaceContext?.masterTemplate, (masterTemplate) => {
-				this.#masterTemplateUnique = masterTemplate?.unique ?? null;
-				this._masterTemplateName = masterTemplate?.name ?? null;
+			this.observe(this.#templateWorkspaceContext?.layout, (layout) => {
+				this.#layoutUnique = layout?.unique ?? null;
+				this._layoutName = layout?.name ?? null;
 			});
 
 			this.observe(this.#templateWorkspaceContext?.isNew, (isNew) => {
@@ -101,11 +101,11 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 			.catch(() => undefined);
 	}
 
-	#resetMasterTemplate() {
-		this.#templateWorkspaceContext?.setMasterTemplate(null, true);
+	#resetLayout() {
+		this.#templateWorkspaceContext?.setLayout(null, true);
 	}
 
-	#openMasterTemplatePicker() {
+	#openLayoutPicker() {
 		const modalContext = this.#modalContext?.open(this, UMB_TEMPLATE_PICKER_MODAL, {
 			data: {
 				pickableFilter: (item) => {
@@ -113,7 +113,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 				},
 			},
 			value: {
-				selection: [this.#masterTemplateUnique],
+				selection: [this.#layoutUnique],
 			},
 		});
 
@@ -121,7 +121,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 			?.onSubmit()
 			.then((value) => {
 				if (!value?.selection) return;
-				this.#templateWorkspaceContext?.setMasterTemplate(value.selection[0] ?? null, true);
+				this.#templateWorkspaceContext?.setLayout(value.selection[0] ?? null, true);
 			})
 			.catch(() => undefined);
 	}
@@ -139,19 +139,19 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 			.catch(() => undefined);
 	}
 
-	#renderMasterTemplatePicker() {
+	#renderLayoutPicker() {
 		return html`
 			<uui-button-group>
 				<uui-button
-					@click=${this.#openMasterTemplatePicker}
+					@click=${this.#openLayoutPicker}
 					look="secondary"
-					id="master-template-button"
-					label="${this.localize.term('template_mastertemplate')}: ${this._masterTemplateName
-						? this._masterTemplateName
-						: this.localize.term('template_noMaster')}"></uui-button>
-				${this._masterTemplateName
+					id="layout-button"
+					label="${this.localize.term('template_layout')}: ${this._layoutName
+						? this._layoutName
+						: this.localize.term('template_noLayout')}"></uui-button>
+				${this._layoutName
 					? html`<uui-button look="secondary" label=${this.localize.term('actions_remove')} compact>
-							<uui-icon name="icon-delete" @click=${this.#resetMasterTemplate}></uui-icon>
+							<uui-icon name="icon-delete" @click=${this.#resetLayout}></uui-icon>
 						</uui-button>`
 					: nothing}
 			</uui-button-group>
@@ -177,7 +177,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 				</umb-input-with-alias>
 
 				<uui-box>
-					<div slot="header" id="code-editor-menu-container">${this.#renderMasterTemplatePicker()}</div>
+					<div slot="header" id="code-editor-menu-container">${this.#renderLayoutPicker()}</div>
 					<div slot="header-actions">
 						<umb-templating-insert-menu @insert=${this.#insertSnippet}></umb-templating-insert-menu>
 						<uui-button

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/Template/Templates.spec.ts
@@ -81,7 +81,7 @@ test('can delete a template', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.template.isTemplateRootTreeItemVisible(templateName, false, false);
 });
 
-test('can set a template as master template', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
+test('can set a template as layout', {tag: '@release'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const childTemplateName = 'ChildTemplate';
   await umbracoApi.template.ensureNameNotExists(childTemplateName);
@@ -90,23 +90,23 @@ test('can set a template as master template', {tag: '@release'}, async ({umbraco
 
   // Act
   await umbracoUi.template.goToTemplate(childTemplateName);
-  await umbracoUi.template.clickChangeMasterTemplateButton();
+  await umbracoUi.template.clickChangeLayoutButton();
   await umbracoUi.template.clickModalMenuItemWithName(templateName);
   await umbracoUi.template.clickChooseButton();
   await umbracoUi.template.clickSaveButtonAndWaitForTemplateToBeUpdated();
 
   // Assert
-  await umbracoUi.template.isMasterTemplateNameVisible(templateName);
-  // Checks if the childTemplate has the masterTemplate set
+  await umbracoUi.template.isLayoutNameVisible(templateName);
+  // Checks if the childTemplate has the layout set
   const childTemplateData = await umbracoApi.template.getByName(childTemplateName);
-  const masterTemplateData = await umbracoApi.template.getByName(templateName);
-  expect(childTemplateData.masterTemplate.id).toBe(masterTemplateData.id);
+  const layoutData = await umbracoApi.template.getByName(templateName);
+  expect(childTemplateData.layout.id).toBe(layoutData.id);
 
   // Clean
   await umbracoApi.template.ensureNameNotExists(childTemplateName);
 });
 
-test('can remove a master template', async ({umbracoApi, umbracoUi}) => {
+test('can remove a layout', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const childTemplateName = 'ChildTemplate';
   const templateAlias = AliasHelper.toAlias(templateName);
@@ -118,13 +118,13 @@ test('can remove a master template', async ({umbracoApi, umbracoUi}) => {
 
   // Act
   await umbracoUi.template.goToTemplate(templateName, childTemplateName);
-  await umbracoUi.template.clickRemoveMasterTemplateButton();
+  await umbracoUi.template.clickRemoveLayoutButton();
   await umbracoUi.template.clickSaveButtonAndWaitForTemplateToBeUpdated();
 
   // Assert
-  await umbracoUi.template.isMasterTemplateNameVisible('No master');
+  await umbracoUi.template.isLayoutNameVisible('No layout');
   const childTemplate = await umbracoApi.template.getByName(childTemplateName);
-  expect(childTemplate.masterTemplate).toBe(null);
+  expect(childTemplate.layout).toBe(null);
 
   // Clean
   await umbracoApi.template.ensureNameNotExists(childTemplateName);

--- a/tests/Umbraco.Tests.Common/Builders/TemplateBuilder.cs
+++ b/tests/Umbraco.Tests.Common/Builders/TemplateBuilder.cs
@@ -23,10 +23,10 @@ public class TemplateBuilder
     private string _content;
     private DateTime? _createDate;
     private int? _id;
-    private bool? _isMasterTemplate;
+    private bool? _isLayout;
     private Guid? _key;
-    private string _masterTemplateAlias;
-    private Lazy<int> _masterTemplateId;
+    private string _layoutAlias;
+    private Lazy<int> _layoutId;
     private string _name;
     private string _path;
     private DateTime? _updateDate;
@@ -89,13 +89,17 @@ public class TemplateBuilder
         return this;
     }
 
-    public TemplateBuilder AsMasterTemplate(string masterTemplateAlias, int masterTemplateId)
+    public TemplateBuilder AsLayout(string layoutAlias, int layoutId)
     {
-        _isMasterTemplate = true;
-        _masterTemplateAlias = masterTemplateAlias;
-        _masterTemplateId = new Lazy<int>(() => masterTemplateId);
+        _isLayout = true;
+        _layoutAlias = layoutAlias;
+        _layoutId = new Lazy<int>(() => layoutId);
         return this;
     }
+
+    [Obsolete("Use AsLayout instead. This will be removed in Umbraco 19.")]
+    public TemplateBuilder AsMasterTemplate(string masterTemplateAlias, int masterTemplateId)
+        => AsLayout(masterTemplateAlias, masterTemplateId);
 
     public override ITemplate Build()
     {
@@ -107,9 +111,9 @@ public class TemplateBuilder
         var updateDate = _updateDate ?? DateTime.UtcNow;
         var path = _path ?? $"-1,{id}";
         var content = _content;
-        var isMasterTemplate = _isMasterTemplate ?? false;
-        var masterTemplateAlias = _masterTemplateAlias ?? string.Empty;
-        var masterTemplateId = _masterTemplateId ?? new Lazy<int>(() => -1);
+        var isLayout = _isLayout ?? false;
+        var layoutAlias = _layoutAlias ?? string.Empty;
+        var layoutId = _layoutId ?? new Lazy<int>(() => -1);
 
         var shortStringHelper = new DefaultShortStringHelper(new DefaultShortStringHelperConfig());
 
@@ -121,9 +125,9 @@ public class TemplateBuilder
             UpdateDate = updateDate,
             Path = path,
             Content = content,
-            IsMasterTemplate = isMasterTemplate,
-            MasterTemplateAlias = masterTemplateAlias,
-            MasterTemplateId = masterTemplateId
+            IsLayout = isLayout,
+            LayoutAlias = layoutAlias,
+            LayoutId = layoutId
         };
 
         return template;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description
Renames "Master Template" terminology to "Layout" throughout the codebase, aligning with ASP.NET MVC conventions.

The term "Master Template" is inherited from when Umbraco was based on ASP.NET Web Forms. We should have adopted "Layout", which was introduced with the Razor View Engine in MVC 3.0 back in 2011(!) - this change is long overdue.

I could have simply updated the translation file to change the UI label, but I've submitted this as a complete fix since we're 14 years late to the party.

### Naming
Naming is hard. I've chosen `Layout` as I couldn't think of anything better - `LayoutTemplate` felt redundant. Open to suggestions if anyone has a better idea.

### Breaking Changes
I'm uncertain whether this constitutes a breaking change:
- Adding members to interfaces
- Adding values to enums
- Renaming method parameters (affects named arguments)

If this is considered breaking, this PR should target v18 and the obsolete attributes should reference v19 for removal instead.

All public names have been preserved as obsolete aliases pointing to the new names, so existing code will compile with warnings.

### Package Impact
This change will affect packages that interact with templates, including Deploy and uSync.

@KevinJump - heads up on this upcoming change. The old property/method names remain available as obsolete aliases for now.

### Technical Notes

In `TemplateViewModelMapDefinition.cs` - Both `Umbraco.Code.MapAll` comment lines are required. The Roslyn analyzer checks that all properties on `ITemplate` are either mapped or explicitly excluded. Since both the new (`LayoutId`, `IsLayout`, `LayoutAlias`) and obsolete (`MasterTemplateId`, `IsMasterTemplate`, `MasterTemplateAlias`) properties exist on the interface, both sets must be listed.

### Translations
Only the English translation file (`en.ts`) has been updated, which what we usually do since we don't have expertise in other languages. Users with non-English locales may see the English fallback value until community translations are contributed. The old keys (`mastertemplate`, `noMaster`) are preserved alongside the new keys (`layout`, `noLayout`) for backwards compatibility.

### AI
Yes, this PR was created with assistance from Claude Code but has been thoroughly manually reviewed and verified by me.

### Testing
So many words, but to test this it's pretty simple: go into the backoffice and in the Settings section try to create a new template or update the Layout for an existing template. The button label has changed and all the underlying code is using the new naming and should all work. Try removing a layout as well by updating the Razor file to `Layout ="";` or `Layout = null;` or using the UI:

<img width="560" height="241" alt="image" src="https://github.com/user-attachments/assets/e885f869-2cb3-4f87-bcc9-6fe647cced6b" />

**Note:** removing the layout has some problems with updating the tree, but that was the case before this PR as well so that behavior has not changed and is a separate small bug. 