### PR TITLE
Member Authentication: Add member sign-in/sign-out notifications (closes #22461)

### DIFF
--- a/src/Umbraco.Core/Notifications/MemberLoginFailedNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberLoginFailedNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Notifications;
+
+/// <summary>
+///     Notification that is published when a member login attempt fails.
+/// </summary>
+public class MemberLoginFailedNotification : MemberNotification
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MemberLoginFailedNotification"/> class.
+    /// </summary>
+    /// <param name="ipAddress">The source IP address of the failed login attempt.</param>
+    /// <param name="memberKey">The key of the member whose login failed, or <c>null</c> if the member could not be found.</param>
+    public MemberLoginFailedNotification(string ipAddress, Guid? memberKey)
+        : base(ipAddress, memberKey)
+    {
+    }
+}

--- a/src/Umbraco.Core/Notifications/MemberLoginFailedNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberLoginFailedNotification.cs
@@ -6,6 +6,11 @@ namespace Umbraco.Cms.Core.Notifications;
 /// <summary>
 ///     Notification that is published when a member login attempt fails.
 /// </summary>
+/// <remarks>
+///     This notification is useful for audit logging, security monitoring, and detecting potential
+///     brute-force attacks. The <see cref="MemberNotification.MemberKey"/> may be <c>null</c> if the
+///     member could not be found for the given credentials.
+/// </remarks>
 public class MemberLoginFailedNotification : MemberNotification
 {
     /// <summary>

--- a/src/Umbraco.Core/Notifications/MemberLoginFailedNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberLoginFailedNotification.cs
@@ -18,8 +18,15 @@ public class MemberLoginFailedNotification : MemberNotification
     /// </summary>
     /// <param name="ipAddress">The source IP address of the failed login attempt.</param>
     /// <param name="memberKey">The key of the member whose login failed, or <c>null</c> if the member could not be found.</param>
-    public MemberLoginFailedNotification(string ipAddress, Guid? memberKey)
+    /// <param name="reason">The reason the login attempt failed (e.g. "InvalidCredentials", "LockedOut", "NotAllowed", "MemberNotFound").</param>
+    public MemberLoginFailedNotification(string ipAddress, Guid? memberKey, string reason)
         : base(ipAddress, memberKey)
     {
+        Reason = reason;
     }
+
+    /// <summary>
+    ///     Gets the reason the login attempt failed.
+    /// </summary>
+    public string Reason { get; }
 }

--- a/src/Umbraco.Core/Notifications/MemberLoginFailedReason.cs
+++ b/src/Umbraco.Core/Notifications/MemberLoginFailedReason.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Notifications;
+
+/// <summary>
+///     Well-known reason strings for <see cref="MemberLoginFailedNotification"/>.
+/// </summary>
+public static class MemberLoginFailedReason
+{
+    /// <summary>
+    ///     The credentials provided were invalid (wrong password).
+    /// </summary>
+    public const string InvalidCredentials = "InvalidCredentials";
+
+    /// <summary>
+    ///     The member account is locked out due to too many failed attempts.
+    /// </summary>
+    public const string LockedOut = "LockedOut";
+
+    /// <summary>
+    ///     The member account is not allowed to sign in (e.g. not approved or email not confirmed).
+    /// </summary>
+    public const string NotAllowed = "NotAllowed";
+
+    /// <summary>
+    ///     No member was found for the given username.
+    /// </summary>
+    public const string MemberNotFound = "MemberNotFound";
+}

--- a/src/Umbraco.Core/Notifications/MemberLoginSuccessNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberLoginSuccessNotification.cs
@@ -6,6 +6,10 @@ namespace Umbraco.Cms.Core.Notifications;
 /// <summary>
 ///     Notification that is published after a member has successfully logged in.
 /// </summary>
