### PR TITLE
Build: Serialize E2E stages and stagger branch schedules to reduce agent usage

### DIFF
--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -320,6 +320,7 @@ stages:
   - stage: DefaultConfigE2E
     displayName: Default Config E2E Tests
     dependsOn: Integration
+    condition: always()
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       # Enable console logging in Release mode
@@ -501,6 +502,7 @@ stages:
   - stage: AdditionalConfigE2E
     displayName: Additional Config E2E Tests
     dependsOn: DefaultConfigE2E
+    condition: always()
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       ASPNETCORE_URLS: https://localhost:44331


### PR DESCRIPTION
  - Serialize pipeline stages: Build → Integration → DefaultConfigE2E → AdditionalConfigE2E                                                                                                                                                                                      (previously E2E stages ran in parallel after Build)                                                                                                                                                                                                                      
  - Add condition: always() so subsequent stages run even if prior stages fail                                                                                                                                                                                               
  - Schedule only `main `branch at **3AM** (`v16/dev` and `v18/dev` scheduled from their own branches)                                                                                                                                                                                 
  - Remove `v15/dev` from schedule since it is now EOL.

Peak agent usage drops from ~41 to ~16 per branch, and staggered schedules prevent multiple branches from running simultaneously.                                                                                                                                                                                  