### PR TITLE
Migrations: Fix `RetrustForeignKeyAndCheckConstraints` failing when data violates a constraint

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NPoco;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Infrastructure.Persistence;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_3_0;
@@ -18,12 +20,21 @@ public class RetrustForeignKeyAndCheckConstraints : AsyncMigrationBase
     /// Initializes a new instance of the <see cref="RetrustForeignKeyAndCheckConstraints"/> class.
     /// </summary>
     /// <param name="context">The migration context.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 18.")]
+    public RetrustForeignKeyAndCheckConstraints(IMigrationContext context)
+        : this(
+            context,
+            StaticServiceProvider.Instance.GetRequiredService<IUmbracoDatabaseFactory>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetrustForeignKeyAndCheckConstraints"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
     /// <param name="databaseFactory">The database factory used to create separate connections for constraint validation.</param>
     public RetrustForeignKeyAndCheckConstraints(IMigrationContext context, IUmbracoDatabaseFactory databaseFactory)
-        : base(context)
-    {
-        _databaseFactory = databaseFactory;
-    }
+        : base(context) => _databaseFactory = databaseFactory;
 
     /// <inheritdoc />
     protected override Task MigrateAsync()
@@ -71,24 +82,23 @@ public class RetrustForeignKeyAndCheckConstraints : AsyncMigrationBase
 
         Logger.LogInformation("Found {Count} untrusted constraint(s) to re-trust.", untrustedConstraints.Count);
 
+        // ALTER TABLE ... WITH CHECK CHECK CONSTRAINT is executed on a separate database connection
+        // to isolate failures from the migration scope's transaction. When constraint validation fails
+        // (e.g. orphaned FK rows), the error can zombie the .NET SqlTransaction even when caught by
+        // T-SQL TRY...CATCH, because the transaction state change propagates through the TDS (Tabular
+        // Data Stream) protocol layer that underlies SQL Server client-server communication.
+        // Using a separate connection (which has no explicit transaction) avoids this entirely —
+        // TRY...CATCH works correctly and no SqlException is thrown to the .NET layer.
         var retrusted = 0;
         var failed = 0;
 
+        using IUmbracoDatabase db = _databaseFactory.CreateDatabase();
+        EnsureLongCommandTimeout(db);
+
         foreach (UntrustedConstraintDto constraint in untrustedConstraints)
         {
-            // Each ALTER TABLE ... WITH CHECK CHECK CONSTRAINT is executed on a separate database
-            // connection to isolate failures. When constraint validation fails (e.g. orphaned FK rows),
-            // the error can zombie the .NET SqlTransaction even when caught by T-SQL TRY...CATCH,
-            // because the transaction state change propagates through the TDS (Tabular Data Stream)
-            // protocol layer that underlies SQL Server client-server communication.
-            // Using a separate connection (which has no explicit transaction) avoids this entirely —
-            // TRY...CATCH works correctly and no SqlException is thrown to the .NET layer.
-            //
             // Leading semicolon prevents NPoco's auto-select from prepending
             // "SELECT ... FROM []" based on the empty [TableName("")] attribute.
-            using IUmbracoDatabase db = _databaseFactory.CreateDatabase();
-            db.CommandTimeout = 300;
-
             var sql = $@";
 BEGIN TRY
     ALTER TABLE [{constraint.SchemaName}].[{constraint.TableName}] WITH CHECK CHECK CONSTRAINT [{constraint.ConstraintName}];

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_3_0/RetrustForeignKeyAndCheckConstraints.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 using NPoco;
-using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_3_0;
 
@@ -12,13 +12,17 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_3_0;
 /// </summary>
 public class RetrustForeignKeyAndCheckConstraints : AsyncMigrationBase
 {
+    private readonly IUmbracoDatabaseFactory _databaseFactory;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RetrustForeignKeyAndCheckConstraints"/> class.
     /// </summary>
     /// <param name="context">The migration context.</param>
-    public RetrustForeignKeyAndCheckConstraints(IMigrationContext context)
+    /// <param name="databaseFactory">The database factory used to create separate connections for constraint validation.</param>
+    public RetrustForeignKeyAndCheckConstraints(IMigrationContext context, IUmbracoDatabaseFactory databaseFactory)
         : base(context)
     {
+        _databaseFactory = databaseFactory;
     }
 
     /// <inheritdoc />
@@ -67,19 +71,24 @@ public class RetrustForeignKeyAndCheckConstraints : AsyncMigrationBase
 
         Logger.LogInformation("Found {Count} untrusted constraint(s) to re-trust.", untrustedConstraints.Count);
 
-        // Ensure we have a long command timeout, in case the migration targets a huge table.
-        EnsureLongCommandTimeout(Database);
-
         var retrusted = 0;
         var failed = 0;
 
         foreach (UntrustedConstraintDto constraint in untrustedConstraints)
         {
-            // Use T-SQL TRY...CATCH to handle errors at the SQL level. This prevents a constraint
-            // validation failure from dooming the .NET SqlTransaction, which would cause all
-            // subsequent operations to fail with "This SqlTransaction has completed".
+            // Each ALTER TABLE ... WITH CHECK CHECK CONSTRAINT is executed on a separate database
+            // connection to isolate failures. When constraint validation fails (e.g. orphaned FK rows),
+            // the error can zombie the .NET SqlTransaction even when caught by T-SQL TRY...CATCH,
+            // because the transaction state change propagates through the TDS (Tabular Data Stream)
+            // protocol layer that underlies SQL Server client-server communication.
+            // Using a separate connection (which has no explicit transaction) avoids this entirely —
+            // TRY...CATCH works correctly and no SqlException is thrown to the .NET layer.
+            //
             // Leading semicolon prevents NPoco's auto-select from prepending
             // "SELECT ... FROM []" based on the empty [TableName("")] attribute.
+            using IUmbracoDatabase db = _databaseFactory.CreateDatabase();
+            db.CommandTimeout = 300;
+
             var sql = $@";
 BEGIN TRY
     ALTER TABLE [{constraint.SchemaName}].[{constraint.TableName}] WITH CHECK CHECK CONSTRAINT [{constraint.ConstraintName}];
@@ -89,7 +98,7 @@ BEGIN CATCH
     SELECT CAST(0 AS BIT) AS Success, ERROR_MESSAGE() AS ErrorMessage;
 END CATCH";
 
-            RetrustResultDto result = Database.Single<RetrustResultDto>(sql);
+            RetrustResultDto result = db.Single<RetrustResultDto>(sql);
 
             if (result.Success)
             {


### PR DESCRIPTION
## Description

This fixes the `RetrustForeignKeyAndCheckConstraints` migration step which has been shown to break the upgrade when existing data violates a foreign key or check constraint.

The migration was introduced in 17.3 to re-trust untrusted constraints (where `is_not_trusted = 1`) so the SQL Server query optimizer can use them for join elimination and cardinality estimation. When all constraints pass validation this works fine, but when a constraint fails validation (e.g. orphaned FK rows from a previous bug), the upgrade crashes with:

```
System.InvalidOperationException: This SqlTransaction has completed; it is no longer usable.
```

### Root cause

The original code executed `ALTER TABLE ... WITH CHECK CHECK CONSTRAINT` on the migration scope's database connection, which has an active .NET `SqlTransaction`. Although a SQL level TRY...CATCH was in place, when validation fails, the constraint violation error zombies the `SqlTransaction` at the TDS (Tabular Data Stream) protocol layer — the transaction state change propagates to the .NET `SqlClient` before T-SQL error handling can contain it. Once the transaction is zombied:

1. `context.Complete()` (which writes the migration state via `IKeyValueService`) fails because it uses the same dead transaction.
2. `scope.Complete()` is never reached.
3. Scope disposal tries to roll back the already-dead transaction → `"This SqlTransaction has completed"` exception.
4. The migration state is not saved.

### Fix

Each `ALTER TABLE ... WITH CHECK CHECK CONSTRAINT` now executes on a **separate database connection** created via `IUmbracoDatabaseFactory`. This connection operates in SQL Server's autocommit mode (no explicit `SqlTransaction`), which means:

- T-SQL `TRY...CATCH` fully contains the error — no `SqlException` is thrown to .NET.
- The migration scope's own transaction is never touched, so `context.Complete()` and `scope.Complete()` succeed.
- Constraints that pass validation are re-trusted; those that fail are logged as warnings and skipped.


## Testing

**Setup** — create a constraint violation database before upgrading:

```sql
-- Disable the FK so we can insert orphaned data
ALTER TABLE [dbo].[umbracoRelation] NOCHECK CONSTRAINT [FK_umbracoRelation_umbracoNode];

-- Insert a relation pointing to a non-existent node
INSERT INTO [dbo].[umbracoRelation] (parentId, childId, relType, [datetime], comment)
VALUES (
    999999,
    (SELECT TOP 1 id FROM [dbo].[umbracoNode]),
    (SELECT TOP 1 id FROM [dbo].[umbracoRelationType]),
    GETDATE(),
    '')

-- Re-enable the FK without validating existing data (leaves it untrusted)
ALTER TABLE [dbo].[umbracoRelation] WITH NOCHECK CHECK CONSTRAINT [FK_umbracoRelation_umbracoNode];

-- Verify it shows as untrusted
SELECT name, is_not_trusted
FROM sys.foreign_keys
WHERE name = 'FK_umbracoRelation_umbracoNode';
-- Expected: is_not_trusted = 1
```

```sql
-- Try to check the constraint - this is expected to report an error of:
-- The ALTER TABLE statement conflicted with the FOREIGN KEY 
-- constraint "FK_umbracoRelation_umbracoNode".
ALTER TABLE [dbo].[umbracoRelation] WITH CHECK CHECK CONSTRAINT [FK_umbracoRelation_umbracoNode];
```

**Test 1 — upgrade completes without crashing:**

Revert the database to the migration step prior to the `RetrustForeignKeyAndCheckConstraints` step:

```sql
UPDATE umbracoKeyValue
SET value = '{A7B8C9D0-E1F2-4A5B-8C7D-9E0F1A2B3C4D}'
WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
```

1. Start up the site using a build containing this fix.
2. Verify the site starts successfully.
3. Check logs for `"Constraint re-trust complete: X succeeded, Y failed out of Z total."`. Expect at least one failure.
4. Verify a WARNING (not an exception stack trace) is logged for the violated constraint.

**Test 2 — clean constraints are re-trusted:**

Check which constraints are still untrusted after upgrade.  Its expected that only the intentionally violated FK remains untrusted.

```sql
-- Check which constraints are still untrusted after upgrade
SELECT 'FK' AS Type, name, OBJECT_NAME(parent_object_id) AS TableName, is_not_trusted
FROM sys.foreign_keys
WHERE is_not_trusted = 1
  AND (OBJECT_NAME(parent_object_id) LIKE 'umbraco%' OR OBJECT_NAME(parent_object_id) LIKE 'cms%')
UNION ALL
SELECT 'CK', name, OBJECT_NAME(parent_object_id), is_not_trusted
FROM sys.check_constraints
WHERE is_not_trusted = 1
  AND (OBJECT_NAME(parent_object_id) LIKE 'umbraco%' OR OBJECT_NAME(parent_object_id) LIKE 'cms%');
-- Expected: only the intentionally violated FK remains untrusted
```

Remove the orphaned data:

```sql
DELETE FROM [dbo].[umbracoRelation] WHERE [parentId] = 999999;
```

Revert the database again to the migration step prior to the `RetrustForeignKeyAndCheckConstraints` step:

```sql
UPDATE umbracoKeyValue
SET value = '{A7B8C9D0-E1F2-4A5B-8C7D-9E0F1A2B3C4D}'
WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
```

Start up the application again and confirm the migration succeeds.

You should see an information log message of:

```
Constraint re-trust complete: 1 succeeded, 0 failed out of 1 total.
```

Verify that the constraint is now trusted (expect `is_not_trusted = 0`)

```sql
SELECT name, is_not_trusted FROM sys.foreign_keys WHERE name = 'FK_umbracoRelation_umbracoNode';
```