### PR TITLE
Redirect Tracking: Handle empty string in redirect tracker when restoring from recycle bin

### DIFF
--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -112,7 +112,7 @@ internal sealed class RedirectTracker : IRedirectTracker
     }
 
     private int GetNodeIdWithAssignedDomain(IPublishedContent entityContent) =>
-        entityContent.Path.Split(',').Select(int.Parse).Reverse()
+        entityContent.Path.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).Reverse()
             .FirstOrDefault(x => _domainCache.HasAssigned(x, includeWildcards: true));
 
     private string GetUrl(Guid contentKey, string languageIsoCode) =>


### PR DESCRIPTION
### Description
I spotted this exception being logged when restoring an item from the recycle bin.  It's in a try/catch so there's no visible error, but should still be handled more defensively:

```
System.FormatException: The input string '' was not in a correct format.
   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
   at System.Int32.Parse(String s)
   at System.Linq.Enumerable.ArraySelectIterator`2.ToArray()
   at System.Linq.Enumerable.ReverseIterator`1.MoveNext()
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at Umbraco.Cms.Infrastructure.Routing.RedirectTracker.GetNodeIdWithAssignedDomain(IPublishedContent entityContent) in C:\Repos\Umbraco\Umbraco.Cms-V16\src\Umbraco.Infrastructure\Routing\RedirectTracker.cs:line 115
   at Umbraco.Cms.Infrastructure.Routing.RedirectTracker.<>c__DisplayClass9_0.<StoreOldRoute>b__1() in C:\Repos\Umbraco\Umbraco.Cms-V16\src\Umbraco.Infrastructure\Routing\RedirectTracker.cs:line 68
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at Umbraco.Cms.Infrastructure.Routing.RedirectTracker.StoreOldRoute(IContent entity, Dictionary`2 oldRoutes) in C:\Repos\Umbraco\Umbraco.Cms-V16\src\Umbraco.Infrastructure\Routing\RedirectTracker.cs:line 85
```

I've fixed by ensuring we don't end up trying to parse an empty string as an integer.

### Testing

Restore an item from the recycle bin and you should no longer see an exception logged.