### PR TITLE
Relations: Fire relation notifications for automatic relations (closes #22222)

### DIFF
--- a/src/Umbraco.Core/Notifications/RelationDeletedNotification.cs
+++ b/src/Umbraco.Core/Notifications/RelationDeletedNotification.cs
@@ -20,6 +20,7 @@ public class RelationDeletedNotification : DeletedNotification<IRelation>
         : base(target, messages)
     {
     }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RelationDeletedNotification"/>.
     /// </summary>
@@ -33,4 +34,11 @@ public class RelationDeletedNotification : DeletedNotification<IRelation>
         : base(target, messages)
     {
     }
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether the relations were deleted automatically
+    ///     as a side-effect of content being saved (e.g. umbMedia, umbDocument, umbMember),
+    ///     rather than explicitly via <see cref="IRelationService"/>.
+    /// </summary>
+    public bool IsAutomatic { get; set; }
 }

--- a/src/Umbraco.Core/Notifications/RelationSavedNotification.cs
+++ b/src/Umbraco.Core/Notifications/RelationSavedNotification.cs
@@ -20,6 +20,7 @@ public class RelationSavedNotification : SavedNotification<IRelation>
         : base(target, messages)
     {
     }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RelationSavedNotification"/>.
     /// </summary>
@@ -33,4 +34,17 @@ public class RelationSavedNotification : SavedNotification<IRelation>
         : base(target, messages)
     {
     }
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether the relations were saved automatically
+    ///     as a side-effect of content being saved (e.g. umbMedia, umbDocument, umbMember),
+    ///     rather than explicitly via <see cref="IRelationService"/>.
+    /// </summary>
+    /// <remarks>
+    ///     When <c>true</c>, the <see cref="IRelation.Id"/> of each saved entity may be <c>0</c>
+    ///     because automatic relations are persisted via a bulk operation that does not return
+    ///     database identities. <see cref="IRelation.ParentId"/>, <see cref="IRelation.ChildId"/>,
+    ///     and <see cref="IRelation.RelationType"/> are always populated.
+    /// </remarks>
+    public bool IsAutomatic { get; set; }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
@@ -112,6 +112,11 @@ internal sealed class ContentRelationsUpdate :
             .Where(x => automaticRelationTypeAliases.Contains(x.Alias))
             .ToDictionary(x => x.Alias);
 
+        if (relationTypeLookup.Count == 0)
+        {
+            return;
+        }
+
         // Lookup node IDs for all GUID based UDIs.
         IEnumerable<Guid> keys = references.Select(x => x.Udi).OfType<GuidUdi>().Select(x => x.Guid);
         var keysLookup = scope.Database.FetchByGroups<NodeIdKey, Guid>(keys, Constants.Sql.MaxParameterCount, guids =>
@@ -197,9 +202,15 @@ internal sealed class ContentRelationsUpdate :
 
     private IRelation[] GetExistingAutomaticRelations(IScope scope, int entityId, ISet<string> automaticRelationTypeAliases)
     {
-        IEnumerable<int> relationTypeIds = _relationTypeRepository.GetMany(Array.Empty<int>())
+        int[] relationTypeIds = _relationTypeRepository.GetMany(Array.Empty<int>())
             .Where(x => automaticRelationTypeAliases.Contains(x.Alias))
-            .Select(x => x.Id);
+            .Select(x => x.Id)
+            .ToArray();
+
+        if (relationTypeIds.Length == 0)
+        {
+            return [];
+        }
 
         IQuery<IRelation> query = scope.SqlContext.Query<IRelation>()
             .Where(x => x.ParentId == entityId)

--- a/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
 using Umbraco.Cms.Core.Notifications;
@@ -92,17 +93,24 @@ internal sealed class ContentRelationsUpdate :
 
         if (references.Count == 0)
         {
+            // Query existing relations before deleting, so we can publish notifications.
+            IRelation[] deletedRelations = GetExistingAutomaticRelations(scope, entity.Id, automaticRelationTypeAliases);
+
             // Delete all relations using the automatic relation type aliases.
             _relationRepository.DeleteByParent(entity.Id, automaticRelationTypeAliases.ToArray());
 
-            // No need to add new references/relations
+            if (deletedRelations.Length > 0)
+            {
+                scope.Notifications.Publish(new RelationDeletedNotification(deletedRelations, new EventMessages()) { IsAutomatic = true });
+            }
+
             return;
         }
 
-        // Lookup all relation type IDs.
+        // Lookup all relation types.
         var relationTypeLookup = _relationTypeRepository.GetMany(Array.Empty<int>())
             .Where(x => automaticRelationTypeAliases.Contains(x.Alias))
-            .ToDictionary(x => x.Alias, x => x.Id);
+            .ToDictionary(x => x.Alias);
 
         // Lookup node IDs for all GUID based UDIs.
         IEnumerable<Guid> keys = references.Select(x => x.Udi).OfType<GuidUdi>().Select(x => x.Guid);
@@ -123,12 +131,12 @@ internal sealed class ContentRelationsUpdate :
                 // Reference does not specify a relation type alias, so skip adding a relation.
                 _logger.LogDebug("The reference to {Udi} does not specify a relation type alias, so it will not be saved as relation.", reference.Udi);
             }
-            else if (!automaticRelationTypeAliases.Contains(reference.RelationTypeAlias))
+            else if (automaticRelationTypeAliases.Contains(reference.RelationTypeAlias) is false)
             {
                 // Returning a reference that doesn't use an automatic relation type is an issue that should be fixed in code.
                 _logger.LogError("The reference to {Udi} uses a relation type {RelationTypeAlias} that is not an automatic relation type.", reference.Udi, reference.RelationTypeAlias);
             }
-            else if (!relationTypeLookup.TryGetValue(reference.RelationTypeAlias, out int relationTypeId))
+            else if (relationTypeLookup.TryGetValue(reference.RelationTypeAlias, out IRelationType? relationType) is false)
             {
                 // A non-existent relation type could be caused by an environment issue (e.g. it was manually removed).
                 _logger.LogWarning("The reference to {Udi} uses a relation type {RelationTypeAlias} that does not exist.", reference.Udi, reference.RelationTypeAlias);
@@ -140,24 +148,64 @@ internal sealed class ContentRelationsUpdate :
             }
             else
             {
-                relations.Add((id, relationTypeId));
+                relations.Add((id, relationType.Id));
             }
         }
 
         // Get all existing relations (optimize for adding new and keeping existing relations).
