### PR TITLE
Package Manifest: Enable cache buster token replacement for extensions (closes #16893)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
@@ -1,9 +1,9 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.Manifest;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.ViewModels.Manifest;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
@@ -50,6 +50,7 @@ public class AllManifestController : ManifestControllerBase
     {
         IEnumerable<PackageManifest> packageManifests = await _packageManifestService.GetAllPackageManifestsAsync();
         IEnumerable<ManifestResponseModel> models = _umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests);
-        return Ok(ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash));
+        ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash);
+        return Ok(models);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
@@ -29,6 +29,7 @@ public class AllManifestController : ManifestControllerBase
     {
     }
 
+    [ActivatorUtilitiesConstructor]
     public AllManifestController(
         IPackageManifestService packageManifestService,
         IUmbracoMapper umbracoMapper,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/AllManifestController.cs
@@ -3,9 +3,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Manifest;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Cms.Web.Common.Hosting;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Manifest;
 
@@ -15,11 +18,25 @@ public class AllManifestController : ManifestControllerBase
 {
     private readonly IPackageManifestService _packageManifestService;
     private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IBackOfficePathGenerator _backOfficePathGenerator;
 
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public AllManifestController(IPackageManifestService packageManifestService, IUmbracoMapper umbracoMapper)
+        : this(
+            packageManifestService,
+            umbracoMapper,
+            StaticServiceProvider.Instance.GetRequiredService<IBackOfficePathGenerator>())
+    {
+    }
+
+    public AllManifestController(
+        IPackageManifestService packageManifestService,
+        IUmbracoMapper umbracoMapper,
+        IBackOfficePathGenerator backOfficePathGenerator)
     {
         _packageManifestService = packageManifestService;
         _umbracoMapper = umbracoMapper;
+        _backOfficePathGenerator = backOfficePathGenerator;
     }
 
     // NOTE: this endpoint is deliberately created as non-paginated to ensure the fastest possible client initialization
@@ -31,6 +48,7 @@ public class AllManifestController : ManifestControllerBase
     public async Task<IActionResult> AllManifests(CancellationToken cancellationToken)
     {
         IEnumerable<PackageManifest> packageManifests = await _packageManifestService.GetAllPackageManifestsAsync();
-        return Ok(_umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests));
+        IEnumerable<ManifestResponseModel> models = _umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests);
+        return Ok(ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
@@ -10,7 +10,7 @@ namespace Umbraco.Cms.Api.Management.Controllers.Manifest;
 [ApiExplorerSettings(GroupName = "Manifest")]
 public abstract class ManifestControllerBase : ManagementApiControllerBase
 {
-    protected static IEnumerable<ManifestResponseModel> ReplaceCacheBusterTokens(
+    protected static void ReplaceCacheBusterTokens(
         IEnumerable<ManifestResponseModel> models, string cacheBustHash)
     {
         foreach (ManifestResponseModel model in models)
@@ -29,7 +29,5 @@ public abstract class ManifestControllerBase : ManagementApiControllerBase
             json = json.Replace(Constants.Web.CacheBusterToken, cacheBustHash);
             model.Extensions = JsonSerializer.Deserialize<object[]>(json) ?? model.Extensions;
         }
-
-        return models;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
@@ -21,7 +21,7 @@ public abstract class ManifestControllerBase : ManagementApiControllerBase
             }
 
             var json = JsonSerializer.Serialize(model.Extensions);
-            if (!json.Contains(Constants.Web.CacheBusterToken))
+            if (json.Contains(Constants.Web.CacheBusterToken) is false)
             {
                 continue;
             }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
@@ -1,5 +1,8 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Api.Management.ViewModels.Manifest;
+using Umbraco.Cms.Core;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Manifest;
 
@@ -7,4 +10,26 @@ namespace Umbraco.Cms.Api.Management.Controllers.Manifest;
 [ApiExplorerSettings(GroupName = "Manifest")]
 public abstract class ManifestControllerBase : ManagementApiControllerBase
 {
+    protected static IEnumerable<ManifestResponseModel> ReplaceCacheBusterTokens(
+        IEnumerable<ManifestResponseModel> models, string cacheBustHash)
+    {
+        foreach (ManifestResponseModel model in models)
+        {
+            if (model.Extensions.Length == 0)
+            {
+                continue;
+            }
+
+            var json = JsonSerializer.Serialize(model.Extensions);
+            if (!json.Contains(Constants.Web.CacheBusterToken))
+            {
+                continue;
+            }
+
+            json = json.Replace(Constants.Web.CacheBusterToken, cacheBustHash);
+            model.Extensions = JsonSerializer.Deserialize<object[]>(json) ?? model.Extensions;
+        }
+
+        return models;
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBase.cs
@@ -26,7 +26,7 @@ public abstract class ManifestControllerBase : ManagementApiControllerBase
                 continue;
             }
 
-            json = json.Replace(Constants.Web.CacheBusterToken, cacheBustHash);
+            json = json.Replace(Constants.Web.CacheBusterToken, JsonEncodedText.Encode(cacheBustHash).ToString());
             model.Extensions = JsonSerializer.Deserialize<object[]>(json) ?? model.Extensions;
         }
     }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
@@ -29,6 +29,7 @@ public class PrivateManifestManifestController : ManifestControllerBase
     {
     }
 
+    [ActivatorUtilitiesConstructor]
     public PrivateManifestManifestController(
         IPackageManifestService packageManifestService,
         IUmbracoMapper umbracoMapper,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
@@ -1,9 +1,9 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.Manifest;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.ViewModels.Manifest;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
@@ -50,6 +50,7 @@ public class PrivateManifestManifestController : ManifestControllerBase
     {
         IEnumerable<PackageManifest> packageManifests = await _packageManifestService.GetPrivatePackageManifestsAsync();
         IEnumerable<ManifestResponseModel> models = _umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests);
-        return Ok(ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash));
+        ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash);
+        return Ok(models);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PrivateManifestManifestController.cs
@@ -3,9 +3,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Manifest;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Cms.Web.Common.Hosting;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Manifest;
 
@@ -15,11 +18,25 @@ public class PrivateManifestManifestController : ManifestControllerBase
 {
     private readonly IPackageManifestService _packageManifestService;
     private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IBackOfficePathGenerator _backOfficePathGenerator;
 
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public PrivateManifestManifestController(IPackageManifestService packageManifestService, IUmbracoMapper umbracoMapper)
+        : this(
+            packageManifestService,
+            umbracoMapper,
+            StaticServiceProvider.Instance.GetRequiredService<IBackOfficePathGenerator>())
+    {
+    }
+
+    public PrivateManifestManifestController(
+        IPackageManifestService packageManifestService,
+        IUmbracoMapper umbracoMapper,
+        IBackOfficePathGenerator backOfficePathGenerator)
     {
         _packageManifestService = packageManifestService;
         _umbracoMapper = umbracoMapper;
+        _backOfficePathGenerator = backOfficePathGenerator;
     }
 
     // NOTE: this endpoint is deliberately created as non-paginated to ensure the fastest possible client initialization
@@ -31,6 +48,7 @@ public class PrivateManifestManifestController : ManifestControllerBase
     public async Task<IActionResult> PrivateManifests()
     {
         IEnumerable<PackageManifest> packageManifests = await _packageManifestService.GetPrivatePackageManifestsAsync();
-        return Ok(_umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests));
+        IEnumerable<ManifestResponseModel> models = _umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests);
+        return Ok(ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash));
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
@@ -1,9 +1,9 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Api.Management.ViewModels.Manifest;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.ViewModels.Manifest;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
@@ -28,6 +28,7 @@ public class PublicManifestManifestController : ManifestControllerBase
     {
     }
 
