### PR TITLE
Dotnet Templates: Update default UmbracoVersion template value using MSBuild target (closes #21889)

### DIFF
--- a/templates/Umbraco.Templates.csproj
+++ b/templates/Umbraco.Templates.csproj
@@ -34,6 +34,7 @@
     </ItemGroup>
     <Copy SourceFiles="@(_TemplateJsonFiles)" DestinationFiles="%(DestinationFile)" />
     <JsonPathUpdateValue JsonFile="%(_TemplateJsonFiles.DestinationFile)" Path="$.symbols.FinalVersion.parameters.cases.[0].value" Value="&quot;$(PackageVersion)&quot;" />
+    <JsonPathUpdateValue JsonFile="%(_TemplateJsonFiles.DestinationFile)" Path="$.symbols.UmbracoVersion.defaultValue" Value="&quot;$(PackageVersion)&quot;" />
     <ItemGroup>
       <_PackageFiles Include="%(_TemplateJsonFiles.DestinationFile)">
         <PackagePath>%(_TemplateJsonFiles.RelativeDir)</PackagePath>


### PR DESCRIPTION
## Description

The `umbraco-extension` template defaults its Umbraco package references to `*`, which causes CI builds to pull the latest version instead of the version matching the installed template package.

The can cause the problem outlined in https://github.com/umbraco/Umbraco-CMS/issues/21889.

To fix I've applied the same `JsonPathUpdateValue` MSBuild fix that was added for the `umbraco` project template in #13481 — updating `$.symbols.UmbracoVersion.defaultValue` from `*` to `$(PackageVersion)` during `dotnet pack`

## Testing

Firstly run the following to install a new extension project:

```
dotnet new install Umbraco.Templates::17.2.0
dotnet new umbraco-extension --name TestExtension
cd .\TestExtension\
code .
```

Open up `TestExtension.csproj` and note the project references all use "*":

```
<ItemGroup>
  <PackageReference Include="Umbraco.Cms.Web.Website" Version="*" />
  <PackageReference Include="Umbraco.Cms.Web.Common" Version="*" />
  <PackageReference Include="Umbraco.Cms.Api.Common" Version="*" />
  <PackageReference Include="Umbraco.Cms.Api.Management" Version="*" />
</ItemGroup>
```

Now run a `dotnet pack` from this PR.  Perhaps the easiest way is save the `*.nupkg` files [generated from this PR](https://dev.azure.com/umbraco/Umbraco%20Cms/_build/results?buildId=248414&view=artifacts&pathAsName=false&type=publishedArtifacts) into a local folder.

Delete the `TestExtension` folder and run:

```
cd ../
dotnet new install Umbraco.Templates::17.3.0--rc.preview.109.g8c069b7 --nuget-source c:\repos\nuget\Umbraco.Templates.17.3.0--rc.preview.109.g8c069b7.nupkg
dotnet new umbraco-extension --name TestExtension
cd .\TestExtension\
code .
```

Open up `TestExtension.csproj` and note the project references all use the matching version:

```
<ItemGroup>
  <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.3.0--rc.preview.109.g8c069b7" />
  <PackageReference Include="Umbraco.Cms.Web.Common" Version="17.3.0--rc.preview.109.g8c069b7" />
  <PackageReference Include="Umbraco.Cms.Api.Common" Version="17.3.0--rc.preview.109.g8c069b7" />
  <PackageReference Include="Umbraco.Cms.Api.Management" Version="17.3.0--rc.preview.109.g8c069b7" />
</ItemGroup>
```





