### PR TITLE
Fix bug with ContentTypeService bubbling op_Implicit errors.

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepository.cs
@@ -104,12 +104,16 @@ internal sealed class ContentTypeRepository : ContentTypeRepositoryBase<IContent
             return Enumerable.Empty<int>();
         }
 
+        // Workaround for array/span conversion resulting in op_Implicit while visiting expressions.
+        // There's likely way better solutions (don't let alias be nullable?), but this is a quick fix to surface the bug(s).
+        var aliasesList = aliases.ToList();
+
         Sql<ISqlContext> sql = Sql()
             .Select<ContentTypeDto>(x => x.NodeId)
             .From<ContentTypeDto>()
             .InnerJoin<NodeDto>()
             .On<ContentTypeDto, NodeDto>(dto => dto.NodeId, dto => dto.NodeId)
-            .Where<ContentTypeDto>(dto => aliases.Contains(dto.Alias));
+            .Where<ContentTypeDto>(dto => dto.Alias != null && aliasesList.Contains(dto.Alias));
 
         return Database.Fetch<int>(sql);
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentTypeServiceTests.cs
@@ -263,6 +263,21 @@ internal sealed class ContentTypeServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public void Get_Ids_By_Aliases()
+    {
+        // Arrange
+        var contentTypeService = ContentTypeService;
+        var hierarchy = CreateContentTypeHierarchy();
+        contentTypeService.Save(hierarchy, -1); // ensure they are saved!
+
+        // Act
+        var ids = contentTypeService.GetAllContentTypeIds(["masterContentType", "childType0", "childType9"]);
+
+        // Assert
+        Assert.That(ids, Has.All.GreaterThan(0));
+    }
+
+    [Test]
     public void Get_Descendants()
     {
         // Arrange


### PR DESCRIPTION
Added simple fix by converting the aliases array parameter to a list before passed to SqlSyntaxProvider.Where.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #21977 

### Description

Just stumbled over a bug related to the SqlSyntax expression visitation.  
The `ContentTypeService.GetAllContentTypeIds` is 100% unusable.  
It's likely due to C#14+, spans, nullability and the ContenTypeDto.Alias property being nullable.

Added new test `Get_Ids_By_Aliases` - if the use of a list instead of array is commented out in `ContentTypeRepository` it will fail.