+    [ActivatorUtilitiesConstructor]
     public PublicManifestManifestController(
         IPackageManifestService packageManifestService,
         IUmbracoMapper umbracoMapper,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
@@ -49,6 +49,7 @@ public class PublicManifestManifestController : ManifestControllerBase
     {
         IEnumerable<PackageManifest> packageManifests = await _packageManifestService.GetPublicPackageManifestsAsync();
         IEnumerable<ManifestResponseModel> models = _umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests);
-        return Ok(ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash));
+        ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash);
+        return Ok(models);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Manifest/PublicManifestManifestController.cs
@@ -3,8 +3,11 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Umbraco.Cms.Api.Management.ViewModels.Manifest;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Web.Common.Hosting;
 
 namespace Umbraco.Cms.Api.Management.Controllers.Manifest;
 
@@ -14,11 +17,25 @@ public class PublicManifestManifestController : ManifestControllerBase
 {
     private readonly IPackageManifestService _packageManifestService;
     private readonly IUmbracoMapper _umbracoMapper;
+    private readonly IBackOfficePathGenerator _backOfficePathGenerator;
 
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public PublicManifestManifestController(IPackageManifestService packageManifestService, IUmbracoMapper umbracoMapper)
+        : this(
+            packageManifestService,
+            umbracoMapper,
+            StaticServiceProvider.Instance.GetRequiredService<IBackOfficePathGenerator>())
+    {
+    }
+
+    public PublicManifestManifestController(
+        IPackageManifestService packageManifestService,
+        IUmbracoMapper umbracoMapper,
+        IBackOfficePathGenerator backOfficePathGenerator)
     {
         _packageManifestService = packageManifestService;
         _umbracoMapper = umbracoMapper;
+        _backOfficePathGenerator = backOfficePathGenerator;
     }
 
     // NOTE: this endpoint is deliberately created as non-paginated to ensure the fastest possible client initialization
@@ -30,6 +47,7 @@ public class PublicManifestManifestController : ManifestControllerBase
     public async Task<IActionResult> PublicManifests(CancellationToken cancellationToken)
     {
         IEnumerable<PackageManifest> packageManifests = await _packageManifestService.GetPublicPackageManifestsAsync();
-        return Ok(_umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests));
+        IEnumerable<ManifestResponseModel> models = _umbracoMapper.MapEnumerable<PackageManifest, ManifestResponseModel>(packageManifests);
+        return Ok(ReplaceCacheBusterTokens(models, _backOfficePathGenerator.BackOfficeCacheBustHash));
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBaseTests.cs
@@ -66,7 +66,7 @@ public class ManifestControllerBaseTests
     [Test]
     public void ReplaceCacheBusterTokens_Handles_Empty_Extensions()
     {
-        var model = CreateModel(Array.Empty<object>());
+        var model = CreateModel([]);
 
         List<ManifestResponseModel> models = [model];
         TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
@@ -91,7 +91,7 @@ public class ManifestControllerBaseTests
             ],
             "PackageB");
 
