### PR TITLE
Management API: Include ancestor breadcrumbs in search response models

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemController.cs
@@ -1,7 +1,11 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Services;
 using Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -15,17 +19,34 @@ public class SearchDataTypeItemController : DatatypeItemControllerBase
     private readonly IEntitySearchService _entitySearchService;
     private readonly IDataTypeService _dataTypeService;
     private readonly IUmbracoMapper _mapper;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
-    public SearchDataTypeItemController(IEntitySearchService entitySearchService, IDataTypeService dataTypeService, IUmbracoMapper mapper)
+    [ActivatorUtilitiesConstructor]
+    public SearchDataTypeItemController(
+        IEntitySearchService entitySearchService,
+        IDataTypeService dataTypeService,
+        IUmbracoMapper mapper,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _entitySearchService = entitySearchService;
         _dataTypeService = dataTypeService;
         _mapper = mapper;
+        _searchResultAncestorService = searchResultAncestorService;
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchDataTypeItemController(IEntitySearchService entitySearchService, IDataTypeService dataTypeService, IUmbracoMapper mapper)
+        : this(
+            entitySearchService,
+            dataTypeService,
+            mapper,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
     }
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<DataTypeItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchDataTypeItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches data type items.")]
     [EndpointDescription("Searches data type items by the provided query with pagination support.")]
     public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
@@ -33,13 +54,26 @@ public class SearchDataTypeItemController : DatatypeItemControllerBase
         PagedModel<IEntitySlim> searchResult = _entitySearchService.Search(UmbracoObjectTypes.DataType, query, skip, take);
         if (searchResult.Items.Any() is false)
         {
-            return Ok(new PagedModel<DataTypeItemResponseModel> { Total = searchResult.Total });
+            return Ok(new PagedModel<SearchDataTypeItemResponseModel> { Total = searchResult.Total });
         }
 
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(searchResult.Items, UmbracoObjectTypes.DataType);
+
         IEnumerable<IDataType> dataTypes = await _dataTypeService.GetAllAsync(searchResult.Items.Select(item => item.Key).ToArray());
-        var result = new PagedModel<DataTypeItemResponseModel>
+        IEnumerable<SearchDataTypeItemResponseModel> searchModels = _mapper.MapEnumerable<IDataType, SearchDataTypeItemResponseModel>(dataTypes);
+
+        foreach (SearchDataTypeItemResponseModel model in searchModels)
         {
-            Items = _mapper.MapEnumerable<IDataType, DataTypeItemResponseModel>(dataTypes),
+            if (ancestorsByKey.TryGetValue(model.Id, out IReadOnlyList<SearchResultAncestorModel>? ancestors))
+            {
+                model.Ancestors = ancestors;
+            }
+        }
+
+        var result = new PagedModel<SearchDataTypeItemResponseModel>
+        {
+            Items = searchModels,
             Total = searchResult.Total
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/Item/SearchDocumentItemController.cs
@@ -3,7 +3,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Services;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -18,18 +20,35 @@ public class SearchDocumentItemController : DocumentItemControllerBase
     private readonly IIndexedEntitySearchService _indexedEntitySearchService;
     private readonly IDocumentPresentationFactory _documentPresentationFactory;
     private readonly IDataTypeService _dataTypeService;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
     [ActivatorUtilitiesConstructor]
     public SearchDocumentItemController(
         IIndexedEntitySearchService indexedEntitySearchService,
         IDocumentPresentationFactory documentPresentationFactory,
-        IDataTypeService dataTypeService)
+        IDataTypeService dataTypeService,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _indexedEntitySearchService = indexedEntitySearchService;
         _documentPresentationFactory = documentPresentationFactory;
         _dataTypeService = dataTypeService;
+        _searchResultAncestorService = searchResultAncestorService;
     }
 
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchDocumentItemController(
+        IIndexedEntitySearchService indexedEntitySearchService,
+        IDocumentPresentationFactory documentPresentationFactory,
+        IDataTypeService dataTypeService)
+        : this(
+            indexedEntitySearchService,
+            documentPresentationFactory,
+            dataTypeService,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
+    }
+
+#pragma warning disable CS0618 // Type or member is obsolete
     [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 18.")]
     public SearchDocumentItemController(
         IIndexedEntitySearchService indexedEntitySearchService,
@@ -40,6 +59,7 @@ public class SearchDocumentItemController : DocumentItemControllerBase
             StaticServiceProvider.Instance.GetRequiredService<IDataTypeService>())
     {
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     [Obsolete("Please use the overload taking all parameters. Scheduled for removal in Umbraco 18.")]
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -65,7 +85,7 @@ public class SearchDocumentItemController : DocumentItemControllerBase
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<DocumentItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchDocumentItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches document items.")]
     [EndpointDescription("Searches document items by the provided query with pagination support.")]
     public async Task<IActionResult> SearchWithTrashed(
@@ -91,9 +111,23 @@ public class SearchDocumentItemController : DocumentItemControllerBase
             take,
             ignoreUserStartNodes);
 
-        var result = new PagedModel<DocumentItemResponseModel>
+        IDocumentEntitySlim[] documentEntities = searchResult.Items.OfType<IDocumentEntitySlim>().ToArray();
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(documentEntities, UmbracoObjectTypes.Document);
+
+        SearchDocumentItemResponseModel[] items = documentEntities
+            .Select(entity =>
+                _documentPresentationFactory.CreateSearchItemResponseModel(
+                    entity,
+                    ancestorsByKey.TryGetValue(entity.Key, out IReadOnlyList<SearchResultAncestorModel>? ancestors)
+                        ? ancestors
+                        : []))
+            .ToArray();
+
+        var result = new PagedModel<SearchDocumentItemResponseModel>
         {
-            Items = searchResult.Items.OfType<IDocumentEntitySlim>().Select(_documentPresentationFactory.CreateItemResponseModel),
+            Items = items,
             Total = searchResult.Total,
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/SearchDocumentTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/Item/SearchDocumentTypeItemController.cs
@@ -2,7 +2,9 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Services;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType.Item;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
@@ -15,24 +17,53 @@ public class SearchDocumentTypeItemController : DocumentTypeItemControllerBase
 {
     private readonly IUmbracoMapper _mapper;
     private readonly IContentTypeSearchService _contentTypeSearchService;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
-    public SearchDocumentTypeItemController(IUmbracoMapper mapper, IContentTypeSearchService contentTypeSearchService)
+    [ActivatorUtilitiesConstructor]
+    public SearchDocumentTypeItemController(
+        IUmbracoMapper mapper,
+        IContentTypeSearchService contentTypeSearchService,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _mapper = mapper;
         _contentTypeSearchService = contentTypeSearchService;
+        _searchResultAncestorService = searchResultAncestorService;
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchDocumentTypeItemController(IUmbracoMapper mapper, IContentTypeSearchService contentTypeSearchService)
+        : this(
+            mapper,
+            contentTypeSearchService,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
     }
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<DocumentTypeItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchDocumentTypeItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches document type items.")]
     [EndpointDescription("Searches document type items by the provided query with pagination support.")]
     public async Task<IActionResult> SearchDocumentType(CancellationToken cancellationToken, string query, bool? isElement = null, int skip = 0, int take = 100)
     {
         PagedModel<IContentType> contentTypes = await _contentTypeSearchService.SearchAsync(query, isElement, cancellationToken, skip, take);
-        var result = new PagedModel<DocumentTypeItemResponseModel>
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(contentTypes.Items, UmbracoObjectTypes.DocumentType);
+
+        IEnumerable<SearchDocumentTypeItemResponseModel> searchModels = _mapper.MapEnumerable<IContentType, SearchDocumentTypeItemResponseModel>(contentTypes.Items);
+
+        foreach (SearchDocumentTypeItemResponseModel model in searchModels)
         {
-            Items = _mapper.MapEnumerable<IContentType, DocumentTypeItemResponseModel>(contentTypes.Items),
+            if (ancestorsByKey.TryGetValue(model.Id, out IReadOnlyList<SearchResultAncestorModel>? ancestors))
+            {
+                model.Ancestors = ancestors;
+            }
+        }
+
+        var result = new PagedModel<SearchDocumentTypeItemResponseModel>
+        {
+            Items = searchModels,
             Total = contentTypes.Total
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/Item/SearchMediaItemController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Media.Item;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -19,18 +21,35 @@ public class SearchMediaItemController : MediaItemControllerBase
     private readonly IIndexedEntitySearchService _indexedEntitySearchService;
     private readonly IMediaPresentationFactory _mediaPresentationFactory;
     private readonly IDataTypeService _dataTypeService;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
     [ActivatorUtilitiesConstructor]
     public SearchMediaItemController(
         IIndexedEntitySearchService indexedEntitySearchService,
         IMediaPresentationFactory mediaPresentationFactory,
-        IDataTypeService dataTypeService)
+        IDataTypeService dataTypeService,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _indexedEntitySearchService = indexedEntitySearchService;
         _mediaPresentationFactory = mediaPresentationFactory;
         _dataTypeService = dataTypeService;
+        _searchResultAncestorService = searchResultAncestorService;
     }
 
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchMediaItemController(
+        IIndexedEntitySearchService indexedEntitySearchService,
+        IMediaPresentationFactory mediaPresentationFactory,
+        IDataTypeService dataTypeService)
+        : this(
+            indexedEntitySearchService,
+            mediaPresentationFactory,
+            dataTypeService,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
+    }
+
+#pragma warning disable CS0618 // Type or member is obsolete
     [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 18.")]
     public SearchMediaItemController(
         IIndexedEntitySearchService indexedEntitySearchService,
@@ -41,6 +60,7 @@ public class SearchMediaItemController : MediaItemControllerBase
             StaticServiceProvider.Instance.GetRequiredService<IDataTypeService>())
     {
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     [Obsolete("Please use the overload taking all parameters. Scheduled for removal in Umbraco 18.")]
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -66,7 +86,7 @@ public class SearchMediaItemController : MediaItemControllerBase
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<MediaItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchMediaItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches media items.")]
     [EndpointDescription("Searches media items by the provided query with pagination support.")]
     public async Task<IActionResult> SearchFromParentWithAllowedTypes(
@@ -98,9 +118,24 @@ public class SearchMediaItemController : MediaItemControllerBase
             skip,
             take,
             ignoreUserStartNodes);
-        var result = new PagedModel<MediaItemResponseModel>
+
+        IMediaEntitySlim[] mediaEntities = searchResult.Items.OfType<IMediaEntitySlim>().ToArray();
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(mediaEntities, UmbracoObjectTypes.Media);
+
+        SearchMediaItemResponseModel[] items = mediaEntities
+            .Select(entity =>
+                _mediaPresentationFactory.CreateSearchItemResponseModel(
+                    entity,
+                    ancestorsByKey.TryGetValue(entity.Key, out IReadOnlyList<SearchResultAncestorModel>? ancestors)
+                        ? ancestors
+                        : []))
+            .ToArray();
+
+        var result = new PagedModel<SearchMediaItemResponseModel>
         {
-            Items = searchResult.Items.OfType<IMediaEntitySlim>().Select(_mediaPresentationFactory.CreateItemResponseModel),
+            Items = items,
             Total = searchResult.Total,
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
@@ -1,7 +1,11 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType.Item;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -16,34 +20,64 @@ public class SearchMediaTypeItemController : MediaTypeItemControllerBase
     private readonly IEntitySearchService _entitySearchService;
     private readonly IMediaTypeService _mediaTypeService;
     private readonly IUmbracoMapper _mapper;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
-    public SearchMediaTypeItemController(IEntitySearchService entitySearchService, IMediaTypeService mediaTypeService, IUmbracoMapper mapper)
+    [ActivatorUtilitiesConstructor]
+    public SearchMediaTypeItemController(
+        IEntitySearchService entitySearchService,
+        IMediaTypeService mediaTypeService,
+        IUmbracoMapper mapper,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _entitySearchService = entitySearchService;
         _mediaTypeService = mediaTypeService;
         _mapper = mapper;
+        _searchResultAncestorService = searchResultAncestorService;
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchMediaTypeItemController(IEntitySearchService entitySearchService, IMediaTypeService mediaTypeService, IUmbracoMapper mapper)
+        : this(
+            entitySearchService,
+            mediaTypeService,
+            mapper,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
     }
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<MediaTypeItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchMediaTypeItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches media type items.")]
     [EndpointDescription("Searches media type items by the provided query with pagination support.")]
-    public Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
     {
         PagedModel<IEntitySlim> searchResult = _entitySearchService.Search(UmbracoObjectTypes.MediaType, query, skip, take);
         if (searchResult.Items.Any() is false)
         {
-            return Task.FromResult<IActionResult>(Ok(new PagedModel<MediaTypeItemResponseModel> { Total = searchResult.Total }));
+            return Ok(new PagedModel<SearchMediaTypeItemResponseModel> { Total = searchResult.Total });
         }
 
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(searchResult.Items, UmbracoObjectTypes.MediaType);
+
         IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray().EmptyNull());
-        var result = new PagedModel<MediaTypeItemResponseModel>
+        IEnumerable<SearchMediaTypeItemResponseModel> searchModels = _mapper.MapEnumerable<IMediaType, SearchMediaTypeItemResponseModel>(mediaTypes);
+
+        foreach (SearchMediaTypeItemResponseModel model in searchModels)
         {
-            Items = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(mediaTypes),
+            if (ancestorsByKey.TryGetValue(model.Id, out IReadOnlyList<SearchResultAncestorModel>? ancestors))
+            {
+                model.Ancestors = ancestors;
+            }
+        }
+
+        var result = new PagedModel<SearchMediaTypeItemResponseModel>
+        {
+            Items = searchModels,
             Total = searchResult.Total
         };
 
-        return Task.FromResult<IActionResult>(Ok(result));
+        return Ok(result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/SearchMemberItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Member/Item/SearchMemberItemController.cs
@@ -1,8 +1,12 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Member.Item;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
@@ -14,27 +18,57 @@ public class SearchMemberItemController : MemberItemControllerBase
 {
     private readonly IIndexedEntitySearchService _indexedEntitySearchService;
     private readonly IMemberPresentationFactory _memberPresentationFactory;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
-    public SearchMemberItemController(IIndexedEntitySearchService indexedEntitySearchService, IMemberPresentationFactory memberPresentationFactory)
+    [ActivatorUtilitiesConstructor]
+    public SearchMemberItemController(
+        IIndexedEntitySearchService indexedEntitySearchService,
+        IMemberPresentationFactory memberPresentationFactory,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _indexedEntitySearchService = indexedEntitySearchService;
         _memberPresentationFactory = memberPresentationFactory;
+        _searchResultAncestorService = searchResultAncestorService;
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchMemberItemController(IIndexedEntitySearchService indexedEntitySearchService, IMemberPresentationFactory memberPresentationFactory)
+        : this(
+            indexedEntitySearchService,
+            memberPresentationFactory,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
     }
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<MemberItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchMemberItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches member items.")]
     [EndpointDescription("Searches member items by the provided query with pagination support.")]
     public async Task<IActionResult> SearchWithAllowedTypes(CancellationToken cancellationToken, string query, int skip = 0, int take = 100, [FromQuery]IEnumerable<Guid>? allowedMemberTypes = null)
     {
         PagedModel<IEntitySlim> searchResult = await _indexedEntitySearchService.SearchAsync(UmbracoObjectTypes.Member, query, null, allowedMemberTypes, false, "*", skip, take);
-        var result = new PagedModel<MemberItemResponseModel>
+
+        IMemberEntitySlim[] memberEntities = searchResult.Items.OfType<IMemberEntitySlim>().ToArray();
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(memberEntities, UmbracoObjectTypes.Member);
+
+        SearchMemberItemResponseModel[] items = memberEntities
+            .Select(entity =>
+                _memberPresentationFactory.CreateSearchItemResponseModel(
+                    entity,
+                    ancestorsByKey.TryGetValue(entity.Key, out IReadOnlyList<SearchResultAncestorModel>? ancestors)
+                        ? ancestors
+                        : []))
+            .ToArray();
+
+        var result = new PagedModel<SearchMemberItemResponseModel>
         {
-            Items = searchResult.Items.OfType<IMemberEntitySlim>().Select(_memberPresentationFactory.CreateItemResponseModel),
+            Items = items,
             Total = searchResult.Total,
         };
 
-        return await Task.FromResult<IActionResult>(Ok(result));
+        return Ok(result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
@@ -1,7 +1,11 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MemberType.Item;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -15,34 +19,64 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
     private readonly IEntitySearchService _entitySearchService;
     private readonly IMemberTypeService _memberTypeService;
     private readonly IUmbracoMapper _mapper;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
-    public SearchMemberTypeItemController(IEntitySearchService entitySearchService, IMemberTypeService memberTypeService, IUmbracoMapper mapper)
+    [ActivatorUtilitiesConstructor]
+    public SearchMemberTypeItemController(
+        IEntitySearchService entitySearchService,
+        IMemberTypeService memberTypeService,
+        IUmbracoMapper mapper,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _entitySearchService = entitySearchService;
         _memberTypeService = memberTypeService;
         _mapper = mapper;
+        _searchResultAncestorService = searchResultAncestorService;
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchMemberTypeItemController(IEntitySearchService entitySearchService, IMemberTypeService memberTypeService, IUmbracoMapper mapper)
+        : this(
+            entitySearchService,
+            memberTypeService,
+            mapper,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
     }
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<MemberTypeItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchMemberTypeItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches member type items.")]
     [EndpointDescription("Searches member type items by the provided query with pagination support.")]
-    public Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
+    public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
     {
         PagedModel<IEntitySlim> searchResult = _entitySearchService.Search(UmbracoObjectTypes.MemberType, query, skip, take);
         if (searchResult.Items.Any() is false)
         {
-            return Task.FromResult<IActionResult>(Ok(new PagedModel<MemberTypeItemResponseModel> { Total = searchResult.Total }));
+            return Ok(new PagedModel<SearchMemberTypeItemResponseModel> { Total = searchResult.Total });
         }
 
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(searchResult.Items, UmbracoObjectTypes.MemberType);
+
         IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray());
-        var result = new PagedModel<MemberTypeItemResponseModel>
+        IEnumerable<SearchMemberTypeItemResponseModel> searchModels = _mapper.MapEnumerable<IMemberType, SearchMemberTypeItemResponseModel>(memberTypes);
+
+        foreach (SearchMemberTypeItemResponseModel model in searchModels)
         {
-            Items = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(memberTypes),
+            if (ancestorsByKey.TryGetValue(model.Id, out IReadOnlyList<SearchResultAncestorModel>? ancestors))
+            {
+                model.Ancestors = ancestors;
+            }
+        }
+
+        var result = new PagedModel<SearchMemberTypeItemResponseModel>
+        {
+            Items = searchModels,
             Total = searchResult.Total
         };
 
-        return Task.FromResult<IActionResult>(Ok(result));
+        return Ok(result);
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemController.cs
@@ -1,7 +1,11 @@
-﻿using Asp.Versioning;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Template.Item;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -15,17 +19,34 @@ public class SearchTemplateItemController : TemplateItemControllerBase
     private readonly IEntitySearchService _entitySearchService;
     private readonly ITemplateService _templateService;
     private readonly IUmbracoMapper _mapper;
+    private readonly ISearchResultAncestorService _searchResultAncestorService;
 
-    public SearchTemplateItemController(IEntitySearchService entitySearchService, ITemplateService templateService, IUmbracoMapper mapper)
+    [ActivatorUtilitiesConstructor]
+    public SearchTemplateItemController(
+        IEntitySearchService entitySearchService,
+        ITemplateService templateService,
+        IUmbracoMapper mapper,
+        ISearchResultAncestorService searchResultAncestorService)
     {
         _entitySearchService = entitySearchService;
         _templateService = templateService;
         _mapper = mapper;
+        _searchResultAncestorService = searchResultAncestorService;
+    }
+
+    [Obsolete("Use the non-obsolete constructor instead. Scheduled for removal in Umbraco 19.")]
+    public SearchTemplateItemController(IEntitySearchService entitySearchService, ITemplateService templateService, IUmbracoMapper mapper)
+        : this(
+            entitySearchService,
+            templateService,
+            mapper,
+            StaticServiceProvider.Instance.GetRequiredService<ISearchResultAncestorService>())
+    {
     }
 
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
-    [ProducesResponseType(typeof(PagedModel<TemplateItemResponseModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedModel<SearchTemplateItemResponseModel>), StatusCodes.Status200OK)]
     [EndpointSummary("Searches template items.")]
     [EndpointDescription("Searches template items by the provided query with pagination support.")]
     public async Task<IActionResult> Search(CancellationToken cancellationToken, string query, int skip = 0, int take = 100)
@@ -33,13 +54,26 @@ public class SearchTemplateItemController : TemplateItemControllerBase
         PagedModel<IEntitySlim> searchResult = _entitySearchService.Search(UmbracoObjectTypes.Template, query, skip, take);
         if (searchResult.Items.Any() is false)
         {
-            return Ok(new PagedModel<TemplateItemResponseModel> { Total = searchResult.Total });
+            return Ok(new PagedModel<SearchTemplateItemResponseModel> { Total = searchResult.Total });
         }
 
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> ancestorsByKey =
+            await _searchResultAncestorService.ResolveAsync(searchResult.Items, UmbracoObjectTypes.Template);
+
         IEnumerable<ITemplate> templates = await _templateService.GetAllAsync(searchResult.Items.Select(item => item.Key).ToArray());
-        var result = new PagedModel<TemplateItemResponseModel>
+        IEnumerable<SearchTemplateItemResponseModel> searchModels = _mapper.MapEnumerable<ITemplate, SearchTemplateItemResponseModel>(templates);
+
+        foreach (SearchTemplateItemResponseModel model in searchModels)
         {
-            Items = _mapper.MapEnumerable<ITemplate, TemplateItemResponseModel>(templates),
+            if (ancestorsByKey.TryGetValue(model.Id, out IReadOnlyList<SearchResultAncestorModel>? ancestors))
+            {
+                model.Ancestors = ancestors;
+            }
+        }
+
+        var result = new PagedModel<SearchTemplateItemResponseModel>
+        {
+            Items = searchModels,
             Total = searchResult.Total
         };
 

--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/EntityBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/EntityBuilderExtensions.cs
@@ -1,5 +1,6 @@
-﻿using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.Mapping.Item;
+using Umbraco.Cms.Api.Management.Services;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Extensions;
@@ -13,6 +14,7 @@ internal static class EntityBuilderExtensions
         builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
             .Add<ItemTypeMapDefinition>();
         builder.Services.AddUnique<IFileItemPresentationFactory, FileItemPresentationFactory>();
+        builder.Services.AddUnique<ISearchResultAncestorService, SearchResultAncestorService>();
 
         return builder;
     }

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint.Item;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Mapping;
@@ -65,6 +66,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         _flagProviderCollection = flagProviderCollection;
     }
 
+    /// <inheritdoc/>
     public async Task<PublishedDocumentResponseModel> CreatePublishedResponseModelAsync(IContent content)
     {
         PublishedDocumentResponseModel responseModel = _umbracoMapper.Map<PublishedDocumentResponseModel>(content)!;
@@ -80,6 +82,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         return responseModel;
     }
 
+    /// <inheritdoc/>
     public async Task<DocumentResponseModel> CreateResponseModelAsync(IContent content, ContentScheduleCollection schedule)
     {
         DocumentResponseModel responseModel = _umbracoMapper.Map<DocumentResponseModel>(content)!;
@@ -96,6 +99,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         return responseModel;
     }
 
+    /// <inheritdoc/>
     public DocumentItemResponseModel CreateItemResponseModel(IDocumentEntitySlim entity)
     {
         Attempt<Guid> parentKeyAttempt = _idKeyMap.GetKeyForId(entity.ParentId, UmbracoObjectTypes.Document);
@@ -119,6 +123,25 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         return responseModel;
     }
 
+    /// <inheritdoc/>
+    public SearchDocumentItemResponseModel CreateSearchItemResponseModel(IDocumentEntitySlim entity, IEnumerable<SearchResultAncestorModel> ancestors)
+    {
+        DocumentItemResponseModel baseModel = CreateItemResponseModel(entity);
+        return new SearchDocumentItemResponseModel
+        {
+            Id = baseModel.Id,
+            IsTrashed = baseModel.IsTrashed,
+            IsProtected = baseModel.IsProtected,
+            Parent = baseModel.Parent,
+            HasChildren = baseModel.HasChildren,
+            DocumentType = baseModel.DocumentType,
+            Variants = baseModel.Variants,
+            Flags = baseModel.Flags,
+            Ancestors = ancestors,
+        };
+    }
+
+    /// <inheritdoc/>
     public DocumentBlueprintItemResponseModel CreateBlueprintItemResponseModel(IDocumentEntitySlim entity)
     {
         var responseModel = new DocumentBlueprintItemResponseModel
@@ -132,6 +155,7 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         return responseModel;
     }
 
+    /// <inheritdoc/>
     public IEnumerable<DocumentVariantItemResponseModel> CreateVariantsItemResponseModels(IDocumentEntitySlim entity)
     {
         if (entity.Variations.VariesByCulture() is false)
@@ -162,9 +186,11 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         }
     }
 
+    /// <inheritdoc/>
     public DocumentTypeReferenceResponseModel CreateDocumentTypeReferenceResponseModel(IDocumentEntitySlim entity)
         => _umbracoMapper.Map<DocumentTypeReferenceResponseModel>(entity)!;
 
+    /// <inheritdoc/>
     public Attempt<List<CulturePublishScheduleModel>, ContentPublishingOperationStatus> CreateCulturePublishScheduleModels(PublishDocumentRequestModel requestModel)
     {
         var model = new List<CulturePublishScheduleModel>();

--- a/src/Umbraco.Cms.Api.Management/Factories/IDocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IDocumentPresentationFactory.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Api.Management.ViewModels.Document.Item;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentBlueprint.Item;
 using Umbraco.Cms.Api.Management.ViewModels.DocumentType;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
@@ -12,19 +13,80 @@ using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
+/// <summary>
+/// Factory for creating document presentation (view) models from domain models.
+/// </summary>
 public interface IDocumentPresentationFactory
 {
+    /// <summary>
+    /// Creates a published document response model from the specified content.
+    /// </summary>
+    /// <param name="content">The content to create the response model from.</param>
+    /// <returns>A task that represents the asynchronous operation, containing the published document response model.</returns>
     Task<PublishedDocumentResponseModel> CreatePublishedResponseModelAsync(IContent content);
 
+    /// <summary>
+    /// Creates a document response model from the specified content and schedule.
+    /// </summary>
+    /// <param name="content">The content to create the response model from.</param>
+    /// <param name="schedule">The content schedule collection.</param>
+    /// <returns>A task that represents the asynchronous operation, containing the document response model.</returns>
     Task<DocumentResponseModel> CreateResponseModelAsync(IContent content, ContentScheduleCollection schedule);
+
+    /// <summary>
+    /// Creates a document item response model from the specified entity.
+    /// </summary>
+    /// <param name="entity">The document entity.</param>
+    /// <returns>The document item response model.</returns>
     DocumentItemResponseModel CreateItemResponseModel(IDocumentEntitySlim entity);
 
+    /// <summary>
+    /// Creates a search item response model for a document entity, including ancestor breadcrumbs.
+    /// </summary>
+    // TODO (V18): Remove default implementation.
+    SearchDocumentItemResponseModel CreateSearchItemResponseModel(IDocumentEntitySlim entity, IEnumerable<SearchResultAncestorModel> ancestors)
+    {
+        DocumentItemResponseModel baseModel = CreateItemResponseModel(entity);
+        return new SearchDocumentItemResponseModel
+        {
+            Id = baseModel.Id,
+            IsTrashed = baseModel.IsTrashed,
+            IsProtected = baseModel.IsProtected,
+            Parent = baseModel.Parent,
+            HasChildren = baseModel.HasChildren,
+            DocumentType = baseModel.DocumentType,
+            Variants = baseModel.Variants,
+            Flags = baseModel.Flags,
+            Ancestors = ancestors,
+        };
+    }
+
+    /// <summary>
+    /// Creates a blueprint item response model from the specified entity.
+    /// </summary>
+    /// <param name="entity">The document entity.</param>
+    /// <returns>The document blueprint item response model.</returns>
     DocumentBlueprintItemResponseModel CreateBlueprintItemResponseModel(IDocumentEntitySlim entity);
 
+    /// <summary>
+    /// Creates variant item response models for the specified document entity.
+    /// </summary>
+    /// <param name="entity">The document entity.</param>
+    /// <returns>The variant item response models.</returns>
     IEnumerable<DocumentVariantItemResponseModel> CreateVariantsItemResponseModels(IDocumentEntitySlim entity);
 
+    /// <summary>
+    /// Creates a document type reference response model from the specified entity.
+    /// </summary>
+    /// <param name="entity">The document entity.</param>
+    /// <returns>The document type reference response model.</returns>
     DocumentTypeReferenceResponseModel CreateDocumentTypeReferenceResponseModel(IDocumentEntitySlim entity);
 
+    /// <summary>
+    /// Creates culture publish schedule models from the specified publish request.
+    /// </summary>
+    /// <param name="requestModel">The publish document request model containing schedule information.</param>
+    /// <returns>An attempt containing the list of culture publish schedule models, or a failure status.</returns>
     Attempt<List<CulturePublishScheduleModel>, ContentPublishingOperationStatus> CreateCulturePublishScheduleModels(
         PublishDocumentRequestModel requestModel)
     {

--- a/src/Umbraco.Cms.Api.Management/Factories/IMediaPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IMediaPresentationFactory.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels.Content;
+using Umbraco.Cms.Api.Management.ViewModels.Content;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Api.Management.ViewModels.Media.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType;
@@ -7,13 +8,56 @@ using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
+/// <summary>
+/// Factory for creating media presentation (view) models from domain models.
+/// </summary>
 public interface IMediaPresentationFactory
 {
+    /// <summary>
+    /// Creates a media response model from the specified media.
+    /// </summary>
+    /// <param name="media">The media to create the response model from.</param>
+    /// <returns>The media response model.</returns>
     MediaResponseModel CreateResponseModel(IMedia media);
 
+    /// <summary>
+    /// Creates a media item response model from the specified entity.
+    /// </summary>
+    /// <param name="entity">The media entity.</param>
+    /// <returns>The media item response model.</returns>
     MediaItemResponseModel CreateItemResponseModel(IMediaEntitySlim entity);
 
+    /// <summary>
+    /// Creates variant item response models for the specified media entity.
+    /// </summary>
+    /// <param name="entity">The media entity.</param>
+    /// <returns>The variant item response models.</returns>
     IEnumerable<VariantItemResponseModel> CreateVariantsItemResponseModels(IMediaEntitySlim entity);
 
+    /// <summary>
+    /// Creates a media type reference response model from the specified entity.
+    /// </summary>
+    /// <param name="entity">The media entity.</param>
+    /// <returns>The media type reference response model.</returns>
     MediaTypeReferenceResponseModel CreateMediaTypeReferenceResponseModel(IMediaEntitySlim entity);
+
+    /// <summary>
+    /// Creates a search item response model for a media entity, including ancestor breadcrumbs.
+    /// </summary>
+    // TODO (V18): Remove default implementation.
+    SearchMediaItemResponseModel CreateSearchItemResponseModel(IMediaEntitySlim entity, IEnumerable<SearchResultAncestorModel> ancestors)
+    {
+        MediaItemResponseModel baseModel = CreateItemResponseModel(entity);
+        return new SearchMediaItemResponseModel
+        {
+            Id = baseModel.Id,
+            IsTrashed = baseModel.IsTrashed,
+            Parent = baseModel.Parent,
+            HasChildren = baseModel.HasChildren,
+            MediaType = baseModel.MediaType,
+            Variants = baseModel.Variants,
+            Flags = baseModel.Flags,
+            Ancestors = ancestors,
+        };
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IMemberPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IMemberPresentationFactory.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Api.Management.ViewModels.Member;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Api.Management.ViewModels.Member.Item;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
@@ -6,13 +7,56 @@ using Umbraco.Cms.Core.Models.Membership;
 
 namespace Umbraco.Cms.Api.Management.Factories;
 
+/// <summary>
+/// Factory for creating member presentation (view) models from domain models.
+/// </summary>
 public interface IMemberPresentationFactory
 {
+    /// <summary>
+    /// Creates a member response model from the specified member.
+    /// </summary>
+    /// <param name="member">The member to create the response model from.</param>
+    /// <param name="currentUser">The current backoffice user.</param>
+    /// <returns>A task that represents the asynchronous operation, containing the member response model.</returns>
     Task<MemberResponseModel> CreateResponseModelAsync(IMember member, IUser currentUser);
 
+    /// <summary>
+    /// Creates multiple member response models from the specified members.
+    /// </summary>
+    /// <param name="members">The members to create response models from.</param>
+    /// <param name="currentUser">The current backoffice user.</param>
+    /// <returns>A task that represents the asynchronous operation, containing the member response models.</returns>
     Task<IEnumerable<MemberResponseModel>> CreateMultipleAsync(IEnumerable<IMember> members, IUser currentUser);
 
+    /// <summary>
+    /// Creates a member item response model from the specified entity.
+    /// </summary>
+    /// <param name="entity">The member entity.</param>
+    /// <returns>The member item response model.</returns>
     MemberItemResponseModel CreateItemResponseModel(IMemberEntitySlim entity);
 
+    /// <summary>
+    /// Creates a member item response model from the specified member.
+    /// </summary>
+    /// <param name="entity">The member.</param>
+    /// <returns>The member item response model.</returns>
     MemberItemResponseModel CreateItemResponseModel(IMember entity);
+
+    /// <summary>
+    /// Creates a search item response model for a member entity, including ancestor breadcrumbs.
+    /// </summary>
+    // TODO (V18): Remove default implementation.
+    SearchMemberItemResponseModel CreateSearchItemResponseModel(IMemberEntitySlim entity, IEnumerable<SearchResultAncestorModel> ancestors)
+    {
+        MemberItemResponseModel baseModel = CreateItemResponseModel(entity);
+        return new SearchMemberItemResponseModel
+        {
+            Id = baseModel.Id,
+            MemberType = baseModel.MemberType,
+            Variants = baseModel.Variants,
+            Kind = baseModel.Kind,
+            Flags = baseModel.Flags,
+            Ancestors = ancestors,
+        };
+    }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/MediaPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MediaPresentationFactory.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Content;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Media;
 using Umbraco.Cms.Api.Management.ViewModels.Media.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MediaType;
@@ -24,8 +25,10 @@ internal sealed class MediaPresentationFactory : IMediaPresentationFactory
         _idKeyMap = idKeyMap;
     }
 
+    /// <inheritdoc/>
     public MediaResponseModel CreateResponseModel(IMedia media) => _umbracoMapper.Map<MediaResponseModel>(media)!;
 
+    /// <inheritdoc/>
     public MediaItemResponseModel CreateItemResponseModel(IMediaEntitySlim entity)
     {
         Attempt<Guid> parentKeyAttempt = _idKeyMap.GetKeyForId(entity.ParentId, UmbracoObjectTypes.Media);
@@ -41,6 +44,24 @@ internal sealed class MediaPresentationFactory : IMediaPresentationFactory
         };
     }
 
+    /// <inheritdoc/>
+    public SearchMediaItemResponseModel CreateSearchItemResponseModel(IMediaEntitySlim entity, IEnumerable<SearchResultAncestorModel> ancestors)
+    {
+        MediaItemResponseModel baseModel = CreateItemResponseModel(entity);
+        return new SearchMediaItemResponseModel
+        {
+            Id = baseModel.Id,
+            IsTrashed = baseModel.IsTrashed,
+            Parent = baseModel.Parent,
+            HasChildren = baseModel.HasChildren,
+            MediaType = baseModel.MediaType,
+            Variants = baseModel.Variants,
+            Flags = baseModel.Flags,
+            Ancestors = ancestors,
+        };
+    }
+
+    /// <inheritdoc/>
     public IEnumerable<VariantItemResponseModel> CreateVariantsItemResponseModels(IMediaEntitySlim entity)
         =>
         [
@@ -51,6 +72,7 @@ internal sealed class MediaPresentationFactory : IMediaPresentationFactory
             }
         ];
 
+    /// <inheritdoc/>
     public MediaTypeReferenceResponseModel CreateMediaTypeReferenceResponseModel(IMediaEntitySlim entity)
         => _umbracoMapper.Map<MediaTypeReferenceResponseModel>(entity)!;
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MemberPresentationFactory.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.ViewModels.Content;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
 using Umbraco.Cms.Api.Management.ViewModels.Member;
 using Umbraco.Cms.Api.Management.ViewModels.Member.Item;
 using Umbraco.Cms.Api.Management.ViewModels.MemberType;
@@ -40,6 +41,7 @@ internal sealed class MemberPresentationFactory : IMemberPresentationFactory
         _deliveryApiSettings = deliveryApiSettings.Value;
     }
 
+    /// <inheritdoc/>
     public async Task<MemberResponseModel> CreateResponseModelAsync(IMember member, IUser currentUser)
     {
         MemberResponseModel responseModel = _umbracoMapper.Map<MemberResponseModel>(member)!;
@@ -55,6 +57,7 @@ internal sealed class MemberPresentationFactory : IMemberPresentationFactory
             : await RemoveSensitiveDataAsync(member, responseModel);
     }
 
+    /// <inheritdoc/>
     public async Task<IEnumerable<MemberResponseModel>> CreateMultipleAsync(IEnumerable<IMember> members, IUser currentUser)
     {
         var memberResponseModels = new List<MemberResponseModel>();
@@ -66,11 +69,28 @@ internal sealed class MemberPresentationFactory : IMemberPresentationFactory
         return memberResponseModels;
     }
 
+    /// <inheritdoc/>
     public MemberItemResponseModel CreateItemResponseModel(IMemberEntitySlim entity)
         => CreateItemResponseModel<IMemberEntitySlim>(entity);
 
+    /// <inheritdoc/>
     public MemberItemResponseModel CreateItemResponseModel(IMember entity)
         => CreateItemResponseModel<IMember>(entity);
+
+    /// <inheritdoc/>
+    public SearchMemberItemResponseModel CreateSearchItemResponseModel(IMemberEntitySlim entity, IEnumerable<SearchResultAncestorModel> ancestors)
+    {
+        MemberItemResponseModel baseModel = CreateItemResponseModel(entity);
+        return new SearchMemberItemResponseModel
+        {
+            Id = baseModel.Id,
+            MemberType = baseModel.MemberType,
+            Variants = baseModel.Variants,
+            Kind = baseModel.Kind,
+            Flags = baseModel.Flags,
+            Ancestors = ancestors,
+        };
+    }
 
     private MemberItemResponseModel CreateItemResponseModel<T>(T entity)
         where T : ITreeEntity

--- a/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Item/ItemTypeMapDefinition.cs
@@ -33,6 +33,11 @@ public class ItemTypeMapDefinition : IMapDefinition
         mapper.Define<IRelationType, RelationTypeItemResponseModel>((_, _) => new RelationTypeItemResponseModel(), Map);
         mapper.Define<IUserGroup, UserGroupItemResponseModel>((_, _) => new UserGroupItemResponseModel(), Map);
         mapper.Define<IWebhook, WebhookItemResponseModel>((_, _) => new WebhookItemResponseModel(), Map);
+        mapper.Define<IDataType, SearchDataTypeItemResponseModel>((_, _) => new SearchDataTypeItemResponseModel(), (source, target, context) => Map(source, target, context));
+        mapper.Define<IContentType, SearchDocumentTypeItemResponseModel>((_, _) => new SearchDocumentTypeItemResponseModel(), (source, target, context) => Map(source, target, context));
+        mapper.Define<IMediaType, SearchMediaTypeItemResponseModel>((_, _) => new SearchMediaTypeItemResponseModel(), (source, target, context) => Map(source, target, context));
+        mapper.Define<IMemberType, SearchMemberTypeItemResponseModel>((_, _) => new SearchMemberTypeItemResponseModel(), (source, target, context) => Map(source, target, context));
+        mapper.Define<ITemplate, SearchTemplateItemResponseModel>((_, _) => new SearchTemplateItemResponseModel { Alias = string.Empty }, (source, target, context) => Map(source, target, context));
     }
 
     // Umbraco.Code.MapAll

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -1571,7 +1571,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelDataTypeItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchDataTypeItemResponseModel"
                     }
                   ]
                 }
@@ -6813,7 +6813,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelDocumentTypeItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchDocumentTypeItemResponseModel"
                     }
                   ]
                 }
@@ -10984,7 +10984,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelDocumentItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchDocumentItemResponseModel"
                     }
                   ]
                 }
@@ -14674,7 +14674,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelMediaTypeItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchMediaTypeItemResponseModel"
                     }
                   ]
                 }
@@ -17185,7 +17185,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelMediaItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchMediaItemResponseModel"
                     }
                   ]
                 }
