### PR TITLE
Media Picker: Add Cards/Table view switcher (closes #22005)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -640,7 +640,8 @@ export default {
 		seeErrorDialogHeadline: 'Fejl detaljer',
 		selectEvent: 'Vælg begivenhed',
 		editWebhook: 'Rediger webhook',
-		cannotTrashWhenReferenced: (name: string) => `<strong>${name}</strong> kan ikke flyttes til papirkurven, fordi det refereres af andre elementer.`,
+		cannotTrashWhenReferenced: (name: string) =>
+			`<strong>${name}</strong> kan ikke flyttes til papirkurven, fordi det refereres af andre elementer.`,
 		confirmTrash: (name: string) => `Er du sikker på, at du vil flytte <strong>${name}</strong> til papirkurven?`,
 		cannotBulkTrashWhenReferenced: (total: number) =>
 			`De valgte <strong>${total} ${total === 1 ? 'element' : 'elementer'}</strong> kan ikke flyttes til papirkurven, fordi mindst \u00e9t element refereres af andet indhold.`,
@@ -2856,6 +2857,8 @@ export default {
 	collection: {
 		noItemsTitle: 'Intet indhold',
 		addCollectionConfiguration: 'Tilføj samling',
+		cardViewLabel: 'Kort',
+		tableViewLabel: 'Tabel',
 	},
 	linkPicker: {
 		modalSource: 'Kilde',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -236,6 +236,8 @@ export default {
 	collection: {
 		noItemsTitle: 'No items',
 		addCollectionConfiguration: 'Add collection',
+		cardViewLabel: 'Cards',
+		tableViewLabel: 'Table',
 	},
 	content: {
 		isPublished: 'Is Published',
@@ -555,7 +557,8 @@ export default {
 		confirmremoveusageof: 'Are you sure you want to remove the usage of <strong>%0%</strong>',
 		confirmlogout: 'Are you sure?',
 		confirmSure: 'Are you sure?',
-		cannotTrashWhenReferenced: (name: string) => `<strong>${name}</strong> cannot be moved to the Recycle Bin because it is referenced by other items.`,
+		cannotTrashWhenReferenced: (name: string) =>
+			`<strong>${name}</strong> cannot be moved to the Recycle Bin because it is referenced by other items.`,
 		confirmTrash: (name: string) => `Are you sure you want to move <strong>${name}</strong> to the Recycle Bin?`,
 		cannotBulkTrashWhenReferenced: (total: number) =>
 			`The selected <strong>${total} ${total === 1 ? 'item' : 'items'}</strong> cannot be moved to the Recycle Bin because at least one item is referenced by other content.`,

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -238,6 +238,37 @@ describe('UmbLocalizationController', () => {
 		});
 	});
 
+	describe('dateTime', () => {
+		it('should return a localized date with time', () => {
+			const date = new Date(2020, 0, 1, 13, 30, 0);
+			const expected = new Intl.DateTimeFormat('en-us', { dateStyle: 'short', timeStyle: 'medium' }).format(date);
+			expect(controller.dateTime(date)).to.equal(expected);
+		});
+
+		it('should accept a string input', () => {
+			const dateStr = '2020-06-15T10:30:00';
+			const expected = new Intl.DateTimeFormat('en-us', { dateStyle: 'short', timeStyle: 'medium' }).format(
+				new Date(dateStr),
+			);
+			expect(controller.dateTime(dateStr)).to.equal(expected);
+		});
+
+		it('should update the dateTime when the language changes', async () => {
+			const date = new Date(2020, 11, 31, 13, 30, 0);
+			const enResult = controller.dateTime(date);
+
+			// Switch browser to Danish
+			document.documentElement.lang = danishRegional.$code;
+			await aTimeout(0);
+
+			const daResult = controller.dateTime(date);
+			const expectedDa = new Intl.DateTimeFormat('da-dk', { dateStyle: 'short', timeStyle: 'medium' }).format(date);
+
+			expect(daResult).to.equal(expectedDa);
+			expect(daResult).to.not.equal(enResult);
+		});
+	});
+
 	describe('number', () => {
 		it('should return a number', () => {
 			expect(controller.number(123456.789)).to.equal('123,456.789');

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.ts
@@ -234,6 +234,16 @@ export class UmbLocalizationController<LocalizationSetType extends UmbLocalizati
 	}
 
 	/**
+	 * Outputs a localized date with time using short date and medium time format.
+	 * @param {Date | string} dateToFormat - the date to format.
+	 * @returns {string}
+	 */
+	dateTime(dateToFormat: Date | string): string {
+		dateToFormat = new Date(dateToFormat);
+		return new Intl.DateTimeFormat(this.lang(), { dateStyle: 'short', timeStyle: 'medium' }).format(dateToFormat);
+	}
+
+	/**
 	 * Outputs a localized number in the specified format.
 	 * @param {number | string} numberToFormat - the number or string to format.
 	 * @param {Intl.NumberFormatOptions} options - the options to use when formatting the number.

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -600,7 +600,7 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 					},
 					{
 						columnAlias: 'createDate',
-						value: 'createDate' in item ? this.localize.date(item.createDate) : '',
+						value: 'createDate' in item ? this.localize.dateTime(item.createDate) : '',
 					},
 				],
 			};

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -528,13 +528,13 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 					<umb-popover-layout>
 						<div id="view-dropdown">
 							<uui-menu-item
-								label="Cards"
+								label=${this.localize.term('collection_cardViewLabel')}
 								@click-label=${() => this.#onViewSelect('cards')}
 								?active=${this._currentView === 'cards'}>
 								<umb-icon slot="icon" name="icon-grid"></umb-icon>
 							</uui-menu-item>
 							<uui-menu-item
-								label="Table"
+								label=${this.localize.term('collection_tableViewLabel')}
 								@click-label=${() => this.#onViewSelect('table')}
 								?active=${this._currentView === 'table'}>
 								<umb-icon slot="icon" name="icon-table"></umb-icon>

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -113,6 +113,7 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 	#pagingMap = new Map<string, UmbPaginationManager>();
 	#contextCulture?: string | null;
 	#locationInteractionMemoryUnique: string = 'UmbMediaItemPickerLocation';
+	#viewInteractionMemoryUnique: string = 'UmbMediaItemPickerView';
 
 	constructor() {
 		super();
@@ -169,6 +170,11 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 
 				this._searchFrom = { unique: source.unique, entityType: source.entityType };
 			}
+		}
+
+		const viewFromMemory = this.#getViewFromInteractionMemory();
+		if (viewFromMemory) {
+			this._currentView = viewFromMemory;
 		}
 
 		await this.#loadFolderTypes();
@@ -257,6 +263,7 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 
 	#onViewSelect(view: UmbMediaPickerView) {
 		this._currentView = view;
+		this.#setViewInInteractionMemory(view);
 		// TODO: This ignore is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS yet.
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
@@ -423,6 +430,19 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 	#getLocationFromInteractionMemory(): { entity: UmbEntityModel } | undefined {
 		const memory = this._pickerContext.interactionMemory.getMemory(this.#locationInteractionMemoryUnique);
 		return memory?.value?.location;
+	}
+
+	#setViewInInteractionMemory(view: UmbMediaPickerView) {
+		const memory: UmbInteractionMemoryModel = {
+			unique: this.#viewInteractionMemoryUnique,
+			value: { view },
+		};
+		this._pickerContext?.interactionMemory.setMemory(memory);
+	}
+
+	#getViewFromInteractionMemory(): UmbMediaPickerView | undefined {
+		const memory = this._pickerContext.interactionMemory.getMemory(this.#viewInteractionMemoryUnique);
+		return memory?.value?.view;
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -28,12 +28,25 @@ import { UmbFileDropzoneItemStatus, type UmbDropzoneChangeEvent } from '@umbraco
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import type { UmbInteractionMemoryModel } from '@umbraco-cms/backoffice/interaction-memory';
 import type { UmbPickerContext } from '@umbraco-cms/backoffice/picker';
-import type { UUIInputEvent, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
+import type {
+	UUIInputEvent,
+	UUIPaginationEvent,
+	UUIPopoverContainerElement,
+} from '@umbraco-cms/backoffice/external/uui';
+import type {
+	UmbTableColumn,
+	UmbTableConfig,
+	UmbTableDeselectedEvent,
+	UmbTableItem,
+	UmbTableSelectedEvent,
+} from '@umbraco-cms/backoffice/components';
 
 import './components/index.js';
 import '@umbraco-cms/backoffice/imaging';
 
 const root: UmbMediaPathModel = { name: 'Media', unique: null, entityType: UMB_MEDIA_ROOT_ENTITY_TYPE };
+
+type UmbMediaPickerView = 'cards' | 'table';
 
 // TODO: investigate how we can reuse the picker-search-field element, picker context etc.
 @customElement('umb-media-picker-modal')
@@ -90,6 +103,12 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 
 	@query('#dropzone')
 	private _dropzone!: UmbDropzoneMediaElement;
+
+	@query('#media-picker-view-popover')
+	private _viewPopover?: UUIPopoverContainerElement;
+
+	@state()
+	private _currentView: UmbMediaPickerView = 'cards';
 
 	#pagingMap = new Map<string, UmbPaginationManager>();
 	#contextCulture?: string | null;
@@ -234,6 +253,14 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 				await this.#loadChildrenOfCurrentMediaItem();
 			}
 		}
+	}
+
+	#onViewSelect(view: UmbMediaPickerView) {
+		this._currentView = view;
+		// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS yet.
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		this._viewPopover?.hidePopover();
 	}
 
 	// TODO: move to location manager in context
@@ -428,13 +455,15 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 		return html`
 			${!this._searchResult.length && !this._searching
 				? html`<div class="container"><p>${this.localize.term('content_listViewNoItems')}</p></div>`
-				: html`<div id="media-grid">
-						${repeat(
-							this._searchResult,
-							(item) => item.unique,
-							(item) => this.#renderCard(item),
-						)}
-					</div>`}
+				: this._currentView === 'table'
+					? this.#renderTable(this._searchResult)
+					: html`<div id="media-grid">
+							${repeat(
+								this._searchResult,
+								(item) => item.unique,
+								(item) => this.#renderCard(item),
+							)}
+						</div>`}
 		`;
 	}
 
@@ -442,23 +471,25 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 		return html`
 			${!this._currentChildren.length
 				? html`<div class="container"><p>${this.localize.term('content_listViewNoItems')}</p></div>`
-				: html`<div id="media-grid">
-							${repeat(
-								this._currentChildren,
-								(item) => item.unique,
-								(item) => this.#renderCard(item),
-							)}
-						</div>
-						${this._currentTotalPages > 1
-							? html`<uui-pagination
-									.current=${this._currentPage}
-									.total=${this._currentTotalPages}
-									firstlabel=${this.localize.term('general_first')}
-									previouslabel=${this.localize.term('general_previous')}
-									nextlabel=${this.localize.term('general_next')}
-									lastlabel=${this.localize.term('general_last')}
-									@change=${this.#onPageChange}></uui-pagination>`
-							: nothing}`}
+				: html`${this._currentView === 'table'
+						? this.#renderTable(this._currentChildren)
+						: html`<div id="media-grid">
+								${repeat(
+									this._currentChildren,
+									(item) => item.unique,
+									(item) => this.#renderCard(item),
+								)}
+							</div>`}
+					${this._currentTotalPages > 1
+						? html`<uui-pagination
+								.current=${this._currentPage}
+								.total=${this._currentTotalPages}
+								firstlabel=${this.localize.term('general_first')}
+								previouslabel=${this.localize.term('general_previous')}
+								nextlabel=${this.localize.term('general_next')}
+								lastlabel=${this.localize.term('general_last')}
+								@change=${this.#onPageChange}></uui-pagination>`
+						: nothing}`}
 		`;
 	}
 
@@ -490,6 +521,27 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 					label=${this.localize.term('general_upload')}
 					look="outline"
 					color="default"></uui-button>
+				<uui-button compact popovertarget="media-picker-view-popover" label="View">
+					<umb-icon name=${this._currentView === 'cards' ? 'icon-grid' : 'icon-table'}></umb-icon>
+				</uui-button>
+				<uui-popover-container id="media-picker-view-popover" placement="bottom-end">
+					<umb-popover-layout>
+						<div id="view-dropdown">
+							<uui-menu-item
+								label="Cards"
+								@click-label=${() => this.#onViewSelect('cards')}
+								?active=${this._currentView === 'cards'}>
+								<umb-icon slot="icon" name="icon-grid"></umb-icon>
+							</uui-menu-item>
+							<uui-menu-item
+								label="Table"
+								@click-label=${() => this.#onViewSelect('table')}
+								?active=${this._currentView === 'table'}>
+								<umb-icon slot="icon" name="icon-table"></umb-icon>
+							</uui-menu-item>
+						</div>
+					</umb-popover-layout>
+				</uui-popover-container>
 			</div>
 		`;
 	}
@@ -515,6 +567,84 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 					alt=${item.name}
 					icon=${item.mediaType.icon}></umb-imaging-thumbnail>
 			</uui-card-media>
+		`;
+	}
+
+	#buildTableItems(items: Array<UmbMediaTreeItemModel | UmbMediaSearchItemModel>): Array<UmbTableItem> {
+		return items.map((item) => {
+			const canNavigate = this.#allowNavigateToMedia(item);
+			const selectable = this._selectableFilter(item);
+			// When not in selection mode, navigable items open on click (matching card behaviour).
+			// Mark them as non-selectable so the row doesn't intercept the click for selection.
+			const selectableInTable = this._isSelectionMode ? selectable : !canNavigate && selectable;
+			return {
+				id: item.unique,
+				icon: item.mediaType.icon,
+				selectable: selectableInTable,
+				data: [
+					{
+						columnAlias: 'name',
+						value:
+							canNavigate && !this._isSelectionMode
+								? html`<uui-button
+										look="default"
+										compact
+										label=${item.name}
+										@click=${(e: Event) => {
+											e.stopPropagation();
+											this.#onOpen(item);
+										}}
+										>${item.name}</uui-button
+									>`
+								: html`<span class="table-name">${item.name}</span>`,
+					},
+					{
+						columnAlias: 'createDate',
+						value: 'createDate' in item ? this.localize.date(item.createDate) : '',
+					},
+				],
+			};
+		});
+	}
+
+	#onTableSelected(event: UmbTableSelectedEvent) {
+		const itemId = event.getItemId();
+		if (!itemId) return;
+		const item = [...this._currentChildren, ...this._searchResult].find((i) => i.unique === itemId);
+		if (!item) return;
+		this.#onSelected(item);
+	}
+
+	#onTableDeselected(event: UmbTableDeselectedEvent) {
+		const itemId = event.getItemId();
+		if (!itemId) return;
+		const item = [...this._currentChildren, ...this._searchResult].find((i) => i.unique === itemId);
+		if (!item) return;
+		this.#onDeselected(item);
+	}
+
+	#renderTable(items: Array<UmbMediaTreeItemModel | UmbMediaSearchItemModel>) {
+		const tableColumns: Array<UmbTableColumn> = [
+			{
+				name: this.localize.term('general_name'),
+				alias: 'name',
+			},
+			{
+				name: this.localize.term('content_createDate'),
+				alias: 'createDate',
+			},
+		];
+		const tableConfig: UmbTableConfig = {
+			allowSelection: true,
+		};
+		return html`
+			<umb-table
+				.config=${tableConfig}
+				.columns=${tableColumns}
+				.items=${this.#buildTableItems(items)}
+				.selection=${this.value?.selection ?? []}
+				@selected=${this.#onTableSelected}
+				@deselected=${this.#onTableDeselected}></umb-table>
 		`;
 	}
 
@@ -573,7 +703,7 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 				padding-bottom: 5px; /** The modal is a bit jumpy due to the img card focus/hover border. This fixes the issue. */
 			}
 
-			umb-icon {
+			#media-grid umb-icon {
 				font-size: var(--uui-size-8);
 			}
 
@@ -595,6 +725,19 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 			uui-pagination {
 				display: block;
 				margin-top: var(--uui-size-layout-1);
+			}
+
+			.table-name {
+				flex: 1;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			#view-dropdown {
+				padding: var(--uui-size-space-3);
+				--uui-button-content-align: left;
+				--uui-menu-item-flat-structure: 1;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -284,14 +284,14 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 		this.#setLocationInInteractionMemory();
 	}
 
-	#onSelected(item: UmbMediaTreeItemModel | UmbMediaSearchItemModel) {
-		const selection = this.data?.multiple ? [...this.value.selection, item.unique!] : [item.unique!];
+	#onSelected(unique: string) {
+		const selection = this.data?.multiple ? [...this.value.selection, unique] : [unique];
 		this._isSelectionMode = selection.length > 0;
 		this.modalContext?.setValue({ selection });
 	}
 
-	#onDeselected(item: UmbMediaTreeItemModel | UmbMediaSearchItemModel) {
-		const selection = this.value.selection.filter((value) => value !== item.unique);
+	#onDeselected(unique: string) {
+		const selection = this.value.selection.filter((value) => value !== unique);
 		this._isSelectionMode = selection.length > 0;
 		this.modalContext?.setValue({ selection });
 	}
@@ -557,8 +557,8 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 				.name=${item.name}
 				data-mark="${item.entityType}:${item.unique}"
 				@open=${() => this.#onOpen(item)}
-				@selected=${() => this.#onSelected(item)}
-				@deselected=${() => this.#onDeselected(item)}
+				@selected=${() => this.#onSelected(item.unique!)}
+				@deselected=${() => this.#onDeselected(item.unique!)}
 				?selected=${this.value?.selection?.find((value) => value === item.unique)}
 				?selectable=${selectable}
 				?select-only=${this._isSelectionMode || canNavigate === false}>
@@ -610,17 +610,13 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 	#onTableSelected(event: UmbTableSelectedEvent) {
 		const itemId = event.getItemId();
 		if (!itemId) return;
-		const item = [...this._currentChildren, ...this._searchResult].find((i) => i.unique === itemId);
-		if (!item) return;
-		this.#onSelected(item);
+		this.#onSelected(itemId);
 	}
 
 	#onTableDeselected(event: UmbTableDeselectedEvent) {
 		const itemId = event.getItemId();
 		if (!itemId) return;
-		const item = [...this._currentChildren, ...this._searchResult].find((i) => i.unique === itemId);
-		if (!item) return;
-		this.#onDeselected(item);
+		this.#onDeselected(itemId);
 	}
 
 	#renderTable(items: Array<UmbMediaTreeItemModel | UmbMediaSearchItemModel>) {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -257,7 +257,7 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 
 	#onViewSelect(view: UmbMediaPickerView) {
 		this._currentView = view;
-		// TODO: This ignorer is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS yet.
+		// TODO: This ignore is just needed for JSON SCHEMA TO WORK, As its not updated with latest TS yet.
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		this._viewPopover?.hidePopover();


### PR DESCRIPTION
Fixes #22005 

  - Adds a view switcher to the media picker modal, allowing users to toggle between a Cards and a
  Table view. This restores functionality that was available in Umbraco v13.
  - Adds a dateTime() method to UmbLocalizationController that formats a date with both date and time
  components (dateStyle: 'short', timeStyle: 'medium') using the backoffice UI culture, and uses it for the
  creation date column.
  
### Current Card View
<img width="1018" height="1120" alt="Screenshot 2026-03-16 at 10 23 52" src="https://github.com/user-attachments/assets/ada2aaf8-55ec-40ba-8768-e8550e442fd3" />

### New Table View
<img width="1030" height="1122" alt="Screenshot 2026-03-16 at 10 24 12" src="https://github.com/user-attachments/assets/90603969-b861-4e4f-aa4f-417b08571ed0" />

 ### How to test

  - Open a media picker and verify the view switcher button appears in the toolbar
  - Toggle between Cards and Table views and confirm items render correctly in both
  - In Table view, click a folder to verify it navigates into it
  - In Table view, select an item and verify the selection is reflected (checkbox appears, row is highlighted)
  - Verify existing card selection/deselection still works correctly