### PR TITLE
Backoffice: Preserve user-supplied property editor UI group names (closes #22189)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -2657,6 +2657,18 @@ export default {
 		title: 'Vælg Property Editor',
 		openPropertyEditorPicker: 'Vælg Property Editor',
 	},
+
+	propertyEditorUIGroups: {
+		advanced: 'Advanceret',
+		blocks: 'Bloks',
+		common: 'Generelt',
+		date: 'Dato og tid',
+		lists: 'Lister',
+		media: 'Medier',
+		people: 'Personer',
+		pickers: 'Vælgere',
+		richContent: 'Beriget indhold',
+	},
 	healthcheck: {
 		checkSuccessMessage: "Value is set to the recommended value: '%0%'.",
 		checkErrorMessageDifferentExpectedValue:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1426,6 +1426,17 @@ export default {
 		title: 'Select a property editor',
 		openPropertyEditorPicker: 'Select a property editor UI',
 	},
+	propertyEditorUIGroups: {
+		advanced: 'Advanced',
+		blocks: 'Blocks',
+		common: 'Common',
+		date: 'Date',
+		lists: 'Lists',
+		media: 'Media',
+		people: 'People',
+		pickers: 'Pickers',
+		richContent: 'Rich Content',
+	},
 	relatedlinks: {
 		enterExternal: 'enter external link',
 		chooseInternal: 'choose internal page',

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Area Type Permissions',
 		icon: 'icon-document',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-area-type-permission/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Area Type Permissions',
 		icon: 'icon-document',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Areas Configuration',
 		icon: 'icon-document',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-areas-config/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Areas Configuration',
 		icon: 'icon-document',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-column-span/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-column-span/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Column Span',
 		icon: 'icon-document',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-column-span/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-column-span/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Column Span',
 		icon: 'icon-document',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-editor/manifests.ts
@@ -11,7 +11,7 @@ const propertyEditorUi: UmbExtensionManifest = {
 		label: 'Block Grid',
 		propertyEditorSchemaAlias: UMB_BLOCK_GRID_PROPERTY_EDITOR_SCHEMA_ALIAS,
 		icon: 'icon-layout',
-		group: 'richContent',
+		group: 'Rich Content',
 		keywords: ['component', 'layout', 'grid', 'modules', 'widgets', 'page', 'builder', 'canvas'],
 		supportsReadOnly: true,
 		settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-editor/manifests.ts
@@ -11,7 +11,7 @@ const propertyEditorUi: UmbExtensionManifest = {
 		label: 'Block Grid',
 		propertyEditorSchemaAlias: UMB_BLOCK_GRID_PROPERTY_EDITOR_SCHEMA_ALIAS,
 		icon: 'icon-layout',
-		group: 'Rich Content',
+		group: '#propertyEditorUIGroups_richContent',
 		keywords: ['component', 'layout', 'grid', 'modules', 'widgets', 'page', 'builder', 'canvas'],
 		supportsReadOnly: true,
 		settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-group-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-group-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: '',
 		icon: 'icon-box-alt',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-group-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-group-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: '',
 		icon: 'icon-box-alt',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-layout-stylesheet/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-layout-stylesheet/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Layout Stylesheet',
 		icon: 'icon-document',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-layout-stylesheet/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-layout-stylesheet/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Layout Stylesheet',
 		icon: 'icon-document',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Block Configuration',
 		icon: 'icon-autofill',
-		group: 'blocks',
+		group: 'Blocks',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/property-editors/block-grid-type-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Grid Block Configuration',
 		icon: 'icon-autofill',
-		group: 'Blocks',
+		group: '#propertyEditorUIGroups_blocks',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/manifests.ts
@@ -12,7 +12,7 @@ const propertyEditorUi: UmbExtensionManifest = {
 		label: 'Block List',
 		propertyEditorSchemaAlias: UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS,
 		icon: 'icon-thumbnail-list',
-		group: 'Rich Content',
+		group: '#propertyEditorUIGroups_richContent',
 		keywords: ['component', 'list', 'items', 'blocks', 'cards', 'faq', 'testimonials', 'features', 'services'],
 		supportsReadOnly: true,
 		settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-editor/manifests.ts
@@ -12,7 +12,7 @@ const propertyEditorUi: UmbExtensionManifest = {
 		label: 'Block List',
 		propertyEditorSchemaAlias: UMB_BLOCK_LIST_PROPERTY_EDITOR_SCHEMA_ALIAS,
 		icon: 'icon-thumbnail-list',
-		group: 'richContent',
+		group: 'Rich Content',
 		keywords: ['component', 'list', 'items', 'blocks', 'cards', 'faq', 'testimonials', 'features', 'services'],
 		supportsReadOnly: true,
 		settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-type-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-type-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block List Type Configuration',
 		icon: 'icon-autofill',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-type-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/property-editors/block-list-type-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block List Type Configuration',
 		icon: 'icon-autofill',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-editors/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-editors/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Block RTE Type Configuration',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-editors/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/property-editors/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Block RTE Type Configuration',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/manifests.ts
@@ -12,7 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Single Block',
 			propertyEditorSchemaAlias: UMB_BLOCK_SINGLE_PROPERTY_EDITOR_SCHEMA_ALIAS,
 			icon: 'icon-shape-square',
-			group: 'Rich Content',
+			group: '#propertyEditorUIGroups_richContent',
 			keywords: ['component', 'widget', 'banner', 'hero', 'cta', 'promo', 'cta', 'callout', 'spotlight', 'feature'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-editor/manifests.ts
@@ -12,7 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Single Block',
 			propertyEditorSchemaAlias: UMB_BLOCK_SINGLE_PROPERTY_EDITOR_SCHEMA_ALIAS,
 			icon: 'icon-shape-square',
-			group: 'richContent',
+			group: 'Rich Content',
 			keywords: ['component', 'widget', 'banner', 'hero', 'cta', 'promo', 'cta', 'callout', 'spotlight', 'feature'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-type-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-type-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Single Type Configuration',
 		icon: 'icon-autofill',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-type-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/property-editors/block-single-type-configuration/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Block Single Type Configuration',
 		icon: 'icon-autofill',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/manifests.ts
@@ -9,7 +9,7 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Code Editor',
 		propertyEditorSchemaAlias: 'Umbraco.Plain.String',
 		icon: 'icon-brackets',
-		group: 'Rich Content',
+		group: '#propertyEditorUIGroups_richContent',
 		keywords: [
 			'code',
 			'script',

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/manifests.ts
@@ -9,7 +9,7 @@ export const manifest: ManifestPropertyEditorUi = {
 		label: 'Code Editor',
 		propertyEditorSchemaAlias: 'Umbraco.Plain.String',
 		icon: 'icon-brackets',
-		group: 'richContent',
+		group: 'Rich Content',
 		keywords: [
 			'code',
 			'script',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/extensions/property-editor.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/extensions/property-editor.extension.ts
@@ -11,13 +11,15 @@ export interface MetaPropertyEditorUi {
 	label: string;
 	icon: string;
 	/**
-	 * The group that this property editor UI belongs to, which will be used to group the property editor UIs in the property editor picker.
+	 * The group that this property editor UI belongs to, which will be used to group
+	 * the property editor UIs in the property editor picker.
 	 * If not specified, the property editor UI will be grouped under "Common".
 	 *
-	 * Use display-ready names (e.g. `"Common"`, `"Rich Content"`). Legacy camelCase names
-	 * (e.g. `"common"`, `"richContent"`) are still supported and will be automatically converted.
+	 * Core property editors use localization keys prefixed with `#` (e.g. `"#propertyEditorUIGroups_common"`).
+	 * External packages can use either display-ready names (e.g. `"My Group"`) or camelCase names
+	 * (e.g. `"myGroup"`) which will be automatically converted to title case.
 	 * @default "Common"
-	 * @example ["Common", "Rich Content", "Pickers", "Lists", "Media"]
+	 * @example ["#propertyEditorUIGroups_common", "#propertyEditorUIGroups_richContent", "My Custom Group"]
 	 */
 	group: string;
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/extensions/property-editor.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/extensions/property-editor.extension.ts
@@ -13,8 +13,11 @@ export interface MetaPropertyEditorUi {
 	/**
 	 * The group that this property editor UI belongs to, which will be used to group the property editor UIs in the property editor picker.
 	 * If not specified, the property editor UI will be grouped under "Common".
+	 *
+	 * Use display-ready names (e.g. `"Common"`, `"Rich Content"`). Legacy camelCase names
+	 * (e.g. `"common"`, `"richContent"`) are still supported and will be automatically converted.
 	 * @default "Common"
-	 * @example ["Common", "Content", "Media"]
+	 * @example ["Common", "Rich Content", "Pickers", "Lists", "Media"]
 	 */
 	group: string;
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/ui-picker-modal/property-editor-ui-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/ui-picker-modal/property-editor-ui-picker-modal.element.ts
@@ -81,13 +81,19 @@ export class UmbPropertyEditorUIPickerModalElement extends UmbModalBaseElement<
 		}
 	}
 
+	#resolveGroupName(group: string): string {
+		if (group.includes('#')) {
+			return this.localize.string(group);
+		}
+		// Backward compatibility: external packages may still register camelCase group names.
+		return fromCamelCaseIfCamelCase(group);
+	}
+
 	#groupPropertyEditorUIs(items: Array<ManifestPropertyEditorUi>) {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
 		const grouped = Object.groupBy(items, (propertyEditorUi: ManifestPropertyEditorUi) =>
-			// Use fromCamelCaseIfCamelCase for backward compatibility: although core property editors provide
-			// title cased group names, external packages may still register them as camelCase.
-			fromCamelCaseIfCamelCase(propertyEditorUi.meta.group),
+			this.#resolveGroupName(propertyEditorUi.meta.group),
 		);
 
 		this._groupedPropertyEditorUIs = Object.keys(grouped)

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/ui-picker-modal/property-editor-ui-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/ui-picker-modal/property-editor-ui-picker-modal.element.ts
@@ -82,9 +82,10 @@ export class UmbPropertyEditorUIPickerModalElement extends UmbModalBaseElement<
 	}
 
 	#resolveGroupName(group: string): string {
-		if (group.includes('#')) {
+		if (group.startsWith('#')) {
 			return this.localize.string(group);
 		}
+
 		// Backward compatibility: external packages may still register camelCase group names.
 		return fromCamelCaseIfCamelCase(group);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/ui-picker-modal/property-editor-ui-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/ui-picker-modal/property-editor-ui-picker-modal.element.ts
@@ -5,7 +5,7 @@ import type {
 } from './property-editor-ui-picker-modal.token.js';
 import { UmbPropertyEditorUISearchController } from './property-editor-ui-search.controller.js';
 import { css, customElement, html, repeat, state } from '@umbraco-cms/backoffice/external/lit';
-import { debounce, fromCamelCase } from '@umbraco-cms/backoffice/utils';
+import { debounce, fromCamelCaseIfCamelCase } from '@umbraco-cms/backoffice/utils';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
@@ -85,7 +85,9 @@ export class UmbPropertyEditorUIPickerModalElement extends UmbModalBaseElement<
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
 		const grouped = Object.groupBy(items, (propertyEditorUi: ManifestPropertyEditorUi) =>
-			fromCamelCase(propertyEditorUi.meta.group),
+			// Use fromCamelCaseIfCamelCase for backward compatibility: although core property editors provide
+			// title cased group names, external packages may still register them as camelCase.
+			fromCamelCaseIfCamelCase(propertyEditorUi.meta.group),
 		);
 
 		this._groupedPropertyEditorUIs = Object.keys(grouped)

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/string/from-camel-case/from-camel-case.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/string/from-camel-case/from-camel-case.function.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { fromCamelCase } from './from-camel-case.function.js';
+import { fromCamelCase, fromCamelCaseIfCamelCase } from './from-camel-case.function.js';
 
 describe('fromCamelCase', () => {
 	it('should return the string with spaces between words', () => {
@@ -9,5 +9,27 @@ describe('fromCamelCase', () => {
 	it('should uppercase the first character', () => {
 		const result = fromCamelCase('thisIsATest');
 		expect(result.charAt(0)).to.equal('T');
+	});
+});
+
+describe('fromCamelCaseIfCamelCase', () => {
+	it('should transform a camelCase string', () => {
+		expect(fromCamelCaseIfCamelCase('richContent')).to.equal('Rich Content');
+	});
+
+	it('should transform a single lowercase word', () => {
+		expect(fromCamelCaseIfCamelCase('common')).to.equal('Common');
+	});
+
+	it('should return a string with spaces as-is', () => {
+		expect(fromCamelCaseIfCamelCase('Rich Content')).to.equal('Rich Content');
+	});
+
+	it('should return a PascalCase string as-is', () => {
+		expect(fromCamelCaseIfCamelCase('MyCusTomUIGroup')).to.equal('MyCusTomUIGroup');
+	});
+
+	it('should return an uppercase-start string as-is', () => {
+		expect(fromCamelCaseIfCamelCase('Common')).to.equal('Common');
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/string/from-camel-case/from-camel-case.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/string/from-camel-case/from-camel-case.function.ts
@@ -17,3 +17,18 @@ export const fromCamelCase = (str: string) => {
 	const s = str.replace(/([A-Z])/g, ' $1');
 	return s.charAt(0).toUpperCase() + s.slice(1);
 };
+
+/**
+ * Applies {@link fromCamelCase} only when the string looks like camelCase
+ * (starts with a lowercase letter and contains no spaces).
+ * Strings that are already display-ready (PascalCase, contain spaces, etc.)
+ * are returned as-is.
+ * @param {string} str - The string to conditionally convert.
+ * @returns {string} - The converted or original string.
+ */
+export const fromCamelCaseIfCamelCase = (str: string) => {
+	if (str.includes(' ') || str.charAt(0) === str.charAt(0).toUpperCase()) {
+		return str;
+	}
+	return fromCamelCase(str);
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
@@ -13,7 +13,7 @@ import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registr
 import { umbFocus } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
-import { UmbPaginationManager, debounce, fromCamelCase } from '@umbraco-cms/backoffice/utils';
+import { UmbPaginationManager, debounce, fromCamelCaseIfCamelCase } from '@umbraco-cms/backoffice/utils';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UMB_CONTENT_TYPE_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/content-type';
 import { UMB_PROPERTY_TYPE_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/property-type';
@@ -277,7 +277,9 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
 		const grouped = Object.groupBy(dataTypes, (dataType: UmbDataTypeItemModel) =>
-			fromCamelCase(this.#groupLookup[dataType.propertyEditorUiAlias] ?? 'Uncategorized'),
+			// Use fromCamelCaseIfCamelCase for backward compatibility: although core property editors provide
+			// title cased group names, external packages may still register them as camelCase.
+			fromCamelCaseIfCamelCase(this.#groupLookup[dataType.propertyEditorUiAlias] ?? 'Uncategorized'),
 		);
 
 		return Object.keys(grouped)
@@ -289,7 +291,9 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
 		const grouped = Object.groupBy(uis, (propertyEditorUi: ManifestPropertyEditorUi) =>
-			fromCamelCase(propertyEditorUi.meta.group ?? 'Uncategorized'),
+			// Use fromCamelCaseIfCamelCase for backward compatibility: although core property editors provide
+			// title cased group names, external packages may still register them as camelCase.
+			fromCamelCaseIfCamelCase(propertyEditorUi.meta.group ?? 'Uncategorized'),
 		);
 
 		return Object.keys(grouped)

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
@@ -254,9 +254,10 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 	}
 
 	#resolveGroupName(group: string): string {
-		if (group.includes('#')) {
+		if (group.startsWith('#')) {
 			return this.localize.string(group);
 		}
+
 		// Backward compatibility: external packages may still register camelCase group names.
 		return fromCamelCaseIfCamelCase(group);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-modal.element.ts
@@ -253,6 +253,14 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 		await this.#performFiltering();
 	}
 
+	#resolveGroupName(group: string): string {
+		if (group.includes('#')) {
+			return this.localize.string(group);
+		}
+		// Backward compatibility: external packages may still register camelCase group names.
+		return fromCamelCaseIfCamelCase(group);
+	}
+
 	async #performFiltering() {
 		if (this.#currentFilterQuery) {
 			const filteredDataTypes = this.#dataTypes
@@ -277,9 +285,7 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
 		const grouped = Object.groupBy(dataTypes, (dataType: UmbDataTypeItemModel) =>
-			// Use fromCamelCaseIfCamelCase for backward compatibility: although core property editors provide
-			// title cased group names, external packages may still register them as camelCase.
-			fromCamelCaseIfCamelCase(this.#groupLookup[dataType.propertyEditorUiAlias] ?? 'Uncategorized'),
+			this.#resolveGroupName(this.#groupLookup[dataType.propertyEditorUiAlias] ?? 'Uncategorized'),
 		);
 
 		return Object.keys(grouped)
@@ -291,9 +297,7 @@ export class UmbDataTypePickerFlowModalElement extends UmbModalBaseElement<
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-expect-error
 		const grouped = Object.groupBy(uis, (propertyEditorUi: ManifestPropertyEditorUi) =>
-			// Use fromCamelCaseIfCamelCase for backward compatibility: although core property editors provide
-			// title cased group names, external packages may still register them as camelCase.
-			fromCamelCaseIfCamelCase(propertyEditorUi.meta.group ?? 'Uncategorized'),
+			this.#resolveGroupName(propertyEditorUi.meta.group ?? 'Uncategorized'),
 		);
 
 		return Object.keys(grouped)

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/property-editors/document-type-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/property-editors/document-type-picker/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Document Type Picker',
 		icon: 'icon-document-dashed-line',
-		group: 'advanced',
+		group: 'Advanced',
 		keywords: ['doctype', 'type', 'element', 'schema', 'pick'],
 		supportsReadOnly: true,
 		settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/property-editors/document-type-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/property-editors/document-type-picker/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Document Type Picker',
 		icon: 'icon-document-dashed-line',
-		group: 'Advanced',
+		group: '#propertyEditorUIGroups_advanced',
 		keywords: ['doctype', 'type', 'element', 'schema', 'pick'],
 		supportsReadOnly: true,
 		settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/property-editors/document-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/property-editors/document-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Document Picker',
 			propertyEditorSchemaAlias: 'Umbraco.ContentPicker',
 			icon: 'icon-document',
-			group: 'Pickers',
+			group: '#propertyEditorUIGroups_pickers',
 			keywords: ['select', 'page', 'link', 'reference', 'related', 'document', 'target', 'destination'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/property-editors/document-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/property-editors/document-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Document Picker',
 			propertyEditorSchemaAlias: 'Umbraco.ContentPicker',
 			icon: 'icon-document',
-			group: 'pickers',
+			group: 'Pickers',
 			keywords: ['select', 'page', 'link', 'reference', 'related', 'document', 'target', 'destination'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/property-editors/markdown-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/property-editors/markdown-editor/manifests.ts
@@ -17,7 +17,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Markdown Editor',
 			propertyEditorSchemaAlias: 'Umbraco.MarkdownEditor',
 			icon: 'icon-code',
-			group: 'richContent',
+			group: 'Rich Content',
 			keywords: ['content', 'article', 'body', 'markdown', 'documentation', 'md', 'readme'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/property-editors/markdown-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/property-editors/markdown-editor/manifests.ts
@@ -17,7 +17,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Markdown Editor',
 			propertyEditorSchemaAlias: 'Umbraco.MarkdownEditor',
 			icon: 'icon-code',
-			group: 'Rich Content',
+			group: '#propertyEditorUIGroups_richContent',
 			keywords: ['content', 'article', 'body', 'markdown', 'documentation', 'md', 'readme'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/property-editors/media-type-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/property-editors/media-type-picker/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Media Type Picker',
 		icon: 'icon-media-dashed-line',
-		group: 'Advanced',
+		group: '#propertyEditorUIGroups_advanced',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/property-editors/media-type-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/property-editors/media-type-picker/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Media Type Picker',
 		icon: 'icon-media-dashed-line',
-		group: 'advanced',
+		group: 'Advanced',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-cropper/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-cropper/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Image Cropper',
 			icon: 'icon-crop',
-			group: 'Media',
+			group: '#propertyEditorUIGroups_media',
 			keywords: ['image', 'crop', 'photo', 'thumbnail', 'avatar', 'profile', 'cover', 'portrait'],
 			propertyEditorSchemaAlias: 'Umbraco.ImageCropper',
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-cropper/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-cropper/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Image Cropper',
 			icon: 'icon-crop',
-			group: 'media',
+			group: 'Media',
 			keywords: ['image', 'crop', 'photo', 'thumbnail', 'avatar', 'profile', 'cover', 'portrait'],
 			propertyEditorSchemaAlias: 'Umbraco.ImageCropper',
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Image Crops Configuration',
 		icon: 'icon-autofill',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Image Crops Configuration',
 		icon: 'icon-autofill',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-entity-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-entity-picker/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Media Entity Picker',
 		icon: 'icon-picture',
-		group: 'pickers',
+		group: 'Pickers',
 		supportsReadOnly: true,
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-entity-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-entity-picker/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Media Entity Picker',
 		icon: 'icon-picture',
-		group: 'Pickers',
+		group: '#propertyEditorUIGroups_pickers',
 		supportsReadOnly: true,
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Media Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MediaPicker3',
 			icon: 'icon-picture',
-			group: 'Media',
+			group: '#propertyEditorUIGroups_media',
 			keywords: [
 				'select',
 				'image',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Media Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MediaPicker3',
 			icon: 'icon-picture',
-			group: 'media',
+			group: 'Media',
 			keywords: [
 				'select',
 				'image',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/upload-field/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/upload-field/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Upload Field',
 			propertyEditorSchemaAlias: 'Umbraco.UploadField',
 			icon: 'icon-download-alt',
-			group: 'Media',
+			group: '#propertyEditorUIGroups_media',
 			keywords: ['file', 'upload', 'attachment', 'document', 'asset', 'download'],
 		},
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/upload-field/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/upload-field/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Upload Field',
 			propertyEditorSchemaAlias: 'Umbraco.UploadField',
 			icon: 'icon-download-alt',
-			group: 'media',
+			group: 'Media',
 			keywords: ['file', 'upload', 'attachment', 'document', 'asset', 'download'],
 		},
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/property-editor/member-group-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/property-editor/member-group-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Member Group Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MemberGroupPicker',
 			icon: 'icon-users-alt',
-			group: 'People',
+			group: '#propertyEditorUIGroups_people',
 			keywords: ['group', 'role', 'permission', 'audience', 'community', 'members'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/property-editor/member-group-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/property-editor/member-group-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Member Group Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MemberGroupPicker',
 			icon: 'icon-users-alt',
-			group: 'people',
+			group: 'People',
 			keywords: ['group', 'role', 'permission', 'audience', 'community', 'members'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/property-editor/member-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/property-editor/member-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Member Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MemberPicker',
 			icon: 'icon-user',
-			group: 'people',
+			group: 'People',
 			keywords: ['select', 'member', 'person', 'subscriber', 'customer', 'account', 'profile', 'contact', 'author'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/property-editor/member-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/property-editor/member-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Member Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MemberPicker',
 			icon: 'icon-user',
-			group: 'People',
+			group: '#propertyEditorUIGroups_people',
 			keywords: ['select', 'member', 'person', 'subscriber', 'customer', 'account', 'profile', 'contact', 'author'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/property-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/property-editor/manifests.ts
@@ -10,7 +10,7 @@ export const manifests = [
 			label: 'Multi URL Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MultiUrlPicker',
 			icon: 'icon-link',
-			group: 'Pickers',
+			group: '#propertyEditorUIGroups_pickers',
 			keywords: ['url', 'link', 'cta', 'links'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/property-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/property-editor/manifests.ts
@@ -10,7 +10,7 @@ export const manifests = [
 			label: 'Multi URL Picker',
 			propertyEditorSchemaAlias: 'Umbraco.MultiUrlPicker',
 			icon: 'icon-link',
-			group: 'pickers',
+			group: 'Pickers',
 			keywords: ['url', 'link', 'cta', 'links'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Accepted Upload Types',
 		icon: 'icon-ordered-list',
-		group: 'Lists',
+		group: '#propertyEditorUIGroups_lists',
 		supportsReadOnly: true,
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Accepted Upload Types',
 		icon: 'icon-ordered-list',
-		group: 'lists',
+		group: 'Lists',
 		supportsReadOnly: true,
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/checkbox-list/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/checkbox-list/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Checkbox List',
 			propertyEditorSchemaAlias: 'Umbraco.CheckBoxList',
 			icon: 'icon-bulleted-list',
-			group: 'lists',
+			group: 'Lists',
 			keywords: ['select', 'multi', 'options', 'features', 'categories', 'checklist'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/checkbox-list/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/checkbox-list/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Checkbox List',
 			propertyEditorSchemaAlias: 'Umbraco.CheckBoxList',
 			icon: 'icon-bulleted-list',
-			group: 'Lists',
+			group: '#propertyEditorUIGroups_lists',
 			keywords: ['select', 'multi', 'options', 'features', 'categories', 'checklist'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Collection Column Configuration',
 		icon: 'icon-autofill',
-		group: 'lists',
+		group: 'Lists',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Collection Column Configuration',
 		icon: 'icon-autofill',
-		group: 'Lists',
+		group: '#propertyEditorUIGroups_lists',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Collection Layout Configuration',
 		icon: 'icon-autofill',
-		group: 'lists',
+		group: 'Lists',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Collection Layout Configuration',
 		icon: 'icon-autofill',
-		group: 'Lists',
+		group: '#propertyEditorUIGroups_lists',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/order-by/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/order-by/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Collection Order By',
 		icon: 'icon-autofill',
-		group: 'lists',
+		group: 'Lists',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/order-by/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/order-by/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Collection Order By',
 		icon: 'icon-autofill',
-		group: 'Lists',
+		group: '#propertyEditorUIGroups_lists',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/manifests.ts
@@ -13,7 +13,7 @@ const propertyEditorUiManifest: ManifestPropertyEditorUi = {
 		label: 'Collection',
 		propertyEditorSchemaAlias: 'Umbraco.ListView',
 		icon: 'icon-layers',
-		group: 'lists',
+		group: 'Lists',
 		keywords: ['list', 'children', 'items', 'listview', 'table', 'overview'],
 		settings: {
 			properties: [

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/manifests.ts
@@ -13,7 +13,7 @@ const propertyEditorUiManifest: ManifestPropertyEditorUi = {
 		label: 'Collection',
 		propertyEditorSchemaAlias: 'Umbraco.ListView',
 		icon: 'icon-layers',
-		group: 'Lists',
+		group: '#propertyEditorUIGroups_lists',
 		keywords: ['list', 'children', 'items', 'listview', 'table', 'overview'],
 		settings: {
 			properties: [

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/manifests.ts
@@ -12,7 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Color Picker',
 			propertyEditorSchemaAlias: 'Umbraco.ColorPicker',
 			icon: 'icon-colorpicker',
-			group: 'pickers',
+			group: 'Pickers',
 			keywords: [
 				'select',
 				'color',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/manifests.ts
@@ -12,7 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Color Picker',
 			propertyEditorSchemaAlias: 'Umbraco.ColorPicker',
 			icon: 'icon-colorpicker',
-			group: 'Pickers',
+			group: '#propertyEditorUIGroups_pickers',
 			keywords: [
 				'select',
 				'color',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-swatches-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-swatches-editor/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Color Swatches Editor',
 		icon: 'icon-page-add',
-		group: 'Pickers',
+		group: '#propertyEditorUIGroups_pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-swatches-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-swatches-editor/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Color Swatches Editor',
 		icon: 'icon-page-add',
-		group: 'pickers',
+		group: 'Pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-content/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-content/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Content Picker Source',
 		icon: 'icon-page-add',
-		group: 'Pickers',
+		group: '#propertyEditorUIGroups_pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-content/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-content/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Content Picker Source',
 		icon: 'icon-page-add',
-		group: 'pickers',
+		group: 'Pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-type/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-type/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Content Picker Source Type Picker',
 		icon: 'icon-page-add',
-		group: 'Pickers',
+		group: '#propertyEditorUIGroups_pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-type/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/config/source-type/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Content Picker Source Type Picker',
 		icon: 'icon-page-add',
-		group: 'pickers',
+		group: 'Pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/manifests.ts
@@ -12,7 +12,7 @@ const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Content Picker',
 		icon: 'icon-page-add',
-		group: 'Pickers',
+		group: '#propertyEditorUIGroups_pickers',
 		keywords: ['select', 'page', 'node', 'reference', 'related', 'link', 'pages', 'content'],
 		propertyEditorSchemaAlias: 'Umbraco.MultiNodeTreePicker',
 		supportsReadOnly: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/manifests.ts
@@ -12,7 +12,7 @@ const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Content Picker',
 		icon: 'icon-page-add',
-		group: 'pickers',
+		group: 'Pickers',
 		keywords: ['select', 'page', 'node', 'reference', 'related', 'link', 'pages', 'content'],
 		propertyEditorSchemaAlias: 'Umbraco.MultiNodeTreePicker',
 		supportsReadOnly: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Picker',
 			propertyEditorSchemaAlias: 'Umbraco.DateTime',
 			icon: 'icon-time',
-			group: 'Pickers',
+			group: '#propertyEditorUIGroups_pickers',
 			keywords: ['select', 'date', 'calendar', 'schedule', 'event'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Picker',
 			propertyEditorSchemaAlias: 'Umbraco.DateTime',
 			icon: 'icon-time',
-			group: 'pickers',
+			group: 'Pickers',
 			keywords: ['select', 'date', 'calendar', 'schedule', 'event'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-only-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-only-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Only',
 			propertyEditorSchemaAlias: 'Umbraco.DateOnly',
 			icon: 'icon-calendar-alt',
-			group: 'date',
+			group: 'Date',
 			keywords: ['date', 'calendar', 'birthday', 'deadline', 'day', 'anniversary', 'expiry', 'start', 'end', 'release'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-only-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-only-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Only',
 			propertyEditorSchemaAlias: 'Umbraco.DateOnly',
 			icon: 'icon-calendar-alt',
-			group: 'Date',
+			group: '#propertyEditorUIGroups_date',
 			keywords: ['date', 'calendar', 'birthday', 'deadline', 'day', 'anniversary', 'expiry', 'start', 'end', 'release'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Time (unspecified)',
 			propertyEditorSchemaAlias: 'Umbraco.DateTimeUnspecified',
 			icon: 'icon-calendar-alt',
-			group: 'date',
+			group: 'Date',
 			keywords: [
 				'date',
 				'time',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Time (unspecified)',
 			propertyEditorSchemaAlias: 'Umbraco.DateTimeUnspecified',
 			icon: 'icon-calendar-alt',
-			group: 'Date',
+			group: '#propertyEditorUIGroups_date',
 			keywords: [
 				'date',
 				'time',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-with-time-zone-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-with-time-zone-picker/manifests.ts
@@ -11,7 +11,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Time (with time zone)',
 			propertyEditorSchemaAlias: 'Umbraco.DateTimeWithTimeZone',
 			icon: 'icon-calendar-alt',
-			group: 'date',
+			group: 'Date',
 			keywords: [
 				'date',
 				'time',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-with-time-zone-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/date-time-with-time-zone-picker/manifests.ts
@@ -11,7 +11,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Date Time (with time zone)',
 			propertyEditorSchemaAlias: 'Umbraco.DateTimeWithTimeZone',
 			icon: 'icon-calendar-alt',
-			group: 'Date',
+			group: '#propertyEditorUIGroups_date',
 			keywords: [
 				'date',
 				'time',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/time-only-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/time-only-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Time Only',
 			propertyEditorSchemaAlias: 'Umbraco.TimeOnly',
 			icon: 'icon-time',
-			group: 'date',
+			group: 'Date',
 			keywords: ['time', 'clock', 'hour', 'schedule', 'duration', 'opening', 'closing', 'start', 'end', 'minute'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/time-only-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/time-only-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Time Only',
 			propertyEditorSchemaAlias: 'Umbraco.TimeOnly',
 			icon: 'icon-time',
-			group: 'Date',
+			group: '#propertyEditorUIGroups_date',
 			keywords: ['time', 'clock', 'hour', 'schedule', 'duration', 'opening', 'closing', 'start', 'end', 'minute'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/dimensions/manifest.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/dimensions/manifest.ts
@@ -6,6 +6,6 @@ export const manifest: UmbExtensionManifest = {
 	meta: {
 		label: 'Dimensions',
 		icon: 'icon-fullscreen-alt',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Dropdown',
 			propertyEditorSchemaAlias: 'Umbraco.DropDown.Flexible',
 			icon: 'icon-list',
-			group: 'lists',
+			group: 'Lists',
 			keywords: ['select', 'dropdown', 'choice', 'option', 'list'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Dropdown',
 			propertyEditorSchemaAlias: 'Umbraco.DropDown.Flexible',
 			icon: 'icon-list',
-			group: 'Lists',
+			group: '#propertyEditorUIGroups_lists',
 			keywords: ['select', 'dropdown', 'choice', 'option', 'list'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/config/picker-views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/config/picker-views/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Entity Data Picker Picker Views Configuration',
 		icon: 'icon-grid',
-		group: 'pickers',
+		group: 'Pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/config/picker-views/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/config/picker-views/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Entity Data Picker Picker Views Configuration',
 		icon: 'icon-grid',
-		group: 'Pickers',
+		group: '#propertyEditorUIGroups_pickers',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Entity Data Picker',
 			icon: 'icon-page-add',
-			group: 'pickers',
+			group: 'Pickers',
 			keywords: ['select', 'entity', 'data', 'source', 'pick'],
 			propertyEditorSchemaAlias: 'Umbraco.EntityDataPicker',
 			supportsReadOnly: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Entity Data Picker',
 			icon: 'icon-page-add',
-			group: 'Pickers',
+			group: '#propertyEditorUIGroups_pickers',
 			keywords: ['select', 'entity', 'data', 'source', 'pick'],
 			propertyEditorSchemaAlias: 'Umbraco.EntityDataPicker',
 			supportsReadOnly: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/eye-dropper/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/eye-dropper/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Eye Dropper Color Picker',
 			icon: 'icon-colorpicker',
-			group: 'pickers',
+			group: 'Pickers',
 			keywords: ['color', 'colour', 'hex', 'palette', 'hue', 'pick'],
 			propertyEditorSchemaAlias: 'Umbraco.ColorPicker.EyeDropper',
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/eye-dropper/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/eye-dropper/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Eye Dropper Color Picker',
 			icon: 'icon-colorpicker',
-			group: 'Pickers',
+			group: '#propertyEditorUIGroups_pickers',
 			keywords: ['color', 'colour', 'hex', 'palette', 'hue', 'pick'],
 			propertyEditorSchemaAlias: 'Umbraco.ColorPicker.EyeDropper',
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/icon-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/icon-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Icon Picker',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: ['icon', 'symbol', 'glyph'],
 			settings: {
 				properties: [

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/icon-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/icon-picker/manifests.ts
@@ -7,7 +7,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Icon Picker',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 			keywords: ['icon', 'symbol', 'glyph'],
 			settings: {
 				properties: [

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/label/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/label/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Label',
 			icon: 'icon-readonly',
-			group: 'common',
+			group: 'Common',
 			keywords: ['readonly', 'display', 'static', 'computed', 'info', 'key', 'id'],
 			propertyEditorSchemaAlias: 'Umbraco.Label',
 			supportsReadOnly: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/label/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/label/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Label',
 			icon: 'icon-readonly',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: ['readonly', 'display', 'static', 'computed', 'info', 'key', 'id'],
 			propertyEditorSchemaAlias: 'Umbraco.Label',
 			supportsReadOnly: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/multiple-text-string/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/multiple-text-string/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Multiple Text String',
 			propertyEditorSchemaAlias: 'Umbraco.MultipleTextstring',
 			icon: 'icon-ordered-list',
-			group: 'Lists',
+			group: '#propertyEditorUIGroups_lists',
 			keywords: ['string', 'list', 'items', 'values', 'features', 'tags', 'keywords', 'bullets', 'entries', 'array'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/multiple-text-string/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/multiple-text-string/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Multiple Text String',
 			propertyEditorSchemaAlias: 'Umbraco.MultipleTextstring',
 			icon: 'icon-ordered-list',
-			group: 'lists',
+			group: 'Lists',
 			keywords: ['string', 'list', 'items', 'values', 'features', 'tags', 'keywords', 'bullets', 'entries', 'array'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Number Range',
 		icon: 'icon-autofill',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number-range/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Number Range',
 		icon: 'icon-autofill',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/manifests.ts
@@ -18,7 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Decimal',
 			propertyEditorSchemaAlias: 'Umbraco.Decimal',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: [
 				'number',
 				'decimal',
@@ -67,7 +67,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Numeric',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: [
 				'number',
 				'integer',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/manifests.ts
@@ -18,7 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Decimal',
 			propertyEditorSchemaAlias: 'Umbraco.Decimal',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 			keywords: [
 				'number',
 				'decimal',
@@ -67,7 +67,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: 'Numeric',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 			keywords: [
 				'number',
 				'integer',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/order-direction/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/order-direction/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Order Direction',
 		icon: 'icon-autofill',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/order-direction/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/order-direction/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Order Direction',
 		icon: 'icon-autofill',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/radio-button-list/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/radio-button-list/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Radio Button List',
 			propertyEditorSchemaAlias: 'Umbraco.RadioButtonList',
 			icon: 'icon-target',
-			group: 'lists',
+			group: 'Lists',
 			keywords: ['select', 'choice', 'option', 'type', 'category', 'single', 'variant', 'size', 'gender'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/radio-button-list/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/radio-button-list/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Radio Button List',
 			propertyEditorSchemaAlias: 'Umbraco.RadioButtonList',
 			icon: 'icon-target',
-			group: 'Lists',
+			group: '#propertyEditorUIGroups_lists',
 			keywords: ['select', 'choice', 'option', 'type', 'category', 'single', 'variant', 'size', 'gender'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/select/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/select/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Select',
 		icon: 'icon-list',
-		group: 'pickers',
+		group: 'Pickers',
 		keywords: ['dropdown', 'select', 'choice', 'option', 'picker', 'combobox', 'type', 'list'],
 		settings: {
 			properties: [

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/select/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/select/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Select',
 		icon: 'icon-list',
-		group: 'Pickers',
+		group: '#propertyEditorUIGroups_pickers',
 		keywords: ['dropdown', 'select', 'choice', 'option', 'picker', 'combobox', 'type', 'list'],
 		settings: {
 			properties: [

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/manifests.ts
@@ -18,7 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Slider',
 			propertyEditorSchemaAlias: 'Umbraco.Slider',
 			icon: 'icon-navigation-horizontal',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: [
 				'number',
 				'range',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/manifests.ts
@@ -18,7 +18,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Slider',
 			propertyEditorSchemaAlias: 'Umbraco.Slider',
 			icon: 'icon-navigation-horizontal',
-			group: 'common',
+			group: 'Common',
 			keywords: [
 				'number',
 				'range',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/manifests.ts
@@ -19,7 +19,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Text Box',
 			propertyEditorSchemaAlias: 'Umbraco.TextBox',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 			keywords: [
 				'string',
 				'headline',
@@ -61,7 +61,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Email',
 			propertyEditorSchemaAlias: 'Umbraco.EmailAddress',
 			icon: 'icon-message',
-			group: 'common',
+			group: 'Common',
 			keywords: ['email', 'contact', 'address', 'newsletter', 'recipient'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/manifests.ts
@@ -19,7 +19,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Text Box',
 			propertyEditorSchemaAlias: 'Umbraco.TextBox',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: [
 				'string',
 				'headline',
@@ -61,7 +61,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Email',
 			propertyEditorSchemaAlias: 'Umbraco.EmailAddress',
 			icon: 'icon-message',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: ['email', 'contact', 'address', 'newsletter', 'recipient'],
 			supportsReadOnly: true,
 			settings: {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Text Area',
 			propertyEditorSchemaAlias: 'Umbraco.TextArea',
 			icon: 'icon-edit',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: [
 				'string',
 				'description',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Text Area',
 			propertyEditorSchemaAlias: 'Umbraco.TextArea',
 			icon: 'icon-edit',
-			group: 'common',
+			group: 'Common',
 			keywords: [
 				'string',
 				'description',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/toggle/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/toggle/manifests.ts
@@ -17,7 +17,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Toggle',
 			propertyEditorSchemaAlias: 'Umbraco.TrueFalse',
 			icon: 'icon-checkbox',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: [
 				'boolean',
 				'switch',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/toggle/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/toggle/manifests.ts
@@ -17,7 +17,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Toggle',
 			propertyEditorSchemaAlias: 'Umbraco.TrueFalse',
 			icon: 'icon-checkbox',
-			group: 'common',
+			group: 'Common',
 			keywords: [
 				'boolean',
 				'switch',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/value-type/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/value-type/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Value Type',
 		icon: 'icon-autofill',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/value-type/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/value-type/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Value Type',
 		icon: 'icon-autofill',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-file-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-file-picker/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Static File Picker',
 		icon: 'icon-document',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-file-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-file-picker/manifests.ts
@@ -8,6 +8,6 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Static File Picker',
 		icon: 'icon-document',
-		group: 'common',
+		group: 'Common',
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Tags',
 			propertyEditorSchemaAlias: 'Umbraco.Tags',
 			icon: 'icon-tags',
-			group: 'common',
+			group: 'Common',
 			keywords: ['tag', 'label', 'category', 'keyword', 'metadata', 'topics', 'terms', 'taxonomy'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'Tags',
 			propertyEditorSchemaAlias: 'Umbraco.Tags',
 			icon: 'icon-tags',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 			keywords: ['tag', 'label', 'category', 'keyword', 'metadata', 'topics', 'terms', 'taxonomy'],
 			supportsReadOnly: true,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/property-editors/stylesheet-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/property-editors/stylesheet-picker/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Stylesheet Picker',
 		icon: 'icon-document',
-		group: 'common',
+		group: 'Common',
 		keywords: ['css', 'style', 'theme'],
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/property-editors/stylesheet-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/property-editors/stylesheet-picker/manifests.ts
@@ -8,7 +8,7 @@ export const manifest: ManifestPropertyEditorUi = {
 	meta: {
 		label: 'Stylesheet Picker',
 		icon: 'icon-document',
-		group: 'Common',
+		group: '#propertyEditorUIGroups_common',
 		keywords: ['css', 'style', 'theme'],
 	},
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/extensions-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/extensions-configuration/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Tiptap Extensions Configuration',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/extensions-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/extensions-configuration/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Tiptap Extensions Configuration',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Tiptap Statusbar Configuration',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/statusbar-configuration/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Tiptap Statusbar Configuration',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/manifests.ts
@@ -11,7 +11,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 			label: '#rte_label',
 			propertyEditorSchemaAlias: 'Umbraco.RichText',
 			icon: 'icon-browser-window',
-			group: 'Rich Content',
+			group: '#propertyEditorUIGroups_richContent',
 			supportsReadOnly: true,
 			keywords: [
 				'content',

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/manifests.ts
@@ -11,7 +11,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 			label: '#rte_label',
 			propertyEditorSchemaAlias: 'Umbraco.RichText',
 			icon: 'icon-browser-window',
-			group: 'richContent',
+			group: 'Rich Content',
 			supportsReadOnly: true,
 			keywords: [
 				'content',

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Tiptap Toolbar Configuration',
 			icon: 'icon-autofill',
-			group: 'Common',
+			group: '#propertyEditorUIGroups_common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/toolbar-configuration/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 		meta: {
 			label: 'Tiptap Toolbar Configuration',
 			icon: 'icon-autofill',
-			group: 'common',
+			group: 'Common',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/property-editor/user-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/property-editor/user-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'User Picker',
 			propertyEditorSchemaAlias: 'Umbraco.UserPicker',
 			icon: 'icon-user',
-			group: 'people',
+			group: 'People',
 			keywords: ['select', 'user', 'author', 'owner', 'assignee', 'editor', 'creator', 'contributor', 'staff'],
 		},
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/property-editor/user-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/property-editor/user-picker/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 			label: 'User Picker',
 			propertyEditorSchemaAlias: 'Umbraco.UserPicker',
 			icon: 'icon-user',
-			group: 'People',
+			group: '#propertyEditorUIGroups_people',
 			keywords: ['select', 'user', 'author', 'owner', 'assignee', 'editor', 'creator', 'contributor', 'staff'],
 		},
 	},


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/22189 reports a problem with certain group names provided as meta data for property editor UIs, where the resulting text is transformed into something the package or project developer doesn't want.

E.g. illustratively "My CusTom UI Group" would become "My Cus Tom U I Group" (or, more realistically "SEO" would become "S E O").

To fix I've added correct display values to all group names for core property editors - so "richContent" is now "Rich Content".

We have to consider external packages may still register property editor UIs with camelCase group names (e.g. `'richContent'`, `'pickers'`).  So to that end I've introduced a `fromCamelCaseIfCamelCase` function, and called this instead of `fromCamelCase` as we had before.  This is a wrapper around `fromCamelCase` that only transforms strings that actually look like camelCase (start with a lowercase letter and contain no spaces).

Display-ready names are returned as-is. Existing external packages using the old camelCase names will continue to display correctly without any changes on their part.

## Testing

- [x] New unit tests for `fromCamelCaseIfCamelCase` (camelCase, single word, spaces, PascalCase, uppercase-start) are added.
- [ ] Run site, create a data type, open property editor picker — verify built-in groups display correctly.
- [ ] Verify the provided bug reproduction group shows `MyCusTomUIGroup` as is.

### Reproduction sample

Place these two files in `App_Plugins`.

**umbraco-page.json**

```json
{
    "$schema": "../../umbraco-package-schema.json",
    "name": "BugRepro.22189",
    "version": "0.1.0",
    "extensions": [
        {
            "type": "propertyEditorUi",
            "alias": "BugRepro.PropertyEditorUi.22189",
            "name": "Bug Repro 22189",
            "element": "/App_Plugins/BugRepro22189/editor.js",
            "elementName": "bug-repro-22189-editor",
            "meta": {
                "label": "Bug Repro 22189",
                "icon": "icon-bug",
                "group": "MyCusTomUIGroup",
                "propertyEditorSchemaAlias": "Umbraco.Plain.String"
            }
        }
    ]
}
```

**editor.js**

```js
import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";

class BugRepro22189Editor extends UmbElementMixin(HTMLElement) {
    #value = "";

    set value(val) {
        this.#value = val || "";
        this.#render();
    }

    get value() {
        return this.#value;
    }

    connectedCallback() {
        super.connectedCallback();
        this.#render();
    }

    #render() {
        this.innerHTML = `
            <p>
                This property editor exists to reproduce
                <a href="https://github.com/umbraco/Umbraco-CMS/issues/22189" target="_blank">#22189</a>.
            </p>
            <p>
                Its manifest sets <code>"group": "MyCusTomUIGroup"</code>.<br/>
                <strong>Expected:</strong> The group tab reads <em>MyCusTomUIGroup</em>.<br/>
                <strong>Actual:</strong> The group tab reads <em>My Cus Tom U I Group</em>
                (spaces inserted before every capital letter).
            </p>
            <input type="text" value="${this.#value}" />
        `;

        const input = this.querySelector("input");
        input.addEventListener("input", (e) => {
            this.#value = e.target.value;
            this.dispatchEvent(
                new CustomEvent("property-value-change", { bubbles: true, composed: true })
            );
        });
    }
}

customElements.define("bug-repro-22189-editor", BugRepro22189Editor);
```

---
_This item has been added to our backlog AB#67943_