+/// <remarks>
+///     This notification is useful for audit logging, security monitoring, and post-authentication
+///     concerns such as associating session data with a member.
+/// </remarks>
 public class MemberLoginSuccessNotification : MemberNotification
 {
     /// <summary>

--- a/src/Umbraco.Core/Notifications/MemberLoginSuccessNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberLoginSuccessNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Notifications;
+
+/// <summary>
+///     Notification that is published after a member has successfully logged in.
+/// </summary>
+public class MemberLoginSuccessNotification : MemberNotification
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MemberLoginSuccessNotification"/> class.
+    /// </summary>
+    /// <param name="ipAddress">The source IP address of the member logging in.</param>
+    /// <param name="memberKey">The key of the member who logged in.</param>
+    public MemberLoginSuccessNotification(string ipAddress, Guid memberKey)
+        : base(ipAddress, memberKey)
+    {
+    }
+}

--- a/src/Umbraco.Core/Notifications/MemberLogoutSuccessNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberLogoutSuccessNotification.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Notifications;
+
+/// <summary>
+///     Notification that is published after a member has successfully logged out.
+/// </summary>
+public class MemberLogoutSuccessNotification : MemberNotification
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MemberLogoutSuccessNotification"/> class.
+    /// </summary>
+    /// <param name="ipAddress">The source IP address of the member logging out.</param>
+    /// <param name="memberKey">The key of the member who logged out.</param>
+    public MemberLogoutSuccessNotification(string ipAddress, Guid memberKey)
+        : base(ipAddress, memberKey)
+    {
+    }
+}

--- a/src/Umbraco.Core/Notifications/MemberLogoutSuccessNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberLogoutSuccessNotification.cs
@@ -6,6 +6,9 @@ namespace Umbraco.Cms.Core.Notifications;
 /// <summary>
 ///     Notification that is published after a member has successfully logged out.
 /// </summary>
+/// <remarks>
+///     This notification is useful for audit logging and implementing custom post-sign-out behavior.
+/// </remarks>
 public class MemberLogoutSuccessNotification : MemberNotification
 {
     /// <summary>

--- a/src/Umbraco.Core/Notifications/MemberNotification.cs
+++ b/src/Umbraco.Core/Notifications/MemberNotification.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Notifications;
+
+/// <summary>
+///     Abstract base class for member authentication notifications such as login, logout, and login failure.
+/// </summary>
+public abstract class MemberNotification : INotification
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MemberNotification"/> class.
+    /// </summary>
+    /// <param name="ipAddress">The source IP address of the member performing the action.</param>
+    /// <param name="memberKey">The key of the member affected by this action.</param>
+    protected MemberNotification(string ipAddress, Guid? memberKey)
+    {
+        DateTimeUtc = DateTime.UtcNow;
+        IpAddress = ipAddress;
+        MemberKey = memberKey;
+    }
+
+    /// <summary>
+    ///     Gets the date and time in UTC when this notification was created.
+    /// </summary>
+    public DateTime DateTimeUtc { get; }
+
+    /// <summary>
+    ///     Gets the source IP address of the member performing the action.
+    /// </summary>
+    public string IpAddress { get; }
+
+    /// <summary>
+    ///     Gets the key of the member affected by this action, or <c>null</c> if the member could not be found.
+    /// </summary>
+    public Guid? MemberKey { get; }
+}

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -69,7 +69,7 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
     {
         SignInResult result = await base.PasswordSignInAsync(user, password, isPersistent, lockoutOnFailure);
 
-        if (!result.Succeeded && !result.RequiresTwoFactor)
+        if (result.Succeeded is false && result.RequiresTwoFactor is false)
         {
             var ipAddress = _ipResolver.GetCurrentRequestIpAddress();
             var reason = GetFailedLoginReason(result);
@@ -358,11 +358,15 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
                 _eventAggregator.Publish(new MemberLoginSuccessNotification(ipAddress, user.Key));
             }
         }
