### PR TITLE
Accessibility: Add label and localized placeholder to picker search field

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/picker-search-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/picker/search/picker-search-field.element.ts
@@ -42,11 +42,11 @@ export class UmbPickerSearchFieldElement extends UmbLitElement {
 		if (!this._isSearchable) return nothing;
 
 		return html`
-			<uui-input .value=${this._query} placeholder="Search..." @input=${this.#onInput}>
+			<uui-input .value=${this._query} label=${this.localize.term('general_search')}	placeholder=${this.localize.term('placeholders_search')}	@input=${this.#onInput}>
 				<div slot="prepend">
 					${this._searching
 						? html`<uui-loader-circle id="searching-indicator"></uui-loader-circle>`
-						: html`<uui-icon name="search"></uui-icon>`}
+						: html`<uui-icon name="search" aria-hidden="true"></uui-icon>`}
 				</div>
 
 				${this._query


### PR DESCRIPTION
The `uui-input` in the picker search field was missing a `label` attribute, causing a `UUI-INPUT needs a 'label'` console warning and leaving the input without an accessible name.

## Changes
- Added `label=${this.localize.term('general_search')}` to `<uui-input>` in `picker-search-field.element.ts`
- Replaced hardcoded `placeholder="Search..."` with `placeholder=${this.localize.term('placeholders_search')}`
- Added `aria-hidden="true"` to the decorative search icon
<img width="1914" height="628" alt="image" src="https://github.com/user-attachments/assets/4bf090fa-87ae-4470-a3a0-20071ec1bcea" />

## Testing
- The console warning `UUI-INPUT needs a 'label'` no longer appears when opening a picker
- Screen readers announce the input as "Search"
- The placeholder text is now localized