### PR TITLE
Templates: Allow underscore as first character in template alias (closes #21534)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace-editor.element.ts
@@ -15,6 +15,12 @@ import { umbBindToValidation } from '@umbraco-cms/backoffice/validation';
 import '@umbraco-cms/backoffice/code-editor';
 import '../../local-components/insert-menu/index.js';
 
+/**
+ * Template alias pattern - allows first character to be a letter, digit, or underscore.
+ * Mirrors server-side CleanStringType.UnderscoreAlias behavior.
+ */
+const UMB_TEMPLATE_ALIAS_PATTERN = '^[A-Za-z0-9_][A-Za-z0-9_-]{0,254}$';
+
 @customElement('umb-template-workspace-editor')
 export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 	#modalContext?: UmbModalManagerContext;
@@ -169,6 +175,7 @@ export class UmbTemplateWorkspaceEditorElement extends UmbLitElement {
 					placeholder=${this.localize.term('placeholders_entername')}
 					.value=${this._name}
 					.alias=${this._alias}
+					alias-pattern=${UMB_TEMPLATE_ALIAS_PATTERN}
 					?auto-generate-alias=${this.#isNew}
 					@change=${this.#onNameAndAliasChange}
 					required


### PR DESCRIPTION
## Description

Issue https://github.com/umbraco/Umbraco-CMS/issues/21534 raises a regression in 17.1 that prevents the use of an underscore as a leading character for the alias.  This was prevented following https://github.com/umbraco/Umbraco-CMS/pull/20755, which correctly aligns the regular expression pattern for the alias to the server-side behaviour that will clean up invalid characters.

It misses though that template aliases are little more lenient.  They allow `_` as the first character, mainly as these aliases aren't used in models builder classes, so only have to be restricted to allowed characters for files on disk (it's the alias that defines the `.cshtml` file name).

## Change Summary
- Fixes client-side validation for template aliases to allow underscore as the first character.
- Mirrors server-side `CleanStringType.UnderscoreAlias` behaviour which allows letters, digits, or underscores as the first character.
- The default alias pattern introduced in #20755 requires a letter as the first character, which is correct for document types, media types, etc., but templates use a different server-side pattern.

## Change Details
- Added `UMB_TEMPLATE_ALIAS_PATTERN` constant to template workspace editor
- Applied the template-specific pattern to the `umb-input-with-alias` component

## Testing
Create or update a template to use an underscore as the first character of the alias.  It should be allowed.  Verify that a file on disk is created with the expected file name.
Deleting the template should remove the file on disk.