### PR TITLE
Content Editor: Fix display of validation hint badge on tabs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
@@ -277,7 +277,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 				--uui-tab-background: var(--uui-color-surface);
 			}
 			umb-badge {
-				--uui-badge-inset: 0 -8px auto auto;
+				--uui-badge-inset: 0 0 auto auto;
 			}
 		`,
 	];


### PR DESCRIPTION
## Description

This PR fixes what I think is a regression, in that we are no longer seeing validation hints appear as expected on tabs.

I found this in investigating https://github.com/umbraco/Umbraco-CMS/issues/21525 but it's not the same issue as is reported there.  However I don't see this problem occurring before or after this fix, so if in review you also don't see it, it can likely be closed.

## Testing

To verify the found problem, and that this update provides a fix:
- Create a document type with two tabs, with a mandatory property on the second tab.
- Create a document of that type.
- Navigate to the first tab and attempt to save (or save and published) without filling the mandatory field on the second tab
- Verify a validation badge appears on the second tab indicating it contains properties with errors.

<img width="500" height="173" alt="image" src="https://github.com/user-attachments/assets/96b67fe8-69d7-45a0-9132-6c8192d7555d" />

To verify the reported problem, see the linked issue.
