### PR TITLE
Media Collection: Display upload notifications in rows rather than in columns (closes #21502)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
@@ -264,8 +264,9 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 				display: flex;
 				flex-direction: column;
 				flex-wrap: wrap;
-				place-items: center;
+				place-items: start;
 				cursor: pointer;
+				margin: var(--uui-size-space-5) 0;
 			}
 
 			:host([disabled]) #dropzone {
@@ -301,7 +302,7 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 
 			#uploader {
 				display: flex;
-				flex-direction: column;
+				flex-direction: row;
 				flex-wrap: wrap;
 				align-items: center;
 				gap: var(--uui-size-space-3);


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes [Notifications about uploaded media taking up too much space #21502](https://github.com/umbraco/Umbraco-CMS/issues/21502)

### Description
Swapping from flex column to row, to free up space on the page

<img width="949" height="581" alt="image" src="https://github.com/user-attachments/assets/efeec75c-3b6d-47c1-a3b0-2c744cb6ba67" />

### Steps to reproduce 
Upload multiple images.
The list of notifications is growing 

<!-- Thanks for contributing to Umbraco CMS! -->
