### PR TITLE
Entity Service: Batch GetAllPaths queries to avoid SQL Server parameter limit (closes #22470)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
@@ -510,7 +510,10 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     /// <returns>An <see cref="IEnumerable{TreeEntityPath}"/> containing the paths of the matching entities.</returns>
     public IEnumerable<TreeEntityPath> GetAllPaths(Guid objectType, params int[]? ids) =>
         ids?.Any() ?? false
-            ? PerformGetAllPaths(objectType, sql => sql.WhereIn<NodeDto>(x => x.NodeId, ids.Distinct()))
+            ? ids.Distinct().SelectByGroups(
+                group => PerformGetAllPaths(objectType, sql => sql.WhereIn<NodeDto>(x => x.NodeId, group)),
+                Constants.Sql.MaxParameterCount)
+                .ToList()
             : PerformGetAllPaths(objectType);
 
     /// <summary>
@@ -521,7 +524,10 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     /// <returns>An enumerable of <see cref="Umbraco.Cms.Core.Models.TreeEntityPath"/> representing the entity paths.</returns>
     public IEnumerable<TreeEntityPath> GetAllPaths(Guid objectType, params Guid[] keys) =>
         keys.Any()
-            ? PerformGetAllPaths(objectType, sql => sql.WhereIn<NodeDto>(x => x.UniqueId, keys.Distinct()))
+            ? keys.Distinct().SelectByGroups(
+                group => PerformGetAllPaths(objectType, sql => sql.WhereIn<NodeDto>(x => x.UniqueId, group)),
+                Constants.Sql.MaxParameterCount)
+                .ToList()
             : PerformGetAllPaths(objectType);
 
     private IEnumerable<TreeEntityPath> PerformGetAllPaths(Guid objectType, Action<Sql<ISqlContext>>? filter = null)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceGetAllPathsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceGetAllPathsTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+[TestFixture]
+[Category("Slow")]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class EntityServiceGetAllPathsTests : UmbracoIntegrationTest
+{
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private ITemplateService TemplateService => GetRequiredService<ITemplateService>();
+
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IEntityRepository EntityRepository => GetRequiredService<IEntityRepository>();
+
+    private ICoreScopeProvider CoreScopeProvider => GetRequiredService<ICoreScopeProvider>();
+
+    [Test]
+    [Explicit("Slow test that requires LocalDb to reproduce the SQL Server 2100 parameter limit. Run manually to verify the batching fix.")]
+    public async Task GetAllPaths_By_Ids_Returns_All_Paths_In_Batches()
+    {
+        // Create enough content items to exceed SQL Server's hard limit of 2100 parameters,
+        // which is above Constants.Sql.MaxParameterCount (2000). Without batching, the
+        // WhereIn clause will fail with "The incoming request has too many parameters".
+        //
+        // NOTE: SQLite does not enforce a parameter limit, so this test verifies functional
+        // correctness on SQLite and will catch the SQL Server regression when run with LocalDb.
+        const int sqlServerParameterLimit = 2100;
+        var itemCount = sqlServerParameterLimit + 10;
+
+        var contentType = await CreateContentType();
+
+        var root = ContentBuilder.CreateSimpleContent(contentType);
+        ContentService.Save(root);
+
+        var ids = new List<int>();
+        for (var i = 0; i < itemCount; i++)
+        {
+            var child = ContentBuilder.CreateSimpleContent(contentType, $"Item {i}", root);
+            ContentService.Save(child);
+            ids.Add(child.Id);
+        }
+
+        // Use a manually-managed scope so the SQL error surfaces directly
+        // rather than being masked by autoComplete scope disposal.
+        using ICoreScope scope = CoreScopeProvider.CreateCoreScope();
+
+        var objectTypeGuid = Constants.ObjectTypes.Document;
+        TreeEntityPath[]? paths = null;
+
+        // This should not throw SqlException "too many parameters".
+        Assert.DoesNotThrow(() =>
+            paths = EntityRepository.GetAllPaths(objectTypeGuid, ids.ToArray()).ToArray());
+
+        Assert.IsNotNull(paths);
+        Assert.AreEqual(ids.Count, paths!.Length, "Should return a path for every requested ID.");
+        foreach (var id in ids)
+        {
+            Assert.IsTrue(paths.Any(p => p.Id == id), $"Missing path for ID {id}");
+        }
+
+        scope.Complete();
+    }
+
+    [Test]
+    [Explicit("Slow test that requires LocalDb to reproduce the SQL Server 2100 parameter limit. Run manually to verify the batching fix.")]
+    public async Task GetAllPaths_By_Keys_Returns_All_Paths_In_Batches()
+    {
+        // Same verification as the ID-based test but for the Guid key overload.
+        const int sqlServerParameterLimit = 2100;
+        var itemCount = sqlServerParameterLimit + 10;
+
+        var contentType = await CreateContentType();
+
+        var root = ContentBuilder.CreateSimpleContent(contentType);
+        ContentService.Save(root);
+
+        var keys = new List<Guid>();
+        for (var i = 0; i < itemCount; i++)
+        {
+            var child = ContentBuilder.CreateSimpleContent(contentType, $"Item {i}", root);
+            ContentService.Save(child);
+            keys.Add(child.Key);
+        }
+
+        using ICoreScope scope = CoreScopeProvider.CreateCoreScope();
+
+        var objectTypeGuid = Constants.ObjectTypes.Document;
+        TreeEntityPath[]? paths = null;
+
+        // This should not throw SqlException "too many parameters".
+        Assert.DoesNotThrow(() =>
+            paths = EntityRepository.GetAllPaths(objectTypeGuid, keys.ToArray()).ToArray());
+
+        Assert.IsNotNull(paths);
+        Assert.AreEqual(keys.Count, paths!.Length, "Should return a path for every requested key.");
+        foreach (var key in keys)
+        {
+            Assert.IsTrue(paths.Any(p => p.Key == key), $"Missing path for key {key}");
+        }
+
+        scope.Complete();
+    }
+
+    private async Task<ContentType> CreateContentType()
+    {
+        var template = TemplateBuilder.CreateTextPageTemplate("defaultTemplate");
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        var contentType = ContentTypeBuilder.CreateSimpleContentType("umbTextpage", "Textpage", defaultTemplateId: template.Id);
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        return contentType;
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
@@ -1160,68 +1160,6 @@ internal sealed class EntityServiceTests : UmbracoIntegrationTest
         Assert.IsTrue(result[4].Key == children[6].Key);
     }
 
-    [Test]
-    public void GetAllPaths_By_Ids_Returns_All_Paths_In_Batches()
-    {
-        // Create enough content items to span multiple batches when retrieved by IDs.
-        // We use a count slightly above a single batch size to verify the batching logic
-        // aggregates results from multiple groups correctly.
-        const int batchSize = Constants.Sql.MaxParameterCount;
-        var itemCount = batchSize + 10;
-
-        var contentType = ContentTypeService.Get("umbTextpage");
-
-        var root = ContentBuilder.CreateSimpleContent(contentType);
-        ContentService.Save(root);
-
-        var ids = new List<int>();
-        for (var i = 0; i < itemCount; i++)
-        {
-            var child = ContentBuilder.CreateSimpleContent(contentType, $"Item {i}", root);
-            ContentService.Save(child);
-            ids.Add(child.Id);
-        }
-
-        // Retrieve all paths by IDs - this should batch internally and return all results.
-        TreeEntityPath[] paths = EntityService.GetAllPaths(UmbracoObjectTypes.Document, ids.ToArray()).ToArray();
-
-        Assert.AreEqual(ids.Count, paths.Length, "Should return a path for every requested ID.");
-        foreach (var id in ids)
-        {
-            Assert.IsTrue(paths.Any(p => p.Id == id), $"Missing path for ID {id}");
-        }
-    }
-
-    [Test]
-    public void GetAllPaths_By_Keys_Returns_All_Paths_In_Batches()
-    {
-        // Same verification as the ID-based test but for the Guid key overload.
-        const int batchSize = Constants.Sql.MaxParameterCount;
-        var itemCount = batchSize + 10;
-
-        var contentType = ContentTypeService.Get("umbTextpage");
-
-        var root = ContentBuilder.CreateSimpleContent(contentType);
-        ContentService.Save(root);
-
-        var keys = new List<Guid>();
-        for (var i = 0; i < itemCount; i++)
-        {
-            var child = ContentBuilder.CreateSimpleContent(contentType, $"Item {i}", root);
-            ContentService.Save(child);
-            keys.Add(child.Key);
-        }
-
-        // Retrieve all paths by keys - this should batch internally and return all results.
-        TreeEntityPath[] paths = EntityService.GetAllPaths(UmbracoObjectTypes.Document, keys.ToArray()).ToArray();
-
-        Assert.AreEqual(keys.Count, paths.Length, "Should return a path for every requested key.");
-        foreach (var key in keys)
-        {
-            Assert.IsTrue(paths.Any(p => p.Key == key), $"Missing path for key {key}");
-        }
-    }
-
     private List<Content> CreateDocumentSiblingsTestData(int count = 10)
     {
         var contentType = ContentTypeService.Get("umbTextpage");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/EntityServiceTests.cs
@@ -1160,6 +1160,68 @@ internal sealed class EntityServiceTests : UmbracoIntegrationTest
         Assert.IsTrue(result[4].Key == children[6].Key);
     }
 
+    [Test]
+    public void GetAllPaths_By_Ids_Returns_All_Paths_In_Batches()
+    {
+        // Create enough content items to span multiple batches when retrieved by IDs.
+        // We use a count slightly above a single batch size to verify the batching logic
+        // aggregates results from multiple groups correctly.
+        const int batchSize = Constants.Sql.MaxParameterCount;
+        var itemCount = batchSize + 10;
+
+        var contentType = ContentTypeService.Get("umbTextpage");
+
+        var root = ContentBuilder.CreateSimpleContent(contentType);
+        ContentService.Save(root);
+
+        var ids = new List<int>();
+        for (var i = 0; i < itemCount; i++)
+        {
+            var child = ContentBuilder.CreateSimpleContent(contentType, $"Item {i}", root);
+            ContentService.Save(child);
+            ids.Add(child.Id);
+        }
+
+        // Retrieve all paths by IDs - this should batch internally and return all results.
+        TreeEntityPath[] paths = EntityService.GetAllPaths(UmbracoObjectTypes.Document, ids.ToArray()).ToArray();
+
+        Assert.AreEqual(ids.Count, paths.Length, "Should return a path for every requested ID.");
+        foreach (var id in ids)
+        {
+            Assert.IsTrue(paths.Any(p => p.Id == id), $"Missing path for ID {id}");
+        }
+    }
+
+    [Test]
+    public void GetAllPaths_By_Keys_Returns_All_Paths_In_Batches()
+    {
+        // Same verification as the ID-based test but for the Guid key overload.
+        const int batchSize = Constants.Sql.MaxParameterCount;
+        var itemCount = batchSize + 10;
+
+        var contentType = ContentTypeService.Get("umbTextpage");
+
+        var root = ContentBuilder.CreateSimpleContent(contentType);
+        ContentService.Save(root);
+
+        var keys = new List<Guid>();
+        for (var i = 0; i < itemCount; i++)
+        {
+            var child = ContentBuilder.CreateSimpleContent(contentType, $"Item {i}", root);
+            ContentService.Save(child);
+            keys.Add(child.Key);
+        }
+
+        // Retrieve all paths by keys - this should batch internally and return all results.
+        TreeEntityPath[] paths = EntityService.GetAllPaths(UmbracoObjectTypes.Document, keys.ToArray()).ToArray();
+
+        Assert.AreEqual(keys.Count, paths.Length, "Should return a path for every requested key.");
+        foreach (var key in keys)
+        {
+            Assert.IsTrue(paths.Any(p => p.Key == key), $"Missing path for key {key}");
+        }
+    }
+
     private List<Content> CreateDocumentSiblingsTestData(int count = 10)
     {
         var contentType = ContentTypeService.Get("umbTextpage");


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/22470 identifies a repository method that uses `WHERE IN (...)` where we need to retrieve in groups to avoid risking exceeding SQL Servers maximum parameter count.

Both overloads (by `int[]` IDs and `Guid[]` keys) now batch using `SelectByGroups` with `Constants.Sql.MaxParameterCount`, matching the fix pattern from other PRs such as #22340.

Added explicit integration tests in a dedicated test class that verify batched retrieval works for both overloads

## Testing

This fix can be verified by running the two new integration tests: `EntityServiceGetAllPathsTests.GetAllPaths_By_Ids_Returns_All_Paths_In_Batches` and `EntityServiceGetAllPathsTests.GetAllPaths_By_Keys_Returns_All_Paths_In_Batches`.  Both tests fail without the fix when run against SQL Server (LocalDb).

I've marked both tests as explicit as they take a while to run and, beyond verifying this fix, we don't need them running on the pipeline.