### PR TITLE
Hybrid Cache: Resolve IsPublished() returning false in preview mode (closes #21983)

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedContent.cs
@@ -251,6 +251,17 @@ internal class PublishedContent : PublishedContentBase
         // if there is no 'published' published content, no culture can be published
         if (!_contentNode.HasPublished)
         {
+            // In preview mode, the ContentNode only has draft data loaded (published data
+            // is stored in a separate cache entry). Fall back to IPublishStatusQueryService
+            // which is an in-memory service that tracks actual document publish status.
+            if (IsPreviewing && ItemType == PublishedItemType.Content)
+            {
+                culture ??= VariationContextAccessor.VariationContext?.Culture ?? string.Empty;
+                IPublishStatusQueryService publishStatusQueryService =
+                    StaticServiceProvider.Instance.GetRequiredService<IPublishStatusQueryService>();
+                return publishStatusQueryService.IsDocumentPublished(Key, culture);
+            }
+
             return false;
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheTests.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -140,6 +141,32 @@ internal sealed class DocumentHybridCacheTests : UmbracoIntegrationTestWithConte
         // Assert
         AssertPublishedTextPage(textPage);
         Assert.IsFalse(textPage.IsPublished());
+    }
+
+    [Test]
+    public async Task Filtering_By_IsPublished_In_Preview_Mode_Returns_Published_Content()
+    {
+        // Arrange - Initialize the publish status service to simulate production state
+        // (in production, this runs at startup via PostRuntimePremigrationsUpgradeNotification)
+        var publishStatusManagementService = GetRequiredService<IPublishStatusManagementService>();
+        await publishStatusManagementService.InitializeAsync(CancellationToken.None);
+
+        // PublishedTextPage is published, Textpage is draft-only (from base class setup)
+        // Load both in preview mode (simulating a backoffice user viewing the frontend)
+        var publishedPage = await PublishedContentHybridCache.GetByIdAsync(PublishedTextPageId, true);
+        var unpublishedPage = await PublishedContentHybridCache.GetByIdAsync(TextpageId, true);
+
+        Assert.IsNotNull(publishedPage);
+        Assert.IsNotNull(unpublishedPage);
+
+        var allPages = new[] { publishedPage!, unpublishedPage! };
+
+        // Act - filter by IsPublished (the exact pattern that fails in Razor templates)
+        var filteredPages = allPages.Where(x => x.IsPublished()).ToList();
+
+        // Assert - only the published page should pass the filter
+        Assert.AreEqual(1, filteredPages.Count);
+        Assert.AreEqual(PublishedTextPage.Key!.Value, filteredPages[0].Key);
     }
 
     [Test]


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/21983 raises the issue that using the `.IsPublished()` extension method when rendering `IPublishedContent` always returns `false`.  In test I found this was true, but only when the backoffice is open.

This is confusing though, for a backoffice user viewing the frontend.

This was happening because, in preview mode, the Hybrid Cache stores draft and published versions as separate cache entries. Only the draft `ContentCacheNode` is fetched, so `_contentNode.HasPublished` was always `false`.

Now we fall back to `IPublishStatusQueryService.IsDocumentPublished()` when in preview mode for content items, which uses the in-memory publish status cache to determine actual document publish status.

There's no performance impact here for "normal" front-end rendering, as this code path is only exercised in preview mode.

## Testing

### Automated

A new integration test `Filtering_By_IsPublished_In_Preview_Mode_Returns_Published_Content` has been added, which failed before the fix and passes now.

### Manual

Log into backoffice, view published content on frontend in preview mode, confirm `IsPublished()` returns `true`.  You can use this code sample:

```
@{
    var rootChildren = Model.Root().Children().Where(x => x.IsPublished()).ToList();
    <div>Found: @rootChildren.Count</div>
    <ul>
        @foreach (var child in rootChildren)
        {
            <li>@child.Name (Id: @child.Id, ContentType: @child.ContentType.Alias)</li>
        }
    </ul>
}
```

