### PR TITLE
Fix for Redirect URLs that do not contain a backslash (fixes 22308)

### DIFF
--- a/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
@@ -220,23 +220,27 @@ public class NewDefaultUrlProvider : IUrlProvider
         // extract domainUri and path
         // route is /<path> or <domainRootId>/<path>
         var pos = route.IndexOf('/', StringComparison.Ordinal);
-        var path = pos == 0 ? route : route[pos..];
-        DomainAndUri? domainUri = pos == 0
-            ? null
-            : DomainUtilities.DomainForNode(
-                _domainCache,
-                _siteDomainMapper,
-                int.Parse(route[..pos], CultureInfo.InvariantCulture),
-                current,
-                culture);
 
-        var defaultCulture = _languageService.GetDefaultIsoCodeAsync().GetAwaiter().GetResult();
-        if (domainUri is not null ||
-            string.IsNullOrEmpty(culture) ||
-            culture.Equals(defaultCulture, StringComparison.InvariantCultureIgnoreCase))
+        if (pos >= 0)
         {
-            Uri url = AssembleUrl(domainUri, path, current, mode);
-            return UrlInfo.FromUri(url, Alias, culture);
+            var path = pos == 0 ? route : route[pos..];
+            DomainAndUri? domainUri = pos == 0
+                ? null
+                : DomainUtilities.DomainForNode(
+                    _domainCache,
+                    _siteDomainMapper,
+                    int.Parse(route[..pos], CultureInfo.InvariantCulture),
+                    current,
+                    culture);
+
+            var defaultCulture = _languageService.GetDefaultIsoCodeAsync().GetAwaiter().GetResult();
+            if (domainUri is not null ||
+                string.IsNullOrEmpty(culture) ||
+                culture.Equals(defaultCulture, StringComparison.InvariantCultureIgnoreCase))
+            {
+                Uri url = AssembleUrl(domainUri, path, current, mode);
+                return UrlInfo.FromUri(url, Alias, culture);
+            }
         }
 
         return null;


### PR DESCRIPTION
### Prerequisites

I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/22308

### Description

The Redirect URL Management page crashes if the umbracoRedirectUrl table contains a malformed row where the Url value does not contain a / character.

The root cause is in NewDefaultUrlProvider.GetUrlFromRoute, which assumes the route is always in the format {contentId}/{path}.

When IndexOf('/') returns -1 (no / present), the code proceeds to call Substring with a negative index, throwing an ArgumentOutOfRangeException. This propagates and crashes the entire Redirect URL Management page during serialization rather than gracefully handling the invalid row.

### Fix

The existing route processing logic has been wrapped in a if (pos >= 0) guard, returning null when no / is found in the route:

```
var pos = route.IndexOf('/', StringComparison.Ordinal);

if (pos >= 0)
{
    // existing path/domain resolution logic
    ...
    return UrlInfo.FromUri(url, Alias, culture);
}

return null;
```

This ensures that malformed routes without a / are safely handled without throwing an exception.

### How to reproduce

The malformed URL is believed to be the result of a migration (the issue was originally reported on a v13 to v17 upgrade), however I was unable to reproduce the malformed data through normal site usage. To test this fix, the Url value of a row in the umbracoRedirectUrl table can be manually set to a value containing no / character (e.g. 1226#). The exact scenario that originally caused the malformed data to be written is unknown.

### Steps to test

1. Directly update a row in the umbracoRedirectUrl table, setting Url to a value with no / (e.g. UPDATE umbracoRedirectUrl SET Url = '1226#' WHERE Id = )
2. Navigate to the Redirect URL Management dashboard in the Umbraco backoffice
3. Without the fix, the page crashes with an ArgumentOutOfRangeException
4. With the fix applied, the page loads successfully, skipping the malformed row