### PR TITLE
TipTap: Avoid empty target attribute on links

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/link/link.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/link/link.tiptap-extension.ts
@@ -10,6 +10,7 @@ export const UmbLink = Link.extend({
 		return {
 			...this.parent?.(),
 			'data-anchor': { default: null },
+			target: { default: null },
 			title: { default: null },
 			type: { default: 'external' },
 		};


### PR DESCRIPTION
## Description

Fixes https://github.com/umbraco/Umbraco-CMS/issues/21574

Currently all links created via the TipTap rich text editor will include `target=""` even when the user didn't select "Open in new window". This was caused by the `HTMLAttributes` option in the link extension setting `target: ''` as a default.

## Change Summary
- Removes the default empty `target` attribute from TipTap link elements
- The `target` attribute will now only be rendered when it has an actual value (e.g., `_blank`)

## Testing
I've verified the following:
- [x] Create a link in the TipTap editor without checking "Open in new window"
- [x] Verify the rendered HTML does not include an empty `target=""` attribute
- [x] Create a link with "Open in new window" checked
- [x] Verify the rendered HTML includes `target="_blank"`