### PR TITLE
Routing: Fix URL aliases not stored for variant content with shared alias property in `DocumentUrlAliasService`

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -413,7 +413,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
             return aliases;
         }
 
-        // Handle culture-variant content with a culture-variant alias property
+        // Handle culture-variant content with a culture-variant alias property.
         foreach (ILanguage language in languages)
         {
             var aliasValue = document.GetValue<string>(Constants.Conventions.Content.UrlAlias, language.IsoCode);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -534,7 +534,7 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
 
         // Assert - the alias should be stored in the database
         List<PublishedDocumentUrlAlias> storedAliases;
-        using (ICoreScope scope = CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
         {
             storedAliases = DocumentUrlAliasRepository.GetAll()
                 .Where(a => a.DocumentKey == content.Key)
@@ -576,7 +576,7 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
 
         // Assert - the alias should be stored in the database
         List<PublishedDocumentUrlAlias> storedAliases;
-        using (ICoreScope scope = CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
         {
             storedAliases = DocumentUrlAliasRepository.GetAll()
                 .Where(a => a.DocumentKey == content.Key)


### PR DESCRIPTION
## Description

This fixes a bug found in testing of the document URL alias service, introduced as an optimisation for finding documents by URL alias in https://github.com/umbraco/Umbraco-CMS/pull/21396.

I found URL aliases were not being stored for variant content types that have a **shared** (non-culture-varied) `umbracoUrlAlias` property.

The service now checks if the alias property itself varies by culture, not just the content type, which fixes this issue.

## Root Cause

`ExtractAliasesFromDocumentAsync` only checked if the content type varies by culture. For variant content types, it always called `document.GetValue<string>(alias, culture)` with a culture parameter. However, for shared properties, this returns `null` because shared properties don't have culture-specific values.

## Fix

Check if the `umbracoUrlAlias` property itself varies by culture:
- **Invariant content type** → Get value without culture ✓
- **Variant content type + shared alias property** → Get value without culture ✓ (fixed)
- **Variant content type + variant alias property** → Get value with culture ✓

## Testing

For manual verification, create a variant document type with a shared, text string property with an alias of `umbracoUrlAlias`.
Create a document of that type, populate the property and verify it has been recorded in `umbracoDocumentUrlAlias`.

An integration test has been added that verifies this behaviour.