### PR TITLE
Entity Data Picker: Register non-editor manifests statically

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/entry-point.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/entry-point.ts
@@ -1,4 +1,4 @@
-import { manifests as entityDataPickerManifests } from './manifests.js';
+import { manifests as propertyEditorManifests } from './property-editor/manifests.js';
 import type { UmbEntryPointOnInit } from '@umbraco-cms/backoffice/extension-api';
 import { UMB_PICKER_DATA_SOURCE_TYPE } from '@umbraco-cms/backoffice/picker-data-source';
 import type { ManifestPropertyEditorDataSource } from '@umbraco-cms/backoffice/property-editor-data-source';
@@ -18,7 +18,7 @@ export const onInit: UmbEntryPointOnInit = (host, extensionRegistry) => {
 		)
 		.subscribe((pickerPropertyEditorDataSource) => {
 			if (pickerPropertyEditorDataSource.length > 0 && !initialized) {
-				extensionRegistry.registerMany(entityDataPickerManifests);
+				extensionRegistry.registerMany(propertyEditorManifests);
 				initialized = true;
 			}
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/manifests.ts
@@ -2,12 +2,10 @@ import { manifests as pickerCollectionMenuManifests } from './picker-collection/
 import { manifests as pickerItemManifests } from './picker-item/manifests.js';
 import { manifests as pickerSearchManifests } from './picker-search/manifests.js';
 import { manifests as pickerTreeManifests } from './picker-tree/manifests.js';
-import { manifests as propertyEditorManifests } from './property-editor/manifests.js';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	...pickerCollectionMenuManifests,
 	...pickerItemManifests,
 	...pickerSearchManifests,
 	...pickerTreeManifests,
-	...propertyEditorManifests,
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/manifests.ts
@@ -13,6 +13,7 @@ import { manifests as colorPickerManifests } from './color-picker/manifests.js';
 import { manifests as datePickerManifests } from './date-picker/manifests.js';
 import { manifests as dateTimeManifests } from './date-time/manifests.js';
 import { manifests as dropdownManifests } from './dropdown/manifests.js';
+import { manifests as entityDataPickerManifests } from './entity-data-picker/manifests.js';
 import { manifests as eyeDropperManifests } from './eye-dropper/manifests.js';
 import { manifests as iconPickerManifests } from './icon-picker/manifests.js';
 import { manifests as labelManifests } from './label/manifests.js';
@@ -33,6 +34,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 	...datePickerManifests,
 	...dateTimeManifests,
 	...dropdownManifests,
+	...entityDataPickerManifests,
 	...eyeDropperManifests,
 	...iconPickerManifests,
 	...labelManifests,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The entity data picker's picker infrastructure manifests (collection menu, item, search, tree) were previously only registered dynamically via the entry point. This meant they were unavailable until a picker data source was detected, which could cause issues when components depend on these manifests being available without a data source present.

**Changes:**
- Moved non-property-editor manifests (picker collection menu, item, search, tree) to be registered statically via the root `property-editors/manifests.ts`
- Removed property editor manifests from the entity data picker's `manifests.ts` (they remain dynamically registered via `entry-point.ts`)
- Updated `entry-point.ts` to import property editor manifests directly from `./property-editor/manifests.js`

**How to test:**
1. Open the backoffice
2. Verify that entity data picker functionality works correctly (picker collection, items, search, tree)
3. Verify that property editor manifests are still registered dynamically when a picker data source is available
4. Verify that `umb-input-entity-data` element works without a `propertyEditorDataSource` registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)