### PR TITLE
Build: Pin CycloneDX SBOM generation to spec version 1.5

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -117,7 +117,7 @@ stages:
               artifactName: csharp-docs-dlls
           - powershell: |
               dotnet tool install --global CycloneDX
-              dotnet-CycloneDX $(solution) --output $(Build.ArtifactStagingDirectory)/bom --filename bom-dotnet.xml
+              dotnet-CycloneDX $(solution) --spec-version 1.5 --output $(Build.ArtifactStagingDirectory)/bom --filename bom-dotnet.xml
             displayName: 'Generate Backend BOM'
           - powershell: |
               npm install --global @cyclonedx/cyclonedx-npm


### PR DESCRIPTION
## Description
Pins the `dotnet-CycloneDX` SBOM generation to `--spec-version 1.5` in the Azure DevOps build pipeline to fix the failing SBOM upload step.