### PR TITLE
Decimal Property Editor: Increase step size precision for configuration fields (closes #21759)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
@@ -12,7 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 						label: 'Minimum',
 						description: 'Enter the minimum amount of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [{ alias: 'step', value: '0.001' }],
+						config: [{ alias: 'step', value: '0.0000000001' }],
 					},
 					{
 						alias: 'max',
@@ -21,7 +21,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
 						config: [
 							{ alias: 'placeholder', value: '∞' },
-							{ alias: 'step', value: '0.001' },
+							{ alias: 'step', value: '0.0000000001' },
 						],
 					},
 					{
@@ -29,7 +29,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 						label: 'Step size',
 						description: 'Enter the intervals amount between each step of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [{ alias: 'step', value: '0.001' }],
+						config: [{ alias: 'step', value: '0.0000000001' }],
 					},
 				],
 			},


### PR DESCRIPTION
## Description

This PR increases the step precision on the Decimal property editor's configuration fields (min, max, step size) from `0.001` (3 decimal places) to `0.0000000001` (10 decimal places), enabling use cases like latitude/longitude values (see https://github.com/umbraco/Umbraco-CMS/issues/21759).

The backend validation (`ValidationHelper.IsValueValidForStep`) and database layer already support arbitrary precision, so this is currently a frontend-only limitation.

## Testing

Create or edit a Decimal data type in the backoffice and verify the "Step size" field accepts values like `0.000001` (6 decimal places). Check that entries of this precision can be saved on a document that is based on a document type using the created data type.