### PR TITLE
Backoffice: Fix Ctrl+C not terminating the example dev server

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/example-runner/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/example-runner/index.js
@@ -33,13 +33,16 @@ async function pickExampleUI(){
 		const selectedFolder = exampleFolderNames[parseInt(answer) - 1];
 		console.log(`You selected: ${selectedFolder}`);
 
+		// Close readline before starting the dev server so Ctrl+C can terminate the process.
+		rl.close();
+
 		process.env['VITE_EXAMPLE_PATH'] = `${exampleDirectory}/${selectedFolder}`;
 
 		// Start vite server:
 		try {
 			execSync('npm run dev', {stdio: 'inherit'});
 		} catch (error) {
-			// Nothing, cause this is most likely just the server begin stopped.
+			// Nothing, cause this is most likely just the server being stopped.
 			//console.log(error);
 		}
 	});


### PR DESCRIPTION
## Why

It is currently not possible to terminate the dev server when running an example. You have to close the terminal window or tab to start a new one. This PR fixes that.

## Test plan
- [ ] Run `npm run example` from `src/Umbraco.Web.UI.Client`
- [ ] Select any example
- [ ] Once the Vite dev server is running, press Ctrl+C
- [ ] Verify the process exits cleanly without hanging