### PR TITLE
E2E: QA Remove @smoke tags from element tests (temporary)

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/Element.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/Element.spec.ts
@@ -41,7 +41,7 @@ test('can create empty element', async ({umbracoApi, umbracoUi}) => {
   await umbracoUi.library.isElementInTreeVisible(elementName);
 });
 
-test('can save and publish empty element', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can save and publish empty element', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const expectedState = 'Published';
   await umbracoUi.goToBackOffice();
@@ -62,7 +62,7 @@ test('can save and publish empty element', {tag: '@smoke'}, async ({umbracoApi, 
   expect(elementData.variants[0].state).toBe(expectedState);
 });
 
-test.skip('can create element', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test.skip('can create element', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoUi.goToBackOffice();
   await umbracoUi.library.goToSection(ConstantHelper.sections.library);
@@ -101,7 +101,7 @@ test('can rename element', async ({umbracoApi, umbracoUi}) => {
   expect(updatedElementData.variants[0].name).toEqual(elementName);
 });
 
-test('can update element', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can update element', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const wrongElementText = 'This is wrong test element text';
   elementId = await umbracoApi.element.createElementWithTextContent(elementName, elementTypeId, wrongElementText, dataTypeName);
@@ -118,7 +118,7 @@ test('can update element', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   expect(updatedElementData.values[0].value).toBe(elementText);
 });
 
-test('can unpublish element', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can unpublish element', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   elementId = await umbracoApi.element.createElementWithTextContent(elementName, elementTypeId, elementText, dataTypeName);
   await umbracoApi.element.publish(elementId);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementFolder.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementFolder.spec.ts
@@ -21,7 +21,7 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.documentType.ensureNameNotExists(elementTypeName);
 });
 
-test.skip('can create an empty element folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test.skip('can create an empty element folder', async ({umbracoApi, umbracoUi}) => {
   // Act
   await umbracoUi.library.goToSection(ConstantHelper.sections.library);
   await umbracoUi.library.clickActionsMenuAtRoot();
@@ -35,7 +35,7 @@ test.skip('can create an empty element folder', {tag: '@smoke'}, async ({umbraco
   await umbracoUi.library.isElementInTreeVisible(elementFolderName);
 });
 
-test('can trash an element folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can trash an element folder', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.element.createDefaultElementFolder(elementFolderName);
 
@@ -93,7 +93,7 @@ test('can create an element folder in a folder', async ({umbracoApi, umbracoUi})
   await umbracoApi.element.ensureNameNotExists(childFolderName);
 });
 
-test.skip('can create a folder in a folder in a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test.skip('can create a folder in a folder in a folder', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const grandParentFolderName = 'GrandParentElementFolder';
   const parentFolderName = 'ParentElementFolder';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementFolderBulkActions.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementFolderBulkActions.spec.ts
@@ -29,7 +29,7 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.documentType.ensureNameNotExists(elementTypeName);
 });
 
-test('can bulk publish elements in a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can bulk publish elements in a folder', async ({umbracoApi, umbracoUi}) => {
   // Act
   await umbracoUi.library.selectElementWithNameInElementCollectionView(firstElementName);
   await umbracoUi.library.selectElementWithNameInElementCollectionView(secondElementName);
@@ -41,7 +41,7 @@ test('can bulk publish elements in a folder', {tag: '@smoke'}, async ({umbracoAp
   expect(await umbracoApi.element.isElementPublished(secondElementId)).toBeTruthy();
 });
 
-test('can bulk unpublish elements in a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can bulk unpublish elements in a folder', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.element.publish(firstElementId);
   await umbracoApi.element.publish(secondElementId);
@@ -81,7 +81,7 @@ test('can bulk move elements to another folder', async ({umbracoApi, umbracoUi})
   await umbracoApi.element.ensureNameNotExists(targetFolderName);
 });
 
-test('can bulk trash elements in a folder', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can bulk trash elements in a folder', async ({umbracoApi, umbracoUi}) => {
   // Act
   await umbracoUi.library.selectElementWithNameInElementCollectionView(firstElementName);
   await umbracoUi.library.selectElementWithNameInElementCollectionView(secondElementName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementWithElementPicker.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementWithElementPicker.spec.ts
@@ -67,7 +67,7 @@ test('can publish element with the element picker data type', async ({umbracoApi
   expect(elementData.values).toEqual([]);
 });
 
-test('can publish element with an element picker selected', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can publish element with an element picker selected', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const elementPickerDataTypeId = await umbracoApi.dataType.createDefaultElementPickerDataType(elementPickerDataTypeName);
   const elementTypeId = await umbracoApi.documentType.createElementTypeWithPropertyInTab(elementTypeName, 'TestTab', 'TestGroup', elementPickerDataTypeName, elementPickerDataTypeId);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/RecycleBin.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/RecycleBin.spec.ts
@@ -20,7 +20,7 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.element.emptyRecycleBin();
 });
 
-test('can trash an element', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can trash an element', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.element.createDefaultElement(elementName, elementTypeId);
   expect(await umbracoApi.element.doesNameExist(elementName)).toBeTruthy();
@@ -57,8 +57,7 @@ test('can trash an element folder with children', async ({umbracoApi, umbracoUi}
   await umbracoUi.library.isElementInTreeVisible(elementFolderName, false);
 });
 
-// Currently this test fails due to the issue: an 500 error is thrown when trying to empty the recycle bin 
-test('can empty recycle bin', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can empty recycle bin', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const elementId = await umbracoApi.element.createDefaultElement(elementName, elementTypeId);
   await umbracoApi.element.moveToRecycleBin(elementId);
@@ -99,7 +98,6 @@ test('can see trashed element folder in recycle bin', async ({umbracoApi, umbrac
   await umbracoUi.library.isItemVisibleInRecycleBin(elementFolderName);
 });
 
-// Currently this test fails due to the issue: an 500 error is thrown when performance this action
 test('can delete element from recycle bin', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const elementId = await umbracoApi.element.createDefaultElement(elementName, elementTypeId);
@@ -116,7 +114,6 @@ test('can delete element from recycle bin', async ({umbracoApi, umbracoUi}) => {
   expect(await umbracoApi.element.doesItemExistInRecycleBin(elementName)).toBeFalsy();
 });
 
-// Currently this test fails due to the issue: an 500 error is thrown when performance this action
 test('can delete element folder from recycle bin', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const elementFolderId = await umbracoApi.element.createDefaultElementFolder(elementFolderName);
@@ -133,7 +130,6 @@ test('can delete element folder from recycle bin', async ({umbracoApi, umbracoUi
   expect(await umbracoApi.element.doesItemExistInRecycleBin(elementFolderName)).toBeFalsy();
 });
 
-// Currently this test fails due to the issue: an 500 error is thrown when performance this action
 test('can delete element folder with children from recycle bin', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const folderId = await umbracoApi.element.createDefaultElementFolder(elementFolderName);
@@ -152,7 +148,6 @@ test('can delete element folder with children from recycle bin', async ({umbraco
   expect(await umbracoApi.element.doesNameExist(elementName)).toBeFalsy();
 });
 
-// Currently this test fails due to the issue: an 500 error is thrown when performance this action
 test('can delete child element from recycle bin', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const folderId = await umbracoApi.element.createDefaultElementFolder(elementFolderName);
@@ -214,7 +209,6 @@ test('can restore element folder from recycle bin', async ({umbracoApi, umbracoU
   await umbracoUi.library.isElementInTreeVisible(elementFolderName);
 });
 
-// Currently this test fails due to the wrong restore message being shown
 test('can restore child element from recycle bin back to its parent folder', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const folderId = await umbracoApi.element.createDefaultElementFolder(elementFolderName);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UserGroup/DefaultPermissionsInElement.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/Permissions/UserGroup/DefaultPermissionsInElement.spec.ts
@@ -42,7 +42,7 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.element.emptyRecycleBin();
 });
 
-test('can read element with permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can read element with permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   userGroupId = await umbracoApi.userGroup.createUserGroupWithReadElementPermission(userGroupName);
   await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId);
@@ -77,7 +77,7 @@ test.fixme('can not see element in tree with read permission disabled', async ({
 });
 
 // Currently user cannot choose element type to create element even with permission enabled
-test.fixme('can create element with create permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test.fixme('can create element with create permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   userGroupId = await umbracoApi.userGroup.createUserGroupWithCreateElementPermission(userGroupName);
   await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId);
@@ -113,7 +113,7 @@ test('can not see create action menu with create permission disabled', async ({u
   await umbracoUi.library.isActionsMenuForNameVisible(elementName, false);
 });
 
-test('can trash element with delete permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can trash element with delete permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   userGroupId = await umbracoApi.userGroup.createUserGroupWithDeleteElementPermission(userGroupName);
   await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId);
@@ -177,7 +177,7 @@ test('can not empty recycle bin with delete permission disabled', async ({umbrac
   await umbracoUi.library.isActionsMenuForRecycleBinVisible(false);
 });
 
-test('can publish element with publish permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can publish element with publish permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   userGroupId = await umbracoApi.userGroup.createUserGroupWithPublishElementPermission(userGroupName);
   await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId);
@@ -208,7 +208,7 @@ test('can not publish element with publish permission disabled', async ({umbraco
   await umbracoUi.library.isActionsMenuForNameVisible(elementName, false);
 });
 
-test('can unpublish element with unpublish permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can unpublish element with unpublish permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.element.publish(elementId);
   expect(await umbracoApi.element.isElementPublished(elementId)).toBeTruthy();
@@ -243,7 +243,7 @@ test('can not unpublish element with unpublish permission disabled', async ({umb
   await umbracoUi.library.isActionsMenuForNameVisible(elementName, false);
 });
 
-test('can update element with update permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can update element with update permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   userGroupId = await umbracoApi.userGroup.createUserGroupWithUpdateElementPermission(userGroupName);
   await umbracoApi.user.setUserPermissions(testUser.name, testUser.email, testUser.password, userGroupId);
@@ -278,7 +278,7 @@ test.fixme('can not update element with update permission disabled', async ({umb
   await umbracoUi.library.isElementReadOnly(true);
 });
 
-test('can duplicate element with duplicate permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test('can duplicate element with duplicate permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const duplicatedElementName = elementName + ' (1)';
   userGroupId = await umbracoApi.userGroup.createUserGroupWithDuplicateElementPermission(userGroupName);
@@ -320,7 +320,7 @@ test('can not duplicate element with duplicate permission disabled', async ({umb
   await umbracoUi.library.isActionsMenuForNameVisible(elementName, false);
 });
 
-test.skip('can move element with move to permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test.skip('can move element with move to permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const elementFolderName = 'TestElementFolder';
   const elementFolderId = await umbracoApi.element.createDefaultElementFolder(elementFolderName);
@@ -367,7 +367,7 @@ test('can not move element with move to permission disabled', async ({umbracoApi
 });
 
 // Currently the rollback functionality in elements is not working.
-test.fixme('can rollback element with rollback permission enabled', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
+test.fixme('can rollback element with rollback permission enabled', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   userGroupId = await umbracoApi.userGroup.createUserGroupWithRollbackElementPermission(userGroupName);
   await umbracoApi.element.publish(elementId);


### PR DESCRIPTION
**Description**

- Temporarily removed @smoke tags from element-related tests.
- The element feature is still in progress, and these tests are currently unstable.
- This change helps avoid unnecessary pipeline failures.

**Note**
The `@smoke` tags will be added back once the feature is stable.