-        else if (!result.RequiresTwoFactor && user is null)
+        else if (result.RequiresTwoFactor is false)
         {
-            // User not found — PasswordSignInAsync(TUser) override handles the case
-            // where the user exists but the password is wrong.
-            _eventAggregator.Publish(new MemberLoginFailedNotification(ipAddress, memberKey: null, MemberLoginFailedReason.MemberNotFound));
+            // RequiresTwoFactor means "2FA is now required" (not a failure) — skip that.
+            // All other failures reach here:
+            // - User not found (user is null) via PasswordSignInAsync(string)
+            // - Failed 2FA verification (user is not null) via TwoFactorSignInAsync
+            // Note: password failures for existing users are handled by PasswordSignInAsync(TUser) override.
+            var reason = user is null ? MemberLoginFailedReason.MemberNotFound : GetFailedLoginReason(result);
+            _eventAggregator.Publish(new MemberLoginFailedNotification(ipAddress, user?.Key, reason));
         }
 
         return result;

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -4,9 +4,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Extensions;
@@ -19,8 +22,10 @@ namespace Umbraco.Cms.Web.Common.Security;
 public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMemberSignInManager
 {
     private readonly IEventAggregator _eventAggregator;
+    private readonly IIpResolver _ipResolver;
     private readonly IMemberExternalLoginProviders _memberExternalLoginProviders;
 
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
     public MemberSignInManager(
         UserManager<MemberIdentityUser> memberManager,
         IHttpContextAccessor contextAccessor,
@@ -33,10 +38,28 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         IEventAggregator eventAggregator,
         IOptions<SecuritySettings> securitySettings,
         IRequestCache requestCache)
+        : this(memberManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, memberExternalLoginProviders, eventAggregator, securitySettings, requestCache, StaticServiceProvider.Instance.GetRequiredService<IIpResolver>())
+    {
+    }
+
+    public MemberSignInManager(
+        UserManager<MemberIdentityUser> memberManager,
+        IHttpContextAccessor contextAccessor,
+        IUserClaimsPrincipalFactory<MemberIdentityUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        ILogger<SignInManager<MemberIdentityUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<MemberIdentityUser> confirmation,
+        IMemberExternalLoginProviders memberExternalLoginProviders,
+        IEventAggregator eventAggregator,
+        IOptions<SecuritySettings> securitySettings,
+        IRequestCache requestCache,
+        IIpResolver ipResolver)
         : base(memberManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation, securitySettings, requestCache)
     {
         _memberExternalLoginProviders = memberExternalLoginProviders;
         _eventAggregator = eventAggregator;
+        _ipResolver = ipResolver;
     }
 
     protected override bool AllowConcurrentLoginsEnabled => SecuritySettings.GetMemberAllowConcurrentLogins();
@@ -311,7 +334,7 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
     {
         result = await base.HandleSignIn(user, username, result);
 
-        var ipAddress = Context.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+        var ipAddress = _ipResolver.GetCurrentRequestIpAddress();
 
         if (result.Succeeded)
         {
@@ -332,7 +355,7 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
     public override async Task SignOutAsync()
     {
         MemberIdentityUser? user = await UserManager.GetUserAsync(Context.User);
-        var ipAddress = Context.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+        var ipAddress = _ipResolver.GetCurrentRequestIpAddress();
 
         await base.SignOutAsync();
 

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -306,6 +306,42 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
             loginInfo.LoginProvider,
             user.Id);
 
+    /// <inheritdoc />
+    protected override async Task<SignInResult> HandleSignIn(MemberIdentityUser? user, string? username, SignInResult result)
+    {
+        result = await base.HandleSignIn(user, username, result);
+
+        var ipAddress = Context.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+
+        if (result.Succeeded)
+        {
+            if (user is not null)
+            {
+                _eventAggregator.Publish(new MemberLoginSuccessNotification(ipAddress, user.Key));
+            }
+        }
+        else if (!result.RequiresTwoFactor && !result.IsLockedOut)
+        {
+            _eventAggregator.Publish(new MemberLoginFailedNotification(ipAddress, user?.Key));
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public override async Task SignOutAsync()
+    {
+        MemberIdentityUser? user = await UserManager.GetUserAsync(Context.User);
+        var ipAddress = Context.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+
+        await base.SignOutAsync();
+
+        if (user is not null)
+        {
+            _eventAggregator.Publish(new MemberLogoutSuccessNotification(ipAddress, user.Key));
+        }
+    }
+
     protected void NotifyRequiresTwoFactor(MemberIdentityUser user) => Notify(
         user,
         currentUser => new MemberTwoFactorRequestedNotification(currentUser.Key));

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -360,7 +360,8 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
         }
         else if (result.RequiresTwoFactor is false)
         {
-            // RequiresTwoFactor means "2FA is now required" (not a failure) — skip that.
+            // RequiresTwoFactor means "2FA is now required" (not a failure) — so we don't publish a failed notification.
+
             // All other failures reach here:
             // - User not found (user is null) via PasswordSignInAsync(string)
             // - Failed 2FA verification (user is not null) via TwoFactorSignInAsync

--- a/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
+++ b/src/Umbraco.Web.Common/Security/MemberSignInManager.cs
@@ -64,6 +64,21 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
 
     protected override bool AllowConcurrentLoginsEnabled => SecuritySettings.GetMemberAllowConcurrentLogins();
 
+    /// <inheritdoc />
+    public override async Task<SignInResult> PasswordSignInAsync(MemberIdentityUser user, string password, bool isPersistent, bool lockoutOnFailure)
+    {
+        SignInResult result = await base.PasswordSignInAsync(user, password, isPersistent, lockoutOnFailure);
+
+        if (!result.Succeeded && !result.RequiresTwoFactor)
+        {
+            var ipAddress = _ipResolver.GetCurrentRequestIpAddress();
+            var reason = GetFailedLoginReason(result);
+            _eventAggregator.Publish(new MemberLoginFailedNotification(ipAddress, user.Key, reason));
+        }
+
+        return result;
+    }
+
     // use default scheme for members
     protected override string AuthenticationType => IdentityConstants.ApplicationScheme;
 
@@ -343,9 +358,11 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
                 _eventAggregator.Publish(new MemberLoginSuccessNotification(ipAddress, user.Key));
             }
         }
-        else if (!result.RequiresTwoFactor && !result.IsLockedOut)
+        else if (!result.RequiresTwoFactor && user is null)
         {
-            _eventAggregator.Publish(new MemberLoginFailedNotification(ipAddress, user?.Key));
+            // User not found — PasswordSignInAsync(TUser) override handles the case
+            // where the user exists but the password is wrong.
+            _eventAggregator.Publish(new MemberLoginFailedNotification(ipAddress, memberKey: null, MemberLoginFailedReason.MemberNotFound));
         }
 
         return result;
@@ -364,6 +381,13 @@ public class MemberSignInManager : UmbracoSignInManager<MemberIdentityUser>, IMe
             _eventAggregator.Publish(new MemberLogoutSuccessNotification(ipAddress, user.Key));
         }
     }
+
+    private static string GetFailedLoginReason(SignInResult result) => result switch
+    {
+        { IsLockedOut: true } => MemberLoginFailedReason.LockedOut,
+        { IsNotAllowed: true } => MemberLoginFailedReason.NotAllowed,
+        _ => MemberLoginFailedReason.InvalidCredentials,
+    };
 
     protected void NotifyRequiresTwoFactor(MemberIdentityUser user) => Notify(
         user,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberManagerTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -35,7 +35,7 @@ public class MemberSignInManagerTests
     public UserClaimsPrincipalFactory<MemberIdentityUser> CreateClaimsFactory(MemberManager userMgr)
         => new(userMgr, Options.Create(new IdentityOptions()));
 
-    public MemberSignInManager CreateSut()
+    public MemberSignInManager CreateSut(IdentityOptions? identityOptions = null)
     {
         _memberManager = MockMemberManager();
         _mockEventAggregator = new Mock<IEventAggregator>();
@@ -76,7 +76,9 @@ public class MemberSignInManagerTests
             _memberManager.Object,
             Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext),
             CreateClaimsFactory(_memberManager.Object),
-            Mock.Of<IOptions<IdentityOptions>>(),
+            identityOptions is not null
+                ? Options.Create(identityOptions)
+                : Mock.Of<IOptions<IdentityOptions>>(),
             _mockLogger.Object,
             Mock.Of<IAuthenticationSchemeProvider>(),
             Mock.Of<IUserConfirmation<MemberIdentityUser>>(),
@@ -87,7 +89,7 @@ public class MemberSignInManagerTests
             _mockIpResolver.Object);
     }
 
