### PR TITLE
Backoffice: Redirect to list view after entity deletion 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/common/delete/delete.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/common/delete/delete.action.ts
@@ -1,8 +1,10 @@
 import { UmbEntityActionBase } from '../../entity-action-base.js';
+import { UmbEntityDeletedEvent } from '../../entity-deleted.event.js';
 import { UmbRequestReloadStructureForEntityEvent } from '../../request-reload-structure-for-entity.event.js';
 import type { MetaEntityActionDeleteKind } from './types.js';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import type { UmbDetailRepository, UmbItemRepository } from '@umbraco-cms/backoffice/repository';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
@@ -73,6 +75,20 @@ export class UmbDeleteEntityAction<
 		});
 
 		actionEventContext.dispatchEvent(event);
+
+		const deletedEvent = new UmbEntityDeletedEvent({
+			unique: this.args.unique,
+			entityType: this.args.entityType,
+		});
+
+		actionEventContext.dispatchEvent(deletedEvent);
+
+		const notificationContext = await this.getContext(UMB_NOTIFICATION_CONTEXT);
+		if (notificationContext) {
+			notificationContext.peek('positive', {
+				data: { message: this.#localize.term('general_deleted') },
+			});
+		}
 	}
 }
 export default UmbDeleteEntityAction;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


- Create a test user
- Open the test user's profile
- Delete the user via the action menu
- **Expected**: Redirected to users list + success toast shown
- Repeat for other entity types (e.g., Data Type, Template)

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
When an entity is deleted from its detail workspace, the UI now redirects to the parent list view and shows a success notification instead of staying on the deleted entity's page showing a 404 error.

Changes:
- Dispatch UmbEntityDeletedEvent after successful deletion
- Show success notification toast on deletion
- Listen for delete event in workspace editor and navigate to backPath

Closes #21402

## Changes

### `delete.action.ts`
- Dispatch `UmbEntityDeletedEvent` after successful deletion
- Show success notification using `general_deleted` localization term

### `entity-detail-workspace-editor.element.ts`
- Listen for `UmbEntityDeletedEvent` on the action event context
- Navigate to `backPath` when the current entity is deleted
- Proper cleanup of event listener in `destroy()` method



<!-- Thanks for contributing to Umbraco CMS! -->