### PR TITLE
Accessibility: Add labels to member workspace toggles

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/views/member/member-workspace-view-member.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/views/member/member-workspace-view-member.element.ts
@@ -217,6 +217,7 @@ export class UmbMemberWorkspaceViewMemberElement extends UmbLitElement implement
 								<uui-toggle
 									slot="editor"
 									data-mark="toggle:approved"
+									label=${this.localize.term('user_stateApproved')}
 									.checked=${this._workspaceContext!.isApproved}
 									@change=${(e: UUIBooleanInputEvent) => this.#onChange('isApproved', e.target.checked)}>
 								</uui-toggle>
@@ -226,6 +227,7 @@ export class UmbMemberWorkspaceViewMemberElement extends UmbLitElement implement
 								<uui-toggle
 									slot="editor"
 									data-mark="toggle:locked-out"
+									label=${this.localize.term('user_stateLockedOut')}
 									?disabled=${this._isNew || !this._workspaceContext!.isLockedOut}
 									.checked=${this._workspaceContext!.isLockedOut}
 									@change=${(e: UUIBooleanInputEvent) => this.#onChange('isLockedOut', e.target.checked)}>
@@ -237,6 +239,7 @@ export class UmbMemberWorkspaceViewMemberElement extends UmbLitElement implement
 						<uui-toggle
 							slot="editor"
 							data-mark="toggle:two-factor"
+							label=${this.localize.term('member_2fa')}
 							?disabled=${this._isNew || !this._workspaceContext.isTwoFactorEnabled}
 							.checked=${this._workspaceContext.isTwoFactorEnabled}
 							@change=${(e: UUIBooleanInputEvent) => this.#onChange('isTwoFactorEnabled', e.target.checked)}>


### PR DESCRIPTION
The three `uui-toggle` elements in the member workspace view were missing `label` attributes, causing a Lighthouse audit failure ("Form elements do not have associated labels") and leaving the toggle inputs without accessible names for assistive technologies.

## Changes
- Added `label=${this.localize.term('user_stateApproved')}` to the Approved toggle
- Added `label=${this.localize.term('user_stateLockedOut')}` to the Locked Out toggle
- Added `label=${this.localize.term('member_2fa')}` to the Two-Factor Authentication toggle
<img width="1065" height="430" alt="image" src="https://github.com/user-attachments/assets/fd63ad57-6b76-4860-8d84-b0c61bbdeba0" />

## Testing
- Lighthouse audit no longer reports "Form elements do not have associated labels" on the member workspace view
- Screen readers now announce each toggle with its correct label when focused