### PR TITLE
Migrations: Await EF Core premigrations for OpenIddict (closes #22200)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/UpdateToOpenIddictV5.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_14_0_0/UpdateToOpenIddictV5.cs
@@ -22,6 +22,6 @@ public class UpdateToOpenIddictV5 : MigrationBase
 
     protected override void Migrate()
     {
-        _efCoreMigrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.UpdateOpenIddictToV5);
+        _efCoreMigrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.UpdateOpenIddictToV5).GetAwaiter().GetResult();
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/UpdateToOpenIddictV7.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_0_0/UpdateToOpenIddictV7.cs
@@ -22,6 +22,6 @@ public class UpdateToOpenIddictV7 : MigrationBase
 
     protected override void Migrate()
     {
-        _efCoreMigrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.UpdateOpenIddictToV7);
+        _efCoreMigrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.UpdateOpenIddictToV7).GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
## Description

As noted in https://github.com/umbraco/Umbraco-CMS/issues/22200, the pre-migrations for OpenIddict - `UpdateToOpenIddictV5` and `UpdateToOpenIddictV7` - both called `ExecuteSingleMigrationAsync()` without awaiting the returned `Task`, making them fire-and-forget.

The premigration plan would record success before the EF Core migration actually completed. If the application was interrupted during the migration, the database would be left in an incomplete state and Umbraco would never retry the migration.

To fix I've added `.GetAwaiter().GetResult()` to both calls so the migration blocks until the EF Core work completes.

### Why `.GetAwaiter().GetResult()` instead of changing the base class to `AsyncMigrationBase`?

Both classes are public and inherit from `MigrationBase`. Changing the base class to `AsyncMigrationBase` would be a binary breaking change. `MigrationBase` is already scheduled for removal in Umbraco 18, at which point these can be migrated to `AsyncMigrationBase` with proper `await`.

## Testing

- [ ] Upgrade a v13 site to latest and verify the OpenIddict premigrations complete successfully and the backoffice is accessible
- [ ] Verify the `umbracoKeyValue` table records the premigration state only after the EF Core migrations have actually run

```sql
SELECT [value]
FROM umbracoKeyValue
where [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core.Premigrations'
```

Result should be: `{72894BCA-9FAD-4CC3-B0D0-D6CDA2FFA636}`
