### PR TITLE
Build: Cherry pick #22164 for V18

### DIFF
--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -4,12 +4,10 @@ pr: none
 trigger: none
 
 schedules:
-  - cron: '0 0 * * *'
-    displayName: Daily midnight build
+  - cron: '0 6 * * *'
+    displayName: Daily 6AM build (v18/dev)
     branches:
       include:
-        - v16/dev
-        - main
         - v18/dev
 
 parameters:
@@ -321,7 +319,8 @@ stages:
 
   - stage: DefaultConfigE2E
     displayName: Default Config E2E Tests
-    dependsOn: Build
+    dependsOn: Integration
+    condition: always()
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       # Enable console logging in Release mode
@@ -502,7 +501,8 @@ stages:
 
   - stage: AdditionalConfigE2E
     displayName: Additional Config E2E Tests
-    dependsOn: Build
+    dependsOn: DefaultConfigE2E
+    condition: always()
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       ASPNETCORE_URLS: https://localhost:44331


### PR DESCRIPTION
- Serialize pipeline stages: Build → Integration → DefaultConfigE2E → AdditionalConfigE2E (previously E2E stages ran in parallel after Build)
- Add condition: always() so subsequent stages run even if prior stages fail
- Schedule only `v18/dev` branch at **6AM** (`v16/dev` and `main `scheduled from their own branches)

Peak agent usage drops from ~41 to ~16 per branch, and staggered schedules prevent multiple branches from running simultaneously.