-        IQuery<IRelation> query = scope.SqlContext.Query<IRelation>().Where(x => x.ParentId == entity.Id).WhereIn(x => x.RelationTypeId, relationTypeLookup.Values);
+        IQuery<IRelation> query = scope.SqlContext.Query<IRelation>()
+            .Where(x => x.ParentId == entity.Id)
+            .WhereIn(x => x.RelationTypeId, relationTypeLookup.Values
+            .Select(x => x.Id));
         var existingRelations = _relationRepository.GetPagedRelationsByQuery(query, 0, int.MaxValue, out _, null)
             .ToDictionary(x => (x.ChildId, x.RelationTypeId)); // Relations are unique by parent ID, child ID and relation type ID.
 
         // Add relations that don't exist yet.
-        IEnumerable<ReadOnlyRelation> relationsToAdd = relations.Except(existingRelations.Keys).Select(x => new ReadOnlyRelation(entity.Id, x.ChildId, x.RelationTypeId));
+        var newRelationKeys = relations.Except(existingRelations.Keys).ToList();
+        IEnumerable<ReadOnlyRelation> relationsToAdd = newRelationKeys.Select(x => new ReadOnlyRelation(entity.Id, x.ChildId, x.RelationTypeId));
         _relationRepository.SaveBulk(relationsToAdd);
 
+        // Publish saved notification for the newly added relations.
+        // NOTE: Only RelationSavedNotification is published (not RelationSavingNotification) because
+        // SaveBulk is used for performance and does not support cancellation.
+        // The Relation objects will have Id = 0 because SaveBulk does not return database identities.
+        // ParentId, ChildId, and RelationType are fully populated.
+        if (newRelationKeys.Count > 0)
+        {
+            var relationTypeById = relationTypeLookup.Values.ToDictionary(x => x.Id);
+            IRelation[] savedRelations = newRelationKeys
+                .Where(x => relationTypeById.ContainsKey(x.RelationTypeId))
+                .Select(x => new Relation(entity.Id, x.ChildId, relationTypeById[x.RelationTypeId]))
+                .ToArray<IRelation>();
+
+            scope.Notifications.Publish(new RelationSavedNotification(savedRelations, new EventMessages()) { IsAutomatic = true });
+        }
+
         // Delete relations that don't exist anymore.
