### PR TITLE
Content Type: Fix null property description displaying as "null" string (closes #21873)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor-property.element.ts
@@ -166,7 +166,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 			return html`
 				<div id="header">
 					<p>${this.localize.string(this.property.name)}<i>${this.property.alias}</i></p>
-					<p>${this.property.description}</p>
+					<p>${this.property.description ?? ''}</p>
 				</div>
 				<div id="editor">
 					${this.#renderPropertyName()} ${this.#renderPropertyTags()}
@@ -215,7 +215,7 @@ export class UmbContentTypeDesignEditorPropertyElement extends UmbLitElement {
 							data-mark="input:description"
 							id="description-input"
 							placeholder=${this.localize.term('placeholders_enterDescription')}
-							.value=${this.property.description}
+							.value=${this.property.description ?? ''}
 							@input=${(e: CustomEvent) => {
 								if (e.target) this.#singleValueUpdate('description', (e.target as HTMLInputElement).value);
 							}}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
@@ -209,7 +209,7 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 						slot="editor"
 						name="description"
 						@input=${this.#onDescriptionChange}
-						.value=${this._data?.description}
+						.value=${this._data?.description ?? ''}
 						auto-height></uui-textarea>
 				</umb-property-layout>
 


### PR DESCRIPTION
## Description

As shown in https://github.com/umbraco/Umbraco-CMS/issues/21873, when a property type on a document type has no description (null), the backoffice document type editor rendered the literal string "null" instead of showing an empty value,

To fix I've applied nullish coalescing (`?? ''`) to template bindings where `null` was being passed to Lit element properties/interpolations, which JavaScript converts to the string `"null"`.

## Testing

To test, create a document type with a property that has no description and verify the property description area is empty (not showing "null") in the design editor.

Adding, editing and removing descriptions should work as expected.