### PR TITLE
Migrations: Consistently handle GUID casing when using SQLite

### DIFF
--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -102,7 +102,7 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
     /// Guids are serialized in uppercase by ORMs
     /// We need to ensure Guids are stored consistently
     /// </remarks>
-    public override string FormatGuid(Guid guid) => guid.ToString().ToUpper();
+    public override string FormatGuid(Guid guid) => guid.ToString().ToUpperInvariant();
 
     /// <inheritdoc />
     public override string Format(TableDefinition table)

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -96,6 +96,15 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// SQLite does not have the concept of guids / uuid / uniqueidentifier
+    /// Columns are also case sensitive by default
+    /// Guids are serialized in uppercase by ORMs
+    /// We need to ensure Guids are stored consistently
+    /// </remarks>
+    public override string FormatGuid(Guid guid) => guid.ToString().ToUpper();
+
+    /// <inheritdoc />
     public override string Format(TableDefinition table)
     {
         var columns = Format(table.Columns);

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -97,10 +97,10 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
 
     /// <inheritdoc />
     /// <remarks>
-    /// SQLite does not have the concept of guids / uuid / uniqueidentifier
-    /// Columns are also case sensitive by default
-    /// Guids are serialized in uppercase by ORMs
-    /// We need to ensure Guids are stored consistently
+    /// SQLite does not have the concept of guids / uuid / uniqueidentifier and columns are also
+    /// case sensitive by default.
+    /// Guids are serialized in uppercase by ORMs so we need to ensure they are stored in uppercase to
+    /// avoid case sensitivity issues when comparing values.
     /// </remarks>
     public override string FormatGuid(Guid guid) => guid.ToString().ToUpperInvariant();
 

--- a/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ConstrainedExecution;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using NPoco;
@@ -107,15 +108,15 @@ public abstract class MigrationExpressionBase : IMigrationExpression
         }
 
         // HACK: We're handling all the constraints higher up the stack for SQLite.
-            if (Context.Database.DatabaseType.IsSqlite())
-            {
-                _expressions = _expressions
-                    .Where(x => x is not CreateConstraintExpression)
-                    .Where(x => x is not CreateForeignKeyExpression)
-                    .ToList();
-            }
+        if (Context.Database.DatabaseType.IsSqlite())
+        {
+            _expressions = _expressions
+                .Where(x => x is not CreateConstraintExpression)
+                .Where(x => x is not CreateForeignKeyExpression)
+                .ToList();
+        }
 
-            foreach (IMigrationExpression expression in _expressions)
+        foreach (IMigrationExpression expression in _expressions)
         {
             expression.Execute();
         }
@@ -180,7 +181,7 @@ public abstract class MigrationExpressionBase : IMigrationExpression
             return "NULL";
         }
 
-        // Guids need to be uppercase for SQLite
+        // Format Guids via the syntax provider to ensure consistent storage (e.g. Guids need to be uppercase for SQLite).
         if (val is Guid guid)
         {
             return SqlSyntax.GetQuotedValue(SqlSyntax.FormatGuid(guid));

--- a/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationExpressionBase.cs
@@ -180,6 +180,12 @@ public abstract class MigrationExpressionBase : IMigrationExpression
             return "NULL";
         }
 
+        // Guids need to be uppercase for SQLite
+        if (val is Guid guid)
+        {
+            return SqlSyntax.GetQuotedValue(SqlSyntax.FormatGuid(guid));
+        }
+
         Type type = val.GetType();
 
         switch (Type.GetTypeCode(type))

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -321,7 +321,7 @@ public interface ISqlSyntaxProvider
     /// </summary>
     /// <param name="guid">The guid.</param>
     /// <returns>A string representation of the guid formatted for SQL.</returns>
-    string FormatGuid(Guid guid);
+    string FormatGuid(Guid guid) => guid.ToString();
 
     /// <summary>
     /// Formats a <see cref="TableDefinition"/> into its corresponding SQL statement.

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -317,6 +317,13 @@ public interface ISqlSyntaxProvider
     string FormatDateTime(DateTime date, bool includeTime = true);
 
     /// <summary>
+    /// Formats a <see cref="Guid"/> value as a string suitable for use in SQL queries.
+    /// </summary>
+    /// <param name="guid">The guid.</param>
+    /// <returns>A string representation of the guid formatted for SQL.</returns>
+    string FormatGuid(Guid guid);
+
+    /// <summary>
     /// Formats a <see cref="TableDefinition"/> into its corresponding SQL statement.
     /// </summary>
     /// <param name="table">The <see cref="TableDefinition"/> to format.</param>

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -546,7 +546,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
     public virtual void AlterSequences(IUmbracoDatabase database, string tableName) => throw new NotSupportedException();
 
     /// <summary>
-    ///     This is used ONLY if we need to format datetime without using SQL parameters (i.e. during migrations)
+    /// This is used ONLY if we need to format datetime without using SQL parameters (i.e. during migrations)
     /// </summary>
     /// <param name="date">The date to format.</param>
     /// <param name="includeTime">Whether to include the time component.</param>
