### PR TITLE
Output Caching: Evict cached documents when a related element is published

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/Caching/DeliveryApiElementOutputCacheEvictionHandler.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Caching/DeliveryApiElementOutputCacheEvictionHandler.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Web.Common.Caching;
+
+namespace Umbraco.Cms.Api.Delivery.Caching;
+
+/// <summary>
+///     Handles <see cref="ElementCacheRefresherNotification"/> to evict Delivery API output cache entries
+///     for content that references the changed element via picker properties (umbElement relations).
+/// </summary>
+internal sealed class DeliveryApiElementOutputCacheEvictionHandler
+    : RelationOutputCacheEvictionHandlerBase, INotificationAsyncHandler<ElementCacheRefresherNotification>
+{
+    private readonly ILogger<DeliveryApiElementOutputCacheEvictionHandler> _logger;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="DeliveryApiElementOutputCacheEvictionHandler"/> class.
+    /// </summary>
+    /// <param name="outputCacheStore">The output cache store for evicting cached responses.</param>
+    /// <param name="relationService">The relation service for querying entity references.</param>
+    /// <param name="idKeyMap">The ID/key mapping service for converting between integer IDs and GUIDs.</param>
+    /// <param name="logger">The logger.</param>
+    public DeliveryApiElementOutputCacheEvictionHandler(
+        IOutputCacheStore outputCacheStore,
+        IRelationService relationService,
+        IIdKeyMap idKeyMap,
+        ILogger<DeliveryApiElementOutputCacheEvictionHandler> logger)
+        : base(outputCacheStore, relationService, idKeyMap)
+        => _logger = logger;
+
+    /// <inheritdoc />
+    public async Task HandleAsync(ElementCacheRefresherNotification notification, CancellationToken cancellationToken)
+    {
+        if (notification.MessageType != MessageType.RefreshByPayload
+            || notification.MessageObject is not ElementCacheRefresher.JsonPayload[] payloads)
+        {
+            return;
+        }
+
+        foreach (ElementCacheRefresher.JsonPayload payload in payloads)
+        {
+            if (payload.ChangeTypes.HasFlag(TreeChangeTypes.RefreshAll))
+            {
+                // Evict all Delivery API responses — content responses may include referenced elements,
+                // so evicting only element-related entries would leave stale element references in content responses.
+                _logger.LogDebug("Element refresh all — evicting all Delivery API output cache entries.");
+                await OutputCacheStore.EvictByTagAsync(Constants.DeliveryApi.OutputCache.AllTag, cancellationToken);
+                return;
+            }
+        }
+
+        // Evict content that references the changed elements via picker properties.
+        await EvictRelatedContentAsync(
+            payloads.Select(p => p.Id),
+            Constants.Conventions.RelationTypes.RelatedElementAlias,
+            Constants.DeliveryApi.OutputCache.ContentTagPrefix,
+            _logger,
+            cancellationToken);
+    }
+}

--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -151,6 +151,7 @@ public static class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<ContentCacheRefresherNotification, DeliveryApiDocumentOutputCacheEvictionHandler>();
         builder.AddNotificationAsyncHandler<MediaCacheRefresherNotification, DeliveryApiMediaOutputCacheEvictionHandler>();
         builder.AddNotificationAsyncHandler<MemberCacheRefresherNotification, DeliveryApiMemberOutputCacheEvictionHandler>();
+        builder.AddNotificationAsyncHandler<ElementCacheRefresherNotification, DeliveryApiElementOutputCacheEvictionHandler>();
 
         // Register extension point default implementations.
         builder.Services.AddSingleton<IDeliveryApiOutputCacheTagProvider, DeliveryApiContentTypeOutputCacheTagProvider>();

