### PR TITLE
Elements: Display trashed state in Element workspace info panel

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/workspace/views/info/element-workspace-view-info.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/workspace/views/info/element-workspace-view-info.element.ts
@@ -119,6 +119,12 @@ export class UmbElementWorkspaceViewInfoElement extends UmbLitElement {
 						${this.localize.term('content_published')}
 					</uui-tag>
 				`;
+			case UmbElementVariantState.TRASHED:
+				return html`
+					<uui-tag color="danger" look="primary" label=${this.localize.term('content_trashed')}>
+						${this.localize.term('content_trashed')}
+					</uui-tag>
+				`;
 			default:
 				return html`
 					<uui-tag look="primary" label=${this.localize.term('content_notCreated')}>


### PR DESCRIPTION
## Summary
- Adds missing `TRASHED` case to the state tag switch statement in the Element workspace info view
- Trashed Elements now correctly display "Trashed" instead of "Not created" when viewed from the recycle bin

## Test plan
- [x] Trash an Element
- [x] Open the trashed Element from the recycle bin
- [x] Verify the info panel shows "Trashed" state with a danger-colored tag