### PR TITLE
Migrations: Fix NPoco auto-select breaking retrust FK migration

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
@@ -78,7 +78,9 @@ public class RetrustForeignKeyAndCheckConstraints : AsyncMigrationBase
             // Use T-SQL TRY...CATCH to handle errors at the SQL level. This prevents a constraint
             // validation failure from dooming the .NET SqlTransaction, which would cause all
             // subsequent operations to fail with "This SqlTransaction has completed".
-            var sql = $@"
+            // Leading semicolon prevents NPoco's auto-select from prepending
+            // "SELECT ... FROM []" based on the empty [TableName("")] attribute.
+            var sql = $@";
 BEGIN TRY
     ALTER TABLE [{constraint.SchemaName}].[{constraint.TableName}] WITH CHECK CHECK CONSTRAINT [{constraint.ConstraintName}];
     SELECT CAST(1 AS BIT) AS Success, NULL AS ErrorMessage;


### PR DESCRIPTION
## Description

In 17.3 we've added a migration that re-trusts foreign key constraints that have become historically untrusted, primarily through use of SQL bulk inserts - see https://github.com/umbraco/Umbraco-CMS/pull/21744.

We had https://github.com/umbraco/Umbraco-CMS/issues/22227 raised against that - that it was attempting to work with non-Umbraco tables and also didn't correctly handle exceptions.  This was fixed in https://github.com/umbraco/Umbraco-CMS/pull/22229 and released in 17.3.0-rc2.

Unfortunately I didn't test that properly, as although it was verified to by-pass non-Umbraco tables, the fix introduced an issue with the actual re-trusting of constraints (in my test database, I no longer had any, so I didn't see it).

So this PR fixes that error.

You would see it with an install of 17.3.0-rc2 when you have a database containing untrusted constraints, with an exception thrown of `An object or column name is missing or empty... Aliases defined as "" or [] are not allowed`) in the `RetrustForeignKeyAndCheckConstraints` migration.

The cause is NPoco's `AutoSelectHelper` prepending `SELECT ... FROM []` when raw SQL doesn't start with a recognized keyword (`SELECT`, `EXEC`, etc.). The TRY/CATCH block starts with `BEGIN`, which triggers auto-select against the empty `[TableName("")]` DTO attribute, producing invalid SQL.

To fix, a leading semicolon `;` is used, which bypasses NPoco's auto-select.

## Testing

Requires SQL Server (not SQLite).

- Set up an untrusted constraint:
  ```sql
  ALTER TABLE [dbo].[umbracoContentSchedule] NOCHECK CONSTRAINT [FK_umbracoContentSchedule_umbracoLanguage_id];
  ALTER TABLE [dbo].[umbracoContentSchedule] CHECK CONSTRAINT [FK_umbracoContentSchedule_umbracoLanguage_id];
  ```
- Verify it is untrusted:
  ```sql
  SELECT fk.name, fk.is_not_trusted
  FROM sys.foreign_keys fk
  WHERE fk.name = 'FK_umbracoContentSchedule_umbracoLanguage_id';
  -- Should show is_not_trusted = 1
  ```
- Reset the migration state to re-run the re-trust step:
  ```sql
   UPDATE umbracoKeyValue
   SET value = '{B2F4A1C3-8D5E-4F6A-9B7C-3E1D2A4F5B6C}'
   WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
  ```
- Start the application — the migration should complete without error
- Verify the constraint is now trusted:
  ```sql
  SELECT fk.name, fk.is_not_trusted
  FROM sys.foreign_keys fk
  WHERE fk.name = 'FK_umbracoContentSchedule_umbracoLanguage_id';
  -- Should show is_not_trusted = 0
  ```