### PR TITLE
DevOps: Add Claude automated PR review action (closes #AB66809)

### DIFF
--- a/.github/workflows/claude-review-auto.yml
+++ b/.github/workflows/claude-review-auto.yml
@@ -1,0 +1,152 @@
+name: Claude Code Review
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr;
+            if (context.eventName === 'workflow_dispatch') {
+              const prNumber = context.payload.inputs?.pr_number;
+              if (!prNumber) throw new Error('pr_number input is required for workflow_dispatch');
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parseInt(prNumber, 10)
+              });
+              pr = data;
+            } else {
+              pr = context.payload.pull_request;
+            }
+
+            // Skip drafts
+            if (pr.draft) {
+              core.info('PR is a draft — skipping.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            // Skip very large PRs
+            if (pr.changed_files > 150) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `This PR changes ${pr.changed_files} files — skipping automated review (limit: 150). Please request a manual review.`
+              });
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            // SHA dedup — skip if this commit was already reviewed
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number
+            });
+            const sha = pr.head.sha.substring(0, 7);
+            const alreadyReviewed = comments.data.some(c =>
+              c.body?.includes(`Based on commit \`${sha}\``)
+            );
+            if (alreadyReviewed && context.eventName !== 'workflow_dispatch') {
+              core.info(`SHA ${sha} already reviewed — skipping.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('skip', 'false');
+            core.setOutput('number', pr.number.toString());
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('author', pr.user.login);
+
+      - name: Checkout
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        if: steps.pr.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-sonnet-4-6"
+          prompt: |
+            You are reviewing a pull request in the Umbraco CMS repository.
+            This is an open-source project that welcomes community contributions.
+
+            PR: #${{ steps.pr.outputs.number }}
+            Base branch: ${{ steps.pr.outputs.base_ref }}
+            Head SHA: ${{ steps.pr.outputs.head_sha }}
+            Author: ${{ steps.pr.outputs.author }}
+
+            ## Review Procedure
+
+            Read and execute the review procedure defined in `.claude/skills/umb-review/SKILL.md`.
+            Use `${{ steps.pr.outputs.base_ref }}` as the target branch (skip auto-detection in step 1).
+
+            ## Output Instructions
+
+            For each finding that references a specific file and line:
+            - Post an individual inline PR comment on that line.
+            - Format: **[Severity]** explanation, then suggestion.
+
+            For the overall summary (header, impact, verdict):
+            - Post ONE top-level PR comment.
+            - Include "Based on commit `${{ steps.pr.outputs.head_sha }}`" at the bottom (used for dedup).
+
+            Do NOT use sticky/updating comments — post new individual comments.
+
+            ## Labeling
+
+            After reviewing, apply labels to the PR based on changed files:
+            - `area/frontend` — if files under `src/Umbraco.Web.UI.Client/` are changed
+            - `area/backend` — if .cs files outside the frontend client are changed
+            - `area/test` — if only test files are changed
+            - `category/api` — if Management API or Delivery API files are changed
+            - `category/breaking` — if breaking changes were detected in the review
+            - `category/localization` — if localization/language files are changed
+            - `category/test-automation` — if only test files are changed
+            - `category/refactor` — if the PR is pure refactoring with no new features
+
+            Only apply labels you are confident about. Never remove existing labels.
+            Use `gh pr edit ${{ steps.pr.outputs.number }} --add-label "<label>"` to apply labels.
+
+            ## Tone
+
+            Be friendly and constructive. This project values community contributions.
+            Thank the author. Frame feedback as suggestions where possible.
+            Reserve firm language for genuine Critical issues only.
+            Do not be condescending. Remember: "We welcome all contributions
+            and will happily give feedback."
+
+            ## Constraints
+
+            - Run fully autonomously. Do NOT ask questions.
+            - Only review changed files. Do not flag pre-existing issues.
+            - Do not suggest changes that would themselves introduce breaking changes.

--- a/.github/workflows/claude-review-auto.yml
+++ b/.github/workflows/claude-review-auto.yml
@@ -61,17 +61,20 @@ jobs:
             }
 
             // SHA dedup — skip if this commit was already reviewed
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number
-            });
-            const sha = pr.head.sha.substring(0, 7);
-            const alreadyReviewed = comments.data.some(c =>
-              c.body?.includes(`Based on commit \`${sha}\``)
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100
+              }
+            );
+            const alreadyReviewed = comments.some(c =>
+              c.body?.includes(`Based on commit \`${pr.head.sha}\``)
             );
             if (alreadyReviewed && context.eventName !== 'workflow_dispatch') {
-              core.info(`SHA ${sha} already reviewed — skipping.`);
+              core.info(`SHA ${pr.head.sha} already reviewed — skipping.`);
               core.setOutput('skip', 'true');
               return;
             }
@@ -82,11 +85,12 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('author', pr.user.login);
 
-      - name: Checkout
+      - name: Checkout PR head
         if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         if: steps.pr.outputs.skip != 'true'

