### PR TITLE
Account login: Enforce `AllowConcurrentLogins` for backoffice users and members

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
@@ -140,15 +140,19 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
 
                 await securityStampValidator.ValidateAsync(ctx);
 
-                // We have to manually specify Issued and Expires,
-                // because the SecurityStampValidator refreshes the principal every 30 minutes,
-                // When the principal is refreshed the Issued is update to time of refresh, however, the Expires remains unchanged
-                // When we then try and renew, the difference of issued and expires effectively becomes the new ExpireTimeSpan
-                // meaning we effectively lose 30 minutes of our ExpireTimeSpan for EVERY principal refresh if we don't
-                // https://github.com/dotnet/aspnetcore/blob/main/src/Security/Authentication/Cookies/src/CookieAuthenticationHandler.cs#L115
-                ctx.Properties.IssuedUtc = _timeProvider.GetUtcNow();
-                ctx.Properties.ExpiresUtc = _timeProvider.GetUtcNow().Add(_globalSettings.TimeOut);
-                ctx.ShouldRenew = true;
+                // Only reset timestamps when a renewal was already triggered (by the SecurityStampValidator
+                // or by EnsureTicketRenewalIfKeepUserLoggedIn above).
+                // When the SecurityStampValidator refreshes the principal, it sets ShouldRenew but updates
+                // IssuedUtc without updating ExpiresUtc, causing the effective cookie lifetime to shrink
+                // with each validation. The manual reset here fixes that drift.
+                // IMPORTANT: Do NOT unconditionally set ShouldRenew or reset IssuedUtc - doing so prevents
+                // the SecurityStampValidator from ever exceeding its ValidationInterval during active use,
+                // which breaks AllowConcurrentLogins enforcement.
+                if (ctx.ShouldRenew)
+                {
+                    ctx.Properties.IssuedUtc = _timeProvider.GetUtcNow();
+                    ctx.Properties.ExpiresUtc = _timeProvider.GetUtcNow().Add(_globalSettings.TimeOut);
+                }
             },
             OnSigningIn = ctx =>
             {

--- a/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
+++ b/src/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptions.cs
@@ -150,8 +150,9 @@ public class ConfigureBackOfficeCookieOptions : IConfigureNamedOptions<CookieAut
                 // which breaks AllowConcurrentLogins enforcement.
                 if (ctx.ShouldRenew)
                 {
-                    ctx.Properties.IssuedUtc = _timeProvider.GetUtcNow();
-                    ctx.Properties.ExpiresUtc = _timeProvider.GetUtcNow().Add(_globalSettings.TimeOut);
+                    DateTimeOffset now = _timeProvider.GetUtcNow();
+                    ctx.Properties.IssuedUtc = now;
+                    ctx.Properties.ExpiresUtc = now.Add(_globalSettings.TimeOut);
                 }
             },
             OnSigningIn = ctx =>

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.MembersIdentity.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilder.MembersIdentity.cs
@@ -63,7 +63,14 @@ public static partial class UmbracoBuilderExtensions
         services.AddScoped(x => (IMemberUserStore)x.GetRequiredService<IUserStore<MemberIdentityUser>>());
         services.AddScoped<IPasswordHasher<MemberIdentityUser>, MemberPasswordHasher>();
 
+        // TODO (V18): Remove this registration. The base SecurityStampValidatorOptions it configures is not consumed by
+        // any validator — both BackOfficeSecurityStampValidator and MemberSecurityStampValidator use their own derived
+        // options types, each configured by their own IConfigureOptions (which call ConfigureSecurityStampOptions.ConfigureOptions
+        // directly).
+        // Kept for the current major in case external consumers depend on IOptions<SecurityStampValidatorOptions>.
         services.ConfigureOptions<ConfigureSecurityStampOptions>();
+
+        services.ConfigureOptions<ConfigureMemberSecurityStampValidatorOptions>();
         services.ConfigureOptions<ConfigureMemberCookieOptions>();
         services.AddScoped<MemberSecurityStampValidator>();
 

