### PR TITLE
Task: De-duplicate TypeScript class names

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area/block-grid-area.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-area/block-grid-area.element.ts
@@ -7,7 +7,7 @@ import { customElement } from '@umbraco-cms/backoffice/external/lit';
  * This element is used to render a single block grid area.
  */
 @customElement('umb-block-grid-area')
-export class UmbBlockGridAreasContainerElement extends UmbBlockGridEntriesElement {
+export class UmbBlockGridAreaElement extends UmbBlockGridEntriesElement {
 	//
 	constructor() {
 		super();
@@ -30,10 +30,10 @@ export class UmbBlockGridAreasContainerElement extends UmbBlockGridEntriesElemen
 	}
 }
 
-export default UmbBlockGridAreasContainerElement;
+export default UmbBlockGridAreaElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-block-grid-area': UmbBlockGridAreasContainerElement;
+		'umb-block-grid-area': UmbBlockGridAreaElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create-blueprint/create-blueprint.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create-blueprint/create-blueprint.action.ts
@@ -5,7 +5,7 @@ import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbEntityActionArgs } from '@umbraco-cms/backoffice/entity-action';
 
-export class UmbCreateDocumentBlueprintEntityAction extends UmbEntityActionBase<never> {
+export class UmbDocumentCreateBlueprintEntityAction extends UmbEntityActionBase<never> {
 	#repository = new UmbDocumentCreateBlueprintRepository(this);
 
 	constructor(host: UmbControllerHost, args: UmbEntityActionArgs<never>) {
@@ -25,4 +25,4 @@ export class UmbCreateDocumentBlueprintEntityAction extends UmbEntityActionBase<
 		await this.#repository.create({ name, parent, document: { id: this.args.unique } });
 	}
 }
-export default UmbCreateDocumentBlueprintEntityAction;
+export default UmbDocumentCreateBlueprintEntityAction;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/preview/workspace-action-menu-item/preview-option.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/preview/workspace-action-menu-item/preview-option.action.ts
@@ -2,7 +2,7 @@ import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '../../workspace/document-workspa
 import type { ManifestWorkspaceActionMenuItemPreviewOptionKind } from './preview-option.workspace-action-menu-item.extension.js';
 import { UmbWorkspaceActionBase } from '@umbraco-cms/backoffice/workspace';
 
-export class UmbDocumentSaveAndPreviewWorkspaceAction extends UmbWorkspaceActionBase {
+export class UmbDocumentSaveAndPreviewOptionWorkspaceAction extends UmbWorkspaceActionBase {
 	manifest?: ManifestWorkspaceActionMenuItemPreviewOptionKind;
 
 	override async execute() {
@@ -14,4 +14,4 @@ export class UmbDocumentSaveAndPreviewWorkspaceAction extends UmbWorkspaceAction
 	}
 }
 
-export { UmbDocumentSaveAndPreviewWorkspaceAction as api };
+export { UmbDocumentSaveAndPreviewOptionWorkspaceAction as api };

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/action/create-member-collection-action.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/collection/action/create-member-collection-action.element.ts
@@ -4,7 +4,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbMemberTypeTreeRepository } from '@umbraco-cms/backoffice/member-type';
 
 @customElement('umb-create-member-collection-action')
-export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
+export class UmbCreateMemberCollectionActionElement extends UmbLitElement {
 	@state()
 	private _options: Array<{ label: string; unique: string; icon: string }> = [];
 
@@ -97,10 +97,10 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 	];
 }
 
-export default UmbCreateDocumentCollectionActionElement;
+export default UmbCreateMemberCollectionActionElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-create-member-collection-action': UmbCreateDocumentCollectionActionElement;
+		'umb-create-member-collection-action': UmbCreateMemberCollectionActionElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/heading/heading6.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/heading/heading6.tiptap-toolbar-api.ts
@@ -1,7 +1,7 @@
 import type { Editor } from '../../externals.js';
 import { UmbTiptapToolbarElementApiBase } from '../tiptap-toolbar-element-api-base.js';
 
