### PR TITLE
Document Repository: Batch document IDs in `GetContentSchedulesByIds` to avoid SQL parameter limit (closes #21865)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentRepository.cs
@@ -1891,6 +1891,7 @@ public class DocumentRepository : ContentRepositoryBase<int, IContent, DocumentR
     public IDictionary<int, IEnumerable<ContentSchedule>> GetContentSchedulesByIds(int[] documentIds)
     {
         var contentScheduleDtos = documentIds
+            .Distinct()
             .InGroupsOf(Constants.Sql.MaxParameterCount)
             .SelectMany(group =>
             {


### PR DESCRIPTION
## Description
`DocumentRepository.GetContentSchedulesByIds` passees all document IDs into a single `WhereIn` clause, which can exceeds SQL Server's 2100 parameter limit when the collection view has a page size of > 2100.

To solve I've used the common repository pattern of batching the IDs using `InGroupsOf(Constants.Sql.MaxParameterCount)` so each query stays under the limit.

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/21865

## Testing

A test against regressions for a small page size is covered by the existing integration test `Can_Get_Content_Schedules_By_Keys`, which still passes.

To fully manually test a collection view containing 2100+ content items, some of which have schedules, needs to be created.  But given this is a well established repository pattern I don't feel this is necessary.