### PR TITLE
Backoffice: Fall back to dedicated Worker when SharedWorker is unsupported

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
@@ -5,7 +5,7 @@ import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import { UserService } from '@umbraco-cms/backoffice/external/backend-api';
 
 export class UmbAuthSessionTimeoutController extends UmbControllerBase {
-	#tokenCheckWorker?: SharedWorker;
+	#tokenCheckWorker?: SharedWorker | Worker;
 	#host: UmbAuthContext;
 	#keepUserLoggedIn = false;
 	#hasCheckedKeepUserLoggedIn = false;
@@ -15,16 +15,21 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 
 		this.#host = host;
 
-		this.#tokenCheckWorker = new SharedWorker(new URL('../workers/token-check.worker.js', import.meta.url), {
-			name: 'TokenCheckWorker',
-			type: 'module',
-		});
+		const workerUrl = new URL('../workers/token-check.worker.js', import.meta.url);
+		const workerOptions: WorkerOptions = { name: 'TokenCheckWorker', type: 'module' };
 
-		// Ensure the worker is ready to receive messages
-		this.#tokenCheckWorker.port.start();
+		// SharedWorker is not supported on all platforms (e.g. Chrome on Android).
+		// Fall back to a dedicated Worker when SharedWorker is unavailable.
+		if (typeof SharedWorker !== 'undefined') {
+			const sharedWorker = new SharedWorker(workerUrl, workerOptions);
+			sharedWorker.port.start();
+			this.#tokenCheckWorker = sharedWorker;
+		} else {
+			this.#tokenCheckWorker = new Worker(workerUrl, workerOptions);
+		}
 
 		// Listen for messages from the token check worker
-		this.#tokenCheckWorker.port.onmessage = async (event) => {
+		this.#onWorkerMessage(async (event) => {
 			// If the user has chosen to stay logged in, we ignore the logout command and instead request a new token
 			if (this.#keepUserLoggedIn) {
 				console.log(
@@ -41,7 +46,7 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 				// If the worker signals a token refresh, we let the user decide whether to continue or logout
 				this.#openTimeoutModal(event.data.secondsUntilLogout);
 			}
-		};
+		});
 
 		// Initialize the token check worker with the current token response
 		this.observe(
@@ -50,7 +55,7 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 				// Inform the token check worker about the new token response
 				console.log('[Auth Context] Informing token check worker about new token response.');
 				// Post the new
-				this.#tokenCheckWorker?.port.postMessage({
+				this.#postWorkerMessage({
 					command: 'init',
 					tokenResponse,
 				});
@@ -63,7 +68,7 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 			host.timeoutSignal,
 			async () => {
 				// Stop the token check worker when the user has timed out
-				this.#tokenCheckWorker?.port.postMessage({
+				this.#postWorkerMessage({
 					command: 'init',
 				});
 
