### PR TITLE
Boot Failed: Add missing BootFailed.html error page (closes #17144)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,8 @@ tools/docfx/
 /src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/assets
 /src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/js
 /src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/lib
-/src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/views
+/src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/views/*
+!/src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/views/errors
 /src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/login
 
 # Environment specific data

--- a/src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/views/errors/BootFailed.html
+++ b/src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/views/errors/BootFailed.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <title>Boot Failed</title>
+
+    <link rel="stylesheet" href="/umbraco/website/nonodes.css" />
+    <style type="text/css">
+        body {
+            color: initial;
+        }
+
+        section {
+            background: none;
+        }
+
+        h1 {
+            margin-bottom: 0.5em;
+        }
+
+        h2 {
+            margin-bottom: 0.2em;
+        }
+    </style>
+</head>
+<body>
+
+    <section>
+        <article>
+            <div>
+                <h1>Boot Failed</h1>
+                <h2>Umbraco failed to boot</h2>
+                <p>If you are the owner of the website please see the log file for more details.</p>
+            </div>
+        </article>
+    </section>
+
+</body>
+</html>

--- a/src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/views/errors/BootFailed.html
+++ b/src/Umbraco.Cms.StaticAssets/wwwroot/umbraco/views/errors/BootFailed.html
@@ -7,7 +7,12 @@
 
     <title>Boot Failed</title>
 
-    <link rel="stylesheet" href="/umbraco/website/nonodes.css" />
+    <!--
+        The {{pathBase}} placeholder is replaced by BootFailedMiddleware
+        with the request's PathBase, so asset URLs resolve correctly when
+        Umbraco is hosted under a virtual directory.
+    -->
+    <link rel="stylesheet" href="{{pathBase}}/umbraco/website/nonodes.css" />
     <style type="text/css">
         body {
             color: initial;

--- a/src/Umbraco.Web.Common/Middleware/BootFailedMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/BootFailedMiddleware.cs
@@ -51,7 +51,9 @@ public class BootFailedMiddleware : IMiddleware
                 if (fileInfo is not null)
                 {
                     using var sr = new StreamReader(fileInfo.CreateReadStream(), Encoding.UTF8);
-                    await context.Response.WriteAsync(await sr.ReadToEndAsync(), Encoding.UTF8);
+                    var html = await sr.ReadToEndAsync();
+                    html = html.Replace("{{pathBase}}", context.Request.PathBase.Value?.TrimEnd('/'));
+                    await context.Response.WriteAsync(html, Encoding.UTF8);
                 }
             }
         }


### PR DESCRIPTION
## Description

Our [documented "boot failed" messaging](https://docs.umbraco.com/umbraco-cms/tutorials/custom-error-page#boot-failed-errors) isn't working correctly at present, as described in https://github.com/umbraco/Umbraco-CMS/issues/17144.

To fix I've added the missing `BootFailed.html` static error page to `Umbraco.Cms.StaticAssets`. The `BootFailedMiddleware` already looks for this file at `wwwroot/umbraco/views/errors/BootFailed.html`, but the file was never create. In non-debug mode, users got an empty HTTP 500 response with no body instead of a friendly error page.

Fixed an overly broad `.gitignore` rule that was ignoring the entire `wwwroot/umbraco/views/` directory, so the file can be committed to the repository.

The page styling matches the existing maintenance/upgrading page design (`Upgrading.cshtml`) using the shared `nonodes.css` stylesheet, and the copy matches [what is documented](https://docs.umbraco.com/umbraco-cms/tutorials/custom-error-page#boot-failed-errors).

<img width="1563" height="866" alt="image" src="https://github.com/user-attachments/assets/c679b02b-90e4-461f-9694-f387f7744343" />

## Testing

### 1. Verify the default boot failed page displays

- In `appsettings.json` (or `appsettings.Development.json`), set `Umbraco:CMS:Hosting:Debug` to `false`.
- Break the database connection string (e.g. change the database name to something that doesn't exist).
- Start the application and browse to any URL.
- **Expected**: A styled "Boot Failed" page is displayed with the message "Umbraco failed to boot" and a prompt to check the log file.

### 2. Verify debug mode still shows the developer exception page

- Set `Umbraco:CMS:Hosting:Debug` back to `true`.
- Keep the broken connection string.
- Start the application and browse to any URL.
- **Expected**: The developer exception page is displayed with the full `BootFailedException` stack trace, not the friendly HTML page.

### 3. Verify the custom override mechanism works

- Set `Umbraco:CMS:Hosting:Debug` to `false`.
- Create a file at `wwwroot/config/errors/BootFailed.html` with custom content (e.g. `<h1>Custom Boot Failed</h1>`).
- Keep the broken connection string and start the application.
- **Expected**: Your custom HTML is displayed instead of the default page, confirming the override works as expected.

## Documentation

We should update the screenshot on the [documentation page](https://docs.umbraco.com/umbraco-cms/tutorials/custom-error-page#boot-failed-errors).