### PR TITLE
Auth: Fix re-entrant /token call after OAuth code exchange

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -494,12 +494,7 @@ export class UmbAuthContext extends UmbContextBase {
 
 			const response = await this.#client.refreshToken();
 			if (response) {
-				this.#inSessionUpdateCallback = true;
-				try {
-					this.#updateSession(response.expiresIn, response.issuedAt);
-				} finally {
-					this.#inSessionUpdateCallback = false;
-				}
+				this.#updateSession(response.expiresIn, response.issuedAt);
 				return true;
 			}
 			return false;
@@ -755,14 +750,23 @@ export class UmbAuthContext extends UmbContextBase {
 	/**
 	 * Sets the in-memory session state without broadcasting.
 	 * Use when the caller handles broadcasting separately (e.g. completeAuthorizationRequest).
+	 *
+	 * Sets #inSessionUpdateCallback around the setValue calls to prevent re-entrant /token
+	 * requests triggered by session$ observers firing synchronously (e.g. keepUserLoggedIn=true
+	 * with a short expiresIn causes #onSessionExpiring to fire immediately).
 	 */
 	#setSessionLocally(expiresIn: number, issuedAt: number) {
 		const accessTokenExpiresAt = issuedAt + expiresIn;
 		// The access_token lives for 1/4 of the refresh_token lifetime.
 		// Multiply to get the full session expiry.
 		const expiresAt = issuedAt + expiresIn * TOKEN_EXPIRY_MULTIPLIER;
-		this.#session.setValue({ accessTokenExpiresAt, expiresAt });
-		this.#isAuthorized.setValue(true);
+		this.#inSessionUpdateCallback = true;
+		try {
+			this.#session.setValue({ accessTokenExpiresAt, expiresAt });
+			this.#isAuthorized.setValue(true);
+		} finally {
+			this.#inSessionUpdateCallback = false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What

Moves the `#inSessionUpdateCallback` re-entrancy guard into `#setSessionLocally()` so all callers are covered, not just the Web Locks lock callback.

## Why (the bug)

PR #22087 added `#inSessionUpdateCallback` in `makeRefreshTokenRequest()`'s lock callback to prevent a double `/token` call when `session$` fired synchronously inside `#updateSession()`. But `completeAuthorizationRequest()` calls `#setSessionLocally()` directly — without ever setting the flag.

With `KeepUserLoggedIn=true` and a short `TimeOut` (e.g. `00:01:00`, giving `expiresIn=15s`), `secondsUntilWarning=0` so `#onSessionExpiring()` fires synchronously from inside `#setSessionLocally()`. This path was unguarded, producing a second `/token` POST immediately after the code exchange 200.

The same gap existed in the no-Web-Locks fallback path in `makeRefreshTokenRequest()`.

## Fix

Move the `try/finally` guard into `#setSessionLocally()` itself. Remove the now-redundant wrapper in `makeRefreshTokenRequest()`'s lock callback. The guard at the top of `makeRefreshTokenRequest()` (`if (this.#inSessionUpdateCallback) return true`) is unchanged — it still works because the flag is now set before `session$` emits.

| Call site | Before | After |
|-----------|--------|-------|
| `makeRefreshTokenRequest()` lock callback → `#updateSession()` → `#setSessionLocally()` | ✅ guarded externally | ✅ guarded in `#setSessionLocally()` |
| `completeAuthorizationRequest()` → `#setSessionLocally()` | ❌ unguarded (the bug) | ✅ guarded |
| `makeRefreshTokenRequest()` no-locks fallback → `#updateSession()` → `#setSessionLocally()` | ❌ unguarded | ✅ guarded |

## Testing

Verified with `KeepUserLoggedIn=true` + `TimeOut=00:01:00`:
- Exactly 1 `/token [200]` after code exchange (was 2)
- No `ID2019` errors
- No spurious `[Auth] Session expiring, auto-refreshing` immediately after login
- Proactive refresh cycle produces 1 `/token [200]` per cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)