### PR TITLE
Elements: Fixes `HasChildren` for Element Folder entities

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Element/Tree/ElementTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Element/Tree/ElementTreeControllerBase.cs
@@ -83,7 +83,6 @@ public class ElementTreeControllerBase : UserStartNodeFolderTreeControllerBase<E
 
         if (entity is IElementEntitySlim elementEntitySlim)
         {
-            responseModel.HasChildren = elementEntitySlim.HasChildren;
             responseModel.CreateDate = elementEntitySlim.CreateDate;
             responseModel.DocumentType = _elementPresentationFactory.CreateDocumentTypeReferenceResponseModel(elementEntitySlim);
             responseModel.Variants = _elementPresentationFactory.CreateVariantsItemResponseModels(elementEntitySlim);

--- a/src/Umbraco.Cms.Api.Management/Controllers/Element/Tree/ElementTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Element/Tree/ElementTreeControllerBase.cs
@@ -83,7 +83,7 @@ public class ElementTreeControllerBase : UserStartNodeFolderTreeControllerBase<E
 
         if (entity is IElementEntitySlim elementEntitySlim)
         {
-            responseModel.HasChildren = false;
+            responseModel.HasChildren = elementEntitySlim.HasChildren;
             responseModel.CreateDate = elementEntitySlim.CreateDate;
             responseModel.DocumentType = _elementPresentationFactory.CreateDocumentTypeReferenceResponseModel(elementEntitySlim);
             responseModel.Variants = _elementPresentationFactory.CreateVariantsItemResponseModels(elementEntitySlim);


### PR DESCRIPTION
### Description

I'd noticed that the Sibling endpoint for the Element Tree management API was returning Element Folders having `HasChildren` as `false`, so the client code removes the expand/collapse caret from the UI.

Investigating the server code, I'd noticed that the Element Tree controller base class's [`MapTreeItemViewModel` method has `.HasChildren = false`](https://github.com/umbraco/Umbraco-CMS/blob/v18/dev/src/Umbraco.Cms.Api.Management/Controllers/Element/Tree/ElementTreeControllerBase.cs#L86), which is correct for Element items, but in this case, this gets set for Element Folder items too.

The fix I've supplied in this PR is a temporary fix, as I believe the underlying cause of the issue is that the Element Folder items shouldn't be retrieved as `IElementEntitySlim`, (as I noticed with the Root endpoint they are just plain old `IEntitySlim`).

I pinpointed it down to this code, but then I got outside of my comfort zone for this fix.
https://github.com/umbraco/Umbraco-CMS/blob/v18/dev/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs#L192-L197

I'm happy for this PR to be thrown away for a proper fix.