### PR TITLE
Templating: Add Production Mode condition to Partial View and Template Collection create actions

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/tree-item-children/collection/action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/tree-item-children/collection/action/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_PARTIAL_VIEW_TREE_ITEM_CHILDREN_COLLECTION_ALIAS } from '../constants.js';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+import { UMB_IS_SERVER_PRODUCTION_MODE_CONDITION_ALIAS } from '@umbraco-cms/backoffice/server';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -7,6 +8,15 @@ export const manifests: Array<UmbExtensionManifest> = [
 		kind: 'create',
 		name: 'Partial View Tree Item Children Collection Create Action',
 		alias: 'Umb.CollectionAction.PartialViewTreeItemChildren.Create',
-		conditions: [{ alias: UMB_COLLECTION_ALIAS_CONDITION, match: UMB_PARTIAL_VIEW_TREE_ITEM_CHILDREN_COLLECTION_ALIAS }],
+		conditions: [
+			{
+				alias: UMB_COLLECTION_ALIAS_CONDITION,
+				match: UMB_PARTIAL_VIEW_TREE_ITEM_CHILDREN_COLLECTION_ALIAS,
+			},
+			{
+				alias: UMB_IS_SERVER_PRODUCTION_MODE_CONDITION_ALIAS,
+				match: false,
+			},
+		],
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/tree-item-children/collection/action/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/tree-item-children/collection/action/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_TEMPLATE_TREE_ITEM_CHILDREN_COLLECTION_ALIAS } from '../constants.js';
 import { UMB_COLLECTION_ALIAS_CONDITION } from '@umbraco-cms/backoffice/collection';
+import { UMB_IS_SERVER_PRODUCTION_MODE_CONDITION_ALIAS } from '@umbraco-cms/backoffice/server';
 
 export const manifests: Array<UmbExtensionManifest> = [
 	{
@@ -7,6 +8,15 @@ export const manifests: Array<UmbExtensionManifest> = [
 		kind: 'create',
 		name: 'Template Tree Item Children Collection Create Action',
 		alias: 'Umb.CollectionAction.TemplateTreeItemChildren.Create',
-		conditions: [{ alias: UMB_COLLECTION_ALIAS_CONDITION, match: UMB_TEMPLATE_TREE_ITEM_CHILDREN_COLLECTION_ALIAS }],
+		conditions: [
+			{
+				alias: UMB_COLLECTION_ALIAS_CONDITION,
+				match: UMB_TEMPLATE_TREE_ITEM_CHILDREN_COLLECTION_ALIAS,
+			},
+			{
+				alias: UMB_IS_SERVER_PRODUCTION_MODE_CONDITION_ALIAS,
+				match: false,
+			},
+		],
 	},
 ];


### PR DESCRIPTION
### Summary

- Add `UMB_IS_SERVER_PRODUCTION_MODE_CONDITION_ALIAS` with `match: false` to the Partial View and Template collection-level create actions
- This aligns the collection "Create" button behavior with the existing entity-level create actions, which already hide in production mode