### PR TITLE
File Uploads: Remove legacy Windows path length checks and related tests

### DIFF
--- a/src/Umbraco.Core/IO/PhysicalFileSystem.cs
+++ b/src/Umbraco.Core/IO/PhysicalFileSystem.cs
@@ -346,13 +346,6 @@ namespace Umbraco.Cms.Core.IO
             // our root path, due to relative segments, so better check
             if (_ioHelper.PathStartsWith(path, _rootPath, Path.DirectorySeparatorChar))
             {
-                // this says that 4.7.2 supports long paths - but Windows does not
-                // https://docs.microsoft.com/en-us/dotnet/api/system.io.pathtoolongexception?view=netframework-4.7.2
-                if (path.Length > 260)
-                {
-                    throw new PathTooLongException($"Path {path} is too long.");
-                }
-
                 return path;
             }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/PhysicalFileSystemTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/IO/PhysicalFileSystemTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.IO;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -14,11 +13,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.IO;
 [TestFixture]
 public class PhysicalFileSystemTests : AbstractFileSystemTests
 {
-    [SetUp]
-    public void Setup()
-    {
-    }
-
     [TearDown]
     public void TearDown()
     {
@@ -44,21 +38,9 @@ public class PhysicalFileSystemTests : AbstractFileSystemTests
             Mock.Of<ILogger<PhysicalFileSystem>>(),
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "FileSysTests"),
             "/Media/"))
-    {
-    }
+    { }
 
     protected override string ConstructUrl(string path) => "/Media/" + path;
-
-    private string Repeat(string pattern, int count)
-    {
-        var text = new StringBuilder();
-        for (var i = 0; i < count; i++)
-        {
-            text.Append(pattern);
-        }
-
-        return text.ToString();
-    }
 
     [Test]
     public void SaveFileTest()
@@ -70,16 +52,7 @@ public class PhysicalFileSystemTests : AbstractFileSystemTests
             _fileSystem.AddFile("sub/f3.txt", ms);
         }
 
-        Assert.IsTrue(File.Exists(Path.Combine(basePath, "sub/f3.txt")));
-
-        var path = Repeat("bah/bah/", 50);
-        Assert.Less(260, path.Length);
-
-        Assert.Throws<PathTooLongException>(() =>
-        {
-            using var ms = new MemoryStream(Encoding.UTF8.GetBytes("foo"));
-            _fileSystem.AddFile(path + "f3.txt", ms);
-        });
+        Assert.IsTrue(File.Exists(Path.Combine(basePath, "sub", "f3.txt")));
     }
 
     [Test]
@@ -98,28 +71,18 @@ public class PhysicalFileSystemTests : AbstractFileSystemTests
         // - does throw on invalid paths
         // works
         var path = _fileSystem.GetFullPath("foo.tmp");
-        Assert.AreEqual(Path.Combine(basePath, @"foo.tmp"), path);
+        Assert.AreEqual(Path.Combine(basePath, "foo.tmp"), path);
 
-        // a very long relative path, which ends up being a short path, works
-        path = Repeat("bah/../", 50);
-        Assert.Less(260, path.Length);
+        // normalize path with parent directory references
+        path = "foo/../bar/../bah/../";
         path = _fileSystem.GetFullPath(path + "foo.tmp");
-        Assert.AreEqual(Path.Combine(basePath, @"foo.tmp"), path);
+        Assert.AreEqual(Path.Combine(basePath, "foo.tmp"), path);
 
         // works too
         path = _fileSystem.GetFullPath("foo/bar.tmp");
-        Assert.AreEqual(Path.Combine(basePath, @$"foo{Path.DirectorySeparatorChar}bar.tmp"), path);
+        Assert.AreEqual(Path.Combine(basePath, "foo", "bar.tmp"), path);
 
         // that path is invalid as it would be outside the root directory
         Assert.Throws<UnauthorizedAccessException>(() => _fileSystem.GetFullPath("../../foo.tmp"));
-
-        // a very long path, which ends up being very long, works
-        path = Repeat("bah/bah/", 50);
-        Assert.Less(260, path.Length);
-        Assert.Throws<PathTooLongException>(() =>
-        {
-            path = _fileSystem.GetFullPath(path + "foo.tmp");
-            Assert.Less(260, path.Length); // gets a >260 path and it's fine (but Windows will not like it)
-        });
     }
 }


### PR DESCRIPTION
Removed explicit 260-character path length checks from `PhysicalFileSystem.GetFullPath` and deleted associated unit tests. Updated tests to focus on path normalization and validity, and improved path assertions for clarity and cross-platform compatibility. No longer enforce or test for legacy Windows path length restrictions.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco.Heartcore.Issues/issues/167, https://github.com/umbraco/Umbraco.Forms.Issues/issues/1349, https://github.com/umbraco/Umbraco.Deploy.Issues/issues/200, https://github.com/umbraco/Umbraco.Cloud.Issues/issues/195 and https://github.com/umbraco/Umbraco.Cloud.Issues/issues/116.

### Description
As discussed internally with @AndyButland, the CMS does an artificially limiting path length check that throws a `PathTooLongException` if it's more than 260 characters (introduced in v8, see https://github.com/umbraco/Umbraco-CMS/commit/3dfe653ef4d231a2110600ec11055d47a3685bce). However, this is a Windows-specific limitation that has been removed in modern .NET (see https://github.com/dotnet/corefx/pull/3001) and later Windows versions (see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later).

As highlighted in the linked Heartcore issue, these longer file paths are no issue when media is uploaded to Azure Blob Storage (since that doesn't use the `PhysicalFileSystem`). Only when these files are transferred/restored using Deploy, it uses the CMS shadow filesystem for transactional consistency, which relies on the `PhysicalFileSystem` and thus runs into this path length limitation.

Testing should be easy: create a file with a long name in C:\ and upload it to the media section. Previously it would return an error, but it should now work correctly (storing the long file name and actual file in the physical media directory).