### PR TITLE
Management API: Fix ambiguous constructor in PasswordConfigurationPresentationFactory

### DIFF
--- a/src/Umbraco.Cms.Api.Management/DependencyInjection/PasswordBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/DependencyInjection/PasswordBuilderExtensions.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Core.DependencyInjection;
 
@@ -11,7 +11,7 @@ public static class PasswordBuilderExtensions
 {
     internal static IUmbracoBuilder AddPasswordConfiguration(this IUmbracoBuilder builder)
     {
-        builder.Services.AddTransient<IPasswordConfigurationPresentationFactory>(sp => ActivatorUtilities.CreateInstance<PasswordConfigurationPresentationFactory>(sp));
+        builder.Services.AddTransient<IPasswordConfigurationPresentationFactory, PasswordConfigurationPresentationFactory>();
         return builder;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
@@ -30,6 +30,7 @@ public class PasswordConfigurationPresentationFactory : IPasswordConfigurationPr
     {
     }
 
+    // This is just here to resolve an ambiguous constructor.
     [Obsolete("Use the constructor that accepts IOptionsSnapshot<SecuritySettings> instead. Scheduled for removal in Umbraco 19.")]
     public PasswordConfigurationPresentationFactory(IOptionsSnapshot<SecuritySettings> securitySettings, IOptionsSnapshot<UserPasswordConfigurationSettings> _)
         : this(securitySettings)

--- a/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PasswordConfigurationPresentationFactory.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Management.ViewModels.Security;
 using Umbraco.Cms.Core.Configuration.Models;
@@ -12,19 +12,11 @@ namespace Umbraco.Cms.Api.Management.Factories;
 public class PasswordConfigurationPresentationFactory : IPasswordConfigurationPresentationFactory
 {
     private readonly SecuritySettings _securitySettings;
-    
-    // TODO (V19): Remove obsolete constructors and the ActivatorUtilitiesConstructor attribute.
-    // Also update UmbracoBuilder where this service is registered using:
-    //   builder.Services.AddTransient<IPasswordConfigurationPresentationFactory>(sp => ActivatorUtilities.CreateInstance<PasswordConfigurationPresentationFactory>(sp));
-    // We do this to allow the ActivatorUtilitiesConstructor to be used (it's otherwise ignored by AddTransient).
-    // Revert it to:
-    //   builder.Services.AddTransient<IPasswordConfigurationPresentationFactory, PasswordConfigurationPresentationFactory>()    
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PasswordConfigurationPresentationFactory"/> class.
     /// </summary>
     /// <param name="securitySettings">An <see cref="IOptionsSnapshot{T}"/> containing the current <see cref="SecuritySettings"/> for user password configuration.</param>
-    [ActivatorUtilitiesConstructor]
     public PasswordConfigurationPresentationFactory(IOptionsSnapshot<SecuritySettings> securitySettings)
         => _securitySettings = securitySettings.Value;
 
@@ -35,6 +27,12 @@ public class PasswordConfigurationPresentationFactory : IPasswordConfigurationPr
     [Obsolete("Use the constructor that accepts IOptionsSnapshot<SecuritySettings> instead. Scheduled for removal in Umbraco 19.")]
     public PasswordConfigurationPresentationFactory(IOptionsSnapshot<UserPasswordConfigurationSettings> userPasswordConfigurationSettings)
         : this(StaticServiceProvider.Instance.GetRequiredService<IOptionsSnapshot<SecuritySettings>>())
+    {
+    }
+
+    [Obsolete("Use the constructor that accepts IOptionsSnapshot<SecuritySettings> instead. Scheduled for removal in Umbraco 19.")]
+    public PasswordConfigurationPresentationFactory(IOptionsSnapshot<SecuritySettings> securitySettings, IOptionsSnapshot<UserPasswordConfigurationSettings> _)
+        : this(securitySettings)
     {
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

`PasswordConfigurationPresentationFactory` had two constructors that were ambiguous to the DI container. Removed the `[ActivatorUtilitiesConstructor]` workaround and `ActivatorUtilities.CreateInstance<>` registration, reverted to standard `AddTransient<TInterface, TImpl>()`, and made the obsolete constructor delegate to the preferred one to resolve the ambiguity.

**How to test:** Run the `UserPresentationFactoryTests`.