### PR TITLE
Backoffice Search: Default global search to current section (closes #21621)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/search/global-search/global-search.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/search/global-search/global-search.extension.ts
@@ -11,6 +11,7 @@ export interface ManifestGlobalSearch
 export interface MetaGlobalSearch {
 	label: string;
 	searchProviderAlias: string;
+	sectionAlias?: string;
 }
 
 declare global {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/search/search-modal/search-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/search/search-modal/search-modal.element.ts
@@ -17,8 +17,6 @@ import { createExtensionApiByAlias, umbExtensionsRegistry } from '@umbraco-cms/b
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbModalContext } from '@umbraco-cms/backoffice/modal';
-import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
-
 import '../search-result/search-result-item.element.js';
 import { UMB_BACKOFFICE_CONTEXT } from '../../../../apps/backoffice/backoffice.context.js';
 
@@ -127,7 +125,7 @@ export class UmbSearchModalElement extends UmbLitElement {
 						name: controller.manifest.meta?.label || controller.manifest.name,
 						api: searchApi,
 						alias: controller.alias,
-						sectionAlias: this.#extractSectionAlias(controller.manifest.conditions),
+						sectionAlias: controller.manifest.meta?.sectionAlias,
 					};
 
 					globalSearch.push(searcher);
@@ -137,16 +135,6 @@ export class UmbSearchModalElement extends UmbLitElement {
 			this._globalSearchers = globalSearch;
 			this.#updateDefaultSearcher();
 		});
-	}
-
-	#extractSectionAlias(conditions?: UmbExtensionConditionConfig[]): string | undefined {
-		if (!conditions) return undefined;
-		const sectionCondition = conditions.find((c) => c.alias === UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS);
-		if (sectionCondition && 'match' in sectionCondition && typeof sectionCondition.match === 'string') {
-			return sectionCondition.match;
-		}
-
-		return undefined;
 	}
 
 	#updateDefaultSearcher() {

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/search/global-search/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Data Types',
 			searchProviderAlias: UMB_DATA_TYPE_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_SETTINGS_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/search/global-search/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Dictionary',
 			searchProviderAlias: UMB_DICTIONARY_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_TRANSLATION_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/search/global-search/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Document Types',
 			searchProviderAlias: UMB_DOCUMENT_TYPE_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_SETTINGS_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/global-search/manifests.ts
@@ -13,6 +13,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Documents',
 			searchProviderAlias: UMB_DOCUMENT_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_CONTENT_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/search/global-search/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Media Types',
 			searchProviderAlias: UMB_MEDIA_TYPE_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_SETTINGS_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/global-search/manifests.ts
@@ -13,6 +13,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Media',
 			searchProviderAlias: UMB_MEDIA_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_MEDIA_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/search/global-search/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Member Types',
 			searchProviderAlias: UMB_MEMBER_TYPE_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_SETTINGS_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/search/global-search/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Members',
 			searchProviderAlias: UMB_MEMBER_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_MEMBER_MANAGEMENT_SECTION_ALIAS,
 		},
 		conditions: [
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/search/global-search/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Templates',
 			searchProviderAlias: UMB_TEMPLATE_SEARCH_PROVIDER_ALIAS,
+			sectionAlias: UMB_SETTINGS_SECTION_ALIAS,
 		},
 		conditions: [
 			{


### PR DESCRIPTION
## Description

This PR addresses the issue raised in https://github.com/umbraco/Umbraco-CMS/issues/21621 where the default global search section is always "Documents" even though the user may already be in a different section.

## Changes

- When opening the backoffice search modal from the header, the search now defaults to a searcher that matches the current section
- If in the Media section, defaults to "Media" search; if in Members section, defaults to "Members" search, etc.
- Falls back to the first searcher (Documents) if no matching searcher is found for the current section

### Details

- Added consumption of `UMB_BACKOFFICE_CONTEXT` to get the active section alias
- Extended `GlobalSearchers` type to include `sectionAlias` field
- Added `#extractSectionAlias()` method to extract section alias from manifest conditions
- Added `#updateDefaultSearcher()` method to select the appropriate default searcher based on current section

## Testing
- [ ] Navigate to the Content section and open search - should default to "Documents"
- [ ] Navigate to the Media section and open search - should default to "Media"
- [ ] Navigate to the Members section and open search - should default to "Members"
- [ ] Navigate to the Settings section and open search - should default to "Document Types" (highest weight Settings searcher)
- [ ] Verify manual tab switching between search providers still works
- [ ] Verify search results work correctly after changing providers