### PR TITLE
Migrations: Fix local link migration losing fragments and query strings (closes #22152)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
@@ -66,11 +66,12 @@ public class LocalLinkProcessor
 
         foreach (HtmlLocalLinkParser.LocalLinkTag tag in tags)
         {
-            string newTagHref;
+            string convertedLocalLink;
+            string entityType;
             if (tag.Udi is not null)
             {
-                newTagHref = tag.TagHref.Replace(tag.Udi.ToString(), tag.Udi.Guid.ToString())
-                             + $"\" type=\"{tag.Udi.EntityType}";
+                convertedLocalLink = tag.TagHref.Replace(tag.Udi.ToString(), tag.Udi.Guid.ToString());
+                entityType = tag.Udi.EntityType;
             }
             else if (tag.IntId is not null)
             {
@@ -81,8 +82,8 @@ public class LocalLinkProcessor
                     continue;
                 }
 
-                newTagHref = tag.TagHref.Replace(tag.IntId.Value.ToString(), conversionResult.Value.Key.ToString())
-                             + $"\" type=\"{conversionResult.Value.EntityType}";
+                convertedLocalLink = tag.TagHref.Replace(tag.IntId.Value.ToString(), conversionResult.Value.Key.ToString());
+                entityType = conversionResult.Value.EntityType;
             }
             else
             {
@@ -90,7 +91,37 @@ public class LocalLinkProcessor
                 continue;
             }
 
-            input = input.Replace(tag.TagHref, newTagHref);
+            // Find where the TagHref occurs in the input, then locate the closing quote of the
+            // href attribute so we can insert the type attribute after it. The href value may
+            // contain trailing content after the localLink closing brace (e.g. #fragment or ?query).
+            var tagHrefIndex = input.IndexOf(tag.TagHref, StringComparison.Ordinal);
+            if (tagHrefIndex < 0)
+            {
+                continue;
+            }
+
+            var afterTagHref = tagHrefIndex + tag.TagHref.Length;
+            var closingQuoteIndex = input.IndexOf('"', afterTagHref);
+            if (closingQuoteIndex < 0)
+            {
+                closingQuoteIndex = input.IndexOf('\'', afterTagHref);
+            }
+
+            if (closingQuoteIndex < 0)
+            {
+                // No closing quote found; fall back to simple replacement without type attribute.
+                input = input.Replace(tag.TagHref, convertedLocalLink);
+                continue;
+            }
+
+            // Extract any trailing href content (fragment, query string) between the localLink and closing quote.
+            var trailingHrefContent = input.Substring(afterTagHref, closingQuoteIndex - afterTagHref);
+            var closingQuote = input[closingQuoteIndex];
+
+            // Build the replacement: converted localLink + trailing content + close quote + type attribute
+            var oldSegment = tag.TagHref + trailingHrefContent + closingQuote;
+            var newSegment = convertedLocalLink + trailingHrefContent + closingQuote + $" type=\"{entityType}\"";
+            input = input.Remove(tagHrefIndex, oldSegment.Length).Insert(tagHrefIndex, newSegment);
         }
 
         return input;

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
@@ -100,12 +100,18 @@ public class LocalLinkProcessor
                 continue;
             }
 
-            var afterTagHref = tagHrefIndex + tag.TagHref.Length;
-            var closingQuoteIndex = input.IndexOf('"', afterTagHref);
-            if (closingQuoteIndex < 0)
+            // Determine the quote character used to open the href attribute. The regex matches
+            // href=['"]..., so the character immediately before the TagHref match is the opening quote.
+            var openingQuoteIndex = tagHrefIndex - 1;
+            if (openingQuoteIndex < 0 || (input[openingQuoteIndex] != '"' && input[openingQuoteIndex] != '\''))
             {
-                closingQuoteIndex = input.IndexOf('\'', afterTagHref);
+                input = input.Replace(tag.TagHref, convertedLocalLink);
+                continue;
             }
