### PR TITLE
Dependencies: Update MailKit to 4.15.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,13 +50,7 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-
-    <!-- TODO (V18): Upgrade MailKit to 4.15.0+.
-         The 4.15.0 update tightened nullability annotations on InternetAddress.TryParse, causing CS8600/CS8601 errors in EmailMessageExtensions.cs.
-         We could fix those of course, but this could cause breaking changes for implentation projects too.
-         So this dependency shouldn't be upgraded beyond 4.14.* until we can do a major version bump for Umbraco 18.
-         -->
-    <PackageVersion Include="MailKit" Version="4.14.1" />
+    <PackageVersion Include="MailKit" Version="4.15.1" />
     <PackageVersion Include="Markdig" Version="0.45.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -10,13 +10,13 @@ internal static class EmailMessageExtensions
     {
         var fromEmail = string.IsNullOrEmpty(mailMessage.From) ? configuredFromAddress : mailMessage.From;
 
-        if (!InternetAddress.TryParse(fromEmail, out InternetAddress fromAddress))
+        if (InternetAddress.TryParse(fromEmail, out InternetAddress? fromAddress) is false)
         {
             throw new ArgumentException(
                 $"Email could not be sent.  Could not parse from address {fromEmail} as a valid email address.");
         }
 
-        var messageToSend = new MimeMessage { From = { fromAddress }, Subject = mailMessage.Subject };
+        var messageToSend = new MimeMessage { From = { fromAddress }, Subject = mailMessage.Subject ?? string.Empty };
 
         AddAddresses(messageToSend, mailMessage.To, x => x.To, true);
         AddAddresses(messageToSend, mailMessage.Cc, x => x.Cc);
@@ -45,7 +45,7 @@ internal static class EmailMessageExtensions
         else
         {
             messageToSend.Body =
-                new TextPart(mailMessage.IsBodyHtml ? TextFormat.Html : TextFormat.Plain) { Text = mailMessage.Body };
+                new TextPart(mailMessage.IsBodyHtml ? TextFormat.Html : TextFormat.Plain) { Text = mailMessage.Body ?? string.Empty };
         }
 
         return messageToSend;
@@ -78,7 +78,7 @@ internal static class EmailMessageExtensions
         {
             foreach (var address in addresses)
             {
-                if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
+                if (InternetAddress.TryParse(address, out InternetAddress? internetAddress))
                 {
                     addressListGetter(message).Add(internetAddress);
                     foundValid = true;
@@ -94,12 +94,10 @@ internal static class EmailMessageExtensions
 
     private static NotificationEmailAddress? ToNotificationAddress(string? address)
     {
-        if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
+        if (InternetAddress.TryParse(address, out InternetAddress? internetAddress) &&
+            internetAddress is MailboxAddress mailboxAddress)
         {
-            if (internetAddress is MailboxAddress mailboxAddress)
-            {
-                return new NotificationEmailAddress(mailboxAddress.Address, internetAddress.Name);
-            }
+            return new NotificationEmailAddress(mailboxAddress.Address, internetAddress.Name ?? string.Empty);
         }
 
         return null;


### PR DESCRIPTION
## Description

Updates MailKit from 4.14.1 to 4.15.1 to address a moderate security vulnerability in a transitive dependency (Mimekit).

After making this upgrade I got some compile errors in the internal class `EmailMessageExtensions` relating to nullability annotation changes introduced in MailKit 4.15.0+.

### Breaking change risk

It seems that MailKit/Mimekit 4.15.0 tightened nullability annotations on several public APIs in a minor release.  We've resolved them for Core in this PR, but there's a risk for implementors that may have code that interacts with these types directly.

## Testing

Visual inspection and consideration of the breaking change risk should suffice.  I've verified locally that sending an email still works as expected.