### PR TITLE
Content Types: Fix deletion of properties without containers (closes #21566)

### DIFF
--- a/src/Umbraco.Core/Models/ContentTypeBase.cs
+++ b/src/Umbraco.Core/Models/ContentTypeBase.cs
@@ -492,8 +492,8 @@ public abstract class ContentTypeBase : TreeEntityBase, IContentTypeBase
     protected void PropertyGroupsChanged(object? sender, NotifyCollectionChangedEventArgs e) =>
         OnPropertyChanged(nameof(PropertyGroups));
 
-    protected void PropertyTypesChanged(object? sender, NotifyCollectionChangedEventArgs e) =>
-
+    protected void PropertyTypesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
         // enable this to detect duplicate property aliases. We do want this, however making this change in a
         // patch release might be a little dangerous
         ////detect if there are any duplicate aliases - this cannot be allowed
@@ -508,6 +508,11 @@ public abstract class ContentTypeBase : TreeEntityBase, IContentTypeBase
         //    }
         // }
         OnPropertyChanged(nameof(PropertyTypes));
+
+        // Also mark NoGroupPropertyTypes as dirty so the persistence layer
+        // detects changes to properties without containers (tabs/groups).
+        OnPropertyChanged(nameof(NoGroupPropertyTypes));
+    }
 
     protected override void PerformDeepClone(object clone)
     {


### PR DESCRIPTION
## Description

This PR fixes the bug raised in https://github.com/umbraco/Umbraco-CMS/issues/21566 where properties on document types that are not in a tab or group (no container) could not be deleted.  When such a property was removed and the document type saved, the property would still be present after reload

**Root cause**: `PropertyTypesChanged` in `ContentTypeBase` only marked `PropertyTypes` as dirty, but the persistence layer checks `NoGroupPropertyTypes` dirty flag to trigger deletion synchronization.

To fix we need to also mark `NoGroupPropertyTypes` as dirty.

## Testing

I've added integration test `Can_Remove_Properties_Without_Container` that verifies the fix (it failed before, and passes with this update in place).

To manually test, see the steps to reproduce on the linked issue.