### PR TITLE
Localization: Remove unused recycleBin keys from XML language files

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -448,10 +448,6 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Rezultati zakazanih Umbraco provjera zdravlja koji se pokreću na %0% na %1% su sljedeći:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Status provjere zdravlja Umbraco: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Sadržaj u otpadu s ID-om: {0} povezan je s originalnim nadređenim sadržajem s ID-om: {1}</key>
-    <key alias="mediaTrashed">Medij u otpadu s ID-om: {0} povezan je s originalnim nadređenim medijem s ID-om: {1}</key>
-  </area>
   <area alias="permissions">
     <key alias="FolderCreation">Kreiranje foldera</key>
     <key alias="FileWritingForPackages">Pisanje datoteka za pakete</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cs.xml
@@ -354,8 +354,4 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Výsledky plánovaných kontrol Umbraco Health Checks provedených na %0% v %1% jsou následující:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Stav Umbraco Health Check: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Obsah s ID: {0} v koši souvisí s původním nadřazeným obsahem s ID: {1}</key>
-    <key alias="mediaTrashed">Média s ID: {0} v koši souvisí s původním nadřazeným médiem s ID: {1}</key>
-  </area>
 </language>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -459,10 +459,6 @@
     <key alias="smtpMailSettingsHostNotConfigured">Nid oedd modd dod o hyd i'r ffurfweddiad 'Umbraco:CMS:Global:Smtp:Host'.</key>
     <key alias="smtpMailSettingsConnectionFail">Methwyd cyrraedd y gweinydd SMTP a ffurfweddwyd gyda gwesteiwr '%0%' a phorth '%1%'. Gwiriwch i sicrhau bod y gosodiadau SMTP yn y ffurfweddiad 'Umbraco:CMS:Global:Smtp' yn gywir.</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Wedi chwalu cynnwys gyda Id: {0} yn berthnasol i gynnwys rhiant gwreiddiol gyda Id: {1}</key>
-    <key alias="mediaTrashed">Wedi chwalu cyfrwng gyda Id: {0} yn berthnasol i gyfrwng rhiant gwreiddiol gyda Id: {1}</key>
-  </area>
   <area alias="permissions">
     <key alias="FolderCreation">Creu ffolder</key>
     <key alias="FileWritingForPackages">Ysgrifennu ffeiliau ar gyfer pecynnau</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/da.xml
@@ -208,10 +208,6 @@
     <key alias="multipleNotOneOfOptions">Værdierne '%0%' er ikke tilstede i de tilgængelige valgmuligheder.</key>
     <key alias="invalidColor">"Den valgte farve '%0%' er ikke en af de tilgængelige valgmuligheder.</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Slettet indhold med Id: {0} Relateret til original "parent" med id: {1}</key>
-    <key alias="mediaTrashed">Slettet medie med Id: {0} relateret til original "parent" / mappe med id: {1}</key>
-  </area>
   <area alias="permissions">
     <key alias="FolderCreation">Mappeoprettelse</key>
     <key alias="FileWritingForPackages">Filskrivning for pakker</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de.xml
@@ -393,10 +393,6 @@
     ]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Status der Umbraco Systemzustand: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Inhalt mit Id = {0} des Oberknotens mit Id = {1} wurde verworfen</key>
-    <key alias="mediaTrashed">Medienelement mit Id = {0} des Oberknotens mit Id = {1} wurde verworfen</key>
-  </area>
   <area alias="permissions">
     <key alias="FolderCreation">Ornder erstellen</key>
     <key alias="FileWritingForPackages">Dateien durch Packages erstellen lassen</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/de_ch.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/de_ch.xml
@@ -2335,16 +2335,7 @@
 	<area alias="textbox">
 		<key alias="characters_left">Buchstaben verbleiben</key>
 	</area>