-        foreach (IRelation relation in existingRelations.Where(x => !relations.Contains(x.Key)).Select(x => x.Value))
+        IRelation[] relationsToDelete = existingRelations.Where(x => !relations.Contains(x.Key)).Select(x => x.Value).ToArray();
+        foreach (IRelation relation in relationsToDelete)
         {
             _relationRepository.Delete(relation);
         }
+
+        // Publish deleted notification for the removed relations.
+        if (relationsToDelete.Length > 0)
+        {
+            scope.Notifications.Publish(new RelationDeletedNotification(relationsToDelete, new EventMessages()) { IsAutomatic = true });
+        }
+    }
+
+    private IRelation[] GetExistingAutomaticRelations(IScope scope, int entityId, ISet<string> automaticRelationTypeAliases)
+    {
+        IEnumerable<int> relationTypeIds = _relationTypeRepository.GetMany(Array.Empty<int>())
+            .Where(x => automaticRelationTypeAliases.Contains(x.Alias))
+            .Select(x => x.Id);
+
+        IQuery<IRelation> query = scope.SqlContext.Query<IRelation>()
+            .Where(x => x.ParentId == entityId)
+            .WhereIn(x => x.RelationTypeId, relationTypeIds);
+
+        return _relationRepository.GetPagedRelationsByQuery(query, 0, int.MaxValue, out _, null).ToArray();
     }
 
     private sealed class NodeIdKey

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackRelationsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackRelationsTests.cs
@@ -1,7 +1,6 @@
-using System.Linq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
@@ -10,7 +9,6 @@ using Umbraco.Cms.Tests.Common.Attributes;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
@@ -31,36 +29,47 @@ internal sealed class TrackRelationsTests : UmbracoIntegrationTestWithContent
 
     private IRelationService RelationService => GetRequiredService<IRelationService>();
 
+    private ITemplateService TemplateService => GetRequiredService<ITemplateService>();
+
     protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
         base.CustomTestSetup(builder);
         builder
-            .AddNotificationHandler<ContentSavedNotification, ContentRelationsUpdate>();
+            .AddNotificationHandler<ContentSavedNotification, ContentRelationsUpdate>()
+            .AddNotificationHandler<RelationSavedNotification, RelationSavedTracker>()
+            .AddNotificationHandler<RelationDeletedNotification, RelationDeletedTracker>();
+    }
+
+    [SetUp]
+    public override void Setup()
+    {
+        RelationSavedTracker.Reset();
+        RelationDeletedTracker.Reset();
+        base.Setup();
     }
 
     [Test]
     [LongRunning]
