### PR TITLE
Background Jobs: Use `ApplicationMainUrl` as fallback for absolute URL provision (closes #22420)

### DIFF
--- a/src/Umbraco.Web.Common/UmbracoContext/UmbracoContext.cs
+++ b/src/Umbraco.Web.Common/UmbracoContext/UmbracoContext.cs
@@ -16,6 +16,8 @@ namespace Umbraco.Cms.Web.Common.UmbracoContext;
 /// </summary>
 public class UmbracoContext : DisposableObjectSlim, IUmbracoContext
 {
+    private static readonly Uri FallbackUrl = new("http://localhost");
+
     private readonly ICookieManager _cookieManager;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IHttpContextAccessor _httpContextAccessor;
@@ -116,7 +118,7 @@ public class UmbracoContext : DisposableObjectSlim, IUmbracoContext
 
             // Don't cache fallback values — ApplicationMainUrl may become available after the
             // first HTTP request is processed (see EnsureApplicationMainUrl).
-            return _hostingEnvironment.ApplicationMainUrl ?? new Uri("http://localhost");
+            return _hostingEnvironment.ApplicationMainUrl ?? FallbackUrl;
         }
     }
 
@@ -136,7 +138,9 @@ public class UmbracoContext : DisposableObjectSlim, IUmbracoContext
 
             Uri cleaned = _uriUtility.UriToUmbraco(OriginalRequestUrl);
 
