### PR TITLE
UFM: Skip leading whitespace in token parser (closes #20341)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.plugin.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.plugin.ts
@@ -9,10 +9,11 @@ export function ufm(plugins: Array<UfmPlugin> = []): MarkedExtension {
 	return {
 		extensions: plugins.map(({ alias, marker, render }) => {
 			const prefix = `(${alias}:${marker ? `|${marker}` : ''})`;
+			const startPattern = new RegExp(`\\{\\s*${prefix}`);
 			return {
 				name: alias,
 				level: 'inline',
-				start: (src: string) => src.search(`{${prefix}`),
+				start: (src: string) => src.search(startPattern),
 				tokenizer: (src: string) => {
 					const pattern = `^\\{\\s*${prefix}([^}]*)\\}`;
 					const regex = new RegExp(pattern);

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.test.ts
@@ -18,6 +18,7 @@ describe('UmbMarkedUfm', () => {
 			},
 			{ ufm: '{umbValue:prop1}', expected: '<ufm-label-value alias="prop1"></ufm-label-value>' },
 			{ ufm: '{ umbValue:prop1 }', expected: '<ufm-label-value alias="prop1"></ufm-label-value>' },
+			{ ufm: '{ umbValue: prop1 }', expected: '<ufm-label-value alias="prop1"></ufm-label-value>' },
 			{ ufm: '{#general_add}', expected: '<ufm-localize alias="general_add"></ufm-localize>' },
 			{ ufm: '{umbLocalize:general_add}', expected: '<ufm-localize alias="general_add"></ufm-localize>' },
 			{ ufm: '{~contentPicker}', expected: '<ufm-content-name alias="contentPicker"></ufm-content-name>' },


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #20341 

### Description

This pull request proposes a change to the ufm tokenizer that allows 0 or more whitespace characters after the opening curly bracket per the description in #20341 .
An additional unit test to the tokenizer confirms that the change works as expected.

#### How to test
- Create an element type with at least one property (a richtext property for example)
- Create a blocklist type with at least one block, using the element type that you just created. Use following examples as label
  ```
  {umbValue: text | strip-html | word-limit:50}
  { umbValue: text | strip-html | word-limit:50 }
  ```
- Create a document type with a property that uses the blocklist, allow to create at root
- Create a new page with the document type and create a block in the blocklist property
- Notice the label displaying as expected

Example:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/05a8ba11-25ab-4d02-88eb-23437c7f0315" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/4279beb9-6aa6-4b5a-ac0c-898556fff072" />



<!-- Thanks for contributing to Umbraco CMS! -->
