### PR TITLE
External Logins: Handle duplicate key race condition intermittently triggered in `ExternalLoginRepository`

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
@@ -1,14 +1,18 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
+using static Umbraco.Cms.Tests.Integration.Testing.BaseTestDatabase;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
@@ -274,5 +278,63 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
         var logins = ExternalLoginService.GetExternalLogins(user.Key).ToList();
 
         Assert.AreEqual("hello world", logins[0].UserData);
+    }
+
+    [Test]
+    [LongRunning]
+    public async Task Concurrent_Save_Same_Login_Should_Not_Throw_Duplicate_Key_Exception()
+    {
+        if (IsSqlite())
+        {
+            Assert.Ignore("This concurrency test requires SQL Server to reliably reproduce the race condition.");
+            return;
+        }
+
+        // Arrange
+        var user = new UserBuilder().Build();
+        UserService.Save(user);
+
+        const int NumberOfConcurrentOperations = 10;
+        var exceptions = new ConcurrentBag<Exception>();
+        var providerKey = Guid.NewGuid().ToString("N");
+
+        // Barrier ensures all threads start the Save operation at the same time,
+        // maximizing the chance of triggering the race condition where multiple
+        // concurrent requests try to insert the same login record.
+        using var barrier = new Barrier(NumberOfConcurrentOperations);
+
+        var tasks = new List<Task>();
+        for (var i = 0; i < NumberOfConcurrentOperations; i++)
+        {
+            // Must suppress execution context flow so each task gets its own scope context.
+            // Otherwise all tasks share the same ambient scope which isn't thread-safe.
+            using (ExecutionContext.SuppressFlow())
+            {
+                tasks.Add(Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    try
+                    {
+                        var login = new ExternalLogin("TestProvider", providerKey);
+                        ExternalLoginService.Save(user.Key, [login]);
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }));
+            }
+        }
+
+        // Act
+        await Task.WhenAll(tasks);
+
+        // Assert
+        var exceptionDetails = exceptions.Select(e =>
+            $"Type: {e.GetType().FullName}, Message: {e.Message}, Inner: {e.InnerException?.GetType().FullName}: {e.InnerException?.Message}");
+        Assert.IsEmpty(exceptions, $"Expected no duplicate key exceptions but got {exceptions.Count}:\n{string.Join("\n", exceptionDetails)}");
+
+        var logins = ExternalLoginService.GetExternalLogins(user.Key).ToList();
+        Assert.AreEqual(1, logins.Count, "Should have exactly one login");
     }
 }


### PR DESCRIPTION
## Description

We've had reports on sites with many members with an external login provider that duplicate key exceptions can be thrown:

```
Microsoft.Data.SqlClient.SqlException (0x80131904): 
  Cannot insert duplicate key row in object 'dbo.umbracoExternalLogin' 
  with unique index 'IX_umbracoExternalLogin_LoginProvider'. 
  The duplicate key value is (UmbracoMembers.Salesforce, 1b5c27fb-ced7-487e-8f67-8cb61ac3092d). 
  The statement has been terminated.

Stack Trace:
   at Microsoft.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, SqlCommand command, Boolean callerHasConnectionLock, Boolean asyncClose)
   at Microsoft.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
   at Microsoft.Data.SqlClient.TdsParser.Run(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj)
   at Microsoft.Data.SqlClient.SqlBulkCopy.RunParser(BulkCopySimpleResultSet bulkCopyHandler)
   at Microsoft.Data.SqlClient.SqlBulkCopy.CopyBatchesAsyncContinuedOnSuccess(BulkCopySimpleResultSet internalResults, String updateBulkCommandText, CancellationToken cts, TaskCompletionSource`1 source)
   at Microsoft.Data.SqlClient.SqlBulkCopy.CopyBatchesAsyncContinued(BulkCopySimpleResultSet internalResults, String updateBulkCommandText, CancellationToken cts, TaskCompletionSource`1 source)
   at Microsoft.Data.SqlClient.SqlBulkCopy.CopyBatchesAsync(BulkCopySimpleResultSet internalResults, String updateBulkCommandText, CancellationToken cts, TaskCompletionSource`1 source)
   at Microsoft.Data.SqlClient.SqlBulkCopy.WriteToServerInternalRestContinuedAsync(BulkCopySimpleResultSet internalResults, CancellationToken cts, TaskCompletionSource`1 source)
   at Microsoft.Data.SqlClient.SqlBulkCopy.WriteToServerInternalRestAsync(CancellationToken cts, TaskCompletionSource`1 source)
   at Microsoft.Data.SqlClient.SqlBulkCopy.WriteToServerInternalAsync(CancellationToken ctoken)
   at Microsoft.Data.SqlClient.SqlBulkCopy.WriteRowSourceToServerAsync(Int32 columnCount, CancellationToken ctoken)
   at Microsoft.Data.SqlClient.SqlBulkCopy.WriteToServer(DataTable table, DataRowState rowState)
   at NPoco.SqlServer.SqlBulkCopyHelper.BulkInsert[T](IDatabase db, IEnumerable`1 list, SqlBulkCopyOptions sqlBulkCopyOptions, InsertBulkOptions insertBulkOptions)
   at NPoco.SqlServer.SqlBulkCopyHelper.BulkInsert[T](IDatabase db, IEnumerable`1 list, InsertBulkOptions insertBulkOptions)
   at NPoco.Database.InsertBulk[T](IEnumerable`1 pocos, InsertBulkOptions options)
   at Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.ExternalLoginRepository.Save(Guid userOrMemberKey, IEnumerable`1 logins)
   at Umbraco.Cms.Core.Services.ExternalLoginService.Save(Guid userOrMemberKey, IEnumerable`1 logins)
   at Umbraco.Cms.Core.Security.MemberUserStore.UpdateAsync(MemberIdentityUser user, CancellationToken cancellationToken)
```

This PR adds an initially failing integration test that can trigger this scenario, and a fix which is verified by the test now passing.

## Change Summary

- Fix race condition when concurrent SSO callback requests try to save the same external login.
- When a user has no existing logins, concurrent requests both see empty results and both try to INSERT, causing a duplicate key violation.
- The fix catches duplicate key exceptions on bulk insert and falls back to individual upsert operations.
- Added integration test that reproduces the race condition (SQL Server only).

## Test plan
Given this can't be replicated consistently verifying the integration test passes and code inspection of the fix should suffice.
