### PR TITLE
User History: Replace raw URL with readable detail in recent history (closes #22441)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,9 @@ tools/docfx/
 /build/csharp-docs/_site/
 
 # Local config
-.claude/settings.local.json
+.claude/*
+!.claude/skills/
+!.claude/settings.json
 .env.local
 
 # Build

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -909,6 +909,7 @@ export default {
 		insert: 'Insert',
 		install: 'Install',
 		invalid: 'Invalid',
+		items: 'Items',
 		justify: 'Justify',
 		label: 'Label',
 		language: 'Language',

--- a/src/Umbraco.Web.UI.Client/src/mocks/data/utils/file-system/file-system-tree.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/data/utils/file-system/file-system-tree.manager.ts
@@ -25,6 +25,19 @@ export class UmbMockFileSystemTreeManager<T extends FileSystemTreeItemPresentati
 		return this.#pagedTreeResult({ items, skip, take });
 	}
 
+	getAncestorsOf({ descendantPath }: { descendantPath: string }): Array<FileSystemTreeItemPresentationModel> {
+		const items: Array<T> = [];
+		let currentPath: string | undefined = descendantPath;
+		while (currentPath) {
+			const item = this.#db.getAll().find((i) => i.path === currentPath);
+			if (!item) break;
+			items.push(item);
+			currentPath = item.parent?.path;
+		}
+		// Returned root-first, including the descendant itself (matches Management API contract).
+		return items.reverse().map((item) => createFileSystemTreeItem(item));
+	}
+
 	#pagedTreeResult({ items, skip, take }: { items: Array<T>; skip: number; take: number }) {
 		const paged = pagedResult(items, skip, take);
 		const treeItems = paged.items.map((item) => createFileSystemTreeItem(item));

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/document-blueprint/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/document-blueprint/tree.handlers.ts
@@ -19,4 +19,11 @@ export const treeHandlers = [
 		const response = umbDocumentBlueprintMockDb.tree.getChildrenOf({ parentId, skip, take });
 		return HttpResponse.json(response);
 	}),
+
+	http.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), ({ request }) => {
+		const descendantId = new URL(request.url).searchParams.get('descendantId');
+		if (!descendantId) return;
+		const response = umbDocumentBlueprintMockDb.tree.getAncestorsOf({ descendantId });
+		return HttpResponse.json(response);
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/member-type/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/member-type/tree.handlers.ts
@@ -21,4 +21,11 @@ export const treeHandlers = [
 		const response = umbMemberTypeMockDb.tree.getChildrenOf({ parentId, skip, take });
 		return HttpResponse.json(response);
 	}),
+
+	http.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), ({ request }) => {
+		const descendantId = new URL(request.url).searchParams.get('descendantId');
+		if (!descendantId) return;
+		const response = umbMemberTypeMockDb.tree.getAncestorsOf({ descendantId });
+		return HttpResponse.json(response);
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/partial-view/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/partial-view/tree.handlers.ts
@@ -19,4 +19,11 @@ export const treeHandlers = [
 		const response = umbPartialViewMockDB.tree.getChildrenOf({ parentPath, skip, take });
 		return HttpResponse.json(response);
 	}),
+
+	http.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), ({ request }) => {
+		const descendantPath = new URL(request.url).searchParams.get('descendantPath');
+		if (!descendantPath) return new HttpResponse(null, { status: 400 });
+		const response = umbPartialViewMockDB.tree.getAncestorsOf({ descendantPath });
+		return HttpResponse.json(response);
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/script/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/script/tree.handlers.ts
@@ -19,4 +19,11 @@ export const treeHandlers = [
 		const response = umbScriptMockDb.tree.getChildrenOf({ parentPath, skip, take });
 		return HttpResponse.json(response);
 	}),
+
+	http.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), ({ request }) => {
+		const descendantPath = new URL(request.url).searchParams.get('descendantPath');
+		if (!descendantPath) return new HttpResponse(null, { status: 400 });
+		const response = umbScriptMockDb.tree.getAncestorsOf({ descendantPath });
+		return HttpResponse.json(response);
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/static-file/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/static-file/tree.handlers.ts
@@ -21,4 +21,11 @@ export const treeHandlers = [
 		const response = umbStaticFileMockDb.tree.getChildrenOf({ parentPath, skip, take });
 		return HttpResponse.json(response);
 	}),
+
+	http.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), ({ request }) => {
+		const descendantPath = new URL(request.url).searchParams.get('descendantPath');
+		if (!descendantPath) return new HttpResponse(null, { status: 400 });
+		const response = umbStaticFileMockDb.tree.getAncestorsOf({ descendantPath });
+		return HttpResponse.json(response);
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/stylesheet/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/stylesheet/tree.handlers.ts
@@ -19,4 +19,11 @@ export const treeHandlers = [
 		const response = umbStylesheetMockDb.tree.getChildrenOf({ parentPath, skip, take });
 		return HttpResponse.json(response);
 	}),
+
+	http.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), ({ request }) => {
+		const descendantPath = new URL(request.url).searchParams.get('descendantPath');
+		if (!descendantPath) return new HttpResponse(null, { status: 400 });
+		const response = umbStylesheetMockDb.tree.getAncestorsOf({ descendantPath });
+		return HttpResponse.json(response);
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/mocks/handlers/template/tree.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/src/mocks/handlers/template/tree.handlers.ts
@@ -19,4 +19,11 @@ export const treeHandlers = [
 		const response = umbTemplateMockDb.tree.getChildrenOf({ parentId, skip, take });
 		return HttpResponse.json(response);
 	}),
+
+	http.get(umbracoPath(`/tree${UMB_SLUG}/ancestors`), ({ request }) => {
+		const descendantId = new URL(request.url).searchParams.get('descendantId');
+		if (!descendantId) return;
+		const response = umbTemplateMockDb.tree.getAncestorsOf({ descendantId });
+		return HttpResponse.json(response);
+	}),
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -282,7 +282,11 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		this.#name.setValue(title);
 
 		if (this.#modalContext) {
-			this.view.setTitle(title);
+			if (title) {
+				this.view.setSegments('leaf', { label: title, kind: 'workspace' });
+			} else {
+				this.view.clearSegments('leaf');
+			}
 		}
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.ts
@@ -128,7 +128,7 @@ export class UmbBlockWorkspaceViewEditContentNoRouterElement extends UmbLitEleme
 				});
 			}
 
-			view.setTitle(tabName);
+			view.setTitle(tabName, { kind: 'tab' });
 			view.inheritFrom(this.#blockManager.view);
 
 			this.observe(
@@ -198,7 +198,7 @@ export class UmbBlockWorkspaceViewEditContentNoRouterElement extends UmbLitEleme
 		// ViewAlias null is only for the root tab, therefor we can implement this hack.
 		if (viewAlias === null) {
 			// Specific hack for the Generic tab to only show its name if there are other tabs.
-			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined);
+			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined, { kind: 'tab' });
 		}
 		view.provideAt(this);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.ts
@@ -128,7 +128,7 @@ export class UmbBlockWorkspaceViewEditContentNoRouterElement extends UmbLitEleme
 				});
 			}
 
-			view.setTitle(tabName, { kind: 'tab' });
+			view.setSegments('tab', { label: tabName, kind: 'tab' });
 			view.inheritFrom(this.#blockManager.view);
 
 			this.observe(
@@ -198,7 +198,11 @@ export class UmbBlockWorkspaceViewEditContentNoRouterElement extends UmbLitEleme
 		// ViewAlias null is only for the root tab, therefor we can implement this hack.
 		if (viewAlias === null) {
 			// Specific hack for the Generic tab to only show its name if there are other tabs.
-			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined, { kind: 'tab' });
+			if (this._tabs && this._tabs?.length > 0) {
+				view.setSegments('tab', { label: '#general_generic', kind: 'tab' });
+			} else {
+				view.clearSegments('tab');
+			}
 		}
 		view.provideAt(this);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit.element.ts
@@ -181,7 +181,7 @@ export class UmbBlockWorkspaceViewEditElement extends UmbLitElement implements U
 				});
 			}
 
-			view.setTitle(tabName);
+			view.setTitle(tabName, { kind: 'tab' });
 			view.inheritFrom(this.#blockManager.view);
 
 			this.observe(
@@ -214,7 +214,7 @@ export class UmbBlockWorkspaceViewEditElement extends UmbLitElement implements U
 		// ViewAlias null is only for the root tab, therefor we can implement this hack.
 		if (viewAlias === null) {
 			// Specific hack for the Generic tab to only show its name if there are other tabs.
-			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined);
+			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined, { kind: 'tab' });
 		}
 		view.provideAt(component as any);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/views/edit/block-workspace-view-edit.element.ts
@@ -181,7 +181,7 @@ export class UmbBlockWorkspaceViewEditElement extends UmbLitElement implements U
 				});
 			}
 
-			view.setTitle(tabName, { kind: 'tab' });
+			view.setSegments('tab', { label: tabName, kind: 'tab' });
 			view.inheritFrom(this.#blockManager.view);
 
 			this.observe(
@@ -214,7 +214,11 @@ export class UmbBlockWorkspaceViewEditElement extends UmbLitElement implements U
 		// ViewAlias null is only for the root tab, therefor we can implement this hack.
 		if (viewAlias === null) {
 			// Specific hack for the Generic tab to only show its name if there are other tabs.
-			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined, { kind: 'tab' });
+			if (this._tabs && this._tabs?.length > 0) {
+				view.setSegments('tab', { label: '#general_generic', kind: 'tab' });
+			} else {
+				view.clearSegments('tab');
+			}
 		}
 		view.provideAt(component as any);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
@@ -71,7 +71,8 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 
 		// Keep current data in sync with the owner content type - This is used for the discard changes feature
 		this.observe(this.structure.ownerContentType, (data) => this._data.setCurrent(data), null);
-		this.observe(this.name, (name) => this.view.setTitle(name), null);
+		const typeLabel = args.typeLabel;
+		this.observe(this.name, (name) => this.view.setTitle(name, { kind: 'workspace', typeLabel }), null);
 		// TODO: sometimes the browserTitle for a parent view is set later than the child is updating. We need to fix this as well enable a parent browser title to be updating on the go. [NL]
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
@@ -8,7 +8,7 @@ import {
 	UmbRequestReloadStructureForEntityEvent,
 } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
-import type { Observable } from '@umbraco-cms/backoffice/observable-api';
+import { type Observable, observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import type {
@@ -76,10 +76,10 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 			this.view.setSegments('workspace-type', { label: typeLabel, kind: 'workspace-type' });
 		}
 		this.observe(
-			this.name,
-			(name) => {
+			observeMultiple([this.name, this.icon]),
+			([name, icon]) => {
 				if (name) {
-					this.view.setSegments('leaf', { label: name, kind: 'workspace' });
+					this.view.setSegments('leaf', { label: name, kind: 'workspace', ...(icon ? { icon } : {}) });
 				} else {
 					this.view.clearSegments('leaf');
 				}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/content-type-workspace-context-base.ts
@@ -72,7 +72,20 @@ export abstract class UmbContentTypeWorkspaceContextBase<
 		// Keep current data in sync with the owner content type - This is used for the discard changes feature
 		this.observe(this.structure.ownerContentType, (data) => this._data.setCurrent(data), null);
 		const typeLabel = args.typeLabel;
-		this.observe(this.name, (name) => this.view.setTitle(name, { kind: 'workspace', typeLabel }), null);
+		if (typeLabel) {
+			this.view.setSegments('workspace-type', { label: typeLabel, kind: 'workspace-type' });
+		}
+		this.observe(
+			this.name,
+			(name) => {
+				if (name) {
+					this.view.setSegments('leaf', { label: name, kind: 'workspace' });
+				} else {
+					this.view.clearSegments('leaf');
+				}
+			},
+			null,
+		);
 		// TODO: sometimes the browserTitle for a parent view is set later than the child is updating. We need to fix this as well enable a parent browser title to be updating on the go. [NL]
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -400,7 +400,11 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 	 */
 	protected _setViewTitle(variantName: string | undefined): void {
 		const icon: string | undefined = (this._data.getCurrent() as any)?.[this.#contentTypePropertyName]?.icon;
-		this.view.setTitle(variantName, icon ? { icon } : undefined);
+		if (variantName) {
+			this.view.setSegments('leaf', { label: variantName, kind: 'workspace', ...(icon ? { icon } : {}) });
+		} else {
+			this.view.clearSegments('leaf');
+		}
 	}
 
 	public async loadLanguages() {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -393,13 +393,14 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 	}
 
 	/**
-	 * Publishes the active variant name to the view title. Subclasses can override
-	 * this to include additional options such as a per-entity icon resolved from
-	 * the content type.
+	 * Publishes the active variant name and content-type icon to the view title.
+	 * The icon is resolved generically from the content-type property identified
+	 * by {@link UmbContentDetailWorkspaceContextArgs.contentTypePropertyName}.
 	 * @param variantName The active variant's display name.
 	 */
 	protected _setViewTitle(variantName: string | undefined): void {
-		this.view.setTitle(variantName);
+		const icon: string | undefined = (this._data.getCurrent() as any)?.[this.#contentTypePropertyName]?.icon;
+		this.view.setTitle(variantName, icon ? { icon } : undefined);
 	}
 
 	public async loadLanguages() {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -352,7 +352,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 				const variantName = variants.find(
 					(v) => v.culture === activeVariant?.culture && v.segment === activeVariant?.segment,
 				)?.name;
-				this.view.setTitle(variantName);
+				this._setViewTitle(variantName);
 			},
 			null,
 		);
@@ -390,6 +390,16 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 		);
 
 		this.loadLanguages();
+	}
+
+	/**
+	 * Publishes the active variant name to the view title. Subclasses can override
+	 * this to include additional options such as a per-entity icon resolved from
+	 * the content type.
+	 * @param variantName The active variant's display name.
+	 */
+	protected _setViewTitle(variantName: string | undefined): void {
+		this.view.setTitle(variantName);
 	}
 
 	public async loadLanguages() {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
@@ -132,7 +132,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 		}
 
 		if (this._tabs.length > 0) {
-			this._tabs?.forEach((tab) => {
+			this._tabs.forEach((tab) => {
 				const tabName = tab.name ?? '';
 				const path = `tab/${encodeFolderName(tabName)}`;
 				routes.push({
@@ -206,7 +206,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 		// ViewAlias null is only for the root tab, therefor we can implement this hack.
 		if (viewAlias === null) {
 			// Specific hack for the Generic tab to only show its name if there are other tabs.
-			if (this._tabs && this._tabs?.length > 0) {
+			if (this._tabs && this._tabs.length > 0) {
 				view.setSegments('tab', { label: '#general_generic', kind: 'tab' });
 			} else {
 				view.clearSegments('tab');

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
@@ -173,7 +173,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 				view.hints.setPathFilter((paths) => paths[0].includes('tab/') === false);
 			}
 
-			view.setTitle(tabName);
+			view.setTitle(tabName, { kind: 'tab' });
 			view.inheritFrom(this.#viewContext);
 
 			this.observe(
@@ -206,7 +206,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 		// ViewAlias null is only for the root tab, therefor we can implement this hack.
 		if (viewAlias === null) {
 			// Specific hack for the Generic tab to only show its name if there are other tabs.
-			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined);
+			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined, { kind: 'tab' });
 		}
 		view.provideAt(component as any);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/views/edit/content-editor.element.ts
@@ -173,7 +173,7 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 				view.hints.setPathFilter((paths) => paths[0].includes('tab/') === false);
 			}
 
-			view.setTitle(tabName, { kind: 'tab' });
+			view.setSegments('tab', { label: tabName, kind: 'tab' });
 			view.inheritFrom(this.#viewContext);
 
 			this.observe(
@@ -206,7 +206,11 @@ export class UmbContentWorkspaceViewEditElement extends UmbLitElement implements
 		// ViewAlias null is only for the root tab, therefor we can implement this hack.
 		if (viewAlias === null) {
 			// Specific hack for the Generic tab to only show its name if there are other tabs.
-			view.setTitle(this._tabs && this._tabs?.length > 0 ? '#general_generic' : undefined, { kind: 'tab' });
+			if (this._tabs && this._tabs?.length > 0) {
+				view.setSegments('tab', { label: '#general_generic', kind: 'tab' });
+			} else {
+				view.clearSegments('tab');
+			}
 		}
 		view.provideAt(component as any);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/property-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/property-type-workspace.context.ts
@@ -75,7 +75,11 @@ export class UmbPropertyTypeWorkspaceContext
 		this.observe(
 			this.name,
 			(name) => {
-				this.view.setTitle(name);
+				if (name) {
+					this.view.setSegments('leaf', { label: name, kind: 'workspace' });
+				} else {
+					this.view.clearSegments('leaf');
+				}
 			},
 			null,
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/hint/context/hint.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/hint/context/hint.controller.ts
@@ -24,6 +24,9 @@ export class UmbHintController<
 	setPathFilter(filter: (path: Array<string>) => boolean) {
 		this.#pathFilter = filter;
 	}
+	get hasPathFilter(): boolean {
+		return this.#pathFilter !== undefined;
+	}
 
 	#scaffold = new UmbObjectState<Partial<HintType>>({});
 	readonly scaffold = this.#scaffold.asObservable();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -10,6 +10,9 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbAncestorsEntityContext, UmbParentEntityContext, type UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { UMB_VIEW_CONTEXT } from '@umbraco-cms/backoffice/view';
+import type { UmbViewContext } from '@umbraco-cms/backoffice/view';
+import { umbPublishAncestorsToView } from './publish-ancestors-to-view.function.js';
 
 interface UmbMenuTreeStructureWorkspaceContextBaseArgs {
 	treeRepositoryAlias: string;
@@ -34,6 +37,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 	#parentContext = new UmbParentEntityContext(this);
 	#ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
+	#viewContext?: UmbViewContext;
 	#isModalContext: boolean = false;
 	#isNew: boolean | undefined = undefined;
 
@@ -50,6 +54,19 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		this.consumeContext(UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT, (instance) => {
 			this.#sectionSidebarMenuContext = instance;
 		});
+
+		this.consumeContext(UMB_VIEW_CONTEXT, (instance) => {
+			this.#viewContext = instance;
+			// Publish the current structure (if any) as ancestor segments so the user
+			// history breadcrumb reflects the entity's tree path.
+			this.#publishAncestorsToView();
+		});
+
+		this.observe(
+			this.structure,
+			() => this.#publishAncestorsToView(),
+			'observeStructureForAncestorPublish',
+		);
 
 		this.consumeContext(UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, (instance) => {
 			this.#workspaceContext = instance;
@@ -141,6 +158,15 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		if (menuItemAlias && !this.#isModalContext) {
 			this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 		}
+	}
+
+	#publishAncestorsToView(): void {
+		umbPublishAncestorsToView(
+			this.#viewContext,
+			this.#structure.getValue(),
+			this.#workspaceContext?.getUnique(),
+			(item) => item.name,
+		);
 	}
 
 	#setParentData(structureItems: Array<UmbStructureItemModel>) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -17,6 +17,9 @@ import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { UMB_VIEW_CONTEXT } from '@umbraco-cms/backoffice/view';
+import type { UmbViewContext } from '@umbraco-cms/backoffice/view';
+import { umbPublishAncestorsToView } from './publish-ancestors-to-view.function.js';
 
 interface UmbMenuVariantTreeStructureWorkspaceContextBaseArgs {
 	treeRepositoryAlias: string;
@@ -43,6 +46,7 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 	#parentContext = new UmbParentEntityContext(this);
 	#ancestorContext = new UmbAncestorsEntityContext(this);
 	#sectionSidebarMenuContext?: typeof UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT.TYPE;
+	#viewContext?: UmbViewContext;
 	#isModalContext: boolean = false;
 	#isNew: boolean | undefined = undefined;
 	#variantWorkspaceContext?: typeof UMB_VARIANT_WORKSPACE_CONTEXT.TYPE;
@@ -73,6 +77,17 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 		this.consumeContext(UMB_SECTION_SIDEBAR_MENU_SECTION_CONTEXT, (instance) => {
 			this.#sectionSidebarMenuContext = instance;
 		});
+
+		this.consumeContext(UMB_VIEW_CONTEXT, (instance) => {
+			this.#viewContext = instance;
+			this.#publishAncestorsToView();
+		});
+
+		this.observe(
+			this.structure,
+			() => this.#publishAncestorsToView(),
+			'observeStructureForAncestorPublish',
+		);
 
 		this.consumeContext(UMB_SUBMITTABLE_TREE_ENTITY_WORKSPACE_CONTEXT, (instance) => {
 			this.#workspaceContext = instance;
@@ -195,6 +210,15 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 				this.#expandSectionSidebarMenu(structureItems, menuItemAlias);
 			}
 		}
+	}
+
+	#publishAncestorsToView(): void {
+		umbPublishAncestorsToView(
+			this.#viewContext,
+			this.#structure.getValue(),
+			this.#workspaceContext?.getUnique(),
+			(item) => item.variants[0]?.name,
+		);
 	}
 
 	#setParentData(structureItems: Array<UmbVariantStructureItemModel>) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/publish-ancestors-to-view.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/publish-ancestors-to-view.function.ts
@@ -1,0 +1,29 @@
+import type { UmbViewContext } from '@umbraco-cms/backoffice/view';
+import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
+
+/**
+ * Publish ancestor labels derived from a workspace structure list into a view
+ * context's title chain, so the user history breadcrumb and `document.title`
+ * both reflect the entity's tree path.
+ *
+ * Shared between {@link UmbMenuTreeStructureWorkspaceContextBase} and
+ * {@link UmbMenuVariantTreeStructureWorkspaceContextBase}; they differ only
+ * in how each structure item exposes its display name.
+ * @param viewContext - Destination view; skipped when unbound.
+ * @param items - Structure items, root-first.
+ * @param currentUnique - The current entity's unique; removed from the chain.
+ * @param getName - Pulls the display label out of a structure item.
+ */
+export function umbPublishAncestorsToView<T extends { unique: UmbEntityUnique }>(
+	viewContext: UmbViewContext | undefined,
+	items: ReadonlyArray<T>,
+	currentUnique: UmbEntityUnique | undefined,
+	getName: (item: T) => string | undefined,
+): void {
+	if (!viewContext) return;
+	const ancestors = items
+		.filter((item) => item.unique !== currentUnique)
+		.map((item) => getName(item) ?? '')
+		.filter((name) => name.length > 0);
+	viewContext.setAncestors(ancestors);
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/publish-ancestors-to-view.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/publish-ancestors-to-view.function.ts
@@ -28,7 +28,14 @@ export function umbPublishAncestorsToView<T extends { unique: UmbEntityUnique }>
 	if (ancestors.length) {
 		viewContext.setSegments(
 			'ancestors',
-			...ancestors.map((label) => ({ label, kind: 'workspace-ancestor' as const })),
+			// The first ancestor is the tree root, whose label often matches the
+			// workspace-type segment (e.g. both are "Scripts"). Mark it as `replaces`
+			// so only the ancestor (with its richer position in the chain) survives.
+			...ancestors.map((label, i) => ({
+				label,
+				kind: 'workspace-ancestor' as const,
+				...(i === 0 ? { replaces: true } : {}),
+			})),
 		);
 	} else {
 		viewContext.clearSegments('ancestors');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/publish-ancestors-to-view.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/publish-ancestors-to-view.function.ts
@@ -25,5 +25,12 @@ export function umbPublishAncestorsToView<T extends { unique: UmbEntityUnique }>
 		.filter((item) => item.unique !== currentUnique)
 		.map((item) => getName(item) ?? '')
 		.filter((name) => name.length > 0);
-	viewContext.setAncestors(ancestors);
+	if (ancestors.length) {
+		viewContext.setSegments(
+			'ancestors',
+			...ancestors.map((label) => ({ label, kind: 'workspace-ancestor' as const })),
+		);
+	} else {
+		viewContext.clearSegments('ancestors');
+	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal.context.ts
@@ -88,7 +88,7 @@ export class UmbModalContext<
 			title = this.alias.getDefaultModal()?.title ?? undefined;
 		}
 
-		this.view.setTitle(title);
+		this.view.setTitle(title, { kind: 'modal' });
 
 		this.type = args.modal?.type || this.type;
 		size = args.modal?.size ?? size;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal.context.ts
@@ -88,7 +88,11 @@ export class UmbModalContext<
 			title = this.alias.getDefaultModal()?.title ?? undefined;
 		}
 
-		this.view.setTitle(title, { kind: 'modal' });
+		if (title) {
+			this.view.setSegments('modal', { label: title, kind: 'modal' });
+		} else {
+			this.view.clearSegments('modal');
+		}
 
 		this.type = args.modal?.type || this.type;
 		size = args.modal?.size ?? size;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
@@ -68,8 +68,7 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 		}
 		const matchingView = this._views.find((manifest) => this.#constructViewPath(manifest) === activePath);
 		if (matchingView) {
-			const name = matchingView.meta.label ? this.localize.string(matchingView.meta.label) : (matchingView.name ?? matchingView.alias);
-			this.#viewContext.setSegments('dashboard', { label: name, kind: 'workspace' });
+			this.#viewContext.setSegments('dashboard', { label: this.#getViewName(matchingView), kind: 'workspace' });
 			return;
 		}
 		this.#viewContext.clearSegments('dashboard');
@@ -146,6 +145,10 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 		return dashboard.meta?.label ? this.localize.string(dashboard.meta.label) : (dashboard.name ?? dashboard.alias);
 	}
 
+	#getViewName(view: ManifestSectionView) {
+		return view.meta?.label ? this.localize.string(view.meta.label) : (view.name ?? view.alias);
+	}
+
 	#renderDashboards() {
 		// Only show dashboards if there are more than one dashboard or if there are both dashboards and views
 		return (this._dashboards.length > 0 && this._views.length > 0) || this._dashboards.length > 1
@@ -176,7 +179,7 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 			? html`
 					<uui-tab-group slot="navigation" id="views">
 						${this._views.map((view) => {
-							const viewName = view.meta.label ? this.localize.string(view.meta.label) : (view.name ?? view.alias);
+							const viewName = this.#getViewName(view);
 							const viewPath = this.#constructViewPath(view);
 							// If this path matches, or if this is the default view and the active path is empty.
 							const isActive =

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
@@ -55,7 +55,7 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 
 	#updateActiveViewTitle(): void {
 		if (!this._activePath && !this._defaultView) {
-			this.#viewContext.setTitle(undefined);
+			this.#viewContext.clearSegments('dashboard');
 			return;
 		}
 		const activePath = this._activePath || this._defaultView;
@@ -63,17 +63,16 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 			(manifest) => this.#constructDashboardPath(manifest) === activePath,
 		);
 		if (matchingDashboard) {
-			this.#viewContext.setTitle(this.#getDashboardName(matchingDashboard));
+			this.#viewContext.setSegments('dashboard', { label: this.#getDashboardName(matchingDashboard), kind: 'workspace' });
 			return;
 		}
 		const matchingView = this._views.find((manifest) => this.#constructViewPath(manifest) === activePath);
 		if (matchingView) {
-			this.#viewContext.setTitle(
-				matchingView.meta.label ? this.localize.string(matchingView.meta.label) : (matchingView.name ?? matchingView.alias),
-			);
+			const name = matchingView.meta.label ? this.localize.string(matchingView.meta.label) : (matchingView.name ?? matchingView.alias);
+			this.#viewContext.setSegments('dashboard', { label: name, kind: 'workspace' });
 			return;
 		}
-		this.#viewContext.setTitle(undefined);
+		this.#viewContext.clearSegments('dashboard');
 	}
 
 	#constructDashboardPath(manifest: ManifestDashboard) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
@@ -7,6 +7,7 @@ import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registr
 import { UmbExtensionsManifestInitializer, createExtensionElement } from '@umbraco-cms/backoffice/extension-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { pathFolderName } from '@umbraco-cms/backoffice/utils';
+import { UmbViewContext } from '@umbraco-cms/backoffice/view';
 
 @customElement('umb-section-main-views')
 export class UmbSectionMainViewElement extends UmbLitElement {
@@ -31,8 +32,15 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 	@state()
 	private _routes: Array<UmbRoute> = [];
 
+	// A view context that publishes the currently active dashboard / section-view's
+	// title, inheriting the section's title so the history breadcrumb and the
+	// browser's `document.title` both carry the section as the parent.
+	#viewContext = new UmbViewContext(this, null);
+
 	constructor() {
 		super();
+
+		this.#viewContext.inherit();
 
 		new UmbExtensionsManifestInitializer(this, umbExtensionsRegistry, 'dashboard', null, (dashboards) => {
 			this._dashboards = dashboards.map((dashboard) => dashboard.manifest);
@@ -43,6 +51,29 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 			this._views = views.map((view) => view.manifest);
 			this.#createRoutes();
 		});
+	}
+
+	#updateActiveViewTitle(): void {
+		if (!this._activePath && !this._defaultView) {
+			this.#viewContext.setTitle(undefined);
+			return;
+		}
+		const activePath = this._activePath || this._defaultView;
+		const matchingDashboard = this._dashboards.find(
+			(manifest) => this.#constructDashboardPath(manifest) === activePath,
+		);
+		if (matchingDashboard) {
+			this.#viewContext.setTitle(this.#getDashboardName(matchingDashboard));
+			return;
+		}
+		const matchingView = this._views.find((manifest) => this.#constructViewPath(manifest) === activePath);
+		if (matchingView) {
+			this.#viewContext.setTitle(
+				matchingView.meta.label ? this.localize.string(matchingView.meta.label) : (matchingView.name ?? matchingView.alias),
+			);
+			return;
+		}
+		this.#viewContext.setTitle(undefined);
 	}
 
 	#constructDashboardPath(manifest: ManifestDashboard) {
@@ -104,6 +135,7 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 							}}
 							@change=${(event: UmbRouterSlotChangeEvent) => {
 								this._activePath = event.target.localActiveViewPath;
+								this.#updateActiveViewTitle();
 							}}>
 						</umb-router-slot>
 					</umb-body-layout>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
@@ -62,13 +62,24 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 		const matchingDashboard = this._dashboards.find(
 			(manifest) => this.#constructDashboardPath(manifest) === activePath,
 		);
+		// Dashboards/section-views are a more specific refinement of the section,
+		// so when their label matches the section's, replace it (e.g. "Media"
+		// dashboard inside the "Media" section → just "Media" in the chain).
 		if (matchingDashboard) {
-			this.#viewContext.setSegments('dashboard', { label: this.#getDashboardName(matchingDashboard), kind: 'workspace' });
+			this.#viewContext.setSegments('dashboard', {
+				label: this.#getDashboardName(matchingDashboard),
+				kind: 'workspace',
+				replaces: true,
+			});
 			return;
 		}
 		const matchingView = this._views.find((manifest) => this.#constructViewPath(manifest) === activePath);
 		if (matchingView) {
-			this.#viewContext.setSegments('dashboard', { label: this.#getViewName(matchingView), kind: 'workspace' });
+			this.#viewContext.setSegments('dashboard', {
+				label: this.#getViewName(matchingView),
+				kind: 'workspace',
+				replaces: true,
+			});
 			return;
 		}
 		this.#viewContext.clearSegments('dashboard');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
@@ -79,6 +79,7 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 				label: this.#getViewName(matchingView),
 				kind: 'workspace',
 				replaces: true,
+				...(matchingView.meta.icon ? { icon: matchingView.meta.icon } : {}),
 			});
 			return;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-main-views/section-main-views.element.ts
@@ -119,6 +119,9 @@ export class UmbSectionMainViewElement extends UmbLitElement {
 			});
 		}
 		this._routes = routes;
+		// Re-evaluate the active view title: the manifests may have loaded after
+		// the router's initial @change event, so the title wasn't set then.
+		this.#updateActiveViewTitle();
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section.context.ts
@@ -33,7 +33,11 @@ export class UmbSectionContext extends UmbContextBase implements UmbApi {
 
 		const sectionLabel = manifest ? manifest.meta?.label || manifest.name : undefined;
 		this.#manifestLabel.setValue(sectionLabel);
-		this.#viewContext.setTitle(sectionLabel, { kind: 'section' });
+		if (sectionLabel) {
+			this.#viewContext.setSegments('section', { label: sectionLabel, kind: 'section' });
+		} else {
+			this.#viewContext.clearSegments('section');
+		}
 	}
 	public get manifest(): ManifestSection | undefined {
 		return this._manifest;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section.context.ts
@@ -33,7 +33,7 @@ export class UmbSectionContext extends UmbContextBase implements UmbApi {
 
 		const sectionLabel = manifest ? manifest.meta?.label || manifest.name : undefined;
 		this.#manifestLabel.setValue(sectionLabel);
-		this.#viewContext.setTitle(sectionLabel);
+		this.#viewContext.setTitle(sectionLabel, { kind: 'section' });
 	}
 	public get manifest(): ManifestSection | undefined {
 		return this._manifest;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
@@ -1,0 +1,59 @@
+import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
+
+/**
+ * The kind of a single title segment, indicating what part of the application
+ * contributed it. Consumers can filter segments by kind — for example, the user
+ * history list excludes `'tab'` segments from its breadcrumb but includes them
+ * in the browser's `document.title`.
+ */
+export type UmbViewTitleKind =
+	| 'section'
+	| 'workspace-type'
+	| 'workspace-ancestor'
+	| 'workspace'
+	| 'tab'
+	| 'modal';
+
+/**
+ * A single segment in the active view's title chain, annotated with the kind
+ * of view that produced it.
+ */
+export type UmbCurrentViewTitleSegment = {
+	label: string;
+	kind: UmbViewTitleKind;
+};
+
+/**
+ * Structured representation of the currently active view's title, published by {@link UmbViewController}.
+ * Parallel to `document.title`, but exposed as an observable so consumers do not have to parse the joined string.
+ */
+export type UmbCurrentViewTitle = {
+	/**
+	 * `window.location.pathname` at the moment the title was published.
+	 * Subscribers can use this to guard against stale emissions during fast navigation.
+	 */
+	path: string;
+	/**
+	 * Title segments ordered from topmost ancestor to leaf (current) view.
+	 * `segments.map(s => s.label).join(' | ')` reproduces the string form used for `document.title`.
+	 */
+	segments: ReadonlyArray<UmbCurrentViewTitleSegment>;
+};
+
+const state = new UmbObjectState<UmbCurrentViewTitle | undefined>(undefined);
+
+/**
+ * Observable of the currently active view's structured title.
+ * Emits whenever the active view's title chain changes.
+ */
+export const umbCurrentViewTitle = state.asObservable();
+
+/**
+ * Internal: set by UmbViewController only.
+ * @param value The new value for the current view title.
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const _setUmbCurrentViewTitle = (value: UmbCurrentViewTitle | undefined): void => {
+	state.setValue(value);
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
@@ -15,6 +15,35 @@ export type UmbViewTitleKind =
 	| 'modal';
 
 /**
+ * Canonical slot keys recognised by {@link UmbViewController.setSegments}.
+ *
+ * Each slot is owned by a single kind of caller, so the canonical names give
+ * autocomplete and discoverability for the common cases. Plugin authors may
+ * still pass any other string (the type widens via `string & {}`) to define
+ * their own slot — but stick to the canonical names where one fits.
+ *
+ * | Key | Owner |
+ * |------|-------|
+ * | `'section'` | `UmbSectionContext` — top-level section name |
+ * | `'dashboard'` | Section main views — active dashboard / section-view |
+ * | `'workspace-type'` | Workspace contexts — entity-type label (e.g. "Member") |
+ * | `'ancestors'` | Tree structure helpers — tree path leading to the leaf |
+ * | `'leaf'` | Workspace contexts — the active entity (variant name, etc.) |
+ * | `'tab'` | Workspace editors — the active tab |
+ * | `'modal'` | `UmbModalContext` — active modal title |
+ */
+export type UmbViewSegmentSlotKey =
+	| 'section'
+	| 'dashboard'
+	| 'workspace-type'
+	| 'ancestors'
+	| 'leaf'
+	| 'tab'
+	| 'modal'
+	// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+	| (string & {});
+
+/**
  * A single segment in the active view's title chain, annotated with the kind
  * of view that produced it.
  */

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
@@ -26,6 +26,14 @@ export type UmbCurrentViewTitleSegment = {
 	 * Consumers like the user history list may render this alongside the label.
 	 */
 	icon?: string;
+	/**
+	 * When true, this segment replaces the immediately preceding segment if it
+	 * has the same label. Use this when a workspace root shares its hosting
+	 * section's name (e.g. "Content" root under the Content section) to avoid
+	 * "Content › Content" in the breadcrumb while keeping the richer segment's
+	 * metadata (icon, kind).
+	 */
+	replaces?: boolean;
 };
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/current-view-title.ts
@@ -21,6 +21,11 @@ export type UmbViewTitleKind =
 export type UmbCurrentViewTitleSegment = {
 	label: string;
 	kind: UmbViewTitleKind;
+	/**
+	 * Optional icon name (e.g. `icon-document-js`) associated with this segment.
+	 * Consumers like the user history list may render this alongside the label.
+	 */
+	icon?: string;
 };
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/index.ts
@@ -5,5 +5,6 @@ export { umbCurrentViewTitle } from './current-view-title.js';
 export type {
 	UmbCurrentViewTitle,
 	UmbCurrentViewTitleSegment,
+	UmbViewSegmentSlotKey,
 	UmbViewTitleKind,
 } from './current-view-title.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/index.ts
@@ -1,3 +1,9 @@
 export * from './view.controller.js';
 export * from './view.context.js';
 export * from './view.context-token.js';
+export { umbCurrentViewTitle } from './current-view-title.js';
+export type {
+	UmbCurrentViewTitle,
+	UmbCurrentViewTitleSegment,
+	UmbViewTitleKind,
+} from './current-view-title.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -1,6 +1,8 @@
 import { UmbShortcutController } from '../../shortcut/context/shortcut.controller.js';
 import { UMB_VIEW_CONTEXT } from './view.context-token.js';
-import { UmbClassState, UmbStringState, mergeObservables } from '@umbraco-cms/backoffice/observable-api';
+import { _setUmbCurrentViewTitle } from './current-view-title.js';
+import type { UmbCurrentViewTitleSegment, UmbViewTitleKind } from './current-view-title.js';
+import { UmbClassState, UmbObjectState, mergeObservables } from '@umbraco-cms/backoffice/observable-api';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbHintController } from '@umbraco-cms/backoffice/hint';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
@@ -61,8 +63,14 @@ export class UmbViewController extends UmbControllerBase {
 	#explicitInheritance?: boolean;
 	#parentView?: UmbViewController;
 	#title?: string;
-	#computedTitle = new UmbStringState(undefined);
-	readonly computedTitle = this.#computedTitle.asObservable();
+	#titleKind: UmbViewTitleKind = 'workspace';
+	#titleTypeLabel?: string;
+	#titleAncestors?: ReadonlyArray<string>;
+	#computedTitleSegments = new UmbObjectState<ReadonlyArray<UmbCurrentViewTitleSegment> | undefined>(undefined);
+	readonly computedTitleSegments = this.#computedTitleSegments.asObservable();
+	readonly computedTitle = this.#computedTitleSegments.asObservablePart((segs) =>
+		segs?.length ? segs.map((s) => s.label).join(' | ') : undefined,
+	);
 
 	public readonly viewAlias: string | null;
 
@@ -119,9 +127,44 @@ export class UmbViewController extends UmbControllerBase {
 		this.hints.updateScaffold({ variantId: variantId });
 	}
 
-	public setTitle(title: string | undefined): void {
-		if (this.#title === title) return;
+	/**
+	 * Set this view's title. When the view is active (and has no active children),
+	 * the title contributes to `document.title` and to the published breadcrumb.
+	 * @param title The view's own title. Localization keys like `#foo_bar` are resolved automatically.
+	 * @param options Optional metadata. `kind` classifies the segment (default: `'workspace'`). `typeLabel`
+	 *   optionally inserts an additional segment with kind `'workspace-type'` immediately before this one — useful
+	 *   for entity workspaces that want to disambiguate e.g. "User Group" from "User" in the breadcrumb.
+	 */
+	public setTitle(
+		title: string | undefined,
+		options?: { kind?: UmbViewTitleKind; typeLabel?: string },
+	): void {
+		const { kind = 'workspace', typeLabel } = options ?? {};
+		if (this.#title === title && this.#titleKind === kind && this.#titleTypeLabel === typeLabel) return;
 		this.#title = title;
+		this.#titleKind = kind;
+		this.#titleTypeLabel = typeLabel;
+		this.#computeTitle();
+		this.#updateTitle();
+	}
+
+	/**
+	 * Set additional breadcrumb segments representing ancestors of this view in a
+	 * hierarchical entity tree (e.g. the parent folders of a media item). Ancestors
+	 * are inserted into the title chain between the parent view's contribution and
+	 * this view's own title, with `kind: 'workspace-ancestor'`.
+	 *
+	 * Ordered root → leaf (closest ancestor last). Pass `undefined` or an empty
+	 * array to clear.
+	 * @param ancestors Ancestor labels, root-most first.
+	 */
+	public setAncestors(ancestors: ReadonlyArray<string> | undefined): void {
+		const normalized = ancestors?.length ? ancestors : undefined;
+		const current = this.#titleAncestors;
+		if (current === normalized) return;
+		if (current && normalized && current.length === normalized.length && current.every((v, i) => v === normalized[i]))
+			return;
+		this.#titleAncestors = normalized;
 		this.#computeTitle();
 		this.#updateTitle();
 	}
@@ -216,7 +259,13 @@ export class UmbViewController extends UmbControllerBase {
 			},
 			'observeParentTitle',
 		);
-		this.hints.inheritFrom(this.#parentView?.hints);
+		// Hint inheritance requires a viewAlias or pathFilter on this view to target.
+		// Views without an alias (e.g. workspace-level views inheriting from a section
+		// purely to receive the section's title chain) have no hint target to resolve
+		// and must skip hint inheritance — title inheritance alone is supported.
+		if (this.viewAlias) {
+			this.hints.inheritFrom(this.#parentView?.hints);
+		}
 	}
 
 	#requestActivateParent() {
@@ -305,26 +354,68 @@ export class UmbViewController extends UmbControllerBase {
 		if (!this.#active || this.#hasActiveChildren()) {
 			return;
 		}
-		const localTitle = this.getComputedTitle();
-		if (!localTitle) {
+		const segments = this.#computedTitleSegments.getValue();
+		if (!segments || segments.length === 0) {
 			return;
 		}
+		const localTitle = segments.map((s) => s.label).join(' | ');
 		document.title = localTitle + ' | Umbraco';
+
+		_setUmbCurrentViewTitle({
+			path: window.location.pathname,
+			segments,
+		});
 	}
 
 	#computeTitle() {
-		const titles = [];
+		const segments: UmbCurrentViewTitleSegment[] = [];
 		if (this.#inherit && this.#parentView) {
-			titles.push(this.#parentView.getComputedTitle());
+			const parentSegments = this.#parentView.getComputedTitleSegments();
+			if (parentSegments) {
+				segments.push(...parentSegments);
+			}
 		}
 		if (this.#title) {
-			titles.push(this.#localize.string(this.#title));
+			if (this.#titleTypeLabel) {
+				segments.push({
+					label: this.#localize.string(this.#titleTypeLabel),
+					kind: 'workspace-type',
+				});
+			}
+			if (this.#titleAncestors) {
+				for (const ancestor of this.#titleAncestors) {
+					// Ancestor names can arrive as localization keys (e.g. a tree root's
+					// `#treeHeaders_dataTypes`), so resolve them the same way the leaf and
+					// type-label titles do.
+					segments.push({ label: this.#localize.string(ancestor), kind: 'workspace-ancestor' });
+				}
+			}
+			segments.push({
+				label: this.#localize.string(this.#title),
+				kind: this.#titleKind,
+			});
 		}
-		this.#computedTitle.setValue(titles.length > 0 ? titles.join(' | ') : undefined);
+		// Collapse consecutive segments with the same label. Primary case: a tree
+		// root sharing its hosting section's name (e.g. "Content" root under the
+		// Content section) — dedup avoids "Content | Content". Side effect: if a
+		// child entity has the exact same name as its parent (e.g. folder "Images"
+		// inside folder "Images"), the breadcrumb loses one level; the full URL
+		// is preserved on the history `path` so navigation still works.
+		const deduped: UmbCurrentViewTitleSegment[] = [];
+		for (const seg of segments) {
+			if (deduped[deduped.length - 1]?.label === seg.label) continue;
+			deduped.push(seg);
+		}
+		this.#computedTitleSegments.setValue(deduped.length ? deduped : undefined);
 	}
 
 	public getComputedTitle(): string | undefined {
-		return this.#computedTitle.getValue();
+		const segs = this.#computedTitleSegments.getValue();
+		return segs?.length ? segs.map((s) => s.label).join(' | ') : undefined;
+	}
+
+	public getComputedTitleSegments(): ReadonlyArray<UmbCurrentViewTitleSegment> | undefined {
+		return this.#computedTitleSegments.getValue();
 	}
 
 	#children: UmbViewController[] = [];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -1,7 +1,7 @@
 import { UmbShortcutController } from '../../shortcut/context/shortcut.controller.js';
 import { UMB_VIEW_CONTEXT } from './view.context-token.js';
 import { _setUmbCurrentViewTitle } from './current-view-title.js';
-import type { UmbCurrentViewTitleSegment, UmbViewTitleKind } from './current-view-title.js';
+import type { UmbCurrentViewTitleSegment, UmbViewSegmentSlotKey, UmbViewTitleKind } from './current-view-title.js';
 import { UmbClassState, UmbObjectState, mergeObservables } from '@umbraco-cms/backoffice/observable-api';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbHintController } from '@umbraco-cms/backoffice/hint';
@@ -63,7 +63,7 @@ export class UmbViewController extends UmbControllerBase {
 	#inherit = false;
 	#explicitInheritance?: boolean;
 	#parentView?: UmbViewController;
-	#segmentSlots = new Map<string, ReadonlyArray<UmbCurrentViewTitleSegment>>();
+	#segmentSlots = new Map<UmbViewSegmentSlotKey, ReadonlyArray<UmbCurrentViewTitleSegment>>();
 	#computedTitleSegments = new UmbObjectState<ReadonlyArray<UmbCurrentViewTitleSegment> | undefined>(undefined);
 	readonly computedTitleSegments = this.#computedTitleSegments.asObservable();
 	readonly computedTitle = this.#computedTitleSegments.asObservablePart((segs) =>
@@ -133,7 +133,7 @@ export class UmbViewController extends UmbControllerBase {
 	 * @param slotKey Unique key identifying this caller's contribution.
 	 * @param segments One or more segments to store under the slot. Pass none to clear.
 	 */
-	public setSegments(slotKey: string, ...segments: UmbCurrentViewTitleSegment[]): void {
+	public setSegments(slotKey: UmbViewSegmentSlotKey, ...segments: UmbCurrentViewTitleSegment[]): void {
 		if (segments.length === 0) {
 			this.clearSegments(slotKey);
 			return;
@@ -148,7 +148,7 @@ export class UmbViewController extends UmbControllerBase {
 	 * Remove all segments for a named slot.
 	 * @param slotKey The slot to clear.
 	 */
-	public clearSegments(slotKey: string): void {
+	public clearSegments(slotKey: UmbViewSegmentSlotKey): void {
 		if (!this.#segmentSlots.has(slotKey)) return;
 		this.#segmentSlots.delete(slotKey);
 		this.#computeTitle();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -158,7 +158,7 @@ export class UmbViewController extends UmbControllerBase {
 	}
 
 	/**
-	 * @deprecated Use {@link setSegments} instead. Will be removed in Umbraco 19.
+	 * @deprecated Use {@link setSegments} instead. Scheduled for removal in Umbraco 19.
 	 * Convenience wrapper that maps the legacy positional API to named segment slots.
 	 */
 	public setTitle(
@@ -166,30 +166,38 @@ export class UmbViewController extends UmbControllerBase {
 		options?: { kind?: UmbViewTitleKind; typeLabel?: string; icon?: string },
 	): void {
 		const { kind = 'workspace', typeLabel, icon } = options ?? {};
+		// Batch slot mutations to avoid intermediate publishes.
 		if (title) {
 			if (typeLabel) {
-				this.setSegments('workspace-type', { label: typeLabel, kind: 'workspace-type' });
+				this.#segmentSlots.set('workspace-type', [{ label: typeLabel, kind: 'workspace-type' }]);
+			} else {
+				this.#segmentSlots.delete('workspace-type');
 			}
-			this.setSegments('leaf', { label: title, kind, ...(icon ? { icon } : {}) });
+			this.#segmentSlots.set('leaf', [{ label: title, kind, ...(icon ? { icon } : {}) }]);
 		} else {
-			this.clearSegments('workspace-type');
-			this.clearSegments('leaf');
+			this.#segmentSlots.delete('workspace-type');
+			this.#segmentSlots.delete('leaf');
 		}
+		this.#computeTitle();
+		this.#updateTitle();
 	}
 
 	/**
-	 * @deprecated Use {@link setSegments} with kind `'workspace-ancestor'` instead. Will be removed in Umbraco 19.
+	 * @deprecated Use {@link setSegments} with kind `'workspace-ancestor'` instead. Scheduled for removal in Umbraco 19.
 	 * Convenience wrapper that maps ancestor labels to the `'ancestors'` segment slot.
 	 */
 	public setAncestors(ancestors: ReadonlyArray<string> | undefined): void {
 		if (!ancestors?.length) {
-			this.clearSegments('ancestors');
-			return;
+			if (!this.#segmentSlots.has('ancestors')) return;
+			this.#segmentSlots.delete('ancestors');
+		} else {
+			this.#segmentSlots.set(
+				'ancestors',
+				ancestors.map((label): UmbCurrentViewTitleSegment => ({ label, kind: 'workspace-ancestor' })),
+			);
 		}
-		this.setSegments(
-			'ancestors',
-			...ancestors.map((label): UmbCurrentViewTitleSegment => ({ label, kind: 'workspace-ancestor' })),
-		);
+		this.#computeTitle();
+		this.#updateTitle();
 	}
 
 	public provideAt(controllerHost: UmbClassInterface): void {
@@ -253,6 +261,12 @@ export class UmbViewController extends UmbControllerBase {
 
 	public inherit() {
 		this.#inherit = true;
+		// If the parent was already resolved (synchronous context lookup) before
+		// inherit() was called, #setParentView saw #inherit=false and skipped
+		// #inheritFromParent. Re-evaluate now that inheritance is enabled.
+		if (this.#parentView) {
+			this.#inheritFromParent();
+		}
 	}
 
 	public inheritFrom(context?: UmbViewController): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -62,11 +62,7 @@ export class UmbViewController extends UmbControllerBase {
 	#inherit = false;
 	#explicitInheritance?: boolean;
 	#parentView?: UmbViewController;
-	#title?: string;
-	#titleKind: UmbViewTitleKind = 'workspace';
-	#titleTypeLabel?: string;
-	#titleAncestors?: ReadonlyArray<string>;
-	#titleIcon?: string;
+	#segmentSlots = new Map<string, ReadonlyArray<UmbCurrentViewTitleSegment>>();
 	#computedTitleSegments = new UmbObjectState<ReadonlyArray<UmbCurrentViewTitleSegment> | undefined>(undefined);
 	readonly computedTitleSegments = this.#computedTitleSegments.asObservable();
 	readonly computedTitle = this.#computedTitleSegments.asObservablePart((segs) =>
@@ -128,56 +124,72 @@ export class UmbViewController extends UmbControllerBase {
 		this.hints.updateScaffold({ variantId: variantId });
 	}
 
+	// ── Segment-slot API ──────────────────────────────────────────────
+	// Each caller owns a named slot. The controller flattens all slots,
+	// sorts by kind priority, localizes labels, and deduplicates.
+
 	/**
-	 * Set this view's title. When the view is active (and has no active children),
-	 * the title contributes to `document.title` and to the published breadcrumb.
-	 * @param title The view's own title. Localization keys like `#foo_bar` are resolved automatically.
-	 * @param options Optional metadata. `kind` classifies the segment (default: `'workspace'`). `typeLabel`
-	 *   optionally inserts an additional segment with kind `'workspace-type'` immediately before this one — useful
-	 *   for entity workspaces that want to disambiguate e.g. "User Group" from "User" in the breadcrumb. `icon`
-	 *   attaches an icon to the leaf segment (e.g. `icon-document-js`) so consumers like the user history list
-	 *   can render an entity-specific icon alongside the label.
+	 * Add or replace segments under a named slot. Each slot key is owned by a
+	 * single caller (e.g. `'leaf'`, `'workspace-type'`, `'ancestors'`).
+	 * Labels may be raw localization keys (`#foo_bar`) — they are resolved
+	 * automatically when the title is computed.
+	 * @param slotKey Unique key identifying this caller's contribution.
+	 * @param segments One or more segments to store under the slot. Pass none to clear.
+	 */
+	public setSegments(slotKey: string, ...segments: UmbCurrentViewTitleSegment[]): void {
+		if (segments.length === 0) {
+			this.clearSegments(slotKey);
+			return;
+		}
+		this.#segmentSlots.set(slotKey, segments);
+		this.#computeTitle();
+		this.#updateTitle();
+	}
+
+	/**
+	 * Remove all segments for a named slot.
+	 * @param slotKey The slot to clear.
+	 */
+	public clearSegments(slotKey: string): void {
+		if (!this.#segmentSlots.has(slotKey)) return;
+		this.#segmentSlots.delete(slotKey);
+		this.#computeTitle();
+		this.#updateTitle();
+	}
+
+	/**
+	 * @deprecated Use {@link setSegments} instead. Will be removed in Umbraco 19.
+	 * Convenience wrapper that maps the legacy positional API to named segment slots.
 	 */
 	public setTitle(
 		title: string | undefined,
 		options?: { kind?: UmbViewTitleKind; typeLabel?: string; icon?: string },
 	): void {
 		const { kind = 'workspace', typeLabel, icon } = options ?? {};
-		if (
-			this.#title === title &&
-			this.#titleKind === kind &&
-			this.#titleTypeLabel === typeLabel &&
-			this.#titleIcon === icon
-		) {
-			return;
+		if (title) {
+			if (typeLabel) {
+				this.setSegments('workspace-type', { label: typeLabel, kind: 'workspace-type' });
+			}
+			this.setSegments('leaf', { label: title, kind, ...(icon ? { icon } : {}) });
+		} else {
+			this.clearSegments('workspace-type');
+			this.clearSegments('leaf');
 		}
-		this.#title = title;
-		this.#titleKind = kind;
-		this.#titleTypeLabel = typeLabel;
-		this.#titleIcon = icon;
-		this.#computeTitle();
-		this.#updateTitle();
 	}
 
 	/**
-	 * Set additional breadcrumb segments representing ancestors of this view in a
-	 * hierarchical entity tree (e.g. the parent folders of a media item). Ancestors
-	 * are inserted into the title chain between the parent view's contribution and
-	 * this view's own title, with `kind: 'workspace-ancestor'`.
-	 *
-	 * Ordered root → leaf (closest ancestor last). Pass `undefined` or an empty
-	 * array to clear.
-	 * @param ancestors Ancestor labels, root-most first.
+	 * @deprecated Use {@link setSegments} with kind `'workspace-ancestor'` instead. Will be removed in Umbraco 19.
+	 * Convenience wrapper that maps ancestor labels to the `'ancestors'` segment slot.
 	 */
 	public setAncestors(ancestors: ReadonlyArray<string> | undefined): void {
-		const normalized = ancestors?.length ? ancestors : undefined;
-		const current = this.#titleAncestors;
-		if (current === normalized) return;
-		if (current && normalized && current.length === normalized.length && current.every((v, i) => v === normalized[i]))
+		if (!ancestors?.length) {
+			this.clearSegments('ancestors');
 			return;
-		this.#titleAncestors = normalized;
-		this.#computeTitle();
-		this.#updateTitle();
+		}
+		this.setSegments(
+			'ancestors',
+			...ancestors.map((label): UmbCurrentViewTitleSegment => ({ label, kind: 'workspace-ancestor' })),
+		);
 	}
 
 	public provideAt(controllerHost: UmbClassInterface): void {
@@ -381,41 +393,45 @@ export class UmbViewController extends UmbControllerBase {
 		});
 	}
 
+	static #KIND_PRIORITY: Record<UmbViewTitleKind, number> = {
+		section: 0,
+		'workspace-type': 1,
+		'workspace-ancestor': 2,
+		workspace: 3,
+		tab: 4,
+		modal: 5,
+	};
+
 	#computeTitle() {
 		const segments: UmbCurrentViewTitleSegment[] = [];
+
+		// 1. Inherited parent segments (already localized by the parent's own computation).
 		if (this.#inherit && this.#parentView) {
 			const parentSegments = this.#parentView.getComputedTitleSegments();
 			if (parentSegments) {
 				segments.push(...parentSegments);
 			}
 		}
-		if (this.#title) {
-			if (this.#titleTypeLabel) {
-				segments.push({
-					label: this.#localize.string(this.#titleTypeLabel),
-					kind: 'workspace-type',
+
+		// 2. This view's own segments: flatten all slots, sort by kind priority,
+		//    and localize labels (which may be raw localization keys like `#foo_bar`).
+		const local: UmbCurrentViewTitleSegment[] = [];
+		for (const slot of this.#segmentSlots.values()) {
+			for (const seg of slot) {
+				local.push({
+					...seg,
+					label: this.#localize.string(seg.label),
 				});
 			}
-			if (this.#titleAncestors) {
-				for (const ancestor of this.#titleAncestors) {
-					// Ancestor names can arrive as localization keys (e.g. a tree root's
-					// `#treeHeaders_dataTypes`), so resolve them the same way the leaf and
-					// type-label titles do.
-					segments.push({ label: this.#localize.string(ancestor), kind: 'workspace-ancestor' });
-				}
-			}
-			segments.push({
-				label: this.#localize.string(this.#title),
-				kind: this.#titleKind,
-				...(this.#titleIcon ? { icon: this.#titleIcon } : {}),
-			});
 		}
-		// Collapse consecutive segments with the same label. Primary case: a tree
-		// root sharing its hosting section's name (e.g. "Content" root under the
-		// Content section) — dedup avoids "Content | Content". Side effect: if a
-		// child entity has the exact same name as its parent (e.g. folder "Images"
-		// inside folder "Images"), the breadcrumb loses one level; the full URL
-		// is preserved on the history `path` so navigation still works.
+		local.sort(
+			(a, b) => (UmbViewController.#KIND_PRIORITY[a.kind] ?? 99) - (UmbViewController.#KIND_PRIORITY[b.kind] ?? 99),
+		);
+		segments.push(...local);
+
+		// 3. Collapse consecutive segments with the same label. Primary case: a tree
+		//    root sharing its hosting section's name (e.g. "Content" root under the
+		//    Content section) — dedup avoids "Content | Content".
 		const deduped: UmbCurrentViewTitleSegment[] = [];
 		for (const seg of segments) {
 			if (deduped[deduped.length - 1]?.label === seg.label) continue;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -141,6 +141,12 @@ export class UmbViewController extends UmbControllerBase {
 			this.clearSegments(slotKey);
 			return;
 		}
+		const current = this.#segmentSlots.get(slotKey);
+		if (current && current.length === segments.length && current.every((s, i) =>
+			s.label === segments[i].label && s.kind === segments[i].kind && s.icon === segments[i].icon,
+		)) {
+			return;
+		}
 		this.#segmentSlots.set(slotKey, segments);
 		this.#computeTitle();
 		this.#updateTitle();
@@ -457,7 +463,16 @@ export class UmbViewController extends UmbControllerBase {
 			if (deduped[deduped.length - 1]?.label === seg.label) continue;
 			deduped.push(seg);
 		}
-		this.#computedTitleSegments.setValue(deduped.length ? deduped : undefined);
+		// Skip the observable emission when the result hasn't changed — prevents
+		// cascading recomputations in inheriting child views for no-op updates.
+		const result = deduped.length ? deduped : undefined;
+		const prev = this.#computedTitleSegments.getValue();
+		if (prev && result && prev.length === result.length && prev.every((s, i) =>
+			s.label === result[i].label && s.kind === result[i].kind && s.icon === result[i].icon,
+		)) {
+			return;
+		}
+		this.#computedTitleSegments.setValue(result);
 	}
 
 	public getComputedTitle(): string | undefined {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -388,6 +388,12 @@ export class UmbViewController extends UmbControllerBase {
 		});
 		this.shortcuts.deactivate();
 		this.#removeActive();
+
+		// Clear the global title when the top-level (non-inheriting) active view
+		// deactivates, so subscribers don't see stale data between navigations.
+		if (!this.#inherit) {
+			_setUmbCurrentViewTitle(undefined);
+		}
 	}
 
 	#updateTitle() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -457,10 +457,16 @@ export class UmbViewController extends UmbControllerBase {
 
 		// 3. Collapse consecutive segments with the same label. Primary case: a tree
 		//    root sharing its hosting section's name (e.g. "Content" root under the
-		//    Content section) — dedup avoids "Content | Content".
+		//    Content section) — dedup avoids "Content | Content". When collapsing,
+		//    prefer the later segment's metadata (icon, kind) since deeper views
+		//    carry richer information than their parents.
 		const deduped: UmbCurrentViewTitleSegment[] = [];
 		for (const seg of segments) {
-			if (deduped[deduped.length - 1]?.label === seg.label) continue;
+			const prev = deduped[deduped.length - 1];
+			if (prev?.label === seg.label) {
+				deduped[deduped.length - 1] = seg;
+				continue;
+			}
 			deduped.push(seg);
 		}
 		const result = deduped.length ? deduped : undefined;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -66,6 +66,7 @@ export class UmbViewController extends UmbControllerBase {
 	#titleKind: UmbViewTitleKind = 'workspace';
 	#titleTypeLabel?: string;
 	#titleAncestors?: ReadonlyArray<string>;
+	#titleIcon?: string;
 	#computedTitleSegments = new UmbObjectState<ReadonlyArray<UmbCurrentViewTitleSegment> | undefined>(undefined);
 	readonly computedTitleSegments = this.#computedTitleSegments.asObservable();
 	readonly computedTitle = this.#computedTitleSegments.asObservablePart((segs) =>
@@ -133,17 +134,27 @@ export class UmbViewController extends UmbControllerBase {
 	 * @param title The view's own title. Localization keys like `#foo_bar` are resolved automatically.
 	 * @param options Optional metadata. `kind` classifies the segment (default: `'workspace'`). `typeLabel`
 	 *   optionally inserts an additional segment with kind `'workspace-type'` immediately before this one — useful
-	 *   for entity workspaces that want to disambiguate e.g. "User Group" from "User" in the breadcrumb.
+	 *   for entity workspaces that want to disambiguate e.g. "User Group" from "User" in the breadcrumb. `icon`
+	 *   attaches an icon to the leaf segment (e.g. `icon-document-js`) so consumers like the user history list
+	 *   can render an entity-specific icon alongside the label.
 	 */
 	public setTitle(
 		title: string | undefined,
-		options?: { kind?: UmbViewTitleKind; typeLabel?: string },
+		options?: { kind?: UmbViewTitleKind; typeLabel?: string; icon?: string },
 	): void {
-		const { kind = 'workspace', typeLabel } = options ?? {};
-		if (this.#title === title && this.#titleKind === kind && this.#titleTypeLabel === typeLabel) return;
+		const { kind = 'workspace', typeLabel, icon } = options ?? {};
+		if (
+			this.#title === title &&
+			this.#titleKind === kind &&
+			this.#titleTypeLabel === typeLabel &&
+			this.#titleIcon === icon
+		) {
+			return;
+		}
 		this.#title = title;
 		this.#titleKind = kind;
 		this.#titleTypeLabel = typeLabel;
+		this.#titleIcon = icon;
 		this.#computeTitle();
 		this.#updateTitle();
 	}
@@ -393,6 +404,7 @@ export class UmbViewController extends UmbControllerBase {
 			segments.push({
 				label: this.#localize.string(this.#title),
 				kind: this.#titleKind,
+				...(this.#titleIcon ? { icon: this.#titleIcon } : {}),
 			});
 		}
 		// Collapse consecutive segments with the same label. Primary case: a tree

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -412,8 +412,17 @@ export class UmbViewController extends UmbControllerBase {
 		if (!segments || segments.length === 0) {
 			return;
 		}
-		const localTitle = segments.map((s) => s.label).join(' | ');
-		document.title = localTitle + ' | Umbraco';
+		// Reverse the segment order for the browser title so the most specific
+		// item (workspace name) appears first — Chrome truncates tabs after ~20
+		// characters, so the item the user is editing must be leftmost.
+		// The segments array itself retains hierarchy order (section → leaf) for
+		// consumers like the user history breadcrumb.
+		const browserTitle = segments
+			.slice()
+			.reverse()
+			.map((s) => s.label)
+			.join(' | ');
+		document.title = browserTitle + ' | Umbraco';
 
 		_setUmbCurrentViewTitle({
 			path: window.location.pathname,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -124,10 +124,6 @@ export class UmbViewController extends UmbControllerBase {
 		this.hints.updateScaffold({ variantId: variantId });
 	}
 
-	// ── Segment-slot API ──────────────────────────────────────────────
-	// Each caller owns a named slot. The controller flattens all slots,
-	// sorts by kind priority, localizes labels, and deduplicates.
-
 	/**
 	 * Add or replace segments under a named slot. Each slot key is owned by a
 	 * single caller (e.g. `'leaf'`, `'workspace-type'`, `'ancestors'`).
@@ -141,12 +137,7 @@ export class UmbViewController extends UmbControllerBase {
 			this.clearSegments(slotKey);
 			return;
 		}
-		const current = this.#segmentSlots.get(slotKey);
-		if (current && current.length === segments.length && current.every((s, i) =>
-			s.label === segments[i].label && s.kind === segments[i].kind && s.icon === segments[i].icon,
-		)) {
-			return;
-		}
+		if (UmbViewController.#segmentsEqual(this.#segmentSlots.get(slotKey), segments)) return;
 		this.#segmentSlots.set(slotKey, segments);
 		this.#computeTitle();
 		this.#updateTitle();
@@ -428,6 +419,15 @@ export class UmbViewController extends UmbControllerBase {
 		modal: 5,
 	};
 
+	static #segmentsEqual(
+		a: ReadonlyArray<UmbCurrentViewTitleSegment> | undefined,
+		b: ReadonlyArray<UmbCurrentViewTitleSegment> | undefined,
+	): boolean {
+		if (a === b) return true;
+		if (!a || !b || a.length !== b.length) return false;
+		return a.every((s, i) => s.label === b[i].label && s.kind === b[i].kind && s.icon === b[i].icon);
+	}
+
 	#computeTitle() {
 		const segments: UmbCurrentViewTitleSegment[] = [];
 
@@ -463,15 +463,8 @@ export class UmbViewController extends UmbControllerBase {
 			if (deduped[deduped.length - 1]?.label === seg.label) continue;
 			deduped.push(seg);
 		}
-		// Skip the observable emission when the result hasn't changed — prevents
-		// cascading recomputations in inheriting child views for no-op updates.
 		const result = deduped.length ? deduped : undefined;
-		const prev = this.#computedTitleSegments.getValue();
-		if (prev && result && prev.length === result.length && prev.every((s, i) =>
-			s.label === result[i].label && s.kind === result[i].kind && s.icon === result[i].icon,
-		)) {
-			return;
-		}
+		if (UmbViewController.#segmentsEqual(this.#computedTitleSegments.getValue(), result)) return;
 		this.#computedTitleSegments.setValue(result);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -259,8 +259,11 @@ export class UmbViewController extends UmbControllerBase {
 			},
 			'observeParentVariantId',
 		);
+		// Observe the full segment list rather than the joined string so that
+		// metadata-only changes (icon, kind) on parent segments propagate to
+		// inheriting children even when the labels haven't changed.
 		this.observe(
-			this.#parentView?.computedTitle,
+			this.#parentView?.computedTitleSegments,
 			() => {
 				this.#computeTitle();
 				// Check for parent view as it is undefined in a disassembling state and we do not want to update the title in that situation. [NL]

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -6,6 +6,7 @@ import { UmbClassState, UmbObjectState, mergeObservables } from '@umbraco-cms/ba
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbHintController } from '@umbraco-cms/backoffice/hint';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 import type { UmbClassInterface } from '@umbraco-cms/backoffice/class-api';
 import type { UmbContextConsumerController, UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
@@ -162,6 +163,11 @@ export class UmbViewController extends UmbControllerBase {
 		title: string | undefined,
 		options?: { kind?: UmbViewTitleKind; typeLabel?: string; icon?: string },
 	): void {
+		new UmbDeprecation({
+			deprecated: 'UmbViewController.setTitle()',
+			removeInVersion: '19.0.0',
+			solution: 'Use view.setSegments() and view.clearSegments() instead.',
+		}).warn();
 		const { kind = 'workspace', typeLabel, icon } = options ?? {};
 		// Batch slot mutations to avoid intermediate publishes.
 		if (title) {
@@ -184,6 +190,11 @@ export class UmbViewController extends UmbControllerBase {
 	 * Convenience wrapper that maps ancestor labels to the `'ancestors'` segment slot.
 	 */
 	public setAncestors(ancestors: ReadonlyArray<string> | undefined): void {
+		new UmbDeprecation({
+			deprecated: 'UmbViewController.setAncestors()',
+			removeInVersion: '19.0.0',
+			solution: 'Use view.setSegments() with kind "workspace-ancestor" instead.',
+		}).warn();
 		if (!ancestors?.length) {
 			if (!this.#segmentSlots.has('ancestors')) return;
 			this.#segmentSlots.delete('ancestors');
@@ -425,7 +436,9 @@ export class UmbViewController extends UmbControllerBase {
 	): boolean {
 		if (a === b) return true;
 		if (!a || !b || a.length !== b.length) return false;
-		return a.every((s, i) => s.label === b[i].label && s.kind === b[i].kind && s.icon === b[i].icon);
+		return a.every((s, i) =>
+			s.label === b[i].label && s.kind === b[i].kind && s.icon === b[i].icon && s.replaces === b[i].replaces,
+		);
 	}
 
 	#computeTitle() {
@@ -455,21 +468,19 @@ export class UmbViewController extends UmbControllerBase {
 		);
 		segments.push(...local);
 
-		// 3. Collapse consecutive segments with the same label. Primary case: a tree
-		//    root sharing its hosting section's name (e.g. "Content" root under the
-		//    Content section) — dedup avoids "Content | Content". When collapsing,
-		//    prefer the later segment's metadata (icon, kind) since deeper views
-		//    carry richer information than their parents.
-		const deduped: UmbCurrentViewTitleSegment[] = [];
+		// 3. Apply explicit replacements: when a segment has `replaces: true` and
+		//    the preceding segment has the same label, replace it. This is opt-in
+		//    so callers control exactly when dedup happens (no hidden metadata loss).
+		const resolved: UmbCurrentViewTitleSegment[] = [];
 		for (const seg of segments) {
-			const prev = deduped[deduped.length - 1];
-			if (prev?.label === seg.label) {
-				deduped[deduped.length - 1] = seg;
+			const prev = resolved[resolved.length - 1];
+			if (seg.replaces && prev?.label === seg.label) {
+				resolved[resolved.length - 1] = seg;
 				continue;
 			}
-			deduped.push(seg);
+			resolved.push(seg);
 		}
-		const result = deduped.length ? deduped : undefined;
+		const result = resolved.length ? resolved : undefined;
 		if (UmbViewController.#segmentsEqual(this.#computedTitleSegments.getValue(), result)) return;
 		this.#computedTitleSegments.setValue(result);
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -274,10 +274,10 @@ export class UmbViewController extends UmbControllerBase {
 			'observeParentTitle',
 		);
 		// Hint inheritance requires a viewAlias or pathFilter on this view to target.
-		// Views without an alias (e.g. workspace-level views inheriting from a section
+		// Views without either (e.g. workspace-level views inheriting from a section
 		// purely to receive the section's title chain) have no hint target to resolve
 		// and must skip hint inheritance — title inheritance alone is supported.
-		if (this.viewAlias) {
+		if (this.viewAlias || this.hints.hasPathFilter) {
 			this.hints.inheritFrom(this.#parentView?.hints);
 		}
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
@@ -42,7 +42,7 @@ export class UmbWorkspaceEditorContext extends UmbContextBase {
 					.forEach((manifest) => {
 						const context = new UmbWorkspaceViewContext(this, manifest);
 						context.setVariantId(this.#variantId);
-						context.setTitle(manifest.meta.label);
+						context.setTitle(manifest.meta.label, { kind: 'tab' });
 						context.inherit();
 						contexts.push(context);
 					});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
@@ -42,7 +42,7 @@ export class UmbWorkspaceEditorContext extends UmbContextBase {
 					.forEach((manifest) => {
 						const context = new UmbWorkspaceViewContext(this, manifest);
 						context.setVariantId(this.#variantId);
-						context.setTitle(manifest.meta.label, { kind: 'tab' });
+						context.setSegments('tab', { label: manifest.meta.label, kind: 'tab' });
 						context.inherit();
 						contexts.push(context);
 					});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
@@ -27,7 +27,7 @@ export abstract class UmbEntityNamedDetailWorkspaceContextBase<
 	constructor(host: UmbControllerHost, args: UmbEntityDetailWorkspaceContextArgs) {
 		super(host, args);
 		this.nameWriteGuard.fallbackToPermitted();
-		const typeLabel = args.typeLabel;
+		const { typeLabel, icon } = args;
 		// Combine name with the forbidden state so the breadcrumb gets a
 		// meaningful label even when the entity can't be loaded — otherwise the
 		// section title is the only thing left in the chain (e.g. "Settings"
@@ -36,7 +36,7 @@ export abstract class UmbEntityNamedDetailWorkspaceContextBase<
 			mergeObservables([this.name, this.forbidden.isOn], ([name, isForbidden]) => ({ name, isForbidden })),
 			({ name, isForbidden }) => {
 				const title = isForbidden ? '#routing_routeForbiddenTitle' : name;
-				this.view.setTitle(title, { kind: 'workspace', typeLabel });
+				this.view.setTitle(title, { kind: 'workspace', typeLabel, icon });
 			},
 			null,
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
@@ -26,10 +26,11 @@ export abstract class UmbEntityNamedDetailWorkspaceContextBase<
 	constructor(host: UmbControllerHost, args: UmbEntityDetailWorkspaceContextArgs) {
 		super(host, args);
 		this.nameWriteGuard.fallbackToPermitted();
+		const typeLabel = args.typeLabel;
 		this.observe(
 			this.name,
 			(name) => {
-				this.view.setTitle(name);
+				this.view.setTitle(name, { kind: 'workspace', typeLabel });
 			},
 			null,
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
@@ -28,6 +28,11 @@ export abstract class UmbEntityNamedDetailWorkspaceContextBase<
 		super(host, args);
 		this.nameWriteGuard.fallbackToPermitted();
 		const { typeLabel, icon } = args;
+
+		if (typeLabel) {
+			this.view.setSegments('workspace-type', { label: typeLabel, kind: 'workspace-type' });
+		}
+
 		// Combine name with the forbidden state so the breadcrumb gets a
 		// meaningful label even when the entity can't be loaded — otherwise the
 		// section title is the only thing left in the chain (e.g. "Settings"
@@ -35,8 +40,12 @@ export abstract class UmbEntityNamedDetailWorkspaceContextBase<
 		this.observe(
 			mergeObservables([this.name, this.forbidden.isOn], ([name, isForbidden]) => ({ name, isForbidden })),
 			({ name, isForbidden }) => {
-				const title = isForbidden ? '#routing_routeForbiddenTitle' : name;
-				this.view.setTitle(title, { kind: 'workspace', typeLabel, icon });
+				const label = isForbidden ? '#routing_routeForbiddenTitle' : name;
+				if (label) {
+					this.view.setSegments('leaf', { label, kind: 'workspace', ...(icon ? { icon } : {}) });
+				} else {
+					this.view.clearSegments('leaf');
+				}
 			},
 			null,
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
@@ -3,6 +3,7 @@ import { UmbNameWriteGuardManager } from '../namable/index.js';
 import { UmbEntityDetailWorkspaceContextBase } from './entity-detail-workspace-base.js';
 import type { UmbEntityDetailWorkspaceContextArgs, UmbEntityDetailWorkspaceContextCreateArgs } from './types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { mergeObservables } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbDetailRepository } from '@umbraco-cms/backoffice/repository';
 import type { UmbNamedEntityModel } from '@umbraco-cms/backoffice/entity';
 
@@ -27,10 +28,15 @@ export abstract class UmbEntityNamedDetailWorkspaceContextBase<
 		super(host, args);
 		this.nameWriteGuard.fallbackToPermitted();
 		const typeLabel = args.typeLabel;
+		// Combine name with the forbidden state so the breadcrumb gets a
+		// meaningful label even when the entity can't be loaded — otherwise the
+		// section title is the only thing left in the chain (e.g. "Settings"
+		// instead of "Settings › Partial Views › Access denied").
 		this.observe(
-			this.name,
-			(name) => {
-				this.view.setTitle(name, { kind: 'workspace', typeLabel });
+			mergeObservables([this.name, this.forbidden.isOn], ([name, isForbidden]) => ({ name, isForbidden })),
+			({ name, isForbidden }) => {
+				const title = isForbidden ? '#routing_routeForbiddenTitle' : name;
+				this.view.setTitle(title, { kind: 'workspace', typeLabel });
 			},
 			null,
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/entity-named-detail-workspace-base.ts
@@ -29,6 +29,19 @@ export abstract class UmbEntityNamedDetailWorkspaceContextBase<
 		this.nameWriteGuard.fallbackToPermitted();
 		const { typeLabel, icon } = args;
 
+		if (!typeLabel) {
+			console.warn(
+				`[UmbEntityNamedDetailWorkspaceContextBase] Workspace "${args.workspaceAlias}" is missing a typeLabel. ` +
+				`Set typeLabel in the workspace args to improve the user history breadcrumb.`,
+			);
+		}
+		if (!icon) {
+			console.warn(
+				`[UmbEntityNamedDetailWorkspaceContextBase] Workspace "${args.workspaceAlias}" is missing an icon. ` +
+				`Set icon in the workspace args to show an entity-specific icon in the user history.`,
+			);
+		}
+
 		if (typeLabel) {
 			this.view.setSegments('workspace-type', { label: typeLabel, kind: 'workspace-type' });
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/types.ts
@@ -12,6 +12,12 @@ export interface UmbEntityDetailWorkspaceContextArgs {
 	 * of different types that share the same section. Localization keys are supported.
 	 */
 	typeLabel?: string;
+	/**
+	 * Optional icon to attach to this entity's leaf title segment (e.g. `icon-document-js`).
+	 * Surfaced by consumers like the user history list. For workspaces whose icon varies
+	 * per-entity (e.g. document type), set the icon directly via `view.setTitle(...)` instead.
+	 */
+	icon?: string;
 }
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/types.ts
@@ -15,7 +15,9 @@ export interface UmbEntityDetailWorkspaceContextArgs {
 	/**
 	 * Optional icon to attach to this entity's leaf title segment (e.g. `icon-document-js`).
 	 * Surfaced by consumers like the user history list. For workspaces whose icon varies
-	 * per-entity (e.g. document type), set the icon directly via `view.setTitle(...)` instead.
+	 * per-entity (e.g. document type), update the `leaf` segment directly via
+	 * `view.setSegments(...)` / `view.clearSegments(...)` instead. `view.setTitle(...)`
+	 * remains legacy compatibility, but is not the recommended API for this.
 	 */
 	icon?: string;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/entity-detail/types.ts
@@ -5,6 +5,13 @@ export interface UmbEntityDetailWorkspaceContextArgs {
 	entityType: string;
 	workspaceAlias: string;
 	detailRepositoryAlias: string;
+	/**
+	 * Optional user-friendly label for this entity type (e.g. "User Group", "Member").
+	 * When set, the workspace's title chain includes an additional breadcrumb segment
+	 * above the entity name, used by the user history list to disambiguate entities
+	 * of different types that share the same section. Localization keys are supported.
+	 */
+	typeLabel?: string;
 }
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
@@ -24,7 +24,8 @@ export class UmbDefaultWorkspaceContext extends UmbContextBase implements UmbWor
 	set manifest(manifest: ManifestWorkspaceDefaultKind) {
 		this.workspaceAlias = manifest.alias;
 		this.setEntityType(manifest.meta.entityType);
-		this.view.setTitle(manifest.meta.headline, { icon: manifest.meta.icon });
+		const icon = manifest.meta.icon;
+		this.view.setSegments('leaf', { label: manifest.meta.headline, kind: 'workspace', ...(icon ? { icon } : {}) });
 	}
 
 	setUnique(unique: UmbEntityUnique): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
@@ -25,7 +25,10 @@ export class UmbDefaultWorkspaceContext extends UmbContextBase implements UmbWor
 		this.workspaceAlias = manifest.alias;
 		this.setEntityType(manifest.meta.entityType);
 		const icon = manifest.meta.icon;
-		this.view.setSegments('leaf', { label: manifest.meta.headline, kind: 'workspace', ...(icon ? { icon } : {}) });
+		// Root workspaces often share their section's label (e.g. "Content" root
+		// in the Content section). Mark as `replaces` so the breadcrumb shows
+		// only the workspace segment (with its richer icon/kind metadata).
+		this.view.setSegments('leaf', { label: manifest.meta.headline, kind: 'workspace', replaces: true, ...(icon ? { icon } : {}) });
 	}
 
 	setUnique(unique: UmbEntityUnique): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
@@ -24,7 +24,7 @@ export class UmbDefaultWorkspaceContext extends UmbContextBase implements UmbWor
 	set manifest(manifest: ManifestWorkspaceDefaultKind) {
 		this.workspaceAlias = manifest.alias;
 		this.setEntityType(manifest.meta.entityType);
-		this.view.setTitle(manifest.meta.headline);
+		this.view.setTitle(manifest.meta.headline, { icon: manifest.meta.icon });
 	}
 
 	setUnique(unique: UmbEntityUnique): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/default-workspace.context.ts
@@ -15,6 +15,10 @@ export class UmbDefaultWorkspaceContext extends UmbContextBase implements UmbWor
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_WORKSPACE_CONTEXT.toString());
+		// Inherit the view from the hosting section so the section title propagates
+		// into this workspace's title chain (and thereby document.title and the user
+		// history breadcrumb).
+		this.view.inherit();
 	}
 
 	set manifest(manifest: ManifestWorkspaceDefaultKind) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/kinds/default/types.ts
@@ -10,6 +10,11 @@ export interface ManifestWorkspaceDefaultKind
 
 export interface MetaWorkspaceDefaultKind extends MetaWorkspace {
 	headline: string;
+	/**
+	 * Optional icon for this workspace (e.g. `icon-globe`).
+	 * Surfaced by consumers like the user history list.
+	 */
+	icon?: string;
 }
 
 declare global {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/submittable/submittable-workspace-context-base.ts
@@ -53,6 +53,10 @@ export abstract class UmbSubmittableWorkspaceContextBase<WorkspaceDataModelType>
 	constructor(host: UmbControllerHost, workspaceAlias: string) {
 		super(host, UMB_WORKSPACE_CONTEXT.toString());
 		this.workspaceAlias = workspaceAlias;
+		// Inherit the view from the hosting section so the section title propagates
+		// into this workspace's title chain (and thereby document.title and the user
+		// history breadcrumb).
+		this.view.inherit();
 		// TODO: Consider if we can move this consumption to #resolveSubmit, just as a getContext, but it depends if others use the modalContext prop.. [NL]
 		this.consumeContext(UMB_MODAL_CONTEXT, (context) => {
 			(this.modalContext as UmbModalContext | undefined) = context;

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/data-type-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/data-type-root/manifests.ts
@@ -9,6 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_DATA_TYPE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_dataTypes',
+			icon: 'icon-autofill',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/workspace/data-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/workspace/data-type-folder-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbDataTypeFolderWorkspaceContext
 			entityType: UMB_DATA_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DATA_TYPE_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_dataTypes',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/workspace/data-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/workspace/data-type-folder-workspace.context.ts
@@ -20,6 +20,7 @@ export class UmbDataTypeFolderWorkspaceContext
 			workspaceAlias: UMB_DATA_TYPE_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_DATA_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DATA_TYPE_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_dataTypes',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -85,6 +85,7 @@ export class UmbDataTypeWorkspaceContext
 			entityType: UMB_DATA_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DATA_TYPE_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_dataTypes',
+			icon: 'icon-autofill',
 		});
 
 		this.#observePropertyEditorSchemaAlias();

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -84,6 +84,7 @@ export class UmbDataTypeWorkspaceContext
 			workspaceAlias: UMB_DATA_TYPE_WORKSPACE_ALIAS,
 			entityType: UMB_DATA_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DATA_TYPE_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_dataTypes',
 		});
 
 		this.#observePropertyEditorSchemaAlias();

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/workspace/dictionary-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/workspace/dictionary-workspace.context.ts
@@ -23,6 +23,7 @@ export class UmbDictionaryWorkspaceContext
 			entityType: UMB_DICTIONARY_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DICTIONARY_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_dictionary',
+			icon: 'icon-book-alt',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/dictionary/workspace/dictionary-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/dictionary/workspace/dictionary-workspace.context.ts
@@ -22,6 +22,7 @@ export class UmbDictionaryWorkspaceContext
 			workspaceAlias: UMB_DICTIONARY_WORKSPACE_ALIAS,
 			entityType: UMB_DICTIONARY_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DICTIONARY_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_dictionary',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/document-blueprint-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/document-blueprint-folder-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbDocumentBlueprintFolderWorkspaceContext
 			workspaceAlias: UMB_DOCUMENT_BLUEPRINT_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_DOCUMENT_BLUEPRINT_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DOCUMENT_BLUEPRINT_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_contentBlueprints',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/document-blueprint-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/document-blueprint-folder-workspace.context.ts
@@ -22,6 +22,7 @@ export class UmbDocumentBlueprintFolderWorkspaceContext
 			entityType: UMB_DOCUMENT_BLUEPRINT_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DOCUMENT_BLUEPRINT_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_contentBlueprints',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/manifests.ts
@@ -56,6 +56,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_DOCUMENT_BLUEPRINT_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_contentBlueprints',
+			icon: 'icon-blueprint',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
@@ -124,6 +124,17 @@ export class UmbDocumentBlueprintWorkspaceContext
 		return this.getData()?.documentType.unique;
 	}
 
+	// The blueprint detail response doesn't include documentType.icon, so the
+	// base class's generic _setViewTitle finds no icon. Use icon-blueprint as a
+	// static fallback matching the tree item representation.
+	protected override _setViewTitle(variantName: string | undefined): void {
+		if (variantName) {
+			this.view.setSegments('leaf', { label: variantName, kind: 'workspace', icon: 'icon-blueprint' });
+		} else {
+			this.view.clearSegments('leaf');
+		}
+	}
+
 	/**
 	 * Override mandatory validation to filter out variants without a name before validating.
 	 * Blueprints allow partial variant data and users may only provide a name for some cultures.

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace.context.ts
@@ -48,6 +48,8 @@ export class UmbDocumentBlueprintWorkspaceContext
 			ignoreValidationResultOnSubmit: true,
 		});
 
+		this.view.setSegments('workspace-type', { label: '#treeHeaders_contentBlueprints', kind: 'workspace-type' });
+
 		this.observe(
 			this.contentTypeUnique,
 			(unique) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/workspace/document-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/workspace/document-type-folder-workspace.context.ts
@@ -23,6 +23,7 @@ export class UmbDocumentTypeFolderWorkspaceContext
 			workspaceAlias: UMB_DOCUMENT_TYPE_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_DOCUMENT_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DOCUMENT_TYPE_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_documentTypes',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/workspace/document-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/workspace/document-type-folder-workspace.context.ts
@@ -24,6 +24,7 @@ export class UmbDocumentTypeFolderWorkspaceContext
 			entityType: UMB_DOCUMENT_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DOCUMENT_TYPE_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_documentTypes',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type-root/manifests.ts
@@ -9,6 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_DOCUMENT_TYPE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_documentTypes',
+			icon: 'icon-plugin',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/document-type-workspace.context.ts
@@ -44,6 +44,7 @@ export class UmbDocumentTypeWorkspaceContext
 			workspaceAlias: UMB_DOCUMENT_TYPE_WORKSPACE_ALIAS,
 			entityType: UMB_DOCUMENT_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_DOCUMENT_TYPE_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_documentTypes',
 		});
 
 		// Document type specific:

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/root/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/root/workspace/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_DOCUMENT_RECYCLE_BIN_ROOT_ENTITY_TYPE,
 			headline: '#general_recycleBin',
+			icon: 'icon-trash',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -222,11 +222,6 @@ export class UmbDocumentWorkspaceContext
 		]);
 	}
 
-	protected override _setViewTitle(variantName: string | undefined): void {
-		const icon = this._data.getCurrent()?.documentType?.icon;
-		this.view.setTitle(variantName, { icon: icon || undefined });
-	}
-
 	override resetState(): void {
 		super.resetState();
 		this.#isTrashedContext.setIsTrashed(false);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -222,6 +222,11 @@ export class UmbDocumentWorkspaceContext
 		]);
 	}
 
+	protected override _setViewTitle(variantName: string | undefined): void {
+		const icon = this._data.getCurrent()?.documentType?.icon;
+		this.view.setTitle(variantName, { icon: icon || undefined });
+	}
+
 	override resetState(): void {
 		super.resetState();
 		this.#isTrashedContext.setIsTrashed(false);

--- a/src/Umbraco.Web.UI.Client/src/packages/extension-insights/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/extension-insights/workspace/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_EXTENSION_ROOT_ENTITY_TYPE,
 			headline: 'Extension Insights',
+			icon: 'icon-wand',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/language/workspace/language-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/workspace/language-root/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_LANGUAGE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_languages',
+			icon: 'icon-globe',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/language/workspace/language/language-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/workspace/language/language-workspace.context.ts
@@ -25,6 +25,7 @@ export class UmbLanguageWorkspaceContext
 			entityType: UMB_LANGUAGE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_LANGUAGE_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_languages',
+			icon: 'icon-globe',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/language/workspace/language/language-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/workspace/language/language-workspace.context.ts
@@ -24,6 +24,7 @@ export class UmbLanguageWorkspaceContext
 			workspaceAlias: UMB_LANGUAGE_WORKSPACE_ALIAS,
 			entityType: UMB_LANGUAGE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_LANGUAGE_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_languages',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -109,7 +109,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 		this.#repository = new UmbLogViewerRepository(host);
 
 		this.view.inherit();
-		this.view.setTitle('#treeHeaders_logViewer');
+		this.view.setTitle('#treeHeaders_logViewer', { icon: 'icon-box-alt' });
 	}
 
 	override hostConnected() {

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -108,6 +108,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 		this.provideContext(UMB_WORKSPACE_CONTEXT, this);
 		this.#repository = new UmbLogViewerRepository(host);
 
+		this.view.inherit();
 		this.view.setTitle('#treeHeaders_logViewer');
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -109,7 +109,7 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 		this.#repository = new UmbLogViewerRepository(host);
 
 		this.view.inherit();
-		this.view.setTitle('#treeHeaders_logViewer', { icon: 'icon-box-alt' });
+		this.view.setSegments('leaf', { label: '#treeHeaders_logViewer', kind: 'workspace', icon: 'icon-box-alt' });
 	}
 
 	override hostConnected() {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/media-type-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/media-type-root/manifests.ts
@@ -9,6 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_mediaTypes',
+			icon: 'icon-document-dashed-line',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/workspace/media-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/workspace/media-type-folder-workspace.context.ts
@@ -22,6 +22,7 @@ export class UmbMediaTypeFolderWorkspaceContext
 			entityType: UMB_MEDIA_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEDIA_TYPE_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_mediaTypes',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/workspace/media-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/workspace/media-type-folder-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbMediaTypeFolderWorkspaceContext
 			workspaceAlias: UMB_MEDIA_TYPE_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_MEDIA_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEDIA_TYPE_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_mediaTypes',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/manifests.ts
@@ -49,6 +49,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_mediaTypes',
+			icon: 'icon-document-dashed-line',
 		},
 	},
 	...folderManifests,

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace.context.ts
@@ -25,6 +25,7 @@ export class UmbMediaTypeWorkspaceContext
 			entityType: UMB_MEDIA_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEDIA_TYPE_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_mediaTypes',
+			icon: 'icon-document-dashed-line',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/workspace/media-type-workspace.context.ts
@@ -24,6 +24,7 @@ export class UmbMediaTypeWorkspaceContext
 			workspaceAlias: UMB_MEDIA_TYPE_WORKSPACE_ALIAS,
 			entityType: UMB_MEDIA_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEDIA_TYPE_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_mediaTypes',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/root/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/root/workspace/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_MEDIA_RECYCLE_BIN_ROOT_ENTITY_TYPE,
 			headline: '#general_recycleBin',
+			icon: 'icon-trash',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
@@ -117,11 +117,6 @@ export class UmbMediaWorkspaceContext
 		]);
 	}
 
-	protected override _setViewTitle(variantName: string | undefined): void {
-		const icon = this._data.getCurrent()?.mediaType?.icon;
-		this.view.setTitle(variantName, { icon: icon || undefined });
-	}
-
 	public override resetState() {
 		super.resetState();
 		this.#isTrashedContext.setIsTrashed(false);

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace.context.ts
@@ -117,6 +117,11 @@ export class UmbMediaWorkspaceContext
 		]);
 	}
 
+	protected override _setViewTitle(variantName: string | undefined): void {
+		const icon = this._data.getCurrent()?.mediaType?.icon;
+		this.view.setTitle(variantName, { icon: icon || undefined });
+	}
+
 	public override resetState() {
 		super.resetState();
 		this.#isTrashedContext.setIsTrashed(false);

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/workspace/member-group-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/workspace/member-group-root/manifests.ts
@@ -11,6 +11,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_MEMBER_GROUP_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_memberGroups',
+			icon: 'icon-users',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/workspace/member-group/member-group-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/workspace/member-group/member-group-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbMemberGroupWorkspaceContext
 			workspaceAlias: UMB_MEMBER_GROUP_WORKSPACE_ALIAS,
 			entityType: UMB_MEMBER_GROUP_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEMBER_GROUP_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#content_membergroup',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/workspace/member-group/member-group-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/workspace/member-group/member-group-workspace.context.ts
@@ -22,6 +22,7 @@ export class UmbMemberGroupWorkspaceContext
 			entityType: UMB_MEMBER_GROUP_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEMBER_GROUP_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#content_membergroup',
+			icon: 'icon-users',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/member-type-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/member-type-root/manifests.ts
@@ -9,7 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_MEMBER_TYPE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_memberTypes',
-			icon: 'icon-member-dashed-line',
+			icon: 'icon-user',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/member-type-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/member-type-root/manifests.ts
@@ -9,6 +9,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_MEMBER_TYPE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_memberTypes',
+			icon: 'icon-member-dashed-line',
 		},
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/workspace/member-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/workspace/member-type-folder-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbMemberTypeFolderWorkspaceContext
 			workspaceAlias: UMB_MEMBER_TYPE_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_MEMBER_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEMBER_TYPE_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_memberTypes',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/workspace/member-type-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/workspace/member-type-folder-workspace.context.ts
@@ -22,6 +22,7 @@ export class UmbMemberTypeFolderWorkspaceContext
 			entityType: UMB_MEMBER_TYPE_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEMBER_TYPE_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_memberTypes',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace.context.ts
@@ -24,6 +24,7 @@ export class UmbMemberTypeWorkspaceContext
 			entityType: UMB_MEMBER_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEMBER_TYPE_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_memberTypes',
+			icon: 'icon-member-dashed-line',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace.context.ts
@@ -24,7 +24,7 @@ export class UmbMemberTypeWorkspaceContext
 			entityType: UMB_MEMBER_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEMBER_TYPE_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_memberTypes',
-			icon: 'icon-member-dashed-line',
+			icon: 'icon-user',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/member-type-workspace.context.ts
@@ -23,6 +23,7 @@ export class UmbMemberTypeWorkspaceContext
 			workspaceAlias: UMB_MEMBER_TYPE_WORKSPACE_ALIAS,
 			entityType: UMB_MEMBER_TYPE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_MEMBER_TYPE_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_memberTypes',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member-root/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_MEMBER_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_member',
+			icon: 'icon-user',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -131,7 +131,7 @@ export class UmbMemberWorkspaceContext
 			({ variantName, username, email }) => {
 				const name = variantName || username || email;
 				if (name) {
-					this.view.setTitle(name, { kind: 'workspace', typeLabel: '#member_memberKindDefault' });
+					this.view.setTitle(name, { kind: 'workspace', typeLabel: '#member_memberKindDefault', icon: 'icon-user' });
 				}
 			},
 			null,

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -122,6 +122,8 @@ export class UmbMemberWorkspaceContext
 		// member's username or email so the user history always gets a usable label,
 		// and tag it with a typeLabel so the history breadcrumb can show "Member"
 		// rather than just the section name.
+		this.view.setSegments('workspace-type', { label: '#member_memberKindDefault', kind: 'workspace-type' });
+
 		this.observe(
 			this._data.createObservablePartOfCurrent((data) => ({
 				variantName: data?.variants?.[0]?.name,
@@ -132,11 +134,13 @@ export class UmbMemberWorkspaceContext
 			({ variantName, username, email, memberTypeIcon }) => {
 				const name = variantName || username || email;
 				if (name) {
-					this.view.setTitle(name, {
+					this.view.setSegments('leaf', {
+						label: name,
 						kind: 'workspace',
-						typeLabel: '#member_memberKindDefault',
 						icon: memberTypeIcon || 'icon-user',
 					});
+				} else {
+					this.view.clearSegments('leaf');
 				}
 			},
 			null,

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -115,6 +115,27 @@ export class UmbMemberWorkspaceContext
 			},
 			null,
 		);
+
+		// Publish a stable, member-specific title to the view chain. The content base
+		// sets the title from the active variant's name, but members aren't true
+		// variant content — the variant name may be empty. We fall back to the
+		// member's username or email so the user history always gets a usable label,
+		// and tag it with a typeLabel so the history breadcrumb can show "Member"
+		// rather than just the section name.
+		this.observe(
+			this._data.createObservablePartOfCurrent((data) => ({
+				variantName: data?.variants?.[0]?.name,
+				username: data?.username,
+				email: data?.email,
+			})),
+			({ variantName, username, email }) => {
+				const name = variantName || username || email;
+				if (name) {
+					this.view.setTitle(name, { kind: 'workspace', typeLabel: '#member_memberKindDefault' });
+				}
+			},
+			null,
+		);
 	}
 
 	#hintedMsgs: Set<string> = new Set();

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/workspace/member/member-workspace.context.ts
@@ -127,11 +127,16 @@ export class UmbMemberWorkspaceContext
 				variantName: data?.variants?.[0]?.name,
 				username: data?.username,
 				email: data?.email,
+				memberTypeIcon: data?.memberType?.icon,
 			})),
-			({ variantName, username, email }) => {
+			({ variantName, username, email, memberTypeIcon }) => {
 				const name = variantName || username || email;
 				if (name) {
-					this.view.setTitle(name, { kind: 'workspace', typeLabel: '#member_memberKindDefault', icon: 'icon-user' });
+					this.view.setTitle(name, {
+						kind: 'workspace',
+						typeLabel: '#member_memberKindDefault',
+						icon: memberTypeIcon || 'icon-user',
+					});
 				}
 			},
 			null,

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/relation-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/relation-type-workspace.context.ts
@@ -6,6 +6,7 @@ import { UmbWorkspaceRouteManager } from '@umbraco-cms/backoffice/workspace';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
+import { UmbViewContext } from '@umbraco-cms/backoffice/view';
 
 export class UmbRelationTypeWorkspaceContext extends UmbContextBase {
 	public readonly workspaceAlias = 'Umb.Workspace.RelationType';
@@ -23,9 +24,16 @@ export class UmbRelationTypeWorkspaceContext extends UmbContextBase {
 	readonly isDependency = this.#data.asObservablePart((data) => data?.isDependency);
 
 	readonly routes = new UmbWorkspaceRouteManager(this);
+	public readonly view = new UmbViewContext(this, null);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_RELATION_TYPE_WORKSPACE_CONTEXT);
+		this.view.inherit();
+		this.observe(
+			this.name,
+			(name) => this.view.setTitle(name, { kind: 'workspace', typeLabel: '#treeHeaders_relationTypes' }),
+			null,
+		);
 
 		this.routes.setRoutes([
 			{

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/relation-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/relation-type-workspace.context.ts
@@ -31,7 +31,7 @@ export class UmbRelationTypeWorkspaceContext extends UmbContextBase {
 		this.view.inherit();
 		this.observe(
 			this.name,
-			(name) => this.view.setTitle(name, { kind: 'workspace', typeLabel: '#treeHeaders_relationTypes' }),
+			(name) => this.view.setTitle(name, { kind: 'workspace', typeLabel: '#treeHeaders_relationTypes', icon: 'icon-trafic' }),
 			null,
 		);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/relation-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/relation-types/workspace/relation-type/relation-type-workspace.context.ts
@@ -29,9 +29,16 @@ export class UmbRelationTypeWorkspaceContext extends UmbContextBase {
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_RELATION_TYPE_WORKSPACE_CONTEXT);
 		this.view.inherit();
+		this.view.setSegments('workspace-type', { label: '#treeHeaders_relationTypes', kind: 'workspace-type' });
 		this.observe(
 			this.name,
-			(name) => this.view.setTitle(name, { kind: 'workspace', typeLabel: '#treeHeaders_relationTypes', icon: 'icon-trafic' }),
+			(name) => {
+				if (name) {
+					this.view.setSegments('leaf', { label: name, kind: 'workspace', icon: 'icon-trafic' });
+				} else {
+					this.view.clearSegments('leaf');
+				}
+			},
 			null,
 		);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/relations/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/relations/workspace/manifests.ts
@@ -10,6 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: 'relations-root',
 			headline: 'Relations',
+			icon: 'icon-trafic',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/workspace/partial-view-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/workspace/partial-view-folder-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbPartialViewFolderWorkspaceContext
 			workspaceAlias: UMB_PARTIAL_VIEW_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_PARTIAL_VIEW_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_PARTIAL_VIEW_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_partialViews',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/workspace/partial-view-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/workspace/partial-view-folder-workspace.context.ts
@@ -22,6 +22,7 @@ export class UmbPartialViewFolderWorkspaceContext
 			entityType: UMB_PARTIAL_VIEW_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_PARTIAL_VIEW_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_partialViews',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/manifests.ts
@@ -60,6 +60,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_PARTIAL_VIEW_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_partialViews',
+			icon: 'icon-document-html',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
@@ -39,6 +39,7 @@ export class UmbPartialViewWorkspaceContext
 			workspaceAlias: UMB_PARTIAL_VIEW_WORKSPACE_ALIAS,
 			entityType: UMB_PARTIAL_VIEW_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_PARTIAL_VIEW_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_partialViews',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/workspace/partial-view-workspace.context.ts
@@ -40,6 +40,7 @@ export class UmbPartialViewWorkspaceContext
 			entityType: UMB_PARTIAL_VIEW_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_PARTIAL_VIEW_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_partialViews',
+			icon: 'icon-document-html',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/workspace/script-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/workspace/script-folder-workspace.context.ts
@@ -20,6 +20,7 @@ export class UmbScriptFolderWorkspaceContext
 			workspaceAlias: UMB_SCRIPT_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_SCRIPT_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_SCRIPT_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_scripts',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/workspace/script-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/workspace/script-folder-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbScriptFolderWorkspaceContext
 			entityType: UMB_SCRIPT_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_SCRIPT_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_scripts',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/manifests.ts
@@ -52,6 +52,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_SCRIPT_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_scripts',
+			icon: 'icon-document-js',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -25,6 +25,7 @@ export class UmbScriptWorkspaceContext
 			workspaceAlias: UMB_SCRIPT_WORKSPACE_ALIAS,
 			entityType: UMB_SCRIPT_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_SCRIPT_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_scripts',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/workspace/script-workspace.context.ts
@@ -26,6 +26,7 @@ export class UmbScriptWorkspaceContext
 			entityType: UMB_SCRIPT_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_SCRIPT_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_scripts',
+			icon: 'icon-document-js',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/workspace/stylesheet-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/workspace/stylesheet-folder-workspace.context.ts
@@ -20,6 +20,7 @@ export class UmbStylesheetFolderWorkspaceContext
 			workspaceAlias: UMB_STYLESHEET_FOLDER_WORKSPACE_ALIAS,
 			entityType: UMB_STYLESHEET_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_STYLESHEET_FOLDER_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_stylesheets',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/workspace/stylesheet-folder-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/workspace/stylesheet-folder-workspace.context.ts
@@ -21,6 +21,7 @@ export class UmbStylesheetFolderWorkspaceContext
 			entityType: UMB_STYLESHEET_FOLDER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_STYLESHEET_FOLDER_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_stylesheets',
+			icon: 'icon-folder',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/manifests.ts
@@ -57,6 +57,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_STYLESHEET_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_stylesheets',
+			icon: 'icon-palette',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -25,6 +25,7 @@ export class UmbStylesheetWorkspaceContext
 			workspaceAlias: UMB_STYLESHEET_WORKSPACE_ALIAS,
 			entityType: UMB_STYLESHEET_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_STYLESHEET_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_stylesheets',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/workspace/stylesheet-workspace.context.ts
@@ -26,6 +26,7 @@ export class UmbStylesheetWorkspaceContext
 			entityType: UMB_STYLESHEET_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_STYLESHEET_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_stylesheets',
+			icon: 'icon-palette',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/tree/manifests.ts
@@ -51,6 +51,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_TEMPLATE_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_templates',
+			icon: 'icon-document-html',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -35,6 +35,7 @@ export class UmbTemplateWorkspaceContext
 			workspaceAlias: UMB_TEMPLATE_WORKSPACE_ALIAS,
 			entityType: UMB_TEMPLATE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_TEMPLATE_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_templates',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/templates/workspace/template-workspace.context.ts
@@ -36,6 +36,7 @@ export class UmbTemplateWorkspaceContext
 			entityType: UMB_TEMPLATE_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_TEMPLATE_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_templates',
+			icon: 'icon-document-html',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
@@ -92,7 +92,7 @@ export class UmbCurrentUserHistoryUserProfileAppElement extends UmbLitElement {
 		const label = Array.isArray(item.label) ? item.label[0] : item.label;
 		return html`
 			<uui-ref-node name=${label} detail=${this.#truncate(item.displayPath, 50)} href=${item.path}>
-				<uui-icon slot="icon" name="icon-link"></uui-icon>
+				<umb-icon slot="icon" name=${item.icon ?? 'icon-link'}></umb-icon>
 			</uui-ref-node>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
@@ -40,7 +40,11 @@ export class UmbCurrentUserHistoryUserProfileAppElement extends UmbLitElement {
 			this.observe(
 				this.#currentUserHistoryStore.latestHistory,
 				(history) => {
-					this._history = history.reverse();
+					// Do NOT use `history.reverse()` — it mutates the array in place,
+					// and the source observable caches its last emission via shareReplay(1),
+					// so mutating here corrupts subsequent subscriptions (the order would
+					// flip on every re-subscribe). Copy first.
+					this._history = history.slice().reverse();
 					this.#pagination.setTotalItems(this._history.length);
 				},
 				'umbCurrentUserHistoryObserver',

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
@@ -1,6 +1,6 @@
 import type { UmbCurrentUserHistoryItem, UmbCurrentUserHistoryStore } from './current-user-history.store.js';
 import { UMB_CURRENT_USER_HISTORY_STORE_CONTEXT } from './current-user-history.store.token.js';
-import { html, customElement, state, nothing, css, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { html, customElement, state, nothing, css, repeat, ifDefined } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
@@ -90,8 +90,9 @@ export class UmbCurrentUserHistoryUserProfileAppElement extends UmbLitElement {
 
 	#renderItem(item: UmbCurrentUserHistoryItem) {
 		const label = Array.isArray(item.label) ? item.label[0] : item.label;
+		const detail = item.displayPath ? this.#truncate(item.displayPath, 50) : undefined;
 		return html`
-			<uui-ref-node name=${label} detail=${this.#truncate(item.displayPath, 50)} href=${item.path}>
+			<uui-ref-node name=${label} detail=${ifDefined(detail)} href=${item.path}>
 				<umb-icon slot="icon" name=${item.icon ?? 'icon-link'}></umb-icon>
 			</uui-ref-node>
 		`;

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history-user-profile-app.element.ts
@@ -64,13 +64,10 @@ export class UmbCurrentUserHistoryUserProfileAppElement extends UmbLitElement {
 	#truncate(input: string | undefined, length: number, separator = '...'): string {
 		if (!input) return '';
 		if (input.length <= length) return input;
-
-		const separatorLength = separator.length;
-		const charsToShow = length - separatorLength;
-		const frontChars = Math.ceil(charsToShow / 2);
-		const backChars = Math.floor(charsToShow / 2);
-
-		return input.substring(0, frontChars) + separator + input.substring(input.length - backChars);
+		// Truncate from the LEFT so the rightmost segments (the leaf's immediate
+		// parents) survive — they carry more contextual relevance than the section
+		// at the start of the breadcrumb.
+		return separator + input.substring(input.length - (length - separator.length));
 	}
 
 	override render() {
@@ -91,9 +88,11 @@ export class UmbCurrentUserHistoryUserProfileAppElement extends UmbLitElement {
 	#renderItem(item: UmbCurrentUserHistoryItem) {
 		const label = Array.isArray(item.label) ? item.label[0] : item.label;
 		const detail = item.displayPath ? this.#truncate(item.displayPath, 50) : undefined;
+		// Omit the icon entirely when none is provided — better than a misleading
+		// fallback (e.g. `icon-link` implies a hyperlink/relation, not a history entry).
 		return html`
 			<uui-ref-node name=${label} detail=${ifDefined(detail)} href=${item.path}>
-				<umb-icon slot="icon" name=${item.icon ?? 'icon-link'}></umb-icon>
+				${item.icon ? html`<umb-icon slot="icon" name=${item.icon}></umb-icon>` : nothing}
 			</uui-ref-node>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.test.ts
@@ -1,0 +1,212 @@
+import { UmbCurrentUserHistoryStore } from './current-user-history.store.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+// Reach into the module directly for the internal setter; the public barrel
+// intentionally only exposes the observable, not the writer.
+import { _setUmbCurrentViewTitle } from '../../../core/view/context/current-view-title.js';
+import type { UmbCurrentViewTitleSegment } from '@umbraco-cms/backoffice/view';
+import { UmbId } from '@umbraco-cms/backoffice/id';
+
+@customElement('test-current-user-history-store-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+type NavigateListener = (event: { destination: { url: string } }) => void;
+
+function installNavigationMock(origin = window.location.origin) {
+	const listeners: Record<string, NavigateListener[]> = {};
+	const previous = (window as any).navigation;
+	(window as any).navigation = {
+		addEventListener: (type: string, cb: NavigateListener) => {
+			(listeners[type] ||= []).push(cb);
+		},
+		removeEventListener: (type: string, cb: NavigateListener) => {
+			listeners[type] = (listeners[type] ?? []).filter((f) => f !== cb);
+		},
+	};
+	return {
+		fire(path: string) {
+			(listeners.navigate ?? []).forEach((cb) => cb({ destination: { url: origin + path } }));
+		},
+		restore() {
+			if (previous === undefined) {
+				delete (window as any).navigation;
+			} else {
+				(window as any).navigation = previous;
+			}
+		},
+	};
+}
+
+function segment(label: string, kind: UmbCurrentViewTitleSegment['kind']): UmbCurrentViewTitleSegment {
+	return { label, kind };
+}
+
+describe('UmbCurrentUserHistoryStore', () => {
+	let host: UmbTestControllerHostElement;
+	let store: UmbCurrentUserHistoryStore;
+	let nav: ReturnType<typeof installNavigationMock>;
+
+	beforeEach(() => {
+		nav = installNavigationMock();
+		host = new UmbTestControllerHostElement();
+		store = new UmbCurrentUserHistoryStore(host);
+	});
+
+	afterEach(() => {
+		store.destroy();
+		nav.restore();
+		_setUmbCurrentViewTitle(undefined);
+	});
+
+	function currentItems() {
+		let items: ReadonlyArray<any> = [];
+		store.history.subscribe((v) => (items = v as any)).unsubscribe();
+		return items;
+	}
+
+	function publish(path: string, ...segments: UmbCurrentViewTitleSegment[]) {
+		_setUmbCurrentViewTitle({ path, segments });
+	}
+
+	it('creates a history entry with path-derived label and no displayPath on navigate', () => {
+		nav.fire('/umbraco/section/users/workspace/user/edit/abc');
+		const items = currentItems();
+		expect(items).to.have.length(1);
+		expect(items[0].path).to.equal('/umbraco/section/users/workspace/user/edit/abc');
+		expect(items[0].displayPath).to.equal(undefined);
+	});
+
+	it('uses the leaf non-tab segment as label and earlier segments as breadcrumb', () => {
+		const path = '/umbraco/section/users/workspace/user/edit/abc';
+		nav.fire(path);
+		publish(path, segment('Users', 'section'), segment('User', 'workspace-type'), segment('Amelie Walker', 'workspace'));
+		const item = currentItems()[0];
+		expect(item.label).to.equal('Amelie Walker');
+		expect(item.displayPath).to.equal('Users › User');
+	});
+
+	it('filters tab segments from both the label and the breadcrumb', () => {
+		// Full URL (including tab) is preserved on `path` for click-through, but the tab name isn't surfaced.
+		const path = '/umbraco/section/users/workspace/user/edit/abc';
+		nav.fire(path);
+		publish(
+			path,
+			segment('Users', 'section'),
+			segment('User', 'workspace-type'),
+			segment('Amelie Walker', 'workspace'),
+			segment('Details', 'tab'),
+		);
+		const item = currentItems()[0];
+		expect(item.label).to.equal('Amelie Walker');
+		expect(item.displayPath).to.equal('Users › User');
+	});
+
+	it('includes workspace-ancestor segments in the breadcrumb', () => {
+		const path = '/umbraco/section/media/workspace/media/edit/abc';
+		nav.fire(path);
+		publish(
+			path,
+			segment('Media', 'section'),
+			segment('People', 'workspace-ancestor'),
+			segment('John Doe', 'workspace'),
+			segment('Details', 'tab'),
+		);
+		const item = currentItems()[0];
+		expect(item.label).to.equal('John Doe');
+		expect(item.displayPath).to.equal('Media › People');
+	});
+
+	it('distinguishes a user group from a user with the same breadcrumb slot', () => {
+		const path = '/umbraco/section/users/workspace/user-group/edit/admins';
+		nav.fire(path);
+		publish(
+			path,
+			segment('Users', 'section'),
+			segment('User Group', 'workspace-type'),
+			segment('Administrators', 'workspace'),
+			segment('Details', 'tab'),
+		);
+		const item = currentItems()[0];
+		expect(item.label).to.equal('Administrators');
+		expect(item.displayPath).to.equal('Users › User Group');
+	});
+
+	it('leaves displayPath undefined when there is only one non-tab segment', () => {
+		const path = '/umbraco/section/users';
+		nav.fire(path);
+		publish(path, segment('Users', 'section'));
+		const item = currentItems()[0];
+		expect(item.label).to.equal('Users');
+		expect(item.displayPath).to.equal(undefined);
+	});
+
+	it('ignores updates with only tab segments (no breadcrumb content)', () => {
+		const path = '/umbraco/section/users/workspace/user/edit/abc';
+		nav.fire(path);
+		const labelBefore = currentItems()[0].label;
+		publish(path, segment('Details', 'tab'));
+		expect(currentItems()[0].label).to.equal(labelBefore);
+	});
+
+	it('ignores modal emissions that would otherwise overwrite the current page entry', () => {
+		// Regression: opening a modal (e.g. the current-user profile dialog) must not
+		// rewrite the underlying page's history entry, because modals don't change the URL.
+		const path = '/umbraco/section/member-management/workspace/member-root';
+		nav.fire(path);
+		publish(path, segment('Members', 'section'), segment('Members', 'workspace'));
+		const labelBeforeModal = currentItems()[0].label;
+
+		publish(path, segment('User', 'modal'));
+
+		expect(currentItems()[0].label).to.equal(labelBeforeModal);
+		expect(currentItems()[0].label).to.equal('Members');
+	});
+
+	it('does not split entity names containing " | "', () => {
+		const path = '/umbraco/section/content/workspace/document/edit/abc';
+		nav.fire(path);
+		publish(path, segment('Content', 'section'), segment('A | B', 'workspace'));
+		const item = currentItems()[0];
+		expect(item.label).to.equal('A | B');
+		expect(item.displayPath).to.equal('Content');
+	});
+
+	it('ignores stale view title emissions during fast navigation', () => {
+		nav.fire('/umbraco/section/users');
+		nav.fire('/umbraco/section/content');
+		// Late arrival from the previous page must not land on the new entry.
+		publish('/umbraco/section/users', segment('Users', 'section'), segment('John Doe', 'workspace'));
+		const items = currentItems();
+		const latest = items[items.length - 1];
+		expect(latest.path).to.equal('/umbraco/section/content');
+		expect(latest.label).to.equal('Content');
+	});
+
+	it('removes an entry ending in a GUID if no title ever arrived for it', () => {
+		const guid = UmbId.new();
+		const path = `/umbraco/section/content/workspace/document/edit/${guid}`;
+		nav.fire(path);
+		nav.fire('/umbraco/section/users');
+		expect(currentItems().every((i) => i.path !== path)).to.equal(true);
+	});
+
+	it('keeps an entry ending in a GUID once the title is resolved', () => {
+		const guid = UmbId.new();
+		const path = `/umbraco/section/content/workspace/document/edit/${guid}`;
+		nav.fire(path);
+		publish(path, segment('Content', 'section'), segment('My Page', 'workspace'));
+		nav.fire('/umbraco/section/users');
+		expect(currentItems().some((i) => i.path === path && i.label === 'My Page')).to.equal(true);
+	});
+
+	it('clears lastAdded tracking on clear()', () => {
+		nav.fire('/umbraco/section/users');
+		expect(currentItems()).to.have.length(1);
+		store.clear();
+		expect(currentItems()).to.have.length(0);
+		// A subsequent title emission must not resurrect any entry.
+		publish('/umbraco/section/users', segment('Users', 'section'));
+		expect(currentItems()).to.have.length(0);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
@@ -84,6 +84,17 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 			if (!breadcrumb.length) return;
 
 			const leaf = breadcrumb[breadcrumb.length - 1];
+
+			// Guard against stale section-only re-publications. When a workspace
+			// disconnects during navigation, the parent section view re-publishes
+			// its own title (just the section name). Because the URL has already
+			// changed, the path guard above passes. Reject emissions that have no
+			// workspace-kind segment if the entry already has a resolved label.
+			if (!breadcrumb.some((s) => s.kind === 'workspace')) {
+				const item = this._data.getValue().find((i) => i.unique === this.#lastAddedUnique);
+				if (item && item.label !== this.#extractLabelFromPath(this.#lastAddedPath)) return;
+			}
+
 			const parents = breadcrumb.slice(0, -1);
 			this.updateItem(this.#lastAddedUnique, {
 				label: leaf.label,

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
@@ -1,4 +1,5 @@
 import { UMB_CURRENT_USER_HISTORY_STORE_CONTEXT } from './current-user-history.store.token.js';
+import { umbCurrentViewTitle } from '@umbraco-cms/backoffice/view';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
@@ -17,6 +18,8 @@ export type UmbCurrentUserHistoryItem = {
 	displayPath?: string;
 };
 
+const BREADCRUMB_SEPARATOR = ' › ';
+
 export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHistoryItem> {
 	public readonly history = this._data.asObservable();
 
@@ -27,34 +30,30 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 
 	#lastAddedUnique: string | null = null;
 	#lastAddedPath: string | null = null;
-	#titleObserver: MutationObserver | null = null;
-	#headObserver: MutationObserver | null = null;
-	#titleUpdateTimer: ReturnType<typeof setTimeout> | null = null;
-
-	#handleNavigateSuccess = () => {
-		// Update label for the most recent history item after navigation completes.
-		this.#scheduleTitleUpdate();
-	};
 
 	#handleNavigate = (event: any) => {
 		const url = new URL(event.destination.url);
-		const path = this.#normalizePath(url.pathname);
+		// `path` stores the full (unnormalized) URL so that clicking the entry
+		// in the history takes the user back to exactly where they were — e.g.
+		// the specific workspace tab or culture variant.
+		const fullPath = url.pathname;
+		const normalizedPath = this.#normalizePath(fullPath);
 
-		// Before adding a new item, finalize the label of the previous item
-		// using the current document title (before it changes).
-		this.#finalizeCurrentLabel();
+		// Before adding a new item, finalize the state of the previous item.
+		// If it ended in a GUID and never received a title, drop it.
+		this.#removeUnresolvedGuidEntry();
 
 		const unique = UmbId.new();
-		const historyItem = {
+		const historyItem: UmbCurrentUserHistoryItem = {
 			unique,
-			path,
-			displayPath: this.#formatDisplayPath(path),
-			label: this.#extractLabelFromPath(path),
+			path: fullPath,
+			label: this.#extractLabelFromPath(normalizedPath),
+			displayPath: undefined,
 		};
 		const wasAdded = this.#pushIfNew(historyItem);
 		if (wasAdded) {
 			this.#lastAddedUnique = unique;
-			this.#lastAddedPath = path;
+			this.#lastAddedPath = normalizedPath;
 		}
 	};
 
@@ -65,45 +64,48 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 			new UmbArrayState<UmbCurrentUserHistoryItem>([], (x) => x.unique),
 		);
 		if (!('navigation' in window)) return;
-		(window as any).navigation.addEventListener('navigatesuccess', this.#handleNavigateSuccess);
 		(window as any).navigation.addEventListener('navigate', this.#handleNavigate);
 
-		this.#setupTitleObserver();
+		// Mirror the active view's structured title onto the latest history entry.
+		// Skip modal-kind segments (modals don't change the URL — without this, an
+		// opened modal would rewrite the underlying page's entry) and tab-kind
+		// segments (which sub-view the user was on is noise in a breadcrumb; the
+		// full URL is still preserved on `path` for click-through).
+		this.observe(umbCurrentViewTitle, (view) => {
+			if (!view || !this.#lastAddedUnique || !this.#lastAddedPath) return;
+			// Guard against stale emissions during fast navigation.
+			if (this.#normalizePath(view.path) !== this.#lastAddedPath) return;
+			if (view.segments.some((s) => s.kind === 'modal')) return;
+
+			const breadcrumb = view.segments.filter((s) => s.kind !== 'tab');
+			if (!breadcrumb.length) return;
+
+			const leaf = breadcrumb[breadcrumb.length - 1];
+			const parents = breadcrumb.slice(0, -1);
+			this.updateItem(this.#lastAddedUnique, {
+				label: leaf.label,
+				displayPath: parents.length ? parents.map((s) => s.label).join(BREADCRUMB_SEPARATOR) : undefined,
+			});
+		});
 	}
 
 	/**
-	 * Normalize a path by stripping sub-route suffixes (variants, views, tabs)
-	 * and trailing /collection segments. This ensures that internal workspace
-	 * navigation (e.g., switching tabs or variants) does not create separate
-	 * history entries, while still creating an entry for the base entity path.
+	 * Normalize a path by stripping sub-route suffixes so that internal workspace
+	 * navigation (switching tabs, variants, sub-views) doesn't create separate
+	 * history entries. The first regex handles `/invariant`, `/root`, `/<locale>`,
+	 * `/view`, and `/tab` segments (each possibly followed by more path), the
+	 * second collapses a trailing `/collection` into the parent path.
+	 * @param path
 	 */
 	#normalizePath(path: string): string {
-		// Strip sub-route suffixes: variant paths (/invariant, /en-us), /root
-		path = path.replace(/\/(?:invariant|root)(?:\/.*)?$/, '');
-		path = path.replace(/\/[a-z]{2}-[a-z]{2}(?:\/.*)?$/i, '');
-		// Strip view and tab sub-routes
-		path = path.replace(/\/(?:view|tab)(?:\/.*)?$/, '');
-		// Strip trailing /collection to de-duplicate with parent
-		path = path.replace(/\/collection$/, '');
-		return path;
+		return path
+			.replace(/\/(?:invariant|root|[a-z]{2}-[a-z]{2}|view|tab)(?:\/.*)?$/i, '')
+			.replace(/\/collection$/, '');
 	}
 
 	/**
-	 * Finalize the current item's label before navigating away.
-	 * If the path ends in a GUID and the title wasn't resolved in time, remove the entry.
-	 */
-	#finalizeCurrentLabel(): void {
-		if (this.#titleUpdateTimer) {
-			clearTimeout(this.#titleUpdateTimer);
-			this.#titleUpdateTimer = null;
-		}
-
-		this.#removeUnresolvedGuidEntry();
-	}
-
-	/**
-	 * Remove the last added entry if it ends in a GUID and the label wasn't resolved from the title.
-	 * This cleans up entries where the user navigated away too quickly.
+	 * Remove the last added entry if it ends in a GUID and the label wasn't resolved from the active view's title.
+	 * This cleans up entries where the user navigated away before a workspace had time to publish its title.
 	 */
 	#removeUnresolvedGuidEntry(): void {
 		if (!this.#lastAddedUnique || !this.#lastAddedPath) return;
@@ -120,6 +122,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 
 	/**
 	 * Get the last segment of a path.
+	 * @param path
 	 */
 	#getLastPathSegment(path: string): string {
 		return path.split('/').filter(Boolean).pop() ?? '';
@@ -128,136 +131,55 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 	/**
 	 * Extract a readable label from a path.
 	 * Tries to get the last meaningful segment (usually entity ID or section name).
+	 * @param path
 	 */
 	#extractLabelFromPath(path: string): string {
 		return this.#formatSegmentAsLabel(this.#getLastPathSegment(path));
 	}
 
 	/**
-	 * Format a URL segment as a readable label.
-	 * Handles special suffixes and converts kebab-case to Title Case.
+	 * Format a URL segment as a readable label: converts kebab-case to Title Case,
+	 * pluralises the `-root` / `-management` tree-root conventions (e.g.
+	 * `user-root` → `Users`), and handles a handful of known identifiers.
+	 * @param segment
 	 */
 	#formatSegmentAsLabel(segment: string): string {
 		if (!segment) return '';
-
-		// Special cases: Handle specific common and known segments to provide something more user-friendly.
-		if (segment === 'dashboardTabsContentIntro') {
-			return 'Welcome to Umbraco';
-		}
-
-		// Special cases: Handle known and common suffixes: "user-root" -> "Users", "member-management" -> "Members"
-		if (segment.endsWith('-root') || segment.endsWith('-management')) {
-			const base = segment.replace(/-(root|management)$/, '');
-			const titleCased = this.#toTitleCase(base);
-			return titleCased + 's';
-		}
-
-		// Convert kebab-case to Title Case for better display
-		// e.g., "models-builder" -> "Models Builder"
-		return this.#toTitleCase(segment);
-	}
-
-	/**
-	 * Convert a kebab-case string to Title Case.
-	 * e.g., "models-builder" -> "Models Builder"
-	 */
-	#toTitleCase(str: string): string {
-		if (!str) return '';
-		return str
+		if (segment === 'dashboardTabsContentIntro') return 'Welcome to Umbraco';
+		const rootMatch = segment.match(/^(.+)-(?:root|management)$/);
+		const base = rootMatch ? rootMatch[1] : segment;
+		const titleCased = base
 			.split('-')
 			.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
 			.join(' ');
+		return rootMatch ? titleCased + 's' : titleCased;
 	}
 
 	/**
-	 * Format a path for display by stripping common prefixes.
-	 * e.g., "/umbraco/section/content/..." -> "content/..."
-	 */
-	#formatDisplayPath(path: string): string {
-		return path.replace(/^\/(umbraco\/)?(section\/)?/, '');
-	}
-
-	#setupTitleObserver(): void {
-		const titleElement = document.querySelector('title');
-		if (titleElement) {
-			this.#titleObserver = new MutationObserver(() => this.#onTitleChange());
-			this.#titleObserver.observe(titleElement, { childList: true, characterData: true, subtree: true });
-		} else {
-			// If title element doesn't exist yet, observe head for its creation.
-			this.#headObserver = new MutationObserver(() => {
-				const title = document.querySelector('title');
-				if (title) {
-					this.#headObserver?.disconnect();
-					this.#headObserver = null;
-					this.#titleObserver = new MutationObserver(() => this.#onTitleChange());
-					this.#titleObserver.observe(title, { childList: true, characterData: true, subtree: true });
-				}
-			});
-			this.#headObserver.observe(document.head, { childList: true });
-		}
-	}
-
-	#onTitleChange(): void {
-		this.#scheduleTitleUpdate();
-	}
-
-	#scheduleTitleUpdate(): void {
-		if (this.#titleUpdateTimer) {
-			clearTimeout(this.#titleUpdateTimer);
-		}
-		// Capture the target path at schedule time so the update only fires
-		// if we're still on the same page when the timer completes.
-		// This prevents updating the wrong entry during fast navigation.
-		const targetPath = this.#lastAddedPath;
-		this.#titleUpdateTimer = setTimeout(() => {
-			if (targetPath && this.#normalizePath(window.location.pathname) === targetPath) {
-				this.#updateLatestLabel();
-			}
-		}, 150);
-	}
-
-	#updateLatestLabel(): void {
-		if (!this.#lastAddedUnique || !this.#lastAddedPath) return;
-
-		const title = document.title;
-		if (!title) return;
-
-		// Extract friendly title by removing " | Umbraco" suffix.
-		let friendlyTitle = title.replace(/ \| Umbraco$/, '');
-		if (!friendlyTitle) return;
-
-		// Take only the first part if there are multiple pipe-separated segments
-		// e.g., "My Blog Post | Content" -> "My Blog Post".
-		const pipeIndex = friendlyTitle.indexOf(' | ');
-		if (pipeIndex > 0) {
-			friendlyTitle = friendlyTitle.substring(0, pipeIndex);
-		}
-
-		// Skip generic/technical labels that aren't useful as entity names.
-		const skipLabels = ['invariant', 'content', 'media', 'settings', 'users', 'packages', 'members', 'user'];
-		if (skipLabels.includes(friendlyTitle.toLowerCase())) {
-			return;
-		}
-
-		// Update the item in the store for immediate display
-		this.updateItem(this.#lastAddedUnique, { label: friendlyTitle });
-	}
-
-	/**
-	 * Pushes a new history item, removing any existing item with the same path.
-	 * @returns true if the item was added, false if it was a duplicate of the last item
+	 * Pushes a new history item, removing any existing item with the same normalized path.
+	 * Paths are compared after normalization so that tab / variant switches within the
+	 * same entity are treated as the same entry — but the full path (including the
+	 * current tab) is preserved on the item so clicking it returns the user to the
+	 * exact place they left.
+	 * @param historyItem
+	 * @returns true if the item was added, false if it was an immediate duplicate of the last item
 	 */
 	#pushIfNew(historyItem: UmbCurrentUserHistoryItem): boolean {
 		const history = this._data.getValue();
 		const lastItem = history[history.length - 1];
+		const incomingNormalized = this.#normalizePath(historyItem.path);
 
-		// Skip if this is the same as the last item (immediate duplicate).
-		if (lastItem && lastItem.path === historyItem.path) {
+		// Skip if this is the same (normalized) as the last item — but still bump the
+		// stored path so the entry reflects the most recently visited tab / variant.
+		if (lastItem && this.#normalizePath(lastItem.path) === incomingNormalized) {
+			if (lastItem.path !== historyItem.path) {
+				this.updateItem(lastItem.unique, { path: historyItem.path });
+			}
 			return false;
 		}
 
-		// Remove any earlier entry with the same path (de-duplicate).
-		const filteredHistory = history.filter((item) => item.path !== historyItem.path);
+		// Remove any earlier entry with the same normalized path (de-duplicate).
+		const filteredHistory = history.filter((item) => this.#normalizePath(item.path) !== incomingNormalized);
 
 		this._data.setValue([...filteredHistory, historyItem]);
 		return true;
@@ -286,20 +208,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 
 	override destroy(): void {
 		if ('navigation' in window) {
-			(window as any).navigation.removeEventListener('navigatesuccess', this.#handleNavigateSuccess);
 			(window as any).navigation.removeEventListener('navigate', this.#handleNavigate);
-		}
-		if (this.#headObserver) {
-			this.#headObserver.disconnect();
-			this.#headObserver = null;
-		}
-		if (this.#titleObserver) {
-			this.#titleObserver.disconnect();
-			this.#titleObserver = null;
-		}
-		if (this.#titleUpdateTimer) {
-			clearTimeout(this.#titleUpdateTimer);
-			this.#titleUpdateTimer = null;
 		}
 		super.destroy();
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
@@ -135,27 +135,12 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 	/**
 	 * Extract a readable label from a path.
 	 * Tries to get the last meaningful segment (usually entity ID or section name).
-	 * For server-file-system uniques (e.g. `%2Ffolder%2Fitems%25dot%25cshtml`)
-	 * the segment is itself a URL-encoded path with `%dot%` standing in for `.` —
-	 * decode it and reduce to the filename so the user doesn't see raw
-	 * percent-encoding while waiting for the entity title to load.
+	 * This is a transient fallback — the real title arrives via `umbCurrentViewTitle`
+	 * once the workspace publishes its segments.
 	 * @param path
 	 */
 	#extractLabelFromPath(path: string): string {
-		const lastSegment = this.#getLastPathSegment(path);
-		const decoded = this.#decodeFileSystemUnique(lastSegment);
-		// Decoding may produce another path; take its last segment.
-		return this.#formatSegmentAsLabel(decoded.split('/').filter(Boolean).pop() ?? decoded);
-	}
-
-	#decodeFileSystemUnique(segment: string): string {
-		if (!segment.includes('%')) return segment;
-		try {
-			return decodeURIComponent(segment).replace(/%dot%/g, '.');
-		} catch {
-			// Malformed percent-encoding — leave as-is rather than throwing.
-			return segment;
-		}
+		return this.#formatSegmentAsLabel(this.#getLastPathSegment(path));
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
@@ -37,9 +37,8 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 
 	#handleNavigate = (event: any) => {
 		const url = new URL(event.destination.url);
-		// `path` stores the full (unnormalized) URL so that clicking the entry
-		// in the history takes the user back to exactly where they were — e.g.
-		// the specific workspace tab or culture variant.
+		// `path` stores the full (unnormalized) pathname so that clicking the
+		// entry navigates back to the specific tab or culture variant.
 		const fullPath = url.pathname;
 		const normalizedPath = this.#normalizePath(fullPath);
 
@@ -104,7 +103,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 	 */
 	#normalizePath(path: string): string {
 		return path
-			.replace(/\/(?:invariant|root|[a-z]{2}-[a-z]{2}|view|tab)(?:\/.*)?$/i, '')
+			.replace(/\/(?:invariant|root|[a-z]{2}-[a-z]{2}|view|tab)\b.*$/i, '')
 			.replace(/\/collection$/, '');
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
@@ -13,7 +13,11 @@ export type UmbCurrentUserHistoryItem = {
 	path: string;
 	/** @deprecated `label` type will be changed to `string` only in Umbraco 19. [LK] */
 	label: string | Array<string>;
-	/** @deprecated No longer used internally. This will be removed in Umbraco 19. [LK] */
+	/**
+	 * Optional icon name (e.g. `icon-document-js`) attached to the entry by the
+	 * active workspace via its title chain. When absent the consumer should fall
+	 * back to a generic icon (e.g. `icon-link`).
+	 */
 	icon?: string;
 	displayPath?: string;
 };
@@ -84,6 +88,7 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 			const parents = breadcrumb.slice(0, -1);
 			this.updateItem(this.#lastAddedUnique, {
 				label: leaf.label,
+				icon: leaf.icon,
 				displayPath: parents.length ? parents.map((s) => s.label).join(BREADCRUMB_SEPARATOR) : undefined,
 			});
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
@@ -85,12 +85,17 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 
 			const leaf = breadcrumb[breadcrumb.length - 1];
 
-			// Guard against stale section-only re-publications. When a workspace
-			// disconnects during navigation, the parent section view re-publishes
-			// its own title (just the section name). Because the URL has already
-			// changed, the path guard above passes. Reject emissions that have no
-			// workspace-kind segment if the entry already has a resolved label.
+			// Guard against section-only emissions polluting a workspace entry.
+			// Two cases need rejecting, both missing a `kind: 'workspace'` segment:
+			//   1. A workspace disconnects during navigation and the parent section
+			//      re-publishes just the section name — the entry already has the
+			//      richer label from the previous view, don't clobber it.
+			//   2. The user opens the avatar modal *before* the workspace has
+			//      mounted and published its leaf; the section's title would
+			//      otherwise overwrite the URL fallback on a workspace URL. We
+			//      prefer to wait: the workspace will publish shortly.
 			if (!breadcrumb.some((s) => s.kind === 'workspace')) {
+				if (this.#lastAddedPath.includes('/workspace/')) return;
 				const item = this._data.getValue().find((i) => i.unique === this.#lastAddedUnique);
 				if (item && item.label !== this.#extractLabelFromPath(this.#lastAddedPath)) return;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/history/current-user-history.store.ts
@@ -131,10 +131,27 @@ export class UmbCurrentUserHistoryStore extends UmbStoreBase<UmbCurrentUserHisto
 	/**
 	 * Extract a readable label from a path.
 	 * Tries to get the last meaningful segment (usually entity ID or section name).
+	 * For server-file-system uniques (e.g. `%2Ffolder%2Fitems%25dot%25cshtml`)
+	 * the segment is itself a URL-encoded path with `%dot%` standing in for `.` —
+	 * decode it and reduce to the filename so the user doesn't see raw
+	 * percent-encoding while waiting for the entity title to load.
 	 * @param path
 	 */
 	#extractLabelFromPath(path: string): string {
-		return this.#formatSegmentAsLabel(this.#getLastPathSegment(path));
+		const lastSegment = this.#getLastPathSegment(path);
+		const decoded = this.#decodeFileSystemUnique(lastSegment);
+		// Decoding may produce another path; take its last segment.
+		return this.#formatSegmentAsLabel(decoded.split('/').filter(Boolean).pop() ?? decoded);
+	}
+
+	#decodeFileSystemUnique(segment: string): string {
+		if (!segment.includes('%')) return segment;
+		try {
+			return decodeURIComponent(segment).replace(/%dot%/g, '.');
+		} catch {
+			// Malformed percent-encoding — leave as-is rather than throwing.
+			return segment;
+		}
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group-root/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_USER_GROUP_ROOT_ENTITY_TYPE,
 			headline: '#user_usergroups',
+			icon: 'icon-users',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace.context.ts
@@ -36,6 +36,7 @@ export class UmbUserGroupWorkspaceContext
 			workspaceAlias: UMB_USER_GROUP_WORKSPACE_ALIAS,
 			entityType: UMB_USER_GROUP_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_USER_GROUP_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#user_usergroup',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-group/workspace/user-group/user-group-workspace.context.ts
@@ -37,6 +37,7 @@ export class UmbUserGroupWorkspaceContext
 			entityType: UMB_USER_GROUP_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_USER_GROUP_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#user_usergroup',
+			icon: 'icon-users',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user-root/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user-root/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_USER_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_users',
+			icon: 'icon-user',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/user-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/user-workspace.context.ts
@@ -44,6 +44,7 @@ export class UmbUserWorkspaceContext
 			entityType: UMB_USER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_USER_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#general_user',
+			icon: 'icon-user',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/user-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/user-workspace.context.ts
@@ -43,6 +43,7 @@ export class UmbUserWorkspaceContext
 			workspaceAlias: UMB_USER_WORKSPACE_ALIAS,
 			entityType: UMB_USER_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_USER_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#general_user',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-root/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook-root/workspace/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			entityType: UMB_WEBHOOK_ROOT_ENTITY_TYPE,
 			headline: '#treeHeaders_webhooks',
+			icon: 'icon-webhook',
 		},
 	},
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/webhook-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/webhook-workspace.context.ts
@@ -29,6 +29,7 @@ export class UmbWebhookWorkspaceContext
 			workspaceAlias: UMB_WEBHOOK_WORKSPACE_ALIAS,
 			entityType: UMB_WEBHOOK_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_WEBHOOK_DETAIL_REPOSITORY_ALIAS,
+			typeLabel: '#treeHeaders_webhooks',
 		});
 
 		this.routes.setRoutes([

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/webhook-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/webhook-workspace.context.ts
@@ -30,6 +30,7 @@ export class UmbWebhookWorkspaceContext
 			entityType: UMB_WEBHOOK_ENTITY_TYPE,
 			detailRepositoryAlias: UMB_WEBHOOK_DETAIL_REPOSITORY_ALIAS,
 			typeLabel: '#treeHeaders_webhooks',
+			icon: 'icon-webhook',
 		});
 
 		this.routes.setRoutes([

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/CurrentUserProfileUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/CurrentUserProfileUiHelper.ts
@@ -1,13 +1,38 @@
-﻿import {Locator, Page} from "@playwright/test"
+﻿import {expect, Locator, Page} from "@playwright/test"
 import {UiBaseLocators} from "./UiBaseLocators";
 import {ConstantHelper} from "./ConstantHelper";
 
 export class CurrentUserProfileUiHelper extends UiBaseLocators {
   private readonly changePasswordBtn: Locator;
+  private readonly historyEntries: Locator;
 
   constructor(page: Page) {
     super(page);
     this.changePasswordBtn = page.getByLabel('Change password');
+    this.historyEntries = page.locator('umb-current-user-history-user-profile-app uui-ref-node');
+  }
+
+  async getHistoryEntryByName(name: string): Promise<Locator> {
+    return this.historyEntries.filter({has: this.page.locator(`[name="${name}"]`)});
+  }
+
+  async getHistoryEntryDetail(name: string): Promise<string | null> {
+    const entry = await this.getHistoryEntryByName(name);
+    return entry.getAttribute('detail');
+  }
+
+  async isHistoryEntryVisible(name: string, isVisible: boolean = true): Promise<void> {
+    const entry = await this.getHistoryEntryByName(name);
+    if (isVisible) {
+      await expect(entry).toBeVisible();
+    } else {
+      await expect(entry).not.toBeVisible();
+    }
+  }
+
+  async countHistoryEntriesWithName(name: string): Promise<number> {
+    const entry = await this.getHistoryEntryByName(name);
+    return entry.count();
   }
 
   async clickChangePasswordButton() {

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/CurrentUserProfileUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/CurrentUserProfileUiHelper.ts
@@ -12,17 +12,19 @@ export class CurrentUserProfileUiHelper extends UiBaseLocators {
     this.historyEntries = page.locator('umb-current-user-history-user-profile-app uui-ref-node');
   }
 
-  async getHistoryEntryByName(name: string): Promise<Locator> {
-    return this.historyEntries.filter({has: this.page.locator(`[name="${name}"]`)});
+  getHistoryEntryByName(name: string): Locator {
+    // uui-ref-node renders name and detail as child text nodes. Match entries
+    // whose accessible link name starts with the exact entity name.
+    return this.historyEntries.getByRole('link', {name: new RegExp('^' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b')});
   }
 
-  async getHistoryEntryDetail(name: string): Promise<string | null> {
-    const entry = await this.getHistoryEntryByName(name);
-    return entry.getAttribute('detail');
+  async getHistoryEntryText(name: string): Promise<string | null> {
+    const entry = this.getHistoryEntryByName(name);
+    return entry.first().textContent();
   }
 
   async isHistoryEntryVisible(name: string, isVisible: boolean = true): Promise<void> {
-    const entry = await this.getHistoryEntryByName(name);
+    const entry = this.getHistoryEntryByName(name);
     if (isVisible) {
       await expect(entry).toBeVisible();
     } else {
@@ -31,7 +33,7 @@ export class CurrentUserProfileUiHelper extends UiBaseLocators {
   }
 
   async countHistoryEntriesWithName(name: string): Promise<number> {
-    const entry = await this.getHistoryEntryByName(name);
+    const entry = this.getHistoryEntryByName(name);
     return entry.count();
   }
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
@@ -42,17 +42,16 @@ test.describe('Recent History', () => {
   const childName = 'Child Page';
 
   test.beforeEach(async ({umbracoApi}) => {
-    await umbracoApi.documentType.ensureNameNotExists(docTypeName);
     await umbracoApi.document.ensureNameNotExists(childName);
     await umbracoApi.document.ensureNameNotExists(parentName);
     await umbracoApi.document.ensureNameNotExists(rootName);
+    await umbracoApi.documentType.ensureNameNotExists(docTypeName);
 
-    // Create a self-referencing doc type (allows itself as child + root)
+    // Create a doc type that allows as root and allows itself as child (self-referencing)
     const docTypeId = await umbracoApi.documentType.createDefaultDocumentTypeWithAllowAsRoot(docTypeName);
-    // Update to allow itself as a child document type
     const docType = await umbracoApi.documentType.get(docTypeId);
-    docType.allowedDocumentTypes = [{id: docTypeId, sortOrder: 0}];
-    await umbracoApi.documentType.update(docTypeId, docType);
+    docType.allowedDocumentTypes = [{documentType: {id: docTypeId}, sortOrder: 0}];
+    await umbracoApi.put(umbracoApi.baseUrl + '/umbraco/management/api/v1/document-type/' + docTypeId, docType);
 
     // Create 3-level document tree
     const rootId = await umbracoApi.document.createDefaultDocument(rootName, docTypeId);
@@ -81,11 +80,11 @@ test.describe('Recent History', () => {
     // Open profile modal
     await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
 
-    // Assert
+    // Assert — the entry's accessible text contains the name and parent breadcrumbs
     await umbracoUi.currentUserProfile.isHistoryEntryVisible(childName);
-    const detail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(childName);
-    expect(detail).toContain(rootName);
-    expect(detail).toContain(parentName);
+    const text = await umbracoUi.currentUserProfile.getHistoryEntryText(childName);
+    expect(text).toContain(rootName);
+    expect(text).toContain(parentName);
   });
 
   test('shows breadcrumb path at each nesting level', async ({umbracoUi}) => {
@@ -108,35 +107,38 @@ test.describe('Recent History', () => {
     // Open profile modal
     await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
 
-    // Assert — each entry has the correct breadcrumb depth
-    const rootDetail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(rootName);
-    expect(rootDetail).toContain('Content');
+    // Assert — each entry's text contains the correct breadcrumb depth
+    const rootText = await umbracoUi.currentUserProfile.getHistoryEntryText(rootName);
+    expect(rootText).toContain('Content');
 
-    const parentDetail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(parentName);
-    expect(parentDetail).toContain(rootName);
+    const parentText = await umbracoUi.currentUserProfile.getHistoryEntryText(parentName);
+    expect(parentText).toContain(rootName);
 
-    const childDetail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(childName);
-    expect(childDetail).toContain(rootName);
-    expect(childDetail).toContain(parentName);
+    const childText = await umbracoUi.currentUserProfile.getHistoryEntryText(childName);
+    expect(childText).toContain(rootName);
+    expect(childText).toContain(parentName);
   });
 
-  test('tab switching does not create duplicate history entries', async ({umbracoUi}) => {
+  test('revisiting a document does not create duplicate history entries', async ({umbracoUi}) => {
     // Arrange
     await umbracoUi.goToBackOffice();
     await umbracoUi.content.goToSection(ConstantHelper.sections.content);
     await umbracoUi.content.clickCaretButtonForContentName(rootName);
     await umbracoUi.content.clickCaretButtonForContentName(parentName);
+
+    // Act — visit child, then parent, then child again
+    await umbracoUi.content.goToContentWithName(childName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.short);
+    await umbracoUi.content.goToContentWithName(parentName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.short);
     await umbracoUi.content.goToContentWithName(childName);
     await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
-
-    // Act — switch to the Info tab
-    await umbracoUi.content.clickInfoTab();
-    await umbracoUi.waitForTimeout(ConstantHelper.wait.short);
 
     // Open profile modal
     await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
 
-    // Assert — only one entry for the child document
+    // Assert — entry exists and is not duplicated
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible(childName);
     const count = await umbracoUi.currentUserProfile.countHistoryEntriesWithName(childName);
     expect(count).toBe(1);
   });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
@@ -1,4 +1,5 @@
 import {ConstantHelper, NotificationConstantHelper, test} from '@umbraco/acceptance-test-helpers';
+import {expect} from "@playwright/test";
 
 const userPassword = '0123456789';
 
@@ -33,3 +34,110 @@ for (const userGroup of userGroups) {
     await umbracoUi.currentUserProfile.doesSuccessNotificationHaveText(NotificationConstantHelper.success.passwordChanged);
   });
 }
+
+test.describe('Recent History', () => {
+  const docTypeName = 'HistoryTestDocType';
+  const rootName = 'Root Page';
+  const parentName = 'Parent Page';
+  const childName = 'Child Page';
+
+  test.beforeEach(async ({umbracoApi}) => {
+    await umbracoApi.documentType.ensureNameNotExists(docTypeName);
+    await umbracoApi.document.ensureNameNotExists(childName);
+    await umbracoApi.document.ensureNameNotExists(parentName);
+    await umbracoApi.document.ensureNameNotExists(rootName);
+
+    // Create a self-referencing doc type (allows itself as child + root)
+    const docTypeId = await umbracoApi.documentType.createDefaultDocumentTypeWithAllowAsRoot(docTypeName);
+    // Update to allow itself as a child document type
+    const docType = await umbracoApi.documentType.get(docTypeId);
+    docType.allowedDocumentTypes = [{id: docTypeId, sortOrder: 0}];
+    await umbracoApi.documentType.update(docTypeId, docType);
+
+    // Create 3-level document tree
+    const rootId = await umbracoApi.document.createDefaultDocument(rootName, docTypeId);
+    const parentId = await umbracoApi.document.createDefaultDocumentWithParent(parentName, docTypeId, rootId);
+    await umbracoApi.document.createDefaultDocumentWithParent(childName, docTypeId, parentId);
+  });
+
+  test.afterEach(async ({umbracoApi}) => {
+    await umbracoApi.document.ensureNameNotExists(childName);
+    await umbracoApi.document.ensureNameNotExists(parentName);
+    await umbracoApi.document.ensureNameNotExists(rootName);
+    await umbracoApi.documentType.ensureNameNotExists(docTypeName);
+  });
+
+  test('shows readable label and breadcrumb after visiting a nested document', async ({umbracoUi}) => {
+    // Arrange
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+    // Act — navigate to the child document
+    await umbracoUi.content.clickCaretButtonForContentName(rootName);
+    await umbracoUi.content.clickCaretButtonForContentName(parentName);
+    await umbracoUi.content.goToContentWithName(childName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Open profile modal
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+
+    // Assert
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible(childName);
+    const detail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(childName);
+    expect(detail).toContain(rootName);
+    expect(detail).toContain(parentName);
+  });
+
+  test('shows breadcrumb path at each nesting level', async ({umbracoUi}) => {
+    // Arrange
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+    // Act — visit each level
+    await umbracoUi.content.clickCaretButtonForContentName(rootName);
+    await umbracoUi.content.goToContentWithName(rootName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.short);
+
+    await umbracoUi.content.clickCaretButtonForContentName(parentName);
+    await umbracoUi.content.goToContentWithName(parentName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.short);
+
+    await umbracoUi.content.goToContentWithName(childName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Open profile modal
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+
+    // Assert — each entry has the correct breadcrumb depth
+    const rootDetail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(rootName);
+    expect(rootDetail).toContain('Content');
+
+    const parentDetail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(parentName);
+    expect(parentDetail).toContain(rootName);
+
+    const childDetail = await umbracoUi.currentUserProfile.getHistoryEntryDetail(childName);
+    expect(childDetail).toContain(rootName);
+    expect(childDetail).toContain(parentName);
+  });
+
+  test('tab switching does not create duplicate history entries', async ({umbracoUi}) => {
+    // Arrange
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+    await umbracoUi.content.clickCaretButtonForContentName(rootName);
+    await umbracoUi.content.clickCaretButtonForContentName(parentName);
+    await umbracoUi.content.goToContentWithName(childName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Act — switch to the Info tab
+    await umbracoUi.content.clickInfoTab();
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.short);
+
+    // Open profile modal
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+
+    // Assert — only one entry for the child document
+    const count = await umbracoUi.currentUserProfile.countHistoryEntriesWithName(childName);
+    expect(count).toBe(1);
+  });
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
@@ -66,7 +66,7 @@ test.describe('Recent History', () => {
     await umbracoApi.documentType.ensureNameNotExists(docTypeName);
   });
 
-  test('shows readable label and breadcrumb after visiting a nested document', async ({umbracoUi}) => {
+  test('shows readable label and breadcrumb after visiting a nested document', {tag: '@smoke'}, async ({umbracoUi}) => {
     // Arrange
     await umbracoUi.goToBackOffice();
     await umbracoUi.content.goToSection(ConstantHelper.sections.content);
@@ -117,6 +117,48 @@ test.describe('Recent History', () => {
     const childText = await umbracoUi.currentUserProfile.getHistoryEntryText(childName);
     expect(childText).toContain(rootName);
     expect(childText).toContain(parentName);
+  });
+
+  test('shows document type in history when visited', async ({umbracoUi}) => {
+    // Arrange
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.settings);
+
+    // Act — navigate to the document type
+    await umbracoUi.content.clickCaretButtonForContentName('Document Types');
+    await umbracoUi.content.goToContentWithName(docTypeName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Open profile modal
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+
+    // Assert
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible(docTypeName);
+    const text = await umbracoUi.currentUserProfile.getHistoryEntryText(docTypeName);
+    expect(text).toContain('Document Types');
+  });
+
+  test('clicking a history entry navigates back to the document', async ({umbracoUi, page}) => {
+    // Arrange — visit a document to create a history entry
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+    await umbracoUi.content.clickCaretButtonForContentName(rootName);
+    await umbracoUi.content.goToContentWithName(rootName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Navigate away to a different section
+    await umbracoUi.content.goToSection(ConstantHelper.sections.settings);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.short);
+
+    // Act — open profile modal and click the history entry
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible(rootName);
+    const entry = umbracoUi.currentUserProfile.getHistoryEntryByName(rootName);
+    await entry.click();
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Assert — we're back on the document workspace
+    expect(page.url()).toContain('/workspace/document/edit/');
   });
 
   test('revisiting a document does not create duplicate history entries', async ({umbracoUi}) => {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
@@ -107,7 +107,9 @@ test.describe('Recent History', () => {
     // Open profile modal
     await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
 
-    // Assert — each entry's text contains the correct breadcrumb depth
+    // Assert — wait for entries to render, then check breadcrumb depth
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible(childName);
+
     const rootText = await umbracoUi.currentUserProfile.getHistoryEntryText(rootName);
     expect(rootText).toContain('Content');
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
@@ -207,4 +207,36 @@ test.describe('Recent History', () => {
     const count = await umbracoUi.currentUserProfile.countHistoryEntriesWithName(childName);
     expect(count).toBe(1);
   });
+
+  test('opening the user profile modal does not overwrite the underlying entry', async ({umbracoUi}) => {
+    // Arrange — visit a document so we have a resolved entry
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+    await umbracoUi.content.clickCaretButtonForContentName(rootName);
+    await umbracoUi.content.goToContentWithName(rootName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Act — open the profile modal (which publishes its own title with kind 'modal')
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+
+    // Assert — the workspace entry is still the document, not the modal title.
+    // Guards against regression of the `kind === 'modal'` filter in the history store.
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible(rootName);
+  });
+
+  test('Recycle Bin entry shows static icon and Content breadcrumb', async ({umbracoUi}) => {
+    // Arrange — visit the content recycle bin (a static-icon root workspace, no entity name)
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+    await umbracoUi.content.goToContentWithName('Recycle Bin');
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Open profile modal
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+
+    // Assert — entry exists with the Content section as its breadcrumb
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible('Recycle Bin');
+    const text = await umbracoUi.currentUserProfile.getHistoryEntryText('Recycle Bin');
+    expect(text).toContain('Content');
+  });
 });

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Users/CurrentUserProfile.spec.ts
@@ -163,6 +163,27 @@ test.describe('Recent History', () => {
     expect(page.url()).toContain('/workspace/document/edit/');
   });
 
+  test('document entry retains its label after navigating to another section', async ({umbracoUi}) => {
+    // Arrange — visit a document
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+    await umbracoUi.content.clickCaretButtonForContentName(rootName);
+    await umbracoUi.content.goToContentWithName(rootName);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Act — navigate to a different section
+    await umbracoUi.content.goToSection(ConstantHelper.sections.settings);
+    await umbracoUi.waitForTimeout(ConstantHelper.wait.medium);
+
+    // Open profile modal
+    await umbracoUi.currentUserProfile.clickCurrentUserAvatarButton();
+
+    // Assert — the document entry still has its name, not just "Content"
+    await umbracoUi.currentUserProfile.isHistoryEntryVisible(rootName);
+    const text = await umbracoUi.currentUserProfile.getHistoryEntryText(rootName);
+    expect(text).toContain('Content');
+  });
+
   test('revisiting a document does not create duplicate history entries', async ({umbracoUi}) => {
     // Arrange
     await umbracoUi.goToBackOffice();


### PR DESCRIPTION
## Summary

Rewrites the "Your recent history" panel so entries show readable labels, entity-specific icons, and a breadcrumb path instead of raw URL segments.

**Before:**
<img width="1912" height="1090" alt="Image" src="https://github.com/user-attachments/assets/23eaffd2-46fd-47fa-9639-1e1385726e52" />

**After:**
<img width="493" height="662" alt="image" src="https://github.com/user-attachments/assets/c3a9b2cb-708e-4f35-8cb3-3a6c64c1c4ef" />

## How it works

Introduces a named-slot segment API on `UmbViewController`:

```ts
view.setSegments('workspace-type', { label: '#treeHeaders_scripts', kind: 'workspace-type' });
view.setSegments('leaf', { label: 'test.js', kind: 'workspace', icon: 'icon-document-js' });
view.clearSegments('leaf');
```

The controller flattens slots, sorts by kind priority (`section → workspace-type → workspace-ancestor → workspace → tab → modal`), applies opt-in `replaces` dedup, and publishes the result. Parent segments are inherited automatically.

The history store subscribes to the published title chain and mirrors the leaf segment (label + icon) onto the latest entry, using the full breadcrumb as the detail. `modal` and `tab` segments are filtered out.

`setTitle()` / `setAncestors()` remain as deprecated wrappers with runtime `UmbDeprecation` warnings. All internal callers have been migrated.

## What's included

- Segment-slot API on `UmbViewController` with shallow-equality guards
- Content/media/member workspaces publish their content-type icon; content-types publish their own
- Static icons for templating, data types, dictionary, languages, users, groups, webhooks, etc.
- Forbidden entities publish *Access denied* instead of the section name
- New `/tree/{entity}/ancestors` MSW handlers for scripts, stylesheets, partial-views, templates, document-blueprints, member-types
- 7 E2E tests in `CurrentUserProfile.spec.ts` covering nested breadcrumbs, click-back, section-switch retention, and dedup

Fixes #22441

## Test plan

**Automated (E2E):** nested document breadcrumb · breadcrumb depth per level · document type in history · click-back navigation · label retention across sections · revisit dedup

**Manual:**
- [ ] Media / member entries show their type's icon
- [ ] Scripts in a subfolder show the folder in the breadcrumb
- [ ] Document blueprints use `icon-blueprint`
- [ ] Access-denied entries show *Access denied*
- [ ] Renaming a document updates the live history entry label
- [ ] Opening a modal doesn't overwrite the underlying entry
- [ ] Validation hints still work on content editor + block editor tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)