### PR TITLE
Rendering: Use explicit dependency instead of access-via-casting

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/PublishedElement.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedElement.cs
@@ -46,7 +46,7 @@ internal class PublishedElement : PublishableContentBase, IPublishedElement
             // add one property per property type - this is required, for the indexing to work
             // if contentData supplies pdatas, use them, else use null
             contentData.Properties.TryGetValue(propertyType.Alias, out PropertyData[]? propertyDatas); // else will be null
-            properties[i++] = new PublishedProperty(propertyType, this, variationContextAccessor, preview, propertyDatas, elementsCache, propertyType.CacheLevel);
+            properties[i++] = new PublishedProperty(propertyType, this, variationContextAccessor, PropertyRenderingContextAccessor, preview, propertyDatas, elementsCache, propertyType.CacheLevel);
         }
 
         _properties = properties;

--- a/src/Umbraco.PublishedCache.HybridCache/PublishedElement.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedElement.cs
@@ -46,7 +46,7 @@ internal class PublishedElement : PublishableContentBase, IPublishedElement
             // add one property per property type - this is required, for the indexing to work
             // if contentData supplies pdatas, use them, else use null
             contentData.Properties.TryGetValue(propertyType.Alias, out PropertyData[]? propertyDatas); // else will be null
-            properties[i++] = new PublishedProperty(propertyType, this, variationContextAccessor, PropertyRenderingContextAccessor, preview, propertyDatas, elementsCache, propertyType.CacheLevel);
+            properties[i++] = new PublishedProperty(propertyType, this, variationContextAccessor, propertyRenderingContextAccessor, preview, propertyDatas, elementsCache, propertyType.CacheLevel);
         }
 
         _properties = properties;

--- a/src/Umbraco.PublishedCache.HybridCache/PublishedProperty.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/PublishedProperty.cs
@@ -14,6 +14,7 @@ internal sealed class PublishedProperty : PublishedPropertyBase
     private readonly IPublishedElement _element;
     private readonly bool _isPreviewing;
     private readonly IVariationContextAccessor _variationContextAccessor;
+    private readonly IPropertyRenderingContextAccessor _propertyRenderingContextAccessor;
     private readonly IElementsCache _elementsCache;
     private readonly bool _isMember;
     private string? _valuesCacheKey;
@@ -39,6 +40,7 @@ internal sealed class PublishedProperty : PublishedPropertyBase
         IPublishedPropertyType propertyType,
         IPublishedElement element,
         IVariationContextAccessor variationContextAccessor,
+        IPropertyRenderingContextAccessor propertyRenderingContextAccessor,
         bool preview,
         PropertyData[]? sourceValues,
         IElementsCache elementsElementsCache,
@@ -70,6 +72,7 @@ internal sealed class PublishedProperty : PublishedPropertyBase
 
         _element = element;
         _variationContextAccessor = variationContextAccessor;
+        _propertyRenderingContextAccessor = propertyRenderingContextAccessor;
         _isPreviewing = preview;
         _isMember = element.ContentType.ItemType == PublishedItemType.Member;
         _elementsCache = elementsElementsCache;
@@ -169,11 +172,7 @@ internal sealed class PublishedProperty : PublishedPropertyBase
 
         // Include the fallback policy in the cache key so that different fallback strategies
         // produce separate cached values (e.g., block editors filter differently with Fallback.ToLanguage).
-        Fallback fallback = default;
-        if (_element is PublishedElement publishedElement)
-        {
-            fallback = publishedElement.PropertyRenderingContextAccessor.PropertyRenderingContext?.Fallback ?? default;
-        }
+        Fallback fallback = _propertyRenderingContextAccessor.PropertyRenderingContext?.Fallback ?? default;
 
         CacheValue cacheValues = GetCacheValues(PropertyType.CacheLevel).For(culture, segment, fallback);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/CacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/CacheTests.cs
@@ -41,7 +41,7 @@ public class CacheTests : DeliveryApiTests
 
         var propertyData = new PropertyData { Culture = "abc", Segment = string.Empty, Value = "n/a" };
 
