### PR TITLE
Media: Auto-name media item from uploaded file (closes #21764)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -18,6 +18,8 @@ import './image-cropper-field.element.js';
 import './image-cropper-focus-setter.element.js';
 import './image-cropper-preview.element.js';
 import './image-cropper.element.js';
+import { UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_MEDIA_ENTITY_TYPE } from '../../entity.js';
 
 const DefaultFocalPoint = { left: 0.5, top: 0.5 };
 const DefaultValue: UmbImageCropperPropertyEditorValue = {
@@ -96,11 +98,26 @@ export class UmbInputImageCropperElement extends UmbFormControlMixin<
 
 		this._file = file;
 
+		const underlyingFile = file.temporaryFile?.file;
+		if (underlyingFile) {
+			void this.#ensureMediaNameFromFile(underlyingFile);
+		}
+
 		this.value = assignToFrozenObject(this.value ?? DefaultValue, {
 			temporaryFileId: file.temporaryFile?.temporaryUnique,
 		});
 
 		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	async #ensureMediaNameFromFile(file: File) {
+		const datasetContext = await this.getContext(UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT);
+		if (datasetContext.getEntityType() !== UMB_MEDIA_ENTITY_TYPE) return;
+
+		const currentName = datasetContext.getName();
+		if (currentName?.trim()) return;
+
+		datasetContext.setName(file.name);
 	}
 
 	#onRemove = () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -17,6 +17,8 @@ import type {
 import type { UmbTemporaryFileModel } from '@umbraco-cms/backoffice/temporary-file';
 import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UMB_MEDIA_ENTITY_TYPE } from '../../entity.js';
 
 @customElement('umb-input-upload-field')
 export class UmbInputUploadFieldElement extends UmbFormControlMixin<UmbMediaValueType, typeof UmbLitElement>(
@@ -161,7 +163,19 @@ export class UmbInputUploadFieldElement extends UmbFormControlMixin<UmbMediaValu
 		const blobUrl = URL.createObjectURL(this.temporaryFile.file);
 		this.value = { src: blobUrl };
 
+		void this.#ensureMediaNameFromFile(this.temporaryFile.file);
+
 		this.dispatchEvent(new UmbChangeEvent());
+	}
+
+	async #ensureMediaNameFromFile(file: File) {
+		const datasetContext = await this.getContext(UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT);
+		if (datasetContext.getEntityType() !== UMB_MEDIA_ENTITY_TYPE) return;
+
+		const currentName = datasetContext.getName();
+		if (currentName?.trim()) return;
+
+		datasetContext.setName(file.name);
 	}
 
 	override render() {


### PR DESCRIPTION
## Summary

- When uploading a file via the Upload Field or Image Cropper property editors in the Media workspace, the media item name is automatically set to the uploaded filename if the name is empty
- This matches the existing drag-and-drop behavior in the media tree, where dropped files auto-name the media item
- Only applies to media entities (checks entity type) and never overwrites user-provided names
- Based on the approach from community PR #21775

### Implementation

Both `input-upload-field.element.ts` and `input-image-cropper.element.ts` now call `#ensureMediaNameFromFile(file)` after upload, which:
1. Gets the `UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT` from the component context
2. Checks the entity type is `media` (skips for content or other types)
3. Checks the current name is empty/blank (won't overwrite user input)
4. Sets the name to `file.name` (with extension, consistent with drag-and-drop)

## Test plan

- [ ] Create a new media item, upload a file via Upload Field — verify the media name auto-populates with the filename
- [ ] Create a new media item, upload an image via Image Cropper — verify the media name auto-populates
- [ ] Create a new media item, type a name first, then upload — verify the typed name is NOT overwritten
- [ ] Create a new content item with an Upload Field — verify no auto-naming occurs (content, not media)
- [ ] Drag-and-drop a file into the media tree — verify existing behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)