### PR TITLE
Backoffice Identity: Add `Override` method to `IBackOfficeSecurityAccessor` for background processing

### DIFF
--- a/src/Umbraco.Core/Security/IBackofficeSecurityAccessor.cs
+++ b/src/Umbraco.Core/Security/IBackofficeSecurityAccessor.cs
@@ -17,7 +17,7 @@ public interface IBackOfficeSecurityAccessor
     ///     of the returned scope. Disposing the scope clears the override.
     /// </summary>
     /// <remarks>
-    ///     This is intended for background processing scenarios  where no HTTP context is available
+    ///     This is intended for background processing scenarios where no HTTP context is available
     ///     but CMS code still needs a backoffice identity.
     /// </remarks>
     /// <param name="backOfficeSecurity">The identity to use for the duration of the scope.</param>

--- a/src/Umbraco.Core/Security/IBackofficeSecurityAccessor.cs
+++ b/src/Umbraco.Core/Security/IBackofficeSecurityAccessor.cs
@@ -1,12 +1,29 @@
 namespace Umbraco.Cms.Core.Security;
 
 /// <summary>
-///     Provides access to the <see cref="IBackOfficeSecurity" /> instance for the current request.
+///     Provides access to the <see cref="IBackOfficeSecurity" /> instance for the current request
+///     or ambient async context.
 /// </summary>
 public interface IBackOfficeSecurityAccessor
 {
     /// <summary>
-    ///     Gets the <see cref="IBackOfficeSecurity" /> instance for the current request.
+    ///     Gets the <see cref="IBackOfficeSecurity" /> instance for the current request or async context.
     /// </summary>
     IBackOfficeSecurity? BackOfficeSecurity { get; }
+
+    /// <summary>
+    ///     Sets an ambient <see cref="IBackOfficeSecurity" /> override for the current async flow.
+    ///     The override takes precedence over the HTTP-context-based resolution for the lifetime
+    ///     of the returned scope. Disposing the scope clears the override.
+    /// </summary>
+    /// <remarks>
+    ///     This is intended for background processing scenarios  where no HTTP context is available
+    ///     but CMS code still needs a backoffice identity.
+    /// </remarks>
+    /// <param name="backOfficeSecurity">The identity to use for the duration of the scope.</param>
+    /// <returns>An <see cref="IDisposable" /> that clears the override when disposed.</returns>
+    IDisposable Override(IBackOfficeSecurity backOfficeSecurity)
+        => throw new NotImplementedException(
+            "This implementation does not support ambient identity overrides. "
+            + "Ensure you are using an implementation that supports background processing.");
 }

--- a/src/Umbraco.Web.Common/Security/BackOfficeSecurityAccessor.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeSecurityAccessor.cs
@@ -4,8 +4,15 @@ using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Web.Common.Security;
 
+/// <summary>
+///     Default <see cref="IBackOfficeSecurityAccessor" /> implementation that resolves the
+///     backoffice identity from the current HTTP context's request services, with support for
+///     <see cref="AsyncLocal{T}" />-based overrides for background processing scenarios
+///     where no HTTP context is available.
+/// </summary>
 public class BackOfficeSecurityAccessor : IBackOfficeSecurityAccessor
 {
+    private static readonly AsyncLocal<IBackOfficeSecurity?> _ambientOverride = new();
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     /// <summary>
@@ -17,7 +24,28 @@ public class BackOfficeSecurityAccessor : IBackOfficeSecurityAccessor
     /// <summary>
     ///     Gets the current <see cref="IBackOfficeSecurity" /> object.
     /// </summary>
-    // RequestServices can be null when testing, even though compiler says it can't
+    /// <remarks>
+    ///     Returns the ambient override if one has been set for the current async flow via
+    ///     <see cref="Override" />, otherwise resolves from the HTTP context's request services.
+    ///     RequestServices can be null when testing, even though compiler says it can't.
+    /// </remarks>
     public IBackOfficeSecurity? BackOfficeSecurity
-        => _httpContextAccessor.HttpContext?.RequestServices?.GetService<IBackOfficeSecurity>();
+        => _ambientOverride.Value
+           ?? _httpContextAccessor.HttpContext?.RequestServices?.GetService<IBackOfficeSecurity>();
+
+    /// <inheritdoc />
+    public IDisposable Override(IBackOfficeSecurity backOfficeSecurity)
+    {
+        _ambientOverride.Value = backOfficeSecurity;
+        return new OverrideScope();
+    }
+
+    /// <summary>
+    ///     Disposable scope that clears the <see cref="AsyncLocal{T}" />-based ambient override
+    ///     for the current async flow when disposed.
+    /// </summary>
+    private sealed class OverrideScope : IDisposable
+    {
+        public void Dispose() => _ambientOverride.Value = null;
+    }
 }

--- a/src/Umbraco.Web.Common/Security/BackOfficeSecurityAccessor.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeSecurityAccessor.cs
@@ -36,16 +36,23 @@ public class BackOfficeSecurityAccessor : IBackOfficeSecurityAccessor
     /// <inheritdoc />
     public IDisposable Override(IBackOfficeSecurity backOfficeSecurity)
     {
+        ArgumentNullException.ThrowIfNull(backOfficeSecurity);
+
+        IBackOfficeSecurity? previous = _ambientOverride.Value;
         _ambientOverride.Value = backOfficeSecurity;
-        return new OverrideScope();
+        return new OverrideScope(previous);
     }
 
     /// <summary>
