### PR TITLE
Developer Experience: Clarify nullability for `BackOfficeAuthenticationBuilder.SchemeForBackOffice` (closes #21689)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
 using Umbraco.Cms.Core;
 using Umbraco.Extensions;
 

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
@@ -20,7 +20,8 @@ public class BackOfficeAuthenticationBuilder : AuthenticationBuilder
         : base(services)
         => _loginProviderOptions = loginProviderOptions ?? (x => { });
 
-    public static string? SchemeForBackOffice(string scheme)
+    [return: NotNullIfNotNull(nameof(scheme))]
+    public static string? SchemeForBackOffice(string? scheme)
         => scheme?.EnsureStartsWith(Constants.Security.BackOfficeExternalAuthenticationTypePrefix);
 
     /// <summary>

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeAuthenticationBuilder.cs
@@ -21,8 +21,9 @@ public class BackOfficeAuthenticationBuilder : AuthenticationBuilder
         : base(services)
         => _loginProviderOptions = loginProviderOptions ?? (x => { });
 
+    // TODO (V18): Change the return value to be not nullable and remove the NotNullIfNotNull attribute.
     [return: NotNullIfNotNull(nameof(scheme))]
-    public static string? SchemeForBackOffice(string? scheme)
+    public static string? SchemeForBackOffice(string scheme)
         => scheme?.EnsureStartsWith(Constants.Security.BackOfficeExternalAuthenticationTypePrefix);
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [21689](https://github.com/umbraco/Umbraco-CMS/issues/21689)

### Description
I have added an attribute that improves the signature.
Also, I have added "?" to the signature as it is not a breaking change, but I am not sure. Maybe better to throw an exception if the incoming scheme is null and remove all nullability logic at all. Since this method will be used by devs directly and they must not pass null value into it.

Anyway, we need to fix such the CS8604 warning.

<!-- Thanks for contributing to Umbraco CMS! -->
