### PR TITLE
Code Quality/Logging: Fix 'occured' -> 'occurred' typos in log/error/comment strings

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
@@ -102,7 +102,7 @@ public class DocumentUrlFactory : IDocumentUrlFactory
 
             if (await _previewService.TryEnterPreviewAsync(currentUser) is false)
             {
-                _logger.LogError("A server error occured, could not initiate an authenticated preview state for the current user.");
+                _logger.LogError("A server error occurred, could not initiate an authenticated preview state for the current user.");
                 return null;
             }
         }

--- a/src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs
@@ -124,7 +124,7 @@ public class IndexPresentationFactory : IIndexPresentationFactory
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "An error occured trying to get the searcher name of index {IndexName}", index.Name);
+            _logger.LogError(e, "An error occurred trying to get the searcher name of index {IndexName}", index.Name);
             name = "Could not determine searcher name because of error.";
             return false;
         }
@@ -139,7 +139,7 @@ public class IndexPresentationFactory : IIndexPresentationFactory
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "An error occured trying to get the document count of index {IndexName}", index.Name);
+            _logger.LogError(e, "An error occurred trying to get the document count of index {IndexName}", index.Name);
             documentCount = 0;
             return false;
         }
@@ -154,7 +154,7 @@ public class IndexPresentationFactory : IIndexPresentationFactory
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "An error occured trying to get the field name count of index {IndexName}", index.Name);
+            _logger.LogError(e, "An error occurred trying to get the field name count of index {IndexName}", index.Name);
             fieldNameCount = 0;
             return false;
         }

--- a/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
+++ b/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/CollectibleRuntimeViewCompiler.cs
@@ -391,7 +391,7 @@ internal sealed class CollectibleRuntimeViewCompiler : IViewCompiler
 
         foreach (var message in messages ?? Enumerable.Empty<string>())
         {
-            _logger.LogError(compilationException, "Compilation error occured with message: {ErrorMessage}", message);
+            _logger.LogError(compilationException, "Compilation error occurred with message: {ErrorMessage}", message);
         }
     }
 

--- a/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
@@ -305,7 +305,7 @@ internal class ExamineIndexRebuilder : IIndexRebuilder
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "An error occured trying to get determine index shouldRebuild status for index {IndexName}. The index will NOT be considered for rebuilding", index.Name);
+            _logger.LogError(e, "An error occurred trying to get determine index shouldRebuild status for index {IndexName}. The index will NOT be considered for rebuilding", index.Name);
             return false;
         }
     }

--- a/src/Umbraco.Web.Common/Preview/UserBasedPreviewTokenGenerator.cs
+++ b/src/Umbraco.Web.Common/Preview/UserBasedPreviewTokenGenerator.cs
@@ -48,7 +48,7 @@ public class UserBasedPreviewTokenGenerator : IPreviewTokenGenerator
         }
         catch (Exception e)
         {
-            _logger.LogDebug(e, "An error occured when trying to get the user from the encrypted token");
+            _logger.LogDebug(e, "An error occurred when trying to get the user from the encrypted token");
         }
 
         return Attempt.Fail<Guid?>(null);

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app-error.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app-error.element.ts
@@ -185,7 +185,7 @@ export class UmbAppErrorElement extends UmbLitElement {
 					<div slot="headline">
 						${this.errorHeadline
 							? this.errorHeadline
-							: html` <umb-localize key="errors_defaultError">An unknown failure has occured</umb-localize> `}
+							: html` <umb-localize key="errors_defaultError">An unknown failure has occurred</umb-localize> `}
 					</div>
 					<div id="message">${this.errorMessage}</div>
 					${this.error

--- a/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts
@@ -205,7 +205,7 @@ export class UmbInputDropzoneElement extends UmbFormControlMixin<UmbUploadableIt
 					)}
 					${when(
 						item.status === UmbFileDropzoneItemStatus.ERROR,
-						() => html`<div class="error">An error occured</div>`,
+						() => html`<div class="error">An error occurred</div>`,
 					)}
 					${when(item.status === UmbFileDropzoneItemStatus.CANCELLED, () => html`<div class="error">Cancelled</div>`)}
 					${when(

--- a/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
+++ b/src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs
@@ -203,9 +203,9 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
     }
 
     /// <summary>
-    ///     Check whether dynamic routing is currently active in an request where no exception has occured.
+    ///     Check whether dynamic routing is currently active in an request where no exception has occurred.
     /// </summary>
-    /// <returns>[true] if dynamic routing is active, [false] if inactive or an exception has occured.</returns>
+    /// <returns>[true] if dynamic routing is active, [false] if inactive or an exception has occurred.</returns>
     private static bool CheckActiveDynamicRoutingAndNoException(HttpContext httpContext)
     {
         // Don't execute if there are already UmbracoRouteValues assigned.
@@ -219,7 +219,7 @@ public class UmbracoRouteValueTransformer : DynamicRouteValueTransformer
             return false;
         }
 
-        // There is dynamic routing active so we have to check whether an exception occured in the current request.
+        // There is dynamic routing active so we have to check whether an exception occurred in the current request.
         // If this is the case we do want dynamic routing since it might be an Umbraco content page which is used as an error page.
         IExceptionHandlerFeature? exceptionHandlerFeature = httpContext.Features.Get<IExceptionHandlerFeature>();
 

--- a/tests/Umbraco.Tests.Integration/Testing/BaseTestDatabase.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/BaseTestDatabase.cs
@@ -116,7 +116,7 @@ public abstract class BaseTestDatabase
             }
             catch (DbException)
             {
-                // Console.Error.WriteLine($"SqlException occured, but we try again {i+1}/{maxIterations}.\n{e}");
+                // Console.Error.WriteLine($"SqlException occurred, but we try again {i+1}/{maxIterations}.\n{e}");
                 // This can occur when there's a transaction deadlock which means (i think) that the database is still in use and hasn't been closed properly yet
                 // so we need to just wait a little bit
                 Thread.Sleep(100 * i);


### PR DESCRIPTION
Fix 14 instances of \`occured\` → \`occurred\` across 9 files.

## Files

| File | Instances | Kind |
|------|-----------|------|
| \`src/Umbraco.Cms.Api.Management/Factories/IndexPresentationFactory.cs\` | 3 | Log messages |
| \`src/Umbraco.Web.Website/Routing/UmbracoRouteValueTransformer.cs\` | 3 | Doc comments |
| \`src/Umbraco.Web.UI.Client/src/apps/app/app-error.element.ts\` | 1 | **User-visible UI text** |
| \`src/Umbraco.Web.UI.Client/src/packages/media/dropzone/components/input-dropzone/input-dropzone.element.ts\` | 1 | **User-visible error UI** |
| \`src/Umbraco.Web.Common/Preview/UserBasedPreviewTokenGenerator.cs\` | 1 | Log message |
| \`src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs\` | 1 | Log message |
| \`src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/CollectibleRuntimeViewCompiler.cs\` | 1 | Log message |
| \`src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs\` | 1 | Log message |
| \`tests/Umbraco.Tests.Integration/Testing/BaseTestDatabase.cs\` | 1 | Inline comment |

**Intentionally NOT changed:** The \`ExceptionOccured\` public property and \`exceptionOccured\` DB column name (introduced in \`AddExceptionOccured\` migration at V_13_0_0) are left as-is to preserve API and database compatibility. Those are documented in `WebhookLog.cs`, `WebhookLogDto.cs`, and `WebhookLogResponseModel.cs` — and referenced in factories — and would require a migration to rename.

Log/comment/UI-string-only change.