-    public void Automatically_Track_Relations()
+    public async Task Automatically_Track_Relations()
     {
         var mt = MediaTypeBuilder.CreateSimpleMediaType("testMediaType", "Test Media Type");
-        MediaTypeService.Save(mt);
+        await MediaTypeService.CreateAsync(mt, Constants.Security.SuperUserKey);
         var m1 = MediaBuilder.CreateSimpleMedia(mt, "hello 1", -1);
         var m2 = MediaBuilder.CreateSimpleMedia(mt, "hello 1", -1);
         MediaService.Save(m1);
         MediaService.Save(m2);
 
         var memberType = MemberTypeBuilder.CreateSimpleMemberType("testMemberType", "Test Member Type");
-        MemberTypeService.Save(memberType);
+        await MemberTypeService.CreateAsync(memberType, Constants.Security.SuperUserKey);
         var member = MemberBuilder.CreateSimpleMember(memberType, "Test Member", "test@test.com", "xxxxxxxx", "testMember");
         MemberService.Save(member);
 
         var template = TemplateBuilder.CreateTextPageTemplate();
-        FileService.SaveTemplate(template);
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
 
         var ct = ContentTypeBuilder.CreateTextPageContentType("richTextTest", defaultTemplateId: template.Id);
         ct.AllowedTemplates = Enumerable.Empty<ITemplate>();
-
-        ContentTypeService.Save(ct);
+        await ContentTypeService.CreateAsync(ct, Constants.Security.SuperUserKey);
 
         var c1 = ContentBuilder.CreateTextpageContent(ct, "my content 1", -1);
         ContentService.Save(c1);
@@ -92,5 +101,178 @@ internal sealed class TrackRelationsTests : UmbracoIntegrationTestWithContent
         Assert.AreEqual(c1.Id, relations[2].ChildId);
         Assert.AreEqual(Constants.Conventions.RelationTypes.RelatedMemberAlias, relations[3].RelationType.Alias);
         Assert.AreEqual(member.Id, relations[3].ChildId);
+    }
+
+    [Test]
+    [LongRunning]
+    public async Task Automatic_Relations_Publish_Saved_Notification()
+    {
+        var mt = MediaTypeBuilder.CreateSimpleMediaType("testMediaType", "Test Media Type");
+        await MediaTypeService.CreateAsync(mt, Constants.Security.SuperUserKey);
+        var m1 = MediaBuilder.CreateSimpleMedia(mt, "media 1", -1);
+        var m2 = MediaBuilder.CreateSimpleMedia(mt, "media 2", -1);
+        MediaService.Save(m1);
+        MediaService.Save(m2);
+
+        var template = TemplateBuilder.CreateTextPageTemplate();
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+        var ct = ContentTypeBuilder.CreateTextPageContentType("richTextTest", defaultTemplateId: template.Id);
+        ct.AllowedTemplates = Enumerable.Empty<ITemplate>();
+        await ContentTypeService.CreateAsync(ct, Constants.Security.SuperUserKey);
+
+        var content = ContentBuilder.CreateTextpageContent(ct, "my content", -1);
+        content.Properties["bodyText"]!.SetValue(
+            "<p><img src='/media/1.jpg' data-udi='umb://media/" + m1.Key.ToString("N") + "' /></p>" +
+            "<p><img src='/media/2.jpg' data-udi='umb://media/" + m2.Key.ToString("N") + "' /></p>");
+
+        RelationSavedTracker.Reset();
+        ContentService.Save(content);
+
+        // Verify the saved notification was published with the correct relations.
+        Assert.AreEqual(2, RelationSavedTracker.SavedRelations.Count);
+        Assert.IsTrue(RelationSavedTracker.SavedRelations.Any(r => r.ChildId == m1.Id && r.RelationType.Alias == Constants.Conventions.RelationTypes.RelatedMediaAlias));
+        Assert.IsTrue(RelationSavedTracker.SavedRelations.Any(r => r.ChildId == m2.Id && r.RelationType.Alias == Constants.Conventions.RelationTypes.RelatedMediaAlias));
+        Assert.IsTrue(RelationSavedTracker.SavedRelations.All(r => r.ParentId == content.Id));
+        Assert.IsTrue(RelationSavedTracker.LastIsAutomatic);
+    }
+
+    [Test]
+    [LongRunning]
+    public async Task Automatic_Relations_Publish_Deleted_Notification_When_References_Removed()
+    {
+        var mt = MediaTypeBuilder.CreateSimpleMediaType("testMediaType", "Test Media Type");
+        await MediaTypeService.CreateAsync(mt, Constants.Security.SuperUserKey);
+        var m1 = MediaBuilder.CreateSimpleMedia(mt, "media 1", -1);
+        var m2 = MediaBuilder.CreateSimpleMedia(mt, "media 2", -1);
+        MediaService.Save(m1);
+        MediaService.Save(m2);
+
+        var template = TemplateBuilder.CreateTextPageTemplate();
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+        var ct = ContentTypeBuilder.CreateTextPageContentType("richTextTest", defaultTemplateId: template.Id);
+        ct.AllowedTemplates = Enumerable.Empty<ITemplate>();
+        await ContentTypeService.CreateAsync(ct, Constants.Security.SuperUserKey);
+
+        // Save content with two media references.
+        var content = ContentBuilder.CreateTextpageContent(ct, "my content", -1);
+        content.Properties["bodyText"]!.SetValue(
+            "<p><img src='/media/1.jpg' data-udi='umb://media/" + m1.Key.ToString("N") + "' /></p>" +
+            "<p><img src='/media/2.jpg' data-udi='umb://media/" + m2.Key.ToString("N") + "' /></p>");
+        ContentService.Save(content);
+
+        // Remove one media reference, keeping only m1.
+        RelationDeletedTracker.Reset();
+        content.Properties["bodyText"]!.SetValue(
+            "<p><img src='/media/1.jpg' data-udi='umb://media/" + m1.Key.ToString("N") + "' /></p>");
+        ContentService.Save(content);
+
+        // Verify the deleted notification was published for the removed relation.
+        Assert.AreEqual(1, RelationDeletedTracker.DeletedRelations.Count);
+        Assert.AreEqual(m2.Id, RelationDeletedTracker.DeletedRelations[0].ChildId);
+        Assert.AreEqual(content.Id, RelationDeletedTracker.DeletedRelations[0].ParentId);
+        Assert.IsTrue(RelationDeletedTracker.LastIsAutomatic);
+    }
+
+    [Test]
+    [LongRunning]
+    public async Task Automatic_Relations_Publish_Deleted_Notification_When_All_References_Removed()
+    {
+        var mt = MediaTypeBuilder.CreateSimpleMediaType("testMediaType", "Test Media Type");
+        await MediaTypeService.CreateAsync(mt, Constants.Security.SuperUserKey);
+        var m1 = MediaBuilder.CreateSimpleMedia(mt, "media 1", -1);
+        MediaService.Save(m1);
+
+        var template = TemplateBuilder.CreateTextPageTemplate();
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+        var ct = ContentTypeBuilder.CreateTextPageContentType("richTextTest", defaultTemplateId: template.Id);
+        ct.AllowedTemplates = Enumerable.Empty<ITemplate>();
+        await ContentTypeService.CreateAsync(ct, Constants.Security.SuperUserKey);
+
+        // Save content with a media reference.
+        var content = ContentBuilder.CreateTextpageContent(ct, "my content", -1);
+        content.Properties["bodyText"]!.SetValue(
+            "<p><img src='/media/1.jpg' data-udi='umb://media/" + m1.Key.ToString("N") + "' /></p>");
+        ContentService.Save(content);
+
+        // Remove all references (hits the early-exit path in ContentRelationsUpdate).
+        RelationDeletedTracker.Reset();
+        content.Properties["bodyText"]!.SetValue("<p>no references</p>");
+        ContentService.Save(content);
+
+        // Verify the deleted notification was published for the removed relation.
+        Assert.AreEqual(1, RelationDeletedTracker.DeletedRelations.Count);
+        Assert.AreEqual(m1.Id, RelationDeletedTracker.DeletedRelations[0].ChildId);
+        Assert.AreEqual(content.Id, RelationDeletedTracker.DeletedRelations[0].ParentId);
+        Assert.IsTrue(RelationDeletedTracker.LastIsAutomatic);
+    }
+
+    [Test]
+    [LongRunning]
+    public async Task Automatic_Relations_No_Notification_When_Unchanged()
+    {
+        var mt = MediaTypeBuilder.CreateSimpleMediaType("testMediaType", "Test Media Type");
+        await MediaTypeService.CreateAsync(mt, Constants.Security.SuperUserKey);
+        var m1 = MediaBuilder.CreateSimpleMedia(mt, "media 1", -1);
+        MediaService.Save(m1);
+
+        var template = TemplateBuilder.CreateTextPageTemplate();
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+        var ct = ContentTypeBuilder.CreateTextPageContentType("richTextTest", defaultTemplateId: template.Id);
+        ct.AllowedTemplates = Enumerable.Empty<ITemplate>();
+        await ContentTypeService.CreateAsync(ct, Constants.Security.SuperUserKey);
+
+        // Save content with a media reference.
+        var content = ContentBuilder.CreateTextpageContent(ct, "my content", -1);
+        content.Properties["bodyText"]!.SetValue(
+            "<p><img src='/media/1.jpg' data-udi='umb://media/" + m1.Key.ToString("N") + "' /></p>");
+        ContentService.Save(content);
+
+        // Save again with the same references - no notifications should fire.
+        RelationSavedTracker.Reset();
+        RelationDeletedTracker.Reset();
+        ContentService.Save(content);
+
+        Assert.AreEqual(0, RelationSavedTracker.SavedRelations.Count);
+        Assert.AreEqual(0, RelationDeletedTracker.DeletedRelations.Count);
+        Assert.IsNull(RelationSavedTracker.LastIsAutomatic);
+        Assert.IsNull(RelationDeletedTracker.LastIsAutomatic);
+    }
+
+    private sealed class RelationSavedTracker : INotificationHandler<RelationSavedNotification>
+    {
+        public static List<IRelation> SavedRelations { get; } = new();
+
+        public static bool? LastIsAutomatic { get; private set; }
+
+        public static void Reset()
+        {
+            SavedRelations.Clear();
+            LastIsAutomatic = null;
+        }
+
+        public void Handle(RelationSavedNotification notification)
+        {
+            SavedRelations.AddRange(notification.SavedEntities);
+            LastIsAutomatic = notification.IsAutomatic;
+        }
+    }
+
+    private sealed class RelationDeletedTracker : INotificationHandler<RelationDeletedNotification>
+    {
+        public static List<IRelation> DeletedRelations { get; } = new();
+
+        public static bool? LastIsAutomatic { get; private set; }
+
+        public static void Reset()
+        {
+            DeletedRelations.Clear();
+            LastIsAutomatic = null;
+        }
+
+        public void Handle(RelationDeletedNotification notification)
+        {
+            DeletedRelations.AddRange(notification.DeletedEntities);
+            LastIsAutomatic = notification.IsAutomatic;
+        }
     }
 }


