### PR TITLE
Property Layout: Display alias below label to prevent overlap (closes #21499)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property-layout/property-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property-layout/property-layout.element.ts
@@ -79,6 +79,7 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 						() => html`<div id="invalid-badge"><uui-badge color="invalid" attention>!</uui-badge></div>`,
 					)}
 				</uui-label>
+				${this.#renderAlias()}
 				<slot name="action-menu"></slot>
 				${this.#renderDescription()}
 				<slot name="description"></slot>
@@ -89,6 +90,12 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 				</umb-form-validation-message>
 			</div>
 		`;
+	}
+
+	#renderAlias() {
+		// Show alias below label when it's different from the label and not empty
+		if (!this.alias || this.alias === this.label) return;
+		return html`<div id="alias">${this.alias}</div>`;
 	}
 
 	#renderDescription() {
@@ -152,6 +159,12 @@ export class UmbPropertyLayoutElement extends UmbLitElement {
 				//height: var(--uui-color-invalid);
 				background-color: var(--umb-temp-uui-color-invalid);
 				color: var(--uui-color-invalid-contrast);
+			}
+
+			#alias {
+				color: var(--uui-color-text-alt);
+				font-size: var(--uui-font-size-3);
+				margin-top: var(--uui-size-space-1);
 			}
 
 			#description {


### PR DESCRIPTION
## Description

Fixes issue #21499 where property names and aliases were overlapping when alias names were long, making it difficult or impossible to read both.

## Changes

- Added `#renderAlias()` method to display the alias below the label
- Alias is only shown when it's different from the label and not empty
- Styled alias with muted color (`--uui-color-text-alt`) and smaller font size to match description styling
- This matches the behavior of properties from compositions where alias is displayed below the name

## Testing

1. Create a property with a long alias name
2. Verify that the property name is displayed on top
3. Verify that the alias is displayed below the name (when different)
4. Verify that both are readable without overlap

## Related Issue

Closes #21499