### PR TITLE
Tests: Set AllowedInLibrary on element content type in permission tests

### DIFF
--- a/tests/Umbraco.Tests.Integration/ManagementApi/User/Current/GetElementPermissionsCurrentUserControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/User/Current/GetElementPermissionsCurrentUserControllerTests.cs
@@ -25,6 +25,7 @@ public class GetElementPermissionsCurrentUserControllerTests : ManagementApiUser
             name: Guid.NewGuid().ToString(),
             alias: Guid.NewGuid().ToString());
         contentType.IsElement = true;
+        contentType.AllowedInLibrary = true;
         await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
 
         // Content


### PR DESCRIPTION
## Summary

The `GetElementPermissionsCurrentUserControllerTests` were failing because the test setup created an element content type without setting `AllowedInLibrary` to `true`. The `ElementEditingService.TryGetAndValidateContentType` method requires both `IsElement` and `AllowedInLibrary` to be `true` for element creation to succeed, so the test's `SetUp` was failing at `ElementEditingService.CreateAsync`.

## Testing

Run the integration tests in `GetElementPermissionsCurrentUserControllerTests` and verify all 6 tests pass.