### PR TITLE
Elements: Fix element recycle bin node insertion on SQL Server

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/AddElements.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/AddElements.cs
@@ -66,20 +66,39 @@ public class AddElements : AsyncMigrationBase
             return;
         }
 
-        Database.Insert(Constants.DatabaseSchema.Tables.Node, "id", false,
-            new NodeDto
-            {
-                NodeId = Constants.System.RecycleBinElement,
-                Trashed = false,
-                ParentId = -1,
-                UserId = -1,
-                Level = 0,
-                Path = "-1,-22",
-                SortOrder = 0,
-                UniqueId = Constants.System.RecycleBinElementKey,
-                Text = "Recycle Bin",
-                NodeObjectType = Constants.ObjectTypes.ElementRecycleBin,
-                CreateDate = DateTime.UtcNow,
-            });
+        ToggleIdentityInsertForNodes(true);
+        try
+        {
+            Database.Insert(
+                Constants.DatabaseSchema.Tables.Node,
+                "id",
+                false,
+                new NodeDto
+                {
+                    NodeId = Constants.System.RecycleBinElement,
+                    Trashed = false,
+                    ParentId = -1,
+                    UserId = -1,
+                    Level = 0,
+                    Path = "-1,-22",
+                    SortOrder = 0,
+                    UniqueId = Constants.System.RecycleBinElementKey,
+                    Text = "Recycle Bin",
+                    NodeObjectType = Constants.ObjectTypes.ElementRecycleBin,
+                    CreateDate = DateTime.UtcNow,
+                });
+        }
+        finally
+        {
+            ToggleIdentityInsertForNodes(false);
+        }
+    }
+
+    private void ToggleIdentityInsertForNodes(bool toggleOn)
+    {
+        if (SqlSyntax.SupportsIdentityInsert())
+        {
+            Database.Execute(new Sql($"SET IDENTITY_INSERT {SqlSyntax.GetQuotedTableName(NodeDto.TableName)} {(toggleOn ? "ON" : "OFF")} "));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Enable IDENTITY_INSERT before inserting the element recycle bin node with an explicit ID
- Disable IDENTITY_INSERT after the insert completes (in a finally block)
- This follows the same pattern used in `MigrateMediaTypeLabelProperties`

This fixes the `AddElements` migration failing on SQL Server with the error:
```
Cannot insert explicit value for identity column in table 'umbracoNode' when IDENTITY_INSERT is set to OFF.
```

The fix is a no-op for SQLite which doesn't support/require identity insert.