### PR TITLE
Build: Extract nbgv version step into shared template

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -188,16 +188,9 @@ stages:
             parameters:
               nodeVersion: ${{ variables.nodeVersion }}
               npm_config_cache: ${{ variables.npm_config_cache }}
-          - bash: |
-              echo "##[command]Install nbgv"
-              dotnet tool install --tool-path . nbgv
-              echo "##[command]Running nbgv get-version"
-              PACKAGE_VERSION=$(nbgv get-version -v NpmPackageVersion)
-              echo "##[command]Running npm version"
-              echo "##[debug]Version: $PACKAGE_VERSION"
-              cd tests/Umbraco.Tests.AcceptanceTest
-              npm version $PACKAGE_VERSION --allow-same-version --no-git-tag-version
-            displayName: Set NPM Version
+          - template: templates/set-npm-version.yml
+            parameters:
+              workingDirectory: tests/Umbraco.Tests.AcceptanceTest
           - bash: |
               echo "##[command]Running npm pack"
               mkdir $(Build.ArtifactStagingDirectory)/npm-testhelpers

--- a/build/templates/backoffice-install.yml
+++ b/build/templates/backoffice-install.yml
@@ -6,16 +6,9 @@ steps:
       versionSource: 'fromFile'
       versionFilePath: src/Umbraco.Web.UI.Client/.nvmrc
 
-  - bash: |
-      echo "##[command]Install nbgv"
-      dotnet tool install --tool-path . nbgv
-      echo "##[command]Running nbgv get-version"
-      PACKAGE_VERSION=$(nbgv get-version -v NpmPackageVersion)
-      echo "##[command]Running npm version"
-      echo "##[debug]Version: $PACKAGE_VERSION"
-      cd src/Umbraco.Web.UI.Client
-      npm version $PACKAGE_VERSION --allow-same-version --no-git-tag-version
-    displayName: Set NPM Version
+  - template: set-npm-version.yml
+    parameters:
+      workingDirectory: src/Umbraco.Web.UI.Client
 
   - task: Cache@2
     displayName: Cache node_modules

--- a/build/templates/set-npm-version.yml
+++ b/build/templates/set-npm-version.yml
@@ -1,0 +1,15 @@
+parameters:
+  - name: workingDirectory
+    type: string
+
+steps:
+  - bash: |
+      echo "##[command]Install nbgv"
+      dotnet tool install --tool-path . nbgv
+      echo "##[command]Running nbgv get-version"
+      PACKAGE_VERSION=$(nbgv get-version -v NpmPackageVersion)
+      echo "##[command]Running npm version"
+      echo "##[debug]Version: $PACKAGE_VERSION"
+      cd ${{ parameters.workingDirectory }}
+      npm version $PACKAGE_VERSION --allow-same-version --no-git-tag-version
+    displayName: Set NPM Version


### PR DESCRIPTION
## Description
The "Install nbgv → set NPM version" bash step was duplicated in `build/azure-pipelines.yml` and `build/templates/backoffice-install.yml`. Extracted it into a new shared template `build/templates/set-npm-version.yml` parameterised by
  `workingDirectory`, and updated both callsites to use it.
## Test plan
  - [ ] CI passes on this PR
  - [ ] `Set NPM Version` step still resolves the same version at both callsites
