### PR TITLE
Dependencies: Bumps @umbraco-ui/uui from 1.17.0 to 1.17.1

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -3815,923 +3815,923 @@
 			"link": true
 		},
 		"node_modules/@umbraco-ui/uui": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.17.0.tgz",
-			"integrity": "sha512-muFT9Awi05+xP2Dxvkj6pzIypVS+Bbk+UqraM2vTuHg+WEZstLugXnk6PEMwe3KJy2xMA3lM12YWwmgFsPbLag==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.17.1.tgz",
+			"integrity": "sha512-EZauPlrbTb6jjerQXEU0JSnGDAhnc27rJmMcTDBtOhDnU5tOf4Z6H/pVQyMudfF+g6aLAoSTSCOq3nwj5e9X+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-action-bar": "1.17.0",
-				"@umbraco-ui/uui-avatar": "1.17.0",
-				"@umbraco-ui/uui-avatar-group": "1.17.0",
-				"@umbraco-ui/uui-badge": "1.17.0",
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-boolean-input": "1.17.0",
-				"@umbraco-ui/uui-box": "1.17.0",
-				"@umbraco-ui/uui-breadcrumbs": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-button-copy-text": "1.17.0",
-				"@umbraco-ui/uui-button-group": "1.17.0",
-				"@umbraco-ui/uui-button-inline-create": "1.17.0",
-				"@umbraco-ui/uui-card": "1.17.0",
-				"@umbraco-ui/uui-card-block-type": "1.17.0",
-				"@umbraco-ui/uui-card-content-node": "1.17.0",
-				"@umbraco-ui/uui-card-media": "1.17.0",
-				"@umbraco-ui/uui-card-user": "1.17.0",
-				"@umbraco-ui/uui-caret": "1.17.0",
-				"@umbraco-ui/uui-checkbox": "1.17.0",
-				"@umbraco-ui/uui-color-area": "1.17.0",
-				"@umbraco-ui/uui-color-picker": "1.17.0",
-				"@umbraco-ui/uui-color-slider": "1.17.0",
-				"@umbraco-ui/uui-color-swatch": "1.17.0",
-				"@umbraco-ui/uui-color-swatches": "1.17.0",
-				"@umbraco-ui/uui-combobox": "1.17.0",
-				"@umbraco-ui/uui-combobox-list": "1.17.0",
-				"@umbraco-ui/uui-css": "1.17.0",
-				"@umbraco-ui/uui-dialog": "1.17.0",
-				"@umbraco-ui/uui-dialog-layout": "1.17.0",
-				"@umbraco-ui/uui-file-dropzone": "1.17.0",
-				"@umbraco-ui/uui-file-preview": "1.17.0",
-				"@umbraco-ui/uui-form": "1.17.0",
-				"@umbraco-ui/uui-form-layout-item": "1.17.0",
-				"@umbraco-ui/uui-form-validation-message": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0",
-				"@umbraco-ui/uui-icon-registry": "1.17.0",
-				"@umbraco-ui/uui-icon-registry-essential": "1.17.0",
-				"@umbraco-ui/uui-input": "1.17.0",
-				"@umbraco-ui/uui-input-file": "1.17.0",
-				"@umbraco-ui/uui-input-lock": "1.17.0",
-				"@umbraco-ui/uui-input-password": "1.17.0",
-				"@umbraco-ui/uui-keyboard-shortcut": "1.17.0",
-				"@umbraco-ui/uui-label": "1.17.0",
-				"@umbraco-ui/uui-loader": "1.17.0",
-				"@umbraco-ui/uui-loader-bar": "1.17.0",
-				"@umbraco-ui/uui-loader-circle": "1.17.0",
-				"@umbraco-ui/uui-menu-item": "1.17.0",
-				"@umbraco-ui/uui-modal": "1.17.0",
-				"@umbraco-ui/uui-pagination": "1.17.0",
-				"@umbraco-ui/uui-popover": "1.17.0",
-				"@umbraco-ui/uui-popover-container": "1.17.0",
-				"@umbraco-ui/uui-progress-bar": "1.17.0",
-				"@umbraco-ui/uui-radio": "1.17.0",
-				"@umbraco-ui/uui-range-slider": "1.17.0",
-				"@umbraco-ui/uui-ref": "1.17.0",
-				"@umbraco-ui/uui-ref-list": "1.17.0",
-				"@umbraco-ui/uui-ref-node": "1.17.0",
-				"@umbraco-ui/uui-ref-node-data-type": "1.17.0",
-				"@umbraco-ui/uui-ref-node-document-type": "1.17.0",
-				"@umbraco-ui/uui-ref-node-form": "1.17.0",
-				"@umbraco-ui/uui-ref-node-member": "1.17.0",
-				"@umbraco-ui/uui-ref-node-package": "1.17.0",
-				"@umbraco-ui/uui-ref-node-user": "1.17.0",
-				"@umbraco-ui/uui-scroll-container": "1.17.0",
-				"@umbraco-ui/uui-select": "1.17.0",
-				"@umbraco-ui/uui-slider": "1.17.0",
-				"@umbraco-ui/uui-symbol-expand": "1.17.0",
-				"@umbraco-ui/uui-symbol-file": "1.17.0",
-				"@umbraco-ui/uui-symbol-file-dropzone": "1.17.0",
-				"@umbraco-ui/uui-symbol-file-thumbnail": "1.17.0",
-				"@umbraco-ui/uui-symbol-folder": "1.17.0",
-				"@umbraco-ui/uui-symbol-lock": "1.17.0",
-				"@umbraco-ui/uui-symbol-more": "1.17.0",
-				"@umbraco-ui/uui-symbol-sort": "1.17.0",
-				"@umbraco-ui/uui-table": "1.17.0",
-				"@umbraco-ui/uui-tabs": "1.17.0",
-				"@umbraco-ui/uui-tag": "1.17.0",
-				"@umbraco-ui/uui-textarea": "1.17.0",
-				"@umbraco-ui/uui-toast-notification": "1.17.0",
-				"@umbraco-ui/uui-toast-notification-container": "1.17.0",
-				"@umbraco-ui/uui-toast-notification-layout": "1.17.0",
-				"@umbraco-ui/uui-toggle": "1.17.0",
-				"@umbraco-ui/uui-visually-hidden": "1.17.0"
+				"@umbraco-ui/uui-action-bar": "1.17.1",
+				"@umbraco-ui/uui-avatar": "1.17.1",
+				"@umbraco-ui/uui-avatar-group": "1.17.1",
+				"@umbraco-ui/uui-badge": "1.17.1",
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-boolean-input": "1.17.1",
+				"@umbraco-ui/uui-box": "1.17.1",
+				"@umbraco-ui/uui-breadcrumbs": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-button-copy-text": "1.17.1",
+				"@umbraco-ui/uui-button-group": "1.17.1",
+				"@umbraco-ui/uui-button-inline-create": "1.17.1",
+				"@umbraco-ui/uui-card": "1.17.1",
+				"@umbraco-ui/uui-card-block-type": "1.17.1",
+				"@umbraco-ui/uui-card-content-node": "1.17.1",
+				"@umbraco-ui/uui-card-media": "1.17.1",
+				"@umbraco-ui/uui-card-user": "1.17.1",
+				"@umbraco-ui/uui-caret": "1.17.1",
+				"@umbraco-ui/uui-checkbox": "1.17.1",
+				"@umbraco-ui/uui-color-area": "1.17.1",
+				"@umbraco-ui/uui-color-picker": "1.17.1",
+				"@umbraco-ui/uui-color-slider": "1.17.1",
+				"@umbraco-ui/uui-color-swatch": "1.17.1",
+				"@umbraco-ui/uui-color-swatches": "1.17.1",
+				"@umbraco-ui/uui-combobox": "1.17.1",
+				"@umbraco-ui/uui-combobox-list": "1.17.1",
+				"@umbraco-ui/uui-css": "1.17.1",
+				"@umbraco-ui/uui-dialog": "1.17.1",
+				"@umbraco-ui/uui-dialog-layout": "1.17.1",
+				"@umbraco-ui/uui-file-dropzone": "1.17.1",
+				"@umbraco-ui/uui-file-preview": "1.17.1",
+				"@umbraco-ui/uui-form": "1.17.1",
+				"@umbraco-ui/uui-form-layout-item": "1.17.1",
+				"@umbraco-ui/uui-form-validation-message": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1",
+				"@umbraco-ui/uui-icon-registry": "1.17.1",
+				"@umbraco-ui/uui-icon-registry-essential": "1.17.1",
+				"@umbraco-ui/uui-input": "1.17.1",
+				"@umbraco-ui/uui-input-file": "1.17.1",
+				"@umbraco-ui/uui-input-lock": "1.17.1",
+				"@umbraco-ui/uui-input-password": "1.17.1",
+				"@umbraco-ui/uui-keyboard-shortcut": "1.17.1",
+				"@umbraco-ui/uui-label": "1.17.1",
+				"@umbraco-ui/uui-loader": "1.17.1",
+				"@umbraco-ui/uui-loader-bar": "1.17.1",
+				"@umbraco-ui/uui-loader-circle": "1.17.1",
+				"@umbraco-ui/uui-menu-item": "1.17.1",
+				"@umbraco-ui/uui-modal": "1.17.1",
+				"@umbraco-ui/uui-pagination": "1.17.1",
+				"@umbraco-ui/uui-popover": "1.17.1",
+				"@umbraco-ui/uui-popover-container": "1.17.1",
+				"@umbraco-ui/uui-progress-bar": "1.17.1",
+				"@umbraco-ui/uui-radio": "1.17.1",
+				"@umbraco-ui/uui-range-slider": "1.17.1",
+				"@umbraco-ui/uui-ref": "1.17.1",
+				"@umbraco-ui/uui-ref-list": "1.17.1",
+				"@umbraco-ui/uui-ref-node": "1.17.1",
+				"@umbraco-ui/uui-ref-node-data-type": "1.17.1",
+				"@umbraco-ui/uui-ref-node-document-type": "1.17.1",
+				"@umbraco-ui/uui-ref-node-form": "1.17.1",
+				"@umbraco-ui/uui-ref-node-member": "1.17.1",
+				"@umbraco-ui/uui-ref-node-package": "1.17.1",
+				"@umbraco-ui/uui-ref-node-user": "1.17.1",
+				"@umbraco-ui/uui-scroll-container": "1.17.1",
+				"@umbraco-ui/uui-select": "1.17.1",
+				"@umbraco-ui/uui-slider": "1.17.1",
+				"@umbraco-ui/uui-symbol-expand": "1.17.1",
+				"@umbraco-ui/uui-symbol-file": "1.17.1",
+				"@umbraco-ui/uui-symbol-file-dropzone": "1.17.1",
+				"@umbraco-ui/uui-symbol-file-thumbnail": "1.17.1",
+				"@umbraco-ui/uui-symbol-folder": "1.17.1",
+				"@umbraco-ui/uui-symbol-lock": "1.17.1",
+				"@umbraco-ui/uui-symbol-more": "1.17.1",
+				"@umbraco-ui/uui-symbol-sort": "1.17.1",
+				"@umbraco-ui/uui-table": "1.17.1",
+				"@umbraco-ui/uui-tabs": "1.17.1",
+				"@umbraco-ui/uui-tag": "1.17.1",
+				"@umbraco-ui/uui-textarea": "1.17.1",
+				"@umbraco-ui/uui-toast-notification": "1.17.1",
+				"@umbraco-ui/uui-toast-notification-container": "1.17.1",
+				"@umbraco-ui/uui-toast-notification-layout": "1.17.1",
+				"@umbraco-ui/uui-toggle": "1.17.1",
+				"@umbraco-ui/uui-visually-hidden": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-action-bar": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.17.0.tgz",
-			"integrity": "sha512-H63V908ANYhbVeeLeoQ7qpkOWRs+Aka5M/Qe9OvA1R06EwNvBGs1Q9TQisecjCwIqBpgc0zTDprPLNofBBLmHQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.17.1.tgz",
+			"integrity": "sha512-68ZZmnfxr4TaiclPGntUCiM/XYRvVkksOqaTiUjgKLDKj36v4qTT5qak1qKrDicOjkkooKWUj3/OdmOv39QZVQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button-group": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button-group": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-avatar": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.17.0.tgz",
-			"integrity": "sha512-wMAmBVzvRLZm4TJUPxaPBdnMA7pcmYl2UXRMOJeCYsNd4OJ+3dEMA/OausAfQTicqUhWPaJ//H8q6co4biLB0w==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.17.1.tgz",
+			"integrity": "sha512-OLNRdRLazTS1kUa59GaSLgOKshXyS3NvGH2xjjmKuMILWQ//cpaPV7oShkMAJSNiHK7kiVjYs6JctO31bjaD6Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-avatar-group": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.17.0.tgz",
-			"integrity": "sha512-N4fY1+4EzFjvJGf3akU1epKQopbOPG2JNhmZ2kStJ7YrVWkea7ACszk36KYRxHrRHuS66SHZQ7R0IQgTrDIIkg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.17.1.tgz",
+			"integrity": "sha512-bOSl8A65q6JW0Jz4hPuhxBL9JI5tZiSHb2Jt47hD32SX8jQ5pkgpoQGrYFPEwMQVPb5q/1wl1aXBOh1sRN1p7g==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-avatar": "1.17.0",
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-avatar": "1.17.1",
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-badge": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.17.0.tgz",
-			"integrity": "sha512-1aMbiQvjmo9gY/yxW3em7faGGqF/BftDisQTHcaNa0lsJsgFZt/krz7Z5AbVY3dTr8SnibBzcyX2DZQVv9Kv+Q==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.17.1.tgz",
+			"integrity": "sha512-BVM6thjJouNm6IgXKqzZrfQQo/AT5Zdk6xKRbKI7QVEUAqNpHif3pd6QRhoja8SP2Ve5EvVJWuBWRn4ci2ZTIA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-base": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.17.0.tgz",
-			"integrity": "sha512-BrZWefmFHYKMMY+K3Tr1dbj5BM6n3Imicm51yNcN6Cxr2MGT2X/9Rks5J8MFyHrbOBJjOSZViKJvtphGi3zjMA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.17.1.tgz",
+			"integrity": "sha512-FxgtSS3YMza+tBDqZBE0ePQ5sYMHNJpC9yUO+nr/ZcYvgIh0aRMI32Af44PpXYXWB5E6wZU7QbucOIIfy2wR6g==",
 			"license": "MIT",
 			"peerDependencies": {
 				"lit": ">=2.8.0"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-boolean-input": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.17.0.tgz",
-			"integrity": "sha512-Ci6CZ8PnYQrLtD21qeXw261D5JhMVF7xozY6CDfdXaGkZAA6nwjh+AF7QODfxnglPmdlfQGiK56mnnhkzl7ulQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.17.1.tgz",
+			"integrity": "sha512-jsdkpqfVgTiZlfAFQ1lZc8++VHyfZYKFhbDmJQWDF++pX6gSSLLJZD77ZBkP7rg3vFNX023mBEyQ1OtIFG1PfA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-box": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.17.0.tgz",
-			"integrity": "sha512-piMqOMxv/jRoYnyURkTLSevYXXuLlqz4w1HnfnE8u6Vq2sGq2jcg8y/6SBj7CmZAmERla0HvGutm3OJ6OenHMQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.17.1.tgz",
+			"integrity": "sha512-/wGyJHDnAIRFLjki/iitIjxJUd/mxzUNtOOS8B6hbf5R759yG8uPNKV8QGXJaDJ4bQ1oYsKkAOiDlO4EqN0N1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-css": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-css": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-breadcrumbs": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.17.0.tgz",
-			"integrity": "sha512-GkWQtbGtcXTzEaf63YdP/sHUzIYCoc/i7d9FF2Nz0yv9zvJuD4TFaA4Nq8XpOlIN8L4O5DkquKO1hX03y59dkg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.17.1.tgz",
+			"integrity": "sha512-yh6AEH/zrxHhMc6Pvq0w6DEhbMbJxSyjh8adOtUEQu7RCLbIh1by8714x7mlucNLqlIrMtsjN7SzxcNpFaUeyQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-responsive-container": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-responsive-container": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-button": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.17.0.tgz",
-			"integrity": "sha512-HR5KVMVuZWSsUXfa2NjXj0eRYILmugYF/KmbgzYtTZtqnLb94+8sy5iPnmsoFuBPp0Idng2toHrjOw31kUBB2g==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.17.1.tgz",
+			"integrity": "sha512-E0zFbw7efofIZHg+UFb2UoSqGGIzzI0xFsY/NncHtdu6A72F2x8QkXY3NjB0tRKUba2o96fInl7EB7vEuRK0dg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-icon-registry-essential": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-icon-registry-essential": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-button-copy-text": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.17.0.tgz",
-			"integrity": "sha512-eS7w7vSGmJVJfdKst8g5ZftgSH/EvYJ9ejdAFMTnyTehEvT1aF8hdIuraC7RitwJUc7JlUsC0BXxVBCrycpVvQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.17.1.tgz",
+			"integrity": "sha512-sFCj8EZBcOUgfn+xIxbd+meO7ySoR565+WSFl6gjrRi4D/kq4m905yWuqzh1HJ5ftdpIK2MR4Twf59uve4UdXA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-button-group": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.17.0.tgz",
-			"integrity": "sha512-bOloGGU1wuo5kc/8KWmRfIlahgK6ooLfMYSMWK6u2WdVja0ncBB3sPPvDspjsosaQoZlGWhss/8oWZr3JiHYuQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.17.1.tgz",
+			"integrity": "sha512-OEkALhfeeMgicPyoYvX7SCi6zlJTPuP7IbwskPE9Fb3B9JcFLVIqhTjAbd/xegID8rIp0prkPOyLDM8s9HM/QA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-button-inline-create": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.17.0.tgz",
-			"integrity": "sha512-4oRI9TtA68KniTWOMP1ldq7ooGvjYcPaVrgurn9jNMJyEfGu4spT2y6izgsWfxmODambVNXwzBhvuwmgGODYLQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.17.1.tgz",
+			"integrity": "sha512-ZRILOHOD9/VuV0slHioiCMwMkZUecAC0IIQ8AkYf4UYlL1MKz72a0YGe23CmIP31DDQVznX3Cq7UXTYRbuwQdQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-card": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.17.0.tgz",
-			"integrity": "sha512-wtTHUlTjy1Yz5T5Vhhj55Xef5e1drY2O2HDf4QAof1rwxO6zwAJoZpf5c566Xn9c0Yrso8SqjKMeiss4atTexw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.17.1.tgz",
+			"integrity": "sha512-xLY8gYUkYCycozxvY8xY+XeVTwC8MkrQDquk7fZXQQm3pIEffAW49bvusz7l6NK+jOStgm8xtIBLebqfzyDzgQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-checkbox": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-checkbox": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-card-block-type": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.17.0.tgz",
-			"integrity": "sha512-d98dQo9FpFQq0ifjuuOho0K0DB+y8ED9yk+XXYb6uP4qK7BY22utGBWeqjZtZpQtm8E0qd6wR46e2taz3Tc4Zw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.17.1.tgz",
+			"integrity": "sha512-vHiZMj6o4vadhqF8jP+SuHAh8y+1sDHs3Npld++/IM6TywsFiA/FDAFZO91CFZhho6VVe1Mn/oFRZZMeM+ancw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-card": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-card": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-card-content-node": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.17.0.tgz",
-			"integrity": "sha512-5Mqb2qKy05pi7c2inure6wvtet2ybYm7jfzO+J2MYYzjMRWj3Fhp72JsivZAS/gY9/POHz3Z2wbQg5JCmtauwg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.17.1.tgz",
+			"integrity": "sha512-cMpBJav1elSJLCS71cJ3RTGSCKjp95K4yHO+OulCdR/PZNvV5BR+5Gi72riLlnAYuj9ACvA4aFdGixYyHSZJ0w==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-card": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-card": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-card-media": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.17.0.tgz",
-			"integrity": "sha512-CHG7mmIiKwsFI6of7gYwBVwc5ssBfpZysqt82ELw62srKSo1w5Vu/U4KRY1ysb9mE/DJ+1TOu/ZTpj2eZw4JTQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.17.1.tgz",
+			"integrity": "sha512-cF3RtY1wiedE0TJlEtpMKGGbDNTQnYehWARpa+6pY/b0vFOQDR0qmrqpfKzRugd77JLIM/QGbvvPs78jRShzbg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-card": "1.17.0",
-				"@umbraco-ui/uui-symbol-file": "1.17.0",
-				"@umbraco-ui/uui-symbol-folder": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-card": "1.17.1",
+				"@umbraco-ui/uui-symbol-file": "1.17.1",
+				"@umbraco-ui/uui-symbol-folder": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-card-user": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.17.0.tgz",
-			"integrity": "sha512-oCnZuIMpGaXTN4Lr02LQ9DN79AlXiOuNqkFrQqEhiTxRIPhczjkqOUZbYFLG8AFUC9nCjU+1OKs35GmaTVB4SQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.17.1.tgz",
+			"integrity": "sha512-8nMPjc2kkcNP0F+PdSwhaELXVAH7gGj+A64UOR7oR1uVROVG8IJl3d4IGTIWg5QcC13ZxP7yJZe+y9kiN5D9fQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-avatar": "1.17.0",
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-card": "1.17.0"
+				"@umbraco-ui/uui-avatar": "1.17.1",
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-card": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-caret": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.17.0.tgz",
-			"integrity": "sha512-zlvDEiIn0iHtJkrl0/mFr83+uMDllF7Vv9RN7fHsQPJS4G4k6fGrIJAHzVvYaP/aDwZTMuxRYEjJcGSQFlmdeg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.17.1.tgz",
+			"integrity": "sha512-FHJwZhZ0WofbSYKrGRuk/zLnc6JTJYrgOTrSauU8eHWkiBc898l7gYZD4Ng1OshU2lu2VNytpCB8YIWV0m0gnw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-checkbox": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.17.0.tgz",
-			"integrity": "sha512-mp6DsoPKIgaC64PZ/rvqQoTmOXSEB4bFb8HYE4IBWWq6CSbNoAgmpZeMAAcaxjigE7GYifC3apjf9WFkSSKj3g==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.17.1.tgz",
+			"integrity": "sha512-1b5g34xPlUK40KyZUjXw2qaWXy21gXUpVwlZcFqwuVOxmHonKcpyQv71wTYlQXzCCw1pj7VnJB4waz4G97NduQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-boolean-input": "1.17.0",
-				"@umbraco-ui/uui-icon-registry-essential": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-boolean-input": "1.17.1",
+				"@umbraco-ui/uui-icon-registry-essential": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-color-area": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.17.0.tgz",
-			"integrity": "sha512-lFxlz+vamU09b+qkmxL1mWsjMFieEeeJunr6QZHMAaZAUsicUy9zbnplkbgbPRjfkpK8ruX+4Q6LfxtDsgtXnA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.17.1.tgz",
+			"integrity": "sha512-8dA14Brz19MZq38KuGDMm/Czv8PZA/s4y5aLe1SbIaIipYraDY96mNo0yDZa19XIReWalI3lIgwyF4A1L+34Kg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
+				"@umbraco-ui/uui-base": "1.17.1",
 				"colord": "^2.9.3"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-color-picker": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.17.0.tgz",
-			"integrity": "sha512-bW2QCl6DwPPcjswLzPsC/U3vsCLG7PtF4VuFx54qel4Iz0WgBjfHEwoExu1RF+hGvHlYVe2vtbBlJFGbD9AD7Q==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.17.1.tgz",
+			"integrity": "sha512-e6u/TFjx7kKQRcVMM3Syu/CGREhK2XGx/0VW5rAFB9U08BYEXHZr25JDM71Dg1J6+bClyXeTAvda5a63KdvwuQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-popover-container": "1.17.0",
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-popover-container": "1.17.1",
 				"colord": "^2.9.3"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-color-slider": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.17.0.tgz",
-			"integrity": "sha512-ypnBgYCwROFPS8eEn00OgfeihQ4j/uy4ARMYjeC3HV4Lmh+ieZGohNiRWagJDDsEHpp2Lqgm34jO0dOBMPVV5g==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.17.1.tgz",
+			"integrity": "sha512-c3MAUuTnQ6foAPM0xm4YB1a1SvJSQS8I4Vf+1y+URBE51iu/59E00NnT3Z/HdlNlKwoMygmDcUzYtyw0PQaCFA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-color-swatch": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.17.0.tgz",
-			"integrity": "sha512-4vuyMKw3nPNyNPQ7ABr+5c+XIL2y9v3eInm16H2H9O2n4RVm7+fYvlQKCDOTqdqTTZ6bW5T4yVa5incCBTTM/w==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.17.1.tgz",
+			"integrity": "sha512-RZj4gVEBj4VGELZgIcR5xi9uQvHPnXJA2nrPPsXrQV1C8UoDX6/sLRIZYPAVPVeW7ZNOXW2jzYrIwNnT0F8k3A==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-icon-registry-essential": "1.17.0",
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-icon-registry-essential": "1.17.1",
 				"colord": "^2.9.3"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-color-swatches": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.17.0.tgz",
-			"integrity": "sha512-7yCXo+3xcyI/Qk/6P7k4nscxV6j5xmF7mDX2LoVdaS/UPm7N/2exv9dkcWAVQ1Wr1lRo0Macb3geHlfGCuc05w==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.17.1.tgz",
+			"integrity": "sha512-rtZ2ACIpqfAA6kYG+qzwT9rG/nzgrXLgTCXQhUOkO96/xI5a9SyO/D7J0OA56tCkcqFrAafZaUww3zf10coWCA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-color-swatch": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-color-swatch": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-combobox": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.17.0.tgz",
-			"integrity": "sha512-lIQGDN2TkFuB2IdraRb+FkqCN7FT0oqA9DAuMJOMzHCh4DKOAwj/wocGvIUVaIjSuhgOb724kz41kgwLFCdcDg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.17.1.tgz",
+			"integrity": "sha512-ReNLnGRzsNetWDwbWYoSm+fAYiuTXLQlYebHSmMxtHdwopMbNZ62kgHosW6K614n+eHEJtvgPFYnidsWLG3kRA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-combobox-list": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0",
-				"@umbraco-ui/uui-popover-container": "1.17.0",
-				"@umbraco-ui/uui-scroll-container": "1.17.0",
-				"@umbraco-ui/uui-symbol-expand": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-combobox-list": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1",
+				"@umbraco-ui/uui-popover-container": "1.17.1",
+				"@umbraco-ui/uui-scroll-container": "1.17.1",
+				"@umbraco-ui/uui-symbol-expand": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-combobox-list": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.17.0.tgz",
-			"integrity": "sha512-KJgup/oQ00ZwLA6VwK6dbgLsDY69vphdQ+INDtEwcey3lxRMSvvMXDze0sz8+9k1ecKrCYHH77OR52rCDZhchw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.17.1.tgz",
+			"integrity": "sha512-4ieGHi0UcnDHTnOHNI0d2dt357hSDSkf4y8ovfaJaOS+dfG+iS90o6mMOIP2mRd9kEYqjkxjUSmL50PiyVK/Qg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-css": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.17.0.tgz",
-			"integrity": "sha512-kwsN4ODQK21goc0QmWrbQVrt10iFUzOXxXqdeQXeshqGDWS3/3T6xik7NrrcAWecGo/PZ5vlwadcTRo4sw+OoA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.17.1.tgz",
+			"integrity": "sha512-dEDDZMREcHxOmrJf5zChOUgRLyIFD+HVUoZiRvElwvbNY7u5Y+CGFA5xQqpw9SEN4aI2vVbmO4YwB66WiZ/IGw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"lit": ">=2.8.0"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-dialog": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.17.0.tgz",
-			"integrity": "sha512-H2tEfieP2BRUdA2DqFNCfpE+57w/Dwdmerkhn+X41exI+icRU38P0IkC+b2rC2kbOpx6gPWOv1+JjZQprRpjdg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.17.1.tgz",
+			"integrity": "sha512-vWVWv1o27YmMP74JpaW3qiUXv8VK3oVofSpTINOgLg5QQJ1WnAfD5wc2kCxJqCl/AVhxbbTdLIu1yn418rvNAA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-css": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-css": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-dialog-layout": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.17.0.tgz",
-			"integrity": "sha512-FEpJR7FC5mbeeP9ASnFaaHKQ3GCbjhiZXP21x/SpcmFnYjJ7meXa9yrCY+CO0FqxdkQS23Ovn4z6Ib4l04djJg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.17.1.tgz",
+			"integrity": "sha512-7c81aiiWlaLXIDo4uVu1s9GW2cP8cT94q0sa8B29iGplRYGHrv1IBBC5IejCFNopH6GRb7LnzXCTG5A7f1COTw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-file-dropzone": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.17.0.tgz",
-			"integrity": "sha512-8I8I9mCnFwiOJ2h244Q8BcMjqWhsLWteU53t/+eoeMHYwHC0pfyqtxZ0Ly4hNgn1GEATFy2LOy2ctoPl7VHiSA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.17.1.tgz",
+			"integrity": "sha512-205s3p9w7y5ZhoMf4RcNmanVSPPgEqgZaf0Gl8b4+Y1IiOJUjVrCriil4SVsiyitzixG2/CH5u10lS7JggCSYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-symbol-file-dropzone": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-symbol-file-dropzone": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-file-preview": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.17.0.tgz",
-			"integrity": "sha512-ghw/5b6lMT0v0nYu5zBqUH6VcBJoX1YCoBmnrbB9wmp4tLrTgKc+ZFeL1fJ1SEBbn3ETxjePmNge1B3i1usZSw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.17.1.tgz",
+			"integrity": "sha512-LgzHJiFJ6DuAxnA33DCwHv/kx7ocaBCSt5nrcGZEpNPOQATMkoaQdzUS7tg5ssphFNSTh3YFwzBSQliR7IILMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-symbol-file": "1.17.0",
-				"@umbraco-ui/uui-symbol-file-thumbnail": "1.17.0",
-				"@umbraco-ui/uui-symbol-folder": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-symbol-file": "1.17.1",
+				"@umbraco-ui/uui-symbol-file-thumbnail": "1.17.1",
+				"@umbraco-ui/uui-symbol-folder": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-form": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.17.0.tgz",
-			"integrity": "sha512-7hmw+rCRk2QZhflO9cOx/q/NI7vNF6Md+0130L4IpRsar5kXjm0JM61tmFtghvRH12zuXWXTjV9IhswqEdU8yA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.17.1.tgz",
+			"integrity": "sha512-SxMBq+KUk63+boIk1TbXd0AoPDqDtv+SOExmEKy6nRPaZrOyLqT2M6Q9NWf8Cz8geO99g+6kyImzEvrgG/cR/Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-form-layout-item": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.17.0.tgz",
-			"integrity": "sha512-SosvBH3DfhEVWMjaKLu7rhYWzecI70c/OnKyD2I521n0v9H15Gor4vvjTihkcBsaDDGTq00dnC0JRtbIAjSJZw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.17.1.tgz",
+			"integrity": "sha512-nYb0jvXXaNkn9of8ZxASjnrlXODzZxaPJIV5nhyOtBFm+euC7Rm9WNHcXrY+lQA+hBDv+T0Hmi3dICIjMioCpg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-form-validation-message": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-form-validation-message": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-form-validation-message": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.17.0.tgz",
-			"integrity": "sha512-E0zQcqXORTnHwP13lHOVX8PWOKb2t0aGSSId1/1fBtGWHdn1MtaWdO5Yt94zVR+r7rQhMlEOl8DEzQwQwxuSWg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.17.1.tgz",
+			"integrity": "sha512-imVlxMuU8HRpB/zuhHfEjl3FNi0oZYcw7SroWGfofAzjCJ55H24jEJLsrMNyP42AQp6HF2mDsUUMw2dKQt2Zow==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-icon": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.17.0.tgz",
-			"integrity": "sha512-pvBq+NeLlHFAudg5NMySLR10EVmOGFfMamRH8zHcxi5xiqf1T6BYSkXlw2xZe8nV4OGoxKdFr4DXvHP8hcRdfA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.17.1.tgz",
+			"integrity": "sha512-F929f/qhQhStwX9CSQIf8qR7QZs9RP4MC7+s1FawxGOVpgnELq2bcuZ6l8+aF6eQ/z2DIid+57xRfWtMYiTPdQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-icon-registry": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.17.0.tgz",
-			"integrity": "sha512-ANre1ws1X7OxKgOURqD41pywBzJ0agXZEYjxBExT/Zpewkx/WpSQK9KHofqRyZp00KHsTnz4bxO1ppcDK05oRA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.17.1.tgz",
+			"integrity": "sha512-khEP/4/BVxVjmOa3OigCvL3k4SjYq9ZD6PnHCxRxxWnEQtBVLaC8bkW2eEqq4TWzP5hyRwKCrdG5iuvO5rpR2A==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-icon-registry-essential": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.17.0.tgz",
-			"integrity": "sha512-4+MhgYB/ezeOv6N3edHL1BwlErXkUWPGbT12P5sOMm28ZJHl0Z4y/t23/JKVcMUK5u7L1N/lCpRGMkOfvx3LvA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.17.1.tgz",
+			"integrity": "sha512-b2moTCpLRjlWUZ82/x3b0SGz5xlrYxfj9mvhKIQU0f0zXkmKW4peHLwWeu6E/AItwwNy3vLqOdt1dHAPP1dICg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-icon-registry": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-icon-registry": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-input": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.17.0.tgz",
-			"integrity": "sha512-yXfWU56fCzmFmYfYuMKwAqGswOkqm9cSsulHoGyu3R01vjeK/SU6PhuieX6aQg4iFEmp0M02gan96eJQQSupcw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.17.1.tgz",
+			"integrity": "sha512-ozK5ezqwnt7sZ55r09D81zddVt803y8CaVW+b39LZawDn7QAGpAVbFbtxH+pmDvgzxSAERetCovcvTBA7y4G4g==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-input-file": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.17.0.tgz",
-			"integrity": "sha512-IVifm6WnhTCaPkhfcWxy8jxNz8qTuTK5pcF7+93QPHP62LZ0W7MJ3S8C0Ia4KXhyxnbt78QZGYDNkZGWY0q+vA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.17.1.tgz",
+			"integrity": "sha512-ZvBQ7rrpYnNOcjsNTl8mYp/UjdcKoIu1Afp+nbnoZ6cuDYYw0Cc5tjbvKxEbOp1sgo8EoHirKH0MZUUWA4PTFA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-action-bar": "1.17.0",
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-file-dropzone": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0",
-				"@umbraco-ui/uui-icon-registry-essential": "1.17.0"
+				"@umbraco-ui/uui-action-bar": "1.17.1",
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-file-dropzone": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1",
+				"@umbraco-ui/uui-icon-registry-essential": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-input-lock": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.17.0.tgz",
-			"integrity": "sha512-7BNc+a4VnvxKGazTk51qXCuJDV3XIfJf4ZhGWSgLjJFSwY3ZXniiaR6mrivbw7ryqAtkkJvVlPJpwwpjgg3h3w==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.17.1.tgz",
+			"integrity": "sha512-DNciBLbkWA1ogMrY2aOnJYsEQuM7g/2OQh4leu3kYo2O2YPOSDaMMucmsSVByqSXb6x90mrmGDj5bXFZIRaedA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0",
-				"@umbraco-ui/uui-input": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1",
+				"@umbraco-ui/uui-input": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-input-password": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.17.0.tgz",
-			"integrity": "sha512-Ds3KFEp6Ja/o13EMrcvtSr+5koLNC0ZmXRvbQqCQu8r7AASGb6kFLoUbjO5fF1y7KCmm5BMhJyHnLCndo2CmCQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.17.1.tgz",
+			"integrity": "sha512-SCrkSZ4w5KocTi5LMdyDi4/bclnKPtww+M6bnUJdPSUCcGdDZw2Dmzv9aGatxBrVEclH19GKc57If6kOCrayGw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-icon-registry-essential": "1.17.0",
-				"@umbraco-ui/uui-input": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-icon-registry-essential": "1.17.1",
+				"@umbraco-ui/uui-input": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-keyboard-shortcut": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.17.0.tgz",
-			"integrity": "sha512-wXOYHih/hWE8WEVan5JSAT80nRaGEjya7xGU2qI4YVX1Hx/ZXlz4GRJHuwOXjZcBw7PhefLZ8iJafDta47dbkg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.17.1.tgz",
+			"integrity": "sha512-qUmP4NZLXupxyVP5aK8bur+GbEDFFcutJZvhCsHre6FbwWdGtJl0GhseNrZupD5o1anTJpNfzL9cZHbb/E0Kew==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-label": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.17.0.tgz",
-			"integrity": "sha512-5F45mWzb5FEnBuTfFnXjIAH9mIW7nDxnTwop54zemkzZ150Oe/JSTITkKNYtqdEDwLbT4BtNMMjWbIJsETI8vA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.17.1.tgz",
+			"integrity": "sha512-IwMOSq3KhMfIpW8e/cdfCZulRX68ZcT/V9ZfQPg9JmytFNfIOEpP0PtmfazDbPeZLyHoYMqXq6qVyARV9/YEqQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-loader": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.17.0.tgz",
-			"integrity": "sha512-Q3rrmb94J6b3cAlzfTV1rtzpMc/yIWSCaPmYBDb/XxNQgdwjpJYxUhMNJjnEFLV3btsgTr1fnljlyXiQgYrNMA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.17.1.tgz",
+			"integrity": "sha512-/2azZuHDYSHFyMnro5IrPMspV8XEZP6F+GjTXJcbayQOPneR7Gg+g6pbyeRqRcoDe91h8l6dQ6FNwkuvTQEMLQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-loader-bar": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.17.0.tgz",
-			"integrity": "sha512-y5xQhC9eY8lghW7q3ro3xOz1DkCBa3GgEZNnjsd3kQH1IhYuGuxJaUCk1tlx861N9vDBg1nbRaE7noRpuEg/rA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.17.1.tgz",
+			"integrity": "sha512-/6YXfo1RqRgi70nTowCdzzVJgJNzs/UTIHnr972Xly8sqlOQPqX1caWPqPgnc8PS0izh4b1PBq3t9gQFvWQyEg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-loader-circle": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.17.0.tgz",
-			"integrity": "sha512-vFUguSfTMgrYCXG2hIXe9NlnlelXofQoqdIOtlwTg6dMJng/hFldWJwDSvayhaBWUICcSDQo16j88uatox/giw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.17.1.tgz",
+			"integrity": "sha512-/9Q7NlLDHDhX03NuqlDAZiHKIMYvVI9fXGvrPmoCQu9c6qjN0NkPSQ474EONyHcm93zmOjZNZRZqXQ7n6VGb2A==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-menu-item": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.17.0.tgz",
-			"integrity": "sha512-Knx8Fds7HdaGlt2Vd/HXZEH/1oDGkvtURkTKyuyj/3gsVn7EDZUCn2fsLf8Hv8OouuPij9kLxWnH+pOfXwvRhQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.17.1.tgz",
+			"integrity": "sha512-S/FjXNuOWN8OGquC8FzVVOuE0pvhQeR3RCgMo2/v4w5f64jhCFLKn2qX/nHeaZLs0gVdPMf5aIS6AZNDX6erDg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-loader-bar": "1.17.0",
-				"@umbraco-ui/uui-symbol-expand": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-loader-bar": "1.17.1",
+				"@umbraco-ui/uui-symbol-expand": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-modal": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.17.0.tgz",
-			"integrity": "sha512-nJ9XXwqSi0sJyZKV/Egyq1PAVeKUABYzlZjeqfgstPeCBkyBxvfk5NAOv8zXG7Insvn6YuydZc5uN1BWK9riCw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.17.1.tgz",
+			"integrity": "sha512-pWtuzqoNVJgBMnetwlpicvCAvycMxITrnb6PzRZYBl7qPBm6AC+pqGGmuFXJ2rJEcMmND5nidv0rhQlTIl74XA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-pagination": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.17.0.tgz",
-			"integrity": "sha512-6Bdz/t/7f6LugzUeoN6VUoKbW13W1McGJjV3hO7sfx85ZjxFQiLG4vmPtPGCJCfPfRBHQvmToyX0wXx8w+Xdfw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.17.1.tgz",
+			"integrity": "sha512-Me8xi6O5YA05Uyz1x5vw4WX7422Fr3S7LOF0rCnVrkB0Uobn43VYUBXVc5MYGkfZWX5R1vclIYzVfPF5V7lByQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-button-group": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-button-group": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-popover": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.17.0.tgz",
-			"integrity": "sha512-5hKfPqRjx4Tvsjd8GWmL4erkp4JZJkcgztuEoQhUFHjrSxie0miQtnuC3cDfgDyEF3s/khzff72wIys0djjOwg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.17.1.tgz",
+			"integrity": "sha512-PAkm7T+VFaC2QfkO5km+3Aipjh8qybfFhQVs+q8Ax20+bDeis6BwUgsor0lhWqydfZ1CeUTGl+UmcL6421szpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-popover-container": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.17.0.tgz",
-			"integrity": "sha512-UJkuxwdSBK5tDjYrrxT2yiNwiZ5nXl8Lj4tffFaSx4rbmrBWIq9md26AiTzRWn0ftFZ+Shq4iKT/sR82jyNHjA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.17.1.tgz",
+			"integrity": "sha512-QBIx9IEo5pYmxTujJUAB8aJFdfzrSQ6M8IMCatzqMDjYbpQtPNVxgwcyEQtAi7QqGptMYg1HLO1W8yBKS3RsDA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-progress-bar": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.17.0.tgz",
-			"integrity": "sha512-7S801vwKMi+uczvi8tBy7umUNEzLGOa/OqeshJVNlGbzTGP4BasIHD8VbVO3mTVEA0gIawuItnzfaPN4uHknNQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.17.1.tgz",
+			"integrity": "sha512-PrTDOE0+P8DlD2ldbKwYKGCbwZ2nyKbvHXu6xo3xVBUcMOrv45VhoriMOYKdV2C/5plbwGnquPGgWkwkr1G6Dw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-radio": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.17.0.tgz",
-			"integrity": "sha512-nr8sfsNsHpDeGLqRMSoup3hs5r8HkkGZJAkYEMtn3bFUvVxL7NwdqwHS81cseU32A/7DeZNoda4GgKE9wimyPg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.17.1.tgz",
+			"integrity": "sha512-JnW80tmMv9HIfcTsQ5OlATbPVjG19JpPyrYLlsf71Bxniypo28ebuTd86DI9Sem/DuNZi6f+095Pia5WN3P5pw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-range-slider": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.17.0.tgz",
-			"integrity": "sha512-Kib3Nr9XRnhpIbLsgmhabUOJUfMTLg0LcuI7ykeP9/70JLKNwMU66KNwIjNgkicEe43TxFuJ5MZx+i2FY+a83A==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.17.1.tgz",
+			"integrity": "sha512-QRPLa4bma4JAWl0P0oAxTYx+CEDAWr9IDbMWkmy5vAUk2qP+f1cyTNeBjp0+HEQF2egRPxTXOcvY8j61CUxKyw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.17.0.tgz",
-			"integrity": "sha512-6JVtMsZ2u7DBG//bfo+JwPGGu8QQ8Wsacv0/wbHjvfMbQSJoN4YD/iJEV8jqn1M9wNrUrMu8E0Hp0rNtotpAPQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.17.1.tgz",
+			"integrity": "sha512-97wfC73BdM2CSwuS2a5WZy7o1oqNTwWsNNZGJ/2NQC/KiwHGOJOv14xwJtXvtRm8xE5zXk4eNd7OGo2QANyRkw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-list": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.17.0.tgz",
-			"integrity": "sha512-ZaG2ddLHTvFCHO6RZ2DxChivLjRUFM0pQKCuLj4S9Qn/9Zn2Fui+fBcHWm+W6k6GdJq5YDHWb0fH3nT6c3S5Lw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.17.1.tgz",
+			"integrity": "sha512-xcYeo4Es1+GZTLx8VSCbofbUgpw8vBFeuLb3r4+Iu/7GVwYCINmgLlbzKC3YYYCpPLjaEu7cybkhUjZOLoEjRg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-node": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.17.0.tgz",
-			"integrity": "sha512-ZnCvK+6A73q+fIYKoxFOYX1FcGgrK8O4v3FPrqsrjEajEM6VWYgRSG98Xais6g/7B8jkhNXflPqiqu7AtW5V6g==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.17.1.tgz",
+			"integrity": "sha512-qan+Hpco/kIv972i5K8kyM2aMihVMwdNBtqiHfXEgvCtmdFC+SgTjvmpsoOjJhoa70Bc5tEVqcj0yAfLyFl8TQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0",
-				"@umbraco-ui/uui-ref": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1",
+				"@umbraco-ui/uui-ref": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-node-data-type": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.17.0.tgz",
-			"integrity": "sha512-NJjd6kKOgaxiTvj6BpeFSWMAzALIt9x3SLh4LqsxQCbnhjkQUtPxe20kjwLy4SC3VstU6ijPQa7i0kvGgQgh8Q==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.17.1.tgz",
+			"integrity": "sha512-ISHy0Sj2bFDnIq1XxfjthxMWMowOyRwq3jprOJ/g/tdseVuKZjBtJTVfHn6PEkA2oZaksZ1m0SbaqnKoLA21xA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-ref-node": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-ref-node": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-node-document-type": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.17.0.tgz",
-			"integrity": "sha512-SmT+CfcnrpSZNcV/cHdcewima+J41gUu+sAcSsbrPDEY1CaFZpxguSg9VKGa1f9VrIP/C8YKaWhKukmZMxzXBA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.17.1.tgz",
+			"integrity": "sha512-QVSeGT7roRG1TYDxNWMyMYbnJ74OyvXn3c8f27uqsLY6XZIkQB+3ir/gG42b/MMkkX4qz6zBrNLh81OUimW4+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-ref-node": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-ref-node": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-node-form": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.17.0.tgz",
-			"integrity": "sha512-OKFFV0ZznQ4if9UTP3jRiMCpZL5X/0FlVE8zb/SwqMTudS+9DQIuivRySax7r9Dz0z99XHkHGWoxLPiHM6tKRw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.17.1.tgz",
+			"integrity": "sha512-stRGqnndsIA0FdpF1UC6AA6UvrAoZVvDI8xOmpjhDK2bhkBGsUQEFeFb6oXNbc494wBQsOrfXFIULrMhJqTihQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-ref-node": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-ref-node": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-node-member": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.17.0.tgz",
-			"integrity": "sha512-3ZOpkwkvFp84dqHZ7ewFEm8yPRc1RPjlEx2V9cJqwnnQWszlB8AE6s39M5R+7uimbvyZLL+eLzhnT4/9bY3NYg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.17.1.tgz",
+			"integrity": "sha512-AoTzz0KMmN0J0PcWlMn5TqwUxNtbp+GuYDIdmZ08dPeV6S7DndpNTHCmbvXBaR2jRHX/t//AqdsQQyUScPVc7Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-ref-node": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-ref-node": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-node-package": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.17.0.tgz",
-			"integrity": "sha512-begfL/VFJSdWC0HdIr8YCcjwob0mfojupW8ag7r1ret6qVegQzq4AMIzzVeEcIrgABgSk70ZTho8NZXBYjaIlg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.17.1.tgz",
+			"integrity": "sha512-GkD6PkJ91k6+N1ZOm6OVwsTXPrNZ8iXKqyIzt2xuYbEesJBih549Afm+UGJ+7HUNtrVSFbotS4EKIXcg+xq5cA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-ref-node": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-ref-node": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-ref-node-user": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.17.0.tgz",
-			"integrity": "sha512-9vFdVIlVikWq52Wu7RiHuHezvG9lhNBW4BK0UJbNNOve5MLwmTjJjH3SMPOgCt37HggbyFMTXz2JQjUKlGtXow==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.17.1.tgz",
+			"integrity": "sha512-5CCKQzHgElIhC/DmRnitjZutYzbkymrZPdW2EKKVjX7UfLb3i6naR7DIRv7GkcQLCfMBDRYN8hwgD9nuU4CASg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-ref-node": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-ref-node": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-responsive-container": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.17.0.tgz",
-			"integrity": "sha512-7EVTi9dVcI8u8+GKpb8BhAP1xx3BOqUyMCIQp4JTs0Yal92OX0m2Z+BTrAuSvnNtntI/562NqSEciM/oUFtVmg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.17.1.tgz",
+			"integrity": "sha512-fBbISCLe0UzgNhCxtm1oKEHBzkXpdJ1ZSakul76pBEoy3jXhKkemetWnkg1V8Pkp9QOQx1NI+f2mzVeNd0NYxA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-button-group": "1.17.0",
-				"@umbraco-ui/uui-popover-container": "1.17.0",
-				"@umbraco-ui/uui-symbol-more": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-button-group": "1.17.1",
+				"@umbraco-ui/uui-popover-container": "1.17.1",
+				"@umbraco-ui/uui-symbol-more": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-scroll-container": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.17.0.tgz",
-			"integrity": "sha512-7qQ3Pfp5AS+nN2HeHjZ6kTGpQYmRWBE2+QO0cZV1ualN6o61Eyg26CSQCCYPRd3oNX3qgFg/96s06XNYzxCk8w==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.17.1.tgz",
+			"integrity": "sha512-RE6BplvSWtoHLVAhTUISeLQZ0nrwkzaK7mACFpaXigqD0CrOKxTbOCbG9hgsuOg7jeL+3smV3VM2VoeTBlGGHQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-select": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.17.0.tgz",
-			"integrity": "sha512-MnKFDkK8rz+heIIaM8Dh6hde+G0owJg6+lVZwY+LSt4mgby8pcpwbuxMePC3wUUKlYUx8aJA/YqrVeXp3XcHcw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.17.1.tgz",
+			"integrity": "sha512-B4LpUYUWLApnOQZ2QMIlt6ISB22qt9uRbxMxEVpkt9P15EB34vUEvXU0aQmm/lHr3d8oVqWrq55lmymCn33/Dg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-slider": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.17.0.tgz",
-			"integrity": "sha512-x189YH6wJqFBvV3qj9SRbFJrOdEBCs93hQq8JPQig/DwcLGUCijvMAGNf1kzJP/DD+A+2R4XCJmbnaAQadhxKg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.17.1.tgz",
+			"integrity": "sha512-n8ahsoXR15y2lCYa1X1JyGnyQx1ZYQcjKagQxMbPfqMN88POJ/+IEnjU5pXkvaXiSL+dBcAsiJWbf9iI5HbplA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-expand": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.17.0.tgz",
-			"integrity": "sha512-ctrZ0K7VE7MXs34w7NbPAJfbOxGewFj/AGBCEPVClqQYK1MK31my9J9x+OpTg7AEGgoRDe1T2qwOAY3QEPRWMA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.17.1.tgz",
+			"integrity": "sha512-T7ARVIhvfZZ2zACVQAJ5kLpADiHEf2Gwcht5VZpBP8Tde90pwWn+GZw0x+bRBqB81EyAiY/fA7C5fViKo9caNQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-file": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.17.0.tgz",
-			"integrity": "sha512-iU9HE9k4Y0vbxUJaweMZD51RwSiRPm05ppnlpkPtBKDtJwojfIMuQWmEXZC9wSe87LoHz5BXAmleQgfWjvDSIA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.17.1.tgz",
+			"integrity": "sha512-wlGUF8N46vQeVVX1ihkGNWhvf1q+QT8hy10cJH9hy6xyjJOSKAY00Cp/7M6/g/E4RTyr6rwO2T/o/E0T7Y0HRw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.17.0.tgz",
-			"integrity": "sha512-xH+u9vUXFs/JpAuZRNPTPq9NDsw4PqH1HCEBjkQZt/LYRe44bJNp3sOGsi1H2WtWV1+yrshEU7GY5i4ypdBdFQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.17.1.tgz",
+			"integrity": "sha512-TbOzES7+Mlh/jwkR4nkd2uFoSVfv8724N5FYK1H/VG4xRtq27LfkRWm72E05Bvo6z2qJnX1/UgstEIrp1APGog==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.17.0.tgz",
-			"integrity": "sha512-tcLb6ZfNQZ0nnzF4qkMMSzlPud0KSVIZuCrXfTd+ZNsRvQa2qCrEowIvIFqMCEnH0rpavAGqQOEQ7wa91xhRPw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.17.1.tgz",
+			"integrity": "sha512-agLFQzg69EpqZ1w44HjVuzDW5YYNBqSCopPt/CsZ1yC3X4h4Whji+TztDOhn3LogsRkKPjl8PBrQyFEdJgyngA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-folder": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.17.0.tgz",
-			"integrity": "sha512-n2KiNtDe8anJknD7gZaz/HzXy+vd7mcDhimYTlnNR3TaGD8qzSLDaG1g7d6U6reuL6zASzcIAwvBTrMKdvmNMg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.17.1.tgz",
+			"integrity": "sha512-Bisl0G00LX82pSoxzJtYNzWLeilxry/bLtGgImdzVzT2F+4KmVXHjWL94kN18CT1Pxc5nxAZlPSjZwg2hIilPw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-lock": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.17.0.tgz",
-			"integrity": "sha512-pzI7AhCoIEyhEZQUl6m9OriPRUKf/vosOr4PkRXu7NEutOa7sKTvDP419xpisJsVQ55z0UQULLUe24iq7DBYZQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.17.1.tgz",
+			"integrity": "sha512-pz/vRDduZasKTt9KHlcli+IGN+8z1A2FX1WZQFvMmDGe9/uBGBM+Cgsnsgd4rF6CMHw/fyF95YRtYj8GOPGtmQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-more": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.17.0.tgz",
-			"integrity": "sha512-z+32abMn8NQ6+miUQmROfF96Y/M9rkqJHT9V1boFkpn0DJ7L0zBLCkEw82NRNLf+2t9Lb/7YzQm2LDpBdE1Rcw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.17.1.tgz",
+			"integrity": "sha512-MFs9D+Y1aQGnSU57YwtjUoltUE/EsArOsQvAOkU+KQUU707JpJpFNFz+FJUkR4UlikSTCTQPxIvX6ILyeD7drQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-symbol-sort": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.17.0.tgz",
-			"integrity": "sha512-MqNZoZ/2YyPC6hYAb0j0sWYJ5WJsjSF2S1kxiF35v77S/Uv1FYHNJ4bz9+sKj4wKQ9BMXRCKXlv/jM64wHvU8Q==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.17.1.tgz",
+			"integrity": "sha512-RsAqFWUH2kpec5l3By8sJLkWwPiNJWrlyPXTfDtTKGXQOqfgrJCMd4wbr38VJbUAGNNV3zgDvVI5eArfjmeqpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-table": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.17.0.tgz",
-			"integrity": "sha512-zre6CR8Nv4XB0vzzgqMBZDdH9bayCQHPisN9iZS1BxVtORRVgvwcsAk4dbVGjVeYDyH9dtscZj8Qoq/Tkb56gg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.17.1.tgz",
+			"integrity": "sha512-edVhShkFrZksCkHxezBn1aotDGExMH+VBGojFfxQ9l1vMmZlKlPsxVoPo6M0ie3T8SLx33o6OkFQuJv08Pky6g==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-tabs": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.17.0.tgz",
-			"integrity": "sha512-mbGknDUuysAlyu/KcUs6KZTc9Mt6uC3SbCuxIzrYrGl++R5uVI3hOZej5+VRRBHkCWTpoMyO45jPwzRfFAQyBA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.17.1.tgz",
+			"integrity": "sha512-0rbk4snBQunZ7nHRBKPD8yLjsUPK5P4rJzSFiE9CWQkK0FzG6vXeEG3pp9mTIraMZQfzOiUINNK34/tt1KbQxg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-popover-container": "1.17.0",
-				"@umbraco-ui/uui-symbol-more": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-popover-container": "1.17.1",
+				"@umbraco-ui/uui-symbol-more": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-tag": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.17.0.tgz",
-			"integrity": "sha512-F07+NpG2pwWaGmpL1BKm8cRdiF2fY+JXTRMqAlZPiyfat13ypA1NIz8g+fBMWq9XFGJOwSscjSSBsbU3uDQpzQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.17.1.tgz",
+			"integrity": "sha512-Ny2OT5DBNkdmy/DPy7Alz9m2HZ6O22kAFT+bkL+dY3E5aC08jME9N44dBjcEOsF4Y1rY0sRi7z36iF02Lhxuqw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-textarea": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.17.0.tgz",
-			"integrity": "sha512-fXPWiVvnfrekXoFqGGuSU9MmUrmPrA98IBayJ4VikujdQuIPRHim+11egrKYqkdhgvp1C9H8TwnuTxuzaHWT6Q==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.17.1.tgz",
+			"integrity": "sha512-58DricpU2Oe57feAnspie23LRr4Jhl5Zqx34/Ifuk6nNuAt7ow3fsAKWVEisLmbLIkYQPFy4iMjCIZavOwklDA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-toast-notification": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.17.0.tgz",
-			"integrity": "sha512-JODX9HxfzlkHs7j0c+AFM7YoZuAyYKpg+pxNgFNTOrYaGbku7ts7vAgnXwFF9yWxtb98pMN2EBa643uannR5ug==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.17.1.tgz",
+			"integrity": "sha512-RZe8PGUfWl4zu86aLSxIWyr+aIqOs/PaR9YgxEZqW475TKPRTwsF5Kk/HU1bEJYcajW+ooDaWnrqKfZreOrDkg==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-button": "1.17.0",
-				"@umbraco-ui/uui-css": "1.17.0",
-				"@umbraco-ui/uui-icon": "1.17.0",
-				"@umbraco-ui/uui-icon-registry-essential": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-button": "1.17.1",
+				"@umbraco-ui/uui-css": "1.17.1",
+				"@umbraco-ui/uui-icon": "1.17.1",
+				"@umbraco-ui/uui-icon-registry-essential": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-toast-notification-container": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.17.0.tgz",
-			"integrity": "sha512-W+s6R8g0NKIDiNNJ2SnLbQHNm/WQV8h6Imm6bhzi5TSePmJYLAYAo3QxXZgEzypNf3mYEtYGJLXbh+poM9e3Mg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.17.1.tgz",
+			"integrity": "sha512-9zsyFCwIug6ESIt/PFTIdEowge9APqVIVnJbaAu6klxc2apc+6VUR2kATQZSff9zHlM4bFQbisRkh5o5wgEc/A==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-toast-notification": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-toast-notification": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-toast-notification-layout": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.17.0.tgz",
-			"integrity": "sha512-j7A+InK9WMfd9CBoZ5lwLDhpg5nCFNtkdD61KynlPkCiiDixVDmN7sFYw48kOtMl+5CcgPaZ3G4vzVVwfm5esw==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.17.1.tgz",
+			"integrity": "sha512-V2HBRuqDZuKXCBGOTrKDzKDXC4JmBuzMR6otjUkWjj8K6s/gQusqa1NH2TzPBnzAzHIyVo5Di2Tm5etuBZoGTw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-css": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-css": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-toggle": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.17.0.tgz",
-			"integrity": "sha512-ZadCpECthaJMVLJf2JucnzhUvVqjgW5/pO+LE//M40lSSxlP68WhBtvS6vSAndTO+tIvhvl2qmNx3XloJMcNQg==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.17.1.tgz",
+			"integrity": "sha512-nlCjjK6AE5UBhekQpUuPIBajCfMFJVViElH7iJPwFzO1zwv1FKbhNcUbsy7U1CoIjrJUy8eznHnIyvoX+kEglA==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0",
-				"@umbraco-ui/uui-boolean-input": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1",
+				"@umbraco-ui/uui-boolean-input": "1.17.1"
 			}
 		},
 		"node_modules/@umbraco-ui/uui-visually-hidden": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.17.0.tgz",
