### PR TITLE
E2E: QA Updated acceptance tests to match the recent UI changes

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ConstantHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ConstantHelper.ts
@@ -164,7 +164,8 @@
     6: ['Overlay size', 'Select the width of the overlay (link picker).'],
     7: ['Available Blocks', 'Define the available blocks.'],
     8: ['Image Upload Folder', 'Choose the upload location of pasted images.'],
-    9: ['Ignore User Start Nodes', ''],
+    9: ['Accepted media types', 'Limit to specific media types for the media picker toolbar and drag-and-drop uploads.'],
+    10: ['Ignore User Start Nodes', ''],
   }
 
   public static readonly tinyMCESettings = {

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
@@ -132,6 +132,7 @@ export class UiBaseLocators extends BasePage {
   public readonly systemFieldsOption: Locator;
   public readonly chooseFieldValueDropDown: Locator;
   public readonly breadcrumbsTemplateModal: Locator;
+  public readonly pageFieldBuilderSubmitBtn: Locator;
 
   // Rename
   public readonly newNameTxt: Locator;
@@ -413,14 +414,12 @@ export class UiBaseLocators extends BasePage {
 
     // Insert & Template
     this.insertValueBtn = page
-      .locator("uui-button")
+      .locator("uui-card")
       .filter({ has: page.locator('[key="template_insertPageField"]') });
     this.insertPartialViewBtn = page
-      .locator("uui-button")
+      .locator("uui-card")
       .filter({ has: page.locator('[key="template_insertPartialView"]') });
-    this.insertDictionaryItemBtn = page
-      .locator("uui-button")
-      .filter({ has: page.locator('[key="template_insertDictionaryItem"]') });
+    this.insertDictionaryItemBtn = page.locator('uui-card[label="Dictionary item"]');
     this.chooseFieldDropDown = page.locator("#preview #expand-symbol-wrapper");
     this.systemFieldsOption = page.getByText("System fields");
     this.chooseFieldValueDropDown = page.locator(
@@ -429,6 +428,7 @@ export class UiBaseLocators extends BasePage {
     this.breadcrumbsTemplateModal = page
       .locator("uui-modal-sidebar")
       .locator("umb-template-workspace-editor uui-breadcrumbs");
+    this.pageFieldBuilderSubmitBtn = page.locator('umb-templating-page-field-builder-modal').getByRole('button', {name: 'Submit'});
 
     // Rename
     this.newNameTxt = page.getByRole("textbox", { name: "Enter new name..." });
@@ -1457,6 +1457,7 @@ export class UiBaseLocators extends BasePage {
   async insertDictionaryItem(dictionaryName: string) {
     await this.clickInsertButton();
     await this.click(this.insertDictionaryItemBtn);
+    await this.clickSubmitButton();
     await this.click(this.page.getByLabel(dictionaryName));
     await this.click(this.chooseBtn);
   }
@@ -1464,16 +1465,18 @@ export class UiBaseLocators extends BasePage {
   async insertSystemFieldValue(fieldValue: string) {
     await this.clickInsertButton();
     await this.click(this.insertValueBtn);
+    await this.clickSubmitButton();
     await this.click(this.chooseFieldDropDown);
     await this.click(this.systemFieldsOption);
     await this.click(this.chooseFieldValueDropDown);
     await this.click(this.page.getByText(fieldValue));
-    await this.clickSubmitButton();
+    await this.click(this.pageFieldBuilderSubmitBtn);
   }
 
   async insertPartialView(partialViewName: string) {
     await this.clickInsertButton();
     await this.click(this.insertPartialViewBtn);
+    await this.clickSubmitButton();
     await this.click(this.page.getByLabel(partialViewName));
     await this.clickChooseButton();
   }

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/differentAppSettingsHelpers/MediaDeliveryApiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/differentAppSettingsHelpers/MediaDeliveryApiHelper.ts
@@ -73,13 +73,13 @@ export class MediaDeliveryApiHelper {
     if (mediaTypeName === 'Image') {
       const mediaWidth = mediaData.values.find(x => x.alias === 'umbracoWidth')?.value;
       const mediaHeight = mediaData.values.find(x => x.alias === 'umbracoHeight')?.value;
-      expect(mediaItemJson.width).toBe(mediaWidth ? Number(mediaWidth) : null);
-      expect(mediaItemJson.height).toBe(mediaHeight ? Number(mediaHeight) : null);
+      expect(mediaItemJson.width).toBe(mediaWidth ? Number(mediaWidth) : 0);
+      expect(mediaItemJson.height).toBe(mediaHeight ? Number(mediaHeight) : 0);
       expect(mediaItemJson.focalPoint).toBe(mediaData.values[0].value.focalPoint);
       expect(mediaItemJson.crops).toEqual(mediaData.values[0].value.crops);
     } else {
-      expect(mediaItemJson.width).toBeNull();
-      expect(mediaItemJson.height).toBeNull();
+      expect(mediaItemJson.width).toBe(0);
+      expect(mediaItemJson.height).toBe(0);
       expect(mediaItemJson.focalPoint).toBeNull();
       expect(mediaItemJson.crops).toBeNull();  
     }

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/differentAppSettingsHelpers/MediaDeliveryApiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/differentAppSettingsHelpers/MediaDeliveryApiHelper.ts
@@ -70,16 +70,16 @@ export class MediaDeliveryApiHelper {
       expect(mediaItemJson.bytes).toBeNull();  
     }
     // Verify width and height (in pixels), focalPoint and crops are included for most images.
-    if (mediaTypeName === 'Image') {
+    if (mediaTypeName === 'Image' || mediaTypeName === 'Vector Graphics (SVG)') {
       const mediaWidth = mediaData.values.find(x => x.alias === 'umbracoWidth')?.value;
       const mediaHeight = mediaData.values.find(x => x.alias === 'umbracoHeight')?.value;
       expect(mediaItemJson.width).toBe(mediaWidth ? Number(mediaWidth) : 0);
       expect(mediaItemJson.height).toBe(mediaHeight ? Number(mediaHeight) : 0);
-      expect(mediaItemJson.focalPoint).toBe(mediaData.values[0].value.focalPoint);
-      expect(mediaItemJson.crops).toEqual(mediaData.values[0].value.crops);
+      expect(mediaItemJson.focalPoint).toBe(mediaData.values[0].value.focalPoint ? mediaData.values[0].value.focalPoint : null);
+      expect(mediaItemJson.crops).toEqual(mediaData.values[0].value.crops ? mediaData.values[0].value.crops : null);
     } else {
-      expect(mediaItemJson.width).toBe(0);
-      expect(mediaItemJson.height).toBe(0);
+      expect(mediaItemJson.width).toBeNull();
+      expect(mediaItemJson.height).toBeNull();
       expect(mediaItemJson.focalPoint).toBeNull();
       expect(mediaItemJson.crops).toBeNull();  
     }


### PR DESCRIPTION
This PR fixes these failing tests due to UI changes:

- can fetch a vector graphics item by its ID
- tiptap is the default property editor in rich text editor
- can insert dictionary item into a partial view 
- can insert value into a partial view 
- can insert dictionary item into a template 
- can insert partial view into a template 
- can insert value into a template 