### PR DESCRIPTION
## Description

**Automatic relations** (e.g. `umbMedia`, `umbDocument`, `umbMember`) are created/deleted as a side-effect of saving content, media, or members — they are managed by `ContentRelationsUpdate`, which bypasses the `IRelationService` and writes directly to `IRelationRepository`.

This meant `RelationSavedNotification` and `RelationDeletedNotification` never fired for them, unlike **explicit relations** saved via `IRelationService.Save()`.

This PR publishes `RelationSavedNotification` after automatic relations are bulk-inserted, and `RelationDeletedNotification` after stale automatic relations are removed.

An `IsAutomatic` property is added to both `RelationSavedNotification` and `RelationDeletedNotification` so consumers can distinguish automatic relation notifications from explicit ones.

### Design decisions

#### No `RelationSavingNotification` / `RelationDeletingNotification`

Only the post-fact `Saved` and `Deleted` notifications are emitted. The cancellable `Saving`/`Deleting` notifications are intentionally omitted because:

1. **Performance**: Automatic relations use `SaveBulk` for efficient batch inserts. Supporting cancellation would require saving relations individually, defeating the purpose of the bulk path.
2. **Correctness**: These relations are a derived side-effect of content property values. Cancelling them would leave the relation state inconsistent with the content — the content has already been saved with the media/document references, so the relations should reflect that. We don't want to allow these to be cancelled.

