### PR TITLE
Application URL: Add `ApplicationUrlDetection` setting to control application URL auto-detection

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/ResetPasswordController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/ResetPasswordController.cs
@@ -49,9 +49,13 @@ public class ResetPasswordController : SecurityControllerBase
 
         // If this feature is switched off in configuration, the UI will be amended to not make the request to reset password available.
         // So this is just a server-side secondary check.
+        // ApplicationUrlNotConfigured is also surfaced since it is a server-wide configuration issue, not user-specific.
         // Regardless of other status values, it will just return Ok, so you can't use this endpoint to determine whether the email exists in the system.
-        return result.Result == UserOperationStatus.CannotPasswordReset
-            ? BadRequest()
-            : Ok();
+        return result.Result switch
+        {
+            UserOperationStatus.CannotPasswordReset => BadRequest(),
+            UserOperationStatus.ApplicationUrlNotConfigured => UserOperationStatusResult(result.Result),
+            _ => Ok(),
+        };
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Security/SecurityControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Security/SecurityControllerBase.cs
@@ -33,6 +33,10 @@ public abstract class SecurityControllerBase : ManagementApiControllerBase
                 .WithTitle("Unknown failure")
                 .WithDetail(errorMessageResult?.Error?.ErrorMessage ?? "The error was unknown")
                 .Build()),
+            UserOperationStatus.ApplicationUrlNotConfigured => BadRequest(problemDetailsBuilder
+                .WithTitle("Application URL not configured")
+                .WithDetail("The application URL is not configured. Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration, or change Umbraco:CMS:WebRouting:ApplicationUrlDetection to 'FirstRequest' or 'EveryRequest'.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown user operation status.")
                 .Build()),

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -140,6 +140,10 @@ public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerB
                 .WithDetail("The target user type does not support this operation.")
                 .Build()),
             UserOperationStatus.Forbidden => Forbidden(),
+            UserOperationStatus.ApplicationUrlNotConfigured => BadRequest(problemDetailsBuilder
+                .WithTitle("Application URL not configured")
+                .WithDetail("The application URL is not configured. Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration, or change Umbraco:CMS:WebRouting:ApplicationUrlDetection to 'FirstRequest' or 'EveryRequest'.")
+                .Build()),
             _ => StatusCode(StatusCodes.Status500InternalServerError, problemDetailsBuilder
                 .WithTitle("Unknown user operation status.")
                 .Build()),

