### PR TITLE
Media Picker: Uploaded files should automatically be selected (closes #21115)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -198,8 +198,9 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 		const completedUniques = completedItems.map((item) => item.unique);
 
 		if (this.data?.multiple) {
-			// Multiple selection: add all uploaded items to selection
-			const newSelection = [...(this.value?.selection ?? []), ...completedUniques];
+			// Multiple selection: add all uploaded items to selection, avoiding duplicates
+			const existingSelection = this.value?.selection ?? [];
+			const newSelection = [...new Set([...existingSelection, ...completedUniques])];
 			this._isSelectionMode = newSelection.length > 0;
 			this.modalContext?.setValue({ selection: newSelection });
 		} else {


### PR DESCRIPTION
## Summary

**Auto-select uploaded media** - Uploaded media items are now automatically selected in the media picker

When uploading media in the media picker modal with paginated folders (>100 items), uploaded items would not be auto-selected because the code tried to find them in _currentChildren (current page items only).

Solution: Instead of searching for the uploaded item in the current page's children, directly add the uploaded item's unique ID to the selection and navigate to the last page where new uploads appear.

Fixes #21115

## How to test

**Media Picker Auto-Selection**

- [ ]  Open a media picker property
- [ ]  Upload a single image → verify it's auto-selected
- [ ]  Upload multiple images → verify all are selected (multiple mode) or first (single mode)
- [ ]  Test in a folder with >100 items → uploaded items should still be selected