### PR TITLE
Management API: Fix document URLs returning all languages for invariant content (closes #21459)

### DIFF
--- a/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
+++ b/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
@@ -45,7 +45,12 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
     public async Task<ISet<UrlInfo>> GetAllAsync(IContent content)
     {
         HashSet<UrlInfo> urlInfos = [];
-        IEnumerable<string> cultures = await _languageService.GetAllIsoCodesAsync();
+
+        // For invariant content, only return the URL for the default language.
+        // Invariant content doesn't vary by culture, so it only has one URL.
+        IEnumerable<string> cultures = content.ContentType.VariesByCulture()
+            ? await _languageService.GetAllIsoCodesAsync()
+            : [(await _languageService.GetDefaultIsoCodeAsync())];
 
         // First we get the urls of all cultures, using the published router, meaning we respect any extensions.
         foreach (var culture in cultures)


### PR DESCRIPTION
## Description

This PR addresses the issue raised in https://github.com/umbraco/Umbraco-CMS/issues/21459 where URLs for invariant content show for all languages in the "Info" workspace view.

## Change Summary
- Fixes the `/umbraco/management/api/v1/document/urls` endpoint returning URL records for all configured languages even for invariant documents.
- For invariant content (content that doesn't vary by culture), only the default language URL is now returned.

## Root Cause
It looks like this issue was introduced in PR #18072 "V15: Fix Url Preview" on January 29, 2025.

The `PublishedUrlInfoProvider.GetAllAsync` method was changed to iterate through **all configured languages** without checking if the content is variant or invariant. The previous implementation (`IDocumentUrlService.ListUrlsAsync`) had filtering logic that would skip non-default languages for content without assigned domains:

This filtering was lost when switching to the new `IPublishedUrlInfoProvider.GetAllAsync` implementation.

## Fix
I haven't looked to revert any logic from that PR as it was doing more than handle the functionality related to this issue.  Rather I think we can just check if the document is invariant, and if so, only consider the default language.

So fhe fix checks if the content type varies by culture before determining which languages to iterate:
- **Variant content**: iterate through all languages (existing behaviour)
- **Invariant content**: only use the default language's ISO code

## Testing
I've added integration test `Invariant_content_returns_only_default_language_url` that verifies invariant content only returns one URL for the default language.

And in testing I see for invariant now only the default language and a single URL, and for variant the appropriate URL for the selected language.