### PR TITLE
Decimal Property Editor: Align step precision with database storage (closes #22003)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
@@ -12,7 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 						label: 'Minimum',
 						description: 'Enter the minimum amount of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [{ alias: 'step', value: '0.0000000001' }],
+						config: [{ alias: 'step', value: '0.000001' }],
 					},
 					{
 						alias: 'max',
@@ -21,7 +21,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
 						config: [
 							{ alias: 'placeholder', value: '∞' },
-							{ alias: 'step', value: '0.0000000001' },
+							{ alias: 'step', value: '0.000001' },
 						],
 					},
 					{
@@ -29,7 +29,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 						label: 'Step size',
 						description: 'Enter the intervals amount between each step of number to be entered',
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [{ alias: 'step', value: '0.0000000001' }],
+						config: [{ alias: 'step', value: '0.000001' }],
 					},
 				],
 			},


### PR DESCRIPTION
## Description

This PR reduces the step precision on the Decimal property editor's configuration fields (min, max, step size) from `0.0000000001` (10 decimal places) to `0.000001` (6 decimal places).

This aligns the frontend constraint with the `umbracoPropertyData.decimalValue` column definition of `DECIMAL(38,6)`.

This addresses https://github.com/umbraco/Umbraco-CMS/issues/22003 and corrects #21769, which increased precision from 3 to 10 decimal places without accounting for the DB column's precision.

## Testing

Visual inspection should suffice here given #21769 was already tested.

But to manually verify. create or edit a Decimal data type in the backoffice and verify the "Step size" field accepts values like 0.000001 (6 decimal places). Check that entries of this precision can be saved on a document that is based on a document type using the created data type.