### PR TITLE
Migrations: Run `AddSortableValueToPropertyData` before `MoveDocumentBlueprintsToFolders`

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -80,8 +80,9 @@ public class UmbracoPlan : MigrationPlan
 
         // MoveDocumentBlueprintsToFolders uses IContentService which loads content through the
         // repository layer. PropertyDataDto now maps the sortableValue column (added in v17.3),
-        // so the column must exist before NPoco tries to query it. This migration is idempotent
-        // (checks ColumnExists), so if and when the v17.3 instance below runs it will be a no-op.
+        // so the column must exist before NPoco tries to query it. The migration checks whether
+        // the column already exists (via GetColumnsInSchema) before adding it, so the v17.3
+        // instance below will be a no-op.
         To<V_17_3_0.AddSortableValueToPropertyData>("{A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D}");
         To<V_14_0_0.MoveDocumentBlueprintsToFolders>("{1A0FBC8A-6FC6-456C-805C-B94816B2E570}");
 


### PR DESCRIPTION
## Description

I found this issue in testing a migration from 13 to 17.3.

The `MoveDocumentBlueprintsToFolders` uses the `IContentService`, which will throw an exception if the `sortableValue` which is added in 17.3 isn't found.

To fix I've placed a copy of the 17.3 migration prior to this, so it will ensure the column exists before the previously failing migration runs.

It remains later for upgrades from 15+, but will be a no-op if coming from 14 and the earlier introduced migration step has run.

## Testing

Upgrade a v13 database to v17.3+ and verify migrations complete without error (I've done this).