--- a/src/Umbraco.Cms.Api.Management/Security/ForgotPasswordUriProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/ForgotPasswordUriProvider.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
@@ -16,10 +16,10 @@ namespace Umbraco.Cms.Api.Management.Security;
 /// </summary>
 public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
 {
-
     private readonly ICoreBackOfficeUserManager _userManager;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<ForgotPasswordUriProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ForgotPasswordUriProvider"/> class.
@@ -27,16 +27,39 @@ public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
     /// <param name="userManager">An <see cref="ICoreBackOfficeUserManager"/> instance for managing back office users.</param>
     /// <param name="hostingEnvironment">An <see cref="IHostingEnvironment"/> instance representing the current hosting environment.</param>
     /// <param name="httpContextAccessor">An <see cref="IHttpContextAccessor"/> instance for accessing the current HTTP context.</param>
+    /// <param name="logger">A logger instance for diagnostic messages.</param>
     public ForgotPasswordUriProvider(
         ICoreBackOfficeUserManager userManager,
         IHostingEnvironment hostingEnvironment,
-        IHttpContextAccessor httpContextAccessor)
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<ForgotPasswordUriProvider> logger)
     {
         _userManager = userManager;
         _hostingEnvironment = hostingEnvironment;
         _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ForgotPasswordUriProvider"/> class.
+    /// </summary>
+    /// <param name="userManager">An <see cref="ICoreBackOfficeUserManager"/> instance for managing back office users.</param>
+    /// <param name="hostingEnvironment">An <see cref="IHostingEnvironment"/> instance representing the current hosting environment.</param>
+    /// <param name="httpContextAccessor">An <see cref="IHttpContextAccessor"/> instance for accessing the current HTTP context.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
+    public ForgotPasswordUriProvider(
+        ICoreBackOfficeUserManager userManager,
+        IHostingEnvironment hostingEnvironment,
+        IHttpContextAccessor httpContextAccessor)
+        : this(
+            userManager,
+            hostingEnvironment,
+            httpContextAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<ILogger<ForgotPasswordUriProvider>>())
+    {
+    }
+
+    /// <inheritdoc/>
     public async Task<Attempt<Uri, UserOperationStatus>> CreateForgotPasswordUriAsync(IUser user)
     {
         Attempt<string, UserOperationStatus> tokenAttempt = await _userManager.GeneratePasswordResetTokenAsync(user);
@@ -52,14 +75,30 @@ public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
             throw new NotSupportedException("Needs a HttpContext");
         }
 
-        var uriBuilder = new UriBuilder(_hostingEnvironment.ApplicationMainUrl);
-        uriBuilder.Path = BackOfficeLoginController.LoginPath;
-        uriBuilder.Query = QueryString.Create(new KeyValuePair<string, string?>[]
+        var query = QueryString.Create(new KeyValuePair<string, string?>[]
         {
-            new ("flow", "reset-password"),
-            new ("userId", user.Key.ToString()),
-            new ("resetCode", tokenAttempt.Result.ToUrlBase64()),
+            new("flow", "reset-password"),
+            new("userId", user.Key.ToString()),
+            new("resetCode", tokenAttempt.Result.ToUrlBase64()),
         }).ToUriComponent();
+
+        Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
+        if (appUrl is null)
+        {
+            _logger.LogWarning(
+                "ApplicationMainUrl is not configured. Password reset link will use a relative path. "
+                + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.");
+
+            return Attempt.SucceedWithStatus(
+                UserOperationStatus.Success,
+                new Uri(BackOfficeLoginController.LoginPath + query, UriKind.Relative));
+        }
+
+        var uriBuilder = new UriBuilder(appUrl)
+        {
+            Path = BackOfficeLoginController.LoginPath,
+            Query = query,
+        };
 
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, uriBuilder.Uri);
     }

--- a/src/Umbraco.Cms.Api.Management/Security/ForgotPasswordUriProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/ForgotPasswordUriProvider.cs
@@ -36,7 +36,10 @@ public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
     /// <inheritdoc/>
     public async Task<Attempt<Uri, UserOperationStatus>> CreateForgotPasswordUriAsync(IUser user)
     {
-        HttpRequest? request = _httpContextAccessor.HttpContext?.Request ?? throw new NotSupportedException("Needs a HttpContext");
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            throw new NotSupportedException("Needs a HttpContext");
+        }
 
         Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
         if (appUrl is null)
@@ -48,7 +51,7 @@ public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
 
         if (tokenAttempt.Success is false)
         {
-            return Attempt.FailWithStatus(tokenAttempt.Status, new Uri(string.Empty));
+            return Attempt.FailWithStatus<Uri, UserOperationStatus>(tokenAttempt.Status, default!);
         }
 
         var uriBuilder = new UriBuilder(appUrl)

--- a/src/Umbraco.Cms.Api.Management/Security/ForgotPasswordUriProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/ForgotPasswordUriProvider.cs
@@ -1,8 +1,5 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
@@ -19,7 +16,6 @@ public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
     private readonly ICoreBackOfficeUserManager _userManager;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly ILogger<ForgotPasswordUriProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ForgotPasswordUriProvider"/> class.
@@ -27,41 +23,27 @@ public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
     /// <param name="userManager">An <see cref="ICoreBackOfficeUserManager"/> instance for managing back office users.</param>
     /// <param name="hostingEnvironment">An <see cref="IHostingEnvironment"/> instance representing the current hosting environment.</param>
     /// <param name="httpContextAccessor">An <see cref="IHttpContextAccessor"/> instance for accessing the current HTTP context.</param>
-    /// <param name="logger">A logger instance for diagnostic messages.</param>
-    public ForgotPasswordUriProvider(
-        ICoreBackOfficeUserManager userManager,
-        IHostingEnvironment hostingEnvironment,
-        IHttpContextAccessor httpContextAccessor,
-        ILogger<ForgotPasswordUriProvider> logger)
-    {
-        _userManager = userManager;
-        _hostingEnvironment = hostingEnvironment;
-        _httpContextAccessor = httpContextAccessor;
-        _logger = logger;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ForgotPasswordUriProvider"/> class.
-    /// </summary>
-    /// <param name="userManager">An <see cref="ICoreBackOfficeUserManager"/> instance for managing back office users.</param>
-    /// <param name="hostingEnvironment">An <see cref="IHostingEnvironment"/> instance representing the current hosting environment.</param>
-    /// <param name="httpContextAccessor">An <see cref="IHttpContextAccessor"/> instance for accessing the current HTTP context.</param>
-    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public ForgotPasswordUriProvider(
         ICoreBackOfficeUserManager userManager,
         IHostingEnvironment hostingEnvironment,
         IHttpContextAccessor httpContextAccessor)
-        : this(
-            userManager,
-            hostingEnvironment,
-            httpContextAccessor,
-            StaticServiceProvider.Instance.GetRequiredService<ILogger<ForgotPasswordUriProvider>>())
     {
+        _userManager = userManager;
+        _hostingEnvironment = hostingEnvironment;
+        _httpContextAccessor = httpContextAccessor;
     }
 
     /// <inheritdoc/>
     public async Task<Attempt<Uri, UserOperationStatus>> CreateForgotPasswordUriAsync(IUser user)
     {
+        HttpRequest? request = _httpContextAccessor.HttpContext?.Request ?? throw new NotSupportedException("Needs a HttpContext");
+
+        Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
+        if (appUrl is null)
+        {
+            return Attempt.FailWithStatus<Uri, UserOperationStatus>(UserOperationStatus.ApplicationUrlNotConfigured, default!);
+        }
+
         Attempt<string, UserOperationStatus> tokenAttempt = await _userManager.GeneratePasswordResetTokenAsync(user);
 
         if (tokenAttempt.Success is false)
@@ -69,35 +51,15 @@ public class ForgotPasswordUriProvider : IForgotPasswordUriProvider
             return Attempt.FailWithStatus(tokenAttempt.Status, new Uri(string.Empty));
         }
 
-        HttpRequest? request = _httpContextAccessor.HttpContext?.Request;
-        if (request is null)
-        {
-            throw new NotSupportedException("Needs a HttpContext");
-        }
-
-        var query = QueryString.Create(new KeyValuePair<string, string?>[]
-        {
-            new("flow", "reset-password"),
-            new("userId", user.Key.ToString()),
-            new("resetCode", tokenAttempt.Result.ToUrlBase64()),
-        }).ToUriComponent();
-
-        Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
-        if (appUrl is null)
-        {
-            _logger.LogWarning(
-                "ApplicationMainUrl is not configured. Password reset link will use a relative path. "
-                + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.");
-
-            return Attempt.SucceedWithStatus(
-                UserOperationStatus.Success,
-                new Uri(BackOfficeLoginController.LoginPath + query, UriKind.Relative));
-        }
-
         var uriBuilder = new UriBuilder(appUrl)
         {
             Path = BackOfficeLoginController.LoginPath,
-            Query = query,
+            Query = QueryString.Create(new KeyValuePair<string, string?>[]
+            {
+                new("flow", "reset-password"),
+                new("userId", user.Key.ToString()),
+                new("resetCode", tokenAttempt.Result.ToUrlBase64()),
+            }).ToUriComponent(),
         };
 
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, uriBuilder.Uri);

--- a/src/Umbraco.Cms.Api.Management/Security/InviteUriProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/InviteUriProvider.cs
@@ -42,7 +42,10 @@ public class InviteUriProvider : IInviteUriProvider
     /// </returns>
     public async Task<Attempt<Uri, UserOperationStatus>> CreateInviteUriAsync(IUser invitee)
     {
-        HttpRequest? request = _httpContextAccessor.HttpContext?.Request ?? throw new NotSupportedException("Needs a HttpContext");
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            throw new NotSupportedException("Needs a HttpContext");
+        }
 
         Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
         if (appUrl is null)
@@ -54,7 +57,7 @@ public class InviteUriProvider : IInviteUriProvider
 
         if (tokenAttempt.Success is false)
         {
-            return Attempt.FailWithStatus(tokenAttempt.Status, new Uri(string.Empty));
+            return Attempt.FailWithStatus<Uri, UserOperationStatus>(tokenAttempt.Status, default!);
         }
 
         var uriBuilder = new UriBuilder(appUrl)

--- a/src/Umbraco.Cms.Api.Management/Security/InviteUriProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/InviteUriProvider.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
@@ -16,6 +19,7 @@ public class InviteUriProvider : IInviteUriProvider
     private readonly ICoreBackOfficeUserManager _userManager;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IHostingEnvironment _hostingEnvironment;
+    private readonly ILogger<InviteUriProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Security.InviteUriProvider"/> class, used to generate invite URIs for user management.
@@ -23,15 +27,36 @@ public class InviteUriProvider : IInviteUriProvider
     /// <param name="userManager">The user manager responsible for core back office user operations.</param>
     /// <param name="httpContextAccessor">Provides access to the current HTTP context.</param>
     /// <param name="hostingEnvironment">Provides information about the web hosting environment.</param>
+    /// <param name="logger">A logger instance for diagnostic messages.</param>
+    public InviteUriProvider(
+        ICoreBackOfficeUserManager userManager,
+        IHttpContextAccessor httpContextAccessor,
+        IHostingEnvironment hostingEnvironment,
+        ILogger<InviteUriProvider> logger)
+    {
+        _userManager = userManager;
+        _httpContextAccessor = httpContextAccessor;
+        _hostingEnvironment = hostingEnvironment;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Security.InviteUriProvider"/> class, used to generate invite URIs for user management.
+    /// </summary>
+    /// <param name="userManager">The user manager responsible for core back office user operations.</param>
+    /// <param name="httpContextAccessor">Provides access to the current HTTP context.</param>
+    /// <param name="hostingEnvironment">Provides information about the web hosting environment.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public InviteUriProvider(
         ICoreBackOfficeUserManager userManager,
         IHttpContextAccessor httpContextAccessor,
         IHostingEnvironment hostingEnvironment)
+        : this(
+            userManager,
+            httpContextAccessor,
+            hostingEnvironment,
+            StaticServiceProvider.Instance.GetRequiredService<ILogger<InviteUriProvider>>())
     {
-
-        _userManager = userManager;
-        _httpContextAccessor = httpContextAccessor;
-        _hostingEnvironment = hostingEnvironment;
     }
 
     /// <summary>
@@ -56,14 +81,28 @@ public class InviteUriProvider : IInviteUriProvider
             throw new NotSupportedException("Needs a HttpContext");
         }
 
-        var uriBuilder = new UriBuilder(_hostingEnvironment.ApplicationMainUrl);
-        uriBuilder.Path = BackOfficeLoginController.LoginPath;
-        uriBuilder.Query = QueryString.Create(new KeyValuePair<string, string?>[]
+        var query = QueryString.Create(new KeyValuePair<string, string?>[]
         {
             new ("flow", "invite-user"),
             new ("userId", invitee.Key.ToString()),
             new ("inviteCode", tokenAttempt.Result.ToUrlBase64()),
         }).ToUriComponent();
+
+        Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
+        if (appUrl is null)
+        {
+            _logger.LogWarning(
+                "ApplicationMainUrl is not configured. Invite link will use a relative path. "
+                + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.");
+
+            return Attempt.SucceedWithStatus(
+                UserOperationStatus.Success,
+                new Uri(BackOfficeLoginController.LoginPath + query, UriKind.Relative));
+        }
+
+        var uriBuilder = new UriBuilder(appUrl);
+        uriBuilder.Path = BackOfficeLoginController.LoginPath;
+        uriBuilder.Query = query;
 
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, uriBuilder.Uri);
     }

--- a/src/Umbraco.Cms.Api.Management/Security/InviteUriProvider.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/InviteUriProvider.cs
@@ -1,8 +1,5 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
@@ -19,7 +16,6 @@ public class InviteUriProvider : IInviteUriProvider
     private readonly ICoreBackOfficeUserManager _userManager;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IHostingEnvironment _hostingEnvironment;
-    private readonly ILogger<InviteUriProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Security.InviteUriProvider"/> class, used to generate invite URIs for user management.
@@ -27,36 +23,14 @@ public class InviteUriProvider : IInviteUriProvider
     /// <param name="userManager">The user manager responsible for core back office user operations.</param>
     /// <param name="httpContextAccessor">Provides access to the current HTTP context.</param>
     /// <param name="hostingEnvironment">Provides information about the web hosting environment.</param>
-    /// <param name="logger">A logger instance for diagnostic messages.</param>
-    public InviteUriProvider(
-        ICoreBackOfficeUserManager userManager,
-        IHttpContextAccessor httpContextAccessor,
-        IHostingEnvironment hostingEnvironment,
-        ILogger<InviteUriProvider> logger)
-    {
-        _userManager = userManager;
-        _httpContextAccessor = httpContextAccessor;
-        _hostingEnvironment = hostingEnvironment;
-        _logger = logger;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Security.InviteUriProvider"/> class, used to generate invite URIs for user management.
-    /// </summary>
-    /// <param name="userManager">The user manager responsible for core back office user operations.</param>
-    /// <param name="httpContextAccessor">Provides access to the current HTTP context.</param>
-    /// <param name="hostingEnvironment">Provides information about the web hosting environment.</param>
-    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public InviteUriProvider(
         ICoreBackOfficeUserManager userManager,
         IHttpContextAccessor httpContextAccessor,
         IHostingEnvironment hostingEnvironment)
-        : this(
-            userManager,
-            httpContextAccessor,
-            hostingEnvironment,
-            StaticServiceProvider.Instance.GetRequiredService<ILogger<InviteUriProvider>>())
     {
+        _userManager = userManager;
+        _httpContextAccessor = httpContextAccessor;
+        _hostingEnvironment = hostingEnvironment;
     }
 
     /// <summary>
@@ -68,6 +42,14 @@ public class InviteUriProvider : IInviteUriProvider
     /// </returns>
     public async Task<Attempt<Uri, UserOperationStatus>> CreateInviteUriAsync(IUser invitee)
     {
+        HttpRequest? request = _httpContextAccessor.HttpContext?.Request ?? throw new NotSupportedException("Needs a HttpContext");
+
+        Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
+        if (appUrl is null)
+        {
+            return Attempt.FailWithStatus<Uri, UserOperationStatus>(UserOperationStatus.ApplicationUrlNotConfigured, default!);
+        }
+
         Attempt<string, UserOperationStatus> tokenAttempt = await _userManager.GenerateEmailConfirmationTokenAsync(invitee);
 
         if (tokenAttempt.Success is false)
@@ -75,34 +57,16 @@ public class InviteUriProvider : IInviteUriProvider
             return Attempt.FailWithStatus(tokenAttempt.Status, new Uri(string.Empty));
         }
 
-        HttpRequest? request = _httpContextAccessor.HttpContext?.Request;
-        if (request is null)
+        var uriBuilder = new UriBuilder(appUrl)
         {
-            throw new NotSupportedException("Needs a HttpContext");
-        }
-
-        var query = QueryString.Create(new KeyValuePair<string, string?>[]
-        {
-            new ("flow", "invite-user"),
-            new ("userId", invitee.Key.ToString()),
-            new ("inviteCode", tokenAttempt.Result.ToUrlBase64()),
-        }).ToUriComponent();
-
-        Uri? appUrl = _hostingEnvironment.ApplicationMainUrl;
-        if (appUrl is null)
-        {
-            _logger.LogWarning(
-                "ApplicationMainUrl is not configured. Invite link will use a relative path. "
-                + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.");
-
-            return Attempt.SucceedWithStatus(
-                UserOperationStatus.Success,
-                new Uri(BackOfficeLoginController.LoginPath + query, UriKind.Relative));
-        }
-
-        var uriBuilder = new UriBuilder(appUrl);
-        uriBuilder.Path = BackOfficeLoginController.LoginPath;
-        uriBuilder.Query = query;
+            Path = BackOfficeLoginController.LoginPath,
+            Query = QueryString.Create(new KeyValuePair<string, string?>[]
+            {
+                new ("flow", "invite-user"),
+                new ("userId", invitee.Key.ToString()),
+                new ("inviteCode", tokenAttempt.Result.ToUrlBase64()),
+            }).ToUriComponent()
+        };
 
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, uriBuilder.Uri);
     }

