### PR TITLE
Persistence models: Fix incorrect webhook DTO

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/WebhookDto.cs
@@ -48,6 +48,6 @@ internal sealed class WebhookDto
 
     [ResultColumn]
     [Reference(ReferenceType.Many, ReferenceMemberName = Webhook2HeadersDto.ReferenceMemberName)]
-    public List<Webhook2ContentTypeKeysDto> Webhook2Headers { get; set; } = new();
+    public List<Webhook2HeadersDto> Webhook2Headers { get; set; } = new();
 }
 


### PR DESCRIPTION
Fixes the webhook DTO references the wrong dto in Webhook2Headers

# Testing

Try and create a webhook with custom headers in the backoffice and ensure it still works