--- a/.github/workflows/claude-review-auto.yml
+++ b/.github/workflows/claude-review-auto.yml
@@ -1,8 +1,6 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
-    types: [opened, ready_for_review, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/claude-review-auto.yml
+++ b/.github/workflows/claude-review-auto.yml
@@ -131,6 +131,9 @@ jobs:
             - `category/localization` — if localization/language files are changed
             - `category/test-automation` — if only test files are changed
             - `category/refactor` — if the PR is pure refactoring with no new features
+            - `category/performance` — if performance-related changes are detected
+            - `category/ux` — if user-facing changes are detected
+            - `category/ui` — if changes to the UI layer are detected
 
             Only apply labels you are confident about. Never remove existing labels.
             Use `gh pr edit ${{ steps.pr.outputs.number }} --add-label "<label>"` to apply labels.

--- a/.github/workflows/claude-review-on-demand.yml
+++ b/.github/workflows/claude-review-on-demand.yml
@@ -16,7 +16,6 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: false # disabled — enable once auto workflow is validated
 
     steps:
       - name: Check commenter permission

--- a/.github/workflows/claude-review-on-demand.yml
+++ b/.github/workflows/claude-review-on-demand.yml
@@ -1,0 +1,121 @@
+name: Claude Code Review (On Demand)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-review-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude review')
+
+    steps:
+      - name: Check commenter permission
+        id: permission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login
+            });
+            const allowed = ['admin', 'write'].includes(data.permission);
+            if (!allowed) {
+              core.info(`${context.payload.comment.user.login} has '${data.permission}' — skipping.`);
+            }
+            core.setOutput('allowed', allowed ? 'true' : 'false');
+
+      - name: Get PR info
+        if: steps.permission.outputs.allowed == 'true'
+        id: pr_info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('author', pr.user.login);
+
+      - name: Checkout
+        if: steps.permission.outputs.allowed == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        if: steps.permission.outputs.allowed == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude review"
+          claude_args: "--model claude-sonnet-4-6"
+          prompt: |
+            You are reviewing a pull request in the Umbraco CMS repository.
+            This is an open-source project that welcomes community contributions.
+
+            PR: #${{ github.event.issue.number }}
+            Base branch: ${{ steps.pr_info.outputs.base_ref }}
+            Head SHA: ${{ steps.pr_info.outputs.sha }}
+            Author: ${{ steps.pr_info.outputs.author }}
+
+            ## Review Procedure
+
+            Read and execute the review procedure defined in `.claude/skills/umb-review/SKILL.md`.
+            Use `${{ steps.pr_info.outputs.base_ref }}` as the target branch (skip auto-detection in step 1).
+
+            ## Output Instructions
+
+            For each finding that references a specific file and line:
+            - Post an individual inline PR comment on that line.
+            - Format: **[Severity]** explanation, then suggestion.
+
+            For the overall summary (header, impact, verdict):
+            - Post ONE top-level PR comment.
+            - Include "Based on commit `${{ steps.pr_info.outputs.sha }}`" at the bottom (used for dedup).
+
+            Do NOT use sticky/updating comments — post new individual comments.
+
+            ## Labeling
+
+            After reviewing, apply labels to the PR based on changed files:
+            - `area/frontend` — if files under `src/Umbraco.Web.UI.Client/` are changed
+            - `area/backend` — if .cs files outside the frontend client are changed
+            - `area/test` — if only test files are changed
+            - `category/api` — if Management API or Delivery API files are changed
+            - `category/breaking` — if breaking changes were detected in the review
+            - `category/localization` — if localization/language files are changed
+            - `category/test-automation` — if only test files are changed
+            - `category/refactor` — if the PR is pure refactoring with no new features
+
+            Only apply labels you are confident about. Never remove existing labels.
+            Use `gh pr edit ${{ github.event.issue.number }} --add-label "<label>"` to apply labels.
+
+            ## Tone
+
+            Be friendly and constructive. This project values community contributions.
+            Thank the author. Frame feedback as suggestions where possible.
+            Reserve firm language for genuine Critical issues only.
+            Do not be condescending. Remember: "We welcome all contributions
+            and will happily give feedback."
+
+            ## Constraints
+
+            - Run fully autonomously. Do NOT ask questions.
+            - Only review changed files. Do not flag pre-existing issues.
+            - Do not suggest changes that would themselves introduce breaking changes.

--- a/.github/workflows/claude-review-on-demand.yml
+++ b/.github/workflows/claude-review-on-demand.yml
@@ -28,7 +28,7 @@ jobs:
               repo: context.repo.repo,
               username: context.payload.comment.user.login
             });
-            const allowed = ['admin', 'write'].includes(data.permission);
+            const allowed = ['admin', 'maintain', 'write'].includes(data.permission);
             if (!allowed) {
               core.info(`${context.payload.comment.user.login} has '${data.permission}' — skipping.`);
             }