--- a/src/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptions.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Web.Common.Security;
+
+/// <summary>
+///     Configures the member security stamp options.
+/// </summary>
+public class ConfigureMemberSecurityStampValidatorOptions : IConfigureOptions<MemberSecurityStampValidatorOptions>
+{
+    private static readonly TimeSpan MemberValidationInterval = TimeSpan.FromSeconds(30);
+
+    private readonly SecuritySettings _securitySettings;
+
+    public ConfigureMemberSecurityStampValidatorOptions(IOptions<SecuritySettings> securitySettings)
+        => _securitySettings = securitySettings.Value;
+
+    /// <inheritdoc />
+    public void Configure(MemberSecurityStampValidatorOptions options)
+    {
+        // Apply the shared configuration (claim merging, etc.) which also sets
+        // ValidationInterval to TimeSpan.Zero when AllowConcurrentLogins is false.
+        ConfigureSecurityStampOptions.ConfigureOptions(options, _securitySettings);
+
+        // Override the validation interval for members. The backoffice needs TimeSpan.Zero
+        // because the OpenIddict /authorize endpoint can silently re-authenticate within
+        // any non-zero window. Members authenticate directly via cookies with no silent
+        // re-authentication mechanism, so a short interval is sufficient and avoids a
+        // per-request DB lookup on every authenticated page load.
+        if (_securitySettings.AllowConcurrentLogins is false
+            && options.ValidationInterval == TimeSpan.Zero)
+        {
+            options.ValidationInterval = MemberValidationInterval;
+        }
+    }
+}

