### PR TITLE
Distributed Locking: Add ROWLOCK hint to prevent cross-row contention on umbracoLock table (closes #22113)

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqlServerEFCoreDistributedLockingMechanism.cs
@@ -157,7 +157,7 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                         "A transaction with minimum ReadCommitted isolation level is required.");
                 }
 
-                var number = await dbContext.Database.ExecuteScalarAsync<int?>($"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};SELECT value FROM dbo.umbracoLock WITH (REPEATABLEREAD) WHERE id={LockId}");
+                var number = await dbContext.Database.ExecuteScalarAsync<int?>($"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};SELECT value FROM dbo.umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id={LockId}");
 
                 if (number == null)
                 {
@@ -190,7 +190,7 @@ internal sealed class SqlServerEFCoreDistributedLockingMechanism<T> : IDistribut
                 }
 
 #pragma warning disable EF1002
-                var rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(@$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={LockId}");
+                var rowsAffected = await dbContext.Database.ExecuteSqlRawAsync(@$"SET LOCK_TIMEOUT {(int)_timeout.TotalMilliseconds};UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id={LockId}");
 #pragma warning restore EF1002
 
                 if (rowsAffected == 0)

--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerDistributedLockingMechanism.cs
@@ -144,7 +144,7 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
                     "A transaction with minimum ReadCommitted isolation level is required.");
             }
 
-            const string query = "SELECT value FROM umbracoLock WITH (REPEATABLEREAD)  WHERE id=@id";
+            const string query = "SELECT value FROM umbracoLock WITH (ROWLOCK, REPEATABLEREAD) WHERE id=@id";
 
             var lockTimeoutQuery = $"SET LOCK_TIMEOUT {_timeout.TotalMilliseconds}";
 
@@ -180,7 +180,7 @@ public class SqlServerDistributedLockingMechanism : IDistributedLockingMechanism
             }
 
             const string query =
-                @"UPDATE umbracoLock WITH (REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id";
+                @"UPDATE umbracoLock WITH (ROWLOCK, REPEATABLEREAD) SET value = (CASE WHEN (value=1) THEN -1 ELSE 1 END) WHERE id=@id";
 
             var lockTimeoutQuery = $"SET LOCK_TIMEOUT {_timeout.TotalMilliseconds}";
 


### PR DESCRIPTION
## Description

Follows investigation into: https://github.com/umbraco/Umbraco-CMS/issues/22113

This PR adds a `ROWLOCK` table hint to SQL Server distributed locking queries (both NPoco and EF Core) to prevent SQL Server from choosing page-level lock granularity on the small `umbracoLock` table.

## Analysis

The `umbracoLock` table has ~18 rows which all fit on a single 8KB SQL Server data page. The existing locking SQL uses `WITH (REPEATABLEREAD)` but no `ROWLOCK` hint, leaving lock granularity up to SQL Server's query optimizer.

From what I understand, it's possible for SQL Server to choose a page or table lock here, which could lead problems similar to that described in the reported issue.

For example, when a long-running content operation (e.g., `EmptyRecycleBin`) holds a lock on `ContentTree` (-333), SQL Server may use a page-level lock that also covers the `DistributedJobs` row (-347). Other servers polling `TryTakeRunnableAsync` every 5 seconds then fail to acquire `WriteLock(-347)`, producing `DistributedWriteLockTimeoutException` ("Failed to acquire write lock for id: -347").

Adding `ROWLOCK` ensures SQL Server locks only the specific row being accessed, so locks on different IDs never contend with each other regardless of table size or optimizer decisions.

## Testing

I've used some local integration tests to verify that if a page lock is explicitly requested, then we do see the contention between the row locks.  But as this isn't deterministic it's not possible to demonstrate conclusively that this problem occurs and is resolved by this update.

My suggestion is that I can't see any harm in doing this.  We definitely want row level locking on this table, as that's the point of being able to lock certain aggregate roots and not others.  So being explicit could be useful here in some where lock escalation to a page or table level could otherwise occur.