@@ -20310,7 +20310,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelMemberTypeItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchMemberTypeItemResponseModel"
                     }
                   ]
                 }
@@ -22583,7 +22583,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelMemberItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchMemberItemResponseModel"
                     }
                   ]
                 }
@@ -30662,7 +30662,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedModelTemplateItemResponseModel"
+                      "$ref": "#/components/schemas/PagedModelSearchTemplateItemResponseModel"
                     }
                   ]
                 }
@@ -46222,102 +46222,6 @@
         },
         "additionalProperties": false
       },
-      "PagedModelDataTypeItemResponseModel": {
-        "required": [
-          "items",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DataTypeItemResponseModel"
-                }
-              ]
-            }
-          },
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PagedModelDocumentItemResponseModel": {
-        "required": [
-          "items",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentItemResponseModel"
-                }
-              ]
-            }
-          },
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PagedModelDocumentTypeItemResponseModel": {
-        "required": [
-          "items",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/DocumentTypeItemResponseModel"
-                }
-              ]
-            }
-          },
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "additionalProperties": false
-      },
-      "PagedModelMediaItemResponseModel": {
-        "required": [
-          "items",
-          "total"
-        ],
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/MediaItemResponseModel"
-                }
-              ]
-            }
-          },
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          }
-        },
-        "additionalProperties": false
-      },
       "PagedModelMediaTypeItemResponseModel": {
         "required": [
           "items",
@@ -46342,7 +46246,7 @@
         },
         "additionalProperties": false
       },
