### PR TITLE
Developer Tools: Add `umb-bump-version` skill for automating version bumps

### DIFF
--- a/.claude/skills/umb-bump-version/SKILL.md
+++ b/.claude/skills/umb-bump-version/SKILL.md
@@ -34,7 +34,9 @@ Extract the version from `$ARGUMENTS`. It must be a valid semver-like string (e.
 
 ### 2. Read the Current Version
 
-Read `version.json` and extract the current `"version"` value. Display both the current and target versions to the user for confirmation context:
+Read `version.json` and extract the current `"version"` value. If the current version already equals the target version, report that the version is already set and stop — do not edit, stage, or commit anything.
+
+Otherwise, display both versions:
 
 ```
 Bumping version: {current} -> {target}
@@ -52,11 +54,13 @@ Use targeted edits — do NOT rewrite entire files. Be precise to avoid changing
 
 ### 4. Verify
 
-After all edits, grep for the new version string across the 5 files to confirm all updates landed correctly:
+After all edits, grep for the target version value across the 5 files to confirm all updates landed correctly:
 
 ```bash
-grep -n "\"version\"" version.json src/Umbraco.Web.UI.Client/package.json src/Umbraco.Web.UI.Client/package-lock.json tests/Umbraco.Tests.AcceptanceTest/package.json tests/Umbraco.Tests.AcceptanceTest/package-lock.json | head -20
+grep -n "\"version\": \"{version}\"" version.json src/Umbraco.Web.UI.Client/package.json src/Umbraco.Web.UI.Client/package-lock.json tests/Umbraco.Tests.AcceptanceTest/package.json tests/Umbraco.Tests.AcceptanceTest/package-lock.json
 ```
+
+Expect exactly 7 matches (one per `package.json` and `version.json`, two per `package-lock.json`).
 
 ### 5. Stage and Commit
 

--- a/.claude/skills/umb-bump-version/SKILL.md
+++ b/.claude/skills/umb-bump-version/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: umb-bump-version
+description: Bump the Umbraco CMS version across all required files. Use when the user asks to bump, update, or set the version number — e.g., "bump version to 17.3.4", "set version to 18.0.0-rc", "update version". Accepts the target version as an argument.
+argument-hint: <version> (e.g., 17.3.4, 18.0.0-rc)
+---
+
+# Bump Version - Umbraco CMS
+
+Updates the Umbraco CMS version string across all files that track it.
+
+**Do NOT use AskUserQuestion if a version argument is provided. Only ask if `$ARGUMENTS` is empty or cannot be parsed as a version.**
+
+## Arguments
+
+- `$ARGUMENTS` - Required: the target version string (e.g., `17.3.4`, `18.0.0-rc`)
+
+## Files to Update
+
+The following 5 files must be updated with the new version:
+
+| # | File | Field |
+|---|------|-------|
+| 1 | `version.json` | `"version"` |
+| 2 | `src/Umbraco.Web.UI.Client/package.json` | `"version"` |
+| 3 | `src/Umbraco.Web.UI.Client/package-lock.json` | top-level `"version"` AND `packages[""].version` |
+| 4 | `tests/Umbraco.Tests.AcceptanceTest/package.json` | `"version"` |
+| 5 | `tests/Umbraco.Tests.AcceptanceTest/package-lock.json` | top-level `"version"` AND `packages[""].version` |
+
+## Instructions
+
+### 1. Parse and Validate the Version
+
+Extract the version from `$ARGUMENTS`. It must be a valid semver-like string (e.g., `17.3.4`, `18.0.0-rc`, `17.4.0-preview.1`). If no version is provided or it cannot be parsed, ask the user for the target version.
+
+### 2. Read the Current Version
+
+Read `version.json` and extract the current `"version"` value. Display both the current and target versions to the user for confirmation context:
+
+```
+Bumping version: {current} -> {target}
+```
+
+### 3. Update All Files
+
+Update each of the 5 files listed above, replacing the old version with the new version. For each file:
+
+- **`version.json`**: Replace the `"version"` value.
+- **`package.json` files**: Replace the `"version"` value (near the top of the file).
+- **`package-lock.json` files**: Replace BOTH the top-level `"version"` value AND the `"version"` inside the `"packages": { "": { ... } }` block. These are always in the first ~10 lines of the file.
+
+Use targeted edits — do NOT rewrite entire files. Be precise to avoid changing version strings in dependency entries.
+
+### 4. Verify
+
+After all edits, grep for the new version string across the 5 files to confirm all updates landed correctly:
+
+```bash
+grep -n "\"version\"" version.json src/Umbraco.Web.UI.Client/package.json src/Umbraco.Web.UI.Client/package-lock.json tests/Umbraco.Tests.AcceptanceTest/package.json tests/Umbraco.Tests.AcceptanceTest/package-lock.json | head -20
+```
+
+### 5. Stage and Commit
+
+Stage only the 5 changed files:
+
+```bash
+git add version.json src/Umbraco.Web.UI.Client/package.json src/Umbraco.Web.UI.Client/package-lock.json tests/Umbraco.Tests.AcceptanceTest/package.json tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+```
+
+Then commit with the message `Bump version to {version}.` — replacing `{version}` with the target version:
+
+```bash
+git commit -m "Bump version to {version}."
+```
+
+### 6. Report
+
+Output a summary:
+
+```
+Version bumped to {version} in:
+- version.json
+- src/Umbraco.Web.UI.Client/package.json
+- src/Umbraco.Web.UI.Client/package-lock.json
+- tests/Umbraco.Tests.AcceptanceTest/package.json
+- tests/Umbraco.Tests.AcceptanceTest/package-lock.json
+
+Changes staged and committed.
+```

--- a/.claude/skills/umb-bump-version/SKILL.md
+++ b/.claude/skills/umb-bump-version/SKILL.md
@@ -26,6 +26,8 @@ The following 5 files must be updated with the new version:
 | 4 | `tests/Umbraco.Tests.AcceptanceTest/package.json` | `"version"` |
 | 5 | `tests/Umbraco.Tests.AcceptanceTest/package-lock.json` | top-level `"version"` AND `packages[""].version` |
 
+**Note**: For major version bumps (e.g., 17.x to 18.x), `src/Umbraco.Web.UI.Login/package.json` has a caret-ranged dependency on `@umbraco-cms/backoffice` (e.g., `^17.2.0`) that will need manual updating. This skill does not handle that — major bumps involve many other changes beyond version strings.
+
 ## Instructions
 
 ### 1. Parse and Validate the Version


### PR DESCRIPTION
## Description

This adds a new Claude Code skill (`umb-bump-version`) that automates version bumps across the repository, a regular task we need to do on every release.

The skill will:

- Accept or request a version number as an argument.
- Update all 5 files that track the version: `version.json`, both `package.json` files, and both `package-lock.json` files
- Stages the changed files and commits with a standard message (`Bump version to {version}.`)

## Testing

To test, start in a temporary branch you'll discard after testing, and invoke with `/umb-bump-version 17.3.4` or natural language, and verify all 5 files are updated with only the expected changes. Verify also that the commit message follows the expected format.