### PR TITLE
Relations: Exclude `relateParentDocumentOnDelete` from EmptyRecycleBin reference check (closes #21926)

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2814,9 +2814,22 @@ public class ContentService : RepositoryService, IContentService
 
             if (contents is not null)
             {
+                // When checking if an item is related, we need to exclude the "relate parent on delete" relation type,
+                // as this is automatically created when items are trashed and would prevent emptying the recycle bin.
+                int[]? relateParentOnDeleteRelationTypeIds = null;
+                if (_contentSettings.DisableDeleteWhenReferenced)
+                {
+                    IRelationType? relateParentOnDeleteRelationType = _relationService.GetRelationTypeByAlias(
+                        Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias);
+                    if (relateParentOnDeleteRelationType is not null)
+                    {
+                        relateParentOnDeleteRelationTypeIds = [relateParentOnDeleteRelationType.Id];
+                    }
+                }
+
                 foreach (IContent content in contents)
                 {
-                    if (_contentSettings.DisableDeleteWhenReferenced && _relationService.IsRelated(content.Id, RelationDirectionFilter.Child))
+                    if (_contentSettings.DisableDeleteWhenReferenced && _relationService.IsRelated(content.Id, RelationDirectionFilter.Child, excludeRelationTypeIds: relateParentOnDeleteRelationTypeIds))
                     {
                         continue;
                     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Delete.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Delete.cs
@@ -70,6 +70,56 @@ public partial class ContentEditingServiceTests
         Assert.IsNull(subpage);
     }
 
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureDisableDeleteWhenReferenced))]
+    public async Task Cannot_EmptyRecycleBin_When_Content_Is_Related_As_A_Child_And_Configured_To_Disable_When_Related()
+    {
+        ContentService.MoveToRecycleBin(Subpage);
+
+        // Setup a relation where the trashed page is related to another page as a child (e.g. the other page has a picker and has selected this page).
+        Relate(Subpage2, Subpage);
+
+        ContentService.EmptyRecycleBin();
+
+        // re-get and verify not deleted (the relation prevents deletion)
+        var subpage = await ContentEditingService.GetAsync(Subpage.Key);
+        Assert.IsNotNull(subpage);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureDisableDeleteWhenReferenced))]
+    public async Task Can_EmptyRecycleBin_When_Content_Is_Related_To_Parent_For_Restore_And_Configured_To_Disable_When_Related()
+    {
+        ContentService.MoveToRecycleBin(Subpage);
+
+        // Setup a relation where the trashed page is related to its parent (created as the location to restore to).
+        // This relation should be excluded from the "disable delete when referenced" check.
+        Relate(Subpage2, Subpage, Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias);
+
+        ContentService.EmptyRecycleBin();
+
+        // re-get and verify is deleted (the restore relation should not prevent deletion)
+        var subpage = await ContentEditingService.GetAsync(Subpage.Key);
+        Assert.IsNull(subpage);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureDisableDeleteWhenReferenced))]
+    public async Task Can_EmptyRecycleBin_When_Content_Is_Related_As_A_Parent_And_Configured_To_Disable_When_Related()
+    {
+        ContentService.MoveToRecycleBin(Subpage);
+
+        // Setup a relation where the trashed page is related to another page as a parent (not a child).
+        // Only child relations should prevent deletion.
+        Relate(Subpage, Subpage2);
+
+        ContentService.EmptyRecycleBin();
+
+        // re-get and verify deleted (parent relations should not prevent deletion)
+        var subpage = await ContentEditingService.GetAsync(Subpage.Key);
+        Assert.IsNull(subpage);
+    }
+
     [TestCase(true)]
     [TestCase(false)]
     public async Task Can_Delete_FromRecycleBin(bool variant)


### PR DESCRIPTION
## Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco-CMS/issues/21926

## Description

When `DisableDeleteWhenReferenced` is set to `true`, emptying the recycle bin silently fails to delete any items. This happens because when content is moved to the recycle bin, a `relateParentDocumentOnDelete` relation is automatically created (by `RelateOnTrashNotificationHandler`) to remember the item's original parent for restore. The `IsRelated` check in `ContentService.EmptyRecycleBin` finds this restore relation and treats it as a real reference, causing every trashed item to be skipped.

The individual delete path (`ContentEditingServiceBase.HandleDeletionAsync`) already handles this correctly - it was fixed in #20811. However, that PR missed the `ContentService.EmptyRecycleBin` code path.

We can apply the same fix though - pass `excludeRelationTypeIds` to the `IsRelated` overload we added in the other PR to exclude the `relateParentDocumentOnDelete` relation type. 

## Testing

### Automated

3 new integration tests are added to verify the fix:

```
dotnet test tests/Umbraco.Tests.Integration --filter "FullyQualifiedName~ContentEditingServiceTests.Can_EmptyRecycleBin|FullyQualifiedName~ContentEditingServiceTests.Cannot_EmptyRecycleBin"
```

### Manual

1. Set `Umbraco:CMS:Content:DisableDeleteWhenReferenced` to `true` in `appsettings.json`.
2. Create a content node (e.g. "Test Page").
3. Move "Test Page" to the recycle bin.
4. Open the recycle bin and click "Empty recycle bin".
5. **Expected**: The recycle bin is emptied successfully.
6. **Before fix**: The recycle bin appears to empty but all items remain (silently skipped).

To also verify that real references still block deletion:
1. Create two content nodes, "Page A" and "Page B"
2. Create a relation between the two - e.g. on "Page A", use a content picker to reference "Page B", or just create "Page B" as a copy of "Page A" and tick the box to create a relation.
3. Move "Page B" to the recycle bin.
4. Empty the recycle bin.
5. **Expected**: "Page B" remains in the recycle bin (blocked by the real reference from "Page A").