+
+            var quoteChar = input[openingQuoteIndex];
+            var afterTagHref = tagHrefIndex + tag.TagHref.Length;
+            var closingQuoteIndex = input.IndexOf(quoteChar, afterTagHref);
 
             if (closingQuoteIndex < 0)
             {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
@@ -1,0 +1,436 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Templates;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0.LocalLinks;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations;
+
+[TestFixture]
+public class LocalLinkProcessorTests
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    private LocalLinkProcessor CreateProcessor(IIdKeyMap? idKeyMap = null)
+    {
+        var parser = new HtmlLocalLinkParser(Mock.Of<IPublishedUrlProvider>());
+        return new LocalLinkProcessor(
+            parser,
+            idKeyMap ?? Mock.Of<IIdKeyMap>(),
+            Enumerable.Empty<ITypedLocalLinkProcessor>());
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    /// <summary>
+    /// Verifies that a UDI-based document link with no hyphens in the GUID
+    /// is converted to the new format with a hyphenated GUID and type attribute.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UdiDocumentLink_ConvertsToGuidWithType()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a UDI-based media link with no hyphens in the GUID
+    /// is converted to the new format with a hyphenated GUID and type attribute.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UdiMediaLink_ConvertsToGuidWithType()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""{localLink:umb://media/7e21a725b9054c5f86dc8c41ec116e39}"">image</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}"" type=""media"">image</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a localLink with a leading slash is converted correctly.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_LeadingSlash_ConvertsToGuidWithType()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that an integer-based document link is resolved via IIdKeyMap
+    /// and converted to the new GUID-based format with a type attribute.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_IntegerDocumentLink_ConvertsToGuidWithType()
+    {
+        var documentKey = Guid.NewGuid();
+        var idKeyMap = new Mock<IIdKeyMap>();
+        idKeyMap
+            .Setup(x => x.GetKeyForId(1234, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(documentKey));
+
+        var processor = CreateProcessor(idKeyMap.Object);
+
+        var input = @"<a href=""{localLink:1234}"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            $@"<a href=""{{localLink:{documentKey}}}"" type=""Document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that an integer-based link that resolves to media (not document)
+    /// is converted with the correct "Media" type attribute.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_IntegerMediaLink_ConvertsToGuidWithType()
+    {
+        var mediaKey = Guid.NewGuid();
+        var idKeyMap = new Mock<IIdKeyMap>();
+        idKeyMap
+            .Setup(x => x.GetKeyForId(5678, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Fail());
+        idKeyMap
+            .Setup(x => x.GetKeyForId(5678, UmbracoObjectTypes.Media))
+            .Returns(Attempt<Guid>.Succeed(mediaKey));
+
+        var processor = CreateProcessor(idKeyMap.Object);
+
+        var input = @"<a href=""{localLink:5678}"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            $@"<a href=""{{localLink:{mediaKey}}}"" type=""Media"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that an integer-based link that cannot be resolved to either
+    /// a document or media key is left unchanged in the output.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UnresolvableIntegerLink_LeftUnchanged()
+    {
+        var idKeyMap = new Mock<IIdKeyMap>();
+        idKeyMap
+            .Setup(x => x.GetKeyForId(9999, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Fail());
+        idKeyMap
+            .Setup(x => x.GetKeyForId(9999, UmbracoObjectTypes.Media))
+            .Returns(Attempt<Guid>.Fail());
+
+        var processor = CreateProcessor(idKeyMap.Object);
+
+        var input = @"<a href=""{localLink:9999}"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(input, result);
+    }
+
+    /// <summary>
+    /// Verifies that input with no local links is returned unchanged.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_NoLocalLinks_ReturnsInputUnchanged()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""https://example.com"">external</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(input, result);
+    }
+
+    /// <summary>
+    /// Verifies that multiple local links in the same input are all converted.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_MultipleLinks_ConvertsAll()
+    {
+        var processor = CreateProcessor();
+
+        var input =
+            @"<a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"">doc</a>" +
+            @"<a href=""{localLink:umb://media/7e21a725b9054c5f86dc8c41ec116e39}"">img</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}"" type=""document"">doc</a>" +
+            @"<a href=""{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}"" type=""media"">img</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that URL-encoded braces (%7B / %7D) are handled and converted.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UrlEncodedBraces_ConvertsToGuidWithType()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""%7BlocalLink:umb://document/ac2038d9dfc24294b7787edf90d1a178%7D"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""%7BlocalLink:ac2038d9-dfc2-4294-b778-7edf90d1a178%7D"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that existing attributes on the anchor tag (title, rel, class, etc.)
+    /// are preserved after the local link conversion.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_ExistingAttributes_PreservedAfterConversion()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"" title=""My Page"" rel=""noopener"" class=""btn"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}"" type=""document"" title=""My Page"" rel=""noopener"" class=""btn"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// When a local link href contains a fragment identifier (#section-99) after the closing brace,
+    /// the fragment should be preserved in the href and the type attribute should be a separate attribute.
+    /// This is an initially failing test for https://github.com/umbraco/Umbraco-CMS/issues/22152.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UdiDocumentLink_WithFragment_PreservesFragment()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}#section-99"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#section-99"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a query string after the localLink closing brace is preserved in the href
+    /// and not merged into the type attribute value.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UdiDocumentLink_WithQueryString_PreservesQueryString()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}?foo=bar"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}?foo=bar"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a fragment identifier on a media UDI link is preserved in the href.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UdiMediaLink_WithFragment_PreservesFragment()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""{localLink:umb://media/7e21a725b9054c5f86dc8c41ec116e39}#top"">image</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}#top"" type=""media"">image</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that both a query string and a fragment identifier after the localLink
+    /// closing brace are preserved in the correct position in the href.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_UdiDocumentLink_WithQueryStringAndFragment_PreservesBoth()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}?v=1#section"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}?v=1#section"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a fragment identifier on an integer-based link is preserved.
+    /// This exercises the IntId code path (distinct from the UDI path) with trailing content.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_IntegerLink_WithFragment_PreservesFragment()
+    {
+        var documentKey = Guid.NewGuid();
+        var idKeyMap = new Mock<IIdKeyMap>();
+        idKeyMap
+            .Setup(x => x.GetKeyForId(1234, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(documentKey));
+
+        var processor = CreateProcessor(idKeyMap.Object);
+
+        var input = @"<a href=""{localLink:1234}#anchor"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            $@"<a href=""{{localLink:{documentKey}}}#anchor"" type=""Document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a query string on an integer-based link is preserved.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_IntegerLink_WithQueryString_PreservesQueryString()
+    {
+        var documentKey = Guid.NewGuid();
+        var idKeyMap = new Mock<IIdKeyMap>();
+        idKeyMap
+            .Setup(x => x.GetKeyForId(1234, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(documentKey));
+
+        var processor = CreateProcessor(idKeyMap.Object);
+
+        var input = @"<a href=""{localLink:1234}?page=2"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            $@"<a href=""{{localLink:{documentKey}}}?page=2"" type=""Document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that when multiple links are present and only some have fragments,
+    /// each link is converted independently without corrupting its neighbours.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_MultipleLinks_OnlyOneWithFragment_ConvertsAllCorrectly()
+    {
+        var processor = CreateProcessor();
+
+        var input =
+            @"<a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"">no fragment</a>" +
+            @"<a href=""{localLink:umb://media/7e21a725b9054c5f86dc8c41ec116e39}#top"">with fragment</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}"" type=""document"">no fragment</a>" +
+            @"<a href=""{localLink:7e21a725-b905-4c5f-86dc-8c41ec116e39}#top"" type=""media"">with fragment</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that an empty fragment (just '#' with nothing after it) is preserved.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_EmptyFragment_PreservesHashSign()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}#"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that an empty query string (just '?' with nothing after it) is preserved.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_EmptyQueryString_PreservesQuestionMark()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}?"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}?"" type=""document"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a local link embedded within a larger HTML document (paragraphs,
+    /// surrounding text) is converted without corrupting the broader HTML context.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_EmbeddedInSurroundingHtml_PreservesContext()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<p>Click <a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"">here</a> for more info.</p><p>Another paragraph.</p>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<p>Click <a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}"" type=""document"">here</a> for more info.</p><p>Another paragraph.</p>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a local link with a fragment embedded within a larger HTML document
+    /// preserves both the fragment and the surrounding HTML context.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_EmbeddedInSurroundingHtml_WithFragment_PreservesBoth()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<p>See <a href=""{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}#details"">details</a> below.</p>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<p>See <a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#details"" type=""document"">details</a> below.</p>",
+            result);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
@@ -15,17 +15,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations;
 [TestFixture]
 public class LocalLinkProcessorTests
 {
-#pragma warning disable CS0618 // Type or member is obsolete
-    private LocalLinkProcessor CreateProcessor(IIdKeyMap? idKeyMap = null)
-    {
-        var parser = new HtmlLocalLinkParser(Mock.Of<IPublishedUrlProvider>());
-        return new LocalLinkProcessor(
-            parser,
-            idKeyMap ?? Mock.Of<IIdKeyMap>(),
-            Enumerable.Empty<ITypedLocalLinkProcessor>());
-    }
-#pragma warning restore CS0618 // Type or member is obsolete
-
     /// <summary>
     /// Verifies that a UDI-based document link with no hyphens in the GUID
     /// is converted to the new format with a hyphenated GUID and type attribute.
@@ -399,6 +388,79 @@ public class LocalLinkProcessorTests
     }
 
     /// <summary>
+    /// Verifies that a single-quoted href attribute is converted correctly.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_SingleQuotedHref_ConvertsToGuidWithType()
+    {
+        var processor = CreateProcessor();
+
+        var input = "<a href='{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}'>link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            "<a href='{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}' type=\"document\">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a single-quoted href with a fragment is handled correctly,
+    /// preserving the fragment in the href and placing the type as a separate attribute.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_SingleQuotedHref_WithFragment_PreservesFragment()
+    {
+        var processor = CreateProcessor();
+
+        var input = "<a href='{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}#anchor'>link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            "<a href='{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#anchor' type=\"document\">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a single-quoted href followed by a double-quoted attribute (e.g. title)
+    /// correctly identifies the closing single quote rather than the double quote from the
+    /// next attribute. Without this, the closing-quote detection would match the wrong quote
+    /// and corrupt the tag.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_SingleQuotedHref_WithDoubleQuotedAttributeAfter_DoesNotCorrupt()
+    {
+        var processor = CreateProcessor();
+
+        var input = "<a href='{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}#anchor' title=\"My Page\">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            "<a href='{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#anchor' type=\"document\" title=\"My Page\">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that a single-quoted href without a fragment but followed by a double-quoted
+    /// attribute still works correctly.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_SingleQuotedHref_NoFragment_WithDoubleQuotedAttributeAfter()
+    {
+        var processor = CreateProcessor();
+
+        var input = "<a href='{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}' title=\"My Page\">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            "<a href='{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}' type=\"document\" title=\"My Page\">link</a>",
+            result);
+    }
+
+    /// <summary>
     /// Verifies that a local link embedded within a larger HTML document (paragraphs,
     /// surrounding text) is converted without corrupting the broader HTML context.
     /// </summary>
@@ -433,4 +495,15 @@ public class LocalLinkProcessorTests
             @"<p>See <a href=""{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#details"" type=""document"">details</a> below.</p>",
             result);
     }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    private LocalLinkProcessor CreateProcessor(IIdKeyMap? idKeyMap = null)
+    {
+        var parser = new HtmlLocalLinkParser(Mock.Of<IPublishedUrlProvider>());
+        return new LocalLinkProcessor(
+            parser,
+            idKeyMap ?? Mock.Of<IIdKeyMap>(),
+            Enumerable.Empty<ITypedLocalLinkProcessor>());
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
 }


### PR DESCRIPTION
## Description

This PR addresses the issue raised in https://github.com/umbraco/Umbraco-CMS/issues/22152 around the conversion of local links migration that occurs going to Umbraco 15, in that it doesn't correctly handle fragment identifiers (`#anchor`) and query strings (`?key=value`) that appear after the `{localLink:...}` closing brace in href attributes.

Previously, the type attribute was injected by appending `" type="document` directly after the localLink replacement, which assumed the `}` was immediately followed by the closing quote of the href. When fragments or query strings were present, they were absorbed into the type attribute value (e.g. `type="document#section-99"`), making the link unresolvable at render time.

At least this is what I see in testing a migration from 13.  It's not exactly what the user reported, but we don't have the source to recover that case.  Nonetheless there's clearly a bug here that I can replicate, and have verified that it's resolved with this fix.

The fixed method wasn't previously covered by unit tests, so I've added those for various edge cases, including the reported issue.  The expected tests fail before the fix and pass afterward.

## Testing

### Automated

Verify the unit tests pass.

### Manual
Create content in Umbraco 13 with RTE links containing `#anchor` suffixes, migrate to v17, verify links are correctly converted with fragment preserved in `href` and `type` as a separate clean attribute.

These are the results from my test of this, so visual inspection rather than repeating this test should be sufficient.

With 3 local links, one without querystring or anchor, one with anchor and one with querystring, the 13 source of the RTE looks like this

```html
<p><a href="/{localLink:umb://document/611d4eb748f3410699e98d7f44daf63f}" title="Test Page 2">Test 1</a></p>
<p><a href="/{localLink:umb://document/611d4eb748f3410699e98d7f44daf63f}#section-99" title="Test Page 2" data-anchor="#section-99">Test 2</a></p>
<p><a href="/{localLink:umb://document/611d4eb748f3410699e98d7f44daf63f}?foo=bar" title="Test Page 2" data-anchor="?foo=bar">Test 3</a></p>
```

After migration on `main` it looks like this, showing the error:

```html
<p><a data-router-slot="disabled" href="/{localLink:611d4eb7-48f3-4106-99e9-8d7f44daf63f}" title="Test Page 2" type="document">Test 1</a></p>
<p><a data-router-slot="disabled" data-anchor="#section-99" href="/{localLink:611d4eb7-48f3-4106-99e9-8d7f44daf63f}" title="Test Page 2" type="document#section-99">Test 2</a></p>
<p><a data-router-slot="disabled" data-anchor="?foo=bar" href="/{localLink:611d4eb7-48f3-4106-99e9-8d7f44daf63f}" title="Test Page 2" type="document?foo=bar">Test 3</a></p>
```

And then after redoing the migration using the code in this PR, we see it corrected:

```html
<p><a data-router-slot="disabled" href="/{localLink:611d4eb7-48f3-4106-99e9-8d7f44daf63f}" title="Test Page 2" type="document">Test 1</a></p>
<p><a data-router-slot="disabled" data-anchor="#section-99" href="/{localLink:611d4eb7-48f3-4106-99e9-8d7f44daf63f}#section-99" title="Test Page 2" type="document">Test 2</a></p>
<p><a data-router-slot="disabled" data-anchor="?foo=bar" href="/{localLink:611d4eb7-48f3-4106-99e9-8d7f44daf63f}?foo=bar" title="Test Page 2" type="document">Test 3</a></p>
```

