### PR TITLE
Elements: Add missing delete permission conditions to recycle bin actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/folder/entity-actions/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/folder/entity-actions/manifests.ts
@@ -1,5 +1,9 @@
 import { UMB_ELEMENT_FOLDER_ENTITY_TYPE } from '../../entity.js';
 import { UMB_ELEMENT_FOLDER_REPOSITORY_ALIAS } from '../repository/constants.js';
+import {
+	UMB_ELEMENT_USER_PERMISSION_CONDITION_ALIAS,
+	UMB_USER_PERMISSION_ELEMENT_DELETE,
+} from '../../user-permissions/constants.js';
 import { manifests as moveManifests } from './move/manifests.js';
 import {
 	UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS,
@@ -16,7 +20,13 @@ const folderDelete: UmbExtensionManifest = {
 		icon: 'icon-trash-empty',
 		folderRepositoryAlias: UMB_ELEMENT_FOLDER_REPOSITORY_ALIAS,
 	},
-	conditions: [{ alias: UMB_ENTITY_IS_TRASHED_CONDITION_ALIAS }],
+	conditions: [
+		{
+			alias: UMB_ELEMENT_USER_PERMISSION_CONDITION_ALIAS,
+			allOf: [UMB_USER_PERMISSION_ELEMENT_DELETE],
+		},
+		{ alias: UMB_ENTITY_IS_TRASHED_CONDITION_ALIAS },
+	],
 };
 
 const folderUpdate: UmbExtensionManifest = {

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/collection/action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/collection/action/manifests.ts
@@ -1,5 +1,9 @@
 import { UMB_ELEMENT_RECYCLE_BIN_REPOSITORY_ALIAS } from '../../repository/constants.js';
 import { UMB_ELEMENT_RECYCLE_BIN_COLLECTION_ALIAS } from '../constants.js';
+import {
+	UMB_ELEMENT_USER_PERMISSION_CONDITION_ALIAS,
+	UMB_USER_PERMISSION_ELEMENT_DELETE,
+} from '../../../user-permissions/constants.js';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
 import type { ManifestCollectionActionEmptyRecycleBinKind } from '@umbraco-cms/backoffice/recycle-bin';
 
@@ -17,6 +21,10 @@ export const manifests: Array<ManifestCollectionActionEmptyRecycleBinKind> = [
 			{
 				alias: UMB_COLLECTION_ALIAS_CONDITION,
 				match: UMB_ELEMENT_RECYCLE_BIN_COLLECTION_ALIAS,
+			},
+			{
+				alias: UMB_ELEMENT_USER_PERMISSION_CONDITION_ALIAS,
+				allOf: [UMB_USER_PERMISSION_ELEMENT_DELETE],
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
- Adds delete permission condition to the Empty Recycle Bin collection action
- Adds delete permission condition to the folder delete entity action
- Both actions were previously visible to users without delete permission

## Test plan
- [x] Create a user without Element delete permission
- [x] Navigate to the Element recycle bin
- [x] Verify the "Empty Recycle Bin" button is not visible
- [x] Open a trashed folder
- [x] Verify the "Delete" action is not available in the context menu