### PR TITLE
Member Group Picker: Add server-side paging to public access modal (closes #21790)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/components/member-group-picker-modal/member-group-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/components/member-group-picker-modal/member-group-picker-modal.element.ts
@@ -4,9 +4,9 @@ import type {
 	UmbMemberGroupPickerModalValue,
 	UmbMemberGroupPickerModalData,
 } from './member-group-picker-modal.token.js';
-import { css, html, customElement, nothing, state, repeat } from '@umbraco-cms/backoffice/external/lit';
-import { UmbPaginationManager, UmbSelectionManager } from '@umbraco-cms/backoffice/utils';
+import { css, customElement, html, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { UmbPaginationManager, UmbSelectionManager } from '@umbraco-cms/backoffice/utils';
 import type { UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 
 const PAGE_SIZE = 50;
@@ -16,15 +16,6 @@ export class UmbMemberGroupPickerModalElement extends UmbModalBaseElement<
 	UmbMemberGroupPickerModalData,
 	UmbMemberGroupPickerModalValue
 > {
-	static override styles = [
-		css`
-			uui-pagination {
-				display: block;
-				margin-top: var(--uui-size-layout-1);
-			}
-		`,
-	];
-
 	@state()
 	private _memberGroups: Array<UmbMemberGroupDetailModel> = [];
 
@@ -83,43 +74,56 @@ export class UmbMemberGroupPickerModalElement extends UmbModalBaseElement<
 	}
 
 	override render() {
-		return html`<umb-body-layout headline=${this.localize.term('defaultdialogs_chooseMemberGroup')}>
-			<uui-box>
-				${repeat(
-					this.#filteredMemberGroups,
-					(item) => item.unique,
-					(item) => html`
-						<uui-menu-item
-							label=${item.name ?? ''}
-							selectable
-							@selected=${() => this.#selectionManager.select(item.unique)}
-							@deselected=${() => this.#selectionManager.deselect(item.unique)}
-							?selected=${this.#selectionManager.isSelected(item.unique)}>
-							<uui-icon slot="icon" name="icon-users"></uui-icon>
-						</uui-menu-item>
-					`,
+		return html`
+			<umb-body-layout headline=${this.localize.term('defaultdialogs_chooseMemberGroup')}>
+				<uui-box>
+					${repeat(
+						this.#filteredMemberGroups,
+						(item) => item.unique,
+						(item) => html`
+							<uui-menu-item
+								label=${item.name ?? ''}
+								selectable
+								@selected=${() => this.#selectionManager.select(item.unique)}
+								@deselected=${() => this.#selectionManager.deselect(item.unique)}
+								?selected=${this.#selectionManager.isSelected(item.unique)}>
+								<uui-icon slot="icon" name="icon-users"></uui-icon>
+							</uui-menu-item>
+						`,
+					)}
+				</uui-box>
+				${when(
+					this._totalPages > 1,
+					() =>
+						html` <uui-pagination
+							.current=${this._currentPage}
+							.total=${this._totalPages}
+							firstlabel=${this.localize.term('general_first')}
+							previouslabel=${this.localize.term('general_previous')}
+							nextlabel=${this.localize.term('general_next')}
+							lastlabel=${this.localize.term('general_last')}
+							@change=${this.#onPageChange}></uui-pagination>`,
 				)}
-			</uui-box>
-			${this._totalPages > 1
-				? html`<uui-pagination
-						.current=${this._currentPage}
-						.total=${this._totalPages}
-						firstlabel=${this.localize.term('general_first')}
-						previouslabel=${this.localize.term('general_previous')}
-						nextlabel=${this.localize.term('general_next')}
-						lastlabel=${this.localize.term('general_last')}
-						@change=${this.#onPageChange}></uui-pagination>`
-				: nothing}
-			<div slot="actions">
-				<uui-button label=${this.localize.term('general_close')} @click=${this.#close}></uui-button>
-				<uui-button
-					label=${this.localize.term('general_choose')}
-					look="primary"
-					color="positive"
-					@click=${this.#submit}></uui-button>
-			</div>
-		</umb-body-layout> `;
+				<div slot="actions">
+					<uui-button label=${this.localize.term('general_close')} @click=${this.#close}></uui-button>
+					<uui-button
+						label=${this.localize.term('general_choose')}
+						look="primary"
+						color="positive"
+						@click=${this.#submit}></uui-button>
+				</div>
+			</umb-body-layout>
+		`;
 	}
+
+	static override styles = [
+		css`
+			uui-pagination {
+				display: block;
+				margin-top: var(--uui-size-layout-1);
+			}
+		`,
+	];
 }
 
 export default UmbMemberGroupPickerModalElement;


### PR DESCRIPTION
## Description

This PR addresses https://github.com/umbraco/Umbraco-CMS/issues/21790 which notes that the member group picker used when protecting a document with public access does support paging, so only the first 100 groups are displayed.  If there are more, they can't be accessed.

I've added the pagination component and set a page size or 50.

## Testing

To manually test this update:

- Create > 50 member groups (or, more easily, temporarily change the page size in this PR to a smaller number to at least one page will be found).
- Add protection to a document and choose "Group based protection".
- Verify the member group picker shows pagination controls when there are more groups than fit on one page.
- Select groups on page 1, navigate to page 2, select more groups, submit - and verify all selected groups are applied.
- With fewer than 50 groups, verify pagination controls are hidden.