--- a/src/Umbraco.Core/Configuration/Models/ApplicationUrlDetection.cs
+++ b/src/Umbraco.Core/Configuration/Models/ApplicationUrlDetection.cs
@@ -1,0 +1,26 @@
+namespace Umbraco.Cms.Core.Configuration.Models;
+
+/// <summary>
+///     Specifies how the application main URL is detected from incoming HTTP requests.
+/// </summary>
+public enum ApplicationUrlDetection
+{
+    /// <summary>
+    ///     No auto-detection. The application URL must be explicitly configured
+    ///     via <see cref="WebRoutingSettings.UmbracoApplicationUrl" />.
+    ///     Emails will use relative links if no URL is configured.
+    /// </summary>
+    None,
+
+    /// <summary>
+    ///     The URL is set from the first HTTP request and then locked.
+    ///     Subsequent requests with different host headers are ignored.
+    /// </summary>
+    FirstRequest,
+
+    /// <summary>
+    ///     The URL is updated from every new incoming HTTP request (legacy behavior).
+    ///     This is vulnerable to host header poisoning.
+    /// </summary>
+    EveryRequest,
+}

--- a/src/Umbraco.Core/Configuration/Models/ApplicationUrlDetection.cs
+++ b/src/Umbraco.Core/Configuration/Models/ApplicationUrlDetection.cs
@@ -8,7 +8,8 @@ public enum ApplicationUrlDetection
     /// <summary>
     ///     No auto-detection. The application URL must be explicitly configured
     ///     via <see cref="WebRoutingSettings.UmbracoApplicationUrl" />.
-    ///     Emails will use relative links if no URL is configured.
+    ///     Operations that require a URL (invitations, password resets) will fail
+    ///     if no explicit URL is configured.
     /// </summary>
     None,
 

--- a/src/Umbraco.Core/Configuration/Models/WebRoutingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/WebRoutingSettings.cs
@@ -63,6 +63,11 @@ public class WebRoutingSettings
     internal const bool StaticUseStrictDomainMatching = false;
 
     /// <summary>
+    ///     The default value for application URL detection mode.
+    /// </summary>
+    internal const ApplicationUrlDetection StaticApplicationUrlDetection = ApplicationUrlDetection.None;
+
+    /// <summary>
     ///     Gets or sets a value indicating whether to check if any routed endpoints match a front-end request before
     ///     the Umbraco dynamic router tries to map the request to an Umbraco content item.
     /// </summary>
@@ -122,6 +127,13 @@ public class WebRoutingSettings
     ///     Gets or sets a value for the Umbraco application URL.
     /// </summary>
     public string UmbracoApplicationUrl { get; set; } = null!;
+
+    /// <summary>
+    ///     Gets or sets a value controlling how the application main URL is auto-detected
+    ///     from incoming HTTP requests (<see cref="ApplicationUrlDetection" />).
+    /// </summary>
+    [DefaultValue(StaticApplicationUrlDetection)]
+    public ApplicationUrlDetection ApplicationUrlDetection { get; set; } = StaticApplicationUrlDetection;
 
     /// <summary>
     ///     Gets or sets a value indicating whether strict domain matching is used when finding content to match the request.

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -437,6 +437,7 @@
     <key alias="httpsCheckExpiredCertificate">Your website's SSL certificate has expired.</key>
     <key alias="httpsCheckExpiringCertificate">Your website's SSL certificate is expiring in %0% days.</key>
     <key alias="healthCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
+    <key alias="httpsCheckNoApplicationUrl">The application URL is not available. Configure Umbraco:CMS:WebRouting:UmbracoApplicationUrl or change ApplicationUrlDetection to enable this check.</key>
     <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
     <key alias="httpsCheckConfigurationRectifyNotPossible">The appSetting 'Umbraco:CMS:Global:UseHttps' is set to 'false' in
       your appSettings.json file. Once you access this site using the HTTPS scheme, that should be set to 'true'.

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -426,6 +426,7 @@
     <key alias="httpsCheckExpiredCertificate">Your website's SSL certificate has expired.</key>
     <key alias="httpsCheckExpiringCertificate">Your website's SSL certificate is expiring in %0% days.</key>
     <key alias="healthCheckInvalidUrl">Error pinging the URL %0% - '%1%'</key>
+    <key alias="httpsCheckNoApplicationUrl">The application URL is not available. Configure Umbraco:CMS:WebRouting:UmbracoApplicationUrl or change ApplicationUrlDetection to enable this check.</key>
     <key alias="httpsCheckIsCurrentSchemeHttps">You are currently %0% viewing the site using the HTTPS scheme.</key>
     <key alias="httpsCheckConfigurationRectifyNotPossible">The appSetting 'Umbraco:CMS:Global:UseHttps' is set to 'false' in
       your appSettings.json file. Once you access this site using the HTTPS scheme, that should be set to 'true'.

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/BaseHttpHeaderCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/BaseHttpHeaderCheck.cs
@@ -79,6 +79,16 @@ public abstract class BaseHttpHeaderCheck : HealthCheck
         // Access the site home page and check for the click-jack protection header or meta tag
         var url = _hostingEnvironment.ApplicationMainUrl?.GetLeftPart(UriPartial.Authority);
 
+        if (url is null)
+        {
+            return new HealthCheckStatus(
+                LocalizedTextService.Localize("healthcheck", "httpsCheckNoApplicationUrl"))
+            {
+                ResultType = StatusResultType.Info,
+                ReadMoreLink = ReadMoreLink,
+            };
+        }
+
         try
         {
             using HttpResponseMessage response = await HttpClient.GetAsync(url);

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/ExcessiveHeadersCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/ExcessiveHeadersCheck.cs
@@ -46,6 +46,16 @@ public class ExcessiveHeadersCheck : HealthCheck
         var success = false;
         var url = _hostingEnvironment.ApplicationMainUrl?.GetLeftPart(UriPartial.Authority);
 
+        if (url is null)
+        {
+            return new HealthCheckStatus(
+                _textService.Localize("healthcheck", "httpsCheckNoApplicationUrl"))
+            {
+                ResultType = StatusResultType.Info,
+                ReadMoreLink = Constants.HealthChecks.DocumentationLinks.Security.ExcessiveHeadersCheck,
+            };
+        }
+
         // Access the site home page and check for the headers
         using var request = new HttpRequestMessage(HttpMethod.Head, url);
         try

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/HttpsCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/HttpsCheck.cs
@@ -74,8 +74,27 @@ public class HttpsCheck : HealthCheck
         return sslErrors == SslPolicyErrors.None;
     }
 
+    private HealthCheckStatus? CheckApplicationUrlAvailable()
+    {
+        if (_hostingEnvironment.ApplicationMainUrl is not null)
+        {
+            return null;
+        }
+
+        return new HealthCheckStatus(
+            _textService.Localize("healthcheck", "httpsCheckNoApplicationUrl"))
+        {
+            ResultType = StatusResultType.Info,
+        };
+    }
+
     private async Task<HealthCheckStatus> CheckForValidCertificate()
     {
+        if (CheckApplicationUrlAvailable() is HealthCheckStatus unavailable)
+        {
+            return unavailable;
+        }
+
         string message;
         StatusResultType result;
 
@@ -154,6 +173,11 @@ public class HttpsCheck : HealthCheck
 
     private Task<HealthCheckStatus> CheckIfCurrentSchemeIsHttps()
     {
+        if (CheckApplicationUrlAvailable() is HealthCheckStatus unavailable)
+        {
+            return Task.FromResult(unavailable);
+        }
+
         Uri uri = _hostingEnvironment.ApplicationMainUrl;
         var success = uri.Scheme == Uri.UriSchemeHttps;
 
@@ -169,6 +193,11 @@ public class HttpsCheck : HealthCheck
 
     private Task<HealthCheckStatus> CheckHttpsConfigurationSetting()
     {
+        if (CheckApplicationUrlAvailable() is HealthCheckStatus unavailable)
+        {
+            return Task.FromResult(unavailable);
+        }
+
         var httpsSettingEnabled = _globalSettings.CurrentValue.UseHttps;
         Uri uri = _hostingEnvironment.ApplicationMainUrl;
 

--- a/src/Umbraco.Core/Hosting/IHostingEnvironment.cs
+++ b/src/Umbraco.Core/Hosting/IHostingEnvironment.cs
@@ -83,6 +83,7 @@ public interface IHostingEnvironment
     /// <summary>
     ///     Gets the main application url.
     /// </summary>
+    // TODO (V18): Change to Uri? to reflect that this can be null when ApplicationUrlDetection is None and no explicit URL is configured.
     Uri ApplicationMainUrl { get; }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -189,4 +189,11 @@ public enum UserOperationStatus
     ///     The operation failed because the username is invalid.
     /// </summary>
     InvalidUserName,
+
+    /// <summary>
+    ///     The operation failed because the application URL is not configured.
+    ///     Set <c>Umbraco:CMS:WebRouting:UmbracoApplicationUrl</c> or change
+    ///     <c>ApplicationUrlDetection</c> to <c>FirstRequest</c> or <c>EveryRequest</c>.
+    /// </summary>
+    ApplicationUrlNotConfigured,
 }

--- a/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlConfigurationNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlConfigurationNotificationHandler.cs
@@ -56,8 +56,7 @@ internal sealed class ApplicationUrlConfigurationNotificationHandler
         }
 
         _logger.LogInformation(
-            "Application URL auto-detection is enabled ({DetectionMode}). "
-            + "The URL will be determined from the first HTTP request.",
+            "Application URL auto-detection is enabled ({DetectionMode}). ",
             settings.ApplicationUrlDetection);
     }
 }

