### PR TITLE
Last Synced: Adding A File System Approach to Subscriber Servers

### DIFF
--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
@@ -85,7 +85,9 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<IPublishStatusRepository, PublishStatusRepository>();
         builder.Services.AddUnique<IRepositoryCacheVersionRepository, RepositoryCacheVersionRepository>();
         builder.Services.AddUnique<ILongRunningOperationRepository, LongRunningOperationRepository>();
-        builder.Services.AddUnique<ILastSyncedRepository, LastSyncedRepository>();
+        builder.Services.AddSingleton<FileSystemLastSyncedRepository>();
+        builder.Services.AddSingleton<LastSyncedRepository>();
+        builder.Services.AddUnique<ILastSyncedRepository, ServerRoleAwareLastSyncedRepository>();
         builder.Services.AddUnique<IDistributedJobRepository, DistributedJobRepository>();
 
         return builder;

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.Repositories.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.DynamicRoot.QuerySteps;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Services.Implement;
@@ -87,6 +88,7 @@ public static partial class UmbracoBuilderExtensions
         builder.Services.AddUnique<ILongRunningOperationRepository, LongRunningOperationRepository>();
         builder.Services.AddSingleton<FileSystemLastSyncedRepository>();
         builder.Services.AddSingleton<LastSyncedRepository>();
+        builder.Services.AddUnique<IDatabaseReadOnlyAccessor, DatabaseReadOnlyAccessor>();
         builder.Services.AddUnique<ILastSyncedRepository, ServerRoleAwareLastSyncedRepository>();
         builder.Services.AddUnique<IDistributedJobRepository, DistributedJobRepository>();
 

--- a/src/Umbraco.Infrastructure/Persistence/DatabaseReadOnlyAccessor.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DatabaseReadOnlyAccessor.cs
@@ -1,6 +1,4 @@
-using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Infrastructure.Scoping;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence;
 
