### PR TITLE
Document Types: Prevent disabling isElement when elements of that type exist

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DocumentType/DocumentTypeControllerBase.cs
@@ -118,6 +118,10 @@ public abstract class DocumentTypeControllerBase : ManagementApiControllerBase
                     .WithTitle("Invalid IsElement flag")
                     .WithDetail("Cannot change to document type because this element type is used in the configuration of a data type.")
                     .Build()),
+                ContentTypeOperationStatus.InvalidElementFlagElementHasContent => new BadRequestObjectResult(problemDetailsBuilder
+                    .WithTitle("Invalid IsElement flag")
+                    .WithDetail("Cannot change to document type because content has already been created with this element type.")
+                    .Build()),
                 ContentTypeOperationStatus.InvalidElementFlagComparedToParent => new BadRequestObjectResult(problemDetailsBuilder
                     .WithTitle("Invalid IsElement flag")
                     .WithDetail("Can not create a documentType with inheritance composition where the parent and the new type's IsElement flag are different.")

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ContentTypeEditingService.cs
@@ -164,12 +164,21 @@ internal sealed class ContentTypeEditingService : ContentTypeEditingServiceBase<
 
         // this method should only contain blocking validation, warnings are handled by WarnDocumentTypeElementSwitchNotificationHandler
 
-        // => check whether the element was used in a block structure prior to updating
+        // => switching off the element flag: ensure the element type isn't referenced in block structures
+        //    and that no element instances exist in the library
         if (model.IsElement is false)
         {
-            return await _elementSwitchValidator.ElementToDocumentNotUsedInBlockStructuresAsync(contentType)
-                ? ContentTypeOperationStatus.Success
-                : ContentTypeOperationStatus.InvalidElementFlagElementIsUsedInPropertyEditorConfiguration;
+            if (await _elementSwitchValidator.ElementToDocumentNotUsedInBlockStructuresAsync(contentType) is false)
+            {
+                return ContentTypeOperationStatus.InvalidElementFlagElementIsUsedInPropertyEditorConfiguration;
+            }
+
+            if (await _elementSwitchValidator.ElementToDocumentHasNoContentAsync(contentType) is false)
+            {
+                return ContentTypeOperationStatus.InvalidElementFlagElementHasContent;
+            }
+
+            return ContentTypeOperationStatus.Success;
         }
 
         return await _elementSwitchValidator.DocumentToElementHasNoContentAsync(contentType)

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
@@ -77,14 +77,12 @@ public class ElementSwitchValidator : IElementSwitchValidator
 
     /// <inheritdoc />
     public Task<bool> DocumentToElementHasNoContentAsync(IContentTypeBase contentType) =>
-
-        // if any content for the content type exists, the validation fails.
-        Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
+        HasNoContentNodesAsync(contentType);
 
     /// <inheritdoc />
     public Task<bool> ElementToDocumentHasNoContentAsync(IContentTypeBase contentType) =>
+        HasNoContentNodesAsync(contentType);
 
-        // element instances are also persisted as nodes in the content table (via the FK from umbracoElement),
-        // so HasContentNodes detects element instances when the content type is currently an element.
+    private Task<bool> HasNoContentNodesAsync(IContentTypeBase contentType) =>
         Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
 }

--- a/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/ElementSwitchValidator.cs
@@ -80,4 +80,11 @@ public class ElementSwitchValidator : IElementSwitchValidator
 
         // if any content for the content type exists, the validation fails.
         Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
+
+    /// <inheritdoc />
+    public Task<bool> ElementToDocumentHasNoContentAsync(IContentTypeBase contentType) =>
+
+        // element instances are also persisted as nodes in the content table (via the FK from umbracoElement),
+        // so HasContentNodes detects element instances when the content type is currently an element.
+        Task.FromResult(_contentTypeService.HasContentNodes(contentType.Id) is false);
 }

--- a/src/Umbraco.Core/Services/ContentTypeEditing/IElementSwitchValidator.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/IElementSwitchValidator.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services.ContentTypeEditing;
@@ -85,8 +83,5 @@ public interface IElementSwitchValidator
     ///     Element types with existing element instances in the library cannot be converted
     ///     to document types because document types use a different storage and editing model.
     /// </remarks>
