### PR TITLE
Migrations: Fix retrust constraints migration targeting non-Umbraco tables and transaction failure (closes #22227)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
@@ -87,7 +87,7 @@ BEGIN CATCH
     SELECT CAST(0 AS BIT) AS Success, ERROR_MESSAGE() AS ErrorMessage;
 END CATCH";
 
-            RetrustResultDto result = Database.Fetch<RetrustResultDto>(sql).First();
+            RetrustResultDto result = Database.Single<RetrustResultDto>(sql);
 
             if (result.Success)
             {


### PR DESCRIPTION
## Description

This PR fixes two bugs reported via https://github.com/umbraco/Umbraco-CMS/issues/22227 in the `RetrustForeignKeyAndCheckConstraints` migration (introduced in #21744) that cause upgrade failures when the Umbraco database contains custom or third-party tables:

- **Scoped to Umbraco tables only**: The constraint discovery query now filters to tables prefixed with `umbraco` or `cms`, which are the two prefixes used by all Umbraco tables. Previously, the migration queried all untrusted constraints across the entire database, including custom tables that Umbraco should not touch.

- **T-SQL error handling instead of C# try-catch**: Each `ALTER TABLE ... WITH CHECK CHECK CONSTRAINT` is now wrapped in a T-SQL `BEGIN TRY...END TRY BEGIN CATCH...END CATCH` block. Previously, a constraint validation failure would doom the .NET `SqlTransaction`, causing all subsequent operations to fail with *"This SqlTransaction has completed; it is no longer usable"* — even though the C# `try-catch` appeared to handle the error. By catching errors at the SQL level, they never propagate to the .NET transaction, so the migration can continue processing remaining constraints.  We still log the failure for the site administrator to review and act on.

## Testing

The bug can be replicated with the following setup.

Start from Umbraco 17.2, or wind back the database migration with:

```sql
UPDATE umbracoKeyValue
SET value = '{A7B8C9D0-E1F2-4A5B-8C7D-9E0F1A2B3C4D}'
WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
```

Add custom tables with an untrusted foreign key constraint:

  ```sql
  CREATE TABLE JobAgents (Id INT PRIMARY KEY, Name NVARCHAR(100));
  CREATE TABLE JobAgentHistory (Id INT PRIMARY KEY, AgentId INT);

  INSERT INTO JobAgents VALUES (1, 'Agent1');
  INSERT INTO JobAgentHistory VALUES (1, 999);

  ALTER TABLE JobAgentHistory WITH NOCHECK
      ADD CONSTRAINT FK_JobAgentHistory_JobAgents_Id
      FOREIGN KEY (AgentId) REFERENCES JobAgents(Id);
  ```

Verify there's an untrusted constraint with:

```sql
SELECT name, is_not_trusted 
ROM sys.foreign_keys
WHERE name = 'FK_JobAgentHistory_JobAgents_Id';
```

Upgrade from the current code in `release/17.3.0` and an exception will be thrown when the migration runs.

With this fix the migration should complete successfully.

Clean up with:

```sql
DROP TABLE JobAgentHistory
DROP TABLE JobAgents
```
