### PR TITLE
URL Picker: Fix title field only showing first character when typing URL (closes #22048)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/link-picker-modal/link-picker-modal.element.ts
@@ -145,7 +145,7 @@ export class UmbLinkPickerModalElement extends UmbModalBaseElement<UmbLinkPicker
 		}
 
 		this.#partialUpdateLink({
-			name: name ?? this.value.link.name,
+			name: this.#userEditedTitle ? this.value.link.name : (name ?? ''),
 			type: 'external',
 			url,
 		});


### PR DESCRIPTION
## Description

This PR fixes the issue raised in https://github.com/umbraco/Umbraco-CMS/issues/22048, where the title is only partially populated when entering a manual URL.

It also ensures the title doesn't update when already set and the URL is adjusted.

## Testing

Using a single or multi URL picker, verify that:

- When a URL is added manually, the Title field is correctly populated.
- When the Title is already set, amending the URL keeps the existing title.
- When the Title is removed, setting a new URL will set the title based on the new URL.