### PR TITLE
Chore: Hide generated files from GitHub PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,3 +55,8 @@
 *.sln text=auto eol=crlf merge=union
 
 *.gitattributes text=auto
+
+# Generated files - hidden by default in GitHub diffs
+src/Umbraco.Web.UI.Client/src/packages/core/backend-api/** linguist-generated
+src/Umbraco.Web.UI.Login/src/api/** linguist-generated
+src/Umbraco.Cms.Api.Management/OpenApi.json linguist-generated


### PR DESCRIPTION
## Summary
- Adds `linguist-generated` attributes for hey-api generated TypeScript clients and `OpenApi.json` so they are **collapsed by default in GitHub PR diffs** and **excluded from repository language statistics**
- Covers `src/Umbraco.Web.UI.Client/src/packages/core/backend-api/**` (14 files)
- Covers `src/Umbraco.Web.UI.Login/src/api/**` (14 files)
- Covers `src/Umbraco.Cms.Api.Management/OpenApi.json`

## How it works

From [Customizing how changed files appear on GitHub](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github):

> Use the `linguist-generated` attribute to mark paths that you would like to be ignored for the repository's language statistics and hidden by default in diffs.

The `.gitattributes` file uses the same pattern matching rules as `.gitignore`. Files marked with `linguist-generated` are:
1. **Hidden by default in diffs** — they appear collapsed in PR reviews but can still be expanded if needed
2. **Excluded from language statistics** — they won't skew the repository's detected languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)