-    ///     Disposable scope that clears the <see cref="AsyncLocal{T}" />-based ambient override
-    ///     for the current async flow when disposed.
+    ///     Disposable scope that restores the previous <see cref="AsyncLocal{T}" />-based ambient
+    ///     override for the current async flow when disposed, supporting nested overrides.
     /// </summary>
     private sealed class OverrideScope : IDisposable
     {
-        public void Dispose() => _ambientOverride.Value = null;
+        private readonly IBackOfficeSecurity? _previous;
+
+        public OverrideScope(IBackOfficeSecurity? previous) => _previous = previous;
+
+        public void Dispose() => _ambientOverride.Value = _previous;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/BackOfficeSecurityAccessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/BackOfficeSecurityAccessorTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Web.Common.Security;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Security;
+
+[TestFixture]
+public class BackOfficeSecurityAccessorTests
+{
+    [Test]
+    public void BackOfficeSecurity_NoOverride_NoHttpContext_ReturnsNull()
+    {
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == null);
+        var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
+
+        Assert.That(accessor.BackOfficeSecurity, Is.Null);
+    }
+
+    [Test]
+    public void BackOfficeSecurity_NoOverride_DelegatesToHttpContext()
+    {
+        var expected = Mock.Of<IBackOfficeSecurity>();
+        var httpContext = new DefaultHttpContext();
+        var services = new Mock<IServiceProvider>();
+        services.Setup(s => s.GetService(typeof(IBackOfficeSecurity))).Returns(expected);
+        httpContext.RequestServices = services.Object;
+
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
+        var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
+
+        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(expected));
+    }
+
+    [Test]
+    public void Override_SetsAmbientValue()
+    {
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == null);
+        var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
+        var overrideSecurity = Mock.Of<IBackOfficeSecurity>();
+
+        using var scope = accessor.Override(overrideSecurity);
+
+        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
+    }
+
+    [Test]
+    public void Override_TakesPrecedenceOverHttpContext()
+    {
+        var httpContextSecurity = Mock.Of<IBackOfficeSecurity>();
+        var httpContext = new DefaultHttpContext();
+        var services = new Mock<IServiceProvider>();
+        services.Setup(s => s.GetService(typeof(IBackOfficeSecurity))).Returns(httpContextSecurity);
+        httpContext.RequestServices = services.Object;
+
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
+        var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
+
+        var overrideSecurity = Mock.Of<IBackOfficeSecurity>();
+        using var scope = accessor.Override(overrideSecurity);
+
+        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
+    }
+
+    [Test]
+    public void Override_Dispose_ClearsAmbientValue()
+    {
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == null);
+        var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
+        var overrideSecurity = Mock.Of<IBackOfficeSecurity>();
+
+        var scope = accessor.Override(overrideSecurity);
+        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
+
+        scope.Dispose();
+        Assert.That(accessor.BackOfficeSecurity, Is.Null);
+    }
+
+    [Test]
+    public void Override_Dispose_FallsBackToHttpContext()
+    {
+        var httpContextSecurity = Mock.Of<IBackOfficeSecurity>();
+        var httpContext = new DefaultHttpContext();
+        var services = new Mock<IServiceProvider>();
+        services.Setup(s => s.GetService(typeof(IBackOfficeSecurity))).Returns(httpContextSecurity);
+        httpContext.RequestServices = services.Object;
+
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
+        var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
+
+        var overrideSecurity = Mock.Of<IBackOfficeSecurity>();
+        var scope = accessor.Override(overrideSecurity);
+
+        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
+
+        scope.Dispose();
+
+        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(httpContextSecurity));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/BackOfficeSecurityAccessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Security/BackOfficeSecurityAccessorTests.cs
@@ -73,10 +73,11 @@ public class BackOfficeSecurityAccessorTests
         var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
         var overrideSecurity = Mock.Of<IBackOfficeSecurity>();
 
-        var scope = accessor.Override(overrideSecurity);
-        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
+        using (var scope = accessor.Override(overrideSecurity))
+        {
+            Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
+        }
 
-        scope.Dispose();
         Assert.That(accessor.BackOfficeSecurity, Is.Null);
     }
 
@@ -93,12 +94,33 @@ public class BackOfficeSecurityAccessorTests
         var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
 
         var overrideSecurity = Mock.Of<IBackOfficeSecurity>();
-        var scope = accessor.Override(overrideSecurity);
-
-        Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
-
-        scope.Dispose();
+        using (var scope = accessor.Override(overrideSecurity))
+        {
+            Assert.That(accessor.BackOfficeSecurity, Is.SameAs(overrideSecurity));
+        }
 
         Assert.That(accessor.BackOfficeSecurity, Is.SameAs(httpContextSecurity));
