### PR TITLE
Content Value Transformation: Clean out values when property-type variation transforms

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
@@ -140,9 +140,7 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 						result.push(value);
 					} else if (value.culture === cultureToKeep) {
 						// Culture value: only migrate if no invariant value exists for the same segment
-						const existingInvariantValue = valuesOfAlias.find(
-							(v) => v.culture === null && v.segment === value.segment,
-						);
+						const existingInvariantValue = valuesOfAlias.find((v) => v.culture === null && v.segment === value.segment);
 						if (!existingInvariantValue) {
 							result.push({ ...value, culture: null });
 						}


### PR DESCRIPTION
Improves value transformation when property variation settings (such as varyByCulture) change while a content workspace is open. The main focus is on handling transitions between invariant and variant property types more robustly and efficiently.

Key improvements to value transformation logic:

* Replaces the single-value transformation method (`#transformValueForVariationChange`) with a new batch-processing method (`#transformValuesForVariationChanges`)
* Updated methods ensures handling of property variation changes:
  - For invariant → variant transitions, assigns the default language to the single invariant value.
  - For variant → invariant transitions, retains only values for the default language (or first available culture) and sets them as invariant.
  - Ensures values remain unchanged if no variation change is detected or if property type definitions are missing.

This is an addition and refactor of the work done in: https://github.com/umbraco/Umbraco-CMS/pull/21293