### PR TITLE
Examine: Check for registered populators before emptying indexes

### DIFF
--- a/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
@@ -49,7 +49,7 @@ internal class ExamineIndexRebuilder : IIndexRebuilder
             throw new InvalidOperationException("No index found by name " + indexName);
         }
 
-        return _populators.Any(x => x.IsRegistered(index));
+        return HasRegisteredPopulator(index);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Fixes a bug in our search package, where due to a race condition, indexes are being cleared after startup. https://github.com/umbraco/Umbraco.Cms.Search/issues/50
https://github.com/umbraco/Umbraco.Cms.Search/issues/40

# Notes
- In short, this will now check for a registered `IIndexPopulator` before creating (this will clear if exisiting) the indexes, and then try repopulating it.
- Due to the package rebuilding the indexes on startup, and umbraco rebuilding indexes on first request, we can end up in a state where: 
  - We start the rebuild
  - Umbraco now checks if there is any items in the index (there is not, as we have just created it, but put no items in)
  - It will DELAY rebuilding by a minute.
  - We put items into the index
  - Umbraco has waited a minute, and will now "Creates" the index (clears)
  - Umbraco tries to populate the index, but we have no registered populator.
  - Therefore the index ends up empty 
- It's a safe assumption to NOT clear indexes, if we have no populators, as we have no way of putting content back into the index anyways. Therefore we can assumes rebuilding of these indexes will happen elsewhere.


# How to test
- This is really wierd to test, due to it being a race condition, but I have found a consistent method to reproduce it, hit me up if you want me to show you 😁 
- Install Umbraco.Cms.Search, following the documentation here, make sure you have your composer. 
- But we can still confirm that the indexes WILL be cleared by umbraco, and they should not be..
- Set a breakpoint in `ExamineIndexRebuilder.RebuildIndexes L177`
- I also tampered with the SyncBootStateAccessor to return ColdBootState all the time, just to debug this consistently
- Run your site, and request any umbraco site to trigger the examine rebuild: for example: `https://localhost:44339/`
- Observe the indexes get deleted 🙃 


Here is a GIF of me reproducing the issue: 

![IndexesCleared](https://github.com/user-attachments/assets/402f8216-58c7-42fa-a336-53c681d81ff6)