-    private static Mock<MemberManager> MockMemberManager(IEventAggregator? eventAggregator = null)
+    private static Mock<MemberManager> MockMemberManager()
         => new(
             Mock.Of<IIpResolver>(),
             Mock.Of<IMemberUserStore>(),
@@ -101,8 +103,7 @@ public class MemberSignInManagerTests
             new TestOptionsSnapshot<MemberPasswordConfigurationSettings>(new MemberPasswordConfigurationSettings()),
             Mock.Of<IPublicAccessService>(),
             Mock.Of<IHttpContextAccessor>(),
-            Mock.Of<IPublishedModelFactory>(),
-            eventAggregator ?? Mock.Of<IEventAggregator>());
+            Mock.Of<IPublishedModelFactory>());
 
     [Test]
     public async Task
@@ -210,6 +211,53 @@ public class MemberSignInManagerTests
                 n.IpAddress == TestIpAddress
                 && n.MemberKey == null
                 && n.Reason == MemberLoginFailedReason.MemberNotFound)),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Can_Publish_Login_Failed_Notification_When_Locked_Out()
+    {
+        // arrange
+        var memberKey = Guid.NewGuid();
+        var sut = CreateSut();
+        var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
+
+        _memberManager.Setup(x => x.SupportsUserLockout).Returns(true);
+        _memberManager.Setup(x => x.IsLockedOutAsync(fakeUser)).ReturnsAsync(true);
+
+        // act
+        await sut.PasswordSignInAsync(fakeUser, "password", false, false);
+
+        // assert
+        _mockEventAggregator.Verify(
+            x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
+                n.IpAddress == TestIpAddress
+                && n.MemberKey == memberKey
+                && n.Reason == MemberLoginFailedReason.LockedOut)),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Can_Publish_Login_Failed_Notification_When_Not_Allowed()
+    {
+        // arrange
+        var memberKey = Guid.NewGuid();
+        var identityOptions = new IdentityOptions { SignIn = { RequireConfirmedEmail = true } };
+        var sut = CreateSut(identityOptions);
+        var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
+
+        // IsEmailConfirmedAsync returns false by default on the mock,
+        // so CanSignInAsync returns false → PreSignInCheck returns NotAllowed.
+
+        // act
+        await sut.PasswordSignInAsync(fakeUser, "password", false, false);
+
+        // assert
+        _mockEventAggregator.Verify(
+            x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
+                n.IpAddress == TestIpAddress
+                && n.MemberKey == memberKey
+                && n.Reason == MemberLoginFailedReason.NotAllowed)),
             Times.Once);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -72,7 +72,8 @@ public class MemberSignInManagerTests
             Mock.Of<IMemberExternalLoginProviders>(),
             Mock.Of<IEventAggregator>(),
             Mock.Of<IOptions<SecuritySettings>>(x => x.Value == new SecuritySettings()),