--- a/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlConfigurationNotificationHandler.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/ApplicationUrlConfigurationNotificationHandler.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Umbraco.Cms.Web.Common.AspNetCore;
+
+/// <summary>
+///     Logs the application URL configuration status at startup, providing guidance
+///     when the URL is not configured and auto-detection is disabled.
+/// </summary>
+internal sealed class ApplicationUrlConfigurationNotificationHandler
+    : INotificationHandler<UmbracoApplicationStartedNotification>
+{
+    private readonly ILogger<ApplicationUrlConfigurationNotificationHandler> _logger;
+    private readonly IOptionsMonitor<WebRoutingSettings> _webRoutingSettings;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ApplicationUrlConfigurationNotificationHandler" /> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="webRoutingSettings">The web routing settings monitor.</param>
+    public ApplicationUrlConfigurationNotificationHandler(
+        ILogger<ApplicationUrlConfigurationNotificationHandler> logger,
+        IOptionsMonitor<WebRoutingSettings> webRoutingSettings)
+    {
+        _logger = logger;
+        _webRoutingSettings = webRoutingSettings;
+    }
+
+    /// <inheritdoc/>
+    public void Handle(UmbracoApplicationStartedNotification notification)
+    {
+        WebRoutingSettings settings = _webRoutingSettings.CurrentValue;
+
+        if (settings.UmbracoApplicationUrl is not null)
+        {
+            _logger.LogInformation(
+                "Application URL configured as {ApplicationMainUrl}.",
+                settings.UmbracoApplicationUrl);
+            return;
+        }
+
+        if (settings.ApplicationUrlDetection == ApplicationUrlDetection.None)
+        {
+            _logger.LogWarning(
+                "Application URL auto-detection is disabled and no explicit URL is configured. "
+                + "Email links (invitations, password resets) will not be available. "
+                + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration, "
+                + "or change Umbraco:CMS:WebRouting:ApplicationUrlDetection to 'FirstRequest' or 'EveryRequest'.");
+            return;
+        }
+
+        _logger.LogInformation(
+            "Application URL auto-detection is enabled ({DetectionMode}). "
+            + "The URL will be determined from the first HTTP request.",
+            settings.ApplicationUrlDetection);
+    }
+}

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
@@ -185,22 +185,41 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
             return;
         }
 
+        // Explicit configuration always takes precedence.
         if (_webRoutingSettings.CurrentValue.UmbracoApplicationUrl is not null)
         {
             return;
         }
 
-        // Once ApplicationMainUrl is set via auto-detection, lock it.
-        // This prevents Host header poisoning where a forged Host header
-        // could overwrite the URL used in password reset links, invitations, etc.
-        if (ApplicationMainUrl is not null)
+        switch (_webRoutingSettings.CurrentValue.ApplicationUrlDetection)
         {
-            return;
-        }
+            case ApplicationUrlDetection.None:
+                return;
 
-        if (_applicationUrls.TryAdd(currentApplicationUrl))
-        {
-            ApplicationMainUrl = currentApplicationUrl;
+            case ApplicationUrlDetection.FirstRequest:
+                if (ApplicationMainUrl is not null)
+                {
+                    return;
+                }
+
+                if (_applicationUrls.TryAdd(currentApplicationUrl))
+                {
+                    ApplicationMainUrl = currentApplicationUrl;
+                }
+
+                break;
+
+            case ApplicationUrlDetection.EveryRequest:
+                var change = _applicationUrls.Contains(currentApplicationUrl) is false;
+                if (change)
+                {
+                    if (_applicationUrls.TryAdd(currentApplicationUrl))
+                    {
+                        ApplicationMainUrl = currentApplicationUrl;
+                    }
+                }
+
+                break;
         }
     }
 

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.DataProtection.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Core.Configuration;
@@ -12,6 +11,10 @@ using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Web.Common.AspNetCore;
 
