### PR TITLE
Slider: Persist value updates on drag-and-drop (closes #22183)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-slider/input-slider.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-slider/input-slider.element.ts
@@ -179,12 +179,6 @@ export class UmbInputSliderElement extends UmbFormControlMixin<string, typeof Um
 		return undefined;
 	}
 
-	#onInput(event: UUISliderEvent) {
-		event.stopPropagation();
-		this.value = event.target.value as string;
-		this.dispatchEvent(new UmbChangeEvent());
-	}
-
 	#onChange(event: UUISliderEvent) {
 		event.stopPropagation();
 		this.value = event.target.value as string;
@@ -203,7 +197,7 @@ export class UmbInputSliderElement extends UmbFormControlMixin<string, typeof Um
 				.max=${this.max}
 				.step=${this.step}
 				.value=${undefinedFallbackToString(this.valueLow, this.min).toString()}
-				@input=${this.#onInput}
+				@input=${this.#onChange}
 				@change=${this.#onChange}
 				?readonly=${this.readonly}>
 			</uui-slider>
@@ -221,7 +215,7 @@ export class UmbInputSliderElement extends UmbFormControlMixin<string, typeof Um
 					this.valueHigh,
 					this.max,
 				).toString()}"
-				@input=${this.#onInput}
+				@input=${this.#onChange}
 				@change=${this.#onChange}
 				?readonly=${this.readonly}>
 			</uui-range-slider>


### PR DESCRIPTION
## Description

This PR fixes the slider property editor not saving its value when the user drags the thumb instead of clicking on tick marks, as reported in https://github.com/umbraco/Umbraco-CMS/issues/22183.

The underlying `uui-slider` component fires `input` events during drag (which update its internal value) and a `change` event on release, but its `_onChange` handler does not re-sync the value from the native input — it only dispatches an event. The `umb-input-slider` wrapper was only listening for `change`, so drag-based value changes could be lost.

To fix I added an `@input` event listener alongside the existing `@change` listener on both `uui-slider` and `uui-range-slider`, ensuring value changes are captured and propagated during drag interactions

## Testing

- Configure a slider property editor with min=0, max=1, initial value=0.5, step=0.25
- Drag the slider thumb to a new position (e.g. 1.0) and save — verify the value persists after reload
- Click on a tick mark to set the value — verify it still works as before
