### PR TITLE
Elements: Add missing documentation endpoint attributes

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Element/RecycleBin/RestoreElementFolderRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Element/RecycleBin/RestoreElementFolderRecycleBinController.cs
@@ -40,6 +40,8 @@ public class RestoreElementFolderRecycleBinController : ElementRecycleBinControl
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [EndpointSummary("Restores an element folder from the recycle bin.")]
+    [EndpointDescription("Restores an element folder from the recycle bin to its original location or a specified parent.")]
     public async Task<IActionResult> RestoreFolder(CancellationToken cancellationToken, Guid id, MoveFolderRequestModel moveFolderRequestModel)
     {
         AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(

--- a/src/Umbraco.Cms.Api.Management/Controllers/Element/RecycleBin/RestoreElementRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Element/RecycleBin/RestoreElementRecycleBinController.cs
@@ -40,6 +40,8 @@ public class RestoreElementRecycleBinController : ElementRecycleBinControllerBas
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [EndpointSummary("Restores an element from the recycle bin.")]
+    [EndpointDescription("Restores an element from the recycle bin to its original location or a specified parent.")]
     public async Task<IActionResult> Restore(CancellationToken cancellationToken, Guid id, MoveElementRequestModel moveElementRequestModel)
     {
         AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(


### PR DESCRIPTION
## Summary

Adds missing `[EndpointSummary]` and `[EndpointDescription]` attributes to the two element recycle bin restore controllers that were missed when the element feature was created:

- `RestoreElementRecycleBinController` — "Restores an element from the recycle bin."
- `RestoreElementFolderRecycleBinController` — "Restores an element folder from the recycle bin."

All other Element and ElementVersion API endpoint controllers (41 total) already had both attributes. Follows the style established in #20690.

## Testing

Verify that the Swagger UI at `/umbraco/swagger` renders the new summaries and descriptions correctly for the two restore endpoints under the Element recycle bin section.