-            new DictionaryAppCache());
+            new DictionaryAppCache(),
+            Mock.Of<IIpResolver>());
     }
 
     private static Mock<MemberManager> MockMemberManager()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -13,6 +14,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Net;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common;
@@ -23,14 +25,23 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security;
 [TestFixture]
 public class MemberSignInManagerTests
 {
-    private Mock<ILogger<SignInManager<MemberIdentityUser>>> _mockLogger;
-    private readonly Mock<MemberManager> _memberManager = MockMemberManager();
+    private const string TestIpAddress = "192.168.1.100";
+
+    private Mock<ILogger<SignInManager<MemberIdentityUser>>> _mockLogger = null!;
+    private Mock<MemberManager> _memberManager = null!;
+    private Mock<IEventAggregator> _mockEventAggregator = null!;
+    private Mock<IIpResolver> _mockIpResolver = null!;
 
     public UserClaimsPrincipalFactory<MemberIdentityUser> CreateClaimsFactory(MemberManager userMgr)
         => new(userMgr, Options.Create(new IdentityOptions()));
 
     public MemberSignInManager CreateSut()
     {
+        _memberManager = MockMemberManager();
+        _mockEventAggregator = new Mock<IEventAggregator>();
+        _mockIpResolver = new Mock<IIpResolver>();
+        _mockIpResolver.Setup(x => x.GetCurrentRequestIpAddress()).Returns(TestIpAddress);
+
         // This all needs to be setup because internally aspnet resolves a bunch
         // of services from the HttpContext.RequestServices.
         var serviceProviderFactory = new DefaultServiceProviderFactory();
@@ -70,10 +81,10 @@ public class MemberSignInManagerTests
             Mock.Of<IAuthenticationSchemeProvider>(),
             Mock.Of<IUserConfirmation<MemberIdentityUser>>(),
             Mock.Of<IMemberExternalLoginProviders>(),
-            Mock.Of<IEventAggregator>(),
+            _mockEventAggregator.Object,
             Mock.Of<IOptions<SecuritySettings>>(x => x.Value == new SecuritySettings()),
             new DictionaryAppCache(),
-            Mock.Of<IIpResolver>());
+            _mockIpResolver.Object);
     }
 
     private static Mock<MemberManager> MockMemberManager()