+    }
+
+    [Test]
+    public void Override_Nested_InnerDispose_RestoresOuter()
+    {
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == null);
+        var accessor = new BackOfficeSecurityAccessor(httpContextAccessor);
+
+        var outerSecurity = Mock.Of<IBackOfficeSecurity>();
+        var innerSecurity = Mock.Of<IBackOfficeSecurity>();
+
+        using (var outerScope = accessor.Override(outerSecurity))
+        {
+            Assert.That(accessor.BackOfficeSecurity, Is.SameAs(outerSecurity));
+
+            using (var innerScope = accessor.Override(innerSecurity))
+            {
+                Assert.That(accessor.BackOfficeSecurity, Is.SameAs(innerSecurity));
+            }
+
+            Assert.That(accessor.BackOfficeSecurity, Is.SameAs(outerSecurity));
+        }
     }
 }


### PR DESCRIPTION
## Description

Adds an `Override` method to `IBackOfficeSecurityAccessor` that allows packages and hosted services to set an ambient backoffice identity for the current async flow. This is needed for background processing scenarios where no `HttpContext` is available but CMS code still needs to resolve a backoffice user.

### Motivation

This was identified while reviewing [umbraco/Umbraco.Automate#23](https://github.com/umbraco/Umbraco.Automate/pull/23), which needs to set a service account identity during automation action execution. Without a CMS extension point, that PR has to manually decorate `IBackOfficeSecurityAccessor` in the DI container — removing the original registration, wrapping it in a custom decorator, and re-adding it. More work and potentially fragile if other packages do similar, so we thought this would be useful as a core feature.

With this change, the Automate middleware simplifies from ~110 lines of DI decoration code to a single call:

```csharp
using var _ = _backOfficeSecurityAccessor.Override(security);
return await next(context, cancellationToken);
```

## Testing

### Automated

`BackOfficeSecurityAccessor` is now covered by unit tests that verifies the behaviour.

### Manual

To verify end-to-end in a running Umbraco instance, add the following two files and run the site.  They implement a background job that logs the backoffice user that has been applied to the accessor.

<details>
<summary><code>BackOfficeSecurityOverrideComposer.cs</code></summary>

```csharp
using Umbraco.Cms.Core.Composing;

namespace Umbraco.Cms.Web.UI.Custom;

public class BackOfficeSecurityOverrideComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.AddHostedService<BackOfficeSecurityOverrideJob>();
}
```

</details>

<details>
<summary><code>BackOfficeSecurityOverrideJob.cs</code></summary>

```csharp
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Models.Membership;
using Umbraco.Cms.Core.Security;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI.Custom;

public class BackOfficeSecurityOverrideJob : BackgroundService
{
    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
    private readonly IServiceScopeFactory _scopeFactory;
    private readonly ILogger<BackOfficeSecurityOverrideJob> _logger;

    public BackOfficeSecurityOverrideJob(
        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
        IServiceScopeFactory scopeFactory,
        ILogger<BackOfficeSecurityOverrideJob> logger)
    {
        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
        _scopeFactory = scopeFactory;
        _logger = logger;
    }

    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
    {
        await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);

        _logger.LogInformation(
            "[Override Test] BEFORE override — BackOfficeSecurity is {Value}",
            _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Name ?? "(null)");

        using IServiceScope scope = _scopeFactory.CreateScope();
        IUserService userService = scope.ServiceProvider.GetRequiredService<IUserService>();
        IUser? admin = await userService.GetAsync(Constants.Security.SuperUserKey);

        if (admin is null)
        {
            _logger.LogWarning("[Override Test] Super-admin user not found");
            return;
        }

        var security = new SimpleBackOfficeSecurity(admin);
        using (IDisposable _ = _backOfficeSecurityAccessor.Override(security))
        {
            IUser? current = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
            _logger.LogInformation(
                "[Override Test] INSIDE override — CurrentUser is '{Name}' (key: {Key})",
                current?.Name ?? "(null)",
                current?.Key);

            await Task.Delay(100, stoppingToken);

            current = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser;
            _logger.LogInformation(
                "[Override Test] INSIDE override (after await) — CurrentUser is still '{Name}'",
                current?.Name ?? "(null)");
        }

        _logger.LogInformation(
            "[Override Test] AFTER override — BackOfficeSecurity is {Value}",
            _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.Name ?? "(null)");
    }

    private sealed class SimpleBackOfficeSecurity : IBackOfficeSecurity
    {
        public SimpleBackOfficeSecurity(IUser user) => CurrentUser = user;
        public IUser? CurrentUser { get; }
        public bool IsAuthenticated() => true;
        public bool UserHasSectionAccess(string section, IUser user)
            => user.AllowedSections.Contains(section);
    }
}
```

</details>

**Expected log output** (~15 seconds after boot):

```
[Override Test] BEFORE override — BackOfficeSecurity is (null)
[Override Test] INSIDE override — CurrentUser is '<your admin name>' (key: <guid>)
[Override Test] INSIDE override (after await) — CurrentUser is still '<your admin name>'
[Override Test] AFTER override — BackOfficeSecurity is (null)
```

This confirms: no identity outside the scope, identity flows across awaits inside the scope, and dispose clears it.