### PR TITLE
Content picker: Fix dynamic root not firing when inside block list (closes #22008)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/property-editor-ui-content-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/property-editor-ui-content-picker.element.ts
@@ -152,11 +152,10 @@ export class UmbPropertyEditorUIContentPickerElement
 		if (this._rootUnique) return;
 		if (!this.#dynamicRoot) return;
 
-		// TODO: revisit this when getContext supports passContextAliasMatches
-		const workspaceContext = await this.consumeContext(UMB_CONTENT_WORKSPACE_CONTEXT, () => {})
-			.passContextAliasMatches()
-			.asPromise()
-			.catch(() => undefined);
+		// Use passContextAliasMatches to skip past block element workspaces and find the document workspace.
+		const workspaceContext = await this.getContext(UMB_CONTENT_WORKSPACE_CONTEXT, {
+			passContextAliasMatches: true,
+		}).catch(() => undefined);
 
 		// For new documents, the unique is a client-generated GUID that doesn't exist in the DB.
 		// The backend expects null for CurrentKey when creating new content and falls back to ParentKey.


### PR DESCRIPTION

### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes https://github.com/umbraco/Umbraco-CMS/issues/22008

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

Checks whether the content picker is in a block. If so, acts as with a new content node.


To verify:
<img width="1682" height="804" alt="image" src="https://github.com/user-attachments/assets/997664dc-8701-4509-a895-748b4025c5b6" />
prepare this structure. Set content picker dynamic root to Root (editing session) - nearest descendant or self that matches 'different type'. Use the same content picker in the content node and in the element type.
<img width="1683" height="716" alt="image" src="https://github.com/user-attachments/assets/6589b1ca-769d-44be-bbf9-0b5443d079fb" />
The picker within the content node will get the children of the other type page correctly.
<img width="1673" height="680" alt="image" src="https://github.com/user-attachments/assets/840651f7-9744-43cb-9d8a-73fd60b2112d" />
Before the changes, the content picker within the block will just return the content root. After the changes, it will show the children of the other type page correctly.
<img width="2558" height="874" alt="image" src="https://github.com/user-attachments/assets/df422f5c-2ed8-411d-9228-1855690eb125" />

<!-- Thanks for contributing to Umbraco CMS! -->
