### PR TITLE
Sections: Sort sections by display name in user group assignment (closes #22094)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/components/input-section/input-section.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/components/input-section/input-section.element.ts
@@ -1,6 +1,6 @@
 import type { UmbSectionItemModel } from '../../types.js';
 import { UmbSectionPickerInputContext } from './input-section.context.js';
-import { css, html, customElement, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, property, state, repeat } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
@@ -91,7 +91,10 @@ export class UmbInputSectionElement extends UmbFormControlMixin<string | undefin
 		);
 
 		this.observe(this.#pickerContext.selection, (selection) => (this.value = selection.join(',')));
-		this.observe(this.#pickerContext.selectedItems, (selectedItems) => (this._items = selectedItems));
+		this.observe(
+			this.#pickerContext.selectedItems,
+			(selectedItems) => (this._items = [...selectedItems].sort((a, b) => (b.weight ?? 0) - (a.weight ?? 0))),
+		);
 	}
 
 	protected override getFormElement() {
@@ -99,9 +102,8 @@ export class UmbInputSectionElement extends UmbFormControlMixin<string | undefin
 	}
 
 	override render() {
-		const sortedItems = [...(this._items ?? [])].sort((a, b) => (b.weight ?? 0) - (a.weight ?? 0));
 		return html`
-			<uui-ref-list>${sortedItems.map((item) => this._renderItem(item))}</uui-ref-list>
+			<uui-ref-list>${repeat(this._items ?? [], (item) => item.unique, (item) => this._renderItem(item))}</uui-ref-list>
 			<uui-button
 				id="btn-add"
 				look="placeholder"


### PR DESCRIPTION
## Description

Addresses: https://github.com/umbraco/Umbraco-CMS/issues/22094

Sorts sections alphabetically by localized display name in both the "Assign Access" selected sections list and the "Select sections" picker modal.

## Testing

To test you can register a custom section via `App_Plugins` with an alias that sorts differently from its display name:

```json
{
  "$schema": "../../umbraco-package-schema.json",
  "name": "Test.SectionSort",
  "version": "0.1.0",
  "extensions": [
    {
      "type": "section",
      "alias": "Zzz.Section.AlphaTest",
      "name": "Alpha Test Section",
      "weight": 100,
      "meta": {
        "label": "Alpha Test Section",
        "pathname": "alpha-test"
      }
    }
  ]
}
```

1. Place the above in `src/Umbraco.Web.UI/App_Plugins/test-section-sort/umbraco-package.json`
2. Edit a user group → Assign Access → open the section picker
3. **Before fix**: "Alpha Test Section" appears at the bottom (sorted by `Zzz` alias)
4. **After fix**: "Alpha Test Section" appears at the top (sorted alphabetically by display name)
5. Verify the same alphabetical ordering applies to the selected sections list after confirming the selection

From my testing using a similar method, here's the before:

<img width="484" height="445" alt="image" src="https://github.com/user-attachments/assets/c042f841-336b-4108-94f4-25ab0d056a5a" />


And the after:

<img width="483" height="459" alt="image" src="https://github.com/user-attachments/assets/2ab52e6b-5675-4d84-a1ff-b2f329a3d6b0" />



