### PR TITLE
Builder Extensions: Make `AddWebComponents()` idempotent (closes #22344)

### DIFF
--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -275,6 +275,14 @@ public static partial class UmbracoBuilderExtensions
     /// </summary>
     public static IUmbracoBuilder AddWebComponents(this IUmbracoBuilder builder)
     {
+        // Idempotency check - safe to call multiple times.
+        if (builder.Services.Any(s => s.ServiceType == typeof(AddWebComponentsMarker)))
+        {
+            return builder;
+        }
+
+        builder.Services.AddSingleton<AddWebComponentsMarker>();
+
         // Add service session
         // This can be overwritten by the user by adding their own call to AddSession
         // since the last call of AddSession take precedence
@@ -399,6 +407,13 @@ public static partial class UmbracoBuilderExtensions
     /// Marker class to ensure AddCore is only executed once.
     /// </summary>
     private sealed class AddCoreMarker
+    {
+    }
+
+    /// <summary>
+    /// Marker class to ensure AddWebComponents is only executed once.
+    /// </summary>
+    private sealed class AddWebComponentsMarker
     {
     }
 }

--- a/tests/Umbraco.Tests.Integration/TestServerTest/CoreConfigurationTests.cs
+++ b/tests/Umbraco.Tests.Integration/TestServerTest/CoreConfigurationTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
@@ -373,5 +374,52 @@ public class CoreConfigurationTests : UmbracoIntegrationTestBase
             services.Any(s => s.ServiceType == typeof(IBackOfficeEnabledMarker)),
             Is.False,
             "IBackOfficeEnabledMarker should NOT be registered in delivery-only scenario");
+    }
+
+    /// <summary>
+    /// Verifies that calling AddWebComponents() explicitly after AddBackOffice() is safe.
+    /// Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22344.
+    /// </summary>
+    [Test]
+    public void AddWebComponents_IsIdempotent()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(InMemoryConfiguration)
+            .Build();
+
+        services.AddSingleton<IConfiguration>(configuration);
+
+        TypeLoader typeLoader = services.AddTypeLoader(
+            GetType().Assembly,
+            TestHelper.ConsoleLoggerFactory,
+            configuration);
+
+        var builder = new UmbracoBuilder(
+            services,
+            configuration,
+            typeLoader,
+            TestHelper.ConsoleLoggerFactory,
+            TestHelper.Profiler,
+            AppCaches.NoCache);
+
+        // Act - This is the exact chain from the issue that caused duplicate health check crash.
+        // AddBackOffice() calls AddCore() which calls AddWebComponents() internally,
+        // so the explicit AddWebComponents() call is a duplicate.
+        builder
+            .AddBackOffice()
+            .AddWebsite()
+            .AddDeliveryApi()
+            .AddWebComponents()
+            .AddUmbracoSqlServerSupport()
+            .AddUmbracoSqliteSupport();
+
+        builder.Build();
+
+        // Assert - Verify health checks can be resolved without duplicate name errors.
+        // The duplicate "umbraco-ready" registration caused ArgumentException at host startup.
+        var provider = services.BuildServiceProvider();
+        Assert.DoesNotThrow(() => provider.GetRequiredService<HealthCheckService>());
     }
 }


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/22344 raises a concern that from 17.3, after we'd introduced support for running Umbraco with different components of backoffice, website and Delivery API in https://github.com/umbraco/Umbraco-CMS/pull/21630, that the `AddWebComponents()` wasn't made idempotent.

This PR adds an idempotency guard to `AddWebComponents()` using the same marker-class pattern already used by `AddCore()`, preventing duplicate health check registration when `AddWebComponents()` is called explicitly after `AddBackOffice()`.

## Testing

### Automated

A regression integration test has been added that reproduces the exact scenario from the issue and asserts `HealthCheckService` can be resolved without duplicate name errors.

### Manual

See steps to reproduce on the linked issue.  Before the fix an exception would be thrown.  Now the application will start normally.