-	<area alias="recycleBin">
-		<key alias="contentTrashed">Inhalt mit Id = {0} des Oberknotens mit Id = {1} wurde verworfen</key>
-		<key alias="mediaTrashed">Medienelement mit Id = {0} des Oberknotens mit Id = {1} wurde verworfen</key>
-		<key alias="itemCannotBeRestored">Dieses Element kann nicht automatisch wiederhergestellt werden</key>
-		<key alias="itemCannotBeRestoredHelpText">
-			Es gibt keine Position für das automatische Wiederherstellen dieses Elementes.
-			Sie können es manuell mit Hilfe der untenstehenden Baumstruktur verschieben.
-		</key>
-		<key alias="wasRestored">wurde wiederhergestellt unterhalb von</key>
-	</area>
+
 	<area alias="relationType">
 		<key alias="direction">Richtung</key>
 		<key alias="parentToChild">Ober- zu Unterknoten</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -517,12 +517,6 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Trashed content with Id: {0} related to original parent content with Id: {1}</key>
-    <key alias="mediaTrashed">Trashed media with Id: {0} related to original parent media item with Id: {1}</key>
-    <key alias="elementTrashed">Trashed element with Id: {0} related to original parent container with Id: {1}</key>
-    <key alias="elementContainerTrashed">Trashed element container with Id: {0} related to original parent container with Id: {1}</key>
-  </area>
   <area alias="permissions">
     <key alias="FolderCreation">Folder creation</key>
     <key alias="FileWritingForPackages">File writing for packages</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -507,10 +507,6 @@
       <![CDATA[<html><body><p>Results of the scheduled Umbraco Health Checks run on %0% at %1% are as follows:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Trashed content with Id: {0} related to original parent content with Id: {1}</key>
-    <key alias="mediaTrashed">Trashed media with Id: {0} related to original parent media item with Id: {1}</key>
-  </area>
   <area alias="permissions">
     <key alias="FolderCreation">Folder creation</key>
     <key alias="FileWritingForPackages">File writing for packages</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr.xml
@@ -416,8 +416,4 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Les résultats de l'exécution du Umbraco Health Checks planifiée le %0% à %1% sont les suivants :</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Statut du Umbraco Health Check: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Suppression du contenu avec l'Id : {0} lié au contenu parent original avec l'Id : {1}</key>
-    <key alias="mediaTrashed">Suppression du media avec l'Id : {0} lié à l'élément media parent original avec l'Id : {1}</key>
-  </area>
 </language>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/fr_ch.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/fr_ch.xml
@@ -2150,13 +2150,7 @@ Pour gérer votre site, ouvrez simplement le backoffice Umbraco et commencez à 
 		<key alias="characters_left"><![CDATA[<strong>%0%</strong> caractères restant.]]></key>
 		<key alias="characters_exceed"><![CDATA[Maximum %0% caractères, <strong>%1%</strong> en trop.]]></key>
 	</area>
-	<area alias="recycleBin">
-		<key alias="contentTrashed">Suppression du contenu avec l'Id : {0} lié au contenu parent original avec l'Id : {1}</key>
-		<key alias="mediaTrashed">Suppression du media avec l'Id : {0} lié à l'élément media parent original avec l'Id : {1}</key>
-		<key alias="itemCannotBeRestored">Cet élément ne peut pas être restauré automatiquement</key>
-		<key alias="itemCannotBeRestoredHelpText">Il n'y a aucun endroit où cet élément peut être restauré automatiquement. Vous pouvez déplacer l'élément manuellement en utilisant l'arborescence ci-dessous.</key>
-		<key alias="wasRestored">a été restauré sous</key>
-	</area>
+
 	<area alias="relationType">
 		<key alias="direction">Direction</key>
 		<key alias="parentToChild">Parent vers enfant</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -446,10 +446,6 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Rezultati zakazanih Umbraco provjera zdravlja koji se pokreću na %0% na %1% su sljedeći:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Status provjere zdravlja Umbraco: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Sadržaj u otpadu s ID-om: {0} povezan je s originalnim nadređenim sadržajem s ID-om: {1}</key>
-    <key alias="mediaTrashed">Medij u otpadu s ID-om: {0} povezan je s originalnim nadređenim medijem s ID-om: {1}</key>
-  </area>
   <area alias="permissions">
     <key alias="FolderCreation">Kreiranje mape</key>
     <key alias="FileWritingForPackages">Pisanje datoteka za pakete</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it.xml
@@ -449,9 +449,4 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>I risultati dell'Health Check programmato di Umbraco del %0% alle %1% è il seguente:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Stato dell'Health Check di Umbraco: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Contenuto cestinato con Id: {0} relativo al contenuto principale originale con Id: {1}
-    </key>
-    <key alias="mediaTrashed">Media cestinato con Id: {0} relativo al media principale originale con Id: {1}</key>
-  </area>
 </language>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/it_ch.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/it_ch.xml
@@ -2771,18 +2771,7 @@ Per gestire il tuo sito web, è sufficiente aprire il backoffice di Umbraco e in
 		<key alias="characters_left"><![CDATA[<strong>%0%</strong> caratteri rimasti.]]></key>
 		<key alias="characters_exceed"><![CDATA[Massimo %0% caratteri, <strong>%1%</strong> di troppo.]]></key>
 	</area>
-	<area alias="recycleBin">
-		<key alias="contentTrashed">
-			Contenuto cestinato con Id: {0} relativo al contenuto principale originale con Id: {1}
-		</key>
-		<key alias="mediaTrashed">Media cestinato con Id: {0} relativo al media principale originale con Id: {1}</key>
-		<key alias="itemCannotBeRestored">Impossibile ripristinare automaticamente questo elemento</key>
-		<key alias="itemCannotBeRestoredHelpText">
-			Non esiste una posizione in cui questo elemento possa essere ripristinato
-			automaticamente. Puoi spostare l'elemento manualmente utilizzando l'albero sottostante.
-		</key>
-		<key alias="wasRestored"><![CDATA[è stato ripristinato sotto]]></key>
-	</area>
+
 	<area alias="relationType">
 		<key alias="direction">Direzione</key>
 		<key alias="parentToChild">Da genitore a figlio</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/nl.xml
@@ -354,8 +354,4 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>Resultaten van de geplande Umbraco Health Checks uitgevoerd op %0% op %1%:</p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Umbraco Health Check Status: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Content verwijderd met id : {0} gerelateerd aan aan bovenliggend item met Id: {1}</key>
-    <key alias="mediaTrashed">Media verwijderd met id: {0} gerelateerd aan aan bovenliggend item met Id: {1}</key>
-  </area>
 </language>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/tr.xml
@@ -405,8 +405,4 @@
     <key alias="scheduledHealthCheckEmailBody"><![CDATA[<html><body><p>%0% tarihinde %1% ile çalıştırılan planlanmış Umbraco Sağlık Kontrollerinin sonuçları aşağıdaki gibidir: </p>%2%</body></html>]]></key>
     <key alias="scheduledHealthCheckEmailSubject">Umbraco Sağlık Kontrolü Durumu: %0%</key>
   </area>
-  <area alias="recycleBin">
-    <key alias="contentTrashed">Çöp kutusuna gönderilmiş içerik: {0} Şu kimliğe sahip orijinal ana içerikle ilgili: {1}</key>
-    <key alias="mediaTrashed">Şu kimliğe sahip çöp kutusuna gönderilen medya: {0} Şu kimliğe sahip orijinal ana medya öğesiyle ilgili: {1}</key>
-  </area>
 </language>


### PR DESCRIPTION
## Summary

- Removes the entire `recycleBin` area from 15 XML language files in `Umbraco.Core/EmbeddedResources/Lang/`
- Keys removed: `contentTrashed`, `mediaTrashed`, `elementTrashed`, `elementContainerTrashed`, `itemCannotBeRestored`, `itemCannotBeRestoredHelpText`, `wasRestored`
- The `contentTrashed`, `mediaTrashed`, `elementTrashed`, and `elementContainerTrashed` keys became unused after the audit logging was removed from `RelateOnTrashNotificationHandler` in #21481
- The remaining keys (`itemCannotBeRestored`, `itemCannotBeRestoredHelpText`, `wasRestored`) were also found to have no references in any backend C# code