### PR TITLE
Elements: Clean up container relations before deleting them

### DIFF
--- a/src/Umbraco.Core/Services/ElementContainerService.cs
+++ b/src/Umbraco.Core/Services/ElementContainerService.cs
@@ -361,6 +361,7 @@ internal sealed class ElementContainerService : EntityTypeContainerService<IElem
 
         DeleteDescendantsLocked(container.Key, UmbracoObjectTypes.ElementContainer, scope, eventMessages);
 
+        DeleteContainerRelations(container);
         _entityContainerRepository.Delete(container);
 
         await AuditAsync(AuditType.Delete, userKey, container.Id);
@@ -436,6 +437,7 @@ internal sealed class ElementContainerService : EntityTypeContainerService<IElem
     {
         if (descendant.NodeObjectType == Constants.ObjectTypes.ElementContainer)
         {
+            DeleteContainerRelations(descendant);
             EntityContainer descendantContainer = _entityContainerRepository.Get(descendant.Id)
                                                   ?? throw new InvalidOperationException($"Descendant container with ID {descendant.Id} was not found.");
             _entityContainerRepository.Delete(descendantContainer);
@@ -447,6 +449,22 @@ internal sealed class ElementContainerService : EntityTypeContainerService<IElem
                                          ?? throw new InvalidOperationException($"Descendant element with ID {descendant.Id} was not found.");
             _elementRepository.Delete(descendantElement);
             scope.Notifications.Publish(new ElementDeletedNotification(descendantElement, eventMessages));
+        }
+    }
+
+    private void DeleteContainerRelations(IEntity container)
+    {
+        // Even though a container is in the recycle bin, it can still be both parent and child in one or
+        // more relations - for example:
+        // - Parent to an element that is also in the bin (for restoring the element).
+        // - Child to the original location in the elements tree (for restoring the container itself).
+        // Before the container can be deleted, the relations must be cleaned up.
+        IEnumerable<IRelation> relations = _relationService
+            .GetByParentOrChildId(container.Id)
+            .ToArray();
+        foreach (IRelation relation in relations)
+        {
+            _relationService.Delete(relation);
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes the _'FOREIGN KEY constraint failed'_ error mentioned in https://github.com/umbraco/Umbraco-CMS/pull/21872#issuecomment-4029060164

### Description

A container in the Elements tree recycle bin can be part of multiple relations:

- A child relation to the original location in the Elements tree (for restoring the container).
- Multiple parent relations for Elements which have previously been moved to the bin (for restoring the Elements).

We need to clean these relations up, before a container can be deleted. That's what this PR does 😄 

### Testing this PR

It should be possible to invoke `DELETE /umbraco/management/api/v1/recycle-bin/element/folder/{id}` for a container in the recycle bin.

To test cleanup of both child and parent relations:

1. Create the container.
2. Create an element inside the container.
4. Move the element to the bin.
5. Move the container to the bin.
6. Delete the container.