### PR TITLE
Backoffice Search: Discard stale search results when switching providers (closes #21784)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/search/search-modal/search-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/search/search-modal/search-modal.element.ts
@@ -165,6 +165,7 @@ export class UmbSearchModalElement extends UmbLitElement {
 		if (this._currentGlobalSearcher === searcher) return;
 
 		this._currentGlobalSearcher = searcher;
+		this.#searchRequestNumber++;
 
 		this.#focusInput();
 		this._loading = true;
@@ -173,7 +174,7 @@ export class UmbSearchModalElement extends UmbLitElement {
 	}
 
 	async #updateSearchResults() {
-		const requestNumber = ++this.#searchRequestNumber;
+		const requestNumber = this.#searchRequestNumber;
 
 		if (this._search && this._currentGlobalSearcher?.api) {
 			const { data } = await this._currentGlobalSearcher.api.search({ query: this._search });
@@ -202,6 +203,7 @@ export class UmbSearchModalElement extends UmbLitElement {
 		const target = event.target as HTMLInputElement;
 		this._search = target.value.trim();
 
+		this.#searchRequestNumber++;
 		clearTimeout(this.#inputTimer);
 		if (!this._search) {
 			this._loading = false;


### PR DESCRIPTION
## Description

This PR fixes a race condition in the global search modal where switching search providers could cause stale results from a previous provider to overwrite the current results.

The fix adds a request number counter that increments on each search; after the async `search()` call resolves, the response is discarded if a newer search has been initiated.

## Testing

To test the fix:

- Open the global search modal in the backoffice
- Type a search term and, while results are loading, switch to a different search provider — verify the displayed results match the newly selected provider
- [ ] Type a search term, quickly modify it — verify results match the final input, not an intermediate one

🤖 Generated with [Claude Code](https://claude.com/claude-code)