### PR TITLE
Background Jobs: Fix period drift in RecurringHostedServiceBase

### DIFF
--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -153,8 +153,11 @@ public abstract class RecurringHostedServiceBase : IHostedService, IDisposable
         {
             sw.Stop();
 
-            // Subtract elapsed time to prevent period drift; clamp to zero if execution exceeded the period.
-            TimeSpan remaining = ComputeNextDelay(_period, sw.Elapsed);
+            // If the service has been stopped, _period is set to InfiniteTimeSpan in StopAsync.
+            // Preserve it to keep the timer disabled.
+            TimeSpan remaining = _period == Timeout.InfiniteTimeSpan
+                ? Timeout.InfiniteTimeSpan
+                : ComputeNextDelay(_period, sw.Elapsed);
             _timer?.Change(remaining, _period);
         }
     }
@@ -182,6 +185,9 @@ public abstract class RecurringHostedServiceBase : IHostedService, IDisposable
     {
         TimeSpan remaining = period - elapsed;
 
+        // A negative period (e.g. Timeout.InfiniteTimeSpan = -1ms, set by StopAsync) will always produce a
+        // negative remaining value. The caller in ExecuteAsync guards against this by checking for InfiniteTimeSpan
+        // before calling this method, to avoid scheduling an extra execution after stop.
         return remaining < TimeSpan.Zero ? TimeSpan.Zero : remaining;
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBaseTests.cs
@@ -102,4 +102,15 @@ public class RecurringHostedServiceBaseTests
 
         Assert.AreEqual(TimeSpan.Zero, result);
     }
+
+    [Test]
+    public void ComputeNextDelay_Returns_Zero_For_Negative_Period()
+    {
+        var period = TimeSpan.FromMilliseconds(-1);
+        var elapsed = TimeSpan.FromSeconds(1);
+
+        TimeSpan result = RecurringHostedServiceBase.ComputeNextDelay(period, elapsed);
+
+        Assert.AreEqual(TimeSpan.Zero, result);
+    }
 }


### PR DESCRIPTION
## Summary

`RecurringHostedServiceBase` provides a `GetDelay(firstRunTime, cronTabParser, ...)` method that computes the initial delay from a crontab expression, allowing background jobs to be aligned to specific clock times (e.g. "run at 02:00 every night"). The `HealthChecksNotificationSettings.FirstRunTime` configuration uses this exact pattern.

However, this alignment only applies to the **first execution**. After that, the `Timer` reschedules using a fixed period — without accounting for the time the job itself took to execute. Each execution shifts the next tick forward by its own duration:

**Example**: A job configured to run every 6 hours starting at 02:00
- First run: 02:00 (correct, aligned via crontab)
- Job takes 5 seconds to execute
- Next run: 08:00:**05** (5s late — Timer waited a full 6h *after* execution finished)
- Next run: 14:00:**10** (10s late)
- After 30 days of 4 runs/day: **10 minutes of accumulated drift**

For long-running jobs or short periods, the drift is worse. A job with a 5-minute period that takes 10 seconds per execution drifts by 2 minutes per hour.

### Fix

After each execution, subtract the elapsed execution time from the period before rescheduling the `Timer`. If the execution took longer than the period, clamp to zero (execute immediately). This is done via a `Stopwatch` around `PerformExecuteAsync` and the new `ComputeNextDelay` helper.

## Test plan

- [x] `ComputeNextDelay` unit tests: normal subtraction, overshoot clamping, zero elapsed, exact match
- [ ] Verify existing `RecurringHostedServiceBase` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)