+/// <summary>
+/// ASP.NET Core implementation of <see cref="IHostingEnvironment" /> that provides
+/// hosting information such as the application URL, physical paths, site name, and debug mode.
+/// </summary>
 public class AspNetCoreHostingEnvironment : IHostingEnvironment
 {
     private readonly IApplicationDiscriminator? _applicationDiscriminator;
@@ -22,9 +25,14 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
 
     private readonly UrlMode _urlProviderMode;
 
-    private string? _applicationId;
-    private string? _localTempPath;
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AspNetCoreHostingEnvironment" /> class
+    /// with an <see cref="IApplicationDiscriminator" /> for unique application identification.
+    /// </summary>
+    /// <param name="hostingSettings">The hosting settings monitor.</param>
+    /// <param name="webRoutingSettings">The web routing settings monitor.</param>
+    /// <param name="webHostEnvironment">The ASP.NET Core web host environment.</param>
+    /// <param name="applicationDiscriminator">The application discriminator used for generating a unique application identifier.</param>
     public AspNetCoreHostingEnvironment(
         IOptionsMonitor<HostingSettings> hostingSettings,
         IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
@@ -33,6 +41,12 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
         : this(hostingSettings, webRoutingSettings, webHostEnvironment) =>
         _applicationDiscriminator = applicationDiscriminator;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AspNetCoreHostingEnvironment" /> class.
+    /// </summary>
+    /// <param name="hostingSettings">The hosting settings monitor.</param>
+    /// <param name="webRoutingSettings">The web routing settings monitor.</param>
+    /// <param name="webHostEnvironment">The ASP.NET Core web host environment.</param>
     public AspNetCoreHostingEnvironment(
         IOptionsMonitor<HostingSettings> hostingSettings,
         IOptionsMonitor<WebRoutingSettings> webRoutingSettings,
@@ -75,35 +89,35 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
     {
         get
         {
-            if (_applicationId != null)
+            if (field != null)
             {
-                return _applicationId;
+                return field;
             }
 
-            _applicationId = _applicationDiscriminator?.GetApplicationId() ??
-                             _webHostEnvironment.GetTemporaryApplicationId();
+            field = _applicationDiscriminator?.GetApplicationId() ?? _webHostEnvironment.GetTemporaryApplicationId();
 
-            return _applicationId;
+            return field;
         }
     }
 
     /// <inheritdoc />
     public string ApplicationPhysicalPath { get; }
 
-    // TODO how to find this, This is a server thing, not application thing.
+    /// <inheritdoc/>
     public string ApplicationVirtualPath =>
         _hostingSettings.CurrentValue.ApplicationVirtualPath?.EnsureStartsWith('/') ?? "/";
 
     /// <inheritdoc />
     public bool IsDebugMode { get; private set; }
 
+    /// <inheritdoc/>
     public string LocalTempPath
     {
         get
         {
-            if (_localTempPath != null)
+            if (field != null)
             {
-                return _localTempPath;
+                return field;
             }
 
             switch (_hostingSettings.CurrentValue.LocalTempStorageLocation)
@@ -123,11 +137,11 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
                     var hash = hashString.GenerateHash();
                     var siteTemp = Path.Combine(Path.GetTempPath(), "UmbracoData", hash);
 
-                    return _localTempPath = siteTemp;
+                    return field = siteTemp;
 
                 default:
 
-                    return _localTempPath = MapPathContentRoot(Core.Constants.SystemDirectories.TempData);
+                    return field = MapPathContentRoot(Core.Constants.SystemDirectories.TempData);
             }
         }
     }
@@ -163,15 +177,9 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
         return fullPath;
     }
 
+    /// <inheritdoc/>
     public void EnsureApplicationMainUrl(Uri? currentApplicationUrl)
     {
-        // TODO: This causes problems with site swap on azure because azure pre-warms a site by calling into `localhost` and when it does that
-        // it changes the URL to `localhost:80` which actually doesn't work for pinging itself, it only works internally in Azure. The ironic part
-        // about this is that this is here specifically for the slot swap scenario https://issues.umbraco.org/issue/U4-10626
-
-        // see U4-10626 - in some cases we want to reset the application url
-        // (this is a simplified version of what was in 7.x)
-        // note: should this be optional? is it expensive?
         if (currentApplicationUrl is null)
         {
             return;
@@ -182,13 +190,17 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
             return;
         }
 
-        var change = !_applicationUrls.Contains(currentApplicationUrl);
-        if (change)
+        // Once ApplicationMainUrl is set via auto-detection, lock it.
+        // This prevents Host header poisoning where a forged Host header
+        // could overwrite the URL used in password reset links, invitations, etc.
+        if (ApplicationMainUrl is not null)
         {
-            if (_applicationUrls.TryAdd(currentApplicationUrl))
-            {
-                ApplicationMainUrl = currentApplicationUrl;
-            }
+            return;
+        }
+
+        if (_applicationUrls.TryAdd(currentApplicationUrl))
+        {
+            ApplicationMainUrl = currentApplicationUrl;
         }
     }
 

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
@@ -78,8 +78,14 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
     /// <inheritdoc />
     public bool IsHosted { get; } = true;
 
+    private Uri? _applicationMainUrl;
+
     /// <inheritdoc />
-    public Uri ApplicationMainUrl { get; private set; } = null!;
+    public Uri ApplicationMainUrl
+    {
+        get => _applicationMainUrl!;
+        private set => _applicationMainUrl = value;
+    }
 
     /// <inheritdoc />
     public string? SiteName { get; private set; }
@@ -197,16 +203,9 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
                 return;
 
             case ApplicationUrlDetection.FirstRequest:
-                if (ApplicationMainUrl is not null)
-                {
-                    return;
-                }
-
-                if (_applicationUrls.TryAdd(currentApplicationUrl))
-                {
-                    ApplicationMainUrl = currentApplicationUrl;
-                }
-
+                // Atomic: only the first thread to arrive sets the URL.
+                // Subsequent calls (even concurrent ones with different hosts) are no-ops.
+                Interlocked.CompareExchange(ref _applicationMainUrl, currentApplicationUrl, null);
                 break;
 
             case ApplicationUrlDetection.EveryRequest:

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -296,6 +296,7 @@ public static partial class UmbracoBuilderExtensions
         // AspNetCore specific services
         builder.Services.AddUnique<IRequestAccessor, AspNetCoreRequestAccessor>();
         builder.AddNotificationHandler<UmbracoRequestBeginNotification, ApplicationUrlRequestBeginNotificationHandler>();
+        builder.AddNotificationHandler<UmbracoApplicationStartedNotification, ApplicationUrlConfigurationNotificationHandler>();
 
         // Password hasher
         builder.Services.AddUnique<IPasswordHasher, AspNetCorePasswordHasher>();

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -94,23 +94,26 @@ internal sealed class UmbracoRequestMiddleware : IMiddleware
         UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext();
 
         Uri? currentApplicationUrl = GetApplicationUrlFromCurrentRequest(context.Request);
+        Uri? applicationUrlBeforeDetection = _hostingEnvironment.ApplicationMainUrl;
         _hostingEnvironment.EnsureApplicationMainUrl(currentApplicationUrl);
 
         if (_applicationUrlLogged is false && currentApplicationUrl is not null)
         {
+            _applicationUrlLogged = true;
+
             if (_hostingEnvironment.ApplicationMainUrl is not null)
             {
-                _applicationUrlLogged = true;
+                var source = applicationUrlBeforeDetection is not null ? "configured" : "auto-detected";
                 _logger.LogInformation(
-                    "Application URL auto-detected as {ApplicationMainUrl}. To override, set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.",
+                    "Application URL {Source} as {ApplicationMainUrl}.",
+                    source,
                     _hostingEnvironment.ApplicationMainUrl);
             }
             else
             {
-                _applicationUrlLogged = true;
                 _logger.LogWarning(
                     "Application URL auto-detection is disabled and no explicit URL is configured. "
-                    + "Email links (invitations, password resets) will use relative paths. "
+                    + "Email links (invitations, password resets) will not be available. "
                     + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration, "
                     + "or change Umbraco:CMS:WebRouting:ApplicationUrlDetection to 'FirstRequest' or 'EveryRequest'.");
             }

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -96,14 +96,24 @@ internal sealed class UmbracoRequestMiddleware : IMiddleware
         Uri? currentApplicationUrl = GetApplicationUrlFromCurrentRequest(context.Request);
         _hostingEnvironment.EnsureApplicationMainUrl(currentApplicationUrl);
 
-        if (currentApplicationUrl is not null
-            && _applicationUrlLogged is false
-            && _hostingEnvironment.ApplicationMainUrl is not null)
+        if (_applicationUrlLogged is false && currentApplicationUrl is not null)
         {
-            _applicationUrlLogged = true;
-            _logger.LogInformation(
-                "Application URL auto-detected as {ApplicationMainUrl}. To override, set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.",
-                _hostingEnvironment.ApplicationMainUrl);
+            if (_hostingEnvironment.ApplicationMainUrl is not null)
+            {
+                _applicationUrlLogged = true;
+                _logger.LogInformation(
+                    "Application URL auto-detected as {ApplicationMainUrl}. To override, set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.",
+                    _hostingEnvironment.ApplicationMainUrl);
+            }
+            else
+            {
+                _applicationUrlLogged = true;
+                _logger.LogWarning(
+                    "Application URL auto-detection is disabled and no explicit URL is configured. "
+                    + "Email links (invitations, password resets) will use relative paths. "
+                    + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration, "
+                    + "or change Umbraco:CMS:WebRouting:ApplicationUrlDetection to 'FirstRequest' or 'EveryRequest'.");
+            }
         }
 
         var pathAndQuery = context.Request.GetEncodedPathAndQuery();

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -33,8 +33,6 @@ namespace Umbraco.Cms.Web.Common.Middleware;
 /// </remarks>
 internal sealed class UmbracoRequestMiddleware : IMiddleware
 {
-    private static int _applicationUrlLogged;
-
     private readonly IDefaultCultureAccessor _defaultCultureAccessor;
     private readonly IEventAggregator _eventAggregator;
     private readonly IHostingEnvironment _hostingEnvironment;
@@ -94,28 +92,7 @@ internal sealed class UmbracoRequestMiddleware : IMiddleware
         UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext();
 
         Uri? currentApplicationUrl = GetApplicationUrlFromCurrentRequest(context.Request);
-        Uri? applicationUrlBeforeDetection = _hostingEnvironment.ApplicationMainUrl;
         _hostingEnvironment.EnsureApplicationMainUrl(currentApplicationUrl);
-
-        if (currentApplicationUrl is not null && Interlocked.CompareExchange(ref _applicationUrlLogged, 1, 0) == 0)
-        {
-            if (_hostingEnvironment.ApplicationMainUrl is not null)
-            {
-                var source = applicationUrlBeforeDetection is not null ? "configured" : "auto-detected";
-                _logger.LogInformation(
-                    "Application URL {Source} as {ApplicationMainUrl}.",
-                    source,
-                    _hostingEnvironment.ApplicationMainUrl);
-            }
-            else
-            {
-                _logger.LogWarning(
-                    "Application URL auto-detection is disabled and no explicit URL is configured. "
-                    + "Email links (invitations, password resets) will not be available. "
-                    + "Set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration, "
-                    + "or change Umbraco:CMS:WebRouting:ApplicationUrlDetection to 'FirstRequest' or 'EveryRequest'.");
-            }
-        }
 
         var pathAndQuery = context.Request.GetEncodedPathAndQuery();
 

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -33,6 +33,8 @@ namespace Umbraco.Cms.Web.Common.Middleware;
 /// </remarks>
 internal sealed class UmbracoRequestMiddleware : IMiddleware
 {
+    private static bool _applicationUrlLogged;
+
     private readonly IDefaultCultureAccessor _defaultCultureAccessor;
     private readonly IEventAggregator _eventAggregator;
     private readonly IHostingEnvironment _hostingEnvironment;
@@ -93,6 +95,16 @@ internal sealed class UmbracoRequestMiddleware : IMiddleware
 
         Uri? currentApplicationUrl = GetApplicationUrlFromCurrentRequest(context.Request);
         _hostingEnvironment.EnsureApplicationMainUrl(currentApplicationUrl);
+
+        if (currentApplicationUrl is not null
+            && _applicationUrlLogged is false
+            && _hostingEnvironment.ApplicationMainUrl is not null)
+        {
+            _applicationUrlLogged = true;
+            _logger.LogInformation(
+                "Application URL auto-detected as {ApplicationMainUrl}. To override, set Umbraco:CMS:WebRouting:UmbracoApplicationUrl in configuration.",
+                _hostingEnvironment.ApplicationMainUrl);
+        }
 
         var pathAndQuery = context.Request.GetEncodedPathAndQuery();
 

--- a/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
+++ b/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs
@@ -33,7 +33,7 @@ namespace Umbraco.Cms.Web.Common.Middleware;
 /// </remarks>
 internal sealed class UmbracoRequestMiddleware : IMiddleware
 {
-    private static bool _applicationUrlLogged;
+    private static int _applicationUrlLogged;
 
     private readonly IDefaultCultureAccessor _defaultCultureAccessor;
     private readonly IEventAggregator _eventAggregator;
@@ -97,10 +97,8 @@ internal sealed class UmbracoRequestMiddleware : IMiddleware
         Uri? applicationUrlBeforeDetection = _hostingEnvironment.ApplicationMainUrl;
         _hostingEnvironment.EnsureApplicationMainUrl(currentApplicationUrl);
 
-        if (_applicationUrlLogged is false && currentApplicationUrl is not null)
+        if (currentApplicationUrl is not null && Interlocked.CompareExchange(ref _applicationUrlLogged, 1, 0) == 0)
         {
-            _applicationUrlLogged = true;
-
             if (_hostingEnvironment.ApplicationMainUrl is not null)
             {
                 var source = applicationUrlBeforeDetection is not null ? "configured" : "auto-detected";

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/UriProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/UriProviderTests.cs
@@ -2,7 +2,6 @@
 // See LICENSE for more details.
 
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Security;
@@ -45,8 +44,7 @@ public class UriProviderTests
         var sut = new ForgotPasswordUriProvider(
             _userManager.Object,
             _hostingEnvironment.Object,
-            _httpContextAccessor.Object,
-            Mock.Of<ILogger<ForgotPasswordUriProvider>>());
+            _httpContextAccessor.Object);
 
         Attempt<Uri, UserOperationStatus> result = await sut.CreateForgotPasswordUriAsync(_user.Object);
 
@@ -59,7 +57,7 @@ public class UriProviderTests
     }
 
     [Test]
-    public async Task ForgotPasswordUri_WithoutApplicationMainUrl_ReturnsRelativeUri()
+    public async Task ForgotPasswordUri_WithoutApplicationMainUrl_FailsWithApplicationUrlNotConfigured()
     {
         _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns((Uri?)null);
         _userManager
@@ -69,16 +67,12 @@ public class UriProviderTests
         var sut = new ForgotPasswordUriProvider(
             _userManager.Object,
             _hostingEnvironment.Object,
-            _httpContextAccessor.Object,
-            Mock.Of<ILogger<ForgotPasswordUriProvider>>());
+            _httpContextAccessor.Object);
 
         Attempt<Uri, UserOperationStatus> result = await sut.CreateForgotPasswordUriAsync(_user.Object);
 
-        Assert.IsTrue(result.Success);
-        Assert.IsFalse(result.Result.IsAbsoluteUri);
-        var uriString = result.Result.ToString();
-        Assert.That(uriString, Does.StartWith("/umbraco/login"));
-        Assert.That(uriString, Does.Contain("flow=reset-password"));
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(UserOperationStatus.ApplicationUrlNotConfigured, result.Status);
     }
 
     [Test]
@@ -93,8 +87,7 @@ public class UriProviderTests
         var sut = new InviteUriProvider(
             _userManager.Object,
             _httpContextAccessor.Object,
-            _hostingEnvironment.Object,
-            Mock.Of<ILogger<InviteUriProvider>>());
+            _hostingEnvironment.Object);
 
         Attempt<Uri, UserOperationStatus> result = await sut.CreateInviteUriAsync(_user.Object);
 
@@ -107,7 +100,7 @@ public class UriProviderTests
     }
 
     [Test]
-    public async Task InviteUri_WithoutApplicationMainUrl_ReturnsRelativeUri()
+    public async Task InviteUri_WithoutApplicationMainUrl_FailsWithApplicationUrlNotConfigured()
     {
         _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns((Uri?)null);
         _userManager
@@ -117,15 +110,11 @@ public class UriProviderTests
         var sut = new InviteUriProvider(
             _userManager.Object,
             _httpContextAccessor.Object,
-            _hostingEnvironment.Object,
-            Mock.Of<ILogger<InviteUriProvider>>());
+            _hostingEnvironment.Object);
 
         Attempt<Uri, UserOperationStatus> result = await sut.CreateInviteUriAsync(_user.Object);
 
-        Assert.IsTrue(result.Success);
-        Assert.IsFalse(result.Result.IsAbsoluteUri);
-        var uriString = result.Result.ToString();
-        Assert.That(uriString, Does.StartWith("/umbraco/login"));
-        Assert.That(uriString, Does.Contain("flow=invite-user"));
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(UserOperationStatus.ApplicationUrlNotConfigured, result.Status);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/UriProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/UriProviderTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Security;
+
+[TestFixture]
+public class UriProviderTests
+{
+    private Mock<ICoreBackOfficeUserManager> _userManager = null!;
+    private Mock<IHostingEnvironment> _hostingEnvironment = null!;
+    private Mock<IHttpContextAccessor> _httpContextAccessor = null!;
+    private Mock<IUser> _user = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _userManager = new Mock<ICoreBackOfficeUserManager>();
+        _hostingEnvironment = new Mock<IHostingEnvironment>();
+        _httpContextAccessor = new Mock<IHttpContextAccessor>();
+        _httpContextAccessor.Setup(a => a.HttpContext).Returns(new DefaultHttpContext());
+        _user = new Mock<IUser>();
+        _user.Setup(u => u.Key).Returns(Guid.NewGuid());
+    }
+
+    [Test]
+    public async Task ForgotPasswordUri_WithApplicationMainUrl_ReturnsAbsoluteUri()
+    {
+        var appUrl = new Uri("https://my-site.com");
+        _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns(appUrl);
+        _userManager
+            .Setup(m => m.GeneratePasswordResetTokenAsync(It.IsAny<IUser>()))
+            .ReturnsAsync(Attempt.SucceedWithStatus(UserOperationStatus.Success, "test-token"));
+
+        var sut = new ForgotPasswordUriProvider(
+            _userManager.Object,
+            _hostingEnvironment.Object,
+            _httpContextAccessor.Object,
+            Mock.Of<ILogger<ForgotPasswordUriProvider>>());
+
+        Attempt<Uri, UserOperationStatus> result = await sut.CreateForgotPasswordUriAsync(_user.Object);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.Result.IsAbsoluteUri);
+        Assert.AreEqual("https", result.Result.Scheme);
+        Assert.AreEqual("my-site.com", result.Result.Host);
+        Assert.That(result.Result.AbsolutePath, Does.StartWith("/umbraco/login"));
+        Assert.That(result.Result.Query, Does.Contain("flow=reset-password"));
+    }
+
+    [Test]
+    public async Task ForgotPasswordUri_WithoutApplicationMainUrl_ReturnsRelativeUri()
+    {
+        _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns((Uri?)null);
+        _userManager
+            .Setup(m => m.GeneratePasswordResetTokenAsync(It.IsAny<IUser>()))
+            .ReturnsAsync(Attempt.SucceedWithStatus(UserOperationStatus.Success, "test-token"));
+
+        var sut = new ForgotPasswordUriProvider(
+            _userManager.Object,
+            _hostingEnvironment.Object,
+            _httpContextAccessor.Object,
+            Mock.Of<ILogger<ForgotPasswordUriProvider>>());
+
+        Attempt<Uri, UserOperationStatus> result = await sut.CreateForgotPasswordUriAsync(_user.Object);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.Result.IsAbsoluteUri);
+        var uriString = result.Result.ToString();
+        Assert.That(uriString, Does.StartWith("/umbraco/login"));
+        Assert.That(uriString, Does.Contain("flow=reset-password"));
+    }
+
+    [Test]
+    public async Task InviteUri_WithApplicationMainUrl_ReturnsAbsoluteUri()
+    {
+        var appUrl = new Uri("https://my-site.com");
+        _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns(appUrl);
+        _userManager
+            .Setup(m => m.GenerateEmailConfirmationTokenAsync(It.IsAny<IUser>()))
+            .ReturnsAsync(Attempt.SucceedWithStatus(UserOperationStatus.Success, "test-token"));
+
+        var sut = new InviteUriProvider(
+            _userManager.Object,
+            _httpContextAccessor.Object,
+            _hostingEnvironment.Object,
+            Mock.Of<ILogger<InviteUriProvider>>());
+
+        Attempt<Uri, UserOperationStatus> result = await sut.CreateInviteUriAsync(_user.Object);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsTrue(result.Result.IsAbsoluteUri);
+        Assert.AreEqual("https", result.Result.Scheme);
+        Assert.AreEqual("my-site.com", result.Result.Host);
+        Assert.That(result.Result.AbsolutePath, Does.StartWith("/umbraco/login"));
+        Assert.That(result.Result.Query, Does.Contain("flow=invite-user"));
+    }
+
+    [Test]
+    public async Task InviteUri_WithoutApplicationMainUrl_ReturnsRelativeUri()
+    {
+        _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns((Uri?)null);
+        _userManager
+            .Setup(m => m.GenerateEmailConfirmationTokenAsync(It.IsAny<IUser>()))
+            .ReturnsAsync(Attempt.SucceedWithStatus(UserOperationStatus.Success, "test-token"));
+
+        var sut = new InviteUriProvider(
+            _userManager.Object,
+            _httpContextAccessor.Object,
+            _hostingEnvironment.Object,
+            Mock.Of<ILogger<InviteUriProvider>>());
+
+        Attempt<Uri, UserOperationStatus> result = await sut.CreateInviteUriAsync(_user.Object);
+
+        Assert.IsTrue(result.Success);
+        Assert.IsFalse(result.Result.IsAbsoluteUri);
+        var uriString = result.Result.ToString();
+        Assert.That(uriString, Does.StartWith("/umbraco/login"));
+        Assert.That(uriString, Does.Contain("flow=invite-user"));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/UriProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/UriProviderTests.cs
@@ -60,9 +60,6 @@ public class UriProviderTests
     public async Task ForgotPasswordUri_WithoutApplicationMainUrl_FailsWithApplicationUrlNotConfigured()
     {
         _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns((Uri?)null);
-        _userManager
-            .Setup(m => m.GeneratePasswordResetTokenAsync(It.IsAny<IUser>()))
-            .ReturnsAsync(Attempt.SucceedWithStatus(UserOperationStatus.Success, "test-token"));
 
         var sut = new ForgotPasswordUriProvider(
             _userManager.Object,
@@ -73,6 +70,7 @@ public class UriProviderTests
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserOperationStatus.ApplicationUrlNotConfigured, result.Status);
+        _userManager.Verify(m => m.GeneratePasswordResetTokenAsync(It.IsAny<IUser>()), Times.Never());
     }
 
     [Test]
@@ -103,9 +101,6 @@ public class UriProviderTests
     public async Task InviteUri_WithoutApplicationMainUrl_FailsWithApplicationUrlNotConfigured()
     {
         _hostingEnvironment.Setup(h => h.ApplicationMainUrl).Returns((Uri?)null);
-        _userManager
-            .Setup(m => m.GenerateEmailConfirmationTokenAsync(It.IsAny<IUser>()))
-            .ReturnsAsync(Attempt.SucceedWithStatus(UserOperationStatus.Success, "test-token"));
 
         var sut = new InviteUriProvider(
             _userManager.Object,
@@ -116,5 +111,6 @@ public class UriProviderTests
 
         Assert.IsFalse(result.Success);
         Assert.AreEqual(UserOperationStatus.ApplicationUrlNotConfigured, result.Status);
+        _userManager.Verify(m => m.GenerateEmailConfirmationTokenAsync(It.IsAny<IUser>()), Times.Never());
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/ApplicationUrlConfigurationNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/ApplicationUrlConfigurationNotificationHandlerTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Web.Common.AspNetCore;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website;
+
+[TestFixture]
+public class ApplicationUrlConfigurationNotificationHandlerTests
+{
+    private FakeLogger _logger = null!;
+
+    [SetUp]
+    public void SetUp() => _logger = new FakeLogger();
+
+    [Test]
+    public void Handle_WithExplicitUrl_LogsInformationWithConfiguredUrl()
+    {
+        var settings = new WebRoutingSettings { UmbracoApplicationUrl = "https://my-site.com" };
+        var sut = CreateHandler(settings);
+
+        sut.Handle(new UmbracoApplicationStartedNotification(false));
+
+        Assert.That(_logger.LogEntries, Has.Exactly(1).Matches<FakeLogger.LogEntry>(
+            e => e.Level == LogLevel.Information && e.Message.Contains("configured")));
+    }
+
+    [Test]
+    public void Handle_NoneMode_NoExplicitUrl_LogsWarning()
+    {
+        var settings = new WebRoutingSettings { ApplicationUrlDetection = ApplicationUrlDetection.None };
+        var sut = CreateHandler(settings);
+
+        sut.Handle(new UmbracoApplicationStartedNotification(false));
+
+        Assert.That(_logger.LogEntries, Has.Exactly(1).Matches<FakeLogger.LogEntry>(
+            e => e.Level == LogLevel.Warning && e.Message.Contains("auto-detection is disabled")));
+    }
+
+    [Test]
+    public void Handle_FirstRequestMode_NoExplicitUrl_LogsAutoDetectionEnabled()
+    {
+        var settings = new WebRoutingSettings { ApplicationUrlDetection = ApplicationUrlDetection.FirstRequest };
+        var sut = CreateHandler(settings);
+
+        sut.Handle(new UmbracoApplicationStartedNotification(false));
+
+        Assert.That(_logger.LogEntries, Has.Exactly(1).Matches<FakeLogger.LogEntry>(
+            e => e.Level == LogLevel.Information && e.Message.Contains("auto-detection is enabled")));
+    }
+
+    [Test]
+    public void Handle_EveryRequestMode_NoExplicitUrl_LogsAutoDetectionEnabled()
+    {
+        var settings = new WebRoutingSettings { ApplicationUrlDetection = ApplicationUrlDetection.EveryRequest };
+        var sut = CreateHandler(settings);
+
+        sut.Handle(new UmbracoApplicationStartedNotification(false));
+
+        Assert.That(_logger.LogEntries, Has.Exactly(1).Matches<FakeLogger.LogEntry>(
+            e => e.Level == LogLevel.Information && e.Message.Contains("auto-detection is enabled")));
+    }
+
+    [Test]
+    public void Handle_WithExplicitUrl_DoesNotLogWarning()
+    {
+        var settings = new WebRoutingSettings
+        {
+            UmbracoApplicationUrl = "https://my-site.com",
+            ApplicationUrlDetection = ApplicationUrlDetection.None,
+        };
+        var sut = CreateHandler(settings);
+
+        sut.Handle(new UmbracoApplicationStartedNotification(false));
+
+        Assert.That(_logger.LogEntries, Has.None.Matches<FakeLogger.LogEntry>(
+            e => e.Level == LogLevel.Warning));
+    }
+
+    private ApplicationUrlConfigurationNotificationHandler CreateHandler(WebRoutingSettings settings)
+    {
+        var optionsMonitor = Mock.Of<IOptionsMonitor<WebRoutingSettings>>(
+            m => m.CurrentValue == settings);
+        return new ApplicationUrlConfigurationNotificationHandler(_logger, optionsMonitor);
+    }
+
+    /// <summary>
+    ///     Simple logger that captures log entries for assertion, avoiding Moq proxy issues
+    ///     with <c>ILogger&lt;T&gt;</c> of internal types.
+    /// </summary>
+    private sealed class FakeLogger : ILogger<ApplicationUrlConfigurationNotificationHandler>
+    {
+        public List<LogEntry> LogEntries { get; } = [];
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => LogEntries.Add(new LogEntry(logLevel, formatter(state, exception)));
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public record LogEntry(LogLevel Level, string Message);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/AspNetCoreHostingEnvironmentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/AspNetCoreHostingEnvironmentTests.cs
@@ -40,10 +40,10 @@ public class AspNetCoreHostingEnvironmentTests
         Assert.AreEqual("~/Views/Template.cshtml", PathUtility.EnsurePathIsApplicationRootPrefixed("~/Views/Template.cshtml"));
     }
 
-    [AutoMoqData]
     [Test]
-    public void EnsureApplicationMainUrl(AspNetCoreHostingEnvironment sut)
+    public void EnsureApplicationMainUrl()
     {
+        var sut = CreateWithDefaultConfig(ApplicationUrlDetection.FirstRequest);
         var url = new Uri("http://localhost:5000");
         sut.EnsureApplicationMainUrl(url);
         Assert.AreEqual(sut.ApplicationMainUrl, url);
@@ -52,12 +52,15 @@ public class AspNetCoreHostingEnvironmentTests
     /// <summary>
     /// Creates an AspNetCoreHostingEnvironment with UmbracoApplicationUrl = null,
     /// simulating the default configuration where no explicit URL is configured.
-    /// This is the scenario where host header poisoning is possible.
     /// </summary>
-    private static AspNetCoreHostingEnvironment CreateWithDefaultConfig()
+    private static AspNetCoreHostingEnvironment CreateWithDefaultConfig(
+        ApplicationUrlDetection detection = ApplicationUrlDetection.FirstRequest)
     {
         var hostingSettings = new HostingSettings();
-        var webRoutingSettings = new WebRoutingSettings(); // UmbracoApplicationUrl defaults to null
+        var webRoutingSettings = new WebRoutingSettings
+        {
+            ApplicationUrlDetection = detection,
+        };
 
         var hostingSettingsMonitor = Mock.Of<IOptionsMonitor<HostingSettings>>(
             m => m.CurrentValue == hostingSettings);
@@ -78,10 +81,10 @@ public class AspNetCoreHostingEnvironmentTests
     [Test]
     public void EnsureApplicationMainUrl_LocksAfterFirstUrl()
     {
-        var sut = CreateWithDefaultConfig();
+        var sut = CreateWithDefaultConfig(ApplicationUrlDetection.FirstRequest);
 
         var legitimateUrl = new Uri("https://legit-site.com");
-        var attackerUrl = new Uri("https://evil.com");
+        var attackerUrl = new Uri("https://non-configured-site.com");
 
         // Step 1: Normal traffic sets the URL
         sut.EnsureApplicationMainUrl(legitimateUrl);
@@ -99,7 +102,7 @@ public class AspNetCoreHostingEnvironmentTests
     [Test]
     public void EnsureApplicationMainUrl_IgnoresSubsequentUrls()
     {
-        var sut = CreateWithDefaultConfig();
+        var sut = CreateWithDefaultConfig(ApplicationUrlDetection.FirstRequest);
 
         var legitimateUrl = new Uri("https://legit-site.com");
 
@@ -113,13 +116,113 @@ public class AspNetCoreHostingEnvironmentTests
     [Test]
     public void EnsureApplicationMainUrl_NullDoesNotLock()
     {
-        var sut = CreateWithDefaultConfig();
+        var sut = CreateWithDefaultConfig(ApplicationUrlDetection.FirstRequest);
 
         sut.EnsureApplicationMainUrl(null);
 
         var url = new Uri("https://legit-site.com");
         sut.EnsureApplicationMainUrl(url);
         Assert.AreEqual(url, sut.ApplicationMainUrl);
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_NoneMode_NeverSetsUrl()
+    {
+        var sut = CreateWithDefaultConfig(ApplicationUrlDetection.None);
+
+        sut.EnsureApplicationMainUrl(new Uri("https://legit-site.com"));
+
+        Assert.IsNull(sut.ApplicationMainUrl);
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_NoneMode_ExplicitConfigStillWorks()
+    {
+        var webRoutingSettings = new WebRoutingSettings
+        {
+            UmbracoApplicationUrl = "https://configured-site.com",
+            ApplicationUrlDetection = ApplicationUrlDetection.None,
+        };
+
+        var hostingSettingsMonitor = Mock.Of<IOptionsMonitor<HostingSettings>>(
+            m => m.CurrentValue == new HostingSettings());
+        var webRoutingSettingsMonitor = Mock.Of<IOptionsMonitor<WebRoutingSettings>>(
+            m => m.CurrentValue == webRoutingSettings);
+
+        var webHostEnvironment = new Mock<IWebHostEnvironment>();
+        webHostEnvironment.Setup(e => e.ContentRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.WebRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.ApplicationName).Returns("TestApp");
+
+        var sut = new AspNetCoreHostingEnvironment(
+            hostingSettingsMonitor,
+            webRoutingSettingsMonitor,
+            webHostEnvironment.Object);
+
+        // Explicit config is set in the constructor, not via auto-detection
+        Assert.AreEqual(new Uri("https://configured-site.com"), sut.ApplicationMainUrl);
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_EveryRequest_OverwritesOnNewUrl()
+    {
+        var sut = CreateWithDefaultConfig(ApplicationUrlDetection.EveryRequest);
+
+        var url1 = new Uri("https://site-a.com");
+        var url2 = new Uri("https://site-b.com");
+
+        sut.EnsureApplicationMainUrl(url1);
+        Assert.AreEqual(url1, sut.ApplicationMainUrl);
+
+        sut.EnsureApplicationMainUrl(url2);
+        Assert.AreEqual(url2, sut.ApplicationMainUrl, "New URL should overwrite in EveryRequest mode");
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_EveryRequest_SameUrlNoOp()
+    {
+        var sut = CreateWithDefaultConfig(ApplicationUrlDetection.EveryRequest);
+
+        var url = new Uri("https://site-a.com");
+        sut.EnsureApplicationMainUrl(url);
+        sut.EnsureApplicationMainUrl(url);
+
+        Assert.AreEqual(url, sut.ApplicationMainUrl, "Repeated same URL is a no-op");
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_EveryRequest_ExplicitConfigTakesPrecedence()
+    {
+        var webRoutingSettings = new WebRoutingSettings
+        {
+            UmbracoApplicationUrl = "https://configured-site.com",
+            ApplicationUrlDetection = ApplicationUrlDetection.EveryRequest,
+        };
+
+        var hostingSettingsMonitor = Mock.Of<IOptionsMonitor<HostingSettings>>(
+            m => m.CurrentValue == new HostingSettings());
+        var webRoutingSettingsMonitor = Mock.Of<IOptionsMonitor<WebRoutingSettings>>(
+            m => m.CurrentValue == webRoutingSettings);
+
+        var webHostEnvironment = new Mock<IWebHostEnvironment>();
+        webHostEnvironment.Setup(e => e.ContentRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.WebRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.ApplicationName).Returns("TestApp");
+
+        var sut = new AspNetCoreHostingEnvironment(
+            hostingSettingsMonitor,
+            webRoutingSettingsMonitor,
+            webHostEnvironment.Object);
+
+        Assert.AreEqual(new Uri("https://configured-site.com"), sut.ApplicationMainUrl);
+
+        // Attempt to overwrite via auto-detection
+        sut.EnsureApplicationMainUrl(new Uri("https://non-configured-site.com"));
+
+        Assert.AreEqual(
+            new Uri("https://configured-site.com"),
+            sut.ApplicationMainUrl,
+            "Explicit config prevents auto-detection overwrite");
     }
 
     [Test]
@@ -148,10 +251,10 @@ public class AspNetCoreHostingEnvironmentTests
 
         Assert.AreEqual(new Uri("https://configured-site.com"), sut.ApplicationMainUrl);
 
-        // Attempt poisoning
-        sut.EnsureApplicationMainUrl(new Uri("https://evil.com"));
+        // Attempt override.
+        sut.EnsureApplicationMainUrl(new Uri("https://non-configured-site.com"));
 
-        // Should remain configured value
+        // Should remain configured value.
         Assert.AreEqual(
             new Uri("https://configured-site.com"),
             sut.ApplicationMainUrl,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/AspNetCoreHostingEnvironmentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/AspNetCoreHostingEnvironmentTests.cs
@@ -1,7 +1,11 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Tests.UnitTests.AutoFixture;
 using Umbraco.Cms.Web.Common.AspNetCore;
@@ -43,5 +47,114 @@ public class AspNetCoreHostingEnvironmentTests
         var url = new Uri("http://localhost:5000");
         sut.EnsureApplicationMainUrl(url);
         Assert.AreEqual(sut.ApplicationMainUrl, url);
+    }
+
+    /// <summary>
+    /// Creates an AspNetCoreHostingEnvironment with UmbracoApplicationUrl = null,
+    /// simulating the default configuration where no explicit URL is configured.
+    /// This is the scenario where host header poisoning is possible.
+    /// </summary>
+    private static AspNetCoreHostingEnvironment CreateWithDefaultConfig()
+    {
+        var hostingSettings = new HostingSettings();
+        var webRoutingSettings = new WebRoutingSettings(); // UmbracoApplicationUrl defaults to null
+
+        var hostingSettingsMonitor = Mock.Of<IOptionsMonitor<HostingSettings>>(
+            m => m.CurrentValue == hostingSettings);
+        var webRoutingSettingsMonitor = Mock.Of<IOptionsMonitor<WebRoutingSettings>>(
+            m => m.CurrentValue == webRoutingSettings);
+
+        var webHostEnvironment = new Mock<IWebHostEnvironment>();
+        webHostEnvironment.Setup(e => e.ContentRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.WebRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.ApplicationName).Returns("TestApp");
+
+        return new AspNetCoreHostingEnvironment(
+            hostingSettingsMonitor,
+            webRoutingSettingsMonitor,
+            webHostEnvironment.Object);
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_LocksAfterFirstUrl()
+    {
+        var sut = CreateWithDefaultConfig();
+
+        var legitimateUrl = new Uri("https://legit-site.com");
+        var attackerUrl = new Uri("https://evil.com");
+
+        // Step 1: Normal traffic sets the URL
+        sut.EnsureApplicationMainUrl(legitimateUrl);
+        Assert.AreEqual(legitimateUrl, sut.ApplicationMainUrl, "Initial legitimate URL should be set");
+
+        // Step 2: Attacker sends request with forged Host header — must be ignored
+        sut.EnsureApplicationMainUrl(attackerUrl);
+        Assert.AreEqual(legitimateUrl, sut.ApplicationMainUrl, "Attacker URL must not overwrite the legitimate URL");
+
+        // Step 3: Legitimate traffic continues — URL remains stable
+        sut.EnsureApplicationMainUrl(legitimateUrl);
+        Assert.AreEqual(legitimateUrl, sut.ApplicationMainUrl, "Legitimate URL is retained");
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_IgnoresSubsequentUrls()
+    {
+        var sut = CreateWithDefaultConfig();
+
+        var legitimateUrl = new Uri("https://legit-site.com");
+
+        sut.EnsureApplicationMainUrl(legitimateUrl);
+        sut.EnsureApplicationMainUrl(new Uri("https://evil1.com"));
+        sut.EnsureApplicationMainUrl(new Uri("https://evil2.com"));
+
+        Assert.AreEqual(legitimateUrl, sut.ApplicationMainUrl, "First URL is locked, all subsequent URLs are ignored");
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_NullDoesNotLock()
+    {
+        var sut = CreateWithDefaultConfig();
+
+        sut.EnsureApplicationMainUrl(null);
+
+        var url = new Uri("https://legit-site.com");
+        sut.EnsureApplicationMainUrl(url);
+        Assert.AreEqual(url, sut.ApplicationMainUrl);
+    }
+
+    [Test]
+    public void EnsureApplicationMainUrl_WithExplicitConfig_IgnoresHostHeader()
+    {
+        // When UmbracoApplicationUrl IS configured, poisoning should be impossible
+        var webRoutingSettings = new WebRoutingSettings
+        {
+            UmbracoApplicationUrl = "https://configured-site.com",
+        };
+
+        var hostingSettingsMonitor = Mock.Of<IOptionsMonitor<HostingSettings>>(
+            m => m.CurrentValue == new HostingSettings());
+        var webRoutingSettingsMonitor = Mock.Of<IOptionsMonitor<WebRoutingSettings>>(
+            m => m.CurrentValue == webRoutingSettings);
+
+        var webHostEnvironment = new Mock<IWebHostEnvironment>();
+        webHostEnvironment.Setup(e => e.ContentRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.WebRootPath).Returns(Path.GetTempPath());
+        webHostEnvironment.Setup(e => e.ApplicationName).Returns("TestApp");
+
+        var sut = new AspNetCoreHostingEnvironment(
+            hostingSettingsMonitor,
+            webRoutingSettingsMonitor,
+            webHostEnvironment.Object);
+
+        Assert.AreEqual(new Uri("https://configured-site.com"), sut.ApplicationMainUrl);
+
+        // Attempt poisoning
+        sut.EnsureApplicationMainUrl(new Uri("https://evil.com"));
+
+        // Should remain configured value
+        Assert.AreEqual(
+            new Uri("https://configured-site.com"),
+            sut.ApplicationMainUrl,
+            "Explicit config prevents host header poisoning");
     }
 }


### PR DESCRIPTION
### Description

Previously, `ApplicationMainUrl` was automatically set from the `Host` header of incoming HTTP requests. In environments where Umbraco is not behind a reverse proxy that validates the Host header, this could allow a forged `Host` header to overwrite the URL used in password reset links, user invitations, and other email notifications. While this is normally mitigated by proper hosting configuration and setting `UmbracoApplicationUrl` explicitly, the auto-detection behaviour should be hardened up and become an opt-in rather than the default.

This PR adds a new `ApplicationUrlDetection` setting (`Umbraco:CMS:WebRouting:ApplicationUrlDetection`) that gives administrators control over how the application URL is discovered:

| Value | Behaviour |
|-------|-----------|
| `None` (default) | No auto-detection. The URL must be set explicitly via `UmbracoApplicationUrl`. Operations that require it (invitations, password resets) return an error with guidance. |
| `FirstRequest` | URL is set from the first HTTP request and then locked. Subsequent requests with different Host headers are ignored. |
| `EveryRequest` | Original/legacy behaviour. Every new URL from an incoming request can overwrite `ApplicationMainUrl`. |

`UmbracoApplicationUrl` always takes precedence regardless of this setting.

#### Changes

**New configuration:**
- `ApplicationUrlDetection` enum (`None`, `FirstRequest`, `EveryRequest`) in `Umbraco.Core`.
- New property on `WebRoutingSettings` with `None` as default.

**Application URL detection (`AspNetCoreHostingEnvironment`):**
- `EnsureApplicationMainUrl` respects the detection mode.
- `EveryRequest` preserves the exact legacy code path.
- `FirstRequest` locks after first URL is set.

**Email operations (`ForgotPasswordUriProvider`, `InviteUriProvider`):**
- Return `UserOperationStatus.ApplicationUrlNotConfigured` when `ApplicationMainUrl` is null.
- Mapped to `400 Bad Request` with actionable error message in both `SecurityControllerBase` and `UserOrCurrentUserControllerBase`.
- `ResetPasswordController` surfaces this error to users of the feature.

**Health checks (`HttpsCheck`, `BaseHttpHeaderCheck`, `ExcessiveHeadersCheck`):**
- Null guards added — return informational status instead of throwing `NullReferenceException` when `ApplicationMainUrl` is unavailable.

**Middleware logging:**
- Logs a warning when no URL is available with guidance on how to resolve.
- Logs a single information line when the application URL is "configured" or "auto-detected".

### Test plan

#### Automated

```bash
dotnet test --filter "AspNetCoreHostingEnvironmentTests|UriProviderTests"
```

18 unit tests covering all three detection modes, explicit config precedence, and URI provider behaviour.

#### Manual testing

**Prerequisites:**
- Run `src/Umbraco.Web.UI` locally with Kestrel
- Ensure SMTP is configured (or use a mail catcher like [smtp4dev](https://github.com/rnwood/smtp4dev))
- Remove any existing `Umbraco:CMS:WebRouting:UmbracoApplicationUrl` from configuration unless the scenario specifies it

---

**Scenario 1: `None` mode (default) — no explicit URL configured**

Config: No `UmbracoApplicationUrl` set, no `ApplicationUrlDetection` set (defaults to `None`).

1. Start the application, browse to `https://localhost:{port}/umbraco`
2. Check the application log output

Expected:
- [x] A one-time warning is logged: *"Application URL auto-detection is disabled and no explicit URL is configured..."*.
- [x] The warning appears only once.

3. In the backoffice, go to Users and invite a new user

Expected:
- [x] The invitation fails with a `400 Bad Request` response indicating the application URL is not configured.
- [x] No invitation email is sent.

4. Log out. Click "Forgot password", submit a valid email

Expected:
- [x] Returns `400 Bad Request` with an error indicating the application URL is not configured.
- [x] No password reset email is sent.

---

**Scenario 2: `None` mode — explicit URL configured**

Config: `"UmbracoApplicationUrl": "https://localhost:{port}"`

1. Start the application, browse to the backoffice
2. Check the application log output

Expected:
- [x] Info message logged: *"Application URL configured as https://localhost:{port}."*.

3. Invite a user / trigger a password reset

Expected:
- [x] Email links are absolute, using the configured URL.

---

**Scenario 3: `FirstRequest` mode**

Config: `"ApplicationUrlDetection": "FirstRequest"`

1. Start the application, browse to `https://localhost:{port}/umbraco`

Expected:
- [ ] Info message logged: *"Application URL auto-detected as https://localhost:{port}/."*

2. Send forged Host header requests:
   ```bash
   curl -k -H "Host: not-configured.com" https://localhost:{port}/
   ```
3. Invite a user and trigger a password reset

Expected:
- [x] Both emails use the original detected URL, **not** the forged hosts.

---

**Scenario 4: `EveryRequest` mode (legacy behaviour)**

Config: `"ApplicationUrlDetection": "EveryRequest"`

1. Start the application, browse to the backoffice
2. Send a forged Host header request:
   ```bash
   curl -k -H "Host: not-configured.com" https://localhost:{port}/
   ```
3. Invite a user

Expected:
- [x] The invite email uses `not-configured.com` — confirms legacy behaviour is preserved.

---

**Scenario 5: Explicit config takes precedence over detection mode**

Config: `"UmbracoApplicationUrl": "https://localhost:{port}"`, `"ApplicationUrlDetection": "EveryRequest"`

1. Start the application, send a forged Host header, invite a user

Expected:
- [x] Info message logged: *"Application URL configured as https://[my-production-site.com/](localhost:{port})."*
- [x] Email uses `https://[my-production-site.com/](localhost:{port})...` — explicit config wins

---

**Scenario 6: Health checks — no URL available**

Config: No `UmbracoApplicationUrl`, default `None` mode.

1. Log into the backoffice, navigate to _Settings > Health Check > Security_, run checks

Expected:
- [x] HTTPS Configuration, HSTS, and Excessive Headers all show informational status rather than crashing.

---

**Scenario 7: Health checks — URL available**

Config: `"ApplicationUrlDetection": "FirstRequest"`

1. Browse to the backoffice (triggers auto-detection), run health checks

Expected:
- [x] All security health checks run normally against the detected URL