@@ -133,5 +144,86 @@ public class MemberSignInManagerTests
 
         // assert
         Assert.IsFalse(actual.Succeeded);
+    }
+
+    [Test]
+    public async Task Can_Publish_Login_Success_Notification()
+    {
+        // arrange
+        var memberKey = Guid.NewGuid();
+        var sut = CreateSut();
+        var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
+
+        _memberManager.Setup(x => x.GetUserIdAsync(It.IsAny<MemberIdentityUser>())).ReturnsAsync("test-user-id");
+        _memberManager.Setup(x => x.GetUserNameAsync(It.IsAny<MemberIdentityUser>())).ReturnsAsync(fakeUser.UserName);
+        _memberManager.Setup(x => x.FindByNameAsync(It.IsAny<string>())).ReturnsAsync(fakeUser);
+        _memberManager.Setup(x => x.CheckPasswordAsync(fakeUser, "password")).ReturnsAsync(true);
+        _memberManager.Setup(x => x.IsEmailConfirmedAsync(fakeUser)).ReturnsAsync(true);
+        _memberManager.Setup(x => x.IsLockedOutAsync(fakeUser)).ReturnsAsync(false);
+
+        // act
+        await sut.PasswordSignInAsync(fakeUser, "password", false, false);
+
+        // assert
+        _mockEventAggregator.Verify(
+            x => x.Publish(It.Is<MemberLoginSuccessNotification>(n =>
+                n.IpAddress == TestIpAddress && n.MemberKey == memberKey)),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Can_Publish_Login_Failed_Notification_When_User_Not_Found()
+    {
+        // arrange
+        var sut = CreateSut();
+
+        // FindByNameAsync returns null by default on the fresh mock, so the
+        // string overload of PasswordSignInAsync will call HandleSignIn with a null user.
+
+        // act
+        await sut.PasswordSignInAsync("nonexistent_user", "password", false, false);
+
+        // assert
+        _mockEventAggregator.Verify(
+            x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
+                n.IpAddress == TestIpAddress && n.MemberKey == null)),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Can_Publish_Logout_Success_Notification()
+    {
+        // arrange
+        var memberKey = Guid.NewGuid();
+        var sut = CreateSut();
+        var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
+
+        _memberManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(fakeUser);
+
+        // act
+        await sut.SignOutAsync();
+
+        // assert
+        _mockEventAggregator.Verify(
+            x => x.Publish(It.Is<MemberLogoutSuccessNotification>(n =>
+                n.IpAddress == TestIpAddress && n.MemberKey == memberKey)),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Cannot_Publish_Logout_Notification_When_User_Not_Found()
+    {
+        // arrange
+        var sut = CreateSut();
+
+        // GetUserAsync returns null by default on the fresh mock.
+
+        // act
+        await sut.SignOutAsync();
+
+        // assert
+        _mockEventAggregator.Verify(
+            x => x.Publish(It.IsAny<MemberLogoutSuccessNotification>()),
+            Times.Never);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/MemberSignInManagerTests.cs
@@ -87,7 +87,7 @@ public class MemberSignInManagerTests
             _mockIpResolver.Object);
     }
 
-    private static Mock<MemberManager> MockMemberManager()
+    private static Mock<MemberManager> MockMemberManager(IEventAggregator? eventAggregator = null)
         => new(
             Mock.Of<IIpResolver>(),
             Mock.Of<IMemberUserStore>(),
@@ -101,7 +101,8 @@ public class MemberSignInManagerTests
             new TestOptionsSnapshot<MemberPasswordConfigurationSettings>(new MemberPasswordConfigurationSettings()),
             Mock.Of<IPublicAccessService>(),
             Mock.Of<IHttpContextAccessor>(),
-            Mock.Of<IPublishedModelFactory>());
+            Mock.Of<IPublishedModelFactory>(),
+            eventAggregator ?? Mock.Of<IEventAggregator>());
 
     [Test]
     public async Task
@@ -172,13 +173,33 @@ public class MemberSignInManagerTests
     }
 
     [Test]
+    public async Task Can_Publish_Login_Failed_Notification_When_Password_Wrong()
+    {
+        // arrange
+        var memberKey = Guid.NewGuid();
+        var sut = CreateSut();
+        var fakeUser = new MemberIdentityUser(777) { UserName = "TestUser", Key = memberKey };
+
+        // act
+        await sut.PasswordSignInAsync(fakeUser, "wrong_password", false, false);
+
+        // assert
+        _mockEventAggregator.Verify(
+            x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
+                n.IpAddress == TestIpAddress
+                && n.MemberKey == memberKey
+                && n.Reason == MemberLoginFailedReason.InvalidCredentials)),
+            Times.Once);
+    }
+
+    [Test]
     public async Task Can_Publish_Login_Failed_Notification_When_User_Not_Found()
     {
         // arrange
         var sut = CreateSut();
 
         // FindByNameAsync returns null by default on the fresh mock, so the
-        // string overload of PasswordSignInAsync will call HandleSignIn with a null user.
+        // string overload of PasswordSignInAsync calls HandleSignIn with a null user.
 
         // act
         await sut.PasswordSignInAsync("nonexistent_user", "password", false, false);
@@ -186,7 +207,9 @@ public class MemberSignInManagerTests
         // assert
         _mockEventAggregator.Verify(
             x => x.Publish(It.Is<MemberLoginFailedNotification>(n =>
-                n.IpAddress == TestIpAddress && n.MemberKey == null)),
+                n.IpAddress == TestIpAddress
+                && n.MemberKey == null
+                && n.Reason == MemberLoginFailedReason.MemberNotFound)),
             Times.Once);
     }
 


