### PR TITLE
Auth: Skip /token refresh when access token is still valid

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/app/app-auth.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app-auth.controller.ts
@@ -10,7 +10,6 @@ import { setStoredPath } from '@umbraco-cms/backoffice/utils';
 export class UmbAppAuthController extends UmbControllerBase {
 	#retrievedModal: Promise<unknown>;
 	#authContext?: typeof UMB_AUTH_CONTEXT.TYPE;
-	#isFirstCheck = true;
 
 	constructor(host: UmbControllerHost) {
 		super(host);
@@ -33,6 +32,7 @@ export class UmbAppAuthController extends UmbControllerBase {
 	/**
 	 * Checks if the user is authorized.
 	 * If not, the authorization flow is started.
+	 * Session verification is handled by setInitialState() before the router evaluates guards.
 	 */
 	async isAuthorized(): Promise<boolean> {
 		await this.#retrievedModal.catch(() => undefined);
@@ -40,21 +40,8 @@ export class UmbAppAuthController extends UmbControllerBase {
 			throw new Error('[Fatal] Auth context is not available');
 		}
 
-		const isAuthorized = this.#authContext.getIsAuthorized();
-
-		if (isAuthorized) {
-			// If this is the first time we are checking the authorization state (i.e. on first load), we need to make sure
-			// that the token is still valid. If it is not, we need to start the authorization flow.
-			// If the token is still valid, we can return true.
-			if (this.#isFirstCheck) {
-				this.#isFirstCheck = false;
-				const isValid = await this.#authContext.validateToken();
-				if (isValid) {
-					return true;
-				}
-			} else {
-				return true;
-			}
+		if (this.#authContext.getIsAuthorized()) {
+			return true;
 		}
 
 		// Make a request to the auth server to start the auth flow

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -437,6 +437,8 @@ export class UmbAuthContext extends UmbContextBase {
 		}).warn();
 		if (!this.#isAccessTokenValid()) {
 			await this.validateToken();
+		} else {
+			await this.#waitForOngoingRefresh();
 		}
 		return '[redacted]';
 	}
@@ -500,6 +502,23 @@ export class UmbAuthContext extends UmbContextBase {
 	#isAccessTokenValid(): boolean {
 		const session = this.#session.getValue();
 		return !!session && session.accessTokenExpiresAt > Math.floor(Date.now() / 1000);
+	}
+
+	/**
+	 * Waits for any ongoing cross-tab token refresh to complete without performing a refresh itself.
+	 * Prevents sending requests with an access token that is about to be revoked by a proactive
+	 * refresh in another tab (keepUserLoggedIn), which would cause OpenIddict ID2019 errors.
+	 */
+	async #waitForOngoingRefresh(): Promise<void> {
+		if (!navigator.locks) return;
+		const state = await navigator.locks.query();
+		if (state.held?.some((l) => l.name === 'umb:token-refresh')) {
+			// A refresh is in progress in another tab — queue behind it so we send
+			// requests with the new cookie rather than the soon-to-be-revoked one.
+			await navigator.locks.request('umb:token-refresh', async () => {
+				// No-op: we only need to wait for the ongoing refresh to finish.
+			});
+		}
 	}
 
 	/**
@@ -610,6 +629,8 @@ export class UmbAuthContext extends UmbContextBase {
 			auth: async () => {
 				if (!this.#isAccessTokenValid()) {
 					await this.validateToken();
+				} else {
+					await this.#waitForOngoingRefresh();
 				}
 				return '[redacted]';
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -435,19 +435,18 @@ export class UmbAuthContext extends UmbContextBase {
 				'Use configureClient for @hey-api/openapi-ts clients or getOpenApiConfiguration for manual fetch calls. With cookie-based auth this always returns "[redacted]".',
 			removeInVersion: '19.0.0',
 		}).warn();
-		if (!this.#isAccessTokenValid()) {
-			await this.validateToken();
-		} else {
-			await this.#waitForOngoingRefresh();
-		}
+		await this.#ensureTokenReady();
 		return '[redacted]';
 	}
 
 	/**
-	 * Validates the token against the server and returns true if the token is valid.
-	 * Uses Web Locks to prevent concurrent refresh requests across tabs.
+	 * Forces a token refresh against the server (calls `/token`) and returns true if successful.
+	 * Use this when you need to unconditionally refresh — e.g. session timeout keep-alive.
+	 * For per-request token handling, prefer {@link configureClient} which skips the network
+	 * call when the access token is still valid.
+	 * Uses Web Locks to deduplicate concurrent refresh requests across tabs.
 	 * @memberof UmbAuthContext
-	 * @returns True if the token is valid, otherwise false
+	 * @returns True if the refresh succeeded, otherwise false
 	 */
 	async validateToken(): Promise<boolean> {
 		return this.#isBypassed || this.makeRefreshTokenRequest();
@@ -499,17 +498,29 @@ export class UmbAuthContext extends UmbContextBase {
 		return !!session && session.expiresAt > Math.floor(Date.now() / 1000);
 	}
 
+	/**
+	 * Local-only check — no network call.
+	 * Returns true if the cached access token has not yet reached its expiry timestamp.
+	 * Does NOT check the refresh token or server state.
+	 */
 	#isAccessTokenValid(): boolean {
 		const session = this.#session.getValue();
 		return !!session && session.accessTokenExpiresAt > Math.floor(Date.now() / 1000);
 	}
 
 	/**
-	 * Waits for any ongoing cross-tab token refresh to complete without performing a refresh itself.
-	 * Prevents sending requests with an access token that is about to be revoked by a proactive
-	 * refresh in another tab (keepUserLoggedIn), which would cause OpenIddict ID2019 errors.
+	 * Gate for per-request token handling.
+	 * - If the access token is expired: calls {@link validateToken} to refresh it (network call).
+	 * - If the access token is still valid but another tab holds the `umb:token-refresh` lock:
+	 *   waits for that refresh to finish before returning, so the request is sent with the
+	 *   latest cookie and not the token that is about to be revoked (prevents ID2019 errors).
+	 * - Otherwise: returns immediately with no network call.
 	 */
-	async #waitForOngoingRefresh(): Promise<void> {
+	async #ensureTokenReady(): Promise<void> {
+		if (!this.#isAccessTokenValid()) {
+			await this.validateToken();
+			return;
+		}
 		if (!navigator.locks) return;
 		const state = await navigator.locks.query();
 		if (state.held?.some((l) => l.name === 'umb:token-refresh')) {
@@ -627,11 +638,7 @@ export class UmbAuthContext extends UmbContextBase {
 			baseUrl: this.#serverUrl,
 			credentials: 'include',
 			auth: async () => {
-				if (!this.#isAccessTokenValid()) {
-					await this.validateToken();
-				} else {
-					await this.#waitForOngoingRefresh();
-				}
+				await this.#ensureTokenReady();
 				return '[redacted]';
 			},
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -435,7 +435,9 @@ export class UmbAuthContext extends UmbContextBase {
 				'Use configureClient for @hey-api/openapi-ts clients or getOpenApiConfiguration for manual fetch calls. With cookie-based auth this always returns "[redacted]".',
 			removeInVersion: '19.0.0',
 		}).warn();
-		await this.validateToken();
+		if (!this.#isAccessTokenValid()) {
+			await this.validateToken();
+		}
 		return '[redacted]';
 	}
 
@@ -606,7 +608,9 @@ export class UmbAuthContext extends UmbContextBase {
 			baseUrl: this.#serverUrl,
 			credentials: 'include',
 			auth: async () => {
-				await this.validateToken();
+				if (!this.#isAccessTokenValid()) {
+					await this.validateToken();
+				}
 				return '[redacted]';
 			},
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -51,6 +51,12 @@ export class UmbAuthContext extends UmbContextBase {
 	#session = new UmbObjectState<UmbAuthSession | undefined>(undefined);
 	readonly session$ = this.#session.asObservable();
 
+	// True only during the synchronous #updateSession() call inside the lock callback.
+	// Prevents re-entrant /token calls when session$ observers fire synchronously
+	// (e.g. keepUserLoggedIn=true with short expiresIn triggers #onSessionExpiring
+	// from inside the lock, capturing sessionBefore = newSession so the guard can't help).
+	#inSessionUpdateCallback = false;
+
 	// Cross-tab coordination
 	#channel: BroadcastChannel;
 
@@ -477,12 +483,23 @@ export class UmbAuthContext extends UmbContextBase {
 		// would incorrectly skip the refresh when the session is still technically valid.
 		const sessionBefore = this.#session.getValue();
 
+		// Guard against re-entrant calls: if session$ fired synchronously from inside
+		// a lock callback (via #updateSession → observer → keepUserLoggedIn proactive refresh),
+		// sessionBefore would equal the already-updated session so the reference check below
+		// can't help. Return true immediately — the lock holder already refreshed.
+		if (this.#inSessionUpdateCallback) return true;
+
 		return navigator.locks.request('umb:token-refresh', async () => {
 			if (this.#session.getValue() !== sessionBefore && this.#isAccessTokenValid()) return true;
 
 			const response = await this.#client.refreshToken();
 			if (response) {
-				this.#updateSession(response.expiresIn, response.issuedAt);
+				this.#inSessionUpdateCallback = true;
+				try {
+					this.#updateSession(response.expiresIn, response.issuedAt);
+				} finally {
+					this.#inSessionUpdateCallback = false;
+				}
 				return true;
 			}
 			return false;


### PR DESCRIPTION
## Summary

- **Skip `/token` when access token is still valid** — `configureClient()`'s auth callback and `getLatestToken()` now guard with `#isAccessTokenValid()`, so the token endpoint is only hit when the access token has actually expired. Previously every API request triggered a refresh regardless, causing unnecessary token churn and OpenIddict ID2019 errors on in-flight requests.

- **Wait for ongoing cross-tab refresh** — when the access token is valid but another tab holds the `umb:token-refresh` Web Lock (proactive refresh via `keepUserLoggedIn`), the auth callback now waits for that refresh to complete before proceeding. This restores the cross-tab serialization that the guard above removed, preventing requests from being sent with a token that is about to be revoked.

- **Remove redundant first-check `validateToken()` on startup** — `UmbAppAuthController.isAuthorized()` previously called `validateToken()` on the very first guard evaluation, producing a second `/token` call immediately after `setInitialState()` had already verified the session. This was a leftover from the AppAuth/localStorage era. `setInitialState()` now owns server verification; stale peer-sourced sessions are handled lazily by the 401 interceptor.

## How each caller behaves after these changes

| Caller | Behaviour |
|--------|-----------|
| `configureClient()` auth callback (per request) | Skips `/token` when access token valid; waits if another tab is refreshing |
| `getLatestToken()` (deprecated, userland) | Same as above |
| `UmbAuthSessionTimeoutController` → `validateToken()` | Unchanged — always calls `makeRefreshTokenRequest()` for proactive refresh |
| `app-auth.controller.ts` startup guard | Removed redundant first-check; `setInitialState()` is authoritative |

## Why the popup re-auth path doesn't call `/token` from the main window

After timeout → popup re-auth, the popup's `authorization_code` exchange calls `/token` and the server's `HideBackOfficeTokensHandler` writes fresh encrypted cookies to the response. Cookies are domain-scoped, so the main window has the new cookies immediately — no separate `/token` call needed. The "Stay logged in" button takes a different path (`refresh_token` grant directly from the main window), but both paths end with equivalent fresh cookie state.

## Test plan

- [ ] Navigate between sections — `/token` should only fire when the access token expires, not on every request
- [ ] With `keepUserLoggedIn=true`: open two tabs, verify only one `/token` call fires per proactive refresh cycle (no ID2019 on the other tab)
- [ ] Let the session timeout naturally → re-auth via popup → verify the encrypted cookie value changes and subsequent requests succeed without errors
- [ ] Click "Stay logged in" in the timeout modal → verify `/token` is called and the session timer resets
- [ ] Verify startup has exactly one `/token` call (not two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)