### PR TITLE
Accessibility: Add title attributes to buttons in block list entry and property editor UI

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
@@ -460,7 +460,8 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 					label="edit"
 					look="secondary"
 					color=${this._contentInvalid ? 'invalid' : ''}
-					href=${this._workspaceEditContentPath}>
+					href=${this._workspaceEditContentPath}
+					title=${this.localize.term('general_edit')}>
 					<uui-icon name=${this._exposed === false && this._isReadOnly === false ? 'icon-add' : 'icon-edit'}></uui-icon>
 					${this._contentInvalid
 						? html`<uui-badge attention color="invalid" label="Invalid content">!</uui-badge>`
@@ -483,7 +484,8 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 						label="Edit settings"
 						look="secondary"
 						color=${this._settingsInvalid ? 'invalid' : ''}
-						href=${this._workspaceEditSettingsPath}>
+						href=${this._workspaceEditSettingsPath}
+						title=${this.localize.term('general_settings')}>
 						<uui-icon name="icon-settings"></uui-icon>
 						${this._settingsInvalid
 							? html`<uui-badge attention color="invalid" label="Invalid settings">!</uui-badge>`
@@ -495,7 +497,7 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 
 	#renderDeleteAction() {
 		if (this._isReadOnly) return nothing;
-		return html` <uui-button label="delete" look="secondary" @click=${() => this.#context.requestDelete()}>
+		return html` <uui-button label="delete" look="secondary" @click=${() => this.#context.requestDelete()} title=${this.localize.term('general_delete')}>
 			<uui-icon name="icon-remove"></uui-icon>
 		</uui-button>`;
 	}
@@ -505,7 +507,8 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 			<uui-button
 				label=${this.localize.term('clipboard_labelForCopyToClipboard')}
 				look="secondary"
-				@click=${() => this.#copyToClipboard()}>
+				@click=${() => this.#copyToClipboard()}
+				title=${this.localize.term('general_copy')}>
 				<uui-icon name="icon-clipboard-copy"></uui-icon>
 			</uui-button>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/property-editor-ui-block-list.element.ts
@@ -483,7 +483,8 @@ export class UmbPropertyEditorUIBlockListElement
 				label=${this.localize.term('content_createFromClipboard')}
 				look="placeholder"
 				href=${this._catalogueRouteBuilder?.({ view: 'clipboard', index: -1 }) ?? ''}
-				?disabled=${this.readonly}>
+				?disabled=${this.readonly}
+				title=${this.localize.term('general_clipboard')}>
 				<uui-icon name="icon-clipboard-paste"></uui-icon>
 			</uui-button>
 		`;


### PR DESCRIPTION
### Description

This PR restores **tooltips on the Copy and Delete icons for Blocklist items** in the Umbraco Backoffice #21841.  

In earlier versions (v13), hovering over these icons displayed helpful tooltips. In v17, this functionality was missing. This change reintroduces the tooltips to improve editor usability and consistency.

---

### Steps to Test

1. Go to **Umbraco Backoffice**.  
2. Open a page with a **Blocklist**.  
3. Add Blocklist content.  
4. Hover over the **action icons** (Copy, Delete) on the top right of the Blocklist item.  
5. Confirm that **tooltips are now visible** when hovering.  

---

### Screenshots


https://github.com/user-attachments/assets/43b41209-9dfa-4ad1-978f-fe4f24c67ab6

