### PR TITLE
Code Quality: Fix `CS1574` and `CS0419` XML documentation warnings

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/ManagementApiControllerBase.cs
@@ -56,7 +56,7 @@ public abstract class ManagementApiControllerBase : Controller, IUmbracoFeature
     ///     Creates a 403 Forbidden result.
     /// </summary>
     /// <remarks>
-    ///     Use this method instead of <see cref="ManagementApiControllerBase.Forbid()"/> on the controller base.
+    ///     Use this method instead of the controller base class's Forbid() method.
     ///     This method ensures that a proper 403 Forbidden status code is returned to the client.
     /// </remarks>
     // Duplicate code copied between Management API and Delivery API.

--- a/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeExternalLoginProviderErrorMiddleware.cs
+++ b/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeExternalLoginProviderErrorMiddleware.cs
@@ -8,11 +8,11 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Api.Management.Middleware;
 
 /// <summary>
-///     Used to handle errors registered by external login providers
+///     Used to handle errors registered by external login providers.
 /// </summary>
 /// <remarks>
 ///     When an external login provider registers an error with
-///     <see cref="Extensions.HttpContextExtensions.SetExternalLoginProviderErrors" /> during the OAuth process,
+///     <see cref="HttpContextExtensions.SetExternalLoginProviderErrors" /> during the OAuth process,
 ///     this middleware will detect that, store the errors into cookie data and redirect to the back office login so we can
 ///     read the errors back out.
 /// </remarks>

--- a/src/Umbraco.Cms.Api.Management/Services/Entities/IUserStartNodeEntitiesService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Entities/IUserStartNodeEntitiesService.cs
@@ -54,7 +54,7 @@ public interface IUserStartNodeEntitiesService
     /// <summary>
     /// Calculates the applicable child entities from a list of candidate child entities for users without root access.
     /// </summary>
-    /// <param name="candidateChildren">The candidate child entities to filter (i.e. entities fetched with <see cref="EntityService.GetPagedChildren"/>).</param>
+    /// <param name="candidateChildren">The candidate child entities to filter (i.e. entities fetched with the EntityService's GetPagedChildren method).</param>
     /// <param name="userStartNodePaths">The calculated start node paths for the user.</param>
     /// <returns>A list of child entities applicable entities for the user.</returns>
     /// <remarks>

--- a/src/Umbraco.Cms.Api.Management/Services/Flags/HasScheduleFlagProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Flags/HasScheduleFlagProvider.cs
@@ -21,7 +21,7 @@ internal class HasScheduleFlagProvider : IFlagProvider
     private readonly IIdKeyMap _keyMap;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="HasScheduleSignProvider"/> class.
