### PR TITLE
Fix the integration tests project file structure

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -381,6 +381,7 @@
     </Compile>
     <Compile Update="ManagementApi\Services\UserStartNodeEntitiesServiceElementTests.SiblingUserAccessEntities.cs">
       <DependentUpon>UserStartNodeEntitiesServiceElementTests.cs</DependentUpon>
+    </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\UserServiceTests.Permissions.cs">
       <DependentUpon>UserServiceTests.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Something (likely a bad merge) has corrupted `Umbraco.Tests.Integration.csproj`, so the project cannot load - which causes our pipelines to fail.