### PR TITLE
Audit: Fix container update operations incorrectly logged as new

### DIFF
--- a/src/Umbraco.Core/Services/EntityTypeContainerService.cs
+++ b/src/Umbraco.Core/Services/EntityTypeContainerService.cs
@@ -179,7 +179,7 @@ internal abstract class EntityTypeContainerService<TTreeEntity, TEntityContainer
 
                 return EntityContainerOperationStatus.Success;
             },
-            AuditType.New);
+            AuditType.Save);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- `EntityTypeContainerService.UpdateAsync` was passing `AuditType.New` instead of `AuditType.Save` when writing audit logs, causing container rename operations to be incorrectly recorded as creations in the audit trail.
- This affected all container types (document type folders, media type folders, data type folders, etc.).

## Test plan
Rename a document type folder and verify the audit log records the operation as a save instead of a creation.