### PR TITLE
Block RTE: Add missing copy and delete buttons

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -290,8 +290,8 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	#buildEntryName(contexts: {
-		propertyDatasetContext: { getName(): string };
-		propertyContext: { getLabel(): string };
+		propertyDatasetContext: { getName(): string | undefined };
+		propertyContext: { getLabel(): string | undefined };
 		clipboardContext: { write(data: unknown): void };
 	}) {
 		const workspaceName = this.localize.string(contexts.propertyDatasetContext.getName());


### PR DESCRIPTION
## Summary

Fixes missing copy and delete buttons for blocks in the richtext editor.

## Description

Blocks inserted in the richtext editor were missing the copy to clipboard and delete buttons that are available in other block editors (like block-list). This PR restores this functionality by:

- Adding copy to clipboard functionality
- Adding delete button
- Following the same pattern used in `block-list-entry` for consistency

## Testing

- Insert a block in the richtext editor
- Verify copy and delete buttons appear in the action bar
- Test copying a block to clipboard
- Test deleting a block

Fixes #21345