### PR TITLE
URL Picker: Fix validation error persisting after link selection (closes #21903, #21454)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -174,7 +174,7 @@ export class UmbInputMultiUrlElement extends UmbFormControlMixin<string, typeof 
 		this.addValidator(
 			'valueMissing',
 			() => this.requiredMessage,
-			() => !this.readonly && this.required && (!this.value || this.value === ''),
+			() => !this.readonly && this.required && this.urls.length === 0,
 		);
 
 		this.addValidator(
@@ -347,6 +347,7 @@ export class UmbInputMultiUrlElement extends UmbFormControlMixin<string, typeof 
 	}
 
 	#dispatchChangeEvent() {
+		super.value = this.#urls.map((x) => x.url).join(',');
 		this.requestUpdate();
 		this.dispatchEvent(new UmbChangeEvent());
 	}


### PR DESCRIPTION
## Description

Fixes a bug where the "Value cannot be empty" validation error on a mandatory Multi URL Picker persists visually after selecting a link. The error stays even though saving works correctly.

There are two reports of issues with this:
- https://github.com/umbraco/Umbraco-CMS/issues/21903
- https://github.com/umbraco/Umbraco-CMS/issues/21454

In testing though I can't see the more fundamental issue being reported of being unable to save.  I can save, but I see the validation error lingering after it's been resolved, so at the very least there's some confusing behaviour for the editor here.

### Root Cause

The `umb-input-multi-url` component has two data representations:

- `#urls` (Array) — the actual link objects
- `super.value` (string) — a comma-joined URL string used by `UmbFormControlMixin` for form validation

The `urls` **setter** syncs `super.value` correctly:
```ts
super.value = this.#urls.map((x) => x.url).join(',');
```

However, `#setSelection` and `#removeItem` mutate `this.#urls` directly via `push`/`splice`/index assignment — bypassing the setter. This means `super.value` stays stale (empty string) after adding or removing links.

The `valueMissing` validator checks `(!this.value || this.value === '')`, which reads the stale `super.value` → validation fails even though links exist in `#urls`.

### Fix

Two changes in `input-multi-url.element.ts`:

1. **Validator now checks the actual data**: Changed from checking the stale `this.value` string to checking `this.urls.length === 0`. This matches the pattern used by other input components (e.g., `input-content.element.ts` checks `this.selection.length === 0`).

2. **Keep `super.value` in sync**: Added `super.value` sync in `#dispatchChangeEvent()`, which is called after every mutation (`#setSelection`, `#removeItem`, sorter reorder). This is a defensive fix that ensures the form control's internal value stays consistent.

## Testing

### On a document
1. Create a document type with a mandatory Multi URL Picker property
2. Create new content of that type
3. Leave the picker empty and attempt to save → validation error should appear
4. Add a link (URL, content, or media) → **validation error should clear immediately**
5. Save → should succeed without visual error
6. Remove the link → validation error should reappear
7. Add a link again and save → should succeed cleanly

### Inside a block
1. Create a Block List or Block Grid element type with a mandatory Multi URL Picker
2. Add a block of that type to content
3. In the block editor, add a link to the Multi URL Picker → **validation error should clear**
4. Save the block and the content → should succeed without visual error

### Min/max validation still works
1. Set min=2 on the Multi URL Picker
2. Add only 1 link → range underflow validation should appear
3. Add a 2nd link → validation should clear