### PR TITLE
Public Access: Handle inherited protection gracefully in modal dialog (closes #21965)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-public-access/modal/public-access-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-public-access/modal/public-access-modal.element.ts
@@ -8,6 +8,7 @@ import { UmbMemberGroupItemRepository, type UmbInputMemberGroupElement } from '@
 import type { PublicAccessRequestModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UUIRadioEvent } from '@umbraco-cms/backoffice/external/uui';
 import { UmbDocumentItemRepository, type UmbInputDocumentElement } from '@umbraco-cms/backoffice/document';
+import { UmbApiError } from '@umbraco-cms/backoffice/resources';
 
 @customElement('umb-public-access-modal')
 export class UmbPublicAccessModalElement extends UmbModalBaseElement<
@@ -91,12 +92,18 @@ export class UmbPublicAccessModalElement extends UmbModalBaseElement<
 			const { data, error } = await this.#publicAccessRepository.read(this.#unique);
 
 			if (error) {
+				// A 404 means no direct public access entry exists on this node.
+				// This is expected for descendants of a protected document — they inherit
+				// protection from an ancestor. Let the user create a new entry via the setup wizard.
+				if (UmbApiError.isUmbApiError(error) && error.status === 404) {
+					return;
+				}
+
 				this._loadError = 'Failed to load public access settings';
 				return;
 			}
 
 			if (!data) {
-				this._loadError = 'No public access data returned';
 				return;
 			}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco-CMS/issues/21965

### Description

When a parent document has public access configured, opening the public access dialog on a child document shows "Error: Failed to load Public Access settings" instead of allowing the user to create/edit protection rules for that child.

The problem comes about because the front-end relies on a check for `item.isProtected` before calling the management API to get the details of the protection.  However for a child node, the item is protected via inheritance, but there's not specific settings on the node.  So a 404 when under inherited protection is a valid, not an error result.

In this case, instead of displaying an error the setup screen is shown instead,

Note that this overlaps with another raised PR 0- https://github.com/umbraco/Umbraco-CMS/pull/21742 - that amends the behaviour to show the inherited protection for modification.  That's still in review though, so if it doesn't make it for the next release I've raised this to at least fix this bug.

### Testing

To manually test this fix:

1. Create a parent document and set public access protection on it.
2. Create a child document under that parent.
3. Try to set public access protection on it.
4. **Expected**: Setup protection wizard appears (choose Members or Groups) instead of an error message

Also worth checking:

- Save protection on the child document → works correctly.
- Open protection dialog on a directly protected page → shows edit view.
- Open protection dialog on an unprotected page → shows setup wizard.
- Delete protection from a page → works correctly.