### PR TITLE
Razor Template Debugging: Allow Umbraco projects to work with the Razor cohosting editor

### DIFF
--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
@@ -19,18 +19,18 @@
     The Razor editor in VS2026 and the C# extension for VS Code uses the Razor source generator
     for IDE functionality. We need to add some things to make sure it works correctly, but we
     only do them for design time builds, so that we don't impact regular builds or CI.
-    We also have an escape hatch in case it does cause issues, used can set the appropriate property
+    We also have an escape hatch in case it does cause issues, users can set the appropriate property
     in their project file to disable this.
   -->
   <ItemGroup Condition="'$(DesignTimeBuild)' == 'true' and '$(EnableCohostEditorCompatibility)' != 'false'">
-		<!-- 
+    <!-- 
       We have to make sure the source generator can see the .cshtml files, so make them AdditionalFiles.
-		-->
-		<AdditionalFiles Include="**\*.cshtml" />
+    -->
+    <AdditionalFiles Include="**\*.cshtml" />
 
-		<!--
-			Make sure the source generator knows where the project is, so it can compute target paths.
-		-->
-		<CompilerVisibleProperty Include="MSBuildProjectDirectory" />
-	</ItemGroup>
+    <!--
+      Make sure the source generator knows where the project is, so it can compute target paths.
+    -->
+    <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Hello Umbraco friends!

Apologies in advance, for not following good open source practice and just opening a PR blind. Feel free to close it with extreme prejudice, and someone else can post another with the same exact change, I won't mind :)

I work on the Razor tooling team at Microsoft and we have recently shipped a new editor in Visual Studio 2026 and the C# Extension for VS Code, which we refer to as the "cohost" editor. This editor relies on the Razor Source Generator in order to function, and unfortunately, we've had reports from some of our users, who are also your users, that breakpoints and other IDE functionality doesn't work in their projects any more. The root cause of this is that there are some things done in the Microsoft.NET.Sdk.Web and Microsoft.NET.Sdk.Razor SDKs that the IDE relies on, that are not done in your SDK.

This PR represents a polyfill to bridge that gap, and allow your users to continue to be our users, and have the full IDE functionality they expect. I am certainly not an Umbraco expert (or beginner!), so please let me know if this change needs to go somewhere else, but we have had confirmation that putting this little bit of MSBuild goo in a project file successfully unblocks people.

Issues that have been filed against us (hopefully in lieu of this PR resolving any specific issue on _this_ repo):
https://developercommunity.visualstudio.com/t/Breakpoints-is-not-working-in-Razor-file/10978894
https://developercommunity.visualstudio.com/t/A-breakpoint-could-not-be-inserted-at-t/11047278 (with [confirmation](https://developercommunity.visualstudio.com/t/A-breakpoint-could-not-be-inserted-at-t/11047278#T-N11048823) that the change works)

Fixes https://github.com/dotnet/razor/issues/12331 (which is the first issue above, moved to our GitHub repo)

Thanks!
Dave