### PR TITLE
Management API: Add server-side validation preventing element types from varying by segment (closes #21643)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -114,6 +114,10 @@ public abstract class DocumentTypeControllerBase : ManagementApiControllerBase
                     .WithTitle("Invalid IsElement flag")
                     .WithDetail("Can not create a documentType with inheritance composition where the parent and the new type's IsElement flag are different.")
                     .Build()),
+                ContentTypeOperationStatus.InvalidSegmentVariationForElementType => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid segment variation")
+                    .WithDetail("Element types cannot vary by segment.")
+                    .Build()),
                 _ => new ObjectResult("Unknown content type operation status") { StatusCode = StatusCodes.Status500InternalServerError },
             });
 

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingServiceBase.cs
@@ -278,6 +278,12 @@ internal abstract class ContentTypeEditingServiceBase<TContentType, TContentType
             return operationStatus;
         }
 
+        // element types cannot vary by segment
+        if (model.IsElement && model.VariesBySegment)
+        {
+            return ContentTypeOperationStatus.InvalidSegmentVariationForElementType;
+        }
+
         return ContentTypeOperationStatus.Success;
     }
 

--- a/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
@@ -125,4 +125,9 @@ public enum ContentTypeOperationStatus
     /// </summary>
     InvalidTemplateAlias,
     NotImplemented,
+
+    /// <summary>
+    ///     Element types cannot vary by segment.
+    /// </summary>
+    InvalidSegmentVariationForElementType,
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Create.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Create.cs
@@ -1157,4 +1157,16 @@ internal sealed partial class ContentTypeEditingServiceTests
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentTypeOperationStatus.InvalidElementFlagComparedToParent, result.Status);
     }
+
+    [Test]
+    public async Task Cannot_Create_Element_Type_With_Segment_Variation()
+    {
+        var createModel = ContentTypeCreateModel("Test", "test", isElement: true);
+        createModel.VariesBySegment = true;
+
+        var result = await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentTypeOperationStatus.InvalidSegmentVariationForElementType, result.Status);
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Update.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Update.cs
@@ -1136,4 +1136,35 @@ internal sealed partial class ContentTypeEditingServiceTests
             Assert.AreEqual("Same Test Property Alias", compositionProperty.Name);
         });
     }
+
+    [Test]
+    public async Task Cannot_Update_Element_Type_With_Segment_Variation()
+    {
+        var createModel = ContentTypeCreateModel("Test", "test", isElement: true);
+        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result!;
+
+        var updateModel = ContentTypeUpdateModel("Test", "test", isElement: true);
+        updateModel.VariesBySegment = true;
+
+        var result = await ContentTypeEditingService.UpdateAsync(contentType, updateModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentTypeOperationStatus.InvalidSegmentVariationForElementType, result.Status);
+    }
+
+    [Test]
+    public async Task Cannot_Switch_To_Element_Type_With_Existing_Segment_Variation()
+    {
+        var createModel = ContentTypeCreateModel("Test", "test");
+        createModel.VariesBySegment = true;
+        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result!;
+
+        var updateModel = ContentTypeUpdateModel("Test", "test", isElement: true);
+        updateModel.VariesBySegment = true;
+
+        var result = await ContentTypeEditingService.UpdateAsync(contentType, updateModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentTypeOperationStatus.InvalidSegmentVariationForElementType, result.Status);
+    }
 }


### PR DESCRIPTION
## Description

We don't currently support element document types with segmentation. Previously this constraint was enforced **only in the backoffice UI** — the settings view hides the "Allow segmentation" toggle when the element type checkbox is enabled. A direct API call could bypass this, leaving the content type in an invalid state that causes downstream errors (see #21643).

As such in this PR I've added server-side validation that rejects content types configured as both `isElement: true` and `variesBySegment: true`.

## Testing

### Automated
- [x] `Cannot_Create_Element_Type_With_Segment_Variation` — creating an element type with `variesBySegment: true` returns `InvalidSegmentVariationForElementType`.
- [x] `Cannot_Update_Element_Type_With_Segment_Variation` — updating an existing element type to enable segment variation is rejected.
- [x] `Cannot_Switch_To_Element_Type_With_Existing_Segment_Variation` — converting a segment-varying document type to an element type is rejected.
- [x] All 145 `ContentTypeEditingServiceTests` pass.

### Manual — reproduce via Management API

1. Login to the backoffice, save an element type and capture the payload.
2. Via the Swagger UI, send a `PUT` to `/umbraco/management/api/v1/document-type/{id}` with a body containing the JSON payload JSON manipulated such that `"isElement": true` and `"variesBySegment": true`.
3. **Expected**: `400 Bad Request` with `operationStatus: "InvalidSegmentVariationForElementType"` and detail: *"Element types cannot vary by segment."*
4. **Before this fix**: The request would succeed, creating an invalid content type.