-export default class UmbTiptapToolbarHeading3ExtensionApi extends UmbTiptapToolbarElementApiBase {
+export default class UmbTiptapToolbarHeading6ExtensionApi extends UmbTiptapToolbarElementApiBase {
 	override isActive(editor?: Editor) {
 		return editor?.isActive('heading', { level: 6 }) === true;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/subscript/subscript.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/subscript/subscript.tiptap-api.ts
@@ -1,6 +1,6 @@
 import { UmbTiptapExtensionApiBase } from '../tiptap-extension-api-base.js';
 import { Subscript } from '../../externals.js';
 
-export default class UmbTiptapBoldExtensionApi extends UmbTiptapExtensionApiBase {
+export default class UmbTiptapSubscriptExtensionApi extends UmbTiptapExtensionApiBase {
 	getTiptapExtensions = () => [Subscript];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/superscript/superscript.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/superscript/superscript.tiptap-api.ts
@@ -1,6 +1,6 @@
 import { UmbTiptapExtensionApiBase } from '../tiptap-extension-api-base.js';
 import { Superscript } from '../../externals.js';
 
-export default class UmbTiptapBoldExtensionApi extends UmbTiptapExtensionApiBase {
+export default class UmbTiptapSuperscriptExtensionApi extends UmbTiptapExtensionApiBase {
 	getTiptapExtensions = () => [Superscript];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/client-credential/create/modal/create-user-client-credential-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/client-credential/create/modal/create-user-client-credential-modal.element.ts
@@ -9,9 +9,8 @@ import { css, html, customElement, query } from '@umbraco-cms/backoffice/externa
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 
-const elementName = 'umb-create-user-client-credential-modal';
-@customElement(elementName)
-export class UmbCreateUserModalElement extends UmbModalBaseElement<
+@customElement('umb-create-user-client-credential-modal')
+export class UmbCreateUserClientCredentialModalElement extends UmbModalBaseElement<
 	UmbCreateUserClientCredentialModalData,
 	UmbCreateUserClientCredentialModalValue
 > {
@@ -123,10 +122,10 @@ export class UmbCreateUserModalElement extends UmbModalBaseElement<
 	];
 }
 
-export { UmbCreateUserModalElement as element };
+export { UmbCreateUserClientCredentialModalElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbCreateUserModalElement;
+		'umb-create-user-client-credential-modal': UmbCreateUserClientCredentialModalElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/components/user-avatar/user-avatar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/components/user-avatar/user-avatar.element.ts
@@ -13,8 +13,7 @@ import {
 } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const elementName = 'umb-user-avatar';
-@customElement(elementName)
+@customElement('umb-user-avatar')
 export class UmbUserAvatarElement extends UmbLitElement {
 	@property({ type: String })
 	name?: string;
@@ -135,6 +134,6 @@ export class UmbUserAvatarElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbUserAvatarElement;
+		'umb-user-avatar': UmbUserAvatarElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-avatar/user-workspace-avatar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-avatar/user-workspace-avatar.element.ts
@@ -5,7 +5,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTemporaryFileConfigRepository } from '@umbraco-cms/backoffice/temporary-file';
 
 @customElement('umb-user-workspace-avatar')
-export class UmbUserAvatarElement extends UmbLitElement {
+export class UmbUserWorkspaceAvatarElement extends UmbLitElement {
 	@state()
 	private _user?: UmbUserDetailModel;
 
@@ -158,10 +158,10 @@ export class UmbUserAvatarElement extends UmbLitElement {
 	];
 }
 
-export default UmbUserAvatarElement;
+export default UmbUserWorkspaceAvatarElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'umb-user-workspace-avatar': UmbUserAvatarElement;
+		'umb-user-workspace-avatar': UmbUserWorkspaceAvatarElement;
 	}
 }


### PR DESCRIPTION
### Description

Following on from #21460, running the `npm run check:duplicate-class-names` command resulted in several duplicated TypeScript class names.

My assumption is that these were copy-and-paste duplications. This PR renames the duplications with an appropriate class name. Whilst technically this is a breaking-change, the reality is that the majority of these classes are imported via a manifest, e.g. entity-actions or modals. So they shouldn't have been used directly by a 3rd-party.