--- a/src/Umbraco.Web.Website/Caching/WebsiteElementOutputCacheEvictionHandler.cs
+++ b/src/Umbraco.Web.Website/Caching/WebsiteElementOutputCacheEvictionHandler.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Cms.Core.Sync;
+
+namespace Umbraco.Cms.Web.Website.Caching;
+
+/// <summary>
+///     Handles <see cref="ElementCacheRefresherNotification"/> to evict output cache entries
+///     for pages that reference the changed element via picker properties.
+/// </summary>
+internal sealed class WebsiteElementOutputCacheEvictionHandler
+    : RelationOutputCacheEvictionHandlerBase, INotificationAsyncHandler<ElementCacheRefresherNotification>
+{
+    private readonly ILogger<WebsiteElementOutputCacheEvictionHandler> _logger;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="WebsiteElementOutputCacheEvictionHandler"/> class.
+    /// </summary>
+    public WebsiteElementOutputCacheEvictionHandler(
+        IOutputCacheStore outputCacheStore,
+        IRelationService relationService,
+        IIdKeyMap idKeyMap,
+        ILogger<WebsiteElementOutputCacheEvictionHandler> logger)
+        : base(outputCacheStore, relationService, idKeyMap)
+        => _logger = logger;
+
+    /// <inheritdoc />
+    public async Task HandleAsync(ElementCacheRefresherNotification notification, CancellationToken cancellationToken)
+    {
+        if (notification.MessageType != MessageType.RefreshByPayload
+            || notification.MessageObject is not ElementCacheRefresher.JsonPayload[] payloads)
+        {
+            return;
+        }
+
+        foreach (ElementCacheRefresher.JsonPayload payload in payloads)
+        {
+            if (payload.ChangeTypes.HasFlag(TreeChangeTypes.RefreshAll))
+            {
+                _logger.LogDebug("Element refresh all — evicting all website output cache entries.");
+                await OutputCacheStore.EvictByTagAsync(Constants.Website.OutputCache.AllContentTag, cancellationToken);
+                return;
+            }
+        }
+
+        // Evict documents that reference the changed elements via picker properties.
+        await EvictRelatedPagesAsync(
+            payloads.Select(p => p.Id),
+            Constants.Conventions.RelationTypes.RelatedElementAlias,
+            _logger,
+            cancellationToken);
+    }
+}

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -128,6 +128,7 @@ public static partial class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<ContentCacheRefresherNotification, WebsiteDocumentOutputCacheEvictionHandler>();
         builder.AddNotificationAsyncHandler<MediaCacheRefresherNotification, WebsiteMediaOutputCacheEvictionHandler>();
         builder.AddNotificationAsyncHandler<MemberCacheRefresherNotification, WebsiteMemberOutputCacheEvictionHandler>();
+        builder.AddNotificationAsyncHandler<ElementCacheRefresherNotification, WebsiteElementOutputCacheEvictionHandler>();
         builder.Services.AddSingleton<IWebsiteOutputCacheTagProvider, WebsiteContentTypeOutputCacheTagProvider>();
         builder.Services.AddUnique<IWebsiteOutputCacheDurationProvider, DefaultWebsiteOutputCacheDurationProvider>();
         builder.Services.AddUnique<IWebsiteOutputCacheRequestFilter, DefaultWebsiteOutputCacheRequestFilter>();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Caching/DeliveryApiElementOutputCacheEvictionHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Caching/DeliveryApiElementOutputCacheEvictionHandlerTests.cs
