### PR TITLE
Tiptap RTE: Add delete action support for RTE blocks (closes #21345)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -1,20 +1,20 @@
 import type { UmbBlockRteLayoutModel } from '../../types.js';
 import { UMB_BLOCK_RTE } from '../../constants.js';
 import { UmbBlockRteEntryContext } from '../../context/block-rte-entry.context.js';
+import { css, customElement, html, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { html, css, property, state, customElement, nothing } from '@umbraco-cms/backoffice/external/lit';
-import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
+import { UmbDataPathBlockElementDataQuery } from '@umbraco-cms/backoffice/block';
+import { UmbObserveValidationStateController } from '@umbraco-cms/backoffice/validation';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type {
 	ManifestBlockEditorCustomView,
 	UmbBlockEditorCustomViewProperties,
 } from '@umbraco-cms/backoffice/block-custom-view';
-import { stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
+import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbExtensionElementInitializer } from '@umbraco-cms/backoffice/extension-api';
 
 import '../ref-rte-block/index.js';
-import { UmbObserveValidationStateController } from '@umbraco-cms/backoffice/validation';
-import { UmbDataPathBlockElementDataQuery } from '@umbraco-cms/backoffice/block';
-import type { UmbExtensionElementInitializer } from '@umbraco-cms/backoffice/extension-api';
 
 /**
  * @class UmbBlockRteEntryElement
@@ -291,9 +291,12 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	#renderActionBar() {
-		return this._showActions
-			? html`<uui-action-bar>${this.#renderEditAction()}${this.#renderEditSettingsAction()}</uui-action-bar>`
-			: nothing;
+		if (!this._showActions) return nothing;
+		return html`
+			<uui-action-bar>
+				${this.#renderEditAction()}${this.#renderEditSettingsAction()}${this.#renderDeleteAction()}
+			</uui-action-bar>
+		`;
 	}
 
 	#renderBuiltinBlockView = () => {
@@ -351,6 +354,14 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 							: nothing}
 					</uui-button>`
 				: nothing}
+		`;
+	}
+
+	#renderDeleteAction() {
+		return html`
+			<uui-button label="delete" look="secondary" @click=${() => this.#context.requestDelete()}>
+				<uui-icon name="icon-remove"></uui-icon>
+			</uui-button>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-entries.context.ts
@@ -1,14 +1,12 @@
+import { UMB_BLOCK_RTE_WORKSPACE_MODAL } from '../workspace/block-rte-workspace.modal-token.js';
 import type { UmbBlockRteLayoutModel, UmbBlockRteTypeModel, UmbBlockRteValueModel } from '../types.js';
-import {
-	UMB_BLOCK_RTE_WORKSPACE_MODAL,
-	type UmbBlockRteWorkspaceOriginData,
-} from '../workspace/block-rte-workspace.modal-token.js';
+import type { UmbBlockRteWorkspaceOriginData } from '../workspace/block-rte-workspace.modal-token.js';
 import { UMB_BLOCK_RTE_MANAGER_CONTEXT } from './block-rte-manager.context-token.js';
-import { UMB_BLOCK_CATALOGUE_MODAL, UmbBlockEntriesContext } from '@umbraco-cms/backoffice/block';
-import type { UmbBlockDataModel } from '@umbraco-cms/backoffice/block';
+import { UmbBlockEntriesContext, UMB_BLOCK_CATALOGUE_MODAL } from '@umbraco-cms/backoffice/block';
 import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
+import type { UmbBlockDataModel } from '@umbraco-cms/backoffice/block';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 /**
  * Copied from the 'rte' package to avoid a circular dependency.
@@ -119,8 +117,6 @@ export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 		return await this._manager?.createWithPresets(contentElementTypeKey, partialLayoutEntry, originData);
 	}
 
-	// insert Block?
-
 	async insert(
 		layoutEntry: UmbBlockRteLayoutModel,
 		content: UmbBlockDataModel,
@@ -131,10 +127,15 @@ export class UmbBlockRteEntriesContext extends UmbBlockEntriesContext<
 		return this._manager?.insert(layoutEntry, content, settings, originData) ?? false;
 	}
 
-	// create Block?
+	/**
+	 * Delete a block by requesting its removal through the pending deletion mechanism.
+	 * This enables undo support by removing the HTML element first via Tiptap,
+	 * which triggers _filterUnusedBlocks to store block data before removal.
+	 * @param {string} contentKey - The content key of the block to delete.
+	 */
 	override async delete(contentKey: string) {
-		await super.delete(contentKey);
-		this._manager?.deleteLayoutElement(contentKey);
+		await this._retrieveManager;
+		this._manager?.requestPendingDeletion(contentKey);
 	}
 
 	protected async _insertFromPropertyValue(value: UmbBlockRteValueModel, originData: UmbBlockRteWorkspaceOriginData) {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-entry.context.ts
@@ -1,9 +1,10 @@
 import type { UmbBlockRteLayoutModel, UmbBlockRteTypeModel } from '../types.js';
 import { UMB_BLOCK_RTE_MANAGER_CONTEXT } from './block-rte-manager.context-token.js';
 import { UMB_BLOCK_RTE_ENTRIES_CONTEXT } from './block-rte-entries.context-token.js';
+import { mergeObservables } from '@umbraco-cms/backoffice/observable-api';
 import { UmbBlockEntryContext } from '@umbraco-cms/backoffice/block';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { mergeObservables } from '@umbraco-cms/backoffice/observable-api';
+
 export class UmbBlockRteEntryContext extends UmbBlockEntryContext<
 	typeof UMB_BLOCK_RTE_MANAGER_CONTEXT,
 	typeof UMB_BLOCK_RTE_MANAGER_CONTEXT.TYPE,

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/context/block-rte-manager.context.ts
@@ -1,6 +1,7 @@
 import type { UmbBlockRteWorkspaceOriginData } from '../workspace/block-rte-workspace.modal-token.js';
 import type { UmbBlockRteLayoutModel, UmbBlockRteTypeModel } from '../types.js';
 import type { UmbBlockDataModel } from '../../block/types.js';
+import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbBlockManagerContext } from '@umbraco-cms/backoffice/block';
 
 import '../components/block-rte-entry/index.js';
@@ -11,6 +12,33 @@ import '../components/block-rte-entry/index.js';
 export class UmbBlockRteManagerContext<
 	BlockLayoutType extends UmbBlockRteLayoutModel = UmbBlockRteLayoutModel,
 > extends UmbBlockManagerContext<UmbBlockRteTypeModel, BlockLayoutType> {
+	/**
+	 * Pending deletions are used to support undo for block deletions.
+	 * When a block is deleted via the delete button, the contentKey is added to this list.
+	 * The Tiptap API observes this and removes the HTML element, which triggers
+	 * the _filterUnusedBlocks mechanism that stores block data for undo and removes from manager.
+	 */
+	readonly #pendingDeletions = new UmbArrayState<string>([], (x) => x);
+	public readonly pendingDeletions = this.#pendingDeletions.asObservable();
+
+	/**
+	 * Request a block to be deleted. This adds the contentKey to pending deletions,
+	 * which will be processed by the Tiptap API to remove the HTML element first,
+	 * enabling undo support.
+	 * @param {string} contentKey - The content key of the block to delete.
+	 */
+	public requestPendingDeletion(contentKey: string) {
+		this.#pendingDeletions.appendOne(contentKey);
+	}
+
+	/**
+	 * Clear a pending deletion after it has been processed.
+	 * @param {string} contentKey - The content key to clear from pending deletions.
+	 */
+	public clearPendingDeletion(contentKey: string) {
+		this.#pendingDeletions.removeOne(contentKey);
+	}
+
 	removeOneLayout(contentKey: string) {
 		this._layouts.removeOne(contentKey);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/block/block.tiptap-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/block/block.tiptap-api.ts
@@ -8,12 +8,16 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export default class UmbTiptapBlockElementApi extends UmbTiptapExtensionApiBase {
 	#blockTypes?: Map<string, UmbBlockRteTypeModel>;
+	#managerContext?: typeof UMB_BLOCK_RTE_MANAGER_CONTEXT.TYPE;
 
 	constructor(host: UmbControllerHost) {
 		super(host);
 
 		this.consumeContext(UMB_BLOCK_RTE_MANAGER_CONTEXT, (context) => {
 			if (!context) return;
+
+			this.#managerContext = context;
+
 			this.observe(
 				context.blockTypes,
 				(blockTypes) => {
@@ -23,12 +27,21 @@ export default class UmbTiptapBlockElementApi extends UmbTiptapExtensionApiBase 
 				},
 				'_observeBlockTypes',
 			);
+
 			this.observe(
 				context.contents,
 				(contents) => {
 					this.#updateBlocks(contents);
 				},
 				'_observeContents',
+			);
+
+			this.observe(
+				context.pendingDeletions,
+				(pendingDeletions) => {
+					this.#processPendingDeletions(pendingDeletions);
+				},
+				'_observePendingDeletions',
 			);
 		});
 	}
@@ -37,16 +50,46 @@ export default class UmbTiptapBlockElementApi extends UmbTiptapExtensionApiBase 
 		return [umbRteBlock, umbRteBlockInline];
 	}
 
+	/**
+	 * Process pending deletions by removing blocks from the editor.
+	 * This is triggered when blocks are deleted via the delete button.
+	 * Removing HTML first enables undo support via _filterUnusedBlocks.
+	 * @param {Array<string>} pendingDeletions - Array of content keys to delete.
+	 */
+	#processPendingDeletions(pendingDeletions: Array<string>) {
+		if (pendingDeletions.length === 0) return;
+		const editor = this._editor;
+		if (!editor) return;
+
+		// Remove blocks from editor
+		this.#removeBlocksFromEditor(pendingDeletions);
+
+		// Clear processed pending deletions
+		pendingDeletions.forEach((contentKey) => {
+			this.#managerContext?.clearPendingDeletion(contentKey);
+		});
+	}
+
+	/**
+	 * Sync blocks from manager contents to the editor.
+	 * This adds blocks that exist in contents but not in the editor.
+	 * Note: Removal is handled by _filterUnusedBlocks in the RTE base element,
+	 * which enables undo support by storing block data before removal.
+	 * @param {Array<UmbBlockDataModel>} contents - Array of block data models.
+	 */
 	#updateBlocks(contents: Array<UmbBlockDataModel>) {
 		const editor = this._editor;
 		if (!editor) return;
 
 		if (!contents?.length) return;
 
+		// Find existing blocks in the editor
 		const existingBlocks = Array.from(editor.view.dom.querySelectorAll('umb-rte-block, umb-rte-block-inline')).map(
 			(x) => x.getAttribute(UMB_BLOCK_RTE_DATA_CONTENT_KEY),
 		);
-		const newBlocks = contents.filter((x) => !existingBlocks.find((contentKey) => contentKey === x.key));
+
+		// ADD blocks that are in contents but NOT in editor
+		const newBlocks = contents.filter((x) => !existingBlocks.includes(x.key));
 
 		newBlocks.forEach((block) => {
 			const inline = this.#blockTypes?.get(block.contentTypeKey)?.displayInline ?? false;
@@ -56,5 +99,37 @@ export default class UmbTiptapBlockElementApi extends UmbTiptapExtensionApiBase 
 				editor.commands.setBlock({ contentKey: block.key });
 			}
 		});
+	}
+
+	/**
+	 * Remove blocks from the editor by content keys.
+	 * @param {Array<string>} contentKeys - Array of content keys to remove.
+	 */
+	#removeBlocksFromEditor(contentKeys: Array<string>) {
+		const editor = this._editor;
+		if (!editor) return;
+
+		// Collect positions to delete
+		const nodesToDelete: Array<{ pos: number; size: number }> = [];
+
+		editor.state.doc.descendants((node, pos) => {
+			const contentKey = node.attrs[UMB_BLOCK_RTE_DATA_CONTENT_KEY];
+			if (contentKey && contentKeys.includes(contentKey)) {
+				nodesToDelete.push({ pos, size: node.nodeSize });
+			}
+			return true; // Continue traversal to find all matches
+		});
+
+		if (nodesToDelete.length === 0) return;
+
+		// Delete in reverse order (highest position first) to maintain valid positions
+		nodesToDelete.sort((a, b) => b.pos - a.pos);
+
+		let tr = editor.state.tr;
+		for (const { pos, size } of nodesToDelete) {
+			tr = tr.delete(pos, pos + size);
+		}
+
+		editor.view.dispatch(tr);
 	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Adds a delete button to RTE block entries that removes blocks from both the editor HTML and the block manager data. Implements an HTML-first deletion approach that enables Ctrl+Z undo support by leveraging the existing `_filterUnusedBlocks` mechanism.

This is a partial fix towards #21345.

#### Changes

- **block-rte-entry.element.ts**: Add delete button to action bar
- **block-rte-manager.context.ts**: Add `pendingDeletions` state and methods for HTML-first deletion flow
- **block-rte-entries.context.ts**: Override `delete()` to use pending deletion mechanism
- **block.tiptap-api.ts**: Add observer to process pending deletions and remove blocks from editor via ProseMirror transactions

#### How it works

1. User clicks delete button → confirmation modal appears
2. After confirmation, contentKey is added to `pendingDeletions` on the manager
3. Tiptap API observes `pendingDeletions` → removes HTML from editor (creating undo history)
4. Tiptap's `onUpdate` fires → `_filterUnusedBlocks` runs
5. `_filterUnusedBlocks` stores block data in lookup maps (enabling undo) and removes from manager
6. User can press Ctrl+Z → Tiptap restores HTML → `_restoreUnusedBlocks` restores data

#### How to test

1. Create a document type with an RTE property that has blocks enabled
2. Add a block to the RTE
3. Hover over the block to see the action bar
4. Click the delete button (trash icon)
5. Confirm the deletion in the modal
6. **Verify**: Block should disappear from the editor
7. Press **Ctrl+Z** (undo)
8. **Verify**: Block should reappear with its data restored
9. Save and reload to verify persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)