-    // TODO (V19): Remove the default implementation.
-    Task<bool> ElementToDocumentHasNoContentAsync(IContentTypeBase contentType)
-        => Task.FromResult(StaticServiceProvider.Instance.GetRequiredService<IContentTypeService>()
-            .HasContentNodes(contentType.Id) is false);
+    Task<bool> ElementToDocumentHasNoContentAsync(IContentTypeBase contentType);
 }

--- a/src/Umbraco.Core/Services/ContentTypeEditing/IElementSwitchValidator.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/IElementSwitchValidator.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.Services.ContentTypeEditing;
@@ -69,4 +71,22 @@ public interface IElementSwitchValidator
     ///     because element types cannot have directly created content nodes.
     /// </remarks>
     Task<bool> DocumentToElementHasNoContentAsync(IContentTypeBase contentType);
+
+    /// <summary>
+    ///     Validates whether an element type can be converted to a document type by checking
+    ///     if any element instances exist for the content type.
+    /// </summary>
+    /// <param name="contentType">The content type to validate.</param>
+    /// <returns>
+    ///     <c>true</c> if no element instances exist for the content type and it can safely
+    ///     be converted to a document type; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    ///     Element types with existing element instances in the library cannot be converted
+    ///     to document types because document types use a different storage and editing model.
+    /// </remarks>
+    // TODO (V19): Remove the default implementation.
+    Task<bool> ElementToDocumentHasNoContentAsync(IContentTypeBase contentType)
+        => Task.FromResult(StaticServiceProvider.Instance.GetRequiredService<IContentTypeService>()
+            .HasContentNodes(contentType.Id) is false);
 }

--- a/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/ContentTypeOperationStatus.cs
@@ -135,4 +135,9 @@ public enum ContentTypeOperationStatus
     ///     The alias of a system content type cannot be changed.
     /// </summary>
     SystemAliasChangeNotAllowed,
+
+    /// <summary>
+    ///     Cannot change the element flag because the element type has existing element instances.
+    /// </summary>
+    InvalidElementFlagElementHasContent,
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Update.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTests.Update.cs
@@ -1560,4 +1560,61 @@ internal sealed partial class ContentTypeEditingServiceTests
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentTypeOperationStatus.InvalidSegmentVariationForElementType, result.Status);
     }