-        var modelEmpty = CreateModel(Array.Empty<object>(), "PackageC");
+        var modelEmpty = CreateModel([], "PackageC");
 
         List<ManifestResponseModel> models = [modelWithToken, modelWithoutToken, modelEmpty];
         TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
@@ -131,7 +131,7 @@ public class ManifestControllerBaseTests
     public void ReplaceCacheBusterTokens_Preserves_All_Models_In_Output()
     {
         List<ManifestResponseModel> models = Enumerable.Range(0, 5)
-            .Select(i => CreateModel(Array.Empty<object>(), $"Package{i}"))
+            .Select(i => CreateModel([], $"Package{i}"))
             .ToList();
 
         TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
@@ -167,6 +167,27 @@ public class ManifestControllerBaseTests
             Assert.That(json, Does.Contain("/App_Plugins/Foo/three.js"));
             Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
         });
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Produces_Valid_Json_When_Hash_Contains_Special_Characters()
+    {
+        var model = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"js":"/App_Plugins/Foo/bundle.js?v=%CACHE_BUSTER%"}"""),
+            ]);
+
+        const string unsafeHash = """hash"with\special""";
+
+        List<ManifestResponseModel> models = [model];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, unsafeHash);
+
+        var json = JsonSerializer.Serialize(models[0].Extensions);
+        Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
+
+        // Verify the result is still valid JSON by round-tripping
+        Assert.DoesNotThrow(() => JsonSerializer.Deserialize<object[]>(json));
     }
 
     private static ManifestResponseModel CreateModel(object[] extensions, string name = "TestPackage")

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBaseTests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Manifest;
+using Umbraco.Cms.Api.Management.ViewModels.Manifest;
+using Umbraco.Cms.Core;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Controllers.Manifest;
+
+[TestFixture]
+public class ManifestControllerBaseTests
+{
+    private const string CacheBustHash = "abc123hash";
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Replaces_Token_In_Extension_Properties()
+    {
+        var model = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"type":"js","js":"/App_Plugins/Foo/bundle.js?v=%CACHE_BUSTER%"}"""),
+            ]);
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+
+        var json = JsonSerializer.Serialize(result[0].Extensions);
+        Assert.That(json, Does.Contain(CacheBustHash));
+        Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Replaces_Token_In_Multiple_Properties()
+    {
+        var model = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"type":"js","js":"/App_Plugins/Foo/bundle.js?v=%CACHE_BUSTER%","element":"/App_Plugins/Foo/element.js?v=%CACHE_BUSTER%"}"""),
+            ]);
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+
+        var json = JsonSerializer.Serialize(result[0].Extensions);
+        Assert.That(json, Does.Contain($"/App_Plugins/Foo/bundle.js?v={CacheBustHash}"));
+        Assert.That(json, Does.Contain($"/App_Plugins/Foo/element.js?v={CacheBustHash}"));
+        Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Leaves_Extensions_Without_Token_Untouched()
+    {
+        var model = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"type":"js","js":"/App_Plugins/Foo/bundle.js"}"""),
+            ]);
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+
+        var json = JsonSerializer.Serialize(result[0].Extensions);
+        Assert.That(json, Does.Contain("/App_Plugins/Foo/bundle.js"));
+        Assert.That(json, Does.Not.Contain(CacheBustHash));
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Handles_Empty_Extensions()
+    {
+        var model = CreateModel(Array.Empty<object>());
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+
+        Assert.That(result[0].Extensions, Is.Empty);
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Handles_Multiple_Models()
+    {
+        var modelWithToken = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"js":"/App_Plugins/A/a.js?v=%CACHE_BUSTER%"}"""),
+            ],
+            "PackageA");
+
+        var modelWithoutToken = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"js":"/App_Plugins/B/b.js"}"""),
+            ],
+            "PackageB");
+
+        var modelEmpty = CreateModel(Array.Empty<object>(), "PackageC");
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens(
+            [modelWithToken, modelWithoutToken, modelEmpty], CacheBustHash).ToList();
+
+        Assert.Multiple(() =>
+        {
+            var jsonA = JsonSerializer.Serialize(result[0].Extensions);
+            Assert.That(jsonA, Does.Contain(CacheBustHash));
+            Assert.That(jsonA, Does.Not.Contain(Constants.Web.CacheBusterToken));
+
+            var jsonB = JsonSerializer.Serialize(result[1].Extensions);
+            Assert.That(jsonB, Does.Contain("/App_Plugins/B/b.js"));
+            Assert.That(jsonB, Does.Not.Contain(CacheBustHash));
+
+            Assert.That(result[2].Extensions, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Replaces_Token_In_Nested_Extension_Objects()
+    {
+        var model = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"type":"bundle","meta":{"loader":"/App_Plugins/Foo/loader.js?v=%CACHE_BUSTER%"}}"""),
+            ]);
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+
+        var json = JsonSerializer.Serialize(result[0].Extensions);
+        Assert.That(json, Does.Contain($"/App_Plugins/Foo/loader.js?v={CacheBustHash}"));
+        Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Preserves_All_Models_In_Output()
+    {
+        var models = Enumerable.Range(0, 5)
+            .Select(i => CreateModel(Array.Empty<object>(), $"Package{i}"))
+            .ToArray();
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash).ToList();
+
+        Assert.That(result, Has.Count.EqualTo(5));
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.That(result[i].Name, Is.EqualTo($"Package{i}"));
+        }
+    }
+
+    [Test]
+    public void ReplaceCacheBusterTokens_Handles_Multiple_Extensions_In_Single_Model()
+    {
+        var model = CreateModel(
+            [
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"js":"/App_Plugins/Foo/one.js?v=%CACHE_BUSTER%"}"""),
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"js":"/App_Plugins/Foo/two.js?v=%CACHE_BUSTER%"}"""),
+                JsonSerializer.Deserialize<JsonElement>(
+                    """{"js":"/App_Plugins/Foo/three.js"}"""),
+            ]);
+
+        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+
+        var json = JsonSerializer.Serialize(result[0].Extensions);
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain($"/App_Plugins/Foo/one.js?v={CacheBustHash}"));
+            Assert.That(json, Does.Contain($"/App_Plugins/Foo/two.js?v={CacheBustHash}"));
+            Assert.That(json, Does.Contain("/App_Plugins/Foo/three.js"));
+            Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
+        });
+    }
+
+    private static ManifestResponseModel CreateModel(object[] extensions, string name = "TestPackage")
+        => new() { Name = name, Extensions = extensions };
+
+    /// <summary>
+    /// Exposes the protected static method for testing.
+    /// </summary>
+    private class TestableManifestControllerBase : ManifestControllerBase
+    {
+        public static IEnumerable<ManifestResponseModel> TestReplaceCacheBusterTokens(
+            IEnumerable<ManifestResponseModel> models, string cacheBustHash)
+            => ReplaceCacheBusterTokens(models, cacheBustHash);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Manifest/ManifestControllerBaseTests.cs
@@ -20,9 +20,10 @@ public class ManifestControllerBaseTests
                     """{"type":"js","js":"/App_Plugins/Foo/bundle.js?v=%CACHE_BUSTER%"}"""),
             ]);
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+        List<ManifestResponseModel> models = [model];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
-        var json = JsonSerializer.Serialize(result[0].Extensions);
+        var json = JsonSerializer.Serialize(models[0].Extensions);
         Assert.That(json, Does.Contain(CacheBustHash));
         Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
     }
