### PR TITLE
Build: V15 Disable schedule nightly E2E trigger 

### DIFF
--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -3,13 +3,13 @@ name: Nightly_E2E_Test_$(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName
 pr: none
 trigger: none
 
-schedules:
-  - cron: '0 0 * * *'
-    displayName: Daily midnight build
-    branches:
-      include:
-        - v14/dev
-        - v15/dev
+# schedules:
+#   - cron: '0 0 * * *'
+#     displayName: Daily midnight build
+#     branches:
+#       include:
+#         - v14/dev
+#         - v15/dev
 
 parameters:
   - name: differentAppSettingsAcceptanceTests


### PR DESCRIPTION
## Summary
Temporarily disable the scheduled nightly E2E test by commenting out the `schedules` section in the pipeline YAML.

## Changes
- Commented out the cron schedule (`0 0 * * *`) that previously triggered the pipeline daily at midnight
- Affected branches: `v14/dev`, `v15/dev`
- Pipeline can still be triggered manually if needed

## Reason
No longer needed since v15 is EOL now.

## Notes
- To re-enable, simply uncomment the `schedules` block
- No logic or test changes included in this PR