-      "PagedModelMemberItemResponseModel": {
+      "PagedModelSearchDataTypeItemResponseModel": {
         "required": [
           "items",
           "total"
@@ -46354,7 +46258,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/MemberItemResponseModel"
+                  "$ref": "#/components/schemas/SearchDataTypeItemResponseModel"
                 }
               ]
             }
@@ -46366,7 +46270,7 @@
         },
         "additionalProperties": false
       },
-      "PagedModelMemberTypeItemResponseModel": {
+      "PagedModelSearchDocumentItemResponseModel": {
         "required": [
           "items",
           "total"
@@ -46378,7 +46282,7 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/MemberTypeItemResponseModel"
+                  "$ref": "#/components/schemas/SearchDocumentItemResponseModel"
                 }
               ]
             }
@@ -46390,7 +46294,7 @@
         },
         "additionalProperties": false
       },
-      "PagedModelTemplateItemResponseModel": {
+      "PagedModelSearchDocumentTypeItemResponseModel": {
         "required": [
           "items",
           "total"
@@ -46402,7 +46306,127 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/TemplateItemResponseModel"
+                  "$ref": "#/components/schemas/SearchDocumentTypeItemResponseModel"
+                }
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedModelSearchMediaItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchMediaItemResponseModel"
+                }
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedModelSearchMediaTypeItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchMediaTypeItemResponseModel"
+                }
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedModelSearchMemberItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchMemberItemResponseModel"
+                }
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedModelSearchMemberTypeItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchMemberTypeItemResponseModel"
+                }
+              ]
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PagedModelSearchTemplateItemResponseModel": {
+        "required": [
+          "items",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchTemplateItemResponseModel"
                 }
               ]
             }
