### PR TITLE
Dependencies: Update minor and patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,32 +13,32 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.6" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
   </ItemGroup>
   <!-- Umbraco packages -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.JsonSchema.Extensions" Version="0.3.0" />
+    <PackageVersion Include="Umbraco.JsonSchema.Extensions" Version="0.4.0" />
   </ItemGroup>
   <!-- Third-party packages -->
   <ItemGroup>
@@ -50,7 +50,7 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-    <PackageVersion Include="MailKit" Version="4.15.1" />
+    <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="Markdig" Version="0.45.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
@@ -59,9 +59,9 @@
     <PackageVersion Include="ncrontab" Version="3.4.0" />
     <PackageVersion Include="NPoco" Version="6.2.0" />
     <PackageVersion Include="NPoco.SqlServer" Version="6.2.0" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.2.0" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="7.4.0" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.4.0" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.4.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
@@ -77,7 +77,7 @@
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.2.0" />
     <!-- When updating this version, also update templates/UmbracoExtension/Umbraco.Extension.csproj -->
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
   <!-- Transitive pinned versions (only required because our direct dependencies have vulnerable versions of transitive dependencies) -->
   <ItemGroup>

--- a/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
+++ b/src/Umbraco.Infrastructure/Mail/BasicSmtpEmailSenderClient.cs
@@ -30,7 +30,7 @@ namespace Umbraco.Cms.Infrastructure.Mail
             using var client = new SmtpClient();
 
             await client.ConnectAsync(
-                _globalSettings.Smtp!.Host,
+                _globalSettings.Smtp!.Host!,
                 _globalSettings.Smtp.Port,
                 (SecureSocketOptions)(int)_globalSettings.Smtp.SecureSocketOptions);
 

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.6" />
     <!--
     Added the following direct dependency due to Microsoft.EntityFrameworkCore.Design having a dependency on an insecure version.
     Review for removal when Microsoft.EntityFrameworkCore.Design is updated to a newer version.

--- a/templates/UmbracoExtension/Umbraco.Extension.csproj
+++ b/templates/UmbracoExtension/Umbraco.Extension.csproj
@@ -45,7 +45,7 @@
       Most other transitive dependencies don't have this problem because extension code doesn't
       use their types directly - only Swashbuckle/OpenApi types are referenced in the composer.
     -->
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageReference Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
   </ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,12 +5,12 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="10.0.4" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.4" />
+    <PackageVersion Include="System.Data.Odbc" Version="10.0.6" />
+    <PackageVersion Include="System.Data.OleDb" Version="10.0.6" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageVersion Include="System.Data.Odbc" Version="10.0.6" />
     <PackageVersion Include="System.Data.OleDb" Version="10.0.6" />


### PR DESCRIPTION
## Description

For the upcoming build of 17.4, this PR updates all NuGet dependencies to their latest minor/patch versions.

I had to add null-forgiving operator on `SmtpSettings.Host` in `BasicSmtpEmailSenderClient` to fix build error introduced by MailKit 4.16.0 tightening nullable annotations on `SmtpClient.ConnectAsync` (the call site is guarded upstream by `GlobalSettings.IsSmtpServerConfigured` which checks `!string.IsNullOrWhiteSpace(Smtp?.Host)`)

| Package | From | To |
|---------|------|----|
| Microsoft.Extensions.* (19 packages) | 10.0.4 | 10.0.6 |
| Microsoft.EntityFrameworkCore.* | 10.0.4 | 10.0.6 |
| OpenIddict.* | 7.2.0 | 7.4.0 |
| MailKit | 4.15.1 | 4.16.0 |
| Swashbuckle.AspNetCore | 10.1.4 | 10.1.7 |
| Microsoft.Extensions.Caching.Hybrid | 10.4.0 | 10.5.0 |
| Umbraco.JsonSchema.Extensions | 0.3.0 | 0.4.0 |
