### PR TITLE
Code Quality: Removing a variable that is not being used fixing warning `CS0168`

### DIFF
--- a/tests/Umbraco.Tests.Integration/Testing/BaseTestDatabase.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/BaseTestDatabase.cs
@@ -114,7 +114,7 @@ public abstract class BaseTestDatabase
                 action();
                 return;
             }
-            catch (DbException ex)
+            catch (DbException)
             {
                 // Console.Error.WriteLine($"SqlException occured, but we try again {i+1}/{maxIterations}.\n{e}");
                 // This can occur when there's a transaction deadlock which means (i think) that the database is still in use and hasn't been closed properly yet


### PR DESCRIPTION
This is a very small change, just removing an exception variable as it is not being used, it looks like it was used for testing, but now is not required.
