### PR TITLE
Elements: Align `ElementPermissionService` for performance improvements

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IEntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IEntityRepository.cs
@@ -181,6 +181,14 @@ public interface IEntityRepository : IRepository
     IEnumerable<TreeEntityPath> GetAllPaths(Guid objectType, params Guid[] keys);
 
     /// <summary>
+    /// Gets all paths for entities of the specified object types, optionally filtered by the provided entity IDs.
+    /// </summary>
+    /// <param name="objectTypes">The unique identifiers of the object types.</param>
+    /// <param name="keys">Optional array of entity IDs to filter the paths. If not provided, paths for all entities of the specified type are returned.</param>
+    /// <returns>A collection of entity paths.</returns>
+    IEnumerable<TreeEntityPath> GetAllPaths(Guid[] objectTypes, params Guid[] keys);
+
+    /// <summary>
     ///     Checks whether an entity with the specified identifier exists.
     /// </summary>
     /// <param name="id">The identifier of the entity.</param>

--- a/src/Umbraco.Core/Persistence/Repositories/IEntityRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IEntityRepository.cs
@@ -184,7 +184,7 @@ public interface IEntityRepository : IRepository
     /// Gets all paths for entities of the specified object types, optionally filtered by the provided entity IDs.
     /// </summary>
     /// <param name="objectTypes">The unique identifiers of the object types.</param>
-    /// <param name="keys">Optional array of entity IDs to filter the paths. If not provided, paths for all entities of the specified type are returned.</param>
+    /// <param name="keys">Optional array of entity keys to filter the paths. If not provided, paths for all entities of the specified type are returned.</param>
     /// <returns>A collection of entity paths.</returns>
     IEnumerable<TreeEntityPath> GetAllPaths(Guid[] objectTypes, params Guid[] keys);
 

--- a/src/Umbraco.Core/Services/ElementPermissionService.cs
+++ b/src/Umbraco.Core/Services/ElementPermissionService.cs
@@ -2,6 +2,7 @@ using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services.AuthorizationStatus;
 using Umbraco.Extensions;
 
@@ -39,25 +40,35 @@ internal sealed class ElementPermissionService : IElementPermissionService
             return Task.FromResult(ElementAuthorizationStatus.NotFound);
         }
 
+        // Use GetAllPaths instead of loading full content items - we only need paths for authorization
+        TreeEntityPath[] entityPaths = _entityService.GetAllPaths([UmbracoObjectTypes.Element, UmbracoObjectTypes.ElementContainer], keys).ToArray();
+        if (entityPaths.Length == 0)
+        {
+            return Task.FromResult(ElementAuthorizationStatus.NotFound);
+        }
+
         // Fetch both Elements and ElementContainers (folders)
         IEntitySlim[] entities = _entityService.GetAll(
             new[] { UmbracoObjectTypes.Element, UmbracoObjectTypes.ElementContainer },
             keys).ToArray();
-
         if (entities.Length == 0)
         {
             return Task.FromResult(ElementAuthorizationStatus.NotFound);
         }
 
-        if (entities.Any(entity => user.HasElementPathAccess(entity, _entityService, _appCaches) == false))
+        // Check path access using the paths directly
+        int[]? startNodeIds = user.CalculateElementStartNodeIds(_entityService, _appCaches);
+        foreach (TreeEntityPath entityPath in entityPaths)
         {
-            return Task.FromResult(ElementAuthorizationStatus.UnauthorizedMissingPathAccess);
+            if (ContentPermissions.HasPathAccess(entityPath.Path, startNodeIds, Constants.System.RecycleBinElement) == false)
+            {
+                return Task.FromResult(ElementAuthorizationStatus.UnauthorizedMissingPathAccess);
+            }
         }
 
-        return Task.FromResult(
-            HasPermissionAccess(user, entities.Select(e => e.Path), permissionsToCheck)
-                ? ElementAuthorizationStatus.Success
-                : ElementAuthorizationStatus.UnauthorizedMissingPermissionAccess);
+        return Task.FromResult(HasPermissionAccess(user, entityPaths.Select(p => p.Path), permissionsToCheck)
+            ? ElementAuthorizationStatus.Success
+            : ElementAuthorizationStatus.UnauthorizedMissingPermissionAccess);
     }
 
     /// <inheritdoc/>

