### PR TITLE
Auth: Fix preview window stuck loading after Save and Preview (closes #22083)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -226,11 +226,13 @@ export class UmbAppElement extends UmbLitElement {
 			throw new Error('[Fatal] AuthContext requested before it was initialized');
 		}
 
-		// Popup windows are used exclusively for the auth code exchange flow.
-		// Attempting a silent token refresh here would set isAuthorized=true and cause
-		// the oauth_complete handler to redirect the popup to the backoffice instead of
-		// completing the code exchange. The code exchange sets fresh cookies itself.
-		if (window.opener) return;
+		// The oauth_complete popup must not call setInitialState(): a successful silent
+		// refresh would set isAuthorized=true and cause the oauth_complete handler to
+		// redirect the popup to the backoffice instead of completing the code exchange.
+		// Other windows opened via window.open() (e.g. the preview window) DO need
+		// setInitialState() so they can restore the session from a peer tab.
+		const pathname = pathWithoutBasePath({ start: true, end: false });
+		if (window.opener && pathname === '/oauth_complete') return;
 
 		// Auth context configures umbHttpClient in its constructor, so we only need to set initial state
 		await this.#authContext.setInitialState();


### PR DESCRIPTION
## Summary

Fixes #22083

- The `window.opener` guard in `#setAuthStatus()` was too broad — it skipped `setInitialState()` for **any** window opened via `window.open()`, including the preview window
- The preview window was therefore stuck with `isAuthorized = false`, causing the loading spinner to never resolve
- The guard is only needed for the OAuth code exchange popup (`/oauth_complete`), where calling `setInitialState()` could silently refresh the session, set `isAuthorized=true`, and cause the popup to redirect to the backoffice instead of completing the code exchange
- Fix: narrow the guard to `window.opener && pathname === '/oauth_complete'`
- The preview window (at path `/preview`) now correctly calls `setInitialState()`, which restores the session from a peer tab via BroadcastChannel — or falls back to a `/token` call if no peer responds

## Test plan

- [ ] Open a content node and click "Save and Preview" — preview window should load correctly
- [ ] Session timeout re-auth (popup flow) should still work — the OAuth popup at `/oauth_complete` should complete the code exchange without redirecting to backoffice
- [ ] Opening a preview window when no other tab is open (peer fallback to `/token`) should also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)