### PR TITLE
Dark mode: Added color variable to code block in the system information dialog to make it readable

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -86,7 +86,7 @@ export class UmbCodeBlockElement extends LitElement {
 			code {
 				word-wrap: normal;
 				white-space: pre;
-				color: var(--uui-color-text, #eeeeef);
+				color: var(--uui-color-text);
 			}
 
 			#header {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

### Description

Added the text color variable to the code block, this code block is used to display the System Information for example.

No real steps are needed to test this, other than open the System Information :)



