### PR TITLE
adds same drag styling as when dragging item in the content sectin (closes #21620)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
@@ -12,6 +12,7 @@ import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 import type { UmbRepositoryItemsStatus } from '@umbraco-cms/backoffice/repository';
 
 import '@umbraco-cms/backoffice/entity-item';
+import { UUIBlinkAnimationValue } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-input-document-type')
 export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | undefined, typeof UmbLitElement>(
@@ -280,6 +281,55 @@ export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | un
 		css`
 			#btn-add {
 				width: 100%;
+			}
+
+			#loader {
+				margin-top: 10px;
+				opacity: 0;
+				animation: show-loader 0s 120ms forwards;
+			}
+
+			@keyframes show-loader {
+				to {
+					opacity: 1;
+				}
+			}
+
+			uui-ref-node-document-type::after {
+				content: '';
+				position: absolute;
+				z-index: 1;
+				pointer-events: none;
+				inset: 0;
+				border: 1px solid transparent;
+				border-radius: var(--uui-border-radius);
+
+				transition: border-color 240ms ease-in;
+			}
+
+			uui-ref-node-document-type[drag-placeholder] {
+				--uui-color-focus: transparent;
+				color: transparent;
+			}
+
+			uui-ref-node-document-type[drag-placeholder]::after {
+				display: block;
+				border-width: 2px;
+				border-color: var(--uui-color-interactive-emphasis);
+				animation: ${UUIBlinkAnimationValue};
+			}
+			uui-ref-node-document-type[drag-placeholder]::before {
+				content: '';
+				position: absolute;
+				pointer-events: none;
+				inset: 0;
+				border-radius: var(--uui-border-radius);
+				background-color: var(--uui-color-interactive-emphasis);
+				opacity: 0.12;
+			}
+			uui-ref-node-document-type[drag-placeholder] > * {
+				transition: opacity 50ms 16ms;
+				opacity: 0;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/components/input-document-type/input-document-type.element.ts
@@ -283,18 +283,6 @@ export class UmbInputDocumentTypeElement extends UmbFormControlMixin<string | un
 				width: 100%;
 			}
 
-			#loader {
-				margin-top: 10px;
-				opacity: 0;
-				animation: show-loader 0s 120ms forwards;
-			}
-
-			@keyframes show-loader {
-				to {
-					opacity: 1;
-				}
-			}
-
 			uui-ref-node-document-type::after {
 				content: '';
 				position: absolute;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes - [Drag placeholder for child node types in content type is not consistent with pickers](https://github.com/umbraco/Umbraco-CMS/issues/21620)

### Description
This PR adds the same styling for the draggable item as the one used in the content section.

I swapped the selector from host to uui-ref-node-document-type to target the right element

### Steps to reproduce 
Drag "allowed child node types" for a content type and compare styling with dragging items in e.g. block list or multi URL picker.

<!-- Thanks for contributing to Umbraco CMS! -->