@@ -86,8 +91,38 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 
 	override destroy(): void {
 		super.destroy();
-		this.#tokenCheckWorker?.port.close();
+		if (this.#tokenCheckWorker instanceof SharedWorker) {
+			this.#tokenCheckWorker.port.close();
+		} else {
+			this.#tokenCheckWorker?.terminate();
+		}
 		this.#tokenCheckWorker = undefined;
+	}
+
+	/**
+	 * Post a message to the worker, abstracting the difference between
+	 * SharedWorker (port-based) and dedicated Worker (direct) communication.
+	 */
+	#postWorkerMessage(data: unknown): void {
+		if (!this.#tokenCheckWorker) return;
+		if (this.#tokenCheckWorker instanceof SharedWorker) {
+			this.#tokenCheckWorker.port.postMessage(data);
+		} else {
+			this.#tokenCheckWorker.postMessage(data);
+		}
+	}
+
+	/**
+	 * Set an onmessage handler on the worker, abstracting the difference between
+	 * SharedWorker (port-based) and dedicated Worker (direct) communication.
+	 */
+	#onWorkerMessage(handler: (event: MessageEvent) => void): void {
+		if (!this.#tokenCheckWorker) return;
+		if (this.#tokenCheckWorker instanceof SharedWorker) {
+			this.#tokenCheckWorker.port.onmessage = handler;
+		} else {
+			this.#tokenCheckWorker.onmessage = handler;
+		}
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/workers/token-check.worker.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/workers/token-check.worker.ts
@@ -17,7 +17,15 @@ const VALIDATION_INTERVAL = 30000; // 30 seconds in milliseconds
  */
 const TOKEN_EXPIRY_MULTIPLIER = 4;
 
-const ports: MessagePort[] = [];
+/**
+ * A common interface for broadcasting messages to connected clients,
+ * abstracting the difference between SharedWorker ports and regular Worker scope.
+ */
+interface MessageTarget {
+	postMessage(data: unknown): void;
+}
+
+const messageTargets: MessageTarget[] = [];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let interval: any;
@@ -25,33 +33,49 @@ let interval: any;
 console.log('[Token Check Worker] Token check worker initialized.');
 
 /**
- * Define the globalThis object to handle the onconnect event as SharedWorkerGlobalScope.
- * This must be defined manually because TypeScript does not recognize the SharedWorkerGlobalScope type on all environments.
+ * Handles incoming commands from the main thread.
  */
-const _self = globalThis as typeof globalThis & {
-	onconnect: (event: MessageEvent) => void;
-};
-
-_self.onconnect = (event: MessageEvent) => {
-	console.log('[Token Check Worker] Connected to main thread.');
-	const port = event.ports[0];
-
-	ports.push(port);
-
-	// Listen for messages from any port connected to this worker
-	port.onmessage = (e: MessageEvent) => {
-		if (e.data?.command === 'init') {
-			console.log('[Token Check Worker] Initializing with token response:', e.data.tokenResponse);
-			if (e.data.tokenResponse) {
-				init(e.data.tokenResponse);
-			} else if (interval) {
-				console.warn('[Token Check Worker] No token response provided, stopping the interval.');
-				clearInterval(interval);
-				interval = undefined;
-			}
+function handleCommand(e: MessageEvent) {
+	if (e.data?.command === 'init') {
+		console.log('[Token Check Worker] Initializing with token response:', e.data.tokenResponse);
+		if (e.data.tokenResponse) {
+			init(e.data.tokenResponse);
+		} else if (interval) {
+			console.warn('[Token Check Worker] No token response provided, stopping the interval.');
+			clearInterval(interval);
+			interval = undefined;
 		}
+	}
+}
+
+/**
+ * Support both SharedWorker and regular (dedicated) Worker modes.
+ * SharedWorker is not available on all platforms (e.g. Chrome on Android),
+ * so the worker must gracefully handle being loaded as a regular Worker.
+ */
+const isSharedWorkerScope = 'SharedWorkerGlobalScope' in globalThis;
+
+if (isSharedWorkerScope) {
+	// SharedWorker mode: handle connections from multiple tabs
+	const _self = globalThis as typeof globalThis & {
+		onconnect: (event: MessageEvent) => void;
 	};
-};
+
+	_self.onconnect = (event: MessageEvent) => {
+		console.log('[Token Check Worker] Connected to main thread (SharedWorker).');
+		const port = event.ports[0];
+
+		messageTargets.push(port);
+
+		// Listen for messages from any port connected to this worker
+		port.onmessage = (e: MessageEvent) => handleCommand(e);
+	};
+} else {
+	// Regular (dedicated) Worker mode: single connection
+	console.log('[Token Check Worker] Running as dedicated Worker.');
+	messageTargets.push(globalThis as unknown as MessageTarget);
+	globalThis.onmessage = (e: MessageEvent) => handleCommand(e);
+}
 
 /**
  * Checks if the provided token is expired.
@@ -98,10 +122,10 @@ function init(tokenResponse: TokenResponse) {
 
 		if (result.tokenIsExpired) {
 			console.log('[Token Check Worker] Token is expired or missing, triggering logout.');
-			// Trigger logout logic here, e.g., send a message to all connected ports
-			for (const port of ports) {
-				if (port) {
-					port.postMessage({ command: 'logout' });
+			// Trigger logout logic here, e.g., send a message to all connected clients
+			for (const target of messageTargets) {
+				if (target) {
+					target.postMessage({ command: 'logout' });
 				}
 			}
 			clearInterval(interval);
@@ -110,9 +134,9 @@ function init(tokenResponse: TokenResponse) {
 		} else if (result.numberOfSecondsUntilExpiration <= BUFFER_BEFORE_EXPIRATION) {
 			console.log('[Token Check Worker] Token should be refreshed, but it is not expired yet.');
 			// Let all connected clients know that the token should be refreshed
-			for (const port of ports) {
-				if (port) {
-					port.postMessage({
+			for (const target of messageTargets) {
+				if (target) {
+					target.postMessage({
 						command: 'refreshToken',
 						secondsUntilLogout: result.numberOfSecondsUntilExpiration,
 					});


### PR DESCRIPTION

### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #22022 

### Description
It is impossible to log in to the backoffice on Chrome for Android because the authentication session timeout controller unconditionally uses `SharedWorker`, which is [not supported on Android browsers](https://caniuse.com/sharedworkers). This causes a runtime error that prevents the login flow from completing.

**Solution:**
Added a runtime feature-detection fallback so that when `SharedWorker` is unavailable, a standard dedicated `Worker` is used instead.

- **Desktop browsers**: `SharedWorker` is used as before — token-check state is shared across tabs
- **Mobile browsers** (Chrome Android, Safari iOS, etc.): A dedicated `Worker` is used per tab — login works correctly with no other behavioral difference


