### PR TITLE
Backoffice: Add explicit controller aliases to observe() calls in tree components

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/default/default-tree.element.ts
@@ -81,19 +81,21 @@ export class UmbDefaultTreeElement extends UmbLitElement {
 	private _isLoadingNextChildren = false;
 
 	#observeData() {
-		this.observe(this._api?.treeRoot, (treeRoot) => (this._treeRoot = treeRoot));
-		this.observe(this._api?.rootItems, (rootItems) => (this._rootItems = rootItems ?? []));
-		this.observe(this._api?.pagination.currentPage, (value) => (this._currentPage = value ?? 1));
-		this.observe(this._api?.isLoadingPrevChildren, (value) => (this._isLoadingPrevChildren = value ?? false));
-		this.observe(this._api?.isLoadingNextChildren, (value) => (this._isLoadingNextChildren = value ?? false));
+		this.observe(this._api?.treeRoot, (treeRoot) => (this._treeRoot = treeRoot), '_observeTreeRoot');
+		this.observe(this._api?.rootItems, (rootItems) => (this._rootItems = rootItems ?? []), '_observeRootItems');
+		this.observe(this._api?.pagination.currentPage, (value) => (this._currentPage = value ?? 1), '_observeCurrentPage');
+		this.observe(this._api?.isLoadingPrevChildren, (value) => (this._isLoadingPrevChildren = value ?? false), '_observeIsLoadingPrevChildren');
+		this.observe(this._api?.isLoadingNextChildren, (value) => (this._isLoadingNextChildren = value ?? false), '_observeIsLoadingNextChildren');
 
 		this.observe(
 			this._api?.targetPagination?.totalPrevItems,
 			(value) => (this._hasPreviousItems = value ? value > 0 : false),
+			'_observeTotalPrevItems',
 		);
 		this.observe(
 			this._api?.targetPagination?.totalNextItems,
 			(value) => (this._hasNextItems = value ? value > 0 : false),
+			'_observeTotalNextItems',
 		);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-element-base.ts
@@ -84,27 +84,29 @@ export abstract class UmbTreeItemElementBase<
 
 		if (this.#api) {
 			this.#api?.setIsMenu(this._isMenu);
-			this.observe(this.#api.childItems, (value) => (this._childItems = value));
-			this.observe(this.#api.hasChildren, (value) => (this._hasChildren = value));
-			this.observe(this.#api.isActive, (value) => (this._isActive = value));
-			this.observe(this.#api.isOpen, (value) => (this._isOpen = value));
-			this.observe(this.#api.isLoading, (value) => (this._isLoading = value));
-			this.observe(this.#api.isSelectableContext, (value) => (this._isSelectableContext = value));
-			this.observe(this.#api.isSelectable, (value) => (this._isSelectable = value));
-			this.observe(this.#api.isSelected, (value) => (this._isSelected = value));
-			this.observe(this.#api.path, (value) => (this._href = value));
-			this.observe(this.#api.pagination.currentPage, (value) => (this._currentPage = value));
-			this.observe(this.#api.pagination.totalPages, (value) => (this._totalPages = value));
-			this.observe(this.#api.isLoadingPrevChildren, (value) => (this._isLoadingPrevChildren = value ?? false));
-			this.observe(this.#api.isLoadingNextChildren, (value) => (this._isLoadingNextChildren = value ?? false));
+			this.observe(this.#api.childItems, (value) => (this._childItems = value), '_observeChildItems');
+			this.observe(this.#api.hasChildren, (value) => (this._hasChildren = value), '_observeHasChildren');
+			this.observe(this.#api.isActive, (value) => (this._isActive = value), '_observeIsActive');
+			this.observe(this.#api.isOpen, (value) => (this._isOpen = value), '_observeIsOpen');
+			this.observe(this.#api.isLoading, (value) => (this._isLoading = value), '_observeIsLoading');
+			this.observe(this.#api.isSelectableContext, (value) => (this._isSelectableContext = value), '_observeIsSelectableContext');
+			this.observe(this.#api.isSelectable, (value) => (this._isSelectable = value), '_observeIsSelectable');
+			this.observe(this.#api.isSelected, (value) => (this._isSelected = value), '_observeIsSelected');
+			this.observe(this.#api.path, (value) => (this._href = value), '_observePath');
+			this.observe(this.#api.pagination.currentPage, (value) => (this._currentPage = value), '_observeCurrentPage');
+			this.observe(this.#api.pagination.totalPages, (value) => (this._totalPages = value), '_observeTotalPages');
+			this.observe(this.#api.isLoadingPrevChildren, (value) => (this._isLoadingPrevChildren = value ?? false), '_observeIsLoadingPrevChildren');
+			this.observe(this.#api.isLoadingNextChildren, (value) => (this._isLoadingNextChildren = value ?? false), '_observeIsLoadingNextChildren');
 
 			this.observe(
 				this.#api.targetPagination?.totalPrevItems,
 				(value) => (this._hasPreviousItems = value !== undefined ? value > 0 : false),
+				'_observeTotalPrevItems',
 			);
 			this.observe(
 				this.#api.targetPagination?.totalNextItems,
 				(value) => (this._hasNextItems = value !== undefined ? value > 0 : false),
+				'_observeTotalNextItems',
 			);
 
 			this.#initTreeItem();


### PR DESCRIPTION
## Summary

- `observe()` without an explicit alias falls back to hashing `callback.toString()` on every call — in the `api` property setter and `#observeData()` this runs each time the API context changes
- Added explicit string aliases to all 22 `observe()` calls across `tree-item-element-base.ts` (api setter, 15 calls) and `default-tree.element.ts` (`#observeData()`, 7 calls)
- Alias names match the state field they drive (`_observeChildItems`, `_observeTreeRoot`, etc.) making deduplication intent explicit

## Test plan

- [ ] Tree tests pass: `web-test-runner --files "src/packages/core/tree/**/*.test.ts"` (23/23 passing)
- [ ] Tree items render and update correctly in the backoffice
- [ ] Tree root and pagination still update when the API context changes