### PR TITLE
User Service: Prevent fetching all permissions when no IDs are provided

### DIFF
--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2018,6 +2018,11 @@ internal partial class UserService : RepositoryService, IUserService
             return Attempt.FailWithStatus(UserOperationStatus.MediaNodeNotFound, Enumerable.Empty<NodePermissions>());
         }
 
+        if (idAttempt.Result.Count == 0)
+        {
+            return Attempt.SucceedWithStatus(UserOperationStatus.Success, Enumerable.Empty<NodePermissions>());
+        }
+
         Attempt<IEnumerable<NodePermissions>, UserOperationStatus> permissions =
             await GetPermissionsAsync(userKey, idAttempt.Result, [UmbracoObjectTypes.Media]);
         scope.Complete();
@@ -2034,6 +2039,11 @@ internal partial class UserService : RepositoryService, IUserService
         if (idAttempt.Success is false || idAttempt.Result is null)
         {
             return Attempt.FailWithStatus(UserOperationStatus.ContentNodeNotFound, Enumerable.Empty<NodePermissions>());
+        }
+
+        if (idAttempt.Result.Count == 0)
+        {
+            return Attempt.SucceedWithStatus(UserOperationStatus.Success, Enumerable.Empty<NodePermissions>());
         }
 
         Attempt<IEnumerable<NodePermissions>, UserOperationStatus> permissions =

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -2018,11 +2018,6 @@ internal partial class UserService : RepositoryService, IUserService
             return Attempt.FailWithStatus(UserOperationStatus.MediaNodeNotFound, Enumerable.Empty<NodePermissions>());
         }
 
-        if (idAttempt.Result.Count == 0)
-        {
-            return Attempt.SucceedWithStatus(UserOperationStatus.Success, Enumerable.Empty<NodePermissions>());
-        }
-
         Attempt<IEnumerable<NodePermissions>, UserOperationStatus> permissions =
             await GetPermissionsAsync(userKey, idAttempt.Result, [UmbracoObjectTypes.Media]);
         scope.Complete();
@@ -2039,11 +2034,6 @@ internal partial class UserService : RepositoryService, IUserService
         if (idAttempt.Success is false || idAttempt.Result is null)
         {
             return Attempt.FailWithStatus(UserOperationStatus.ContentNodeNotFound, Enumerable.Empty<NodePermissions>());
-        }
-
-        if (idAttempt.Result.Count == 0)
-        {
-            return Attempt.SucceedWithStatus(UserOperationStatus.Success, Enumerable.Empty<NodePermissions>());
         }
 
         Attempt<IEnumerable<NodePermissions>, UserOperationStatus> permissions =
@@ -2065,6 +2055,11 @@ internal partial class UserService : RepositoryService, IUserService
         Dictionary<Guid, int> nodes,
         IEnumerable<UmbracoObjectTypes> objectTypes)
     {
+        if (nodes.Count == 0)
+        {
+            return Attempt.SucceedWithStatus(UserOperationStatus.Success, Enumerable.Empty<NodePermissions>());
+        }
+
         IUser? user = await GetAsync(userKey);
         if (user is null)
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.Permissions.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/UserServiceTests.Permissions.cs
@@ -387,6 +387,33 @@ internal sealed partial class UserServiceTests
     }
 
     [Test]
+    public async Task GetDocumentPermissionsAsync_Returns_Empty_Permissions_For_Empty_Keys()
+    {
+        // Arrange
+        var userGroup = await CreateTestUserGroup();
+        var user = UserService.CreateUserWithIdentity("test1", "test1@test.com");
+        user.AddGroup(userGroup.ToReadOnlyGroup());
+        UserService.Save(user);
+
+        // Create content so the database is non-empty — we want to verify that an an empty key collection
+        // does not return ALL documents, producing a non-empty result instead of the expected empty one.
+        var contentType = ContentTypeBuilder.CreateSimpleContentType();
+        contentType.AllowedTemplates = null;
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        var content = ContentBuilder.CreateSimpleContent(contentType);
+        ContentService.Save(content);
+
+        // Act
+        var result = await UserService
+            .GetDocumentPermissionsAsync(user.Key, Array.Empty<Guid>());
+
+        // Assert
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(UserOperationStatus.Success, result.Status);
+        Assert.IsEmpty(result.Result);
+    }
+
+    [Test]
     public async Task AssignUserGroupPermission_Adds_To_Existing_Permissions()
     {
         // Arrange


### PR DESCRIPTION
Ensures that the UserService does not attempt to fetch permissions when the provided ID collection is empty, avoiding potentially expensive database queries that could return permissions for all nodes.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

fixes #22415 

### Description

Ensure that userservice does not get permissions for all CMS content when no entities are provided. This has been observed when the backoffice calls `/umbraco/management/api/v1/tree/document/root?skip=0&take=0` which should be a simple count query.


To test set up an Umbraco solution and see that the backoffice no longer slows down significantly depending on the amount of content items. If you are testing locally you may need a significant amount of content to see a meaningful change, but in a multi-editor environment it should be easy to see the difference.