+    /// Initializes a new instance of the <see cref="HasScheduleFlagProvider"/> class.
     /// </summary>
     public HasScheduleFlagProvider(IContentService contentService, IIdKeyMap keyMap)
     {

--- a/src/Umbraco.Cms.Persistence.SqlServer/NPocoSqlServerDatabaseExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/NPocoSqlServerDatabaseExtensions.cs
@@ -12,14 +12,12 @@ public static class NPocoSqlServerDatabaseExtensions
     ///     underlying RetryDbConnection and ProfiledDbTransaction
     /// </summary>
     /// <remarks>
-    ///     This is required to use NPoco's own <see cref="Database.InsertBulk{T}(IEnumerable{T})" /> method because we use
+    ///     This is required to use NPoco's own Database.InsertBulk method because we use
     ///     wrapped DbConnection and DbTransaction instances.
-    ///     NPoco's InsertBulk method only caters for efficient bulk inserting records for Sql Server, it does not cater for
-    ///     bulk inserting of records for
-    ///     any other database type and in which case will just insert records one at a time.
+    ///     NPoco's InsertBulk method only caters for efficient bulk inserting records for SQL Server, it does not cater for
+    ///     bulk inserting of records for any other database type and in which case will just insert records one at a time.
     ///     NPoco's InsertBulk method also deals with updating the passed in entity's PK/ID once it's inserted whereas our own
-    ///     BulkInsertRecords methods
-    ///     do not handle this scenario.
+    ///     BulkInsertRecords methods do not handle this scenario.
     /// </remarks>
     public static void ConfigureNPocoBulkExtensions()
     {

--- a/src/Umbraco.Core/DeliveryApi/IApiMediaQueryService.cs
+++ b/src/Umbraco.Core/DeliveryApi/IApiMediaQueryService.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
@@ -24,6 +24,6 @@ public interface IApiMediaQueryService
     ///     Returns the media item that matches the supplied path (if any).
     /// </summary>
     /// <param name="path">The path to look up.</param>
-    /// <returns>The media item at <see cref="path"/>, or null if it does not exist.</returns>
+    /// <returns>The media item at the specified <paramref name="path"/>, or <c>null</c> if it does not exist.</returns>
     IPublishedContent? GetByPath(string path);
 }

--- a/src/Umbraco.Core/Security/Authorization/ContentPermissionResource.cs
+++ b/src/Umbraco.Core/Security/Authorization/ContentPermissionResource.cs
@@ -3,7 +3,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Security.Authorization;
 
 /// <summary>
-///     A resource used for the <see cref="ContentPermissionHandler" />.
+///     A resource used for the ContentPermissionHandler authorization handler.
 /// </summary>
 public class ContentPermissionResource : IPermissionResource
 {

--- a/src/Umbraco.Core/Security/Authorization/MediaPermissionResource.cs
+++ b/src/Umbraco.Core/Security/Authorization/MediaPermissionResource.cs
@@ -3,7 +3,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Security.Authorization;
 
 /// <summary>
-///     A resource used for the <see cref="MediaPermissionHandler" />.
+///     A resource used for the MediaPermissionHandler authorization handler.
 /// </summary>
 public class MediaPermissionResource : IPermissionResource
 {

--- a/src/Umbraco.Core/Security/Authorization/UserGroupPermissionResource.cs
+++ b/src/Umbraco.Core/Security/Authorization/UserGroupPermissionResource.cs
@@ -3,7 +3,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Security.Authorization;
 
 /// <summary>
-///     A resource used for the <see cref="UserGroupPermissionHandler" />.
+///     A resource used for the UserGroupPermissionHandler authorization handler.
 /// </summary>
 public class UserGroupPermissionResource : IPermissionResource
 {

--- a/src/Umbraco.Core/Security/Authorization/UserPermissionResource.cs
+++ b/src/Umbraco.Core/Security/Authorization/UserPermissionResource.cs
@@ -3,7 +3,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Core.Security.Authorization;
 
 /// <summary>
-///     A resource used for the <see cref="UserPermissionHandler" />.
+///     A resource used for the UserPermissionHandler authorization handler.
 /// </summary>
 public class UserPermissionResource : IPermissionResource
 {

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1406,10 +1406,9 @@ public class ContentService : RepositoryService, IContentService
     ///         <see cref="ContentRepositoryExtensions.UnpublishCulture" />.
     ///     </para>
     ///     <para>
-    ///         When publishing or unpublishing a single culture, or all cultures, use <see cref="SaveAndPublish" />
+    ///         When publishing or unpublishing a single culture, or all cultures, use the publishing operations
     ///         and <see cref="Unpublish" />. But if the flexibility to both publish and unpublish in a single operation is
-    ///         required
-    ///         then this method needs to be used in combination with <see cref="ContentRepositoryExtensions.PublishCulture" />
+    ///         required, then this method needs to be used in combination with <see cref="ContentRepositoryExtensions.PublishCulture" />
     ///         and <see cref="ContentRepositoryExtensions.UnpublishCulture" />
     ///         on the content itself - this prepares the content, but does not commit anything - and then, invoke
     ///         <see cref="CommitDocumentChanges" /> to actually commit the changes to the database.

--- a/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ImageCropperPropertyValueEditor.cs
@@ -109,7 +109,7 @@ internal sealed class ImageCropperPropertyValueEditor : DataValueEditor, IDispos
     ///     <para>The <paramref name="currentValue" /> is used to re-use the folder, if possible.</para>
     ///     <para>
     ///         editorValue.Value is used to figure out editorFile and, if it has been cleared, remove the old file.
-    ///         If editorValue.Value deserializes as <see cref="ImageCropperValue"/> and the <see cref="ImageCropperValue.Src"/>
+    ///         If editorValue.Value deserializes as <see cref="ImageCropperValue"/> and the <see cref="TemporaryFileUploadValueBase.Src"/>
     ///         value is a GUID, it is assumed to contain a temporary file key, and we will attempt to replace the currently
     ///         selected file with the corresponding temporary file.
     ///     </para>

--- a/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidators/ModelsBuilderModeValidator.cs
+++ b/src/Umbraco.Infrastructure/Runtime/RuntimeModeValidators/ModelsBuilderModeValidator.cs
@@ -7,9 +7,9 @@ using Umbraco.Cms.Core.Configuration.Models;
 namespace Umbraco.Cms.Infrastructure.Runtime.RuntimeModeValidators;
 
 /// <summary>
-/// Validates that ModelsBuilderMode is set to <see cref="ModelsMode.Nothing" /> when in production runtime mode.
+/// Validates that ModelsBuilderMode is set to <see cref="Constants.ModelsBuilder.ModelsModes.Nothing" /> when in production runtime mode.
 /// </summary>
-/// <seealso cref="Umbraco.Cms.Infrastructure.Runtime.IRuntimeModeValidator" />
+/// <seealso cref="IRuntimeModeValidator" />
 public class ModelsBuilderModeValidator : IRuntimeModeValidator
 {
     private readonly IOptionsMonitor<ModelsBuilderSettings> _modelsBuilderSettings;

--- a/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FriendlyPublishedContentExtensions.cs
@@ -234,9 +234,7 @@ public static class FriendlyPublishedContentExtensions
     ///     The root content (ancestor or self at level 1) for the specified <paramref name="content" />.
     /// </returns>
     /// <remarks>
-    ///     This is the same as calling
-    ///     <see cref="AncestorOrSelf(IPublishedContent, int)" /> with <c>maxLevel</c>
-    ///     set to 1.
+    ///     This method returns the ancestor or self at level 1, which is the root of the content tree.
     /// </remarks>
     public static IPublishedContent Root(this IPublishedContent content)
         => content.Root(GetNavigationQueryService(content), GetPublishedStatusFilteringService(content));
@@ -252,9 +250,8 @@ public static class FriendlyPublishedContentExtensions
     ///     <typeparamref name="T" />.
     /// </returns>
     /// <remarks>
-    ///     This is the same as calling
-    ///     <see cref="AncestorOrSelf{T}(IPublishedContent, int)" /> with
-    ///     <c>maxLevel</c> set to 1.
+    ///     This method returns the ancestor or self at level 1, which is the root of the content tree,
+    ///     if it matches the specified content type <typeparamref name="T" />.
     /// </remarks>
     public static T? Root<T>(this IPublishedContent content)
         where T : class, IPublishedContent

--- a/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceCollectionExtensions
     ///     Create and configure the logger.
     /// </summary>
     /// <remarks>
-    ///     Additional Serilog services are registered during <see cref="HostBuilderExtensions.ConfigureUmbracoDefaults" />.
+    ///     Additional Serilog services are registered during <see cref="HostBuilderExtensions.ConfigureUmbracoDefaults(IHostBuilder)" />.
     /// </remarks>
     public static IServiceCollection AddLogger(
         this IServiceCollection services,

--- a/src/Umbraco.Web.Common/Logging/RegisteredReloadableLogger.cs
+++ b/src/Umbraco.Web.Common/Logging/RegisteredReloadableLogger.cs
@@ -5,8 +5,7 @@ namespace Umbraco.Cms.Web.Common.Logging;
 
 /// <remarks>
 ///     HACK:
-///     Ensures freeze is only called a single time even when resolving a logger from the snapshot container
-///     built for <see cref="RefreshingRazorViewEngine" />.
+///     Ensures freeze is only called a single time even when resolving a logger from a snapshot container.
 /// </remarks>
 internal sealed class RegisteredReloadableLogger
 {


### PR DESCRIPTION
Fixed 17 build warnings related to XML documentation cref attributes:

CS1574 (cref attribute could not be resolved):
- IApiMediaQueryService: Changed see cref to paramref for path parameter
- Permission resources: Removed cross-assembly cref to handlers in Management API
- ContentService: Removed reference to non-existent SaveAndPublish method
- ModelsBuilderModeValidator: Fixed cref to Constants.ModelsBuilder.ModelsModes.Nothing
- ImageCropperPropertyValueEditor: Fixed cref to TemporaryFileUploadValueBase.Src
- NPocoSqlServerDatabaseExtensions: Removed cref to external NPoco method
- RegisteredReloadableLogger: Removed cref to non-existent RefreshingRazorViewEngine
- FriendlyPublishedContentExtensions: Removed cref to non-existent AncestorOrSelf methods
- ManagementApiControllerBase: Removed cref to inherited Forbid() method
- BackOfficeExternalLoginProviderErrorMiddleware: Fixed namespace in cref
- HasScheduleFlagProvider: Fixed typo HasScheduleSignProvider -> HasScheduleFlagProvider

CS0419 (ambiguous cref reference):
- ServiceCollectionExtensions: Specified exact overload ConfigureUmbracoDefaults(IHostBuilder)
- IUserStartNodeEntitiesService: Replaced ambiguous GetPagedChildren cref with plain text
