### PR TITLE
Fix the CSP in our local project to support iframing the marketplace

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/NewsDashboard/NewsDashboardService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.ViewModels.NewsDashboard;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -70,7 +71,7 @@ public class NewsDashboardService : INewsDashboardService
     /// <inheritdoc />
     public async Task<NewsDashboardResponseModel> GetItemsAsync()
     {
-        const string BaseUrl = "https://news-dashboard.umbraco.com";
+        const string BaseUrl = Constants.NewsDashboard.Url;
         const string Path = "/api/News";
 
         var version = _umbracoVersion.SemanticVersion.ToSemanticStringWithoutBuild();

--- a/src/Umbraco.Core/Constants-NewsDashboard.cs
+++ b/src/Umbraco.Core/Constants-NewsDashboard.cs
@@ -1,0 +1,15 @@
+namespace Umbraco.Cms.Core;
+
+public static partial class Constants
+{
+    /// <summary>
+    /// Defines the constants used for the Umbraco News Dashboard.
+    /// </summary>
+    public static class NewsDashboard
+    {
+        /// <summary>
+        ///     The base URL for the Umbraco News Dashboard.
+        /// </summary>
+        public const string Url = "https://news-dashboard.umbraco.com";
+    }
+}

--- a/src/Umbraco.Web.UI/Extensions/WebApplicationExtensions.cs
+++ b/src/Umbraco.Web.UI/Extensions/WebApplicationExtensions.cs
@@ -23,7 +23,7 @@ internal static class WebApplicationExtensions
                 $"default-src 'self'; " +
                 $"script-src 'self' 'nonce-{nonce}'; " +
                 $"style-src 'self' 'unsafe-inline'; " +
-                $"img-src 'self' data: news-dashboard.umbraco.com; " +
+                $"img-src 'self' data: {Constants.NewsDashboard.Url}; " +
                 $"connect-src 'self'; " +
                 $"font-src 'self'; " +
                 $"frame-src 'self' {Constants.Marketplace.Url}");


### PR DESCRIPTION
### Prerequisites

- [X] I have added steps to test this contribution in the description below

### Description

We have a CSP rule setup in our local test project, that should align with what we document at https://docs.umbraco.com/umbraco-cms/extending/health-check/guides/contentsecuritypolicy

Currently it doesn't allow IFRAME of the Marketplace website, so this adds that rule.

I'll also update the docs to match (see: https://github.com/umbraco/UmbracoDocs/pull/7877)

### Testing

Click on "Package" in the backoffice and make sure the Marketplace loads.