### PR TITLE
dotnet Templates: Remove legacy `Umbraco:CMS:Content:MacroErrors` from project template development configuration

### DIFF
--- a/templates/UmbracoProject/appsettings.Development.json
+++ b/templates/UmbracoProject/appsettings.Development.json
@@ -39,9 +39,6 @@
         "UnattendedTelemetryLevel": "UNATTENDED_TELEMETRY_LEVEL_FROM_TEMPLATE"
       },
       //#endif
-      "Content": {
-        "MacroErrors": "Throw"
-      },
       //#if (DevelopmentMode == "IDEDevelopment")
       "Runtime": {
         "Mode": "Development"


### PR DESCRIPTION
When creating a new V17 project from the .NET template, the `appsettings.Development.json` file still includes the `MacroErrors` setting – which was removed in #15794 as part of V14