### PR TITLE
Management API: Fix OAuth client registration permanently skipped after transient failure (closes #22356)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
+++ b/src/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddleware.cs
@@ -18,7 +18,7 @@ namespace Umbraco.Cms.Api.Management.Middleware;
 public class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
 {
     private SemaphoreSlim _firstBackOfficeRequestLocker = new(1); // this only works because this is a singleton
-    private ISet<string> _knownHosts = new HashSet<string>(); // this only works because this is a singleton
+    private ISet<string> _knownHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase); // this only works because this is a singleton
 
     private readonly UmbracoRequestPaths _umbracoRequestPaths;
     private readonly IServiceProvider _serviceProvider;
@@ -88,7 +88,7 @@ public class BackOfficeAuthorizationInitializationMiddleware : IMiddleware
             }
 
             // Ensure we explicitly add UmbracoApplicationUrl if configured (https://github.com/umbraco/Umbraco-CMS/issues/16179).
-            var hostsToRegister = new HashSet<string> { host };
+            var hostsToRegister = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { host };
             if (_webRoutingSettings.UmbracoApplicationUrl.IsNullOrWhiteSpace() is false)
             {
                 hostsToRegister.Add(_webRoutingSettings.UmbracoApplicationUrl);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddlewareTests.cs
@@ -64,14 +64,7 @@ public class BackOfficeAuthorizationInitializationMiddlewareTests
         HttpContext context = CreateBackOfficeHttpContext();
 
         // Act — first request: registration fails.
-        try
-        {
-            await _middleware.InvokeAsync(context, next);
-        }
-        catch
-        {
-            // Expected — the middleware lets the exception propagate.
-        }
+        Assert.ThrowsAsync<Exception>(async () => await _middleware.InvokeAsync(context, next));
 
         // Act — second request: should retry (host was NOT cached).
         await _middleware.InvokeAsync(context, next);
@@ -102,6 +95,7 @@ public class BackOfficeAuthorizationInitializationMiddlewareTests
     }
 
     [Test]
