### PR TITLE
Clipboard: Localize property labels when copying to clipboard (closes #21998)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/block-single-entry/block-single-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/block-single-entry/block-single-entry.element.ts
@@ -308,8 +308,8 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 			throw new Error('Could not get required contexts to copy.');
 		}
 
-		const workspaceName = propertyDatasetContext?.getName();
-		const propertyLabel = propertyContext?.getLabel();
+		const workspaceName = this.localize.string(propertyDatasetContext?.getName());
+		const propertyLabel = this.localize.string(propertyContext?.getLabel());
 		const blockLabel = this.#context.getName();
 
 		const entryName = workspaceName

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/copy/copy-to-clipboard.property-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/property/actions/copy/copy-to-clipboard.property-action.ts
@@ -1,11 +1,13 @@
 import { UMB_CLIPBOARD_PROPERTY_CONTEXT } from '../../context/constants.js';
 import type { MetaPropertyActionCopyToClipboardKind } from './types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 import { UMB_PROPERTY_CONTEXT, UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UmbPropertyActionBase, type UmbPropertyActionArgs } from '@umbraco-cms/backoffice/property-action';
 
 export class UmbCopyToClipboardPropertyAction extends UmbPropertyActionBase<MetaPropertyActionCopyToClipboardKind> {
+	#localize = new UmbLocalizationController(this);
 	#propertyDatasetContext?: typeof UMB_PROPERTY_DATASET_CONTEXT.TYPE;
 	#propertyContext?: typeof UMB_PROPERTY_CONTEXT.TYPE;
 	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
@@ -48,8 +50,8 @@ export class UmbCopyToClipboardPropertyAction extends UmbPropertyActionBase<Meta
 			throw new Error('Property editor alias is not available');
 		}
 
-		const workspaceName = this.#propertyDatasetContext.getName();
-		const propertyLabel = this.#propertyContext.getLabel()!;
+		const workspaceName = this.#localize.string(this.#propertyDatasetContext.getName());
+		const propertyLabel = this.#localize.string(this.#propertyContext.getLabel());
 		const entryName = workspaceName ? `${workspaceName} - ${propertyLabel}` : propertyLabel;
 
 		const propertyValue = this.#propertyContext.getValue();


### PR DESCRIPTION
## Summary

Fixes #21998

- Localize `workspaceName` and `propertyLabel` in the property copy-to-clipboard action using `UmbLocalizationController`
- Localize the same in the block single entry copy method using `this.localize.string()`
- Block list and block grid entries already handled this correctly

Fixes the clipboard showing raw aliases like `#properties_tourKeyHighlights` instead of translated labels.

## Test plan

- [ ] Set up a document type with localized property labels (using `#`-prefixed keys)
- [ ] Copy a property value to clipboard
- [ ] Verify the clipboard panel shows the translated label, not the alias
- [ ] Test with block list, block grid, and block single editors

🤖 Generated with [Claude Code](https://claude.com/claude-code)