### PR TITLE
Repository Caches: Fix GUID cache key prefix in PublishableContentRepositoryBase

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublishableContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PublishableContentRepositoryBase.cs
@@ -1322,7 +1322,7 @@ internal abstract class PublishableContentRepositoryBase<TEntity, TRepository, T
         // The ContentCacheRefresher does the same thing, but by the time it's invoked, custom notification handlers
         // might have already consumed the cached version (which at this point is Key));
         // GUID-keyed read repository uses a separate "uRepoGuid_" prefix.
-        IsolatedCache.Clear(RepositoryCacheKeys.GetGuidKey<IContent>(entity.Key));
+        IsolatedCache.Clear(RepositoryCacheKeys.GetGuidKey<TEntity>(entity.Key));
 
         // troubleshooting
         //if (Database.ExecuteScalar<int>($"SELECT COUNT(*) FROM {Constants.DatabaseSchema.Tables.DocumentVersion} JOIN {Constants.DatabaseSchema.Tables.ContentVersion} ON {Constants.DatabaseSchema.Tables.DocumentVersion}.id={Constants.DatabaseSchema.Tables.ContentVersion}.id WHERE published=1 AND nodeId=" + content.Id) > 1)
@@ -1662,7 +1662,7 @@ internal abstract class PublishableContentRepositoryBase<TEntity, TRepository, T
             }
         }
 
-        private static string GetCacheKey(Guid key) => RepositoryCacheKeys.GetKey<TEntity>() + key;
+        private static string GetCacheKey(Guid key) => GuidReadRepositoryCachePolicy<TEntity>.GetCacheKey(key);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- Fixes GUID repository cache key prefix mismatch introduced when merging the cache key collision fix (9ea0520) from `main` into `v18/dev`
- The original fix targeted `DocumentRepository`'s `IContent`-specific nested class, but in `v18/dev` this code was refactored into the generic `PublishableContentRepositoryBase<TEntity>`, causing two issues:
  - `EntityByGuidReadRepository.GetCacheKey` used the `"uRepo_"` prefix while `GuidReadRepositoryCachePolicy` looks up entries with `"uRepoGuid_"`, so `PopulateCacheByKey` inserted under a key the policy never finds — every GUID lookup hit the database
  - `PersistUpdatedItem` cleared `GetGuidKey<IContent>` instead of `GetGuidKey<TEntity>`, so `ElementRepository` would clear the wrong cache entry on update

## Testing

All integration tests should pass.