### PR TITLE
User Management: Avoid discard changes dialog after enabling/disabling a user (closes #19019)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/user-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/user-workspace.context.ts
@@ -83,14 +83,17 @@ export class UmbUserWorkspaceContext
 		return response;
 	}
 
-	/* TODO: some properties are allowed to update without saving.
-		For a user properties like state will be updated when one of the entity actions are executed.
+	/* Some properties are allowed to update without saving.
+		For a user, properties like state will be updated when one of the entity actions are executed.
 		Therefore we have to subscribe to the user store to update the state in the workspace data.
+		We update both current and persisted so these server-applied changes do not trigger dirty state.
 		There might be a less manual way to do this.
 	*/
 	onUserStoreChanges(user: EntityType | undefined) {
 		if (user) {
-			this._data.updateCurrent({ state: user.state, avatarUrls: user.avatarUrls });
+			const serverAppliedChanges: Partial<EntityType> = { state: user.state, avatarUrls: user.avatarUrls };
+			this._data.updateCurrent(serverAppliedChanges);
+			this._data.updatePersisted(serverAppliedChanges);
 		}
 	}
 


### PR DESCRIPTION
## Description

As reported in https://github.com/umbraco/Umbraco-CMS/issues/19019, when editing a user in the backoffice and using the entity action to enable or disable them, navigating away will incorrectly show the "Discard unsaved changes" dialog.

The enable/disable action is applied instantly on the server, so there's no unsaved change here.

With this update the persisted data is now updated alongside the current data to keep the dirty check in sync, which avoids the incorrect behaviour.

## Root Cause
`onUserStoreChanges` in `UmbUserWorkspaceContext` was only calling `updateCurrent()` when the store changed (e.g. after enable/disable). The persisted data still held the old state, so `getHasUnpersistedChanges()` (which compares persisted vs current via JSON comparison) detected a difference and triggered the dialog.

## Fix
Added `updatePersisted()` call alongside the existing `updateCurrent()` for server-applied changes to `state`. Since this property is already saved on the server by the entity action, both the current and persisted workspace data should reflect them.

If the user has made other edits (name, groups, etc.) before enabling/disabling, those remain only in `current` - so the discard dialog still correctly appears for genuine unsaved changes.

## Testing
- [ ] Open backoffice, go to Users section, edit a user
- [ ] Use the entity action menu to **disable** the user
- [ ] Navigate away — no "Discard unsaved changes" dialog should appear
- [ ] Re-open the user, use the entity action to **enable** the user
- [ ] Navigate away — no dialog should appear
- [ ] Edit the user's name, then enable/disable, then navigate away — the dialog **should** appear (genuine unsaved change)
