### PR TITLE
Content Picker: Fix item reference link navigation (closes #22085)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/document-item-ref.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/document-item-ref.element.ts
@@ -79,8 +79,7 @@ export class UmbDocumentItemRefElement extends UmbLitElement {
 	#getHref() {
 		if (!this._unique) return;
 		const path = UMB_EDIT_DOCUMENT_WORKSPACE_PATH_PATTERN.generateLocal({ unique: this._unique });
-		const culture = this.#item.getCulture();
-		return culture ? `${this._editPath}/${path}/${culture}` : `${this._editPath}/${path}`;
+		return `${this._editPath}/${path}`;
 	}
 
 	#onSelected(event: UUISelectableEvent) {


### PR DESCRIPTION
## Description

This addresses the regression reported in https://github.com/umbraco/Umbraco-CMS/issues/22085.

I've removed the culture path segment from the `umb-document-item-ref` href, which was causing a "Not Found" page when clicking a content picker item link

The culture segment was added in https://github.com/umbraco/Umbraco-CMS/pull/21466 for link picker culture support, it doesn't seem that a culture path segment is supported when routing.

## Testing

- Create or open a content node with a Content Picker property
- Select a content item in the Content Picker
- Click the link of the selected content picker item — it should navigate to the content editor (not "Not Found")