@@ -9,46 +7,39 @@ namespace Umbraco.Cms.Infrastructure.Persistence;
 /// </summary>
 internal sealed class DatabaseReadOnlyAccessor : IDatabaseReadOnlyAccessor
 {
-    private const string CacheKey = "DatabaseReadOnly";
-
     private readonly IScopeAccessor _scopeAccessor;
-    private readonly AppCaches _appCaches;
+    private bool? _isReadOnly;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DatabaseReadOnlyAccessor"/> class.
     /// </summary>
     /// <param name="scopeAccessor">Provides access to the ambient scope for database access.</param>
-    /// <param name="appCaches">The application caches.</param>
-    public DatabaseReadOnlyAccessor(IScopeAccessor scopeAccessor, AppCaches appCaches)
+    public DatabaseReadOnlyAccessor(IScopeAccessor scopeAccessor)
     {
         _scopeAccessor = scopeAccessor;
-        _appCaches = appCaches;
     }
 
     /// <inheritdoc />
     public bool IsReadOnly() =>
-        _appCaches.RuntimeCache.GetCacheItem(CacheKey, Check);
+        _isReadOnly ??= Check();
 
     private bool Check()
     {
-        try
+        IScope? scope = _scopeAccessor.AmbientScope;
+        if (scope is null)
         {
-            IScope? scope = _scopeAccessor.AmbientScope;
-            if (scope is null)
-            {
-                return true;
-            }
-
-            var result = scope.Database.ExecuteScalar<string>(
-                "SELECT CAST(DATABASEPROPERTYEX(DB_NAME(), 'Updateability') AS NVARCHAR(20))");
-
-            return string.Equals(result, "READ_ONLY", StringComparison.OrdinalIgnoreCase);
+            throw new InvalidOperationException("DatabaseReadOnlyAccessor requires an ambient scope.");
         }
-        catch
+
+        if (scope.Database.DatabaseType.IsSqlServer() is false)
         {
-            // Query is SQL Server specific. If it fails, like it would on SQLite
-            // we assume the database is writable.
+            // Assume writeable database if it isn't a SQL Server.
             return false;
         }
+
+        var result = scope.Database.ExecuteScalar<string>(
+            "SELECT CAST(DATABASEPROPERTYEX(DB_NAME(), 'Updateability') AS NVARCHAR(20))");
+
+        return string.Equals(result, "READ_ONLY", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/DatabaseReadOnlyAccessor.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DatabaseReadOnlyAccessor.cs
@@ -1,0 +1,54 @@
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Persistence;
+
+/// <summary>
+/// Checks whether the database is read-only by querying database.
+/// </summary>
+internal sealed class DatabaseReadOnlyAccessor : IDatabaseReadOnlyAccessor
+{
+    private const string CacheKey = "DatabaseReadOnly";
+
+    private readonly IScopeAccessor _scopeAccessor;
+    private readonly AppCaches _appCaches;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatabaseReadOnlyAccessor"/> class.
+    /// </summary>
+    /// <param name="scopeAccessor">Provides access to the ambient scope for database access.</param>
+    /// <param name="appCaches">The application caches.</param>
+    public DatabaseReadOnlyAccessor(IScopeAccessor scopeAccessor, AppCaches appCaches)
+    {
+        _scopeAccessor = scopeAccessor;
+        _appCaches = appCaches;
+    }
+
+    /// <inheritdoc />
+    public bool IsReadOnly() =>
+        _appCaches.RuntimeCache.GetCacheItem(CacheKey, Check);
+
+    private bool Check()
+    {
+        try
+        {
+            IScope? scope = _scopeAccessor.AmbientScope;
+            if (scope is null)
+            {
+                return true;
+            }
+
+            var result = scope.Database.ExecuteScalar<string>(
+                "SELECT CAST(DATABASEPROPERTYEX(DB_NAME(), 'Updateability') AS NVARCHAR(20))");
+
+            return string.Equals(result, "READ_ONLY", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Query is SQL Server specific. If it fails, like it would on SQLite
+            // we assume the database is writable.
+            return false;
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/IDatabaseReadOnlyAccessor.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IDatabaseReadOnlyAccessor.cs
@@ -1,0 +1,12 @@
+namespace Umbraco.Cms.Infrastructure.Persistence;
+
+/// <summary>
+/// Provides a way to check whether the database is read-only.
+/// </summary>
+public interface IDatabaseReadOnlyAccessor
+{
+    /// <summary>
+    /// Gets a value indicating whether the database is read only.
+    /// </summary>
+    bool IsReadOnly();
+}

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/FileSystemLastSyncedRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/FileSystemLastSyncedRepository.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// A file system based implementation of <see cref="ILastSyncedRepository"/> for use on
 /// subscriber servers that cannot write to the database.
 /// </summary>
-public class FileSystemLastSyncedRepository : ILastSyncedRepository
+internal sealed class FileSystemLastSyncedRepository : ILastSyncedRepository
 {
     private readonly IHostingEnvironment _hostingEnvironment;
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/FileSystemLastSyncedRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/FileSystemLastSyncedRepository.cs
@@ -1,0 +1,132 @@
+﻿using System.Globalization;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+
+/// <summary>
+/// A file system based implementation of <see cref="ILastSyncedRepository"/> for use on
+/// subscriber servers that cannot write to the database.
+/// </summary>
+public class FileSystemLastSyncedRepository : ILastSyncedRepository
+{
+    private readonly IHostingEnvironment _hostingEnvironment;
+
+    private string? _distCacheFolder;
+    private string? _internalFilePath;
+    private string? _externalFilePath;
+
+    private int? _lastInternalId;
+    private int? _lastExternalId;
+    private bool _lastInternalIdReady;
+    private bool _lastExternalIdReady;
+    private object? _internalLock;
+    private object? _externalLock;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystemLastSyncedRepository"/> class.
+    /// </summary>
+    /// <param name="hostingEnvironment">The hosting environment used to resolve file paths.</param>
+    public FileSystemLastSyncedRepository(IHostingEnvironment hostingEnvironment)
+        => _hostingEnvironment = hostingEnvironment;
+
+    /// <inheritdoc />
+    public Task<int?> GetInternalIdAsync()
+    {
+        EnsureInternalInitialized();
+        return Task.FromResult(_lastInternalId);
+    }
+
+    /// <inheritdoc />
+    public Task<int?> GetExternalIdAsync()
+    {
+        EnsureExternalInitialized();
+        return Task.FromResult(_lastExternalId);
+    }
+
+    /// <inheritdoc />
+    public Task SaveInternalIdAsync(int id)
+    {
+        EnsureInternalInitialized();
+
+        lock (_internalLock!)
+        {
+            WriteIdToFile(InternalFilePath, id);
+            _lastInternalId = id;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task SaveExternalIdAsync(int id)
+    {
+        EnsureExternalInitialized();
+
+        lock (_externalLock!)
+        {
+            WriteIdToFile(ExternalFilePath, id);
+            _lastExternalId = id;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DeleteEntriesOlderThanAsync(DateTime pruneDate) => Task.CompletedTask;
+
+    private void EnsureInternalInitialized()
+        => LazyInitializer.EnsureInitialized(
+            ref _lastInternalId,
+            ref _lastInternalIdReady,
+            ref _internalLock,
+            () => ReadIdFromFile(InternalFilePath));
+
+    private void EnsureExternalInitialized()
+        => LazyInitializer.EnsureInitialized(
+            ref _lastExternalId,
+            ref _lastExternalIdReady,
+            ref _externalLock,
+            () => ReadIdFromFile(ExternalFilePath));
+
+    private string InternalFilePath => LazyInitializer.EnsureInitialized(
+        ref _internalFilePath,
+        () => Path.Combine(EnsureDistCacheFolder(), GetFileHash() + "-lastsynced-internal.txt"));
+
+    private string ExternalFilePath => LazyInitializer.EnsureInitialized(
+        ref _externalFilePath,
+        () => Path.Combine(EnsureDistCacheFolder(), GetFileHash() + "-lastsynced-external.txt"));
+
+    private string EnsureDistCacheFolder() => LazyInitializer.EnsureInitialized(ref _distCacheFolder, () =>
+    {
+        var folder = Path.Combine(_hostingEnvironment.LocalTempPath, "DistCache");
+
+        if (Directory.Exists(folder) == false)
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        return folder;
+    });
+
+    private string GetFileHash()
+        => (Environment.MachineName + _hostingEnvironment.ApplicationId).GenerateHash();
+
+    private int? ReadIdFromFile(string filePath)
+    {
+        if (File.Exists(filePath))
+        {
+            var content = File.ReadAllText(filePath);
+            if (int.TryParse(content, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+            {
+                return id;
+            }
+        }
+
+        return null;
+    }
+
+    private void WriteIdToFile(string filePath, int id)
+        => File.WriteAllText(filePath, id.ToString(CultureInfo.InvariantCulture));
+}

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Sync;
 
@@ -14,24 +13,22 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// </remarks>
 public class ServerRoleAwareLastSyncedRepository : ILastSyncedRepository
 {
-    private readonly IServiceProvider _serviceProvider;
+    private readonly Lazy<IServerRoleAccessor> _serverRoleAccessor;
     private readonly LastSyncedRepository _databaseRepository;
     private readonly FileSystemLastSyncedRepository _fileSystemRepository;
-
-    private IServerRoleAccessor? _serverRoleAccessor;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ServerRoleAwareLastSyncedRepository"/> class.
     /// </summary>
-    /// <param name="serviceProvider">The service provider used to lazily resolve the server role accessor.</param>
+    /// <param name="serverRoleAccessor">Lazy accessor for the server role, deferred to avoid a singleton resolution deadlock.</param>
     /// <param name="databaseRepository">The database repository for non-subscriber servers.</param>
     /// <param name="fileSystemRepository">The file system repository for subscriber servers.</param>
     public ServerRoleAwareLastSyncedRepository(
-        IServiceProvider serviceProvider,
+        Lazy<IServerRoleAccessor> serverRoleAccessor,
         LastSyncedRepository databaseRepository,
         FileSystemLastSyncedRepository fileSystemRepository)
     {
-        _serviceProvider = serviceProvider;
+        _serverRoleAccessor = serverRoleAccessor;
         _databaseRepository = databaseRepository;
         _fileSystemRepository = fileSystemRepository;
     }
@@ -51,14 +48,8 @@ public class ServerRoleAwareLastSyncedRepository : ILastSyncedRepository
     /// <inheritdoc />
     public Task DeleteEntriesOlderThanAsync(DateTime pruneDate) => GetRepository().DeleteEntriesOlderThanAsync(pruneDate);
 
-    private ILastSyncedRepository GetRepository()
-    {
-        // We have to access the IServerRoleAccessor this way to prevent a deadlock. If IServerRoleAccessor is injected directly
-        // it has circular dependencies that will cause a deadlock.
-        _serverRoleAccessor ??= _serviceProvider.GetRequiredService<IServerRoleAccessor>();
-
-        return _serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber
+    private ILastSyncedRepository GetRepository() =>
+        _serverRoleAccessor.Value.CurrentServerRole == ServerRole.Subscriber
             ? _fileSystemRepository
             : _databaseRepository;
-    }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Sync;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+
+/// <summary>
+/// A decorator around <see cref="ILastSyncedRepository"/> that delegates to either a database
+/// or file system repository based on the server role.
+/// </summary>
+/// <remarks>
+/// Subscriber servers cannot write to the database, so they use a file-system
+/// implementation instead. All other roles use the database implementation.
+/// </remarks>
+public class ServerRoleAwareLastSyncedRepository : ILastSyncedRepository
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly LastSyncedRepository _databaseRepository;
+    private readonly FileSystemLastSyncedRepository _fileSystemRepository;
+
+    private IServerRoleAccessor? _serverRoleAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServerRoleAwareLastSyncedRepository"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider used to lazily resolve the server role accessor.</param>
+    /// <param name="databaseRepository">The database repository for non-subscriber servers.</param>
+    /// <param name="fileSystemRepository">The file system repository for subscriber servers.</param>
+    public ServerRoleAwareLastSyncedRepository(
+        IServiceProvider serviceProvider,
+        LastSyncedRepository databaseRepository,
+        FileSystemLastSyncedRepository fileSystemRepository)
+    {
+        _serviceProvider = serviceProvider;
+        _databaseRepository = databaseRepository;
+        _fileSystemRepository = fileSystemRepository;
+    }
+
+    /// <inheritdoc />
+    public Task<int?> GetInternalIdAsync() => GetRepository().GetInternalIdAsync();
+
+    /// <inheritdoc />
+    public Task<int?> GetExternalIdAsync() => GetRepository().GetExternalIdAsync();
+
+    /// <inheritdoc />
+    public Task SaveInternalIdAsync(int id) => GetRepository().SaveInternalIdAsync(id);
+
+    /// <inheritdoc />
+    public Task SaveExternalIdAsync(int id) => GetRepository().SaveExternalIdAsync(id);
+
+    /// <inheritdoc />
+    public Task DeleteEntriesOlderThanAsync(DateTime pruneDate) => GetRepository().DeleteEntriesOlderThanAsync(pruneDate);
+
+    private ILastSyncedRepository GetRepository()
+    {
+        // We have to access the IServerRoleAccessor this way to prevent a deadlock. If IServerRoleAccessor is injected directly
+        // it has circular dependencies that will cause a deadlock.
+        _serverRoleAccessor ??= _serviceProvider.GetRequiredService<IServerRoleAccessor>();
+
+        return _serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber
+            ? _fileSystemRepository
+            : _databaseRepository;
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
@@ -11,7 +11,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// Subscriber servers cannot write to the database, so they use a file-system
 /// implementation instead. All other roles use the database implementation.
 /// </remarks>
-public class ServerRoleAwareLastSyncedRepository : ILastSyncedRepository
+internal sealed class ServerRoleAwareLastSyncedRepository : ILastSyncedRepository
 {
     private readonly Lazy<IServerRoleAccessor> _serverRoleAccessor;
     private readonly LastSyncedRepository _databaseRepository;

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ServerRoleAwareLastSyncedRepository.cs
@@ -5,32 +5,36 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
 /// <summary>
 /// A decorator around <see cref="ILastSyncedRepository"/> that delegates to either a database
-/// or file system repository based on the server role.
+/// or file system repository based on the server role and database read write permissions.
 /// </summary>
 /// <remarks>
-/// Subscriber servers cannot write to the database, so they use a file-system
-/// implementation instead. All other roles use the database implementation.
+/// Subscriber servers with a read-only database use a file system implementation instead.
+/// If the subscriber database is writable, the database implementation is preferred.
 /// </remarks>
 internal sealed class ServerRoleAwareLastSyncedRepository : ILastSyncedRepository
 {
     private readonly Lazy<IServerRoleAccessor> _serverRoleAccessor;
     private readonly LastSyncedRepository _databaseRepository;
     private readonly FileSystemLastSyncedRepository _fileSystemRepository;
+    private readonly IDatabaseReadOnlyAccessor _databaseReadOnlyAccessor;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ServerRoleAwareLastSyncedRepository"/> class.
     /// </summary>
     /// <param name="serverRoleAccessor">Lazy accessor for the server role, deferred to avoid a singleton resolution deadlock.</param>
     /// <param name="databaseRepository">The database repository for non-subscriber servers.</param>
-    /// <param name="fileSystemRepository">The file system repository for subscriber servers.</param>
+    /// <param name="fileSystemRepository">The file system repository for subscriber servers with read-only databases.</param>
+    /// <param name="databaseReadOnlyAccessor">Accessor for checking whether the database is read-only.</param>
     public ServerRoleAwareLastSyncedRepository(
         Lazy<IServerRoleAccessor> serverRoleAccessor,
         LastSyncedRepository databaseRepository,
-        FileSystemLastSyncedRepository fileSystemRepository)
+        FileSystemLastSyncedRepository fileSystemRepository,
+        IDatabaseReadOnlyAccessor databaseReadOnlyAccessor)
     {
         _serverRoleAccessor = serverRoleAccessor;
         _databaseRepository = databaseRepository;
         _fileSystemRepository = fileSystemRepository;
+        _databaseReadOnlyAccessor = databaseReadOnlyAccessor;
     }
 
     /// <inheritdoc />
@@ -48,8 +52,15 @@ internal sealed class ServerRoleAwareLastSyncedRepository : ILastSyncedRepositor
     /// <inheritdoc />
     public Task DeleteEntriesOlderThanAsync(DateTime pruneDate) => GetRepository().DeleteEntriesOlderThanAsync(pruneDate);
 
-    private ILastSyncedRepository GetRepository() =>
-        _serverRoleAccessor.Value.CurrentServerRole == ServerRole.Subscriber
+    private ILastSyncedRepository GetRepository()
+    {
+        if (_serverRoleAccessor.Value.CurrentServerRole != ServerRole.Subscriber)
+        {
+            return _databaseRepository;
+        }
+
+        return _databaseReadOnlyAccessor.IsReadOnly()
             ? _fileSystemRepository
             : _databaseRepository;
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/FileSystemLastSyncedRepositoryTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/FileSystemLastSyncedRepositoryTest.cs
@@ -1,0 +1,156 @@
+﻿using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence.Repositories;
+
+[TestFixture]
+public class FileSystemLastSyncedRepositoryTest
+{
+    private string _tempPath = null!;
+    private Mock<IHostingEnvironment> _hostingEnvironment = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "UmbracoTests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempPath);
+
+        _hostingEnvironment = new Mock<IHostingEnvironment>();
+        _hostingEnvironment.Setup(x => x.LocalTempPath).Returns(_tempPath);
+        _hostingEnvironment.Setup(x => x.ApplicationId).Returns("TestApplication");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempPath))
+        {
+            Directory.Delete(_tempPath, true);
+        }
+    }
+
+    [Test]
+    public async Task Internal_Id_Is_Initially_Null()
+    {
+        var repo = CreateRepository();
+        var value = await repo.GetInternalIdAsync();
+        Assert.IsNull(value);
+    }
+
+    [Test]
+    public async Task External_Id_Is_Initially_Null()
+    {
+        var repo = CreateRepository();
+        var value = await repo.GetExternalIdAsync();
+        Assert.IsNull(value);
+    }
+
+    [Test]
+    public async Task Save_And_Get_Internal_Id()
+    {
+        var repo = CreateRepository();
+
+        // Read first to initialize the lazy lock.
+        await repo.GetInternalIdAsync();
+
+        var testId = new Random().Next(1, int.MaxValue);
+        await repo.SaveInternalIdAsync(testId);
+
+        var value = await repo.GetInternalIdAsync();
+        Assert.AreEqual(testId, value);
+    }
+
+    [Test]
+    public async Task Save_And_Get_External_Id()
+    {
+        var repo = CreateRepository();
+
+        // Read first to initialize the lazy lock.
+        await repo.GetExternalIdAsync();
+
+        var testId = new Random().Next(1, int.MaxValue);
+        await repo.SaveExternalIdAsync(testId);
+
+        var value = await repo.GetExternalIdAsync();
+        Assert.AreEqual(testId, value);
+    }
+
+    [Test]
+    public async Task Internal_And_External_Ids_Are_Independent()
+    {
+        var repo = CreateRepository();
+
+        await repo.GetInternalIdAsync();
+        await repo.GetExternalIdAsync();
+
+        await repo.SaveInternalIdAsync(100);
+        await repo.SaveExternalIdAsync(200);
+
+        Assert.AreEqual(100, await repo.GetInternalIdAsync());
+        Assert.AreEqual(200, await repo.GetExternalIdAsync());
+    }
+
+    [Test]
+    public async Task Persists_Internal_Id_To_Disk()
+    {
+        var testId = new Random().Next(1, int.MaxValue);
+
+        // Save with one instance.
+        var repo1 = CreateRepository();
+        await repo1.GetInternalIdAsync();
+        await repo1.SaveInternalIdAsync(testId);
+
+        // Read with a fresh instance to verify file persistence.
+        var repo2 = CreateRepository();
+        var value = await repo2.GetInternalIdAsync();
+
+        Assert.AreEqual(testId, value);
+    }
+
+    [Test]
+    public async Task Persists_External_Id_To_Disk()
+    {
+        var testId = new Random().Next(1, int.MaxValue);
+
+        // Save with one instance.
+        var repo1 = CreateRepository();
+        await repo1.GetExternalIdAsync();
+        await repo1.SaveExternalIdAsync(testId);
+
+        // Read with a fresh instance to verify file persistence.
+        var repo2 = CreateRepository();
+        var value = await repo2.GetExternalIdAsync();
+
+        Assert.AreEqual(testId, value);
+    }
+
+    [Test]
+    public async Task Creates_DistCache_Folder()
+    {
+        var repo = CreateRepository();
+        await repo.GetInternalIdAsync();
+
+        var distCacheFolder = Path.Combine(_tempPath, "DistCache");
+        Assert.IsTrue(Directory.Exists(distCacheFolder));
+    }
+
+    [Test]
+    public async Task Delete_Entries_Is_NoOp()
+    {
+        var repo = CreateRepository();
+
+        await repo.GetExternalIdAsync();
+        await repo.SaveExternalIdAsync(42);
+
+        // Delete should not affect file-system entries.
+        await repo.DeleteEntriesOlderThanAsync(DateTime.Now + TimeSpan.FromDays(1));
+
+        var value = await repo.GetExternalIdAsync();
+        Assert.AreEqual(42, value);
+    }
+
+    private FileSystemLastSyncedRepository CreateRepository()
+        => new(_hostingEnvironment.Object);
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/ServerRoleAwareLastSyncedRepositoryTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/ServerRoleAwareLastSyncedRepositoryTest.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Factories;
 using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.Persistence;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 using Umbraco.Cms.Infrastructure.Scoping;
 using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
@@ -14,6 +15,7 @@ public class ServerRoleAwareLastSyncedRepositoryTest
 {
     private string _tempPath = null!;
     private Mock<IServerRoleAccessor> _serverRoleAccessor = null!;
+    private Mock<IDatabaseReadOnlyAccessor> _databaseReadOnlyAccessor = null!;
     private FileSystemLastSyncedRepository _fileSystemRepository = null!;
 
     [SetUp]
@@ -23,6 +25,7 @@ public class ServerRoleAwareLastSyncedRepositoryTest
         Directory.CreateDirectory(_tempPath);
 
         _serverRoleAccessor = new Mock<IServerRoleAccessor>();
+        _databaseReadOnlyAccessor = new Mock<IDatabaseReadOnlyAccessor>();
 
         var hostingEnvironment = new Mock<IHostingEnvironment>();
         hostingEnvironment.Setup(x => x.LocalTempPath).Returns(_tempPath);
@@ -40,9 +43,10 @@ public class ServerRoleAwareLastSyncedRepositoryTest
     }
 
     [Test]
-    public async Task Subscriber_Delegates_To_FileSystemRepository()
+    public async Task Subscriber_With_ReadOnly_Database_Delegates_To_FileSystemRepository()
     {
         _serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Subscriber);
+        _databaseReadOnlyAccessor.Setup(x => x.IsReadOnly()).Returns(true);
 
         await _fileSystemRepository.SaveInternalIdAsync(99);
 
@@ -50,6 +54,18 @@ public class ServerRoleAwareLastSyncedRepositoryTest
         var result = await sut.GetInternalIdAsync();
 
         Assert.AreEqual(99, result);
+    }
+
+    [Test]
+    public void Subscriber_With_Writable_Database_Delegates_To_DatabaseRepository()
+    {
+        _serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Subscriber);
+        _databaseReadOnlyAccessor.Setup(x => x.IsReadOnly()).Returns(false);
+
+        // The database repository has no ambient scope, so it throws InvalidOperationException.
+        // This proves that the call did NOT go to the file system repository.
+        var sut = CreateSut();
+        Assert.ThrowsAsync<InvalidOperationException>(() => sut.GetInternalIdAsync());
     }
 
     [TestCase(ServerRole.Single)]
@@ -60,7 +76,7 @@ public class ServerRoleAwareLastSyncedRepositoryTest
         _serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(role);
 
         // The database repository has no ambient scope, so it throws InvalidOperationException.
-        // This proves that the call went to the database repository.
+        // This proves that the call did NOT go to the file system repository.
         var sut = CreateSut();
         Assert.ThrowsAsync<InvalidOperationException>(() => sut.GetInternalIdAsync());
     }
@@ -72,5 +88,6 @@ public class ServerRoleAwareLastSyncedRepositoryTest
                 Mock.Of<IScopeAccessor>(),
                 AppCaches.NoCache,
                 Mock.Of<IMachineInfoFactory>()),
-            _fileSystemRepository);
+            _fileSystemRepository,
+            _databaseReadOnlyAccessor.Object);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/ServerRoleAwareLastSyncedRepositoryTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/ServerRoleAwareLastSyncedRepositoryTest.cs
@@ -1,0 +1,76 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Factories;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+using Umbraco.Cms.Infrastructure.Scoping;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence.Repositories;
+
+[TestFixture]
+public class ServerRoleAwareLastSyncedRepositoryTest
+{
+    private string _tempPath = null!;
+    private Mock<IServerRoleAccessor> _serverRoleAccessor = null!;
+    private FileSystemLastSyncedRepository _fileSystemRepository = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), "UmbracoTests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempPath);
+
+        _serverRoleAccessor = new Mock<IServerRoleAccessor>();
+
+        var hostingEnvironment = new Mock<IHostingEnvironment>();
+        hostingEnvironment.Setup(x => x.LocalTempPath).Returns(_tempPath);
+        hostingEnvironment.Setup(x => x.ApplicationId).Returns("TestApplication");
+        _fileSystemRepository = new FileSystemLastSyncedRepository(hostingEnvironment.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempPath))
+        {
+            Directory.Delete(_tempPath, true);
+        }
+    }
+
+    [Test]
+    public async Task Subscriber_Delegates_To_FileSystemRepository()
+    {
+        _serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Subscriber);
+
+        await _fileSystemRepository.SaveInternalIdAsync(99);
+
+        var sut = CreateSut();
+        var result = await sut.GetInternalIdAsync();
+
+        Assert.AreEqual(99, result);
+    }
+
+    [TestCase(ServerRole.Single)]
+    [TestCase(ServerRole.SchedulingPublisher)]
+    [TestCase(ServerRole.Unknown)]
+    public void NonSubscriber_Delegates_To_DatabaseRepository(ServerRole role)
+    {
+        _serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(role);
+
+        // The database repository has no ambient scope, so it throws InvalidOperationException.
+        // This proves that the call went to the database repository.
+        var sut = CreateSut();
+        Assert.ThrowsAsync<InvalidOperationException>(() => sut.GetInternalIdAsync());
+    }
+
+    private ServerRoleAwareLastSyncedRepository CreateSut()
+        => new(
+            new Lazy<IServerRoleAccessor>(() => _serverRoleAccessor.Object),
+            new LastSyncedRepository(
+                Mock.Of<IScopeAccessor>(),
+                AppCaches.NoCache,
+                Mock.Of<IMachineInfoFactory>()),
+            _fileSystemRepository);
+}


### PR DESCRIPTION
Closes #21783

### Description
An issue was reported with the recent changes to the way we save the Last Synced ID. Subscriber (read-only) servers cannot write to the database, so with the changes we had made for V17, subscriber servers would not be able to save the ID.

This PR aims to fix that, by re-implementing a file system approach, that will allow subscriber servers to read and write to a file, rather than the database, to save and retrieve the internal and external ID. Our previous file system approach, before we implemented the database approach in V17, did not have an internal and external last synced ID, this new file system approach creates and reads from two files, to support both an internal and external id. One file for each.

### The Automatic Approach
I was torn between two approaches. One that resolves to the file system repository automatically, based on the server role, and another that required a manual overwrite of the dependency injection. I decided to do the automatic approach.

This resulted in a new `ServerRoleAwareLastSyncedRepository.cs` class being created, that acts as a delegator. This class will check which server role is assigned, and then delegates the given task to the correct repository. The reason it has to be done this way, is that services are registered before the server role is assigned. 

This approach forces a lazy injection of the IServerRoleAccessor, otherwise circular dependencies would cause a deadlock.

### Testing
I have written unit tests to ensure the new `FileSystemLastSyncedRepository.cs` works.

For manually testing we need to test both the Subscriber angle, and the regular angle:

**Subscriber Testing**
1. Create an overwrite of the `IServerRoleAccessor`. I have pasted a composer below you could use.
2. Launch Umbraco and start performing actions
3. Ensure that two txt files are created in `Umbraco.Web.UI/umbraco/Data/TEMP/DistCache`
4. Ensure that the txt files contain the latest IDs

Heres the composer:
```
public class SubscriberTestComposer : IComposer
  {
      public void Compose(IUmbracoBuilder builder)
      {
          builder.Services.AddSingleton<IServerRoleAccessor>(
              new SingleServerRoleAccessorOverride());
      }
  }

  public class SingleServerRoleAccessorOverride : IServerRoleAccessor
  {
      public ServerRole CurrentServerRole => ServerRole.Subscriber;
  }
```

**Regular Testing**
1. Without the overwriting composer, launch the application.
2. Start performing some actions, create document types etc.
3. Open the LastSynced database table.
4. Ensure that the database gets updated with the recent LastSyncedIDs


<!-- Thanks for contributing to Umbraco CMS! -->