@@ -1,0 +1,130 @@
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Delivery.Caching;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Cms.Core.Sync;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Delivery.Caching;
+
+[TestFixture]
+public class DeliveryApiElementOutputCacheEvictionHandlerTests
+{
+    private Mock<IOutputCacheStore> _storeMock = null!;
+    private Mock<IRelationService> _relationServiceMock = null!;
+    private Mock<IIdKeyMap> _idKeyMapMock = null!;
+    private DeliveryApiElementOutputCacheEvictionHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _storeMock = new Mock<IOutputCacheStore>();
+        _storeMock
+            .Setup(s => s.EvictByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        _relationServiceMock = new Mock<IRelationService>();
+        _relationServiceMock
+            .Setup(r => r.GetByChildId(It.IsAny<int>(), It.IsAny<string>()))
+            .Returns(Enumerable.Empty<IRelation>());
+
+        _idKeyMapMock = new Mock<IIdKeyMap>();
+
+        _handler = new DeliveryApiElementOutputCacheEvictionHandler(
+            _storeMock.Object,
+            _relationServiceMock.Object,
+            _idKeyMapMock.Object,
+            NullLogger<DeliveryApiElementOutputCacheEvictionHandler>.Instance);
+    }
+
+    [Test]
+    public async Task HandleAsync_RefreshAll_EvictsAllTag()
+    {
+        var notification = CreateNotification(new ElementCacheRefresher.JsonPayload(1, Guid.NewGuid(), TreeChangeTypes.RefreshAll));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        // RefreshAll evicts everything because content responses may reference elements.
+        _storeMock.Verify(
+            s => s.EvictByTagAsync("umb-dapi-all", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_EvictsDocumentsReferencingChangedElement()
+    {
+        const int elementId = 10;
+        const int parentDocumentId = 20;
+        var parentDocumentKey = Guid.NewGuid();
+
+        var relation = new Mock<IRelation>();
+        relation.Setup(r => r.ParentId).Returns(parentDocumentId);
+
+        _relationServiceMock
+            .Setup(r => r.GetByChildId(elementId, Constants.Conventions.RelationTypes.RelatedElementAlias))
+            .Returns(new[] { relation.Object });
+
+        _idKeyMapMock
+            .Setup(m => m.GetKeyForId(parentDocumentId, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(parentDocumentKey));
+
+        var notification = CreateNotification(new ElementCacheRefresher.JsonPayload(elementId, Guid.NewGuid(), TreeChangeTypes.RefreshNode));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        _storeMock.Verify(
+            s => s.EvictByTagAsync($"umb-dapi-content-{parentDocumentKey}", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenNoRelations_DoesNotEvict()
+    {
+        var notification = CreateNotification(new ElementCacheRefresher.JsonPayload(10, Guid.NewGuid(), TreeChangeTypes.RefreshNode));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        _storeMock.Verify(
+            s => s.EvictByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_DeduplicatesParentDocuments()
+    {
+        const int parentDocumentId = 20;
+        var parentDocumentKey = Guid.NewGuid();
+
+        var relation = new Mock<IRelation>();
+        relation.Setup(r => r.ParentId).Returns(parentDocumentId);
+
+        // Both elements reference the same parent document.
+        _relationServiceMock
+            .Setup(r => r.GetByChildId(It.IsAny<int>(), Constants.Conventions.RelationTypes.RelatedElementAlias))
+            .Returns(new[] { relation.Object });
+
+        _idKeyMapMock
+            .Setup(m => m.GetKeyForId(parentDocumentId, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(parentDocumentKey));
+
+        var notification = CreateNotification(
+            new ElementCacheRefresher.JsonPayload(10, Guid.NewGuid(), TreeChangeTypes.RefreshNode),
+            new ElementCacheRefresher.JsonPayload(11, Guid.NewGuid(), TreeChangeTypes.RefreshNode));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        // Parent should only be evicted once despite being referenced by both elements.
+        _storeMock.Verify(
+            s => s.EvictByTagAsync($"umb-dapi-content-{parentDocumentKey}", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static ElementCacheRefresherNotification CreateNotification(params ElementCacheRefresher.JsonPayload[] payloads)
+        => new(payloads, MessageType.RefreshByPayload);
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Caching/WebsiteElementOutputCacheEvictionHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Caching/WebsiteElementOutputCacheEvictionHandlerTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Web.Website.Caching;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Caching;
+
+[TestFixture]
+public class WebsiteElementOutputCacheEvictionHandlerTests
+{
+    private Mock<IOutputCacheStore> _storeMock = null!;
+    private Mock<IRelationService> _relationServiceMock = null!;
+    private Mock<IIdKeyMap> _idKeyMapMock = null!;
+    private WebsiteElementOutputCacheEvictionHandler _handler = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _storeMock = new Mock<IOutputCacheStore>();
+        _storeMock
+            .Setup(s => s.EvictByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        _relationServiceMock = new Mock<IRelationService>();
+        _relationServiceMock
+            .Setup(r => r.GetByChildId(It.IsAny<int>(), It.IsAny<string>()))
+            .Returns(Enumerable.Empty<IRelation>());
+
+        _idKeyMapMock = new Mock<IIdKeyMap>();
+
+        _handler = new WebsiteElementOutputCacheEvictionHandler(
+            _storeMock.Object,
+            _relationServiceMock.Object,
+            _idKeyMapMock.Object,
+            NullLogger<WebsiteElementOutputCacheEvictionHandler>.Instance);
+    }
+
+    [Test]
+    public async Task HandleAsync_RefreshAll_EvictsAllContentTag()
+    {
+        var notification = CreateNotification(new ElementCacheRefresher.JsonPayload(1, Guid.NewGuid(), TreeChangeTypes.RefreshAll));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        _storeMock.Verify(
+            s => s.EvictByTagAsync("umb-content-all", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_EvictsDocumentsReferencingChangedElement()
+    {
+        const int elementId = 10;
+        const int parentDocumentId = 20;
+        var parentDocumentKey = Guid.NewGuid();
+
+        var relation = new Mock<IRelation>();
+        relation.Setup(r => r.ParentId).Returns(parentDocumentId);
+
+        _relationServiceMock
+            .Setup(r => r.GetByChildId(elementId, Constants.Conventions.RelationTypes.RelatedElementAlias))
+            .Returns(new[] { relation.Object });
+
+        _idKeyMapMock
+            .Setup(m => m.GetKeyForId(parentDocumentId, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(parentDocumentKey));
+
+        var notification = CreateNotification(new ElementCacheRefresher.JsonPayload(elementId, Guid.NewGuid(), TreeChangeTypes.RefreshNode));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        _storeMock.Verify(
+            s => s.EvictByTagAsync($"umb-content-{parentDocumentKey}", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_WhenNoRelations_DoesNotEvict()
+    {
+        var notification = CreateNotification(new ElementCacheRefresher.JsonPayload(10, Guid.NewGuid(), TreeChangeTypes.RefreshNode));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        _storeMock.Verify(
+            s => s.EvictByTagAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_DeduplicatesParentDocuments()
+    {
+        const int parentDocumentId = 20;
+        var parentDocumentKey = Guid.NewGuid();
+
+        var relation = new Mock<IRelation>();
+        relation.Setup(r => r.ParentId).Returns(parentDocumentId);
+
+        // Both elements reference the same parent document.
+        _relationServiceMock
+            .Setup(r => r.GetByChildId(It.IsAny<int>(), Constants.Conventions.RelationTypes.RelatedElementAlias))
+            .Returns(new[] { relation.Object });
+
+        _idKeyMapMock
+            .Setup(m => m.GetKeyForId(parentDocumentId, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(parentDocumentKey));
+
+        var notification = CreateNotification(
+            new ElementCacheRefresher.JsonPayload(10, Guid.NewGuid(), TreeChangeTypes.RefreshNode),
+            new ElementCacheRefresher.JsonPayload(11, Guid.NewGuid(), TreeChangeTypes.RefreshNode));
+
+        await _handler.HandleAsync(notification, CancellationToken.None);
+
+        // Parent should only be evicted once despite being referenced by both elements.
+        _storeMock.Verify(
+            s => s.EvictByTagAsync($"umb-content-{parentDocumentKey}", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static ElementCacheRefresherNotification CreateNotification(params ElementCacheRefresher.JsonPayload[] payloads)
+        => new(payloads, MessageType.RefreshByPayload);
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Extends the relation-based output cache eviction introduced in #22338 and #22456 to cover **elements**, a new content entity type in Umbraco 18.

When a document references an element via a picker property, Umbraco tracks this as an `umbElement` relation. Previously, publishing that element would not evict the referencing document from the output cache, leaving stale responses. This PR adds eviction handlers for both the Delivery API and Website output caches, following the same pattern already in place for documents (`umbDocument`), media (`umbMedia`), and members (`umbMember`).

#### What changed

- **`DeliveryApiElementOutputCacheEvictionHandler`** — handles `ElementCacheRefresherNotification` to evict Delivery API output cache entries for content referencing the changed element.
- **`WebsiteElementOutputCacheEvictionHandler`** — same for the website output cache.
- Both handlers are registered in their respective `AddOutputCache()` DI methods alongside the existing media and member handlers.
- Unit tests for both handlers (8 tests total).

When `RefreshAll` is flagged in the element payload, all cached content is evicted (matching the media handler pattern), since any document could reference any element.

### Manual testing steps

#### Website output cache

1. Create an element type with a text property, and a document type with an element picker property.
2. Create and publish a document that picks an element via the element picker.
3. In the document's template, render the current date/time (e.g. `@DateTime.Now`) alongside the element property value.
4. Enable website output caching in `appsettings.json`:
   ```json
   {
     "Umbraco": {
       "CMS": {
         "Website": {
           "OutputCache": {
             "Enabled": true,
             "ContentDuration": "00:01:00"
           }
         }
       }
     }
   }
   ```
5. Visit the page — note the rendered date/time.
6. Refresh — the date/time should remain unchanged (served from cache).
7. Edit and publish the picked element.
8. Refresh the page — the date/time should update, confirming the cached response was evicted.

#### Delivery API output cache

1. Using the same setup, enable Delivery API output caching:
   ```json
   {
     "Umbraco": {
       "CMS": {
         "DeliveryApi": {
           "Enabled": true,
           "PublicAccess": true,
           "OutputCache": {
             "Enabled": true,
             "ContentDuration": "00:01:00"
           }
         }
       }
     }
   }
   ```
2. Request the document via the Delivery API (e.g. `GET /umbraco/delivery/api/v2/content/item/{path}`).
3. Note the `Age` response header — it starts at `0` and increases on subsequent requests while the response is cached.
4. Edit and publish the picked element.
5. Request the same endpoint — the `Age` header should reset to `0`, confirming the cached response was evicted.