### PR TITLE
Data Types: Allows transparency for the approved colors in the color picker.

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ColorPickerConfigurationEditor.cs
@@ -99,7 +99,7 @@ internal sealed partial class ColorPickerConfigurationEditor : ConfigurationEdit
             return normalizedValue;
         }
 
-        [GeneratedRegex("^([0-9a-f]{3}|[0-9a-f]{6})$", RegexOptions.IgnoreCase, "en-GB")]
+        [GeneratedRegex("^([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$", RegexOptions.IgnoreCase, "en-GB")]
         private static partial Regex ColorPattern();
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ColorListValidatorTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/ColorListValidatorTest.cs
@@ -78,4 +78,20 @@ public class ColorListValidatorTest
         Assert.AreEqual(1, result.Count());
         Assert.IsTrue(result.First().ErrorMessage.Contains("ffffff, 000000, ff00aa"));
     }
+
+    [Test]
+    public void Validates_Color_Can_Contain_Transparency()
+    {
+        var validator = new ColorPickerConfigurationEditor.ColorListValidator(ConfigurationEditorJsonSerializer());
+        var result =
+            validator.Validate(
+                new JsonArray(
+                    JsonNode.Parse("""{"value": "ff000050", "label": "Transparent Red"}"""),
+                    JsonNode.Parse("""{"value": "ff0000", "label": "Regular Red"}"""),
+                    JsonNode.Parse("""{"value": "ff0000500", "label": "Invalid Red"}""")),
+                null,
+                null,
+                PropertyValidationContext.Empty());
+        Assert.AreEqual(1, result.Count());
+    }
 }


### PR DESCRIPTION
Closes #21389

### Description
This PR aims to allow for color transparency in the allowed colors, for the data type Color Picker. Previous to this fix, you could add a transparent color to the data type, however upon saving you would be met with a validation error.

I have just adjusted the regex to allow for 8 digit hex values, which is needed for transparency.

### To Test
1. Create a new datatype of type "Color Picker" (or open the default Approved Color datatype).
2. Enter a 8 digit hex value like: "ff000050". It shows the swatch red semi-transparent.
3. Save the datatype.
4. Previously you would get an error. Now it saves just fine.


<!-- Thanks for contributing to Umbraco CMS! -->
