### PR TITLE
Adds a new GetUsersByKey method to the (I)UserService

### DIFF
--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -305,7 +305,7 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
-    IEnumerable<IUser> GetUsersByKey(params Guid[]? keys);
+    IEnumerable<IUser> GetUsersByKey(params Guid[]? keys) => throw new NotImplementedException();
 
     /// <summary>
     ///     Removes a specific section from all user groups

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -299,7 +299,7 @@ public interface IUserService : IMembershipUserService
     IEnumerable<IUser> GetUsersById(params int[]? ids);
 
     /// <summary>
-    ///     Gets a users by Key
+    ///     Gets users by keys
     /// </summary>
     /// <param name="keys">Keys of the users to retrieve</param>
     /// <returns>

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -296,7 +296,7 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
-    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
+    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     IEnumerable<IUser> GetUsersById(params int[]? ids);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -296,7 +296,6 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
-    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     IEnumerable<IUser> GetUsersById(params int[]? ids);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/IUserService.cs
+++ b/src/Umbraco.Core/Services/IUserService.cs
@@ -296,7 +296,17 @@ public interface IUserService : IMembershipUserService
     /// <returns>
     ///     <see cref="IUser" />
     /// </returns>
+    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
     IEnumerable<IUser> GetUsersById(params int[]? ids);
+
+    /// <summary>
+    ///     Gets a users by Key
+    /// </summary>
+    /// <param name="keys">Keys of the users to retrieve</param>
+    /// <returns>
+    ///     <see cref="IUser" />
+    /// </returns>
+    IEnumerable<IUser> GetUsersByKey(params Guid[]? keys);
 
     /// <summary>
     ///     Removes a specific section from all user groups

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1786,7 +1786,6 @@ internal partial class UserService : RepositoryService, IUserService
     }
 
     /// <inheritdoc/>
-    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     public IEnumerable<IUser> GetUsersById(params int[]? ids)
     {
         using IServiceScope scope = _serviceScopeFactory.CreateScope();

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1786,7 +1786,7 @@ internal partial class UserService : RepositoryService, IUserService
     }
 
     /// <inheritdoc/>
-    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
+    [Obsolete($"Use {nameof(GetUsersByKey)} instead. Scheduled for removal in Umbraco 19.")]
     public IEnumerable<IUser> GetUsersById(params int[]? ids)
     {
         using IServiceScope scope = _serviceScopeFactory.CreateScope();

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1786,12 +1786,22 @@ internal partial class UserService : RepositoryService, IUserService
     }
 
     /// <inheritdoc/>
+    [Obsolete($"{nameof(GetUsersById)} is deprecated and will be removed in Umbraco 19. Use {nameof(GetUsersByKey)} instead.")]
     public IEnumerable<IUser> GetUsersById(params int[]? ids)
     {
         using IServiceScope scope = _serviceScopeFactory.CreateScope();
         IBackOfficeUserStore backOfficeUserStore = scope.ServiceProvider.GetRequiredService<IBackOfficeUserStore>();
 
         return backOfficeUserStore.GetUsersAsync(ids).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<IUser> GetUsersByKey(params Guid[]? keys)
+    {
+        using IServiceScope scope = _serviceScopeFactory.CreateScope();
+        IBackOfficeUserStore backOfficeUserStore = scope.ServiceProvider.GetRequiredService<IBackOfficeUserStore>();
+
+        return backOfficeUserStore.GetUsersAsync(keys).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
### Description
This PR introduces a `GetUsersByKey` method to allow resolving users directly by their GUID keys, which can be useful in scenarios where user references are already available as keys.

To avoid introducing a breaking change, the method is added with a default interface implementation that throws a NotImplementedException. This ensures existing implementations of `IUserService` do not break.

### Related
This PR replaces the earlier attempt targeting v18/dev: https://github.com/umbraco/Umbraco-CMS/pull/22483

The previous PR included a breaking change (obsoleting GetUsersById), which has been removed based on feedback. 