### PR TITLE
Media Picker: Fix media picker folder navigation with "ignore user start nodes" enabled (closes #21840 for 13)

### DIFF
--- a/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/EntityController.cs
@@ -1138,7 +1138,7 @@ public class EntityController : UmbracoAuthorizedJsonController
                 .Select(s => int.Parse(s, CultureInfo.InvariantCulture)).Distinct().ToArray();
 
             var ignoreUserStartNodes =
-                IsDataTypeIgnoringUserStartNodes(queryStrings?.GetValue<Guid?>("dataTypeId"));
+                IsDataTypeIgnoringUserStartNodes(queryStrings?.GetValue<Guid?>("dataTypeKey"));
             if (ignoreUserStartNodes == false)
             {
                 int[]? aids = null;

--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -261,7 +261,9 @@ angular.module("umbraco")
                           $scope.path = _.filter(anc, function (f) {
                               return f.path.indexOf($scope.startNodeId) !== -1;
                           });
-                          folder.path = $scope.path[0].path;
+                          if ($scope.path.length > 0) {
+                              folder.path = $scope.path[0].path;
+                          }
                       })
                   : Promise.resolve().then(function () {
                         $scope.path = [];


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/21840 reports an an issue where the media picker (egacy) threw a `TypeError: Cannot read properties of undefined (reading 'path')` when navigating into folders, when the data type had "Ignore user start nodes" enabled and the user had restricted media start node permissions.

The bug was a query parameter name mismatch in `EntityController.GetResultForAncestors`: it read `"dataTypeId"` from the query string but the client sends `"dataTypeKey"`, so the server never detected the `ignoreUserStartNodes` configuration.

I've also added a defensive guard in the client-side `gotoFolder` to handle an empty ancestor path without throwing,

### Root cause

This was reported as a regression in recent versions (which is why I looked at it) but the parameter name mismatch in `EntityController.cs` has existed for years — the `GetResultForAncestors` method reads `"dataTypeId"` from the `FormCollection`, while every other endpoint in the same controller (`GetChildren`, `GetPagedChildren`, `Search`) correctly uses `dataTypeKey` as a named action parameter. The client has always sent `dataTypeKey`. This meant `ignoreUserStartNodes` was effectively always `false` for the `GetAncestors` endpoint.

### Why it only recently surfaced

The bug was latent until PR #20202 (released in 13.12.0) refactored `gotoFolder` to properly chain its promises. Before that PR, `getChildren(folder.id)` was called immediately and unconditionally and not chained to the ancestor resolution promise. So even when `$scope.path[0].path` threw inside the `.then()` callback, the error was silently swallowed and the folder's children still loaded. After #20202 correctly chained `getChildren` after the ancestor path resolution, the exception now rejects the promise chain and prevents the folder contents from loading.

## Testing

For manual testing see "Steps to reproduce" on the linked issue.