@@ -36,9 +37,10 @@ public class ManifestControllerBaseTests
                     """{"type":"js","js":"/App_Plugins/Foo/bundle.js?v=%CACHE_BUSTER%","element":"/App_Plugins/Foo/element.js?v=%CACHE_BUSTER%"}"""),
             ]);
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+        List<ManifestResponseModel> models = [model];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
-        var json = JsonSerializer.Serialize(result[0].Extensions);
+        var json = JsonSerializer.Serialize(models[0].Extensions);
         Assert.That(json, Does.Contain($"/App_Plugins/Foo/bundle.js?v={CacheBustHash}"));
         Assert.That(json, Does.Contain($"/App_Plugins/Foo/element.js?v={CacheBustHash}"));
         Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
@@ -53,9 +55,10 @@ public class ManifestControllerBaseTests
                     """{"type":"js","js":"/App_Plugins/Foo/bundle.js"}"""),
             ]);
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+        List<ManifestResponseModel> models = [model];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
-        var json = JsonSerializer.Serialize(result[0].Extensions);
+        var json = JsonSerializer.Serialize(models[0].Extensions);
         Assert.That(json, Does.Contain("/App_Plugins/Foo/bundle.js"));
         Assert.That(json, Does.Not.Contain(CacheBustHash));
     }