-        var prop1 = new PublishedProperty(propertyType, element.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), cacheLevel);
+        var prop1 = new PublishedProperty(propertyType, element.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), cacheLevel);
 
         var results = new List<string>
         {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentBuilderTests.cs
@@ -26,8 +26,8 @@ public class ContentBuilderTests : DeliveryApiTests
 
         var propertyData = new PropertyData { Value = "n/a", Culture = "abc", Segment = string.Empty };
 
-        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
-        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
 
         var key = Guid.NewGuid();
         var urlSegment = "url-segment";

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentPickerValueConverterTests.cs
@@ -80,8 +80,8 @@ public class ContentPickerValueConverterTests : PropertyValueConverterTests
 
         var propertyData = new PropertyData { Value = "n/a", Culture = "abc", Segment = string.Empty };
 
-        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
-        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
 
         var publishedPropertyType = new Mock<IPublishedPropertyType>();
         publishedPropertyType.SetupGet(p => p.Alias).Returns("test");

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/DeliveryApiTests.cs
@@ -100,6 +100,8 @@ public class DeliveryApiTests
 
     protected IVariationContextAccessor CreateVariationContextAccessor() => new TestVariationContextAccessor();
 
+    protected IPropertyRenderingContextAccessor CreatePropertyRenderingContextAccessor() => new TestPropertyRenderingContextAccessor();
+
     protected IOptions<GlobalSettings> CreateGlobalSettings(bool hideTopLevelNodeFromPath = true)
     {
         var globalSettings = new GlobalSettings { HideTopLevelNodeFromPath = hideTopLevelNodeFromPath };

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/MultiNodeTreePickerValueConverterTests.cs
@@ -130,8 +130,8 @@ public class MultiNodeTreePickerValueConverterTests : PropertyValueConverterTest
 
         var propertyData = new PropertyData { Value = "n/a", Culture = "abc", Segment = string.Empty };
 
-        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
-        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
 
         var key = Guid.NewGuid();
         var urlSegment = "page-url-segment";

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTestBase.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/OutputExpansionStrategyTestBase.cs
@@ -48,8 +48,8 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
         var content = CreatePublishedContentMock();
         var propertyData = new PropertyData { Value = "n/a", Culture = string.Empty, Segment = string.Empty };
 
-        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
-        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop1 = new PublishedProperty(DeliveryApiPropertyType, content.Object, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var prop2 = new PublishedProperty(DefaultPropertyType, content.Object, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
 
         var contentPickerContent = CreateSimplePickedContent(123, 456);
         var contentPickerProperty = CreateContentPickerProperty(content.Object, contentPickerContent.Key, "contentPicker", apiContentBuilder);
@@ -306,7 +306,7 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
 
         var propertyType = SetupPublishedPropertyType(valueConverterMock.Object, "theAlias", Constants.PropertyEditors.Aliases.Label);
         var propertyData = new PropertyData { Value = "doesn't matter, it's mocked", Culture = string.Empty, Segment = string.Empty };
-        var property = new PublishedProperty(propertyType, content.Object, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var property = new PublishedProperty(propertyType, content.Object, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
 
         SetupContentMock(content, property);
 
@@ -383,7 +383,7 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
 
         var propertyData = new PropertyData { Value = new GuidUdi(Constants.UdiEntityType.Document, pickedContentKey).ToString(), Culture = string.Empty, Segment = string.Empty };
 
-        return new PublishedProperty(contentPickerPropertyType, parent, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        return new PublishedProperty(contentPickerPropertyType, parent, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
     }
 
     internal PublishedPropertyBase CreateMediaPickerProperty(IPublishedElement parent, Guid pickedMediaKey, string propertyTypeAlias, IApiMediaBuilder mediaBuilder)
@@ -396,7 +396,7 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
 
         var propertyData = new PropertyData { Value = new GuidUdi(Constants.UdiEntityType.Media, pickedMediaKey).ToString(), Culture = string.Empty, Segment = string.Empty };
 
-        return new PublishedProperty(mediaPickerPropertyType, parent, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        return new PublishedProperty(mediaPickerPropertyType, parent, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
     }
 
     internal PublishedPropertyBase CreateMediaPicker3Property(IPublishedElement parent, Guid pickedMediaKey, string propertyTypeAlias, IApiMediaBuilder mediaBuilder)
@@ -418,14 +418,14 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
 
         var propertyData = new PropertyData { Value = value, Culture = string.Empty, Segment = string.Empty };
 
-        return new PublishedProperty(mediaPickerPropertyType, parent, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        return new PublishedProperty(mediaPickerPropertyType, parent, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
     }
 
     internal PublishedPropertyBase CreateNumberProperty(IPublishedElement parent, int propertyValue, string propertyTypeAlias)
     {
         var numberPropertyType = SetupPublishedPropertyType(new IntegerValueConverter(), propertyTypeAlias, Constants.PropertyEditors.Aliases.Label);
         var propertyData = new PropertyData { Value = propertyValue, Culture = string.Empty, Segment = string.Empty };
-        return new PublishedProperty(numberPropertyType, parent, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        return new PublishedProperty(numberPropertyType, parent, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
     }
 
     internal PublishedPropertyBase CreateElementProperty(
@@ -464,7 +464,7 @@ public abstract class OutputExpansionStrategyTestBase : PropertyValueConverterTe
         var elementPropertyType = SetupPublishedPropertyType(elementValueConverter.Object, elementPropertyAlias, "My.Element.Property");
 
         var propertyData = new PropertyData { Value = "doesn't matter, it's mocked", Culture = string.Empty, Segment = string.Empty  };
-        return new PublishedProperty(elementPropertyType, parent, VariationContextAccessorMock(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        return new PublishedProperty(elementPropertyType, parent, VariationContextAccessorMock(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
     }
 
     protected IApiContentRouteBuilder ApiContentRouteBuilder() => CreateContentRouteBuilder(ApiContentPathProvider, CreateGlobalSettings());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
@@ -741,7 +741,7 @@ public class RichTextParserTests : PropertyValueConverterTests
 
         var numberPropertyType = SetupPublishedPropertyType(new IntegerValueConverter(), "number", Constants.PropertyEditors.Aliases.Label);
         var propertyData = new PropertyData { Value = propertyValue, Culture = string.Empty, Segment = string.Empty };
-        var property = new PublishedProperty(numberPropertyType, element.Object, CreateVariationContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
+        var property = new PublishedProperty(numberPropertyType, element.Object, CreateVariationContextAccessor(), CreatePropertyRenderingContextAccessor(), false, [propertyData], new ElementsDictionaryAppCache(), PropertyCacheLevel.None);
 
         element.SetupGet(c => c.Properties).Returns(new[] { property });
         return element.Object;


### PR DESCRIPTION
### Description

This makes the current property rendering context explicitly available for `PublishedProperty`, thus removing the need for casting the parent `IPublishedElement` to `PublishedElement` in order to access it.