@@ -49,11 +49,12 @@ jobs:
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('author', pr.user.login);
 
-      - name: Checkout
+      - name: Checkout PR head
         if: steps.permission.outputs.allowed == 'true'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: ${{ steps.pr_info.outputs.sha }}
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         if: steps.permission.outputs.allowed == 'true'

--- a/.github/workflows/claude-review-on-demand.yml
+++ b/.github/workflows/claude-review-on-demand.yml
@@ -99,6 +99,9 @@ jobs:
             - `category/localization` — if localization/language files are changed
             - `category/test-automation` — if only test files are changed
             - `category/refactor` — if the PR is pure refactoring with no new features
+            - `category/performance` — if performance-related changes are detected
+            - `category/ux` — if user-facing changes are detected
+            - `category/ui` — if changes to the UI layer are detected
 
             Only apply labels you are confident about. Never remove existing labels.
             Use `gh pr edit ${{ github.event.issue.number }} --add-label "<label>"` to apply labels.

--- a/.github/workflows/claude-review-on-demand.yml
+++ b/.github/workflows/claude-review-on-demand.yml
@@ -16,9 +16,7 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: |
-      github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '@claude review')
+    if: false # disabled — enable once auto workflow is validated
 
     steps:
       - name: Check commenter permission

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,48 @@ The backoffice is published to npm as `@umbraco-cms/backoffice`. Runtime depende
 
 ---
 
+## 7. CI/CD — Claude Automated PR Review
+
+Two GitHub Actions workflows provide automated code review using `anthropics/claude-code-action@v1` and the `umb-review` skill (`.claude/skills/umb-review/SKILL.md`). Reviews are advisory only — they do not block merging.
+
+### Workflows
+
+| File | Trigger | Purpose |
+|------|---------|---------|
+| `claude-review-auto.yml` | `pull_request_target` + `workflow_dispatch` | Auto-review on PR open/push; manual re-run by PR number |
+| `claude-review-on-demand.yml` | `issue_comment` (`@claude review`) | On-demand review triggered by collaborator comment |
+
+### Key Design Decisions
+
+- **`pull_request_target`** (not `pull_request`) — runs in base repo context so it has write access for fork PRs. Checkout must explicitly use `refs/pull/{n}/head` to get the PR code.
+- **`fetch-depth: 0`** — the umb-review skill uses `git diff {target}...HEAD` (triple-dot), which requires the merge base. Shallow clones break this.
+- **SHA dedup** — the auto workflow checks existing PR comments for `Based on commit \`{full-sha}\`` to skip re-reviews of the same commit. Uses `github.paginate()` to handle PRs with many comments.
+- **Permission gate** (on-demand) — `admin`, `maintain`, and `write` collaborators can trigger; others are silently ignored.
+- **Concurrency** — one review at a time per PR number; new pushes cancel in-progress reviews.
+- **Skip conditions** — draft PRs, PRs with >150 changed files.
+
+### Labels
+
+Both workflows instruct Claude to apply labels based on changed files:
+
+| Label | Condition |
+|-------|-----------|
+| `area/frontend` | Files under `src/Umbraco.Web.UI.Client/` |
+| `area/backend` | `.cs` files outside the frontend client |
+| `area/test` | Only test files changed |
+| `category/api` | Management or Delivery API files |
+| `category/breaking` | Breaking changes detected |
+| `category/localization` | Localization/language files |
+| `category/test-automation` | Only test files changed |
+| `category/refactor` | Pure refactoring, no new features |
+| `category/performance` | Performance-related changes |
+| `category/ux` | User-facing changes |
+| `category/ui` | UI layer changes |
+
+Labels are only added, never removed. Claude applies only labels it is confident about.
+
+---
+
 ## Quick Reference
 
 ### Essential Commands


### PR DESCRIPTION
## Summary

- Adds `claude-review-auto.yml`: runs on every non-draft PR (`opened`, `ready_for_review`, `synchronize`) and via `workflow_dispatch` for manual reruns. Skips draft PRs, PRs with >150 changed files, and commits already reviewed (SHA dedup).
- Adds `claude-review-on-demand.yml`: triggers when a collaborator with write access comments `@claude review` on a PR.

Both workflows execute the `.claude/skills/umb-review/SKILL.md` review procedure autonomously, posting individual inline PR comments for file:line findings and one summary comment per run. Claude also applies area and category labels based on changed files.

Reviews are **advisory only** and do not block merging.

## Test plan

- [ ] Create a test PR and verify the auto-review triggers and posts inline + summary comments
- [ ] Verify draft PRs are skipped
- [ ] Verify SHA dedup works (push again — should not re-review same commit)
- [ ] Comment `@claude review` on a PR and verify on-demand review triggers
- [ ] Verify a non-collaborator's `@claude review` comment is ignored
- [ ] Verify a PR with >150 changed files posts the skip message

🤖 Generated with [Claude Code](https://claude.com/claude-code)