### PR TITLE
Published Content Cache: Defensive hardening against race conditions (closes #22254, #22384)

### DIFF
--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -26,10 +26,18 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     private readonly INavigationRepository _navigationRepository;
     private readonly TContentTypeService _typeService;
     private Lazy<Dictionary<string, Guid>> _contentTypeAliasToKeyMap;
-    private ConcurrentDictionary<Guid, NavigationNode> _navigationStructure = new();
-    private ConcurrentDictionary<Guid, NavigationNode> _recycleBinNavigationStructure = new();
-    private HashSet<Guid> _roots = [];
-    private HashSet<Guid> _recycleBinRoots = [];
+
+    /// <summary>
+    ///     Bundles a navigation structure dictionary and its root keys into a single reference so that
+    ///     <see cref="HandleRebuildAsync"/> can swap both atomically with one <see cref="Interlocked.Exchange{T}"/>
+    ///     call and readers always observe a consistent pair.
+    /// </summary>
+    private sealed record NavigationSnapshot(
+        ConcurrentDictionary<Guid, NavigationNode> Structure,
+        HashSet<Guid> Roots);
+
+    private NavigationSnapshot _navigation = new(new(), []);
+    private NavigationSnapshot _recycleBinNavigation = new(new(), []);
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="ContentNavigationServiceBase{TContentType, TContentTypeService}"/> class.
@@ -65,7 +73,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the child node exists in the structure; otherwise, <c>false</c>.</returns>
     public bool TryGetParentKey(Guid childKey, out Guid? parentKey)
-        => TryGetParentKeyFromStructure(_navigationStructure, childKey, out parentKey);
+        => TryGetParentKeyFromStructure(_navigation.Structure, childKey, out parentKey);
 
     /// <summary>
     ///     Attempts to get all root-level node keys from the main navigation structure.
@@ -76,17 +84,13 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// <returns><c>true</c> if the operation succeeds; otherwise, <c>false</c>.</returns>
     public bool TryGetRootKeys(out IEnumerable<Guid> rootKeys)
     {
-        // On subscriber/CD servers in a load-balanced setup, cache refresh notifications trigger a full navigation rebuild
-        // (via RebuildAsync → HandleRebuildAsync), which replaces _roots and _navigationStructure with new instances. These
-        // two swaps cannot happen truly simultaneously, so a concurrent reader that accesses the fields separately could see
-        // the new _roots with the old _navigationStructure (or vice-versa), leading to KeyNotFoundExceptions or wrong results.
-        //
-        // Copying both fields into locals here ensures this method uses a pair of collections that were built together.
+        // On subscriber/CD servers in a load-balanced setup, cache refresh notifications trigger a full navigation
+        // rebuild (via RebuildAsync → HandleRebuildAsync), which replaces the NavigationSnapshot with a new instance.
+        // Reading the snapshot into a local guarantees Structure and Roots are from the same rebuild.
         //
         // Verified by: DocumentNavigationServiceTests.Concurrent_Rebuild_And_Queries_Never_Transiently_Lose_Content
-        HashSet<Guid> roots = _roots;
-        ConcurrentDictionary<Guid, NavigationNode> navigationStructure = _navigationStructure;
-        return TryGetRootKeysFromStructure(roots, navigationStructure, out rootKeys);
+        NavigationSnapshot snapshot = _navigation;
+        return TryGetRootKeysFromStructure(snapshot.Roots, snapshot.Structure, out rootKeys);
     }
 
     /// <summary>
@@ -104,10 +108,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (TryGetContentTypeKey(contentTypeAlias, out Guid? contentTypeKey))
         {
-            // See TryGetRootKeys for why we snapshot both fields into locals.
-            HashSet<Guid> roots = _roots;
-            ConcurrentDictionary<Guid, NavigationNode> navigationStructure = _navigationStructure;
-            return TryGetRootKeysFromStructure(roots, navigationStructure, out rootKeys, contentTypeKey);
+            // See TryGetRootKeys for why we snapshot into a local.
+            NavigationSnapshot snapshot = _navigation;
+            return TryGetRootKeysFromStructure(snapshot.Roots, snapshot.Structure, out rootKeys, contentTypeKey);
         }
 
         // Content type alias doesn't exist
@@ -125,7 +128,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the parent node exists in the structure; otherwise, <c>false</c>.</returns>
     public bool TryGetChildrenKeys(Guid parentKey, out IEnumerable<Guid> childrenKeys)
-        => TryGetChildrenKeysFromStructure(_navigationStructure, parentKey, out childrenKeys);
+        => TryGetChildrenKeysFromStructure(_navigation.Structure, parentKey, out childrenKeys);
 
     /// <summary>
     ///     Attempts to get all child node keys of a specific content type under a parent node.
@@ -143,7 +146,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (TryGetContentTypeKey(contentTypeAlias, out Guid? contentTypeKey))
         {
-            return TryGetChildrenKeysFromStructure(_navigationStructure, parentKey, out childrenKeys, contentTypeKey);
+            return TryGetChildrenKeysFromStructure(_navigation.Structure, parentKey, out childrenKeys, contentTypeKey);
         }
 
         // Content type alias doesn't exist
@@ -161,7 +164,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the parent node exists in the structure; otherwise, <c>false</c>.</returns>
     public bool TryGetDescendantsKeys(Guid parentKey, out IEnumerable<Guid> descendantsKeys)
-        => TryGetDescendantsKeysFromStructure(_navigationStructure, parentKey, out descendantsKeys);
+        => TryGetDescendantsKeysFromStructure(_navigation.Structure, parentKey, out descendantsKeys);
 
     /// <summary>
     ///     Attempts to get all descendant node keys of a specific content type under a parent node.
@@ -179,7 +182,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (TryGetContentTypeKey(contentTypeAlias, out Guid? contentTypeKey))
         {
-            return TryGetDescendantsKeysFromStructure(_navigationStructure, parentKey, out descendantsKeys, contentTypeKey);
+            return TryGetDescendantsKeysFromStructure(_navigation.Structure, parentKey, out descendantsKeys, contentTypeKey);
         }
 
         // Content type alias doesn't exist
@@ -197,7 +200,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the child node exists in the structure; otherwise, <c>false</c>.</returns>
     public bool TryGetAncestorsKeys(Guid childKey, out IEnumerable<Guid> ancestorsKeys)
-        => TryGetAncestorsKeysFromStructure(_navigationStructure, childKey, out ancestorsKeys);
+        => TryGetAncestorsKeysFromStructure(_navigation.Structure, childKey, out ancestorsKeys);
 
     /// <summary>
     ///     Attempts to get all ancestor node keys of a specific content type for a given node.
@@ -215,7 +218,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (TryGetContentTypeKey(contentTypeAlias, out Guid? contentTypeKey))
         {
-            return TryGetAncestorsKeysFromStructure(_navigationStructure, parentKey, out ancestorsKeys, contentTypeKey);
+            return TryGetAncestorsKeysFromStructure(_navigation.Structure, parentKey, out ancestorsKeys, contentTypeKey);
         }
 
         // Content type alias doesn't exist
@@ -234,7 +237,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the node exists in the structure; otherwise, <c>false</c>.</returns>
     public bool TryGetSiblingsKeys(Guid key, out IEnumerable<Guid> siblingsKeys)
-        => TryGetSiblingsKeysFromStructure(_navigationStructure, key, out siblingsKeys);
+        => TryGetSiblingsKeysFromStructure(_navigation.Structure, key, out siblingsKeys);
 
     /// <summary>
     ///     Attempts to get all sibling node keys of a specific content type for a given node.
@@ -252,7 +255,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (TryGetContentTypeKey(contentTypeAlias, out Guid? contentTypeKey))
         {
-            return TryGetSiblingsKeysFromStructure(_navigationStructure, key, out siblingsKeys, contentTypeKey);
+            return TryGetSiblingsKeysFromStructure(_navigation.Structure, key, out siblingsKeys, contentTypeKey);
         }
 
         // Content type alias doesn't exist
@@ -270,7 +273,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the child node exists in the recycle bin; otherwise, <c>false</c>.</returns>
     public bool TryGetParentKeyInBin(Guid childKey, out Guid? parentKey)
-        => TryGetParentKeyFromStructure(_recycleBinNavigationStructure, childKey, out parentKey);
+        => TryGetParentKeyFromStructure(_recycleBinNavigation.Structure, childKey, out parentKey);
 
     /// <summary>
     ///     Attempts to get all child node keys of a parent node in the recycle bin navigation structure.
@@ -282,7 +285,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the parent node exists in the recycle bin; otherwise, <c>false</c>.</returns>
     public bool TryGetChildrenKeysInBin(Guid parentKey, out IEnumerable<Guid> childrenKeys)
-        => TryGetChildrenKeysFromStructure(_recycleBinNavigationStructure, parentKey, out childrenKeys);
+        => TryGetChildrenKeysFromStructure(_recycleBinNavigation.Structure, parentKey, out childrenKeys);
 
     /// <summary>
     ///     Attempts to get all descendant node keys of a parent node in the recycle bin navigation structure.
@@ -294,7 +297,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the parent node exists in the recycle bin; otherwise, <c>false</c>.</returns>
     public bool TryGetDescendantsKeysInBin(Guid parentKey, out IEnumerable<Guid> descendantsKeys)
-        => TryGetDescendantsKeysFromStructure(_recycleBinNavigationStructure, parentKey, out descendantsKeys);
+        => TryGetDescendantsKeysFromStructure(_recycleBinNavigation.Structure, parentKey, out descendantsKeys);
 
     /// <summary>
     ///     Attempts to get all ancestor node keys of a child node in the recycle bin navigation structure.
@@ -306,7 +309,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the child node exists in the recycle bin; otherwise, <c>false</c>.</returns>
     public bool TryGetAncestorsKeysInBin(Guid childKey, out IEnumerable<Guid> ancestorsKeys)
-        => TryGetAncestorsKeysFromStructure(_recycleBinNavigationStructure, childKey, out ancestorsKeys);
+        => TryGetAncestorsKeysFromStructure(_recycleBinNavigation.Structure, childKey, out ancestorsKeys);
 
     /// <summary>
     ///     Attempts to get all sibling node keys of a node in the recycle bin navigation structure.
@@ -318,7 +321,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the node exists in the recycle bin; otherwise, <c>false</c>.</returns>
     public bool TryGetSiblingsKeysInBin(Guid key, out IEnumerable<Guid> siblingsKeys)
-        => TryGetSiblingsKeysFromStructure(_recycleBinNavigationStructure, key, out siblingsKeys);
+        => TryGetSiblingsKeysFromStructure(_recycleBinNavigation.Structure, key, out siblingsKeys);
 
     /// <summary>
     ///     Attempts to get the hierarchical level of a content node in the main navigation structure.
@@ -362,7 +365,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool MoveToBin(Guid key)
     {
-        if (TryRemoveNodeFromParentInStructure(_navigationStructure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
+        if (TryRemoveNodeFromParentInStructure(_navigation.Structure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
         {
             return false; // Node doesn't exist
         }
@@ -371,9 +374,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         AddDescendantsToRecycleBinRecursively(nodeToRemove);
 
         // Reset the SortOrder based on its new position in the bin
-        nodeToRemove.UpdateSortOrder(_recycleBinNavigationStructure.Count);
-        return _recycleBinNavigationStructure.TryAdd(nodeToRemove.Key, nodeToRemove) &&
-               _navigationStructure.TryRemove(key, out _);
+        nodeToRemove.UpdateSortOrder(_recycleBinNavigation.Structure.Count);
+        return _recycleBinNavigation.Structure.TryAdd(nodeToRemove.Key, nodeToRemove) &&
+               _navigation.Structure.TryRemove(key, out _);
     }
 
     /// <summary>
@@ -396,24 +399,24 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         NavigationNode? parentNode = null;
         if (parentKey.HasValue)
         {
-            if (_navigationStructure.TryGetValue(parentKey.Value, out parentNode) is false)
+            if (_navigation.Structure.TryGetValue(parentKey.Value, out parentNode) is false)
             {
                 return false; // Parent node doesn't exist
             }
         }
         else
         {
-            _roots.Add(key);
+            _navigation.Roots.Add(key);
         }
 
         // Note: sortOrder can't be automatically determined for items at root level, so it needs to be passed in
         var newNode = new NavigationNode(key, contentTypeKey, sortOrder ?? 0);
-        if (_navigationStructure.TryAdd(key, newNode) is false)
+        if (_navigation.Structure.TryAdd(key, newNode) is false)
         {
             return false; // Node with this key already exists
         }
 
-        parentNode?.AddChild(_navigationStructure, key);
+        parentNode?.AddChild(_navigation.Structure, key);
 
         return true;
     }
@@ -431,7 +434,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool Move(Guid key, Guid? targetParentKey = null)
     {
-        if (_navigationStructure.TryGetValue(key, out NavigationNode? nodeToMove) is false)
+        if (_navigation.Structure.TryGetValue(key, out NavigationNode? nodeToMove) is false)
         {
             return false; // Node doesn't exist
         }
@@ -441,29 +444,29 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             return false; // Cannot move a node to itself
         }
 
-        _roots.Remove(key); // Just in case
+        _navigation.Roots.Remove(key); // Just in case
 
         NavigationNode? targetParentNode = null;
         if (targetParentKey.HasValue)
         {
-            if (_navigationStructure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
+            if (_navigation.Structure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
             {
                 return false; // Target parent doesn't exist
             }
         }
         else
         {
-            _roots.Add(key);
+            _navigation.Roots.Add(key);
         }
 
         // Remove the node from its current parent's children list
-        if (nodeToMove.Parent is not null && _navigationStructure.TryGetValue(nodeToMove.Parent.Value, out NavigationNode? currentParentNode))
+        if (nodeToMove.Parent is not null && _navigation.Structure.TryGetValue(nodeToMove.Parent.Value, out NavigationNode? currentParentNode))
         {
-            currentParentNode.RemoveChild(_navigationStructure, key);
+            currentParentNode.RemoveChild(_navigation.Structure, key);
         }
 
         // Set the new parent for the node (if parent node is null - the node is moved to root)
-        targetParentNode?.AddChild(_navigationStructure, key);
+        targetParentNode?.AddChild(_navigation.Structure, key);
 
         return true;
     }
@@ -478,7 +481,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool UpdateSortOrder(Guid key, int newSortOrder)
     {
-        if (_navigationStructure.TryGetValue(key, out NavigationNode? node) is false)
+        if (_navigation.Structure.TryGetValue(key, out NavigationNode? node) is false)
         {
             return false; // Node doesn't exist
         }
@@ -498,16 +501,16 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool RemoveFromBin(Guid key)
     {
-        if (TryRemoveNodeFromParentInStructure(_recycleBinNavigationStructure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
+        if (TryRemoveNodeFromParentInStructure(_recycleBinNavigation.Structure, key, out NavigationNode? nodeToRemove) is false || nodeToRemove is null)
         {
             return false; // Node doesn't exist
         }
 
-        _recycleBinRoots.Remove(key);
+        _recycleBinNavigation.Roots.Remove(key);
 
         RemoveDescendantsRecursively(nodeToRemove);
 
-        return _recycleBinNavigationStructure.TryRemove(key, out _);
+        return _recycleBinNavigation.Structure.TryRemove(key, out _);
     }
 
     /// <summary>
@@ -524,26 +527,26 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </returns>
     public bool RestoreFromBin(Guid key, Guid? targetParentKey = null)
     {
-        if (_recycleBinNavigationStructure.TryGetValue(key, out NavigationNode? nodeToRestore) is false)
+        if (_recycleBinNavigation.Structure.TryGetValue(key, out NavigationNode? nodeToRestore) is false)
         {
             return false; // Node doesn't exist
         }
 
         // If a target parent is specified, try to find it in the main structure
         NavigationNode? targetParentNode = null;
-        if (targetParentKey.HasValue && _navigationStructure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
+        if (targetParentKey.HasValue && _navigation.Structure.TryGetValue(targetParentKey.Value, out targetParentNode) is false)
         {
             return false; // Target parent doesn't exist
         }
 
         // Set the new parent for the node (if parent node is null - the node is moved to root)
-        targetParentNode?.AddChild(_recycleBinNavigationStructure, key);
+        targetParentNode?.AddChild(_recycleBinNavigation.Structure, key);
 
         // Restore the node and its descendants from the recycle bin to the main structure
         RestoreNodeAndDescendantsRecursively(nodeToRestore);
 
-        return _navigationStructure.TryAdd(nodeToRestore.Key, nodeToRestore) &&
-               _recycleBinNavigationStructure.TryRemove(key, out _);
+        return _navigation.Structure.TryAdd(nodeToRestore.Key, nodeToRestore) &&
+               _recycleBinNavigation.Structure.TryRemove(key, out _);
     }
 
     /// <summary>
@@ -564,8 +567,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
         scope.ReadLock(readLock);
 
-        // Build into new structures, then swap atomically so that concurrent readers
-        // never observe a transiently empty navigation state.
+        // Build into new structures, then swap the snapshot atomically so that concurrent
+        // readers never observe a transiently empty navigation state or a mismatched pair
+        // of Structure and Roots.
         var newStructure = new ConcurrentDictionary<Guid, NavigationNode>();
         var newRoots = new HashSet<Guid>();
 
@@ -573,15 +577,13 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         {
             IEnumerable<INavigationModel> navigationModels = _navigationRepository.GetTrashedContentNodesByObjectType(objectTypeKey);
             BuildNavigationDictionary(newStructure, newRoots, navigationModels);
-            Interlocked.Exchange(ref _recycleBinNavigationStructure, newStructure);
-            Interlocked.Exchange(ref _recycleBinRoots, newRoots);
+            Interlocked.Exchange(ref _recycleBinNavigation, new NavigationSnapshot(newStructure, newRoots));
         }
         else
         {
             IEnumerable<INavigationModel> navigationModels = _navigationRepository.GetContentNodesByObjectType(objectTypeKey);
             BuildNavigationDictionary(newStructure, newRoots, navigationModels);
-            Interlocked.Exchange(ref _navigationStructure, newStructure);
-            Interlocked.Exchange(ref _roots, newRoots);
+            Interlocked.Exchange(ref _navigation, new NavigationSnapshot(newStructure, newRoots));
         }
 
         return Task.CompletedTask;
@@ -782,41 +784,41 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
 
     private void AddDescendantsToRecycleBinRecursively(NavigationNode node)
     {
-        _recycleBinRoots.Add(node.Key);
-        _roots.Remove(node.Key);
-        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _navigationStructure);
+        _recycleBinNavigation.Roots.Add(node.Key);
+        _navigation.Roots.Remove(node.Key);
+        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _navigation.Structure);
 
         foreach (Guid childKey in childrenKeys)
         {
-            if (_navigationStructure.TryGetValue(childKey, out NavigationNode? childNode) is false)
+            if (_navigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
             {
                 continue;
             }
 
             // Reset the SortOrder based on its new position in the bin
-            childNode.UpdateSortOrder(_recycleBinNavigationStructure.Count);
+            childNode.UpdateSortOrder(_recycleBinNavigation.Structure.Count);
             AddDescendantsToRecycleBinRecursively(childNode);
 
             // Only remove the child from the main structure if it was successfully added to the recycle bin
-            if (_recycleBinNavigationStructure.TryAdd(childKey, childNode))
+            if (_recycleBinNavigation.Structure.TryAdd(childKey, childNode))
             {
-                _navigationStructure.TryRemove(childKey, out _);
+                _navigation.Structure.TryRemove(childKey, out _);
             }
         }
     }
 
     private void RemoveDescendantsRecursively(NavigationNode node)
     {
-        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _recycleBinNavigationStructure);
+        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _recycleBinNavigation.Structure);
         foreach (Guid childKey in childrenKeys)
         {
-            if (_recycleBinNavigationStructure.TryGetValue(childKey, out NavigationNode? childNode) is false)
+            if (_recycleBinNavigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
             {
                 continue;
             }
 
             RemoveDescendantsRecursively(childNode);
-            _recycleBinNavigationStructure.TryRemove(childKey, out _);
+            _recycleBinNavigation.Structure.TryRemove(childKey, out _);
         }
     }
 
@@ -824,15 +826,15 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (node.Parent is null)
         {
-            _roots.Add(node.Key);
+            _navigation.Roots.Add(node.Key);
         }
 
-        _recycleBinRoots.Remove(node.Key);
-        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _recycleBinNavigationStructure);
+        _recycleBinNavigation.Roots.Remove(node.Key);
+        IReadOnlyList<Guid> childrenKeys = GetOrderedChildren(node, _recycleBinNavigation.Structure);
 
         foreach (Guid childKey in childrenKeys)
         {
-            if (_recycleBinNavigationStructure.TryGetValue(childKey, out NavigationNode? childNode) is false)
+            if (_recycleBinNavigation.Structure.TryGetValue(childKey, out NavigationNode? childNode) is false)
             {
                 continue;
             }
@@ -840,9 +842,9 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             RestoreNodeAndDescendantsRecursively(childNode);
 
             // Only remove the child from the recycle bin structure if it was successfully added to the main one
-            if (_navigationStructure.TryAdd(childKey, childNode))
+            if (_navigation.Structure.TryAdd(childKey, childNode))
             {
-                _recycleBinNavigationStructure.TryRemove(childKey, out _);
+                _recycleBinNavigation.Structure.TryRemove(childKey, out _);
             }
         }
     }

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -75,7 +75,19 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     /// </param>
     /// <returns><c>true</c> if the operation succeeds; otherwise, <c>false</c>.</returns>
     public bool TryGetRootKeys(out IEnumerable<Guid> rootKeys)
-        => TryGetRootKeysFromStructure(_roots, out rootKeys);
+    {
+        // On subscriber/CD servers in a load-balanced setup, cache refresh notifications trigger a full navigation rebuild
+        // (via RebuildAsync → HandleRebuildAsync), which replaces _roots and _navigationStructure with new instances. These
+        // two swaps cannot happen truly simultaneously, so a concurrent reader that accesses the fields separately could see
+        // the new _roots with the old _navigationStructure (or vice-versa), leading to KeyNotFoundExceptions or wrong results.
+        //
+        // Copying both fields into locals here ensures this method uses a pair of collections that were built together.
+        //
+        // Verified by: DocumentNavigationServiceTests.Concurrent_Rebuild_And_Queries_Never_Transiently_Lose_Content
+        HashSet<Guid> roots = _roots;
+        ConcurrentDictionary<Guid, NavigationNode> navigationStructure = _navigationStructure;
+        return TryGetRootKeysFromStructure(roots, navigationStructure, out rootKeys);
+    }
 
     /// <summary>
     ///     Attempts to get all root-level node keys of a specific content type from the main navigation structure.
@@ -92,7 +104,10 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     {
         if (TryGetContentTypeKey(contentTypeAlias, out Guid? contentTypeKey))
         {
-            return TryGetRootKeysFromStructure(_roots, out rootKeys, contentTypeKey);
+            // See TryGetRootKeys for why we snapshot both fields into locals.
+            HashSet<Guid> roots = _roots;
+            ConcurrentDictionary<Guid, NavigationNode> navigationStructure = _navigationStructure;
+            return TryGetRootKeysFromStructure(roots, navigationStructure, out rootKeys, contentTypeKey);
         }
 
         // Content type alias doesn't exist
@@ -549,18 +564,24 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
         scope.ReadLock(readLock);
 
-        // Build the corresponding navigation structure
+        // Build into new structures, then swap atomically so that concurrent readers
+        // never observe a transiently empty navigation state.
+        var newStructure = new ConcurrentDictionary<Guid, NavigationNode>();
+        var newRoots = new HashSet<Guid>();
+
         if (trashed)
         {
-            _recycleBinRoots.Clear();
             IEnumerable<INavigationModel> navigationModels = _navigationRepository.GetTrashedContentNodesByObjectType(objectTypeKey);
-            BuildNavigationDictionary(_recycleBinNavigationStructure, _recycleBinRoots,  navigationModels);
+            BuildNavigationDictionary(newStructure, newRoots, navigationModels);
+            Interlocked.Exchange(ref _recycleBinNavigationStructure, newStructure);
+            Interlocked.Exchange(ref _recycleBinRoots, newRoots);
         }
         else
         {
-            _roots.Clear();
             IEnumerable<INavigationModel> navigationModels = _navigationRepository.GetContentNodesByObjectType(objectTypeKey);
-            BuildNavigationDictionary(_navigationStructure, _roots, navigationModels);
+            BuildNavigationDictionary(newStructure, newRoots, navigationModels);
+            Interlocked.Exchange(ref _navigationStructure, newStructure);
+            Interlocked.Exchange(ref _roots, newRoots);
         }
 
         return Task.CompletedTask;
@@ -579,15 +600,19 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
         return false;
     }
 
-    private bool TryGetRootKeysFromStructure(
+    private static bool TryGetRootKeysFromStructure(
         HashSet<Guid> input,
+        ConcurrentDictionary<Guid, NavigationNode> structure,
         out IEnumerable<Guid> rootKeys,
         Guid? contentTypeKey = null)
     {
         var keysWithSortOrder = new List<(Guid Key, int SortOrder)>(input.Count);
         foreach (Guid key in input)
         {
-            NavigationNode navigationNode = _navigationStructure[key];
+            if (structure.TryGetValue(key, out NavigationNode? navigationNode) is false)
+            {
+                continue;
+            }
 
             // Apply contentTypeKey filter
             if (contentTypeKey.HasValue && navigationNode.ContentTypeKey != contentTypeKey.Value)

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -25,7 +25,7 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
     private readonly ICoreScopeProvider _coreScopeProvider;
     private readonly INavigationRepository _navigationRepository;
     private readonly TContentTypeService _typeService;
-    private Lazy<Dictionary<string, Guid>> _contentTypeAliasToKeyMap;
+    private readonly Lazy<Dictionary<string, Guid>> _contentTypeAliasToKeyMap;
 
     /// <summary>
     ///     Bundles a navigation structure dictionary and its root keys into a single reference so that

--- a/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
+++ b/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
@@ -17,7 +17,7 @@ public class PublishStatusService : IPublishStatusManagementService, IPublishSta
     private readonly ILanguageService _languageService;
     private readonly IDocumentNavigationQueryService _documentNavigationQueryService;
 
-    private readonly ConcurrentDictionary<Guid, ISet<string>> _publishedCultures = new();
+    private ConcurrentDictionary<Guid, ISet<string>> _publishedCultures = new();
 
     /// <summary>
     /// Gets or sets the default culture ISO code used when no culture is specified.
@@ -49,7 +49,18 @@ public PublishStatusService(
     /// <inheritdoc/>
     public async Task InitializeAsync(CancellationToken cancellationToken)
     {
-        _publishedCultures.Clear();
+        // On subscriber/CD servers in a load-balanced setup, cache refresh notifications can trigger
+        // re-initialization while other threads are reading _publishedCultures. The previous approach
+        // called _publishedCultures.Clear() then gradually re-added entries, creating a window where
+        // concurrent readers (e.g. HasPublishedAncestorPath) would see an empty dictionary and
+        // incorrectly conclude that content is unpublished.
+        //
+        // Instead, we build a completely new dictionary from the DB, then swap it in with
+        // Interlocked.Exchange. Readers that already hold a reference to the old dictionary continue
+        // to use it safely; new readers pick up the fully populated replacement. There is no window
+        // where the dictionary is empty.
+        //
+        // Verified by: PublishStatusServiceTests.Concurrent_Initialize_Never_Transiently_Loses_Published_Status
         IDictionary<Guid, ISet<string>> publishStatus;
         using (ICoreScope scope = _coreScopeProvider.CreateCoreScope())
         {
@@ -57,15 +68,10 @@ public PublishStatusService(
             scope.Complete();
         }
 
-        foreach ((Guid documentKey, ISet<string> publishedCultures) in publishStatus)
-        {
-            if (_publishedCultures.TryAdd(documentKey, publishedCultures) is false)
-            {
-                _logger.LogWarning("Failed to add published cultures for document {DocumentKey}", documentKey);
-            }
-        }
-
+        var newDictionary = new ConcurrentDictionary<Guid, ISet<string>>(publishStatus);
         DefaultCulture = await _languageService.GetDefaultIsoCodeAsync();
+
+        Interlocked.Exchange(ref _publishedCultures, newDictionary);
     }
 
     /// <inheritdoc/>

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -123,7 +123,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             (contentCacheNode, ancestorCheckFailed) = await GetContentCacheNodeFromRepo();
 
             // Only cache the result if the ancestor check didn't fail.
-            // When content exists in DB but the ancestor check fails, this is could be a transient
+            // When content exists in DB but the ancestor check fails, this could be a transient
             // race condition during cache rebuild. Caching null would poison the distributed cache.
             if (ancestorCheckFailed is false)
             {

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -119,12 +119,20 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         (bool exists, ContentCacheNode? contentCacheNode) = await _hybridCache.TryGetValueAsync<ContentCacheNode?>(cacheKey, CancellationToken.None);
         if (exists is false)
         {
-            contentCacheNode = await GetContentCacheNodeFromRepo();
-            await _hybridCache.SetAsync(
-                cacheKey,
-                contentCacheNode,
-                GetEntryOptions(key, preview),
-                GenerateTags(contentCacheNode));
+            bool ancestorCheckFailed;
+            (contentCacheNode, ancestorCheckFailed) = await GetContentCacheNodeFromRepo();
+
+            // Only cache the result if the ancestor check didn't fail.
+            // When content exists in DB but the ancestor check fails, this is could be a transient
+            // race condition during cache rebuild. Caching null would poison the distributed cache.
+            if (ancestorCheckFailed is false)
+            {
+                await _hybridCache.SetAsync(
+                    cacheKey,
+                    contentCacheNode,
+                    GetEntryOptions(key, preview),
+                    GenerateTags(contentCacheNode));
+            }
         }
 
         if (contentCacheNode is null)
@@ -140,7 +148,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
         return result;
 
-        async Task<ContentCacheNode?> GetContentCacheNodeFromRepo()
+        async Task<(ContentCacheNode? Node, bool AncestorCheckFailed)> GetContentCacheNodeFromRepo()
         {
             using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
             ContentCacheNode? contentCacheNode = await _databaseCacheRepository.GetContentSourceAsync(key, preview);
@@ -153,11 +161,13 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             // cache clear will re-query the database.
             if (preview is false && contentCacheNode is not null && _publishStatusQueryService.HasPublishedAncestorPath(contentCacheNode.Key) is false)
             {
-                // Careful not to early return here. We need to complete the scope even if returning null.
-                contentCacheNode = null;
+                // Content exists in the DB but the ancestor path is not published. Return null but
+                // signal to the caller that this should NOT be cached — the ancestor check may be
+                // transiently wrong during a cache rebuild.
+                return (null, true);
             }
 
-            return contentCacheNode;
+            return (contentCacheNode, false);
         }
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.ThreadSafety.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.ThreadSafety.cs
@@ -37,7 +37,7 @@ internal sealed partial class DocumentNavigationServiceTests
         {
             readerTasks.Add(RunWithSuppressedExecutionContext(() =>
             {
-                while (!cts.IsCancellationRequested)
+                while (cts.IsCancellationRequested is false)
                 {
                     Interlocked.Increment(ref totalReads);
                     try
@@ -54,6 +54,9 @@ internal sealed partial class DocumentNavigationServiceTests
                         // modification can throw. Count these as failures too.
                         Interlocked.Increment(ref exceptionCount);
                     }
+
+                    // Reduce CPU pressure in CI without yielding the thread or losing contention.
+                    Thread.SpinWait(20);
                 }
 
                 return Task.CompletedTask;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.ThreadSafety.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.ThreadSafety.cs
@@ -1,0 +1,86 @@
+using System.Collections.Concurrent;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+
+internal sealed partial class DocumentNavigationServiceTests
+{
+    [Test]
+    public async Task Concurrent_Rebuild_And_Queries_Never_Transiently_Lose_Content()
+    {
+        // Arrange
+        // Create a new DocumentNavigationService and establish baseline via RebuildAsync.
+        var sut = new DocumentNavigationService(
+            GetRequiredService<ICoreScopeProvider>(),
+            GetRequiredService<INavigationRepository>(),
+            GetRequiredService<IContentTypeService>());
+        await sut.RebuildAsync();
+
+        // Confirm baseline: root keys are present.
+        Assert.IsTrue(sut.TryGetRootKeys(out IEnumerable<Guid> initialRootKeys), "Root keys should exist after initial rebuild");
+        Assert.IsTrue(initialRootKeys.Any(), "There should be at least one root key");
+
+        var emptyRootCount = 0;
+        var exceptionCount = 0;
+        var totalReads = 0;
+        using var cts = new CancellationTokenSource();
+
+        // Act - readers loop continuously while rebuilds run.
+        // TryGetRootKeys reads from _roots (a non-thread-safe HashSet) which is
+        // cleared inside HandleRebuildAsync, creating a window where it returns empty.
+        var readerTasks = new List<Task>();
+        for (var i = 0; i < 4; i++)
+        {
+            readerTasks.Add(RunWithSuppressedExecutionContext(() =>
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    Interlocked.Increment(ref totalReads);
+                    try
+                    {
+                        sut.TryGetRootKeys(out IEnumerable<Guid> rootKeys);
+                        if (!rootKeys.Any())
+                        {
+                            Interlocked.Increment(ref emptyRootCount);
+                        }
+                    }
+                    catch
+                    {
+                        // HashSet is not thread-safe; concurrent enumeration during
+                        // modification can throw. Count these as failures too.
+                        Interlocked.Increment(ref exceptionCount);
+                    }
+                }
+
+                return Task.CompletedTask;
+            }));
+        }
+
+        // Run 50 sequential rebuilds. Readers run throughout, maximizing
+        // the chance of observing the transient empty state after _roots.Clear().
+        for (var i = 0; i < 50; i++)
+        {
+            await sut.RebuildAsync();
+        }
+
+        cts.Cancel();
+        await Task.WhenAll(readerTasks);
+
+        var failureCount = emptyRootCount + exceptionCount;
+
+        // Assert - root keys should never be transiently empty during a rebuild.
+        Assert.IsTrue(failureCount == 0, $"Expected all reads to see root keys, but {emptyRootCount} returned empty and {exceptionCount} threw exceptions (out of {totalReads} total reads)");
+    }
+
+    private static Task RunWithSuppressedExecutionContext(Func<Task> action)
+    {
+        using (ExecutionContext.SuppressFlow())
+        {
+            return Task.Run(action);
+        }
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTests.ThreadSafety.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTests.ThreadSafety.cs
@@ -200,13 +200,16 @@ internal sealed partial class PublishStatusServiceTests
         {
             readerTasks.Add(RunWithSuppressedExecutionContext(() =>
             {
-                while (!cts.IsCancellationRequested)
+                while (cts.IsCancellationRequested is false)
                 {
                     Interlocked.Increment(ref totalReads);
                     if (sut.IsDocumentPublishedInAnyCulture(Textpage.Key) is false)
                     {
                         Interlocked.Increment(ref falseCount);
                     }
+
+                    // Reduce CPU pressure in CI without yielding the thread or losing contention.
+                    Thread.SpinWait(20);
                 }
 
                 return Task.CompletedTask;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTests.ThreadSafety.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTests.ThreadSafety.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -173,6 +174,59 @@ internal sealed partial class PublishStatusServiceTests
 
         // Assert
         Assert.IsEmpty(exceptions, $"Expected no exceptions but got {exceptions.Count}: {string.Join(", ", exceptions.Select(e => e.Message))}");
+    }
+
+    [Test]
+    public async Task Concurrent_Initialize_Never_Transiently_Loses_Published_Status()
+    {
+        // Arrange
+        var sut = CreatePublishedStatusService();
+
+        // Publish the Textpage branch so InitializeAsync has data to load.
+        ContentService.PublishBranch(Textpage, PublishBranchFilter.IncludeUnpublished, ["*"]);
+
+        // Initialize once and confirm the baseline.
+        await sut.InitializeAsync(CancellationToken.None);
+        Assert.IsTrue(sut.IsDocumentPublishedInAnyCulture(Textpage.Key), "Textpage should be published after initial load");
+
+        var falseCount = 0;
+        var totalReads = 0;
+        using var cts = new CancellationTokenSource();
+
+        // Act - readers loop continuously while initializers run, ensuring reads
+        // overlap with the Clear()-then-rebuild window inside InitializeAsync.
+        var readerTasks = new List<Task>();
+        for (var i = 0; i < 4; i++)
+        {
+            readerTasks.Add(RunWithSuppressedExecutionContext(() =>
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    Interlocked.Increment(ref totalReads);
+                    if (sut.IsDocumentPublishedInAnyCulture(Textpage.Key) is false)
+                    {
+                        Interlocked.Increment(ref falseCount);
+                    }
+                }
+
+                return Task.CompletedTask;
+            }));
+        }
+
+        // Run 50 sequential re-initializations (simulates repeated cache rebuilds
+        // on a subscriber server). Readers run throughout, maximizing the chance
+        // of observing the transient empty state.
+        for (var i = 0; i < 50; i++)
+        {
+            await sut.InitializeAsync(CancellationToken.None);
+        }
+
+        cts.Cancel();
+        await Task.WhenAll(readerTasks);
+
+        // Assert - every single read should have returned true; the published status
+        // must never be transiently lost during re-initialization.
+        Assert.IsTrue(falseCount == 0, $"Expected all reads to return true, but {falseCount} out of {totalReads} returned false");
     }
 
     private static Task RunWithSuppressedExecutionContext(Func<Task> action)

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheMockTests.cs
@@ -280,6 +280,55 @@ internal sealed class DocumentHybridCacheMockTests : UmbracoIntegrationTestWithC
             Times.Exactly(1));
     }
 
+    [Test]
+    public async Task Null_Is_Not_Cached_When_Content_Exists_But_Ancestor_Check_Fails()
+    {
+        // Arrange - create a new DocumentCacheService with a controllable HasPublishedAncestorPath mock.
+        var ancestorCheckReturnsTrue = false;
+
+        var controllableMock = new Mock<IPublishStatusQueryService>();
+        controllableMock.Setup(x => x.IsDocumentPublishedInAnyCulture(It.IsAny<Guid>())).Returns(true);
+        controllableMock.Setup(x => x.HasPublishedAncestorPath(It.IsAny<Guid>()))
+            .Returns(() => ancestorCheckReturnsTrue);
+
+        var controlledCacheService = new DocumentCacheService(
+            _mockDatabaseCacheRepository.Object,
+            GetRequiredService<IIdKeyMap>(),
+            GetRequiredService<ICoreScopeProvider>(),
+            GetRequiredService<Microsoft.Extensions.Caching.Hybrid.HybridCache>(),
+            GetRequiredService<IPublishedContentFactory>(),
+            GetRequiredService<ICacheNodeFactory>(),
+            GetSeedProviders(controllableMock.Object),
+            new OptionsWrapper<CacheSettings>(new CacheSettings()),
+            GetRequiredService<IPublishedModelFactory>(),
+            GetRequiredService<IPreviewService>(),
+            controllableMock.Object,
+            new NullLogger<DocumentCacheService>());
+
+        var controlledCache = new DocumentCache(
+            controlledCacheService,
+            GetRequiredService<IPublishedContentTypeCache>(),
+            GetRequiredService<IDocumentNavigationQueryService>(),
+            GetRequiredService<IDocumentUrlService>(),
+            new Lazy<IPublishedUrlProvider>(GetRequiredService<IPublishedUrlProvider>));
+
+        // Clear any existing cache entry for this key.
+        var hybridCache = GetRequiredService<Microsoft.Extensions.Caching.Hybrid.HybridCache>();
+        await hybridCache.RemoveAsync($"{Textpage.Key}");
+
+        // Act 1 - ancestor check returns false, so GetByKeyAsync should return null.
+        var firstResult = await controlledCache.GetByIdAsync(Textpage.Key, false);
+        Assert.IsNull(firstResult, "First call should return null when ancestor check fails");
+
+        // Act 2 - now the ancestor check returns true.
+        ancestorCheckReturnsTrue = true;
+        var secondResult = await controlledCache.GetByIdAsync(Textpage.Key, false);
+
+        // Assert - the null from step 1 should NOT have been cached, so step 2 should
+        // hit the database again and return the content.
+        Assert.IsNotNull(secondResult, "Second call should return content because null should not have been cached when ancestor check failed");
+    }
+
     private void AssertTextPage(IPublishedContent textPage)
     {
         Assert.Multiple(() =>


### PR DESCRIPTION
## Description

We have a couple of issues reporting concerns with published content being or becoming unavailable, and needing restore via publishing or rebuilding of caches: #22254, #22384.  Neither have steps to replicate, but I've done some code analysis and found three areas where we could have problems in particular multithreading scenarios.

- **Skip caching null when ancestor check fails in `DocumentCacheService.GetNodeAsync()`**: When content exists in the database but `HasPublishedAncestorPath()` transiently returns false, null was cached. Now we skip the cache write when the null is due to a failed ancestor check (but continue to cache null if the content truly does not exist).
- **Atomic swap in `PublishStatusService.InitializeAsync()`**: Previously called `Clear()` then rebuilt from the database, leaving a window where concurrent readers saw an empty dictionary and concluded content was unpublished. Now builds a new `ConcurrentDictionary` and swaps it in with `Interlocked.Exchange`.
- **Atomic swap in `ContentNavigationServiceBase.HandleRebuildAsync()`**: Previously cleared `_roots` (a non-thread-safe `HashSet`) then rebuilt, causing concurrent readers to see empty roots or throw. Now bundles `Structure` and `Roots` into a single `NavigationSnapshot` record so `HandleRebuildAsync` can replace both with one `Interlocked.Exchange` call. Readers snapshot the single reference to get a guaranteed-consistent pair.

For each of these I've created an integration test to demonstrate the problem and fail expectedly, applied the fix and verified the tests now pass.  So I can be fairly confident that the race conditions identified are real and the fixes are correct.  It's not 100% the case of course that these are the cause of the reported problems, but they do look to align with the symptoms.

## Testing

- [x] `PublishStatusServiceTests.Concurrent_Initialize_Never_Transiently_Loses_Published_Status` — verifies no transient loss during re-initialization.
- [x] `DocumentNavigationServiceTests.Concurrent_Rebuild_And_Queries_Never_Transiently_Lose_Content` — verifies root keys are never transiently empty during concurrent rebuilds.
- [x] `DocumentHybridCacheMockTests.Null_Is_Not_Cached_When_Content_Exists_But_Ancestor_Check_Fails` — verifies null is not cached when ancestor check fails.