### PR TITLE
Accessibility: Add tooltips to block grid entry actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entries/block-grid-entries.element.ts
@@ -487,7 +487,8 @@ export class UmbBlockGridEntriesElement extends UmbFormControlMixin(UmbLitElemen
 				label=${this.localize.term('content_createFromClipboard')}
 				look="placeholder"
 				href=${this.#context.getPathForClipboard(-1) ?? ''}
-				?disabled=${this._isReadOnly}>
+				?disabled=${this._isReadOnly}
+				title=${this.localize.term('general_clipboard')}>
 				<uui-icon name="icon-clipboard-paste"></uui-icon>
 			</uui-button>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -590,7 +590,8 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 						label="edit"
 						look="secondary"
 						color=${this._contentInvalid ? 'danger' : ''}
-						href=${this._workspaceEditContentPath!}>
+						href=${this._workspaceEditContentPath!}
+						title=${this.localize.term('general_edit')}>
 						<uui-icon name=${this._exposed === false ? 'icon-add' : 'icon-edit'}></uui-icon>
 						${when(
 							this._contentInvalid,
@@ -621,7 +622,8 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 							label="Edit settings"
 							look="secondary"
 							color=${this._settingsInvalid ? 'invalid' : ''}
-							href=${this._workspaceEditSettingsPath}>
+							href=${this._workspaceEditSettingsPath}
+							title=${this.localize.term('general_settings')}>
 							<uui-icon name="icon-settings"></uui-icon>
 							${when(
 								this._settingsInvalid,
@@ -638,7 +640,8 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 			<uui-button
 				label=${this.localize.term('clipboard_labelForCopyToClipboard')}
 				look="secondary"
-				@click=${() => this.#context.copyToClipboard()}>
+				@click=${() => this.#context.copyToClipboard()}
+				title=${this.localize.term('general_copy')}>
 				<uui-icon name="icon-clipboard-copy"></uui-icon>
 			</uui-button>
 		`;
@@ -647,7 +650,7 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	#renderDeleteAction() {
 		if (this._isReadOnly) return nothing;
 		return html`
-			<uui-button label="delete" look="secondary" @click=${() => this.#context.requestDelete()}>
+			<uui-button label="delete" look="secondary" @click=${() => this.#context.requestDelete()} title=${this.localize.term('general_delete')}>
 				<uui-icon name="icon-remove"></uui-icon>
 			</uui-button>
 		`;


### PR DESCRIPTION
### Prerequisites

This PR restores tooltips on the Copy, Edit and Delete icons for Blockgrid items in the Umbraco Backoffice https://github.com/umbraco/Umbraco-CMS/issues/20422 .

Steps to Test

1. Go to Umbraco Backoffice.
2. Open a page with a Blockgrid.
3. Add Blockgridcontent.
4. Hover over the action icons (Copy, Edit, Delete) on the right of the Blockgrid entry.
5. Confirm that tooltips are now visible when hovering.
