### PR TITLE
Add GetUsersByKey

### DIFF
--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -305,7 +305,7 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
-    IEnumerable<IUser> GetUsersByKey(params Guid[]? keys);
+    IEnumerable<IUser> GetUsersByKey(params Guid[]? keys) => throw new NotImplementedException();
 
     /// <summary>
     ///     Removes a specific section from all user groups

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -296,7 +296,7 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
-    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
+    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     IEnumerable<IUser> GetUsersById(params int[]? ids);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -296,7 +296,6 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
-    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     IEnumerable<IUser> GetUsersById(params int[]? ids);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -296,7 +296,17 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
+    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
     IEnumerable<IUser> GetUsersById(params int[]? ids);
+
+    /// <summary>
+    ///     Gets a users by Key
+    /// </summary>
+    /// <param name="keys">Keys of the users to retrieve</param>
+    /// <returns>
+    ///     <see cref="IUser" />
+    /// </returns>
+    IEnumerable<IUser> GetUsersByKey(params Guid[]? keys);
 
     /// <summary>
     ///     Removes a specific section from all user groups

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1802,7 +1802,6 @@ internal partial class UserService : RepositoryService, IUserService
     }
 
     /// <inheritdoc/>
-    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     public IEnumerable<IUser> GetUsersById(params int[]? ids)
     {
         using IServiceScope scope = _serviceScopeFactory.CreateScope();

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1802,12 +1802,22 @@ internal partial class UserService : RepositoryService, IUserService
     }
 
     /// <inheritdoc/>
+    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
     public IEnumerable<IUser> GetUsersById(params int[]? ids)
     {
         using IServiceScope scope = _serviceScopeFactory.CreateScope();
         IBackOfficeUserStore backOfficeUserStore = scope.ServiceProvider.GetRequiredService<IBackOfficeUserStore>();
 
         return backOfficeUserStore.GetUsersAsync(ids).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<IUser> GetUsersByKey(params Guid[]? keys)
+    {
+        using IServiceScope scope = _serviceScopeFactory.CreateScope();
+        IBackOfficeUserStore backOfficeUserStore = scope.ServiceProvider.GetRequiredService<IBackOfficeUserStore>();
+
+        return backOfficeUserStore.GetUsersAsync(keys).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1802,7 +1802,7 @@ internal partial class UserService : RepositoryService, IUserService
     }
 
     /// <inheritdoc/>
-    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
+    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     public IEnumerable<IUser> GetUsersById(params int[]? ids)
     {
         using IServiceScope scope = _serviceScopeFactory.CreateScope();


### PR DESCRIPTION
### Description
I have added the GetUsersByKey method so that users can be retrieved by keys instead of IDs. This can be very convenient in certain cases.

Additionally, I have marked GetUsersById as obsolete. I’m not entirely sure if this is desirable, but as far as I know, the preference is to work as much as possible with GUIDs instead of integers.

For this reason, it is also a breaking change, and I have chosen v18/dev as the target branch. Please let me know whether this is indeed desirable or not. 😄 

