### PR TITLE
Documents: Remove deprecated `entityType` from property values (closes #21567)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.test.ts
@@ -5,7 +5,7 @@ import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controlle
 import { UmbDocumentPublishedPendingChangesManager } from './document-published-pending-changes.manager.js';
 import { DocumentVariantStateModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { type UmbDocumentDetailModel } from '../../types.js';
-import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE } from '../../entity.js';
+import { UMB_DOCUMENT_ENTITY_TYPE } from '../../entity.js';
 
 @customElement('test-my-controller-host')
 class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
@@ -73,7 +73,6 @@ describe('UmbSelectionManager', () => {
 				values: [
 					{
 						editorAlias: 'Umbraco.TextBox',
-						entityType: UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE,
 						alias: 'prop1',
 						culture: null,
 						segment: null,
@@ -152,7 +151,6 @@ describe('UmbSelectionManager', () => {
 				values: [
 					{
 						editorAlias: 'Umbraco.TextBox',
-						entityType: UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE,
 						alias: 'prop1',
 						culture: 'en-US',
 						segment: null,
@@ -160,7 +158,6 @@ describe('UmbSelectionManager', () => {
 					},
 					{
 						editorAlias: 'Umbraco.TextBox',
-						entityType: UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE,
 						alias: 'prop1',
 						culture: 'da-DK',
 						segment: null,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
@@ -1,5 +1,5 @@
 import type { UmbDocumentDetailModel, UmbDocumentVariantPublishModel } from '../../types.js';
-import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE } from '../../entity.js';
+import { UMB_DOCUMENT_ENTITY_TYPE } from '../../entity.js';
 import type {
 	CultureAndScheduleRequestModel,
 	PublishDocumentRequestModel,
@@ -162,7 +162,6 @@ export class UmbDocumentPublishingServerDataSource {
 			values: data.values.map((value) => {
 				return {
 					editorAlias: value.editorAlias,
-					entityType: UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE,
 					culture: value.culture || null,
 					segment: value.segment || null,
 					alias: value.alias,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
@@ -1,5 +1,5 @@
 import type { UmbDocumentDetailModel } from '../../types.js';
-import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE } from '../../entity.js';
+import { UMB_DOCUMENT_ENTITY_TYPE } from '../../entity.js';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import type { UmbDetailDataSource } from '@umbraco-cms/backoffice/repository';
 import type {
@@ -85,7 +85,6 @@ export class UmbDocumentServerDataSource
 			values: data.values.map((value) => {
 				return {
 					editorAlias: value.editorAlias,
-					entityType: UMB_DOCUMENT_PROPERTY_VALUE_ENTITY_TYPE,
 					culture: value.culture || null,
 					segment: value.segment || null,
 					alias: value.alias,


### PR DESCRIPTION
## Summary

Fixes #21567.

- Removes the deprecated `entityType` property from document property value mappings in server data sources
- Fixes "Unsaved Changes" modal appearing after saving documents with RTE blocks

## Root Cause

The `entityType: 'document-property-value'` was being added to property values when reading documents from the server, but `setPropertyValue()` in the workspace did not preserve this property when updating values. This caused a JSON comparison mismatch between persisted and current data after save.

## Solution

Since `entityType` on `UmbElementValueModel` is deprecated and marked for removal in v18, the cleanest fix is to stop adding it in the server data source mapping.

## Test plan

- [ ] Create a new document with a Tiptap RTE property
- [ ] Insert an RTE Block
- [ ] Press Save
- [ ] Verify the workspace saves successfully without showing the "Unsaved Changes" modal

🤖 Generated with [Claude Code](https://claude.ai/code)