### PR TITLE
Entity Actions: Adds a descriptive title to the first action so you know what it does

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
@@ -133,7 +133,7 @@ export class UmbEntityActionsBundleElement extends UmbLitElement {
 			<uui-button
 				label=${label}
 				title=${label}
-				data-mark=${'entity-action:' + this._firstActionManifest.alias}
+				data-mark=${`entity-action:${this._firstActionManifest.alias}`}
 				href=${ifDefined(this._firstActionHref)}
 				@click=${this.#onFirstActionClick}>
 				<umb-icon name=${ifDefined(this._firstActionManifest.meta.icon)}></umb-icon>


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `UmbEntityActionsBundleElement` component. The change improves accessibility and usability by adding a `title` attribute to the rendered button.

<img width="430" height="391" alt="image" src="https://github.com/user-attachments/assets/4d2353b4-5900-446f-974c-cc54af9fb1cd" />

The first action is hoisted out into each table row, but you don't necessarily know what it does, because we don't show the label next to it. Instead, we can hint towards the user what the action does by adding a title, which essentially is duplicating the existing `aria-label`.