-            // Only cache when OriginalRequestUrl was itself cached (i.e. from a real HTTP request).
+            // _originalRequestUrl is set as a side effect of the OriginalRequestUrl access above
+            // only when backed by a real HTTP request. When it's still null the value came from a
+            // fallback, so we don't cache — allowing a later-detected ApplicationMainUrl to take effect.
             if (_originalRequestUrl is not null)
             {
                 _cleanedUmbracoUrl = cleaned;

--- a/src/Umbraco.Web.Common/UmbracoContext/UmbracoContext.cs
+++ b/src/Umbraco.Web.Common/UmbracoContext/UmbracoContext.cs
@@ -84,19 +84,67 @@ public class UmbracoContext : DisposableObjectSlim, IUmbracoContext
         : new Uri(_httpContextAccessor.HttpContext.Request.GetEncodedUrl());
 
     /// <inheritdoc />
-    // set the urls lazily, no need to allocate until they are needed...
-    // NOTE: The request will not be available during app startup so we can only set this to an absolute URL of localhost, this
-    // is a work around to being able to access the UmbracoContext during application startup and this will also ensure that people
-    // 'could' still generate URLs during startup BUT any domain driven URL generation will not work because it is NOT possible to get
-    // the current domain during application startup.
-    // see: http://issues.umbraco.org/issue/U4-1890
-    public Uri OriginalRequestUrl =>
-_originalRequestUrl ??= RequestUrl ?? new Uri("http://localhost");
+    /// <remarks>
+    /// <para>The URL is resolved lazily in the following order of precedence:</para>
+    /// <list type="number">
+    ///   <item>The current HTTP request URL, when an <see cref="HttpContext"/> is available.
+    ///   This value is cached for the lifetime of this context instance.</item>
+    ///   <item>The configured <see cref="IHostingEnvironment.ApplicationMainUrl"/>, which is set from
+    ///   <c>Umbraco:CMS:WebRouting:UmbracoApplicationUrl</c> or auto-detected from the first request.
+    ///   This allows background services (e.g. <c>RecurringHostedServiceBase</c>) to generate absolute
+    ///   URLs with the correct scheme and host.</item>
+    ///   <item>A fallback of <c>http://localhost</c> when neither of the above is available (e.g. during
+    ///   application startup before any request has been processed).</item>
+    /// </list>
+    /// <para>Fallback values (2 and 3) are not cached, so that a later-detected
+    /// <see cref="IHostingEnvironment.ApplicationMainUrl"/> is picked up on the next access.</para>
+    /// </remarks>
+    public Uri OriginalRequestUrl
+    {
+        get
+        {
+            if (_originalRequestUrl is not null)
+            {
+                return _originalRequestUrl;
+            }
+
+            // Cache only when we have a real request URL — it is stable for this context's lifetime.
+            if (RequestUrl is not null)
+            {
+                return _originalRequestUrl = RequestUrl;
+            }
+
+            // Don't cache fallback values — ApplicationMainUrl may become available after the
+            // first HTTP request is processed (see EnsureApplicationMainUrl).
+            return _hostingEnvironment.ApplicationMainUrl ?? new Uri("http://localhost");
+        }
+    }
 
     /// <inheritdoc />
-    // set the urls lazily, no need to allocate until they are needed...
-    public Uri CleanedUmbracoUrl =>
-_cleanedUmbracoUrl ??= _uriUtility.UriToUmbraco(OriginalRequestUrl);
+    /// <remarks>
+    /// Like <see cref="OriginalRequestUrl"/>, this value is only cached when a real HTTP request URL
+    /// is available. Fallback-derived values are re-evaluated on each access.
+    /// </remarks>
+    public Uri CleanedUmbracoUrl
+    {
+        get
+        {
+            if (_cleanedUmbracoUrl is not null)
+            {
+                return _cleanedUmbracoUrl;
+            }
+
+            Uri cleaned = _uriUtility.UriToUmbraco(OriginalRequestUrl);
+
+            // Only cache when OriginalRequestUrl was itself cached (i.e. from a real HTTP request).
+            if (_originalRequestUrl is not null)
+            {
+                _cleanedUmbracoUrl = cleaned;
+            }
+
+            return cleaned;
+        }
+    }
 
     /// <inheritdoc />
     public IPublishedContentCache Content => _cacheManager.Content;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/UmbracoContext/UmbracoContextTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/UmbracoContext/UmbracoContextTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.UmbracoContext;
+
+[TestFixture]
+public class UmbracoContextTests
+{
+    [Test]
+    public void OriginalRequestUrl_Without_HttpContext_Uses_ApplicationMainUrl()
+    {
+        // Arrange - simulate a background service scenario: no HttpContext, but ApplicationMainUrl is configured
+        var umbracoContext = CreateUmbracoContext(
+            applicationMainUrl: new Uri("https://example.com"),
+            httpContext: null);
+
+        // Act
+        var originalRequestUrl = umbracoContext.OriginalRequestUrl;
+
+        // Assert - should use the configured ApplicationMainUrl with https scheme, not the hardcoded http://localhost
+        Assert.AreEqual("https", originalRequestUrl.Scheme);
+        Assert.AreEqual("example.com", originalRequestUrl.Host);
+    }
+
+    [Test]
+    public void OriginalRequestUrl_Without_HttpContext_Without_ApplicationMainUrl_Falls_Back_To_Localhost()
+    {
+        // Arrange - no HttpContext and no ApplicationMainUrl configured
+        var umbracoContext = CreateUmbracoContext(
+            applicationMainUrl: null,
+            httpContext: null);
+
+        // Act
+        var originalRequestUrl = umbracoContext.OriginalRequestUrl;
+
+        // Assert - should fall back to http://localhost when no ApplicationMainUrl is available
+        Assert.AreEqual("http", originalRequestUrl.Scheme);
+        Assert.AreEqual("localhost", originalRequestUrl.Host);
+    }
+
+    [Test]
+    public void OriginalRequestUrl_With_HttpContext_Uses_Request_Url()
+    {
+        // Arrange - normal HTTP request scenario
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("my-site.com");
+        httpContext.Request.Path = "/some-page";
+
+        var umbracoContext = CreateUmbracoContext(
+            applicationMainUrl: new Uri("https://example.com"),
+            httpContext: httpContext);
+
+        // Act
+        var originalRequestUrl = umbracoContext.OriginalRequestUrl;
+
+        // Assert - should use the actual request URL, not ApplicationMainUrl
+        Assert.AreEqual("https", originalRequestUrl.Scheme);
+        Assert.AreEqual("my-site.com", originalRequestUrl.Host);
+    }
+
+    private static global::Umbraco.Cms.Web.Common.UmbracoContext.UmbracoContext CreateUmbracoContext(
+        Uri? applicationMainUrl,
+        HttpContext? httpContext)
+    {
+        var webRoutingSettings = new WebRoutingSettings();
+        if (applicationMainUrl is not null)
+        {
+            webRoutingSettings.UmbracoApplicationUrl = applicationMainUrl.ToString();
+        }
+
+        var hostingEnvironment = new TestHostingEnvironment(
+            Mock.Of<IOptionsMonitor<HostingSettings>>(x => x.CurrentValue == new HostingSettings()),
+            Mock.Of<IOptionsMonitor<WebRoutingSettings>>(x => x.CurrentValue == webRoutingSettings),
+            Mock.Of<IWebHostEnvironment>(x =>
+                x.WebRootPath == "/" &&
+                x.ContentRootPath == "/"));
+
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
+        var umbracoRequestPaths = new UmbracoRequestPaths(
+            hostingEnvironment,
+            Options.Create(new UmbracoRequestPathsOptions()));
+        var uriUtility = new UriUtility(hostingEnvironment);
+        var cacheManager = Mock.Of<ICacheManager>(x =>
+            x.Content == Mock.Of<IPublishedContentCache>() &&
+            x.Media == Mock.Of<IPublishedMediaCache>());
+
+        return new global::Umbraco.Cms.Web.Common.UmbracoContext.UmbracoContext(
+            umbracoRequestPaths,
+            hostingEnvironment,
+            uriUtility,
+            Mock.Of<ICookieManager>(),
+            httpContextAccessor,
+            Mock.Of<IWebProfilerService>(),
+            cacheManager);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/UmbracoContext/UmbracoContextTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/UmbracoContext/UmbracoContextTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Tests.Common.Testing;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.UmbracoContext;
 
@@ -71,6 +72,35 @@ public class UmbracoContextTests
         Assert.AreEqual("my-site.com", originalRequestUrl.Host);
     }
 
+    [Test]
+    public void OriginalRequestUrl_Fallback_Is_Not_Cached_And_Picks_Up_Later_ApplicationMainUrl()
+    {
+        // Arrange - simulate early startup: no HttpContext, no ApplicationMainUrl yet.
+        // Then ApplicationMainUrl becomes available (auto-detected from first HTTP request).
+        var hostingEnvironmentMock = new Mock<IHostingEnvironment>();
+        hostingEnvironmentMock.Setup(x => x.ApplicationVirtualPath).Returns("/");
+        hostingEnvironmentMock.Setup(x => x.ToAbsolute(It.IsAny<string>()))
+            .Returns((string path) => path.TrimStart('~'));
+        hostingEnvironmentMock.Setup(x => x.ApplicationMainUrl).Returns((Uri?)null);
+
+        var umbracoContext = CreateUmbracoContextWithHostingEnvironment(
+            hostingEnvironmentMock.Object,
+            httpContext: null);
+
+        // Act - first access falls back to http://localhost
+        var firstUrl = umbracoContext.OriginalRequestUrl;
+        Assert.AreEqual("http", firstUrl.Scheme);
+        Assert.AreEqual("localhost", firstUrl.Host);
+
+        // Simulate ApplicationMainUrl becoming available (e.g. after first HTTP request)
+        hostingEnvironmentMock.Setup(x => x.ApplicationMainUrl).Returns(new Uri("https://example.com"));
+
+        // Act - second access should pick up the newly available ApplicationMainUrl
+        var secondUrl = umbracoContext.OriginalRequestUrl;
+        Assert.AreEqual("https", secondUrl.Scheme);
+        Assert.AreEqual("example.com", secondUrl.Host);
+    }
+
     private static global::Umbraco.Cms.Web.Common.UmbracoContext.UmbracoContext CreateUmbracoContext(
         Uri? applicationMainUrl,
         HttpContext? httpContext)
@@ -88,6 +118,13 @@ public class UmbracoContextTests
                 x.WebRootPath == "/" &&
                 x.ContentRootPath == "/"));
 
