### PR TITLE
Migrations: Quote names when creating index (closes #22409)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddContentVersionDateIndex.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddContentVersionDateIndex.cs
@@ -35,11 +35,9 @@ public class AddContentVersionDateIndex : AsyncMigrationBase
 
         // CREATE INDEX (without NONCLUSTERED) is portable across SQL Server and SQLite.
         // SQL Server defaults to nonclustered; SQLite does not support the NONCLUSTERED keyword.
-        var syntax = Database.SqlContext.SqlSyntax;
-
         Execute.Sql($@"
-            CREATE INDEX {syntax.GetQuotedName(IndexName)}
-            ON {syntax.GetQuotedTableName(ContentVersionDto.TableName)} ({syntax.GetQuotedColumnName(ContentVersionDto.VersionDateColumnName)})
+            CREATE INDEX {SqlSyntax.GetQuotedName(IndexName)}
+            ON {SqlSyntax.GetQuotedTableName(ContentVersionDto.TableName)} ({SqlSyntax.GetQuotedColumnName(ContentVersionDto.VersionDateColumnName)})
             ").Do();
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddContentVersionDateIndex.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddContentVersionDateIndex.cs
@@ -35,9 +35,17 @@ public class AddContentVersionDateIndex : AsyncMigrationBase
 
         // CREATE INDEX (without NONCLUSTERED) is portable across SQL Server and SQLite.
         // SQL Server defaults to nonclustered; SQLite does not support the NONCLUSTERED keyword.
-        Execute.Sql($@"
-            CREATE INDEX [{IndexName}]
-            ON [{ContentVersionDto.TableName}] ([versionDate])
-        ").Do();
+        var syntax = Database.SqlContext.SqlSyntax;
+        try
+        {
+            Execute.Sql($@"
+                CREATE INDEX {syntax.GetQuotedName(IndexName)}
+                ON {syntax.GetQuotedTableName(ContentVersionDto.TableName)} ({syntax.GetQuotedColumnName(ContentVersionDto.VersionDateColumnName)})
+            ").Do();
+        }
+        catch (Exception ex)
+        {
+            throw;
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddContentVersionDateIndex.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddContentVersionDateIndex.cs
@@ -36,16 +36,10 @@ public class AddContentVersionDateIndex : AsyncMigrationBase
         // CREATE INDEX (without NONCLUSTERED) is portable across SQL Server and SQLite.
         // SQL Server defaults to nonclustered; SQLite does not support the NONCLUSTERED keyword.
         var syntax = Database.SqlContext.SqlSyntax;
-        try
-        {
-            Execute.Sql($@"
-                CREATE INDEX {syntax.GetQuotedName(IndexName)}
-                ON {syntax.GetQuotedTableName(ContentVersionDto.TableName)} ({syntax.GetQuotedColumnName(ContentVersionDto.VersionDateColumnName)})
+
+        Execute.Sql($@"
+            CREATE INDEX {syntax.GetQuotedName(IndexName)}
+            ON {syntax.GetQuotedTableName(ContentVersionDto.TableName)} ({syntax.GetQuotedColumnName(ContentVersionDto.VersionDateColumnName)})
             ").Do();
-        }
-        catch (Exception ex)
-        {
-            throw;
-        }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentVersionDto.cs
@@ -15,9 +15,9 @@ public class ContentVersionDto
 {
     public const string TableName = Constants.DatabaseSchema.Tables.ContentVersion;
     public const string PrimaryKeyColumnName = Constants.DatabaseSchema.Columns.PrimaryKeyNameId;
+    public const string VersionDateColumnName = "versionDate";
 
     private const string UserIdColumnName = "userId";
-    private const string VersionDateColumnName = "versionDate";
     private const string CurrentColumnName = "current";
     private const string TextColumnName = "text";
     private const string NodeIdColumnName = Constants.DatabaseSchema.Columns.NodeIdName;


### PR DESCRIPTION
### Prerequisites
Raw sql statement with hard coded escaped names.
This PR closes issue #22409.