### PR TITLE
Unattended Upgrades: Rebuild routing caches after background migrations to fix unroutable document URLs

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -120,19 +120,11 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         if (exists is false)
         {
             contentCacheNode = await GetContentCacheNodeFromRepo();
-
-            // Only cache non-null values. Null results occur when content is not yet in the
-            // database cache or when HasPublishedAncestorPath fails (e.g. during migration
-            // before publish status is fully populated). Caching null with empty tags would
-            // create entries that survive tag-based cache clearing, causing stale nulls.
-            if (contentCacheNode is not null)
-            {
-                await _hybridCache.SetAsync(
-                    cacheKey,
-                    contentCacheNode,
-                    GetEntryOptions(key, preview),
-                    GenerateTags(contentCacheNode));
-            }
+            await _hybridCache.SetAsync(
+                cacheKey,
+                contentCacheNode,
+                GetEntryOptions(key, preview),
+                GenerateTags(contentCacheNode));
         }
 
         if (contentCacheNode is null)
@@ -156,8 +148,9 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             // If we can resolve the content cache node, we still need to check if the ancestor path is published.
             // This does cost some performance, but it's necessary to ensure that the content is actually published.
             // When unpublishing a node, a payload with RefreshBranch is published, so we don't have to worry about this.
-            // Similarly, when a branch is published, next time the content is requested, the parent will be published,
-            // this works because we don't cache null values.
+            // Similarly, when a branch is published, next time the content is requested, the parent will be published.
+            // Null values are cached here are tagged and cleared by ClearMemoryCacheAsync, so the next request after a
+            // cache clear will re-query the database.
             if (preview is false && contentCacheNode is not null && _publishStatusQueryService.HasPublishedAncestorPath(contentCacheNode.Key) is false)
             {
                 // Careful not to early return here. We need to complete the scope even if returning null.
@@ -341,10 +334,25 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
     private static string GetCacheKey(Guid key, bool preview) => preview ? $"{key}+draft" : $"{key}";
 
-    // Generates the cache tags for a given CacheNode
-    // We use the tags to be able to clear all cache entries that are related to a given content item.
-    // Tags for now are only content/media, but can be expanded with draft/published later.
-    private static HashSet<string> GenerateTags(ContentCacheNode? cacheNode) => cacheNode is null ? [] : [Constants.Cache.Tags.Content, ContentTypeIdTag(cacheNode.ContentTypeId)];
+    /// <summary>
+    /// Generates the cache tags for a given <see cref="ContentCacheNode"/>.
+    /// </summary>
+    /// <param name="cacheNode">The cache node to generate tags for, or <c>null</c> for a negative-cache entry.</param>
+    /// <returns>
+    /// A set of tags that always includes <see cref="Constants.Cache.Tags.Content"/>.
+    /// When <paramref name="cacheNode"/> is non-null, the content type ID tag is also included.
+    /// </returns>
+    /// <remarks>
+    /// Tags are used to clear all cache entries related to a given content item or type.
+    /// The <see cref="Constants.Cache.Tags.Content"/> tag is always included — even for null entries — so
+    /// that <see cref="ClearMemoryCacheAsync"/> (which clears by this tag) can evict negative-cache entries.
+    /// Without this, null entries survive tag-based cache clears and become permanently stale.
+    /// Tags currently cover content/media distinctions but can be expanded with draft/published later.
+    /// </remarks>
+    private static HashSet<string> GenerateTags(ContentCacheNode? cacheNode) =>
+        cacheNode is null
+            ? [Constants.Cache.Tags.Content]
+            : [Constants.Cache.Tags.Content, ContentTypeIdTag(cacheNode.ContentTypeId)];
 
     public async Task DeleteItemAsync(IContentBase content)
     {


### PR DESCRIPTION
## Description

This PR fixes a regression issue with 17.3.0-rc2 where documents created by package migrations during an unattended install are published but have unroutable URLs ("This document is published but its URL cannot be routed").

### Cause

`DocumentCacheService.GetNodeAsync` caches the result of `GetContentCacheNodeFromRepo()` in the HybridCache, including null results. Null results occur when `HasPublishedAncestorPath` fails — for example during migration, before the publish status cache is fully populated.

`GenerateTags` returned empty tags for null cache nodes (`cacheNode is null ? [] : [...]`), so these null entries are stored without the `Content` tag. When `ClearMemoryCacheAsync` later clears the HybridCache by tag, the untagged null entries survive. All subsequent lookups return the stale cached null instead of re-querying the database, making the published content permanently unroutable.

This was not observed before PR #22020 because migrations previously ran synchronously during startup, and the timing meant null entries were not cached before publish status was populated. With migrations running in a background service, the window for caching null entries widened.

### Changes

**`DocumentCacheService.cs`**:
 - `GenerateTags` now always includes the `Content` tag, even for null entries, so that `ClearMemoryCacheAsync` — which clears by this tag — can evict them
- Null values continue to be cached (preserving the performance fix from PR #20209 which prevents repeated DB
  queries for deleted content references), but they are now properly tagged and will be evicted on the next cache clear.

## Testing

### Manual

#### Unattended install with a package that creates documents

This requires building local NuGet packages from the PR branch and creating a test project that references a package with migrations that publish documents (e.g. [Clean](https://www.nuget.org/packages/Clean)).

- Download the `.nupkg` files from this PR and save them to a folder from which you will create a local NuGet feed (in my case, `c:\repos\nuget\`.
- Create a test project:

```ps
dotnet new install Umbraco.Templates::17.4.0--rc.preview.58.gd39d2f8 --nuget-source c:\repos\nuget\
dotnet new umbraco --name Test17
cd ./Test17
```

Copy the following `NuGet.config` file into the folder:

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <clear />
    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
    <add key="Local Feed" value="c:\repos\nuget" />
  </packageSources>
  <activePackageSource>
    <add key="All" value="(Aggregate source)" />
  </activePackageSource>
</configuration>
```

- Add the package:

```ps
dotnet add package Clean
```

- Configure unattended install — edit `appsettings.json`:

```json
{
  "ConnectionStrings": {
    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
  },
  "Umbraco": {
    "CMS": {
      "Unattended": {
        "InstallUnattended": true,
        "UnattendedUserName": "Test Admin",
        "UnattendedUserEmail": "admin@test.com",
        "UnattendedUserPassword": "SuperSecret123!",
        "UpgradeUnattended": true,
        "PackageMigrationsUnattended": true
      }
    }
  }
}
```

- Create a folder at `Test17\wwwroot\media\` (without this you'll get an error on start-up for an unrelated reason)

- Run

```ps
dotnet run
```

- Verify that:
    - The content is visible on the front-end websites
    - The documents show as routable under the "Info" tab → "Links" section

#### Attended install with an unattended install of a package that creates documents

Repeat the above except:

- Configure `"InstallUnattended": false`.
- Don't add a connection string.
- When you run the project, complete the installer manually.