@@ -65,9 +68,10 @@ public class ManifestControllerBaseTests
     {
         var model = CreateModel(Array.Empty<object>());
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+        List<ManifestResponseModel> models = [model];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
-        Assert.That(result[0].Extensions, Is.Empty);
+        Assert.That(models[0].Extensions, Is.Empty);
     }
 
     [Test]
@@ -89,20 +93,20 @@ public class ManifestControllerBaseTests
 
         var modelEmpty = CreateModel(Array.Empty<object>(), "PackageC");
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens(
-            [modelWithToken, modelWithoutToken, modelEmpty], CacheBustHash).ToList();
+        List<ManifestResponseModel> models = [modelWithToken, modelWithoutToken, modelEmpty];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
         Assert.Multiple(() =>
         {
-            var jsonA = JsonSerializer.Serialize(result[0].Extensions);
+            var jsonA = JsonSerializer.Serialize(models[0].Extensions);
             Assert.That(jsonA, Does.Contain(CacheBustHash));
             Assert.That(jsonA, Does.Not.Contain(Constants.Web.CacheBusterToken));
 
-            var jsonB = JsonSerializer.Serialize(result[1].Extensions);
+            var jsonB = JsonSerializer.Serialize(models[1].Extensions);
             Assert.That(jsonB, Does.Contain("/App_Plugins/B/b.js"));
             Assert.That(jsonB, Does.Not.Contain(CacheBustHash));
 
-            Assert.That(result[2].Extensions, Is.Empty);
+            Assert.That(models[2].Extensions, Is.Empty);
         });
     }
 
