### PR TITLE
Integration Tests: Avoid hidden `BootFailedException` in `CoreConfigurationHttpTests`

### DIFF
--- a/tests/Umbraco.Tests.Integration/TestServerTest/CoreConfigurationHttpTests.cs
+++ b/tests/Umbraco.Tests.Integration/TestServerTest/CoreConfigurationHttpTests.cs
@@ -78,6 +78,9 @@ public class CoreConfigurationHttpTests : UmbracoIntegrationTestBase
     {
         var contentRoot = GetTestContentRoot();
 
+        // Disable ModelsBuilder to avoid BootFailedException requiring Umbraco.Cms.DevelopmentMode.Backoffice package
+        InMemoryConfiguration["Umbraco:CMS:ModelsBuilder:ModelsMode"] = "Nothing";
+
         return new UmbracoWebApplicationFactory<CoreConfigurationHttpTests>(() => CreateHostBuilder(configureUmbraco, configureApp))
             .WithWebHostBuilder(builder =>
             {


### PR DESCRIPTION
## Description

This PR set `ModelsBuilder:ModelsMode` to `Nothing` in `CoreConfigurationHttpTests` to prevent a hidden `BootFailedException` (`InMemoryAuto requires the Umbraco.Cms.DevelopmentMode.Backoffice package`) that was being silently swallowed during test execution.

We found this in resolving a visible issue for when upgrading NUnit in https://github.com/umbraco/Umbraco-CMS/pull/22155 for 18.

When the `BootFailedException` fires during `CoreRuntime.StartAsync()`, the runtime catches it internally and sets the runtime level to BootFailed. The `BootFailedMiddleware` then intercepts all incoming HTTP requests and returns a 404 response. Since a 404 is still a non-null `HttpResponseMessage`, the assertion passes.

So the tests were "passing" but not really validating what they intended — that Umbraco boots successfully with each configuration. They were just confirming that the boot-failure error page is served.

## Testing

The build checks will confirm that the tests in `CoreConfigurationHttpTests` continue to pass.