### PR TITLE
EFCore: Renaming TId to TKey for consistency.

### DIFF
--- a/src/Umbraco.Core/Cache/AsyncNoCacheRepositoryCachePolicy.cs
+++ b/src/Umbraco.Core/Cache/AsyncNoCacheRepositoryCachePolicy.cs
@@ -3,19 +3,19 @@ using Umbraco.Cms.Core.Models.Entities;
 namespace Umbraco.Cms.Core.Cache;
 
 /// <summary>
-///     Implements <see cref="IAsyncRepositoryCachePolicy{TEntity, TId}" /> with no caching behavior.
+///     Implements <see cref="IAsyncRepositoryCachePolicy{TEntity, TKey}" /> with no caching behavior.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity.</typeparam>
-/// <typeparam name="TId">The type of the entity identifier.</typeparam>
+/// <typeparam name="TKey">The type of the entity key.</typeparam>
 /// <remarks>
 ///     This policy bypasses all caching and directly delegates to the repository methods.
 ///     Used when caching is not desired for a particular repository.
 /// </remarks>
-public class AsyncNoCacheRepositoryCachePolicy<TEntity, TId> : IAsyncRepositoryCachePolicy<TEntity, TId>
+public class AsyncNoCacheRepositoryCachePolicy<TEntity, TKey> : IAsyncRepositoryCachePolicy<TEntity, TKey>
     where TEntity : class, IEntity
 {
     /// <summary>
-    ///     Initializes a new instance of the <see cref="AsyncNoCacheRepositoryCachePolicy{TEntity, TId}" /> class.
+    ///     Initializes a new instance of the <see cref="AsyncNoCacheRepositoryCachePolicy{TEntity, TKey}" /> class.
     /// </summary>
     private AsyncNoCacheRepositoryCachePolicy()
     {
@@ -24,18 +24,18 @@ public class AsyncNoCacheRepositoryCachePolicy<TEntity, TId> : IAsyncRepositoryC
     /// <summary>
     ///     Gets the singleton instance of the no-cache policy.
     /// </summary>
-    public static AsyncNoCacheRepositoryCachePolicy<TEntity, TId> Instance { get; } = new();
+    public static AsyncNoCacheRepositoryCachePolicy<TEntity, TKey> Instance { get; } = new();
 
     /// <inheritdoc />
-    public async Task<TEntity?> GetAsync(TId? id, Func<TId?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll) =>
-        await performGet(id);
+    public async Task<TEntity?> GetAsync(TKey? key, Func<TKey?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll) =>
+        await performGet(key);
 
     /// <inheritdoc />
-    public Task<TEntity?> GetCachedAsync(TId id) => Task.FromResult<TEntity?>(null);
+    public Task<TEntity?> GetCachedAsync(TKey key) => Task.FromResult<TEntity?>(null);
 
     /// <inheritdoc />
-    public async Task<bool> ExistsAsync(TId id, Func<TId, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll) =>
-        await performExists(id);
+    public async Task<bool> ExistsAsync(TKey key, Func<TKey, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll) =>
+        await performExists(key);
 
     /// <inheritdoc />
     public async Task CreateAsync(TEntity entity, Func<TEntity, Task> persistNew) => await persistNew(entity);
@@ -51,8 +51,8 @@ public class AsyncNoCacheRepositoryCachePolicy<TEntity, TId> : IAsyncRepositoryC
         (await performGetAll())?.ToArray() ?? Array.Empty<TEntity>();
 
     /// <inheritdoc />
-    public async Task<TEntity[]> GetManyAsync(TId[] ids, Func<TId[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll) =>
-        (await performGetMany(ids))?.ToArray() ?? Array.Empty<TEntity>();
+    public async Task<TEntity[]> GetManyAsync(TKey[] keys, Func<TKey[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll) =>
+        (await performGetMany(keys))?.ToArray() ?? Array.Empty<TEntity>();
 
     /// <inheritdoc />
     public Task ClearAllAsync() => Task.CompletedTask;

--- a/src/Umbraco.Core/Cache/IAsyncRepositoryCachePolicy.cs
+++ b/src/Umbraco.Core/Cache/IAsyncRepositoryCachePolicy.cs
@@ -6,42 +6,42 @@ namespace Umbraco.Cms.Core.Cache;
 ///     Defines a repository cache policy for managing cached entities.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity.</typeparam>
-/// <typeparam name="TId">The type of the entity identifier.</typeparam>
+/// <typeparam name="TKey">The type of the entity key.</typeparam>
 /// <remarks>
 ///     Repository cache policies control how repositories interact with caches,
 ///     determining when to read from cache, when to populate cache, and how to
 ///     keep caches in sync with the underlying data store.
 /// </remarks>
-public interface IAsyncRepositoryCachePolicy<TEntity, TId>
+public interface IAsyncRepositoryCachePolicy<TEntity, TKey>
     where TEntity : class, IEntity
 {
     /// <summary>
     ///     Gets an entity from the cache, else from the repository.
     /// </summary>
-    /// <param name="id">The identifier.</param>
+    /// <param name="key">The key.</param>
     /// <param name="performGet">The repository PerformGet method.</param>
     /// <param name="performGetAll">The repository PerformGetAll method.</param>
-    /// <returns>The entity with the specified identifier, if it exists, else null.</returns>
+    /// <returns>The entity with the specified key, if it exists, else null.</returns>
     /// <remarks>First considers the cache then the repository.</remarks>
-    Task<TEntity?> GetAsync(TId? id, Func<TId?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll);
+    Task<TEntity?> GetAsync(TKey? key, Func<TKey?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll);
 
     /// <summary>
     ///     Gets an entity from the cache.
     /// </summary>
-    /// <param name="id">The identifier.</param>
-    /// <returns>The entity with the specified identifier, if it is in the cache already, else null.</returns>
+    /// <param name="key">The key.</param>
+    /// <returns>The entity with the specified key, if it is in the cache already, else null.</returns>
     /// <remarks>Does not consider the repository at all.</remarks>
-    Task<TEntity?> GetCachedAsync(TId id);
+    Task<TEntity?> GetCachedAsync(TKey key);
 
     /// <summary>
-    ///     Gets a value indicating whether an entity with a specified identifier exists.
+    ///     Gets a value indicating whether an entity with a specified key exists.
     /// </summary>
-    /// <param name="id">The identifier.</param>
+    /// <param name="key">The key.</param>
     /// <param name="performExists">The repository PerformExists method.</param>
     /// <param name="performGetAll">The repository PerformGetAll method.</param>
-    /// <returns>A value indicating whether an entity with the specified identifier exists.</returns>
+    /// <returns>A value indicating whether an entity with the specified key exists.</returns>
     /// <remarks>First considers the cache then the repository.</remarks>
-    Task<bool> ExistsAsync(TId id, Func<TId, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll);
+    Task<bool> ExistsAsync(TKey key, Func<TKey, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll);
 
     /// <summary>
     ///     Creates an entity.
@@ -78,12 +78,12 @@ public interface IAsyncRepositoryCachePolicy<TEntity, TId>
     /// <summary>
     ///     Gets many entities.
     /// </summary>
-    /// <param name="ids">The identifiers of the entities to retrieve.</param>
+    /// <param name="keys">The keys of the entities to retrieve.</param>
     /// <param name="performGetMany">The repository PerformGetMany method.</param>
     /// <param name="performGetAll">The repository PerformGetAll method.</param>
-    /// <returns>The entities matching the specified identifiers.</returns>
+    /// <returns>The entities matching the specified keys.</returns>
     /// <remarks>Get the entities. Either from the cache or the repository depending on the implementation.</remarks>
-    Task<TEntity[]> GetManyAsync(TId[] ids, Func<TId[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll);
+    Task<TEntity[]> GetManyAsync(TKey[] keys, Func<TKey[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll);
 
     /// <summary>
     ///     Clears the entire cache.

--- a/src/Umbraco.Infrastructure/Cache/AsyncDefaultRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/AsyncDefaultRepositoryCachePolicy.cs
@@ -12,21 +12,21 @@ namespace Umbraco.Cms.Core.Cache;
 ///     Represents the default cache policy.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity.</typeparam>
-/// <typeparam name="TId">The type of the identifier.</typeparam>
+/// <typeparam name="TKey">The type of the entity key.</typeparam>
 /// <remarks>
 ///     <para>The default cache policy caches entities with a 5 minutes sliding expiration.</para>
 ///     <para>Each entity is cached individually.</para>
 ///     <para>If options.GetAllCacheAllowZeroCount then a 'zero-count' array is cached when GetAll finds nothing.</para>
 ///     <para>If options.GetAllCacheValidateCount then we check against the db when getting many entities.</para>
 /// </remarks>
-public class AsyncDefaultRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCachePolicyBase<TEntity, TId>
+public class AsyncDefaultRepositoryCachePolicy<TEntity, TKey> : AsyncRepositoryCachePolicyBase<TEntity, TKey>
     where TEntity : class, IEntity
 {
     private static readonly TEntity[] _emptyEntities = new TEntity[0]; // const
     private readonly AsyncRepositoryCachePolicyOptions _options;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="AsyncDefaultRepositoryCachePolicy{TEntity, TId}"/> class.
+    ///     Initializes a new instance of the <see cref="AsyncDefaultRepositoryCachePolicy{TEntity, TKey}"/> class.
     /// </summary>
     /// <param name="cache">The application policy cache.</param>
     /// <param name="scopeAccessor">The scope accessor for accessing the current scope.</param>
@@ -140,11 +140,11 @@ public class AsyncDefaultRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCa
     }
 
     /// <inheritdoc />
-    public override async Task<TEntity?> GetAsync(TId? id, Func<TId?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll)
+    public override async Task<TEntity?> GetAsync(TKey? key, Func<TKey?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll)
     {
         await EnsureCacheIsSyncedAsync();
 
-        var cacheKey = GetEntityCacheKey(id);
+        var cacheKey = GetEntityCacheKey(key);
 
         TEntity? fromCache = Cache.GetCacheItem<TEntity>(cacheKey);
 
@@ -161,7 +161,7 @@ public class AsyncDefaultRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCa
         }
 
         // Otherwise go to the database to retrieve.
-        TEntity? entity = await performGet(id);
+        TEntity? entity = await performGet(key);
 
         if (entity != null && entity.HasIdentity)
         {
@@ -178,22 +178,22 @@ public class AsyncDefaultRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCa
     }
 
     /// <inheritdoc />
-    public override async Task<TEntity?> GetCachedAsync(TId id)
+    public override async Task<TEntity?> GetCachedAsync(TKey key)
     {
         await EnsureCacheIsSyncedAsync();
-        var cacheKey = GetEntityCacheKey(id);
+        var cacheKey = GetEntityCacheKey(key);
         return Cache.GetCacheItem<TEntity>(cacheKey);
     }
 
     /// <inheritdoc />
-    public override async Task<bool> ExistsAsync(TId id, Func<TId, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll)
+    public override async Task<bool> ExistsAsync(TKey key, Func<TKey, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll)
     {
         await EnsureCacheIsSyncedAsync();
 
         // if found in cache the return else check
-        var cacheKey = GetEntityCacheKey(id);
+        var cacheKey = GetEntityCacheKey(key);
         TEntity? fromCache = Cache.GetCacheItem<TEntity>(cacheKey);
-        return fromCache != null || await performExists(id);
+        return fromCache != null || await performExists(key);
     }
 
     /// <inheritdoc />
@@ -250,15 +250,15 @@ public class AsyncDefaultRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCa
     }
 
     /// <inheritdoc />
-    public override async Task<TEntity[]> GetManyAsync(TId[] ids, Func<TId[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll)
+    public override async Task<TEntity[]> GetManyAsync(TKey[] keys, Func<TKey[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll)
     {
         await EnsureCacheIsSyncedAsync();
-        if (ids.Length > 0)
+        if (keys.Length > 0)
         {
             // try to get each entity from the cache
             // if we can find all of them, return
-            TEntity[] entities = (await Task.WhenAll(ids.Select(GetCachedAsync))).WhereNotNull().ToArray();
-            if (ids.Length.Equals(entities.Length))
+            TEntity[] entities = (await Task.WhenAll(keys.Select(GetCachedAsync))).WhereNotNull().ToArray();
+            if (keys.Length.Equals(entities.Length))
             {
                 return entities; // no need for null checks, we are not caching nulls
             }
@@ -303,7 +303,7 @@ public class AsyncDefaultRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCa
         }
 
         // cache failed, get from repo and cache
-        IEnumerable<TEntity>? repoResult = await performGetMany(ids);
+        IEnumerable<TEntity>? repoResult = await performGetMany(keys);
         TEntity[]? repoEntities = repoResult?
             .WhereNotNull() // exclude nulls!
             .Where(x => x.HasIdentity) // be safe, though would be weird...
@@ -326,23 +326,23 @@ public class AsyncDefaultRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCa
     protected string GetEntityCacheKey(int id) => EntityTypeCacheKey + id;
 
     /// <summary>
-    ///     Gets the cache key for an entity with the specified identifier.
+    ///     Gets the cache key for an entity with the specified key.
     /// </summary>
-    /// <param name="id">The identifier.</param>
+    /// <param name="key">The key.</param>
     /// <returns>The cache key.</returns>
-    protected string GetEntityCacheKey(TId? id)
+    protected string GetEntityCacheKey(TKey? key)
     {
-        if (EqualityComparer<TId>.Default.Equals(id, default))
+        if (EqualityComparer<TKey>.Default.Equals(key, default))
         {
             return string.Empty;
         }
 
-        if (typeof(TId).IsValueType)
+        if (typeof(TKey).IsValueType)
         {
-            return EntityTypeCacheKey + id;
+            return EntityTypeCacheKey + key;
         }
 
-        return EntityTypeCacheKey + id?.ToString()?.ToUpperInvariant();
+        return EntityTypeCacheKey + key?.ToString()?.ToUpperInvariant();
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Cache/AsyncFullDataSetRepositoryCachePolicy.cs
+++ b/src/Umbraco.Infrastructure/Cache/AsyncFullDataSetRepositoryCachePolicy.cs
@@ -11,34 +11,34 @@ namespace Umbraco.Cms.Infrastructure.Cache;
 ///     Represents an async caching policy that caches the entire entities set as a single collection.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity.</typeparam>
-/// <typeparam name="TId">The type of the identifier.</typeparam>
-internal sealed class AsyncFullDataSetRepositoryCachePolicy<TEntity, TId> : AsyncRepositoryCachePolicyBase<TEntity, TId>
+/// <typeparam name="TKey">The type of the entity key.</typeparam>
+internal sealed class AsyncFullDataSetRepositoryCachePolicy<TEntity, TKey> : AsyncRepositoryCachePolicyBase<TEntity, TKey>
     where TEntity : class, IEntity
 {
-    private readonly Func<TEntity, TId> _entityGetId;
+    private readonly Func<TEntity, TKey> _entityGetKey;
 
     private readonly bool _expires;
     private readonly SemaphoreSlim _getAllLock = new(1, 1);
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="AsyncFullDataSetRepositoryCachePolicy{TEntity, TId}"/> class.
+    ///     Initializes a new instance of the <see cref="AsyncFullDataSetRepositoryCachePolicy{TEntity, TKey}"/> class.
     /// </summary>
     /// <param name="globalCache">The global application policy cache.</param>
     /// <param name="scopeAccessor">The scope accessor for accessing the current scope.</param>
     /// <param name="cacheVersionService">The service for managing cache version synchronization.</param>
     /// <param name="cacheSyncService">The service for synchronizing cache changes across servers.</param>
-    /// <param name="entityGetId">A function to extract the identifier from an entity.</param>
+    /// <param name="entityGetKey">A function to extract the identifier from an entity.</param>
     /// <param name="expires">Whether cached items should expire after a timeout.</param>
     public AsyncFullDataSetRepositoryCachePolicy(
         IAppPolicyCache globalCache,
         IScopeAccessor scopeAccessor,
         IRepositoryCacheVersionService cacheVersionService,
         ICacheSyncService cacheSyncService,
-        Func<TEntity, TId> entityGetId,
+        Func<TEntity, TKey> entityGetKey,
         bool expires)
         : base(globalCache, scopeAccessor, cacheVersionService, cacheSyncService)
     {
-        _entityGetId = entityGetId;
+        _entityGetKey = entityGetKey;
         _expires = expires;
     }
 
@@ -74,13 +74,13 @@ internal sealed class AsyncFullDataSetRepositoryCachePolicy<TEntity, TId> : Asyn
     }
 
     /// <inheritdoc/>
-    public override async Task<TEntity?> GetAsync(TId? id, Func<TId?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll)
+    public override async Task<TEntity?> GetAsync(TKey? key, Func<TKey?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll)
     {
         await EnsureCacheIsSyncedAsync();
 
         // get all from the cache, then look for the entity
         IEnumerable<TEntity> all = await GetAllCachedAsync(performGetAll);
-        TEntity? entity = all.FirstOrDefault(x => _entityGetId(x)?.Equals(id) ?? false);
+        TEntity? entity = all.FirstOrDefault(x => _entityGetKey(x)?.Equals(key) ?? false);
 
         // see note in InsertEntities - what we get here is the original
         // cached entity, not a clone, so we need to manually ensure it is deep-cloned.
@@ -88,13 +88,13 @@ internal sealed class AsyncFullDataSetRepositoryCachePolicy<TEntity, TId> : Asyn
     }
 
     /// <inheritdoc/>
-    public override async Task<TEntity?> GetCachedAsync(TId id)
+    public override async Task<TEntity?> GetCachedAsync(TKey key)
     {
         await EnsureCacheIsSyncedAsync();
 
         // get all from the cache -- and only the cache, then look for the entity
         DeepCloneableList<TEntity>? all = Cache.GetCacheItem<DeepCloneableList<TEntity>>(GetEntityTypeCacheKey());
-        TEntity? entity = all?.FirstOrDefault(x => _entityGetId(x)?.Equals(id) ?? false);
+        TEntity? entity = all?.FirstOrDefault(x => _entityGetKey(x)?.Equals(key) ?? false);
 
         // see note in InsertEntities - what we get here is the original
         // cached entity, not a clone, so we need to manually ensure it is deep-cloned.
@@ -102,13 +102,13 @@ internal sealed class AsyncFullDataSetRepositoryCachePolicy<TEntity, TId> : Asyn
     }
 
     /// <inheritdoc/>
-    public override async Task<bool> ExistsAsync(TId id, Func<TId, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll)
+    public override async Task<bool> ExistsAsync(TKey key, Func<TKey, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll)
     {
         await EnsureCacheIsSyncedAsync();
 
         // get all as one set, then look for the entity
         IEnumerable<TEntity> all = await GetAllCachedAsync(performGetAll);
-        return all.Any(x => _entityGetId(x)?.Equals(id) ?? false);
+        return all.Any(x => _entityGetKey(x)?.Equals(key) ?? false);
     }
 
     /// <inheritdoc/>
@@ -179,12 +179,12 @@ internal sealed class AsyncFullDataSetRepositoryCachePolicy<TEntity, TId> : Asyn
     }
 
     /// <inheritdoc/>
-    public override async Task<TEntity[]> GetManyAsync(TId[] ids, Func<TId[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll)
+    public override async Task<TEntity[]> GetManyAsync(TKey[] keys, Func<TKey[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll)
     {
         await EnsureCacheIsSyncedAsync();
 
         // get all as one set, from cache if possible, else repo
-        IEnumerable<TEntity> all = (await GetAllCachedAsync(performGetAll)).Where(x => ids.Contains(_entityGetId(x)));
+        IEnumerable<TEntity> all = (await GetAllCachedAsync(performGetAll)).Where(x => keys.Contains(_entityGetKey(x)));
 
         // see note in SetCacheActionToInsertEntities - what we get here is the original
         // cached entities, not clones, so we need to manually ensure they are deep-cloned.

--- a/src/Umbraco.Infrastructure/Cache/AsyncRepositoryCachePolicyBase.cs
+++ b/src/Umbraco.Infrastructure/Cache/AsyncRepositoryCachePolicyBase.cs
@@ -11,8 +11,8 @@ namespace Umbraco.Cms.Core.Cache;
 ///     A base class for repository cache policies.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity.</typeparam>
-/// <typeparam name="TId">The type of the identifier.</typeparam>
-public abstract class AsyncRepositoryCachePolicyBase<TEntity, TId> : IAsyncRepositoryCachePolicy<TEntity, TId>
+/// <typeparam name="TKey">The type of the entity key.</typeparam>
+public abstract class AsyncRepositoryCachePolicyBase<TEntity, TKey> : IAsyncRepositoryCachePolicy<TEntity, TKey>
     where TEntity : class, IEntity
 {
     private readonly IAppPolicyCache _globalCache;
@@ -21,7 +21,7 @@ public abstract class AsyncRepositoryCachePolicyBase<TEntity, TId> : IAsyncRepos
     private readonly ICacheSyncService _cacheSyncService;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="AsyncRepositoryCachePolicyBase{TEntity, TId}"/> class.
+    ///     Initializes a new instance of the <see cref="AsyncRepositoryCachePolicyBase{TEntity, TKey}"/> class.
     /// </summary>
     /// <param name="globalCache">The global application policy cache.</param>
     /// <param name="scopeAccessor">The scope accessor for accessing the current scope.</param>
@@ -63,13 +63,13 @@ public abstract class AsyncRepositoryCachePolicyBase<TEntity, TId> : IAsyncRepos
     }
 
     /// <inheritdoc />
-    public abstract Task<TEntity?> GetAsync(TId? id, Func<TId?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll);
+    public abstract Task<TEntity?> GetAsync(TKey? key, Func<TKey?, Task<TEntity?>> performGet, Func<Task<IEnumerable<TEntity>?>> performGetAll);
 
     /// <inheritdoc />
-    public abstract Task<TEntity?> GetCachedAsync(TId id);
+    public abstract Task<TEntity?> GetCachedAsync(TKey key);
 
     /// <inheritdoc />
-    public abstract Task<bool> ExistsAsync(TId id, Func<TId, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll);
+    public abstract Task<bool> ExistsAsync(TKey key, Func<TKey, Task<bool>> performExists, Func<Task<IEnumerable<TEntity>?>> performGetAll);
 
     /// <inheritdoc />
     public abstract Task CreateAsync(TEntity entity, Func<TEntity, Task> persistNew);
@@ -84,7 +84,7 @@ public abstract class AsyncRepositoryCachePolicyBase<TEntity, TId> : IAsyncRepos
     public abstract Task<TEntity[]> GetAllAsync(Func<Task<IEnumerable<TEntity>?>> performGetAll);
 
     /// <inheritdoc />
-    public abstract Task<TEntity[]> GetManyAsync(TId[] ids, Func<TId[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll);
+    public abstract Task<TEntity[]> GetManyAsync(TKey[] keys, Func<TKey[], Task<IEnumerable<TEntity>?>> performGetMany, Func<Task<IEnumerable<TEntity>?>> performGetAll);
 
     /// <inheritdoc />
     public abstract Task ClearAllAsync();


### PR DESCRIPTION
### Description
For consistency sake, and because we are migrating EFCore and attempting to get rid of integer IDs, i have renamed the cache policy classes to take TKey rather than TId as to avoid confusion to what these classes take.

There should be no functional change other than renaming.

<!-- Thanks for contributing to Umbraco CMS! -->
