### PR TITLE
Media Picker: Respect start node when drag+dropping files directly onto picker (closes #21422)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -372,6 +372,7 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		return html`<umb-dropzone-media
 			id="dropzone"
 			?multiple=${this.multiple}
+			.parentUnique=${this.startNode?.unique ?? null}
 			@change=${this.#onUploadCompleted}></umb-dropzone-media>`;
 	}
 


### PR DESCRIPTION
## Description

This PR fixes an issue reported in https://github.com/umbraco/Umbraco-CMS/issues/21422 where drag+dropping files directly onto a media picker with a start node configured would upload files to the root of the media library instead of the configured start node folder

This caused validation errors when saving because the uploaded media was outside the allowed start node path.

The cause was the `umb-dropzone-media` component in `input-rich-media.element.ts` not receiving the `parentUnique` property from the configured `startNode`. Without this, uploads defaulted to `null` (media root).

To fix I've passed `startNode.unique` to the dropzone's `parentUnique` property so uploads go to the correct folder.

## Testing
To manually test this fix:

- Create a document type with a media picker configured with a start folder
<img width="895" height="873" alt="image" src="https://github.com/user-attachments/assets/8e56b434-9db9-41aa-b224-d9b997a09675" />

- Create a document of that type.
- Drag and drop a media file on to the media picker without clicking the "Choose" button. 
- Save and published the document.
- Verify that before this fix, you cannot publish the content due to a validation error reported, and the media is uploaded to the root of the media library rather than the start node selected for that media picker.
- With this fix the media is uploaded into the configured start folder and the document can be saved and published.