@@ -47865,6 +47889,417 @@
         },
         "additionalProperties": false
       },
+      "SearchDataTypeItemResponseModel": {
+        "required": [
+          "ancestors",
+          "editorAlias",
+          "flags",
+          "id",
+          "isDeletable",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "editorUiAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "editorAlias": {
+            "type": "string"
+          },
+          "isDeletable": {
+            "type": "boolean"
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchDocumentItemResponseModel": {
+        "required": [
+          "ancestors",
+          "documentType",
+          "flags",
+          "hasChildren",
+          "id",
+          "isProtected",
+          "isTrashed",
+          "variants"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "isTrashed": {
+            "type": "boolean"
+          },
+          "isProtected": {
+            "type": "boolean"
+          },
+          "parent": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "documentType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DocumentTypeReferenceResponseModel"
+              }
+            ]
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DocumentVariantItemResponseModel"
+                }
+              ]
+            }
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchDocumentTypeItemResponseModel": {
+        "required": [
+          "ancestors",
+          "flags",
+          "id",
+          "isElement",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "isElement": {
+            "type": "boolean"
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchMediaItemResponseModel": {
+        "required": [
+          "ancestors",
+          "flags",
+          "hasChildren",
+          "id",
+          "isTrashed",
+          "mediaType",
+          "variants"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "isTrashed": {
+            "type": "boolean"
+          },
+          "parent": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceByIdModel"
+              }
+            ],
+            "nullable": true
+          },
+          "hasChildren": {
+            "type": "boolean"
+          },
+          "mediaType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/MediaTypeReferenceResponseModel"
+              }
+            ]
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/VariantItemResponseModel"
+                }
+              ]
+            }
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchMediaTypeItemResponseModel": {
+        "required": [
+          "ancestors",
+          "flags",
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchMemberItemResponseModel": {
+        "required": [
+          "ancestors",
+          "flags",
+          "id",
+          "kind",
+          "memberType",
+          "variants"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "memberType": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/MemberTypeReferenceResponseModel"
+              }
+            ]
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/VariantItemResponseModel"
+                }
+              ]
+            }
+          },
+          "kind": {
+            "$ref": "#/components/schemas/MemberKindModel"
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchMemberTypeItemResponseModel": {
+        "required": [
+          "ancestors",
+          "flags",
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchResultAncestorModel": {
+        "required": [
+          "entityType",
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "entityType": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "SearchResultResponseModel": {
         "required": [
           "fieldCount",
@@ -47893,6 +48328,49 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/FieldPresentationModel"
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SearchTemplateItemResponseModel": {
+        "required": [
+          "alias",
+          "ancestors",
+          "flags",
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "flags": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/FlagModel"
+                }
+              ]
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "ancestors": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SearchResultAncestorModel"
                 }
               ]
             }

--- a/src/Umbraco.Cms.Api.Management/Services/ISearchResultAncestorService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/ISearchResultAncestorService.cs
@@ -1,0 +1,24 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+
+namespace Umbraco.Cms.Api.Management.Services;
+
+/// <summary>
+/// Resolves ancestor (breadcrumb) details for search result entities in a single batch operation.
+/// </summary>
+public interface ISearchResultAncestorService
+{
+    /// <summary>
+    /// Resolves the ancestors for a collection of tree entities, returning an ordered breadcrumb trail per entity.
+    /// </summary>
+    /// <param name="entities">The search result entities to resolve ancestors for.</param>
+    /// <param name="entityObjectType">The <see cref="UmbracoObjectTypes"/> of the entities being resolved.</param>
+    /// <returns>
+    /// A dictionary keyed by entity key, where each value is an ordered list of ancestor models
+    /// from the topmost ancestor to the immediate parent. Flat entity types (e.g. Member) return empty lists.
+    /// </returns>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>>> ResolveAsync(
+        IEnumerable<ITreeEntity> entities,
+        UmbracoObjectTypes entityObjectType);
+}

