### PR TITLE
Members: Fix SQL error when combining member type and group filters on filter endpoint

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberRepository.cs
@@ -348,18 +348,20 @@ public class MemberRepository : ContentRepositoryBase<int, IMember, MemberReposi
             sql = sql
                 .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((memberNode, memberContent) => memberContent.NodeId == memberNode.NodeId)
                 .InnerJoin<NodeDto>("mtn").On<ContentDto, NodeDto>((memberContent, memberTypeNode) => memberContent.ContentTypeId == memberTypeNode.NodeId, aliasRight: "mtn");
-
-            if (memberFilter.MemberTypeId.HasValue)
-            {
-                sql = sql.Where<NodeDto>(memberTypeNode => memberTypeNode.UniqueId == memberFilter.MemberTypeId, "mtn");
-            }
         }
 
         if (memberFilter.MemberGroupName.IsNullOrWhiteSpace() is false)
         {
             sql = sql
                 .InnerJoin<Member2MemberGroupDto>().On<MemberDto, Member2MemberGroupDto>((m, memberToGroup) => m.NodeId == memberToGroup.Member)
-                .InnerJoin<NodeDto>("mgn").On<NodeDto, Member2MemberGroupDto>((memberGroupNode, memberToGroup) => memberToGroup.MemberGroup == memberGroupNode.NodeId && memberGroupNode.Text == memberFilter.MemberGroupName, "mgn");
+                .InnerJoin<NodeDto>("mgn").On<Member2MemberGroupDto, NodeDto>((memberToGroup, memberGroupNode) => memberToGroup.MemberGroup == memberGroupNode.NodeId, aliasRight: "mgn");
+
+            sql = sql.Where<NodeDto>(memberGroupNode => memberGroupNode.Text == memberFilter.MemberGroupName, "mgn");
+        }
+
+        if (memberFilter.MemberTypeId.HasValue)
+        {
+            sql = sql.Where<NodeDto>(memberTypeNode => memberTypeNode.UniqueId == memberFilter.MemberTypeId, "mtn");
         }
 
         if (memberFilter.IsApproved is not null)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MemberServiceTests.cs
@@ -1603,4 +1603,37 @@ internal sealed class MemberServiceTests : UmbracoIntegrationTest
         result = await MemberService.FilterAsync(filter, "memberType", Direction.Descending, skip: 0, take: 10);
         Assert.AreEqual(new[] { "Charlie", "Bob", "Alice" }, result.Items.Select(m => m.Name).ToArray());
     }
+
+    [Test]
+    public async Task Can_FilterAsync_With_Combined_MemberType_And_MemberGroup()
+    {
+        // Create a member type.
+        IMemberType memberType = MemberTypeBuilder.CreateSimpleMemberType();
+        await MemberTypeService.CreateAsync(memberType, Constants.Security.SuperUserKey);
+
+        // Create two members of that type.
+        IMember member1 = MemberBuilder.CreateSimpleMember(memberType, "Alice", "alice@test.com", "pass", "alice");
+        MemberService.Save(member1);
+
+        IMember member2 = MemberBuilder.CreateSimpleMember(memberType, "Bob", "bob@test.com", "pass", "bob");
+        MemberService.Save(member2);
+
+        // Create a member group and assign only the first member to it.
+        MemberService.AddRole("Test Group");
+        MemberService.AssignRoles([member1.Id], ["Test Group"]);
+
+        // Filter by both member type ID and member group name — this previously caused
+        // a SQL syntax error ("near INNER: syntax error") because a WHERE clause was
+        // inserted between JOIN blocks.
+        var filter = new MemberFilter
+        {
+            MemberTypeId = memberType.Key,
+            MemberGroupName = "Test Group",
+        };
+
+        var result = await MemberService.FilterAsync(filter, "name", Direction.Ascending, skip: 0, take: 10);
+
+        Assert.AreEqual(1, result.Total);
+        Assert.AreEqual("Alice", result.Items.First().Name);
+    }
 }


### PR DESCRIPTION
## Description

A management API request to the member filter endpoint, with a type and group filter, would trigger an exception.

```
GET /umbraco/management/api/v1/filter/member?memberTypeId={id}&memberGroupName={groupName}&orderBy=username&orderDirection=Ascending&skip=0&take=50`
```

Resulting in:

```json
{
    "type": "Error",
    "title": "SQLite Error 1: 'near \"INNER\": syntax error'.",
    "status": 500,
    "detail": "   at ..."
    "instance": "SqliteException"
}
```

This is caused by the query construction incorrectly trying to add a JOIN after the WHERE clause as begun.

To fix I've restructured the query builder to emit all JOINs first, then all WHERE clauses.

## Testing

### Automated

This can be verified via the added integration test `Can_FilterAsync_With_Combined_MemberType_And_MemberGroup` that verifies combined filters return the correct results. This failed before the fix, and passes afterward.

### Manual

Use the Swagger UI to make the above request, filtering by both member type and group, and verify that results are returned.