### PR TITLE
Fix MaxRequestLength default value in TemporaryFileConfigurationPrese…

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemporaryFileConfigurationPresentationFactory.cs
@@ -24,6 +24,7 @@ public class TemporaryFileConfigurationPresentationFactory : ITemporaryFileConfi
             ImageFileTypes = _imageUrlGenerator.SupportedImageFileTypes.ToArray(),
             DisallowedUploadedFilesExtensions = _contentSettings.DisallowedUploadedFileExtensions.ToArray(),
             AllowedUploadedFileExtensions = _contentSettings.AllowedUploadedFileExtensions.ToArray(),
-            MaxFileSize = _runtimeSettings.MaxRequestLength,
+            // Default to 50 MB (51200 KB) when MaxRequestLength is not set, matching ConfigureKestrelServerOptions default
+            MaxFileSize = _runtimeSettings.MaxRequestLength ?? 51200,
         };
 }


### PR DESCRIPTION
…ntationFactory

Fixes #13362

When MaxRequestLength is not set in appsettings, the TemporaryFileConfigurationPresentationFactory was returning null for MaxFileSize, which prevented the client from displaying the max file size information. This fix ensures that the default value of 50 MB (51200 KB) is returned when MaxRequestLength is null, matching the default used in ConfigureKestrelServerOptions.

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->


<!-- Thanks for contributing to Umbraco CMS! -->
