### PR TITLE
Block Grid Editor: improved extension initialization for Inline Mode Blocks

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block-inline/block-grid-block-inline.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block-inline/block-grid-block-inline.element.ts
@@ -88,7 +88,7 @@ export class UmbBlockGridBlockInlineElement extends UmbLitElement {
 	#extensionInitializer?: UmbExtensionApiInitializer;
 	#initExtension() {
 		this.#extensionInitializer?.destroy();
-		if (this.#parentUnique === undefined && this.#areaKey === undefined) {
+		if (this.#parentUnique === undefined || this.#areaKey === undefined) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes an issue where dragging a Block of Block Grid Editor, which is configured to be in Inline Mode.

That would previously result in this JS-issue: (which this PR fixes)
<img width="987" height="46" alt="image" src="https://github.com/user-attachments/assets/45aaec2a-162a-4ae5-b381-64be4c52168f" />

Done by adding a better extension initialization life cycle, which also should improve the destruction cleanup.