### PR DESCRIPTION
## Summary

- Adds `MemberLoginSuccessNotification`, `MemberLoginFailedNotification`, and `MemberLogoutSuccessNotification` notification classes with a `MemberNotification` base class in `Umbraco.Core`
- Overrides `HandleSignIn` in `MemberSignInManager` to publish login success/failure notifications, following the same pattern as `BackOfficeSignInManager`
- Overrides `SignOutAsync` in `MemberSignInManager` to publish logout notifications

This achieves parity with the existing backoffice user authentication notifications (`UserLoginSuccessNotification`, `UserLoginFailedNotification`, `UserLogoutSuccessNotification`) which are published by `BackOfficeSignInManager` but had no member equivalents.

### Motivation

Packages and implementors need to react to member authentication events. For example, Umbraco Commerce needs to assign an open order to a member when they sign in, but currently there is no notification to listen to.

## Test plan

- [ ] Verify `MemberLoginSuccessNotification` is published on successful member login via `UmbLoginController`
- [ ] Verify `MemberLoginFailedNotification` is published on failed member login attempt
- [ ] Verify `MemberLogoutSuccessNotification` is published on member logout via `UmbLoginStatusController`
- [ ] Verify notifications are published for external login flows via `UmbExternalLoginController`
- [ ] Verify notifications are published for 2FA sign-in completion
- [ ] Verify notifications are published for Delivery API member auth flows
- [ ] Verify existing `MemberTwoFactorRequestedNotification` still works as before
- [ ] Verify backoffice user notifications are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)