--- a/src/Umbraco.Core/Services/ElementPermissionService.cs
+++ b/src/Umbraco.Core/Services/ElementPermissionService.cs
@@ -47,15 +47,6 @@ internal sealed class ElementPermissionService : IElementPermissionService
             return Task.FromResult(ElementAuthorizationStatus.NotFound);
         }
 
-        // Fetch both Elements and ElementContainers (folders)
-        IEntitySlim[] entities = _entityService.GetAll(
-            new[] { UmbracoObjectTypes.Element, UmbracoObjectTypes.ElementContainer },
-            keys).ToArray();
-        if (entities.Length == 0)
-        {
-            return Task.FromResult(ElementAuthorizationStatus.NotFound);
-        }
-
         // Check path access using the paths directly
         int[]? startNodeIds = user.CalculateElementStartNodeIds(_entityService, _appCaches);
         foreach (TreeEntityPath entityPath in entityPaths)

--- a/src/Umbraco.Core/Services/EntityService.cs
+++ b/src/Umbraco.Core/Services/EntityService.cs
@@ -832,6 +832,15 @@ public class EntityService : RepositoryService, IEntityService
     }
 
     /// <inheritdoc />
+    public virtual IEnumerable<TreeEntityPath> GetAllPaths(IEnumerable<UmbracoObjectTypes> objectTypes, params Guid[] keys)
+    {
+        using (ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _entityRepository.GetAllPaths(objectTypes.Select(objectType => objectType.GetGuid()).ToArray(), keys);
+        }
+    }
+
+    /// <inheritdoc />
     public int ReserveId(Guid key)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))

--- a/src/Umbraco.Core/Services/IEntityService.cs
+++ b/src/Umbraco.Core/Services/IEntityService.cs
@@ -506,6 +506,11 @@ public interface IEntityService
     IEnumerable<TreeEntityPath> GetAllPaths(UmbracoObjectTypes objectType, params Guid[] keys);
 
     /// <summary>
+    ///     Gets paths for entities.
+    /// </summary>
+    IEnumerable<TreeEntityPath> GetAllPaths(IEnumerable<UmbracoObjectTypes> objectTypes, params Guid[] keys);
+
+    /// <summary>
     ///     Reserves an identifier for a key.
     /// </summary>
     /// <param name="key">They key.</param>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
@@ -587,14 +587,23 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
             ? PerformGetAllPaths(objectType, sql => sql.WhereIn<NodeDto>(x => x.UniqueId, keys.Distinct()))
             : PerformGetAllPaths(objectType);
 
+    /// <inheritdoc/>
+    public IEnumerable<TreeEntityPath> GetAllPaths(Guid[] objectTypes, params Guid[] keys) =>
+        keys.Any()
+            ? PerformGetAllPaths(objectTypes, sql => sql.WhereIn<NodeDto>(x => x.UniqueId, keys.Distinct()))
+            : PerformGetAllPaths(objectTypes);
+
     private IEnumerable<TreeEntityPath> PerformGetAllPaths(Guid objectType, Action<Sql<ISqlContext>>? filter = null)
