### PR TITLE
E2E: V18 Fixed the failing smoke tests

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/LibraryUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/LibraryUiHelper.ts
@@ -279,7 +279,7 @@ export class LibraryUiHelper extends UiBaseLocators {
     this.confirmEmptyRecycleBinBtn = page.locator('#confirm').getByLabel('Empty recycle bin', {exact: true});
     this.duplicateToBtn = page.getByRole('button', {name: 'Duplicate to'});
     this.moveToBtn = page.getByRole('button', {name: 'Move to'});
-    this.duplicateBtn = page.getByLabel('Duplicate to…', {exact: true});
+    this.duplicateBtn = page.getByLabel('Duplicate', {exact: true});
     this.elementTreeRefreshBtn = page.locator('#header').getByLabel('#actions_refreshNode');
     this.sortChildrenBtn = page.getByRole('button', {name: 'Sort children'});
     this.rollbackBtn = page.getByRole('button', { name: 'Rollback…' });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/Element.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/Element.spec.ts
@@ -148,7 +148,7 @@ test('can duplicate a element node to root', async ({umbracoApi, umbracoUi}) => 
   // Duplicate to root
   await umbracoUi.library.clickDuplicateToActionMenuOption();
   await umbracoUi.library.clickLabelWithName('Elements');
-  await umbracoUi.library.clickDuplicateButton();
+  await umbracoUi.library.clickCopyModalButton();
 
   // Assert
   await umbracoUi.library.doesSuccessNotificationHaveText(NotificationConstantHelper.success.duplicated);
@@ -176,7 +176,7 @@ test('can duplicate a element node to other parent', async ({umbracoApi, umbraco
   await umbracoUi.library.clickActionsMenuForElement(elementName);
   await umbracoUi.library.clickDuplicateToActionMenuOption();
   await umbracoUi.library.clickModalMenuItemWithName(elementFolderName);
-  await umbracoUi.library.clickDuplicateButton();
+  await umbracoUi.library.clickCopyModalButton();
 
   // Assert
   await umbracoUi.library.doesSuccessNotificationHaveText(NotificationConstantHelper.success.duplicated);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UserGroup/DefaultPermissionsInElement.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UserGroup/DefaultPermissionsInElement.spec.ts
@@ -290,7 +290,7 @@ test('can duplicate element with duplicate permission enabled', {tag: '@smoke'},
   // Act
   await umbracoUi.library.clickEntityActionOnElementWithName(elementName);
   await umbracoUi.library.clickLabelWithName('Elements');
-  await umbracoUi.library.clickDuplicateButton();
+  await umbracoUi.library.clickCopyModalButton();
 
   // Assert
   await umbracoUi.library.doesSuccessNotificationHaveText(NotificationConstantHelper.success.duplicated);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UserGroup/GranularPermissionsInElement.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UserGroup/GranularPermissionsInElement.spec.ts
@@ -157,7 +157,7 @@ test.fixme('can duplicate a specific element with duplicate permission enabled',
   // Act
   await umbracoUi.library.clickEntityActionOnElementWithName(firstElementName);
   await umbracoUi.library.clickLabelWithName('Elements');
-  await umbracoUi.library.clickDuplicateButton();
+  await umbracoUi.library.clickCopyModalButton();
 
   // Assert
   await umbracoUi.library.doesSuccessNotificationHaveText(NotificationConstantHelper.success.duplicated);


### PR DESCRIPTION
This PR updates the acceptance tests for the element duplication action to match the recent UI changes (the 'Duplicate' button has been renamed to 'Copy').