### PR TITLE
Dotnet Template: Removes unused setting `SanitizeTinyMce`

### DIFF
--- a/templates/UmbracoProject/appsettings.json
+++ b/templates/UmbracoProject/appsettings.json
@@ -26,7 +26,6 @@
         //#if (HasNoNodesViewPath)
         "NoNodesViewPath": "NO_NODES_VIEW_PATH_FROM_TEMPLATE",
         //#endif
-        "SanitizeTinyMce": true
       },
       "Content": {
         "AllowEditInvariantFromNonDefault": true,


### PR DESCRIPTION
### Description

Removes the unused setting `SanitizeTinyMce` from the UmbracoProject template.