### PR TITLE
Build: Cherry pick #22164 for V16

### DIFF
--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -5,12 +5,10 @@ trigger: none
 
 schedules:
   - cron: '0 0 * * *'
-    displayName: Daily midnight build
+    displayName: Daily midnight build (v16/dev)
     branches:
       include:
-        - v15/dev
         - v16/dev
-        - main
 
 parameters:
   - name: skipIntegrationTests
@@ -295,7 +293,8 @@ stages:
 
   - stage: DefaultConfigE2E
     displayName: Default Config E2E Tests
-    dependsOn: Build
+    dependsOn: Integration
+    condition: always()
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       # Enable console logging in Release mode
@@ -476,7 +475,8 @@ stages:
 
   - stage: AdditionalConfigE2E
     displayName: Additional Config E2E Tests
-    dependsOn: Build
+    dependsOn: DefaultConfigE2E
+    condition: always()
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       ASPNETCORE_URLS: https://localhost:44331


### PR DESCRIPTION
- Serialize pipeline stages: Build → Integration → DefaultConfigE2E → AdditionalConfigE2E (previously E2E stages ran in parallel after Build)
- Add condition: always() so subsequent stages run even if prior stages fail
- Schedule only v16/dev branch at midnight (main and v18/dev scheduled from their own branches)
- Remove v15/dev from schedule since it is now EOL.

Peak agent usage drops from ~41 to ~16 per branch, and staggered schedules prevent multiple branches from running simultaneously.