### PR TITLE
View Engines: Make `ProfilingViewEngine._inner` private and modernize string formatting

### DIFF
--- a/src/Umbraco.Web.Website/ViewEngines/ProfilingViewEngine.cs
+++ b/src/Umbraco.Web.Website/ViewEngines/ProfilingViewEngine.cs
@@ -8,30 +8,28 @@ public class ProfilingViewEngine : IViewEngine
 {
     private readonly string _name;
     private readonly IProfiler _profiler;
-
-    //TODO: can this be made private and with underscore?
-    internal readonly IViewEngine Inner;
+    private readonly IViewEngine _inner;
 
     public ProfilingViewEngine(IViewEngine inner, IProfiler profiler)
     {
-        Inner = inner;
+        _inner = inner;
         _profiler = profiler;
         _name = inner.GetType().Name;
     }
 
     public ViewEngineResult FindView(ActionContext context, string viewName, bool isMainPage)
     {
-        using (_profiler.IsEnabled ? _profiler.Step(string.Format("{0}.FindView, {1}, {2}", _name, viewName, isMainPage)) : null)
+        using (_profiler.IsEnabled ? _profiler.Step($"{_name}.FindView, {viewName}, {isMainPage}") : null)
         {
-            return WrapResult(Inner.FindView(context, viewName, isMainPage));
+            return WrapResult(_inner.FindView(context, viewName, isMainPage));
         }
     }
 
     public ViewEngineResult GetView(string? executingFilePath, string viewPath, bool isMainPage)
     {
-        using (_profiler.IsEnabled ? _profiler.Step(string.Format("{0}.GetView, {1}, {2}, {3}", _name, executingFilePath, viewPath, isMainPage)) : null)
+        using (_profiler.IsEnabled ? _profiler.Step($"{_name}.GetView, {executingFilePath}, {viewPath}, {isMainPage}") : null)
         {
-            return Inner.GetView(executingFilePath, viewPath, isMainPage);
+            return _inner.GetView(executingFilePath, viewPath, isMainPage);
         }
     }
 


### PR DESCRIPTION
## Summary

Improves code encapsulation and modernizes string formatting in `ProfilingViewEngine`.

## Changes

- Made `Inner` field private with underscore prefix (`_inner`) following C# conventions
- Replaced `string.Format` calls with string interpolation
- Removed TODO comment

## Benefits

- Better encapsulation: field is now private instead of internal
- Cleaner code: string interpolation is more readable than `string.Format`
- Follows C# naming conventions for private fields