@@ -559,6 +559,9 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
         // need CultureInfo.InvariantCulture because ":" here is the "time separator" and
         // may be converted to something else in different cultures (eg "." in DK).
         date.ToString(includeTime ? "yyyyMMdd HH:mm:ss" : "yyyyMMdd", CultureInfo.InvariantCulture);
+
+    /// <inheritdoc />
+    public virtual string FormatGuid(Guid guid) => guid.ToString();
 
     /// <summary>
     /// Formats a SQL create table statement for the specified table definition.

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerSyntaxProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.SqlServer/SqlServerSyntaxProviderTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Persistence.SqlServer.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.SqlServer;
+
+[TestFixture]
+public class SqlServerSyntaxProviderTests
+{
+    [Test]
+    public void Can_Format_Guid_Unchanged()
+    {
+        var sut = new SqlServerSyntaxProvider(Options.Create(new GlobalSettings()));
+
+        var result = sut.FormatGuid(new Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+
+        Assert.That(result, Is.EqualTo("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/SqliteSyntaxProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.Sqlite/SqliteSyntaxProviderTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Persistence.Sqlite.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.Sqlite;
+
+[TestFixture]
+public class SqliteSyntaxProviderTests
+{
+    [Test]
+    public void Can_Format_Guid_Uppercase()
+    {
+        var sut = new SqliteSyntaxProvider(
+            Options.Create(new GlobalSettings()),
+            Mock.Of<ILogger<SqliteSyntaxProvider>>());
+
+        var result = sut.FormatGuid(new Guid("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+
+        Assert.That(result, Is.EqualTo("A1B2C3D4-E5F6-7890-ABCD-EF1234567890"));
+    }
+}


### PR DESCRIPTION
SQLite doesn't have the concept of guids / uuids / uniqueidentifiers, and so they are stored in a `TEXT` column.

By default these columns are also case sensitive for querying in SQLite. NPoco / Entity Framework stores these values as uppercase strings, and Umbraco has specific NPoco [mappers ](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Cms.Persistence.Sqlite/Mappers/SqlitePocoGuidMapper.cs) for handling this.

Umbraco's migration wrappers include a friendly "builder" API around operations (notably `INSERT`) that generates the raw SQL string directly. There's no specific handling for guids in SQLite migrations, making it possible to insert values inconsistent with the rest of the database when using SQLite.

The consequence of this is data can't be queried by it's ID via NPoco, unless you ToString your guid in the query first (and ensure it's the same case) or use `LOWER()` in your query (super inefficient).

## Example
Create a POCO with a guid property:

```
[TableName(TableName)]
[PrimaryKey("id", AutoIncrement = false)]
[ExplicitColumns]
public class CustomTable
{
    public const string TableName = "CustomTable";

    [Column("id")]
    [PrimaryKeyColumn(Name = $"PK_{TableName}_id", AutoIncrement = false)]
    public Guid Id { get; set; } = Guid.NewGuid();
}
```

Create a migration that creates the table and inserts some data:

```
public class CustomMigration : AsyncMigrationBase
{
    public CustomMigration(IMigrationContext context)
        : base(context)
    {

    }

    protected override Task MigrateAsync()
    {
        if (TableExists(CustomTable.TableName) == false)
        {
            return;
        }

        Create.Table<CustomTable>().Do();

        Insert.IntoTable(CustomTable.TableName)
            .Row(new CustomTable
            {
                Id = Guid.NewGuid()
            })
            .Do();
    }
}
```

And [register the migration with a plan](https://docs.umbraco.com/umbraco-cms/extending/database#using-a-notification-handler).

Upon booting the application a table called "CustomTable" will be created, and a single row inserted with a guid. The guid will be stored as lowercase text.

<img width="272" height="41" alt="image" src="https://github.com/user-attachments/assets/e20926c7-48e8-4e74-ae93-ffa9f89cebd6" />

Change the migration to use NPoco directly, rather than Umbraco's friendly builder API, and the guid is inserted as uppercase (and is therefore queryable and consistent with how ORMs will handle).

```
Database.Insert(new CustomTable
{
    Id = Guid.NewGuid()
});
```

<img width="269" height="41" alt="image" src="https://github.com/user-attachments/assets/eb3f0ba9-eb26-4283-b4ce-58a7b8d7206a" />

## Changes
- Added a new `FormatGuid` method to the `ISqlSyntaxProvider`, like `FormatDate` which exists for similar reasons
- Default implementation just turns it into a string, and the `SqliteSyntaxProvider` uppercases the string
- Call `FormatGuid` within `MigrationExpressionBase`, that underpins the migration builders
  - The .NET typecode for `guid` is `object` so this needs it's own logic for handling outside of the existing switch / case

Whilst it means this change touches a few areas beyond just migrations this felt like the cleanest approach.

I have also separated out a commit that introduces a default implementation for the `FormatGuid` method in the interface. The comment [here ](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs#L12) implies this may not be desirable - but it does at least make this change non-breaking.

Happy to clarify anything, or for suggestions on alternative approaches here!