+
+    [Test]
+    public async Task Cannot_Switch_Document_To_Element_When_Content_Exists()
+    {
+        var createModel = ContentTypeCreateModel("Test", "test");
+        createModel.AllowedAsRoot = true;
+        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result!;
+
+        var content = ContentService.Create("Test Content", Constants.System.Root, contentType.Alias);
+        var saveResult = ContentService.Save(content);
+        Assert.IsTrue(saveResult.Success);
+
+        var updateModel = ContentTypeUpdateModel("Test", "test", isElement: true);
+        var result = await ContentTypeEditingService.UpdateAsync(contentType, updateModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentTypeOperationStatus.InvalidElementFlagDocumentHasContent, result.Status);
+    }
+
+    [Test]
+    public async Task Cannot_Switch_Element_To_Document_When_Element_Instances_Exist()
+    {
+        var createModel = ContentTypeCreateModel("Test", "test", isElement: true);
+        createModel.AllowedInLibrary = true;
+        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result!;
+
+        var element = ElementService.Create("Test Element", contentType.Alias);
+        var saveResult = ElementService.Save(element);
+        Assert.IsTrue(saveResult.Success);
+
+        var updateModel = ContentTypeUpdateModel("Test", "test");
+        var result = await ContentTypeEditingService.UpdateAsync(contentType, updateModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentTypeOperationStatus.InvalidElementFlagElementHasContent, result.Status);
+    }
+
+    [Test]
+    public async Task Cannot_Switch_Element_To_Document_When_Used_In_Block_Structure()
+    {
+        var createModel = ContentTypeCreateModel("Test", "test", isElement: true);
+        var contentType = (await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result!;
+
+        var dataType = DataTypeBuilder.CreateSimpleElementDataType(
+            IOHelper,
+            Constants.PropertyEditors.Aliases.BlockList,
+            contentType.Key,
+            elementSettingKey: null);
+        var dataTypeResult = await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        Assert.IsTrue(dataTypeResult.Success);
+
+        var updateModel = ContentTypeUpdateModel("Test", "test");
+        var result = await ContentTypeEditingService.UpdateAsync(contentType, updateModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentTypeOperationStatus.InvalidElementFlagElementIsUsedInPropertyEditorConfiguration, result.Status);
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTestsBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentTypeEditingServiceTestsBase.cs
@@ -23,6 +23,10 @@ internal abstract class ContentTypeEditingServiceTestsBase : UmbracoIntegrationT
 
     protected IContentService ContentService => GetRequiredService<IContentService>();
 
+    protected IElementService ElementService => GetRequiredService<IElementService>();
+
+    protected IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
+
     protected IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
 
     protected const string TabContainerType = "Tab";

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ElementSwitchValidatorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ElementSwitchValidatorTests.cs
@@ -299,7 +299,7 @@ internal sealed class ElementSwitchValidatorTests : UmbracoIntegrationTest
     {
         var typeBuilder = new ContentTypeBuilder()
             .WithIsElement(isElement)
-            .WithAllowedInLibrary(true);
+            .WithAllowedInLibrary(isElement);
         var contentType = typeBuilder.Build();
         await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
         return contentType;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ElementSwitchValidatorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ElementSwitchValidatorTests.cs
@@ -23,6 +23,8 @@ internal sealed class ElementSwitchValidatorTests : UmbracoIntegrationTest
 
     private IContentService ContentService => GetRequiredService<IContentService>();
 
+    private IElementService ElementService => GetRequiredService<IElementService>();
+
     private IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
 
     [TestCase(new[] { true }, 0, true, true, TestName = "E=>E No Ancestor or children")]
@@ -271,10 +273,33 @@ internal sealed class ElementSwitchValidatorTests : UmbracoIntegrationTest
         Assert.AreEqual(result, validationShouldPass);
     }
 
+    [TestCase(0, true, TestName = "No Elements")]
+    [TestCase(1, false, TestName = "One Element Item")]
+    [TestCase(5, false, TestName = "Many Element Items")]
+    public async Task ElementToDocumentHasNoContent(int amountOfElementsCreated, bool validationShouldPass)
+    {
+        // Arrange
+        var contentType = await SetupContentType(true);
+
+        for (int i = 0; i < amountOfElementsCreated; i++)
+        {
+            var element = ElementService.Create($"Element {i}", contentType.Alias);
+            ElementService.Save(element);
+        }
+
+        // Act
+        contentType.IsElement = false;
+        var result = await ElementSwitchValidator.ElementToDocumentHasNoContentAsync(contentType);
+
+        // Assert
+        Assert.AreEqual(result, validationShouldPass);
+    }
+
     private async Task<IContentType> SetupContentType(bool isElement)
     {
         var typeBuilder = new ContentTypeBuilder()
-            .WithIsElement(isElement);
+            .WithIsElement(isElement)
+            .WithAllowedInLibrary(true);
         var contentType = typeBuilder.Build();
         await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
         return contentType;


### PR DESCRIPTION
## Summary

Mirrors the existing document-to-element guard: switching an element type to a document type is now blocked when elements of that type exist in the library.

- Adds `ElementToDocumentHasNoContentAsync` to `IElementSwitchValidator` (default interface implementation for binary compat) and implements it in `ElementSwitchValidator`.
- Adds `ContentTypeOperationStatus.InvalidElementFlagElementHasContent` and wires it into `ContentTypeEditingService.ValidateElementStatusForUpdateAsync` for the element→document branch (after the existing block-structure check).
- Maps the new status to a `BadRequest` ProblemDetails in `DocumentTypeControllerBase`.

The implementation reuses `IContentTypeService.HasContentNodes(id)` because element instances are persisted as nodes in `umbracoContent` (FK from `umbracoElement`), so the existing check correctly detects elements when the type is currently an element.

## Testing

Open a fresh project and create an element type that allows being added to the library. Add at least one element of that type from the Elements section. Edit the element type and try to disable `Is Element` — saving should fail with a 400 and the message *"Cannot change to document type because content has already been created with this element type."* Then delete the element instance(s) and retry — the save should now succeed. The reverse direction (document with content → element) and the existing block-structure guard should continue to behave as before.