+    [Timeout(5000)] // Fail fast if the semaphore-release regression is reintroduced (deadlock).
     public async Task Registration_Failure_Does_Not_Leak_Semaphore()
     {
         // Arrange — always throws
@@ -115,14 +109,7 @@ public class BackOfficeAuthorizationInitializationMiddlewareTests
         for (var i = 0; i < 3; i++)
         {
             HttpContext context = CreateBackOfficeHttpContext();
-            try
-            {
-                await _middleware.InvokeAsync(context, next);
-            }
-            catch
-            {
-                // Expected
-            }
+            Assert.ThrowsAsync<Exception>(async () => await _middleware.InvokeAsync(context, next));
         }
 
         // Assert — all 3 attempts reached EnsureBackOfficeApplicationAsync (no deadlock).


### PR DESCRIPTION
## Description

This PR addresses the report in https://github.com/umbraco/Umbraco-CMS/issues/22356 of being unable to access the Swagger endpoints before a restart after an unattended install.

I haven't been able to replicate the issue with normal use.  That said, analysis has uncovered a couple of issues that could be more defensively coded and might be the cause of finding the problem in practice.

## Background

PR #22020 introduced `RuntimeLevel.Upgrading` and moved unattended upgrades to a background service. During the `Upgrading` phase, the HTTP server is up and accepting requests while migrations run concurrently in the background.

`BackOfficeAuthorizationInitializationMiddleware` registers OAuth clients on the first backoffice request when `RuntimeLevel >= Upgrade`. The `Upgrading` level (4) satisfies this check, so the middleware attempts registration. However, if `EnsureBackOfficeApplicationAsync` fails during this window — for example due to database contention with the concurrent migration — two bugs in the middleware make the failure permanent (or at least until a restart):

1. **Host cached before registration**: The host was added to `_knownHosts` *before* calling `EnsureBackOfficeApplicationAsync`. On failure, the host remained cached and all subsequent requests skipped registration.

2. **Semaphore leak on failure**: The semaphore was released manually without `try/finally`. If `EnsureBackOfficeApplicationAsync` threw, the semaphore was never released, risking deadlocks for new hosts.

### Theory as to why this isn't always seen

Triggering the issue requires a backoffice request to arrive during the brief `Upgrading` window while the background migration service holds database resources. On a local dev machine with a fresh install and no external packages, migrations typically complete near-instantly, making the window very small. But it could be hit when if a request is made during boot.

After a restart, `RuntimeLevel` resolves directly to `Run` with no concurrent migrations, so registration succeeds — which is why the restart workaround works.

### How the fix resolves it

The fix is defensive — even if we can't always reproduce the exact race condition, the middleware should be resilient to transient failures:

- **Host cached only after success**: `_knownHosts` is populated only after `EnsureBackOfficeApplicationAsync` completes without throwing. If it fails, the next request retries.
- **Semaphore in try/finally**: The semaphore is always released, preventing deadlocks.

## Test plan

### Automated

Unit tests added to `BackOfficeAuthorizationInitializationMiddlewareTests` should pass.

### Manual

As mentioned, I've not been able to replicate with normal use, but have used this method to deterministically reproduce the race condition: add a temporary debug hack that makes the first `EnsureBackOfficeApplicationAsync` call throw, then test with the old and new middleware code.

#### 1. Add debug hack (temporary — revert before merging)

In `src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs`, add a fail-once counter at the top of `EnsureBackOfficeApplicationAsync`:

```csharp
// DEBUG: Remove before merging.
private static int _debugCallCount;

public async Task EnsureBackOfficeApplicationAsync(
    IEnumerable<Uri> backOfficeHosts, CancellationToken cancellationToken = default)
{
    // --- START DEBUG BLOCK (remove before merging) ---
    if (Interlocked.Increment(ref _debugCallCount) == 1)
    {
        _logger.LogWarning(
            "=== DEBUG: Simulating transient failure (attempt #{Count}) ===",
            _debugCallCount);
        await Task.Delay(100, cancellationToken);
        throw new Exception("DEBUG: Simulated database contention during upgrade");
    }
    _logger.LogWarning(
        "=== DEBUG: Registration attempt #{Count} — proceeding normally ===",
        _debugCallCount);
    // --- END DEBUG BLOCK ---

    // ... rest of method unchanged ...
```

#### 2a. Confirm the bug (old middleware code on `main`)

Check out the **original** `InitializeBackOfficeAuthorizationOnceAsync` from `main`

Delete the existing tokens and applications:

```sql
  DELETE FROM umbracoOpenIddictTokens
  DELETE FROM umbracoOpenIddictAuthorizations
  DELETE FROM umbracoOpenIddictApplications WHERE ClientId IN ('umbraco-swagger', 'umbraco-postman')
```

Run `dotnet run --project src/Umbraco.Web.UI`, navigate to `https://localhost:44339/umbraco`.

- Log shows: `Simulating transient failure (attempt #1)`
- Refresh — **no second log line**. The host was cached before the throw, so the middleware skips retry.

Try to authorize via the Swagger UI and the result will be:

```
error:invalid_request
error_description:The specified 'client_id' is invalid.
error_uri:https://documentation.openiddict.com/errors/ID2052
```

#### 2b. Confirm the fix (this PR)

Switch to the **fixed** `InitializeBackOfficeAuthorizationOnceAsync` from this branch:

Delete the tokens and applications again.

Run `dotnet run --project src/Umbraco.Web.UI`, navigate to `https://localhost:44339/umbraco`.

- Log shows **two lines**: `Simulating transient failure (attempt #1)` then `Registration attempt #2 — proceeding normally`.

Try to authorize via the Swagger UI and the result should be successful.

#### 3. Cleanup

Remove the debug code.