--- a/src/Umbraco.Cms.Api.Management/Services/SearchResultAncestorService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/SearchResultAncestorService.cs
@@ -1,0 +1,158 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+using Umbraco.Cms.Core.Extensions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Api.Management.Services;
+
+/// <summary>
+/// Batch-optimized implementation of <see cref="ISearchResultAncestorService"/>.
+/// Collects all unique ancestor IDs across all entities and resolves them efficiently.
+/// For entity types whose ancestors support <see cref="IEntityService.GetAll(UmbracoObjectTypes, int[])"/>
+/// (Document, Media, Template), a single batch call is used. For container-based ancestors
+/// (DataType, DocumentType, MediaType folders), individual <see cref="IEntityService.Get(int)"/> calls
+/// are used because <c>GetAll</c> does not support container object types.
+/// For document ancestors, variant names are resolved using the default language culture.
+/// </summary>
+internal sealed class SearchResultAncestorService : ISearchResultAncestorService
+{
+    private readonly IEntityService _entityService;
+    private readonly ILanguageService _languageService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SearchResultAncestorService"/> class.
+    /// </summary>
+    /// <param name="entityService">The entity service.</param>
+    /// <param name="languageService">The language service.</param>
+    public SearchResultAncestorService(IEntityService entityService, ILanguageService languageService)
+    {
+        _entityService = entityService;
+        _languageService = languageService;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>>> ResolveAsync(
+        IEnumerable<ITreeEntity> entities,
+        UmbracoObjectTypes entityObjectType)
+    {
+        ITreeEntity[] entityArray = entities as ITreeEntity[] ?? entities.ToArray();
+        if (entityArray.Length == 0)
+        {
+            return new Dictionary<Guid, IReadOnlyList<SearchResultAncestorModel>>();
+        }
+
+        UmbracoObjectTypes? ancestorObjectType = GetAncestorObjectType(entityObjectType);
+        if (ancestorObjectType is null)
+        {
+            // Flat entity types (Member, MemberType) have no ancestors to resolve.
+            return entityArray.ToDictionary(
+                e => e.Key,
+                _ => (IReadOnlyList<SearchResultAncestorModel>)[]);
+        }
+
+        // Collect all unique ancestor integer IDs across all entities.
+        Dictionary<Guid, int[]> ancestorIdsByEntityKey = new(entityArray.Length);
+        HashSet<int> allAncestorIds = [];
+
+        foreach (ITreeEntity entity in entityArray)
+        {
+            var ancestorIds = entity.AncestorIds();
+            ancestorIdsByEntityKey[entity.Key] = ancestorIds;
+            foreach (var id in ancestorIds)
+            {
+                allAncestorIds.Add(id);
+            }
+        }
+
+        if (allAncestorIds.Count == 0)
+        {
+            return entityArray.ToDictionary(
+                e => e.Key,
+                _ => (IReadOnlyList<SearchResultAncestorModel>)Array.Empty<SearchResultAncestorModel>());
+        }
+
+        // Fetch all ancestor entities.
+        // IEntityService.GetAll(UmbracoObjectTypes, int[]) does not support container types
+        // (DataTypeContainer, DocumentTypeContainer, MediaTypeContainer), so for those we
+        // fall back to individual Get(int) calls. Container ancestor sets are typically small
+        // (shallow folder trees), so this is acceptable.
+        Dictionary<int, IEntitySlim> ancestorLookup = IsContainerType(ancestorObjectType.Value)
+            ? ResolveByIndividualGet(allAncestorIds)
+            : _entityService.GetAll(ancestorObjectType.Value, allAncestorIds.ToArray()).ToDictionary(e => e.Id);
+
+        // Resolve the default culture for variant document name resolution.
+        string? defaultCulture = entityObjectType == UmbracoObjectTypes.Document
+            ? await _languageService.GetDefaultIsoCodeAsync()
+            : null;
+
+        // Build the result: for each entity, walk ancestor IDs in path order and build the ancestor list.
+        var result = new Dictionary<Guid, IReadOnlyList<SearchResultAncestorModel>>(entityArray.Length);
+        foreach (ITreeEntity entity in entityArray)
+        {
+            var ancestorIds = ancestorIdsByEntityKey[entity.Key];
+            var ancestors = new List<SearchResultAncestorModel>(ancestorIds.Length);
+
+            foreach (var ancestorId in ancestorIds)
+            {
+                if (ancestorLookup.TryGetValue(ancestorId, out IEntitySlim? ancestor))
+                {
+                    ancestors.Add(new SearchResultAncestorModel
+                    {
+                        Id = ancestor.Key,
+                        Name = ResolveAncestorName(ancestor, defaultCulture),
+                        EntityType = ObjectTypes.GetUdiType(ancestor.NodeObjectType),
+                    });
+                }
+            }
+
+            result[entity.Key] = ancestors;
+        }
+
+        return result;
+    }
+
+    private static bool IsContainerType(UmbracoObjectTypes objectType)
+        => objectType is UmbracoObjectTypes.DataTypeContainer
+            or UmbracoObjectTypes.DocumentTypeContainer
+            or UmbracoObjectTypes.MediaTypeContainer;
+
+    private Dictionary<int, IEntitySlim> ResolveByIndividualGet(HashSet<int> ids)
+    {
+        var lookup = new Dictionary<int, IEntitySlim>(ids.Count);
+        foreach (var id in ids)
+        {
+            IEntitySlim? entity = _entityService.Get(id);
+            if (entity is not null)
+            {
+                lookup[entity.Id] = entity;
+            }
+        }
+
+        return lookup;
+    }
+
+    private static UmbracoObjectTypes? GetAncestorObjectType(UmbracoObjectTypes entityObjectType)
+        => entityObjectType switch
+        {
+            UmbracoObjectTypes.DataType => UmbracoObjectTypes.DataTypeContainer,
+            UmbracoObjectTypes.DocumentType => UmbracoObjectTypes.DocumentTypeContainer,
+            UmbracoObjectTypes.MediaType => UmbracoObjectTypes.MediaTypeContainer,
+            UmbracoObjectTypes.Document => UmbracoObjectTypes.Document,
+            UmbracoObjectTypes.Media => UmbracoObjectTypes.Media,
+            UmbracoObjectTypes.Template => UmbracoObjectTypes.Template,
+            _ => null,
+        };
+
+    private static string ResolveAncestorName(IEntitySlim ancestor, string? defaultCulture)
+    {
+        if (defaultCulture is not null && ancestor is IDocumentEntitySlim documentEntity && documentEntity.CultureNames.Count > 0)
+        {
+            return documentEntity.CultureNames.TryGetValue(defaultCulture, out var cultureName)
+                ? cultureName
+                : ancestor.Name ?? string.Empty;
+        }
+
+        return ancestor.Name ?? string.Empty;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/SearchDataTypeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DataType/Item/SearchDataTypeItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
+
+public class SearchDataTypeItemResponseModel : DataTypeItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/Item/SearchDocumentItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/Item/SearchDocumentItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Document.Item;
+
+public class SearchDocumentItemResponseModel : DocumentItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/Item/SearchDocumentTypeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/DocumentType/Item/SearchDocumentTypeItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.DocumentType.Item;
+
+public class SearchDocumentTypeItemResponseModel : DocumentTypeItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Item/SearchResultAncestorModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Item/SearchResultAncestorModel.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.Item;
+
+public class SearchResultAncestorModel
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string EntityType { get; set; } = string.Empty;
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Media/Item/SearchMediaItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Media/Item/SearchMediaItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Media.Item;
+
+public class SearchMediaItemResponseModel : MediaItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/Item/SearchMediaTypeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MediaType/Item/SearchMediaTypeItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.MediaType.Item;
+
+public class SearchMediaTypeItemResponseModel : MediaTypeItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Member/Item/SearchMemberItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Member/Item/SearchMemberItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Member.Item;
+
+public class SearchMemberItemResponseModel : MemberItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/MemberType/Item/SearchMemberTypeItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/MemberType/Item/SearchMemberTypeItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.MemberType.Item;
+
+public class SearchMemberTypeItemResponseModel : MemberTypeItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Template/Item/SearchTemplateItemResponseModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Template/Item/SearchTemplateItemResponseModel.cs
@@ -1,0 +1,8 @@
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Template.Item;
+
+public class SearchTemplateItemResponseModel : TemplateItemResponseModel
+{
+    public IEnumerable<SearchResultAncestorModel> Ancestors { get; set; } = [];
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/SearchResultAncestorServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/SearchResultAncestorServiceTests.cs
@@ -1,0 +1,362 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Services;
+using Umbraco.Cms.Api.Management.ViewModels.Item;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Services;
+
+[TestFixture]
+public class SearchResultAncestorServiceTests
+{
+    private Mock<IEntityService> _entityServiceMock = null!;
+    private Mock<ILanguageService> _languageServiceMock = null!;
+    private SearchResultAncestorService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _entityServiceMock = new Mock<IEntityService>();
+        _languageServiceMock = new Mock<ILanguageService>();
+        _service = new SearchResultAncestorService(_entityServiceMock.Object, _languageServiceMock.Object);
+    }
+
+    [Test]
+    public async Task ResolveAsync_EmptyEntities_ReturnsEmptyDictionary()
+    {
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([], UmbracoObjectTypes.DataType);
+
+        Assert.That(result, Is.Empty);
+        _entityServiceMock.Verify(x => x.GetAll(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()), Times.Never);
+        _entityServiceMock.Verify(x => x.Get(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_FlatEntityType_ReturnsEmptyAncestors()
+    {
+        var entity = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100");
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.Member);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[entity.Key], Is.Empty);
+        _entityServiceMock.Verify(x => x.GetAll(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()), Times.Never);
+        _entityServiceMock.Verify(x => x.Get(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_NoAncestors_ReturnsEmptyLists()
+    {
+        // Path "-1,100" has no ancestors (root is excluded, self is excluded)
+        var entity = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100");
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.DataType);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[entity.Key], Is.Empty);
+    }
+
+    [Test]
+    public async Task ResolveAsync_ContainerAncestor_UsesIndividualGet()
+    {
+        var entityKey = Guid.NewGuid();
+        var ancestorKey = Guid.NewGuid();
+        var entity = CreateEntitySlim(entityKey, 200, "-1,100,200");
+        var ancestor = CreateEntitySlim(ancestorKey, 100, "-1,100", "Folder A", UmbracoObjectTypes.DataTypeContainer.GetGuid());
+
+        _entityServiceMock
+            .Setup(x => x.Get(100))
+            .Returns(ancestor);
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.DataType);
+
+        Assert.That(result[entityKey], Has.Count.EqualTo(1));
+        Assert.That(result[entityKey][0].Id, Is.EqualTo(ancestorKey));
+        Assert.That(result[entityKey][0].Name, Is.EqualTo("Folder A"));
+
+        // Container types use Get(int), not GetAll.
+        _entityServiceMock.Verify(x => x.Get(100), Times.Once);
+        _entityServiceMock.Verify(x => x.GetAll(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_MultipleContainerAncestors_ReturnedInPathOrder()
+    {
+        var entityKey = Guid.NewGuid();
+        var topKey = Guid.NewGuid();
+        var midKey = Guid.NewGuid();
+        var entity = CreateEntitySlim(entityKey, 300, "-1,100,200,300");
+        var topAncestor = CreateEntitySlim(topKey, 100, "-1,100", "Top", UmbracoObjectTypes.DataTypeContainer.GetGuid());
+        var midAncestor = CreateEntitySlim(midKey, 200, "-1,100,200", "Mid", UmbracoObjectTypes.DataTypeContainer.GetGuid());
+
+        _entityServiceMock.Setup(x => x.Get(100)).Returns(topAncestor);
+        _entityServiceMock.Setup(x => x.Get(200)).Returns(midAncestor);
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.DataType);
+
+        Assert.That(result[entityKey], Has.Count.EqualTo(2));
+        Assert.That(result[entityKey][0].Id, Is.EqualTo(topKey));
+        Assert.That(result[entityKey][0].Name, Is.EqualTo("Top"));
+        Assert.That(result[entityKey][1].Id, Is.EqualTo(midKey));
+        Assert.That(result[entityKey][1].Name, Is.EqualTo("Mid"));
+    }
+
+    [Test]
+    public async Task ResolveAsync_SharedContainerAncestors_ResolvedOncePerUniqueId()
+    {
+        var entityKey1 = Guid.NewGuid();
+        var entityKey2 = Guid.NewGuid();
+        var folderKey = Guid.NewGuid();
+        var entity1 = CreateEntitySlim(entityKey1, 200, "-1,100,200");
+        var entity2 = CreateEntitySlim(entityKey2, 300, "-1,100,300");
+        var folder = CreateEntitySlim(folderKey, 100, "-1,100", "Shared Folder", UmbracoObjectTypes.DataTypeContainer.GetGuid());
+
+        _entityServiceMock.Setup(x => x.Get(100)).Returns(folder);
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity1, entity2], UmbracoObjectTypes.DataType);
+
+        // Both entities share the same ancestor.
+        Assert.That(result[entityKey1], Has.Count.EqualTo(1));
+        Assert.That(result[entityKey1][0].Id, Is.EqualTo(folderKey));
+        Assert.That(result[entityKey2], Has.Count.EqualTo(1));
+        Assert.That(result[entityKey2][0].Id, Is.EqualTo(folderKey));
+
+        // Only one Get call for the shared ancestor ID.
+        _entityServiceMock.Verify(x => x.Get(100), Times.Once);
+    }
+
+    [Test]
+    public async Task ResolveAsync_MixedDepthPaths_CorrectAncestorsPerEntity()
+    {
+        var shallowKey = Guid.NewGuid();
+        var deepKey = Guid.NewGuid();
+        var folderAKey = Guid.NewGuid();
+        var folderBKey = Guid.NewGuid();
+
+        var shallow = CreateEntitySlim(shallowKey, 200, "-1,100,200");
+        var deep = CreateEntitySlim(deepKey, 400, "-1,100,300,400");
+
+        var folderA = CreateEntitySlim(folderAKey, 100, "-1,100", "A", UmbracoObjectTypes.DataTypeContainer.GetGuid());
+        var folderB = CreateEntitySlim(folderBKey, 300, "-1,100,300", "B", UmbracoObjectTypes.DataTypeContainer.GetGuid());
+
+        _entityServiceMock.Setup(x => x.Get(100)).Returns(folderA);
+        _entityServiceMock.Setup(x => x.Get(300)).Returns(folderB);
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([shallow, deep], UmbracoObjectTypes.DataType);
+
+        Assert.That(result[shallowKey], Has.Count.EqualTo(1));
+        Assert.That(result[shallowKey][0].Name, Is.EqualTo("A"));
+
+        Assert.That(result[deepKey], Has.Count.EqualTo(2));
+        Assert.That(result[deepKey][0].Name, Is.EqualTo("A"));
+        Assert.That(result[deepKey][1].Name, Is.EqualTo("B"));
+    }
+
+    [Test]
+    public async Task ResolveAsync_DocumentType_UsesIndividualGetForContainerAncestors()
+    {
+        var entity = CreateEntitySlim(Guid.NewGuid(), 200, "-1,100,200");
+        var ancestor = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100", "Folder", UmbracoObjectTypes.DocumentTypeContainer.GetGuid());
+
+        _entityServiceMock.Setup(x => x.Get(100)).Returns(ancestor);
+
+        await _service.ResolveAsync([entity], UmbracoObjectTypes.DocumentType);
+
+        _entityServiceMock.Verify(x => x.Get(100), Times.Once);
+        _entityServiceMock.Verify(x => x.GetAll(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_MediaType_UsesIndividualGetForContainerAncestors()
+    {
+        var entity = CreateEntitySlim(Guid.NewGuid(), 200, "-1,100,200");
+        var ancestor = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100", "Folder", UmbracoObjectTypes.MediaTypeContainer.GetGuid());
+
+        _entityServiceMock.Setup(x => x.Get(100)).Returns(ancestor);
+
+        await _service.ResolveAsync([entity], UmbracoObjectTypes.MediaType);
+
+        _entityServiceMock.Verify(x => x.Get(100), Times.Once);
+        _entityServiceMock.Verify(x => x.GetAll(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_Document_UsesBatchGetAll()
+    {
+        var entity = CreateEntitySlim(Guid.NewGuid(), 200, "-1,100,200");
+        var ancestor = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100", "Parent Doc", UmbracoObjectTypes.Document.GetGuid());
+
+        _entityServiceMock
+            .Setup(x => x.GetAll(UmbracoObjectTypes.Document, It.IsAny<int[]>()))
+            .Returns([ancestor]);
+        _languageServiceMock
+            .Setup(x => x.GetDefaultIsoCodeAsync())
+            .ReturnsAsync("en-US");
+
+        await _service.ResolveAsync([entity], UmbracoObjectTypes.Document);
+
+        _entityServiceMock.Verify(
+            x => x.GetAll(UmbracoObjectTypes.Document, It.IsAny<int[]>()),
+            Times.Once);
+        _entityServiceMock.Verify(x => x.Get(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_DocumentWithVariantAncestor_ResolvesNameFromDefaultCulture()
+    {
+        var entityKey = Guid.NewGuid();
+        var ancestorKey = Guid.NewGuid();
+        var entity = CreateEntitySlim(entityKey, 200, "-1,100,200");
+
+        var documentAncestor = new Mock<IDocumentEntitySlim>();
+        documentAncestor.SetupGet(x => x.Key).Returns(ancestorKey);
+        documentAncestor.SetupGet(x => x.Id).Returns(100);
+        documentAncestor.SetupGet(x => x.Path).Returns("-1,100");
+        documentAncestor.SetupGet(x => x.Name).Returns("Invariant Name");
+        documentAncestor.SetupGet(x => x.NodeObjectType).Returns(UmbracoObjectTypes.Document.GetGuid());
+        documentAncestor.SetupGet(x => x.CultureNames).Returns(
+            new Dictionary<string, string>
+            {
+                { "en-US", "English Name" },
+                { "da-DK", "Danish Name" },
+            });
+
+        _entityServiceMock
+            .Setup(x => x.GetAll(UmbracoObjectTypes.Document, It.IsAny<int[]>()))
+            .Returns([documentAncestor.Object]);
+        _languageServiceMock
+            .Setup(x => x.GetDefaultIsoCodeAsync())
+            .ReturnsAsync("en-US");
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.Document);
+
+        Assert.That(result[entityKey], Has.Count.EqualTo(1));
+        Assert.That(result[entityKey][0].Name, Is.EqualTo("English Name"));
+    }
+
+    [Test]
+    public async Task ResolveAsync_DocumentWithInvariantAncestor_FallsBackToName()
+    {
+        var entityKey = Guid.NewGuid();
+        var ancestorKey = Guid.NewGuid();
+        var entity = CreateEntitySlim(entityKey, 200, "-1,100,200");
+
+        var documentAncestor = new Mock<IDocumentEntitySlim>();
+        documentAncestor.SetupGet(x => x.Key).Returns(ancestorKey);
+        documentAncestor.SetupGet(x => x.Id).Returns(100);
+        documentAncestor.SetupGet(x => x.Path).Returns("-1,100");
+        documentAncestor.SetupGet(x => x.Name).Returns("Invariant Only");
+        documentAncestor.SetupGet(x => x.NodeObjectType).Returns(UmbracoObjectTypes.Document.GetGuid());
+        documentAncestor.SetupGet(x => x.CultureNames).Returns(new Dictionary<string, string>());
+
+        _entityServiceMock
+            .Setup(x => x.GetAll(UmbracoObjectTypes.Document, It.IsAny<int[]>()))
+            .Returns([documentAncestor.Object]);
+        _languageServiceMock
+            .Setup(x => x.GetDefaultIsoCodeAsync())
+            .ReturnsAsync("en-US");
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.Document);
+
+        Assert.That(result[entityKey], Has.Count.EqualTo(1));
+        Assert.That(result[entityKey][0].Name, Is.EqualTo("Invariant Only"));
+    }
+
+    [Test]
+    public async Task ResolveAsync_Media_UsesBatchGetAll()
+    {
+        var entity = CreateEntitySlim(Guid.NewGuid(), 200, "-1,100,200");
+        var ancestor = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100", "Parent Media", UmbracoObjectTypes.Media.GetGuid());
+
+        _entityServiceMock
+            .Setup(x => x.GetAll(UmbracoObjectTypes.Media, It.IsAny<int[]>()))
+            .Returns([ancestor]);
+
+        await _service.ResolveAsync([entity], UmbracoObjectTypes.Media);
+
+        _entityServiceMock.Verify(
+            x => x.GetAll(UmbracoObjectTypes.Media, It.IsAny<int[]>()),
+            Times.Once);
+        _entityServiceMock.Verify(x => x.Get(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_Template_UsesBatchGetAll()
+    {
+        var entity = CreateEntitySlim(Guid.NewGuid(), 200, "-1,100,200");
+        var ancestor = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100", "Parent Template", UmbracoObjectTypes.Template.GetGuid());
+
+        _entityServiceMock
+            .Setup(x => x.GetAll(UmbracoObjectTypes.Template, It.IsAny<int[]>()))
+            .Returns([ancestor]);
+
+        await _service.ResolveAsync([entity], UmbracoObjectTypes.Template);
+
+        _entityServiceMock.Verify(
+            x => x.GetAll(UmbracoObjectTypes.Template, It.IsAny<int[]>()),
+            Times.Once);
+        _entityServiceMock.Verify(x => x.Get(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResolveAsync_AncestorNotFoundInLookup_SkipsAncestor()
+    {
+        var entityKey = Guid.NewGuid();
+
+        // Entity has ancestor IDs 100 and 200, but only 100 exists.
+        var entity = CreateEntitySlim(entityKey, 300, "-1,100,200,300");
+        var existingAncestor = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100", "Exists", UmbracoObjectTypes.DataTypeContainer.GetGuid());
+
+        _entityServiceMock.Setup(x => x.Get(100)).Returns(existingAncestor);
+        _entityServiceMock.Setup(x => x.Get(200)).Returns((IEntitySlim?)null);
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.DataType);
+
+        // Only the found ancestor is included.
+        Assert.That(result[entityKey], Has.Count.EqualTo(1));
+        Assert.That(result[entityKey][0].Name, Is.EqualTo("Exists"));
+    }
+
+    [Test]
+    public async Task ResolveAsync_NullEntityName_ReturnsEmptyString()
+    {
+        var entityKey = Guid.NewGuid();
+        var entity = CreateEntitySlim(entityKey, 200, "-1,100,200");
+        var ancestor = CreateEntitySlim(Guid.NewGuid(), 100, "-1,100", null, UmbracoObjectTypes.DataTypeContainer.GetGuid());
+
+        _entityServiceMock.Setup(x => x.Get(100)).Returns(ancestor);
+
+        IReadOnlyDictionary<Guid, IReadOnlyList<SearchResultAncestorModel>> result =
+            await _service.ResolveAsync([entity], UmbracoObjectTypes.DataType);
+
+        Assert.That(result[entityKey][0].Name, Is.EqualTo(string.Empty));
+    }
+
+    private static IEntitySlim CreateEntitySlim(
+        Guid key,
+        int id,
+        string path,
+        string? name = null,
+        Guid? nodeObjectType = null)
+    {
+        var mock = new Mock<IEntitySlim>();
+        mock.SetupGet(x => x.Key).Returns(key);
+        mock.SetupGet(x => x.Id).Returns(id);
+        mock.SetupGet(x => x.Path).Returns(path);
+        mock.SetupGet(x => x.Name).Returns(name);
+        mock.SetupGet(x => x.NodeObjectType).Returns(nodeObjectType ?? Guid.Empty);
+        return mock.Object;
+    }
+}


### PR DESCRIPTION
## Description

In looking to resolve https://github.com/umbraco/Umbraco-CMS/issues/21107 we are planning to present a "breadcrumb" alongside backoffice search results, showing the ancestors of a result item, in order to better provide context on where it is found.

We expect this is most efficiently done on the search in the construction of the search results, and avoid having to make additional calls from the client to populate this information.

This PR augments all 8 Management API search endpoints to include an `ancestors` array on each result item, providing a breadcrumb trail from the topmost ancestor to the immediate parent.

This is done via the introduction of a new `ISearchResultAncestorService` that batch-resolves ancestors across all search results in a single operation, avoiding N+1 queries.  Shared ancestors across search results are resolved only once.

There are also 8 new `Search*ItemResponseModel` classes (one per entity type) that extend the existing item response models with the `ancestors` property.

## Search endpoints affected

All endpoints add the `ancestors` array to existing responses. The existing response properties are unchanged.

| # | Endpoint | Response model |
|---|---|---|
| 1 | `GET /umbraco/management/api/v1/item/data-type/search?query=…` | `SearchDataTypeItemResponseModel` |
| 2 | `GET /umbraco/management/api/v1/item/document/search?query=…` | `SearchDocumentItemResponseModel` |
| 3 | `GET /umbraco/management/api/v1/item/document-type/search?query=…` | `SearchDocumentTypeItemResponseModel` |
| 4 | `GET /umbraco/management/api/v1/item/media/search?query=…` | `SearchMediaItemResponseModel` |
| 5 | `GET /umbraco/management/api/v1/item/media-type/search?query=…` | `SearchMediaTypeItemResponseModel` |
| 6 | `GET /umbraco/management/api/v1/item/member/search?query=…` | `SearchMemberItemResponseModel` |
| 7 | `GET /umbraco/management/api/v1/item/member-type/search?query=…` | `SearchMemberTypeItemResponseModel` |
| 8 | `GET /umbraco/management/api/v1/item/template/search?query=…` | `SearchTemplateItemResponseModel` |

### Sample response

`GET /umbraco/management/api/v1/item/data-type/search?query=text&skip=0&take=10`

```json
{
  "total": 1,
  "items": [
    {
      "id": "0cc0eba1-9960-42c9-bf9b-60e150b429ae",
      "name": "Textstring",
      "editorUiAlias": "Umb.PropertyEditorUi.TextBox",
      "isDeletable": true,
      "ancestors": [
        {
          "id": "a3b2e1c0-1234-5678-9abc-def012345678",
          "name": "Common Data Types",
          "entityType": "data-type-container"
        }
      ]
    }
  ]
}
```

For hierarchical content (document/media), ancestors are ordered from the topmost ancestor to the immediate parent:

`GET /umbraco/management/api/v1/item/document/search?query=about&skip=0&take=10`

```json
{
  "total": 1,
  "items": [
    {
      "id": "f2c3d4e5-6789-0abc-def0-123456789abc",
      "documentType": { "name": "Content Page", "alias": "contentPage", "icon": "icon-document" },
      "isTrashed": false,
      "isProtected": false,
      "parent": { "id": "b1a2c3d4-5678-9abc-def0-123456789abc" },
      "hasChildren": false,
      "variants": [{ "name": "About Us", "culture": null, "state": "Published" }],
      "ancestors": [
        {
          "id": "a1b2c3d4-5678-9abc-def0-123456789abc",
          "name": "Home",
          "entityType": "document"
        },
        {
          "id": "b1a2c3d4-5678-9abc-def0-123456789abc",
          "name": "Company",
          "entityType": "document"
        }
      ]
    }
  ]
}
```

Flat entity types (member, member-type) always return `"ancestors": []`.

## Testing

Unit tests for `SearchResultAncestorService` have been added covering various cases.

Manual testing can be done via the Swagger UI, verifying that the search endpoints return the `ancestors` array.


---
_This item has been added to our backlog AB#65305_