### PR TITLE
Management API: Defensively handle path integrity issues when resolving ancestors (closes #21822)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Tree/EntityTreeControllerBase.cs
@@ -162,8 +162,8 @@ public abstract class EntityTreeControllerBase<TItem> : ManagementApiControllerB
         if (missingParentIds is not null)
         {
             // Will use the static logger factory here, given this is an exception case and to avoid having to
-            // make widespread chnages to support logging in the base controller.
-            ILogger logger = StaticApplicationLogging.CreateLogger<ILogger<EntityTreeControllerBase<TItem>>>();
+            // make widespread changes to support logging in the base controller.
+            ILogger logger = StaticApplicationLogging.CreateLogger<EntityTreeControllerBase<TItem>>();
             logger.LogWarning(
                 "Ancestor(s) with ID(s) {MissingAncestorIds} not found in the ancestors collection for descendant {DescendantKey}. "
                 + "This indicates a data integrity issue in the entity path; consider running the database integrity health check "


### PR DESCRIPTION
## Description

Issue https://github.com/umbraco/Umbraco-CMS/issues/21822 shared a stack trace indicating an `InvalidOperationException` when ancestor path data is inconsistent.

To fix I've changed `Single()` to `SingleOrDefault()` in `EntityTreeControllerBase.GetAncestors()` to prevent this exception and instead log a warning when missing ancestors are detected - basically when the `Path` value of a node doesn't align with the parents - guiding administrators to run the database integrity health check or move the affected content to rebuild its path.

It's difficult to pinpoint the root cause for this, but presumably this is the historical reason why the "Data Integrity" health check was introduced, so it's perhaps not surprising that it surfaces in upgrades.

## Testing

1. Find the unique Id a content node at depth 3 or more and find it's path:

```sql
select id,text,path
from umbracoNode
where uniqueId = '{id}'
```

2. Corrupt its path by removing an intermediate ancestor and adjusting the level (e.g. for a node with path `-1,4258,4280,4362`):

```sql
update umbracoNode
set path = '-1,4258,9999,4362'
where uniqueId = '{id}'
```

3. Call the ancestors endpoint:

```
GET /umbraco/management/api/v1/tree/document/ancestors?descendantId={id}
```

4. **Before this fix**: `500 Internal Server Error` with `InvalidOperationException: Sequence contains no matching element`:

```json
{
  "type": "Error",
  "title": "Sequence contains no matching element",
  "status": 500,
  ...
```

5. **After this fix**: `200 OK` with the available ancestors, and a warning logged:
   > `Ancestor(s) with ID(s) [{ids}] not found in the ancestors collection for descendant {key}. This indicates a data integrity issue...`

You can also check the "Data Integrity" health check here which should be reporting one issue.

<img width="589" height="482" alt="image" src="https://github.com/user-attachments/assets/11e96cc4-1999-41da-ad59-bd0e21f5ba86" />

6. Restore the data, either via the health check or by 

```sql
update umbracoNode
set path = '-1,4258,4280,4362'
where uniqueId = '{id}'
```