### PR TITLE
Parameterise variables in SqliteSyntaxProvider and SqlServerSyntaxProvider

### DIFF
--- a/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/Services/SqlServerSyntaxProvider.cs
@@ -282,7 +282,7 @@ where tbl.[name]=@0 and col.[name]=@1;",
 
     public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
-        IEnumerable<SqlPrimaryKey>? keys = db.Fetch<SqlPrimaryKey>($"select * from sysobjects where xtype='pk' and  parent_obj in (select id from sysobjects where name='{tableName}')")
+        IEnumerable<SqlPrimaryKey>? keys = db.Fetch<SqlPrimaryKey>("select * from sysobjects where xtype='pk' and parent_obj in (select id from sysobjects where name=@0)", tableName)
             .Where(x => x.Name == primaryKeyName);
         return keys.FirstOrDefault() is not null;
     }

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -213,7 +213,7 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
     /// <inheritdoc />
     public override bool DoesPrimaryKeyExist(IDatabase db, string tableName, string primaryKeyName)
     {
-        IEnumerable<string> items = db.Fetch<string>($"select sql from sqlite_master where type = 'table' and name = '{tableName}'")
+        IEnumerable<string> items = db.Fetch<string>("select sql from sqlite_master where type = 'table' and name = @0", tableName)
             .Where(x => x.Contains($"CONSTRAINT {primaryKeyName} PRIMARY KEY"));
 
         return items.Any();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/SyntaxProvider/DoesPrimaryKeyExistTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/SyntaxProvider/DoesPrimaryKeyExistTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Expressions.Create;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.SyntaxProvider;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewEmptyPerTest)]
+internal sealed class DoesPrimaryKeyExistTests : UmbracoIntegrationTest
+{
+    [Test]
+    public void Can_Detect_Existing_Primary_Key()
+    {
+        var factory = GetRequiredService<IUmbracoDatabaseFactory>();
+        var database = factory.CreateDatabase();
+
+        var builder = GetBuilder(database);
+        builder.Table("foo")
+            .WithColumn("id").AsInt32().PrimaryKey("PK_foo")
+            .Do();
+
+        var result = database.SqlContext.SqlSyntax.DoesPrimaryKeyExist(database, "foo", "PK_foo");
+
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void Cannot_Detect_Non_Existing_Primary_Key()
+    {
+        var factory = GetRequiredService<IUmbracoDatabaseFactory>();
+        var database = factory.CreateDatabase();
+
+        var builder = GetBuilder(database);
+        builder.Table("foo")
+            .WithColumn("id").AsInt32().PrimaryKey("PK_foo")
+            .Do();
+
+        var result = database.SqlContext.SqlSyntax.DoesPrimaryKeyExist(database, "foo", "PK_does_not_exist");
+
+        Assert.IsFalse(result);
+    }
+
+    private CreateBuilder GetBuilder(IUmbracoDatabase db)
+    {
+        var logger = GetRequiredService<ILogger<MigrationContext>>();
+        var ctx = new MigrationContext(new TestPlan(), db, logger);
+        return new CreateBuilder(ctx);
+    }
+
+    private class TestPlan : MigrationPlan
+    {
+        public TestPlan()
+            : base("test-plan")
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below


### Description

- `SqliteSyntaxProvider` and `SqlServerSyntaxProvider` included non-parameterised SQL statements
- Updated each so that the statements are parameterised

In its current implementation, a caller to `DoesPrimaryKeyExist` could pass a crafted SQL statement into the `tableName` variable, and receive SQL Exceptions, including schema details and data.  I discussed this with Anders in ticket `90879238`, and we agreed that this is a low-risk issue, since any user who can call `DoesPrimaryKeyExist` can also just directly execute SQL commands against the db. To help with defense-in-depth hardening though, it's worth a PR to parameterise these vars.  

There's steps to reproduce and test this inside of that ticket if needed.

<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->




<!-- Thanks for contributing to Umbraco CMS! -->
