### PR TITLE
QA: Fix element tree integration tests and SQL Server container service error 

### DIFF
--- a/src/Umbraco.Core/Services/ElementContainerService.cs
+++ b/src/Umbraco.Core/Services/ElementContainerService.cs
@@ -74,7 +74,7 @@ internal sealed class ElementContainerService : EntityTypeContainerService<IElem
         if (_contentSettingsOptions.CurrentValue.DisableUnpublishWhenReferenced)
         {
             Attempt<PagedModel<RelationItemModel>, GetReferencesOperationStatus> referencedDescendants = await _trackedReferencesService
-                .GetPagedDescendantsInReferencesAsync(key, UmbracoObjectTypes.ElementContainer, 0, 0, filterMustBeIsDependency: true);
+                .GetPagedDescendantsInReferencesAsync(key, UmbracoObjectTypes.ElementContainer, 0, 1, filterMustBeIsDependency: true);
 
             if (referencedDescendants.Result.Total > 0)
             {

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/AncestorsElementTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/AncestorsElementTreeControllerTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Controllers.Element.Tree;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
@@ -65,6 +66,7 @@ public class AncestorsElementTreeControllerTests : ManagementApiUserGroupTestBas
             .WithAlias(Guid.NewGuid().ToString("N"))
             .WithName("Test Group With Element Start Node")
             .WithAllowedSections(["library"])
+            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter })
             .WithStartElementId(_parentId)
             .Build();
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/ChildrenElementTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/ChildrenElementTreeControllerTests.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Controllers.Element.Tree;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
@@ -95,6 +96,7 @@ public class ChildrenElementTreeControllerTests : ManagementApiUserGroupTestBase
             .WithAlias(Guid.NewGuid().ToString("N"))
             .WithName("Test Group With Element Start Node")
             .WithAllowedSections(["library"])
+            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter })
             .WithStartElementId(startNodeFolder.Id)
             .Build();
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/RootElementTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/RootElementTreeControllerTests.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Api.Management.Controllers.Element.Tree;
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
@@ -64,6 +65,7 @@ public class RootElementTreeControllerTests : ManagementApiUserGroupTestBase<Roo
             .WithAlias(Guid.NewGuid().ToString("N"))
             .WithName("Test Group With Element Start Node")
             .WithAllowedSections(["library"])
+            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter })
             .WithStartElementId(folder1.Id)
             .Build();
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/SiblingsElementTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/SiblingsElementTreeControllerTests.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Api.Common.ViewModels.Pagination;
 using Umbraco.Cms.Api.Management.Controllers.Element.Tree;
 using Umbraco.Cms.Api.Management.ViewModels.Tree;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
@@ -63,6 +64,7 @@ public class SiblingsElementTreeControllerTests : ManagementApiUserGroupTestBase
             .WithAlias(Guid.NewGuid().ToString("N"))
             .WithName("Test Group With Element Start Node")
             .WithAllowedSections(["library"])
+            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter })
             .WithStartElementId(_folder1Id)
             .Build();
 


### PR DESCRIPTION
Add missing element browse permission to tree tests and fix take=0 in container service     