### PR TITLE
Fix hidden input tag self-closing syntax

### DIFF
--- a/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/HtmlHelperRenderExtensions.cs
@@ -327,7 +327,7 @@ public static class HtmlHelperRenderExtensions
             area,
             additionalRouteVals);
 
-        return "<input name=\"ufprt\" type=\"hidden\" value=\"" + encryptedString + "\" />";
+        return "<input name=\"ufprt\" type=\"hidden\" value=\"" + encryptedString + "\" >";
     }
 
     /// <summary>


### PR DESCRIPTION
Input tags should self-close.

### Prerequisites

Use  Html.BeginUmbracoForm

### Description

This change is to help ensure that the HTML of forms is valid
Ref: https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values