#### `IRelation.Id` is `0` on saved notifications

`SaveBulk` does not return database-generated identities. The `IRelation` objects in `RelationSavedNotification` will have `Id = 0`. However, `ParentId`, `ChildId`, and `RelationType` are all populated, and these are the properties consumers typically need. This is documented in the `IsAutomatic` XML remarks.

Here I'm giving more importance to keeping the performance benefit of the bulk insert (and not requiring an additional database hit to get the IDs after they are inserted) than the correctness of having the `Id` populated.

## Testing

### Automated

Additional integration tests have been added to `TrackRelationsTests` to verify the new behaviour.

### Manual

Add the following composer to `Umbraco.Web.UI`:

```csharp
using Microsoft.Extensions.Logging;
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI;

public class RelationNotificationComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder
            .AddNotificationHandler<RelationSavedNotification, RelationNotificationHandler>()
            .AddNotificationHandler<RelationDeletedNotification, RelationNotificationHandler>();
}

public class RelationNotificationHandler :
    INotificationHandler<RelationSavedNotification>,
    INotificationHandler<RelationDeletedNotification>
{
    private readonly ILogger<RelationNotificationHandler> _logger;

    public RelationNotificationHandler(ILogger<RelationNotificationHandler> logger)
        => _logger = logger;

    public void Handle(RelationSavedNotification notification)
    {
        foreach (IRelation relation in notification.SavedEntities)
        {
            _logger.LogInformation(
                "RelationSavedNotification fired - RelationType: {RelationTypeAlias}, ParentId: {ParentId}, ChildId: {ChildId}, IsAutomatic: {IsAutomatic}",
                relation.RelationType.Alias,
                relation.ParentId,
                relation.ChildId,
                notification.IsAutomatic);
        }
    }

    public void Handle(RelationDeletedNotification notification)
    {
        foreach (IRelation relation in notification.DeletedEntities)
        {
            _logger.LogInformation(
                "RelationDeletedNotification fired - RelationType: {RelationTypeAlias}, ParentId: {ParentId}, ChildId: {ChildId}, IsAutomatic: {IsAutomatic}",
                relation.RelationType.Alias,
                relation.ParentId,
                relation.ChildId,
                notification.IsAutomatic);
        }
    }
}

```

1. Run the site, create a document type with a media picker property.
2. Create content, pick a media item, save — observe `RelationSavedNotification fired` with `IsAutomatic: True` in the log output:

```
[... INF] RelationSavedNotification fired - RelationType: umbMedia, ParentId: 1120, ChildId: 1161, IsAutomatic: True
```
3. Note similar log entries the media is removed or changed for the deletion of the relation.
