### PR TITLE
Block Editors: Resolves incorrect "Discard unsaved changes" message when editing blocks with live editing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -658,7 +658,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 					this.#blockManager?.setOneContent(this.#initialContent);
 				}
 				if (this.#initialSettings) {
-					this.#blockManager?.setOneContent(this.#initialSettings);
+					this.#blockManager?.setOneSettings(this.#initialSettings);
 				}
 			}
 		}


### PR DESCRIPTION
Line 661 calls setOneContent() with settings data instead of setOneSettings(). This pushes the settings element into the contentData array.

I noticed the issue when opening a block list item, not making any changes and then opening another block list item. Umbraco writes to console showing the persisted and current json objects for the page data. When you inspect these objects you can see that the objects are different when they should be identical.

This causes the "Discard unsaved changes" modal to appear when moving away from the current document in the CMS.