-			"integrity": "sha512-mET1gtr5yt7HKPPQ7pYY0EEcVdK9nNyvbbs7PfI249LtvnNYRWdHfHR6sxuIY+VlyUseB51ArTl/iIvWMx0kdQ==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.17.1.tgz",
+			"integrity": "sha512-ola8Bz3rRfOqnD5tnXO3T2Z+FS6L9WnjYBxE9Dq/hQYfOXFETI/wBrp9GcNHg//4OHboxUr3ArLLsGTSjVlkzw==",
 			"license": "MIT",
 			"dependencies": {
-				"@umbraco-ui/uui-base": "1.17.0"
+				"@umbraco-ui/uui-base": "1.17.1"
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -17049,8 +17049,8 @@
 		"src/external/uui": {
 			"name": "@umbraco-backoffice/uui",
 			"dependencies": {
-				"@umbraco-ui/uui": "^1.17.0",
-				"@umbraco-ui/uui-css": "^1.17.0"
+				"@umbraco-ui/uui": "^1.17.1",
+				"@umbraco-ui/uui-css": "^1.17.1"
 			}
 		},
 		"src/libs/class-api": {

--- a/src/Umbraco.Web.UI.Client/src/external/uui/package.json
+++ b/src/Umbraco.Web.UI.Client/src/external/uui/package.json
@@ -6,7 +6,7 @@
 		"build": "vite build"
 	},
 	"dependencies": {
-		"@umbraco-ui/uui": "^1.17.0",
-		"@umbraco-ui/uui-css": "^1.17.0"
+		"@umbraco-ui/uui": "^1.17.1",
+		"@umbraco-ui/uui-css": "^1.17.1"
 	}
 }


### PR DESCRIPTION
This pull request updates the dependencies in the `src/Umbraco.Web.UI.Client/src/external/uui/package.json` file to use the latest patch version of the Umbraco UI packages.

Dependency updates:

* Upgraded `@umbraco-ui/uui` and `@umbraco-ui/uui-css` dependencies from version `^1.17.0` to `^1.17.1` to ensure the latest bug fixes and improvements are included.