### PR TITLE
Login: Show specific password validation messages instead of generic format error (closes #21255)

### DIFF
--- a/src/Umbraco.Web.UI.Login/src/components/layouts/new-password-layout.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/components/layouts/new-password-layout.element.ts
@@ -27,30 +27,11 @@ export default class UmbNewPasswordLayoutElement extends UmbLitElement {
   @state()
   _passwordConfiguration?: typeof UMB_AUTH_CONTEXT.TYPE['passwordConfiguration'];
 
-  @state()
-  _passwordPattern = '';
-
   constructor() {
     super();
 
     this.consumeContext(UMB_AUTH_CONTEXT, (authContext) => {
-      // Build a pattern
-      let pattern = '';
       this._passwordConfiguration = authContext?.passwordConfiguration;
-      if (this._passwordConfiguration?.requireDigit) {
-        pattern += '(?=.*\\d)';
-      }
-      if (this._passwordConfiguration?.requireLowercase) {
-        pattern += '(?=.*[a-z])';
-      }
-      if (this._passwordConfiguration?.requireUppercase) {
-        pattern += '(?=.*[A-Z])';
-      }
-      if (this._passwordConfiguration?.requireNonLetterOrDigit) {
-        pattern += '(?=.*\\W)';
-      }
-      pattern += `.{${this._passwordConfiguration?.minimumPasswordLength ?? 10},}`;
-      this._passwordPattern = pattern;
     });
   }
 
@@ -161,7 +142,6 @@ export default class UmbNewPasswordLayoutElement extends UmbLitElement {
               id="password"
               name="password"
               autocomplete="new-password"
-              pattern="${this._passwordPattern}"
               .minlength=${this._passwordConfiguration?.minimumPasswordLength}
               .minlengthMessage=${this.localize.term('auth_passwordMinLength', this._passwordConfiguration?.minimumPasswordLength ?? 10)}
               .label=${this.localize.term('auth_newPassword')}
@@ -179,7 +159,6 @@ export default class UmbNewPasswordLayoutElement extends UmbLitElement {
               id="confirmPassword"
               name="confirmPassword"
               autocomplete="new-password"
-              pattern="${this._passwordPattern}"
               .minlength=${this._passwordConfiguration?.minimumPasswordLength}
               .minlengthMessage=${this.localize.term('auth_passwordMinLength', this._passwordConfiguration?.minimumPasswordLength ?? 10)}
               .label=${this.localize.term('auth_confirmNewPassword')}


### PR DESCRIPTION
## Description

Fixes issue #21255 where users saw a generic "Please match the requested format" message when setting or resetting passwords from email links, instead of specific validation error messages.

## Changes

- Removed the HTML5 `pattern` attribute from password input fields in `new-password-layout.element.ts`
- Removed unused `_passwordPattern` state variable and pattern-building logic
- The component now relies solely on JavaScript validation logic that provides specific, localized error messages

## Technical Details

The HTML5 `pattern` attribute was triggering browser-native validation which displays the generic "Please match the requested format" message. The component already has comprehensive JavaScript validation in the `#onSubmit` method that:
- Checks all password requirements (minimum length, digits, uppercase, lowercase, special characters)
- Uses `setCustomValidity()` to display specific, localized error messages via `auth_errorInPasswordFormat`

By removing the `pattern` attribute, users will now see the specific error messages (e.g., "The password must be at least {X} characters long and contain at least {Y} special characters") instead of the generic browser message.

## Testing

Tested by:
- Removing the pattern attribute from both password fields
- Verified the JavaScript validation logic remains intact
- Confirmed specific error messages are displayed via `setCustomValidity()`

## Related Issue

Closes #21255

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=157775043