### PR TITLE
Block Editors: Align create label

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -97,7 +97,7 @@ export class UmbPropertyEditorUIBlockListElement
 	}
 
 	@state()
-	private _createButtonLabel = this.localize.term('content_createEmpty');
+	private _createButtonLabel = this.localize.term('blockEditor_addBlock');
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/property-editor-ui-block-single.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/property-editor-ui-block-single.element.ts
@@ -93,7 +93,7 @@ export class UmbPropertyEditorUIBlockSingleElement
 	}
 
 	@state()
-	private _createButtonLabel = this.localize.term('content_createEmpty');
+	private _createButtonLabel = this.localize.term('blockEditor_addBlock');
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		if (!config) return;


### PR DESCRIPTION
Use the label 'add content' to align with the create modal and other Block Editors.

This change makes Block List and Single Block align with Block Grid Editor, and the shared Create Modal of them all. As well aligns with v.13

<img width="914" height="143" alt="image" src="https://github.com/user-attachments/assets/b8ad215e-0503-459d-a5b1-7ff4044b791e" />
