### PR TITLE
Block Grid: Protect against null columnSpan/rowSpan when rendering blocks (closes #22306)

### DIFF
--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
@@ -66,7 +66,7 @@ internal sealed class BlockGridPropertyValueCreator : BlockPropertyValueCreatorB
                 }
 
                 var items = area.Items.Select(item => createBlockItem(item)).WhereNotNull().ToList();
-                return new BlockGridArea(items, areaConfig.Alias!, areaConfig.RowSpan ?? DefaultRowSpan, areaConfig.ColumnSpan ?? DefaultColumnSpan);
+                return new BlockGridArea(items, areaConfig.Alias!, areaConfig.RowSpan ?? DefaultRowSpan, areaConfig.ColumnSpan ?? blockConfig.AreaGridColumns ?? gridColumns ?? DefaultColumnSpan);
             }).WhereNotNull().ToArray();
 
             return blockItem;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockGridNullSpanTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockGridNullSpanTests.cs
@@ -13,12 +13,12 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.PropertyEditors;
 /// Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22306
 /// BlockGrid throws "Nullable object must have a value" when a block item has null columnSpan/rowSpan.
 /// </summary>
-internal sealed class BlockGridNullColumnSpanTests : BlockEditorElementVariationTestBase
+internal sealed class BlockGridNullSpanTests : BlockEditorElementVariationTestBase
 {
     private IJsonSerializer JsonSerializer => GetRequiredService<IJsonSerializer>();
 
     [Test]
-    public async Task Can_Render_BlockGrid_When_Items_Have_Null_ColumnSpan()
+    public async Task Can_Render_BlockGrid_When_Items_Have_Null_Spans()
     {
         var elementType = CreateElementType(ContentVariation.Nothing);
         var areaKey = Guid.NewGuid();
@@ -81,13 +81,17 @@ internal sealed class BlockGridNullColumnSpanTests : BlockEditorElementVariation
 
         Assert.IsNotNull(blocks);
         Assert.AreEqual(1, blocks!.Count);
+
+        // Null RowSpan defaults to 1, null ColumnSpan defaults to gridColumns (12).
         Assert.AreEqual(1, blocks[0].RowSpan);
-        Assert.Greater(blocks[0].ColumnSpan, 0);
+        Assert.AreEqual(12, blocks[0].ColumnSpan);
 
         var area = blocks[0].Areas.FirstOrDefault();
         Assert.IsNotNull(area);
         Assert.AreEqual(1, area!.Count);
+
+        // Nested item gets the same defaults.
         Assert.AreEqual(1, area[0].RowSpan);
-        Assert.Greater(area[0].ColumnSpan, 0);
+        Assert.AreEqual(12, area[0].ColumnSpan);
     }
 }


### PR DESCRIPTION
## Description

This PR replaces the null-forgiving `!.Value` access on `BlockGridLayoutItem.ColumnSpan` and `RowSpan` with null-coalescing defaults (`?? gridColumns ?? 12` for columns, `?? 1` for rows) in `BlockGridPropertyValueCreator`.

This comes from issue #22306 which reports that when the backoffice produces BlockGrid JSON with `columnSpan: null` for items inside areas, rendering the page throws `InvalidOperationException: Nullable object must have a value`. The properties are declared as `int?` on `BlockGridLayoutItem`, so the code should handle null gracefully.

I have not been able to replicate this via the backoffice UI, but the defensive coding makes sense regardless — the model explicitly allows null, and the fix is low-risk with clear defaults matching the standard 12-column grid.

## Testing

- [ ] **Automated**: Run `dotnet test --filter "FullyQualifiedName~BlockGridNullColumnSpanTests"` — the new integration test covers both root-level and nested null span scenarios.
- [ ] **Manual**: Create a Document Type with a BlockGrid property containing a container element type with an area. Add a content block inside the area. Save, publish, and render the page on the frontend — verify no exception is thrown.