### PR TITLE
E2E: QA Added acceptance tests for moving media items

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -23,7 +23,7 @@
     "testSqlite": "npm run build && npx playwright test DefaultConfig --grep-invert \"Users\"",
     "all": "npm run build && npx playwright test",
     "createTest": "node createTest.js",
-    "smokeTest": "npm run build && npx playwright test DefaultConfig --grep \"move a media item\"",
+    "smokeTest": "npm run build && npx playwright test DefaultConfig --grep \"@smoke\"",
     "smokeTestSqlite": "npm run build && npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\"",
     "releaseTest": "npm run build && npx playwright test DefaultConfig --grep \"@release\"",
     "testWindows": "npm run build && npx playwright test DefaultConfig --grep-invert \"RelationType\""


### PR DESCRIPTION
This PR adds acceptance tests for moving media items:
- Can move a media item to another folder 
- Cannot move a media item to another media item (cover the issue: https://github.com/umbraco/Umbraco-CMS/issues/20451)