### PR TITLE
Server Events: Add runtime state check and error handling to `ServerEventRouter`

### DIFF
--- a/src/Umbraco.Cms.Api.Management/ServerEvents/ServerEventRouter.cs
+++ b/src/Umbraco.Cms.Api.Management/ServerEvents/ServerEventRouter.cs
@@ -1,6 +1,11 @@
 ﻿using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.ServerEvents;
 using Umbraco.Cms.Core.ServerEvents;
+using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Cms.Api.Management.ServerEvents;
 
@@ -9,22 +14,59 @@ internal sealed class ServerEventRouter : IServerEventRouter
 {
     private readonly IHubContext<ServerEventHub, IServerEventHub> _eventHub;
     private readonly IUserConnectionManager _connectionManager;
+    private readonly IRuntimeState _runtimeState;
+    private readonly ILogger<ServerEventRouter> _logger;
 
+    [Obsolete("Please use the constructor that takes all parameters. Scheduled for removal in Umbraco 18.")]
     public ServerEventRouter(
         IHubContext<ServerEventHub, IServerEventHub> eventHub,
         IUserConnectionManager connectionManager)
+        : this(
+            eventHub,
+            connectionManager,
+            StaticServiceProvider.Instance.GetRequiredService<IRuntimeState>(),
+            StaticServiceProvider.Instance.GetRequiredService<ILogger<ServerEventRouter>>())
+    {
+    }
+
+    public ServerEventRouter(
+        IHubContext<ServerEventHub, IServerEventHub> eventHub,
+        IUserConnectionManager connectionManager,
+        IRuntimeState runtimeState,
+        ILogger<ServerEventRouter> logger)
     {
         _eventHub = eventHub;
         _connectionManager = connectionManager;
+        _runtimeState = runtimeState;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
-    public Task RouteEventAsync(ServerEvent serverEvent)
-        => _eventHub.Clients.Group(serverEvent.EventSource).notify(serverEvent);
+    public async Task RouteEventAsync(ServerEvent serverEvent)
+    {
+        if (_runtimeState.Level != RuntimeLevel.Run)
+        {
+            return;
+        }
+
+        try
+        {
+            await _eventHub.Clients.Group(serverEvent.EventSource).notify(serverEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to route server event {EventType} for {EventSource}", serverEvent.EventType, serverEvent.EventSource);
+        }
+    }
 
     /// <inheritdoc/>
     public async Task NotifyUserAsync(ServerEvent serverEvent, Guid userKey)
     {
+        if (_runtimeState.Level != RuntimeLevel.Run)
+        {
+            return;
+        }
+
         ISet<string> userConnections = _connectionManager.GetConnections(userKey);
 
         if (userConnections.Any() is false)
@@ -32,10 +74,31 @@ internal sealed class ServerEventRouter : IServerEventRouter
             return;
         }
 
-        await _eventHub.Clients.Clients(userConnections).notify(serverEvent);
+        try
+        {
+            await _eventHub.Clients.Clients(userConnections).notify(serverEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to notify user {UserKey} of server event {EventType}", userKey, serverEvent.EventType);
+        }
     }
 
-
     /// <inheritdoc/>
-    public async Task BroadcastEventAsync(ServerEvent serverEvent) => await _eventHub.Clients.All.notify(serverEvent);
+    public async Task BroadcastEventAsync(ServerEvent serverEvent)
+    {
+        if (_runtimeState.Level != RuntimeLevel.Run)
+        {
+            return;
+        }
+
+        try
+        {
+            await _eventHub.Clients.All.notify(serverEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to broadcast server event {EventType}", serverEvent.EventType);
+        }
+    }
 }


### PR DESCRIPTION
Fixes an issue where you cannot install unattended with Azure SignalR configured.

## Summary

- Add resilience to `ServerEventRouter` to prevent failures during unattended install/upgrade when SignalR (especially Azure SignalR) is configured
- Skip server event routing when runtime level is not `Run` (i.e., during `Install` or `Upgrade`)
- Add try-catch with warning logging for graceful degradation on SignalR connection failures

## Problem

When Azure SignalR is configured via a composer (e.g., `builder.Services.AddSignalR().AddAzureSignalR()`), unattended install/upgrade fails because:

1. During unattended upgrade, the `PostUnattendedInstallNotificationHandler` updates the admin user
2. This triggers a `UserSavedNotification`
3. `ServerEventSender` handles this and calls `IServerEventRouter.RouteEventAsync()` / `NotifyUserAsync()`
4. `ServerEventRouter` attempts to use SignalR to broadcast the event
5. Azure SignalR connection may not be established or fails during the install/upgrade phase
6. The exception crashes the upgrade process

**Failure chain:**
```
Unattended Upgrade
  → PostUnattendedInstallNotificationHandler updates admin user
  → UserSavedNotification published
  → ServerEventSender.HandleAsync() called
  → ServerEventRouter.RouteEventAsync() / NotifyUserAsync()
  → IHubContext<ServerEventHub>.Clients.Group(...).notify(...)
  → Azure SignalR connection fails → EXCEPTION
```

## Solution

1. **Runtime state check**: Before routing any server events, check if `IRuntimeState.Level == RuntimeLevel.Run`. If not (i.e., during `Install` or `Upgrade`), skip the event silently.

2. **Error handling**: Wrap all SignalR calls in try-catch blocks with warning logging. This ensures that even if SignalR fails for any reason, it doesn't crash the application.

## Why this is the right approach

- **Defensive**: Server events are a "nice to have" during install/upgrade - there are no connected clients anyway
- **Graceful degradation**: Even in normal operation, SignalR failures shouldn't crash the application
- **Follows patterns**: Uses the established `StaticServiceProvider` pattern for the obsolete constructor

## Test plan

1. Configure Azure SignalR in a composer as described in the [SignalR in Load Balanced Environments documentation](https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/load-balancing/signalr-in-backoffice-load-balanced-environment)
2. Delete the `umbraco/Data` folder to reset the installation
3. Configure unattended install in `appsettings.json`:
   ```json
   "Umbraco": {
     "CMS": {
       "Unattended": {
         "InstallUnattended": true,
         "UnattendedUserName": "Admin",
         "UnattendedUserEmail": "admin@example.com",
         "UnattendedUserPassword": "YourPassword123!"
       }
     }
   }
   ```
4. Run the application
5. Verify no errors during install/upgrade
6. After installation completes, log into the backoffice and verify real-time notifications work

🤖 Generated with [Claude Code](https://claude.com/claude-code)