### PR TITLE
Media: Only add deleted suffix to URLs for trashed media when recycle bin protection is enabled

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/MediaUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MediaUrlFactory.cs
@@ -32,20 +32,15 @@ public class MediaUrlFactory : IMediaUrlFactory
             .Select(mediaUrl => new MediaUrlInfo
             {
                 Culture = null,
-                Url = CreateMediaUrl(mediaUrl),
+                Url = CreateMediaUrl(mediaUrl, media.Trashed),
             })
             .ToArray();
 
-    private string CreateMediaUrl(string mediaUrl)
+    private string CreateMediaUrl(string mediaUrl, bool isTrashed)
     {
         var url = _absoluteUrlBuilder.ToAbsoluteUrl(mediaUrl).ToString();
 
-        if (_contentSettings.EnableMediaRecycleBinProtection is false)
-        {
-            return url;
-        }
-
-        return _contentSettings.EnableMediaRecycleBinProtection
+        return isTrashed && _contentSettings.EnableMediaRecycleBinProtection
             ? AddProtectedSuffixToMediaUrl(url)
             : url;
     }


### PR DESCRIPTION
## Description
Fixes an issue found in testing the recycle bin media file protection that, when enabled, backoffice links to media files are modified for non-trashed media.

## Change Summary
- Fixed `MediaUrlFactory.CreateMediaUrl` to only add the `.deleted` suffix to media URLs when the media item is **both** trashed and `EnableMediaRecycleBinProtection` is enabled
- Previously, the suffix was incorrectly added to all media URLs when protection was enabled, regardless of whether the media was trashed
- Updated unit tests to properly cover all scenarios: trashed vs non-trashed media with protection enabled/disabled

## Testing
Unit tests are provided in `MediaUrlFactoryTests`.
I've manually checked that image links are correctly shown on the "Info" workspace view for trashed and non-trashed media.