--- a/src/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptions.cs
@@ -9,6 +9,7 @@ namespace Umbraco.Cms.Web.Common.Security;
 /// </summary>
 public class ConfigureMemberSecurityStampValidatorOptions : IConfigureOptions<MemberSecurityStampValidatorOptions>
 {
+    private static readonly TimeSpan DefaultInterval = new SecurityStampValidatorOptions().ValidationInterval;
     private static readonly TimeSpan MemberValidationInterval = TimeSpan.FromSeconds(30);
 
     private readonly SecuritySettings _securitySettings;
@@ -19,17 +20,23 @@ public class ConfigureMemberSecurityStampValidatorOptions : IConfigureOptions<Me
     /// <inheritdoc />
     public void Configure(MemberSecurityStampValidatorOptions options)
     {
+        // Capture the interval before the shared configuration runs, so we can detect
+        // whether a developer has already customized it vs. it being the framework default.
+        TimeSpan originalInterval = options.ValidationInterval;
+
         // Apply the shared configuration (claim merging, etc.) which also sets
         // ValidationInterval to TimeSpan.Zero when AllowConcurrentLogins is false.
         ConfigureSecurityStampOptions.ConfigureOptions(options, _securitySettings);
 
-        // Override the validation interval for members. The backoffice needs TimeSpan.Zero
-        // because the OpenIddict /authorize endpoint can silently re-authenticate within
-        // any non-zero window. Members authenticate directly via cookies with no silent
-        // re-authentication mechanism, so a short interval is sufficient and avoids a
-        // per-request DB lookup on every authenticated page load.
+        // Override the validation interval for members, but only when the original value
+        // was the framework default (30 minutes). If a developer has explicitly customized
+        // the interval (e.g. to TimeSpan.Zero for per-request validation), respect that.
+        // The backoffice needs TimeSpan.Zero because the OpenIddict /authorize endpoint can
+        // silently re-authenticate within any non-zero window. Members authenticate directly
+        // via cookies with no silent re-authentication mechanism, so a short interval is
+        // sufficient and avoids a per-request DB lookup on every authenticated page load.
         if (_securitySettings.AllowConcurrentLogins is false
-            && options.ValidationInterval == TimeSpan.Zero)
+            && originalInterval == DefaultInterval)
         {
             options.ValidationInterval = MemberValidationInterval;
         }

--- a/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
+++ b/src/Umbraco.Web.Common/Security/ConfigureSecurityStampOptions.cs
@@ -28,12 +28,13 @@ public class ConfigureSecurityStampOptions : IConfigureOptions<SecurityStampVali
     /// <param name="securitySettings">The <see cref="SecuritySettings" /> options.</param>
     public static void ConfigureOptions(SecurityStampValidatorOptions options, SecuritySettings securitySettings)
     {
-        // Adjust the security stamp validation interval to a shorter duration
-        // when concurrent logins are not allowed and the duration has the default interval value
-        // (currently defaults to 30 minutes), ensuring quicker re-validation.
+        // When concurrent logins are not allowed, validate the security stamp on every
+        // cookie-authenticated request so that a second login immediately invalidates
+        // the first session's cookie. Without this, the previous 30-second window allowed
+        // silent re-authentication via the OpenIddict /authorize endpoint.
         if (securitySettings.AllowConcurrentLogins is false && options.ValidationInterval == new SecurityStampValidatorOptions().ValidationInterval)
         {
-            options.ValidationInterval = TimeSpan.FromSeconds(30);
+            options.ValidationInterval = TimeSpan.Zero;
         }
 
         // When refreshing the principal, ensure custom claims that

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Configuration/ConfigureBackOfficeCookieOptionsTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Configuration;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Net;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Security;
+using Umbraco.Cms.Web.Common.Security;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Configuration;
+
+[TestFixture]
+public class ConfigureBackOfficeCookieOptionsTests
+{
+    private static readonly DateTimeOffset Now = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+    private Mock<TimeProvider> _timeProviderMock = null!;
+    private GlobalSettings _globalSettings = null!;
+    private SecuritySettings _securitySettings = null!;
+    private Mock<BackOfficeSecurityStampValidator> _mockStampValidator = null!;
+    private Mock<IBackOfficeSignInManager> _mockSignInManager = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _timeProviderMock = new Mock<TimeProvider>();
+        _timeProviderMock.Setup(tp => tp.GetUtcNow()).Returns(Now);
+        _globalSettings = new GlobalSettings { TimeOut = TimeSpan.FromMinutes(60) };
+        _securitySettings = new SecuritySettings { KeepUserLoggedIn = false };
+        _mockSignInManager = new Mock<IBackOfficeSignInManager>();
+        _mockStampValidator = CreateMockStampValidator();
+    }
+
+    [Test]
+    public async Task OnValidatePrincipal_IssuedUtc_Not_Reset_When_No_Renewal_Triggered()
+    {
+        // Arrange: validator does nothing (ShouldRenew stays false)
+        _mockStampValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
+            .Returns(Task.CompletedTask);
+
+        var originalIssuedUtc = Now.AddMinutes(-5);
+        var originalExpiresUtc = Now.AddMinutes(55);
+
+        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(originalIssuedUtc, originalExpiresUtc);
+        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
+
+        // Act
+        await onValidatePrincipal(context);
+
+        // Assert: IssuedUtc should NOT be reset when ShouldRenew was not triggered
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.ShouldRenew, Is.False);
+            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(originalIssuedUtc));
+            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(originalExpiresUtc));
+        });
+    }
+
+    [Test]
+    public async Task OnValidatePrincipal_Timestamps_Reset_When_Validator_Triggers_Renewal()
+    {
+        // Arrange: validator sets ShouldRenew = true (stamp was valid, principal refreshed)
+        _mockStampValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
+            .Callback<CookieValidatePrincipalContext>(ctx => ctx.ShouldRenew = true)
+            .Returns(Task.CompletedTask);
+
+        var originalIssuedUtc = Now.AddMinutes(-35);
+        var originalExpiresUtc = Now.AddMinutes(25);
+
+        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(originalIssuedUtc, originalExpiresUtc);
+        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
+
+        // Act
+        await onValidatePrincipal(context);
+
+        // Assert: timestamps should be reset to now + TimeOut
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.ShouldRenew, Is.True);
+            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(Now));
+            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(Now.Add(_globalSettings.TimeOut)));
+        });
+    }
+
+    [Test]
+    public async Task OnValidatePrincipal_Timestamps_Reset_When_KeepUserLoggedIn_Triggers_Renewal()
+    {
+        // Arrange: KeepUserLoggedIn = true, and timeRemaining < timeElapsed
+        _securitySettings.KeepUserLoggedIn = true;
+
+        _mockStampValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
+            .Returns(Task.CompletedTask);
+
+        // Set IssuedUtc far enough in the past that timeRemaining < timeElapsed
+        // IssuedUtc = now - 40 min, ExpiresUtc = now + 20 min
+        // timeElapsed = 40 min, timeRemaining = 20 min => timeRemaining < timeElapsed => ShouldRenew
+        var originalIssuedUtc = Now.AddMinutes(-40);
+        var originalExpiresUtc = Now.AddMinutes(20);
+
+        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(originalIssuedUtc, originalExpiresUtc);
+        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
+
+        // Act
+        await onValidatePrincipal(context);
+
+        // Assert: ShouldRenew set by EnsureTicketRenewalIfKeepUserLoggedIn, timestamps reset
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.ShouldRenew, Is.True);
+            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(Now));
+            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(Now.Add(_globalSettings.TimeOut)));
+        });
+    }
+
+    [Test]
+    public async Task OnValidatePrincipal_No_Renewal_When_KeepUserLoggedIn_But_TimeRemaining_Greater_Than_TimeElapsed()
+    {
+        // Arrange: KeepUserLoggedIn = true, but timeRemaining > timeElapsed
+        _securitySettings.KeepUserLoggedIn = true;
+
+        _mockStampValidator
+            .Setup(v => v.ValidateAsync(It.IsAny<CookieValidatePrincipalContext>()))
+            .Returns(Task.CompletedTask);
+
+        // IssuedUtc = now - 10 min, ExpiresUtc = now + 50 min
+        // timeElapsed = 10 min, timeRemaining = 50 min => timeRemaining > timeElapsed => no renewal
+        var originalIssuedUtc = Now.AddMinutes(-10);
+        var originalExpiresUtc = Now.AddMinutes(50);
+
+        CookieValidatePrincipalContext context = CreateValidatePrincipalContext(originalIssuedUtc, originalExpiresUtc);
+        Func<CookieValidatePrincipalContext, Task> onValidatePrincipal = GetOnValidatePrincipal();
+
+        // Act
+        await onValidatePrincipal(context);
+
+        // Assert: ShouldRenew stays false, timestamps unchanged
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.ShouldRenew, Is.False);
+            Assert.That(context.Properties.IssuedUtc, Is.EqualTo(originalIssuedUtc));
+            Assert.That(context.Properties.ExpiresUtc, Is.EqualTo(originalExpiresUtc));
+        });
+    }
+
+    private Func<CookieValidatePrincipalContext, Task> GetOnValidatePrincipal()
+    {
+        var sut = new ConfigureBackOfficeCookieOptions(
+            Options.Create(_securitySettings),
+            Options.Create(_globalSettings),
+            Mock.Of<IRuntimeState>(x => x.Level == RuntimeLevel.Run),
+            CreateMockDataProtectionProvider(),
+            Mock.Of<IUserService>(),
+            Mock.Of<IIpResolver>(),
+            _timeProviderMock.Object);
+
+        var options = new CookieAuthenticationOptions();
+        sut.Configure(Constants.Security.BackOfficeAuthenticationType, options);
+        return options.Events.OnValidatePrincipal;
+    }
+
+    private CookieValidatePrincipalContext CreateValidatePrincipalContext(
+        DateTimeOffset issuedUtc,
+        DateTimeOffset expiresUtc)
+    {
+        ClaimsPrincipal principal = CreateBackOfficePrincipal();
+
+        var properties = new AuthenticationProperties
+        {
+            IssuedUtc = issuedUtc,
+            ExpiresUtc = expiresUtc,
+        };
+
+        var ticket = new AuthenticationTicket(principal, properties, Constants.Security.BackOfficeAuthenticationType);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockStampValidator.Object);
+        services.AddSingleton(_mockSignInManager.Object);
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext { RequestServices = serviceProvider };
+
+        var scheme = new AuthenticationScheme(
+            Constants.Security.BackOfficeAuthenticationType,
+            Constants.Security.BackOfficeAuthenticationType,
+            typeof(CookieAuthenticationHandler));
+
+        return new CookieValidatePrincipalContext(
+            httpContext,
+            scheme,
+            new CookieAuthenticationOptions(),
+            ticket);
+    }
+
+    private static ClaimsPrincipal CreateBackOfficePrincipal()
+    {
+        var identity = new ClaimsIdentity(
+            Constants.Security.BackOfficeAuthenticationType,
+            ClaimTypes.Name,
+            ClaimTypes.Role);
+
+        // Add required back office claims (see ClaimsIdentityExtensions.RequiredBackOfficeClaimTypes)
+        identity.AddClaims(
+        [
+            new Claim(ClaimTypes.NameIdentifier, "1234", ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+            new Claim(ClaimTypes.Name, "admin@example.com", ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+            new Claim(ClaimTypes.GivenName, "Admin", ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+            new Claim(ClaimTypes.Locality, "en-US", ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+            new Claim(Constants.Security.SecurityStampClaimType, Guid.NewGuid().ToString(), ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+            new Claim(Constants.Security.SessionIdClaimType, Guid.NewGuid().ToString(), ClaimValueTypes.String, Constants.Security.BackOfficeAuthenticationType),
+        ]);
+
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static IDataProtectionProvider CreateMockDataProtectionProvider()
+    {
+        var mockProtector = new Mock<IDataProtector>();
+        mockProtector
+            .Setup(p => p.CreateProtector(It.IsAny<string>()))
+            .Returns(mockProtector.Object);
+
+        var mockProvider = new Mock<IDataProtectionProvider>();
+        mockProvider
+            .Setup(p => p.CreateProtector(It.IsAny<string>()))
+            .Returns(mockProtector.Object);
+
+        return mockProvider.Object;
+    }
+
+    private static Mock<BackOfficeSecurityStampValidator> CreateMockStampValidator()
+    {
+        // Build up the mock chain needed by BackOfficeSecurityStampValidator's constructor.
+        // None of the inner dependencies are actually called - only ValidateAsync is invoked
+        // (and it's overridden by Moq).
+        BackOfficeUserManager userManager = CreateMockUserManager();
+        BackOfficeSignInManager signInManager = CreateMockSignInManager(userManager);
+
+        var mockValidator = new Mock<BackOfficeSecurityStampValidator>(
+            Options.Create(new BackOfficeSecurityStampValidatorOptions()),
+            signInManager,
+            Mock.Of<ILoggerFactory>());
+
+        return mockValidator;
+    }
+
+    private static BackOfficeUserManager CreateMockUserManager()
+    {
+        var mockTextService = Mock.Of<ILocalizedTextService>();
+        var errorDescriber = new Mock<BackOfficeErrorDescriber>(mockTextService);
+
+        var mock = new Mock<BackOfficeUserManager>(
+            Mock.Of<IIpResolver>(),
+            Mock.Of<IUserStore<BackOfficeIdentityUser>>(),
+            Options.Create(new BackOfficeIdentityOptions()),
+            Mock.Of<IPasswordHasher<BackOfficeIdentityUser>>(),
+            Enumerable.Empty<IUserValidator<BackOfficeIdentityUser>>(),
+            Enumerable.Empty<IPasswordValidator<BackOfficeIdentityUser>>(),
+            errorDescriber.Object,
+            Mock.Of<IServiceProvider>(),
+            Mock.Of<IHttpContextAccessor>(),
+            Mock.Of<ILogger<UserManager<BackOfficeIdentityUser>>>(),
+            Options.Create(new UserPasswordConfigurationSettings()),
+            Mock.Of<IEventAggregator>(),
+            Mock.Of<IBackOfficeUserPasswordChecker>(),
+            Options.Create(new GlobalSettings()));
+
+        return mock.Object;
+    }
+
+    private static BackOfficeSignInManager CreateMockSignInManager(BackOfficeUserManager userManager)
+    {
+        var mock = new Mock<BackOfficeSignInManager>(
+            userManager,
+            Mock.Of<IHttpContextAccessor>(),
+            Mock.Of<IBackOfficeExternalLoginProviders>(),
+            Mock.Of<IUserClaimsPrincipalFactory<BackOfficeIdentityUser>>(),
+            Options.Create(new IdentityOptions()),
+            Options.Create(new GlobalSettings()),
+            Mock.Of<ILogger<SignInManager<BackOfficeIdentityUser>>>(),
+            Mock.Of<IAuthenticationSchemeProvider>(),
+            Mock.Of<IUserConfirmation<BackOfficeIdentityUser>>(),
+            Mock.Of<IEventAggregator>(),
+            Options.Create(new SecuritySettings()),
+            Options.Create(new BackOfficeAuthenticationTypeSettings()),
+            Mock.Of<IRequestCache>());
+
+        return mock.Object;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptionsTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Web.Common.Security;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security;
+
+[TestFixture]
+public class ConfigureMemberSecurityStampValidatorOptionsTests
+{
+    private static readonly TimeSpan _defaultInterval = new SecurityStampValidatorOptions().ValidationInterval;
+    private static readonly TimeSpan _expectedMemberInterval = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public void Sets_30_Second_Interval_When_AllowConcurrentLogins_Is_False()
+    {
+        var securitySettings = new SecuritySettings { AllowConcurrentLogins = false };
+        var sut = new ConfigureMemberSecurityStampValidatorOptions(Options.Create(securitySettings));
+        var options = new MemberSecurityStampValidatorOptions();
+
+        sut.Configure(options);
+
+        Assert.That(options.ValidationInterval, Is.EqualTo(_expectedMemberInterval));
+    }
+
+    [Test]
+    public void Preserves_Default_Interval_When_AllowConcurrentLogins_Is_True()
+    {
+        var securitySettings = new SecuritySettings { AllowConcurrentLogins = true };
+        var sut = new ConfigureMemberSecurityStampValidatorOptions(Options.Create(securitySettings));
+        var options = new MemberSecurityStampValidatorOptions();
+
+        sut.Configure(options);
+
+        Assert.That(options.ValidationInterval, Is.EqualTo(_defaultInterval));
+    }
+
+    [Test]
+    public void Preserves_Custom_Interval_When_AllowConcurrentLogins_Is_False()
+    {
+        // If a developer has already customized the interval, don't override it.
+        var customInterval = TimeSpan.FromMinutes(5);
+        var securitySettings = new SecuritySettings { AllowConcurrentLogins = false };
+        var sut = new ConfigureMemberSecurityStampValidatorOptions(Options.Create(securitySettings));
+        var options = new MemberSecurityStampValidatorOptions { ValidationInterval = customInterval };
+
+        sut.Configure(options);
+
+        Assert.That(options.ValidationInterval, Is.EqualTo(customInterval));
+    }
+
+    [Test]
+    public void Configures_OnRefreshingPrincipal_Callback()
+    {
+        var securitySettings = new SecuritySettings();
+        var sut = new ConfigureMemberSecurityStampValidatorOptions(Options.Create(securitySettings));
+        var options = new MemberSecurityStampValidatorOptions();
+
+        sut.Configure(options);
+
+        Assert.That(options.OnRefreshingPrincipal, Is.Not.Null);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/ConfigureMemberSecurityStampValidatorOptionsTests.cs
@@ -51,6 +51,20 @@ public class ConfigureMemberSecurityStampValidatorOptionsTests
     }
 
     [Test]
+    public void Preserves_Zero_Interval_When_Explicitly_Set_By_Developer()
+    {
+        // A developer may intentionally set TimeSpan.Zero for per-request validation.
+        // This should not be overridden to 30 seconds.
+        var securitySettings = new SecuritySettings { AllowConcurrentLogins = false };
+        var sut = new ConfigureMemberSecurityStampValidatorOptions(Options.Create(securitySettings));
+        var options = new MemberSecurityStampValidatorOptions { ValidationInterval = TimeSpan.Zero };
+
+        sut.Configure(options);
+
+        Assert.That(options.ValidationInterval, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
     public void Configures_OnRefreshingPrincipal_Callback()
     {
         var securitySettings = new SecuritySettings();


### PR DESCRIPTION
## Description

With `Umbraco:CMS:Security:AllowConcurrentLogins` set to `false` (the default), logging into the same account from a second browser should invalidate the first session. However it's not working correctly at the moment, and the original authentication remains active.

I found two bugs here for **backoffice users** that we needed to resolve to get this working

1. **SecurityStampValidator never fired during active use.** `ConfigureBackOfficeCookieOptions` was unconditionally resetting `IssuedUtc` to "now" and set `ShouldRenew = true` on every request. The `SecurityStampValidator` only checks stamps when `now - IssuedUtc > ValidationInterval`, but because `IssuedUtc` was always reset to "now", `timeElapsed` never exceeded the interval.

2. **30-second validation window allowed silent re-authentication.** Even with bug 1 fixed, the backoffice SPA uses OpenIddict tokens (not cookies) for API requests. When User B logs in, User A's tokens are revoked and the SPA gets 401s. The SPA then redirects to the OpenIddict `/authorize` endpoint which validates the cookie.  If the `SecurityStampValidator` hasn't fired within its interval, the cookie is still valid, new tokens are silently issued, and User A continues working.

For **members**, `MemberSecurityStampValidatorOptions` wasn't configured with the `AllowConcurrentLogins` logic. The backoffice had `ConfigureBackOfficeSecurityStampValidatorOptions` calling the shared `ConfigureSecurityStampOptions.ConfigureOptions()` method, but members had no equivalent, so the validator used the ASP.NET Core default interval of 30 minutes, irrespective of the `AllowConcurrentLogins` value.

### Why the intervals differ

**Backoffice needs `TimeSpan.Zero`** because the OpenIddict `/authorize` endpoint creates a silent re-authentication path. Within any non-zero window, the SPA can redirect to `/authorize`, the cookie passes validation (stamp hasn't been checked yet), and new tokens are issued without re-entering credentials. Zero is the only value that fully closes this gap.

**Members use 30 seconds** because there is no token layer or `/authorize` endpoint — the cookie IS the authentication mechanism. Once the `SecurityStampValidator` rejects the cookie, the member must re-enter credentials. A 30-second interval is a reasonable balance between supporting the feature and avoiding the performance cost of per-request validation.

### Performance considerations

**Backoffice (`TimeSpan.Zero`)** has negligible impact. The backoffice SPA authenticates via OpenIddict tokens for API calls. The cookie is only touched on a handful of requests per session (initial page load, `/authorize` token exchange, logout). The vast majority of requests bypass cookie validation entirely.

**Members (30-second interval)** — one stamp check every 30 seconds per authenticated member. This involves a user lookup through the repository cache (typically a memory hit in steady state, DB query only after cache invalidation), principal rebuild, and cookie rewrite. For a public-facing site with many concurrent members, this is dramatically lighter than per-request validation while still invalidating stale sessions within 30 seconds.

Both intervals only apply when `AllowConcurrentLogins` is `false` (the default). If a developer has explicitly customized the `ValidationInterval`, it is preserved.

## Testing

### Automated 

The backoffice cookie options tests verify that `IssuedUtc` and `ExpiresUtc` are only reset when a renewal is triggered (by the `SecurityStampValidator` or the `KeepUserLoggedIn` sliding window), and that timestamps are preserved when no renewal occurs.

The member stamp validator options tests verify that the `ValidationInterval` is set to 30 seconds when `AllowConcurrentLogins` is false, left at the default when concurrent logins are allowed, and preserved when a developer has already customized it.

### Manual

#### Backoffice user concurrent login

- [ ] Set `Umbraco:CMS:Security:AllowConcurrentLogins` to `false` in appsettings.
- [ ] Log in to the backoffice in Browser A.
- [ ] Log in to the backoffice in Browser B (incognito) with the same account.
- [ ] Continue using Browser A — it should be logged out on the very next interaction.

#### Member concurrent login

To test member concurrent login, you need a means of authenticating as a member.  One way is to add a debug controller and a view snippet:

**Debug controller** — add to your test site (e.g. `Controllers/DebugMemberLoginController.cs`):
```csharp
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Web.Common.Security;

[ApiController]
[Route("debug/member")]
public class DebugMemberLoginController : ControllerBase
{
    private readonly IMemberSignInManager _memberSignInManager;

    public DebugMemberLoginController(IMemberSignInManager memberSignInManager)
        => _memberSignInManager = memberSignInManager;

    [HttpGet("login")]
    public async Task<IActionResult> Login()
    {
        var result = await _memberSignInManager.PasswordSignInAsync(
            "your-member@example.com",
            "your-password",
            isPersistent: true,
            lockoutOnFailure: false);

        return Ok(result.Succeeded ? "Logged in." : $"Failed: {result}");
    }

    [HttpGet("logout")]
    public async Task<IActionResult> Logout()
    {
        await _memberSignInManager.SignOutAsync();
        return Ok("Logged out.");
    }
}
```

**View snippet** — add to a template to check auth status:
```html
@if (User.Identity?.IsAuthenticated == true)
{
    <p>Logged in as: @User.Identity.Name</p>
}
else
{
    <p>Not logged in.</p>
}
```

- [ ] Ensure `AllowConcurrentLogins` is `false`.
- [ ] Create a member in the backoffice with credentials matching what you have added to the controller.
- [ ] Open your site in Browser A, visit `/debug/member/login` — should show "Logged in.".
- [ ] Refresh a page with the view snippet — should show the member name.
- [ ] Open your site in Browser B (incognito), visit `/debug/member/login`.
- [ ] Return to Browser A and refresh the page with the view snippet — within 30 seconds it should show "Not logged in."

### Regression checks

- [ ] Single-user backoffice workflow: no visible behavioural change.
- [ ] Single-member website workflow: no visible behavioural change.
- [ ] `AllowConcurrentLogins = true`: both backoffice and member concurrent sessions work normally.