### PR TITLE
Elements: Fix folder link in recycle bin list view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/collection/views/trashed-element-name-table-column.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/collection/views/trashed-element-name-table-column.element.ts
@@ -1,4 +1,5 @@
 import { UMB_EDIT_ELEMENT_WORKSPACE_PATH_PATTERN } from '../../../paths.js';
+import { UMB_EDIT_ELEMENT_FOLDER_WORKSPACE_PATH_PATTERN } from '../../../folder/workspace/constants.js';
 import type { UmbElementRecycleBinTreeItemModel } from '../../tree/types.js';
 //import { UmbElementItemDataResolver } from '../../../item/data-resolver/element-item-data-resolver.js';
 import { css, customElement, html, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
@@ -26,7 +27,11 @@ export class UmbTrashedElementNameTableColumnElement extends UmbLitElement imple
 			//this.#resolver.setData(value);
 			this._name = value.name;
 
-			this._editPath = UMB_EDIT_ELEMENT_WORKSPACE_PATH_PATTERN.generateAbsolute({
+			const pathPattern = value.isFolder
+				? UMB_EDIT_ELEMENT_FOLDER_WORKSPACE_PATH_PATTERN
+				: UMB_EDIT_ELEMENT_WORKSPACE_PATH_PATTERN;
+
+			this._editPath = pathPattern.generateAbsolute({
 				unique: value.unique,
 			});
 		}


### PR DESCRIPTION
## Summary
- Fixes folders in the recycle bin list view linking to the wrong workspace
- The trashed element name column was always using `UMB_EDIT_ELEMENT_WORKSPACE_PATH_PATTERN`, causing folders to navigate to `/section/library/workspace/element/edit/` instead of `/section/library/workspace/element-folder/edit/`
- Now checks `isFolder` and uses the correct path pattern

## Test plan
- [x] Create a folder with a child folder inside
- [x] Trash the parent folder
- [x] Navigate to the recycle bin and open the trashed parent folder
- [x] Click the child folder in the list view
- [x] Verify it opens the folder workspace (not "Not found")