@@ -115,9 +119,10 @@ public class ManifestControllerBaseTests
                     """{"type":"bundle","meta":{"loader":"/App_Plugins/Foo/loader.js?v=%CACHE_BUSTER%"}}"""),
             ]);
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+        List<ManifestResponseModel> models = [model];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
-        var json = JsonSerializer.Serialize(result[0].Extensions);
+        var json = JsonSerializer.Serialize(models[0].Extensions);
         Assert.That(json, Does.Contain($"/App_Plugins/Foo/loader.js?v={CacheBustHash}"));
         Assert.That(json, Does.Not.Contain(Constants.Web.CacheBusterToken));
     }
@@ -125,16 +130,16 @@ public class ManifestControllerBaseTests
     [Test]
     public void ReplaceCacheBusterTokens_Preserves_All_Models_In_Output()
     {
-        var models = Enumerable.Range(0, 5)
+        List<ManifestResponseModel> models = Enumerable.Range(0, 5)
             .Select(i => CreateModel(Array.Empty<object>(), $"Package{i}"))
-            .ToArray();
+            .ToList();
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash).ToList();
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
-        Assert.That(result, Has.Count.EqualTo(5));
+        Assert.That(models, Has.Count.EqualTo(5));
         for (var i = 0; i < 5; i++)
         {
-            Assert.That(result[i].Name, Is.EqualTo($"Package{i}"));
+            Assert.That(models[i].Name, Is.EqualTo($"Package{i}"));
         }
     }
 
@@ -151,9 +156,10 @@ public class ManifestControllerBaseTests
                     """{"js":"/App_Plugins/Foo/three.js"}"""),
             ]);
 
-        var result = TestableManifestControllerBase.TestReplaceCacheBusterTokens([model], CacheBustHash).ToList();
+        List<ManifestResponseModel> models = [model];
+        TestableManifestControllerBase.TestReplaceCacheBusterTokens(models, CacheBustHash);
 
-        var json = JsonSerializer.Serialize(result[0].Extensions);
+        var json = JsonSerializer.Serialize(models[0].Extensions);
         Assert.Multiple(() =>
         {
             Assert.That(json, Does.Contain($"/App_Plugins/Foo/one.js?v={CacheBustHash}"));
@@ -171,7 +177,7 @@ public class ManifestControllerBaseTests
     /// </summary>
     private class TestableManifestControllerBase : ManifestControllerBase
     {
-        public static IEnumerable<ManifestResponseModel> TestReplaceCacheBusterTokens(
+        public static void TestReplaceCacheBusterTokens(
             IEnumerable<ManifestResponseModel> models, string cacheBustHash)
             => ReplaceCacheBusterTokens(models, cacheBustHash);
     }


### PR DESCRIPTION
## Summary

- Replace `%CACHE_BUSTER%` token in extension paths (`js`, `element`, `api`) at the **manifest API controller** level, right before returning the response
- Importmap replacement remains in `HtmlHelperBackOfficeExtensions` where it was already handled (importmap is rendered server-side in HTML, not through the API)
- `PackageManifestService` stays clean — caching and reading only, no presentation concerns

Fixes #16893 — also discussed on the [community forum](https://forum.umbraco.com/t/cache-buster-for-extension-files/6324/6).

## How it works

1. **Extensions** (served via Management API): The 3 manifest controllers (`AllManifestController`, `PrivateManifestManifestController`, `PublicManifestManifestController`) now inject `IBackOfficePathGenerator` and call `ReplaceCacheBusterTokens()` on the mapped response models before returning them. The helper method serializes the extensions array to JSON, replaces the token, and deserializes back. Since the result is immediately serialized to JSON for the HTTP response, no type concerns apply.

2. **Importmap** (rendered in HTML): `HtmlHelperBackOfficeExtensions.BackOfficeImportMapScriptAsync()` replaces the token in the serialized importmap string using `IBackOfficePathGenerator.BackOfficeCacheBustHash` — this was already working before and is unchanged.

## Test plan

- [x] Existing manifest tests continue to pass (4/4)
- [x] Manual: Put `%CACHE_BUSTER%` in both extension `js` and importmap paths in a test `umbraco-package.json`. Verify both are replaced — extensions via manifest API, importmap in page source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)