+        => PerformGetAllPaths([objectType], filter);
+
+    private IEnumerable<TreeEntityPath> PerformGetAllPaths(Guid[] objectTypes, Action<Sql<ISqlContext>>? filter = null)
     {
         // NodeId is named Id on TreeEntityPath = use an alias
         Sql<ISqlContext> sql = Sql().Select<NodeDto>(
                 x => Alias(x.NodeId, nameof(TreeEntityPath.Id)),
                 x => x.Path,
                 x => Alias(x.UniqueId, nameof(TreeEntityPath.Key)))
-            .From<NodeDto>().Where<NodeDto>(x => x.NodeObjectType == objectType);
+            .From<NodeDto>().WhereIn<NodeDto>(x => x.NodeObjectType, objectTypes);
         filter?.Invoke(sql);
         return Database.Fetch<TreeEntityPath>(sql);
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ElementPermissionServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ElementPermissionServiceTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.AuthorizationStatus;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
+
+[TestFixture]
+public class ElementPermissionServiceTests
+{
+    private const int ElementNodeId = 5678;
+    private const string ElementNodePath = "-1,1234,5678";
+    private const int UserStartNodeId = 1234;
+    private const string UserStartNodePath = "-1,1234";
+    private const int UnrelatedStartNodeId = 9876;
+
+    private Mock<IEntityService> _entityServiceMock;
+    private Mock<IUserService> _userServiceMock;
+    private Mock<ILanguageService> _languageServiceMock;
+    private IElementPermissionService _sut;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _entityServiceMock = new Mock<IEntityService>();
+        _userServiceMock = new Mock<IUserService>();
+        _languageServiceMock = new Mock<ILanguageService>();
+        _sut = new ElementPermissionService(
+            _entityServiceMock.Object,
+            _userServiceMock.Object,
+            AppCaches.Disabled,
+            _languageServiceMock.Object);
+    }
+
+    [Test]
+    public async Task Can_Authorize_Access_By_Path()
+    {
+        // Arrange
+        var elementKey = Guid.NewGuid();
+        var user = CreateUser();
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.Is<IEnumerable<UmbracoObjectTypes>>(t => t.Contains(UmbracoObjectTypes.Element)), new[] { elementKey }))
+            .Returns([CreateTreeEntityPath(elementKey, ElementNodeId, ElementNodePath)]);
+
+        SetupPermissions(user, ElementNodePath, ["A"]);
+
+        // Act
+        var result = await _sut.AuthorizeAccessAsync(user, elementKey, "A");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.Success));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Access_When_Element_Not_Found()
+    {
+        // Arrange
+        var elementKey = Guid.NewGuid();
+        var user = CreateUser();
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.Is<IEnumerable<UmbracoObjectTypes>>(t => t.Contains(UmbracoObjectTypes.Element)), new[] { elementKey }))
+            .Returns([]);
+
+        // Act
+        var result = await _sut.AuthorizeAccessAsync(user, elementKey, "A");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.NotFound));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Access_Without_Path_Access()
+    {
+        // Arrange
+        var elementKey = Guid.NewGuid();
+        var user = CreateUser(startElementId: UnrelatedStartNodeId);
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.Is<IEnumerable<UmbracoObjectTypes>>(t => t.Contains(UmbracoObjectTypes.Element)), new[] { elementKey }))
+            .Returns([CreateTreeEntityPath(elementKey, ElementNodeId, ElementNodePath)]);
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()))
+            .Returns([CreateTreeEntityPath(Guid.NewGuid(), UnrelatedStartNodeId, $"-1,{UnrelatedStartNodeId}")]);
+
+        // Act
+        var result = await _sut.AuthorizeAccessAsync(user, elementKey, "A");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.UnauthorizedMissingPathAccess));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Access_Without_Required_Permission()
+    {
+        // Arrange
+        var elementKey = Guid.NewGuid();
+        var user = CreateUser();
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.Is<IEnumerable<UmbracoObjectTypes>>(t => t.Contains(UmbracoObjectTypes.Element)), new[] { elementKey }))
+            .Returns([CreateTreeEntityPath(elementKey, ElementNodeId, ElementNodePath)]);
+
+        SetupPermissions(user, ElementNodePath, ["A", "B", "C"]);
+
+        // Act
+        var result = await _sut.AuthorizeAccessAsync(user, elementKey, "F");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.UnauthorizedMissingPermissionAccess));
+    }
+
+    [Test]
+    public async Task Can_Authorize_Access_With_Required_Permission()
+    {
+        // Arrange
+        var elementKey = Guid.NewGuid();
+        var user = CreateUser();
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.Is<IEnumerable<UmbracoObjectTypes>>(t => t.Contains(UmbracoObjectTypes.Element)), new[] { elementKey }))
+            .Returns([CreateTreeEntityPath(elementKey, ElementNodeId, ElementNodePath)]);
+
+        SetupPermissions(user, ElementNodePath, ["A", "F", "C"]);
+
+        // Act
+        var result = await _sut.AuthorizeAccessAsync(user, elementKey, "F");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.Success));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Access_With_Empty_Keys()
+    {
+        // Arrange
+        var user = CreateUser();
+
+        // Act
+        var result = await _sut.AuthorizeAccessAsync(user, [], new HashSet<string> { "A" });
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.NotFound));
+    }
+
+    [Test]
+    public async Task Can_Authorize_Root_Access_By_Path()
+    {
+        // Arrange
+        var user = CreateUser();
+
+        SetupPermissions(user, Constants.System.RootString, ["A"]);
+
+        // Act
+        var result = await _sut.AuthorizeRootAccessAsync(user, "A");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.Success));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Root_Access_By_Path()
+    {
+        // Arrange
+        var user = CreateUser(startElementId: UserStartNodeId);
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()))
+            .Returns([CreateTreeEntityPath(Guid.NewGuid(), UserStartNodeId, UserStartNodePath)]);
+
+        // Act
+        var result = await _sut.AuthorizeRootAccessAsync(user, "A");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.UnauthorizedMissingRootAccess));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Root_Access_By_Permission()
+    {
+        // Arrange
+        var user = CreateUser();
+
+        SetupPermissions(user, Constants.System.RootString, ["A"]);
+
+        // Act
+        var result = await _sut.AuthorizeRootAccessAsync(user, "B");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.UnauthorizedMissingPermissionAccess));
+    }
+
+    [Test]
+    public async Task Can_Authorize_Bin_Access_By_Path()
+    {
+        // Arrange
+        var user = CreateUser();
+
+        SetupPermissions(user, Constants.System.RecycleBinElementString, ["A"]);
+
+        // Act
+        var result = await _sut.AuthorizeBinAccessAsync(user, "A");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.Success));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Bin_Access_By_Path()
+    {
+        // Arrange
+        var user = CreateUser(startElementId: UserStartNodeId);
+
+        _entityServiceMock
+            .Setup(x => x.GetAllPaths(It.IsAny<UmbracoObjectTypes>(), It.IsAny<int[]>()))
+            .Returns([CreateTreeEntityPath(Guid.NewGuid(), UserStartNodeId, UserStartNodePath)]);
+
+        // Act
+        var result = await _sut.AuthorizeBinAccessAsync(user, "A");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.UnauthorizedMissingBinAccess));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Bin_Access_By_Permission()
+    {
+        // Arrange
+        var user = CreateUser();
+
+        SetupPermissions(user, Constants.System.RecycleBinElementString, ["A"]);
+
+        // Act
+        var result = await _sut.AuthorizeBinAccessAsync(user, "B");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.UnauthorizedMissingPermissionAccess));
+    }
+
+    [Test]
+    public async Task Can_Authorize_Culture_Access_When_Group_Has_All_Languages()
+    {
+        // Arrange
+        var user = CreateUserWithAllLanguageAccess();
+
+        // Act
+        var result = await _sut.AuthorizeCultureAccessAsync(user, new HashSet<string> { "en-US", "da-DK" });
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.Success));
+    }
+
+    [Test]
+    public async Task Can_Authorize_Culture_Access_When_User_Has_Language()
+    {
+        // Arrange
+        var languageId = 1;
+        var user = CreateUserWithLanguageAccess(languageId);
+
+        _languageServiceMock
+            .Setup(x => x.GetIsoCodesByIdsAsync(It.Is<ICollection<int>>(ids => ids.Contains(languageId))))
+            .ReturnsAsync(["en-US"]);
+
+        // Act
+        var result = await _sut.AuthorizeCultureAccessAsync(user, new HashSet<string> { "en-US" });
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.Success));
+    }
+
+    [Test]
+    public async Task Cannot_Authorize_Culture_Access_When_User_Lacks_Language()
+    {
+        // Arrange
+        var languageId = 1;
+        var user = CreateUserWithLanguageAccess(languageId);
+
+        _languageServiceMock
+            .Setup(x => x.GetIsoCodesByIdsAsync(It.Is<ICollection<int>>(ids => ids.Contains(languageId))))
+            .ReturnsAsync(["en-US"]);
+
+        // Act
+        var result = await _sut.AuthorizeCultureAccessAsync(user, new HashSet<string> { "da-DK" });
+
+        // Assert
+        Assert.That(result, Is.EqualTo(ElementAuthorizationStatus.UnauthorizedMissingCulture));
+    }
+
+    private static IUser CreateUser(int id = 0, int? startElementId = null, bool withUserGroup = true)
+    {
+        var builder = new UserBuilder()
+            .WithId(id)
+            .WithStartElementIds(startElementId.HasValue ? [startElementId.Value] : []);
+
+        if (withUserGroup)
+        {
+            builder = builder
+                .AddUserGroup()
+                    .WithId(1)
+                    .WithName("admin")
+                    .WithAlias("admin")
+                .Done();
+        }
+
+        return builder.Build();
+    }
+
+    private static IUser CreateUserWithAllLanguageAccess()
+    {
+        var userGroupMock = new Mock<IReadOnlyUserGroup>();
+        userGroupMock.Setup(x => x.HasAccessToAllLanguages).Returns(true);
+        userGroupMock.Setup(x => x.AllowedLanguages).Returns(new HashSet<int>());
+        // userGroupMock.Setup(x => x.StartContentId).Returns(-1);
+        // userGroupMock.Setup(x => x.StartMediaId).Returns(-1);
+        userGroupMock.Setup(x => x.StartElementId).Returns(-1);
+
+        var userMock = new Mock<IUser>();
+        userMock.Setup(x => x.Groups).Returns([userGroupMock.Object]);
+        return userMock.Object;
+    }
+
+    private static IUser CreateUserWithLanguageAccess(int languageId)
+    {
+        var userGroupMock = new Mock<IReadOnlyUserGroup>();
+        userGroupMock.Setup(x => x.HasAccessToAllLanguages).Returns(false);
+        userGroupMock.Setup(x => x.AllowedLanguages).Returns(new HashSet<int> { languageId });
+        // userGroupMock.Setup(x => x.StartContentId).Returns(-1);
+        // userGroupMock.Setup(x => x.StartMediaId).Returns(-1);
+        userGroupMock.Setup(x => x.StartElementId).Returns(-1);
+
+        var userMock = new Mock<IUser>();
+        userMock.Setup(x => x.Groups).Returns([userGroupMock.Object]);
+        return userMock.Object;
+    }
+
+    private void SetupPermissions(IUser user, string path, string[] assignedPermissions)
+    {
+        var permissions = new EntityPermissionCollection { new(9876, 1234, assignedPermissions.ToHashSet()) };
+        var permissionSet = new EntityPermissionSet(1234, permissions);
+        _userServiceMock.Setup(x => x.GetPermissionsForPath(user, path)).Returns(permissionSet);
+    }
+
+    private static TreeEntityPath CreateTreeEntityPath(Guid key, int id, string path)
+        => Mock.Of<TreeEntityPath>(e => e.Key == key && e.Id == id && e.Path == path);
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR mirrors the (relevant) `ContentPermissionService` performance improvements from #21470 to the `ElementPermissionService`.

Specifically, the use of `IEntityService.GetAllPaths()` when authorizing for specific keys.

Since the `ElementPermissionService` is concerned with both containers and element, new overloads for `IEntityService.GetAllPaths()` and `IEntityRepository.GetAllPaths()` have been introduced, allowing for fetching the paths of multiple object types in one query.

### Testing this PR

Verify that element permissions still work - for example, remove element delete permissions for the admin user group and verify that element deletion is no longer possible (note: the UI still permits the action, but the API should respond in kind with a 403).