+        return CreateUmbracoContextWithHostingEnvironment(hostingEnvironment, httpContext);
+    }
+
+    private static global::Umbraco.Cms.Web.Common.UmbracoContext.UmbracoContext CreateUmbracoContextWithHostingEnvironment(
+        IHostingEnvironment hostingEnvironment,
+        HttpContext? httpContext)
+    {
         var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
         var umbracoRequestPaths = new UmbracoRequestPaths(
             hostingEnvironment,


### PR DESCRIPTION
## Description

As reported in https://github.com/umbraco/Umbraco-CMS/issues/22420, when generating absolute URLs from a background hosted service (e.g. `RecurringHostedServiceBase`), `UmbracoContext.OriginalRequestUrl` fell back to a hardcoded `http://localhost` URI when no `HttpContext` was available. This caused `page.Url(culture, mode: UrlMode.Absolute)` and `IPublishedUrlProvider.GetUrl(page, UrlMode.Absolute, culture)` to always return `http://` URLs in background tasks, even when the site is served over HTTPS.

The fix uses `IHostingEnvironment.ApplicationMainUrl` as an intermediate fallback before `http://localhost`. This URL is set from the `Umbraco:CMS:WebRouting:UmbracoApplicationUrl` config setting, or auto-detected from the first HTTP request.

Fallback values are intentionally **not cached** on `_originalRequestUrl`, so that a later-detected `ApplicationMainUrl` (auto-detected from the first HTTP request) is picked up on subsequent accesses. Only a real HTTP request URL is cached. 

The same non-caching strategy is applied to `CleanedUmbracoUrl`.

## Testing

### Automated

Unit tests have been added covering the calculation of `OriginalRequestUrl`.

### Manual

To reproduce the original issue and verify the fix, create a background job that determines the URL for a page and writes it to the log:

<details>
<summary><code>src/Umbraco.Web.UI/BackgroundTasks/LogPageUrlJob.cs</code></summary>

```csharp
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Routing;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Sync;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Infrastructure.BackgroundJobs;

namespace Umbraco.Cms.Web.UI.BackgroundTasks;

public class LogPageUrlJob : IRecurringBackgroundJob
{
    // Hard-coded GUID for a page.
    private static readonly Guid PageKey = Guid.Parse("{your page GUID here}");

    public TimeSpan Period => TimeSpan.FromMinutes(1);

    public TimeSpan Delay => TimeSpan.FromSeconds(10);

    public ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();

    public event EventHandler PeriodChanged { add { } remove { } }

    private readonly IUmbracoContextFactory _umbracoContextFactory;
    private readonly IPublishedUrlProvider _publishedUrlProvider;
    private readonly ILocalizationService _localizationService;
    private readonly ILogger<LogPageUrlJob> _logger;

    public LogPageUrlJob(
        IUmbracoContextFactory umbracoContextFactory,
        IPublishedUrlProvider publishedUrlProvider,
        ILocalizationService localizationService,
        ILogger<LogPageUrlJob> logger)
    {
        _umbracoContextFactory = umbracoContextFactory;
        _publishedUrlProvider = publishedUrlProvider;
        _localizationService = localizationService;
        _logger = logger;
    }

    public Task RunJobAsync()
    {
        using UmbracoContextReference contextReference = _umbracoContextFactory.EnsureUmbracoContext();

        IPublishedContent? page = contextReference.UmbracoContext.Content?.GetById(PageKey);

        if (page is null)
        {
            _logger.LogInformation("[LogPageUrlJob] No published content found for key {Key}.", PageKey);
            return Task.CompletedTask;
        }

        var defaultCulture = _localizationService.GetDefaultLanguageIsoCode();

        var urlViaExtension = page.Url(defaultCulture, mode: UrlMode.Absolute);
        _logger.LogInformation("[LogPageUrlJob] page.Url(): {Url}", urlViaExtension);

        var urlViaProvider = _publishedUrlProvider.GetUrl(page, UrlMode.Absolute, culture: defaultCulture);
        _logger.LogInformation("[LogPageUrlJob] IPublishedUrlProvider.GetUrl(): {Url}", urlViaProvider);

        return Task.CompletedTask;
    }
}
```

</details>

<details>
<summary><code>src/Umbraco.Web.UI/BackgroundTasks/LogPageUrlComposer.cs</code></summary>

```csharp
using Umbraco.Cms.Core.Composing;

namespace Umbraco.Cms.Web.UI.BackgroundTasks;

public class LogPageUrlComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.AddRecurringBackgroundJob<LogPageUrlJob>();
}
```

</details>

#### Steps

1. Replace the hard-coded `PageKey` GUID with a published content item key from your site.
2. **Without explicit config** (auto-detection from first request):
   - Add to `appSettings.json`:
     ```json
     {
       "Umbraco": {
         "CMS": {
           "WebRouting": {
             "ApplicationUrlDetection": "FirstRequest"
           }
         }
       }
     }
     ```   
   - Start the application. The job fires ~10 seconds after start-up.
   - Check the log — the first run may show `http://localhost` if no HTTP request has been received yet.
   - Make any HTTP request to the site (e.g. browse to the homepage).
   - Wait for the next job run (~1 minute). The log should now show the correct `https://` URL, because `ApplicationMainUrl` was auto-detected from that first request and the fallback is not cached.
4. **With explicit config** (immediate correct URLs):
   - Add to `appsettings.json`:
     ```json
     {
       "Umbraco": {
         "CMS": {
           "WebRouting": {
             "UmbracoApplicationUrl": "https://localhost:44339"
           }
         }
       }
     }
     ```
   - Start the application. Even the very first job run (before any HTTP request) should log `https://localhost:44339/...`.
5. Both `page.Url()` and `IPublishedUrlProvider.GetUrl()` should produce matching `https://` URLs.
