### PR TITLE
Media Item Search: Fixing missing attribute for constructor

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -20,6 +20,7 @@ public class SearchMediaItemController : MediaItemControllerBase
     private readonly IMediaPresentationFactory _mediaPresentationFactory;
     private readonly IDataTypeService _dataTypeService;
 
+    [ActivatorUtilitiesConstructor]
     public SearchMediaItemController(
         IIndexedEntitySearchService indexedEntitySearchService,
         IMediaPresentationFactory mediaPresentationFactory,


### PR DESCRIPTION
### Description
An important attribute on a recent PR went missing, therefore this PR adds it back. This bug was flagged by our e2e tests.

Relates to:
https://github.com/umbraco/Umbraco-CMS/pull/21597


<!-- Thanks for contributing to Umbraco CMS! -->
