### PR TITLE
Tiptap RTE: Fix Clear Formatting errors when HTML attribute extensions aren't enabled (closes #22502)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/clear-formatting/clear-formatting.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/clear-formatting/clear-formatting.tiptap-toolbar-api.ts
@@ -1,8 +1,13 @@
-import type { Editor } from '../../externals.js';
+import type { CommandProps, Editor } from '../../externals.js';
 import { UmbTiptapToolbarElementApiBase } from '../tiptap-toolbar-element-api-base.js';
 
 export default class UmbTiptapToolbarClearFormattingExtensionApi extends UmbTiptapToolbarElementApiBase {
 	override execute(editor?: Editor) {
-		editor?.chain().focus().clearNodes().unsetAllMarks().unsetClassName().unsetStyles().run();
+		const unsetAttrs: (props: CommandProps) => boolean = ({ commands }) => {
+			commands.unsetClassName?.();
+			commands.unsetStyles?.();
+			return true;
+		};
+		editor?.chain().focus()?.clearNodes().unsetAllMarks().command(unsetAttrs).run();
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/clear-formatting/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/clear-formatting/manifests.ts
@@ -5,7 +5,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 		alias: 'Umb.Tiptap.Toolbar.ClearFormatting',
 		name: 'Clear Formatting Tiptap Toolbar Extension',
 		api: () => import('./clear-formatting.tiptap-toolbar-api.js'),
-		forExtensions: ['Umb.Tiptap.HtmlAttributeClass', 'Umb.Tiptap.HtmlAttributeStyle'],
 		meta: {
 			alias: 'clear-formatting',
 			icon: 'icon-clear-formatting',

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/clear-formatting/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/clear-formatting/manifests.ts
@@ -5,6 +5,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		alias: 'Umb.Tiptap.Toolbar.ClearFormatting',
 		name: 'Clear Formatting Tiptap Toolbar Extension',
 		api: () => import('./clear-formatting.tiptap-toolbar-api.js'),
+		forExtensions: ['Umb.Tiptap.HtmlAttributeClass', 'Umb.Tiptap.HtmlAttributeStyle'],
 		meta: {
 			alias: 'clear-formatting',
 			icon: 'icon-clear-formatting',


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #22502

### Description

The "Clear Formatting" toolbar button in the TipTap RTE throws a TypeError on click when the `HtmlAttributeClass` or `HtmlAttributeStyle` extensions are not enabled on the data type:

> `clear-formatting.tiptap-toolbar-api.ts:6 Uncaught TypeError: e?.chain(...).focus(...).clearNodes(...).unsetAllMarks(...).unsetClassName is not a function`

#### Root cause

The "Clear Formatting" toolbar API calls `.unsetClassName()` and `.unsetStyles()` — custom chain commands provided by `Umb.Tiptap.HtmlAttributeClass` and `Umb.Tiptap.HtmlAttributeStyle` respectively. These extensions used to be bundled into "Rich Text Essentials" (guaranteed to be present) but were unbundled into separate opt-in extensions in #20042 (Sep 2025). Users whose saved toolbar still contains "Clear Formatting" after the upgrade — but whose data type doesn''t opt into both underlying extensions — hit the TypeError because the chain commands simply don''t exist.

#### Fix

Invoke `unsetClassName` and `unsetStyles` via a custom Tiptap command using optional chaining on `commands.*`. When the HTML-attribute extensions aren''t registered, those calls silently no-op, while `clearNodes()` and `unsetAllMarks()` (core commands) always run. No manifest dependency is declared — the button stays available regardless of which HTML-attribute extensions are opted into, and degrades gracefully.

#### Behaviour after the fix

- **Users with both HTML-attribute extensions enabled**: no change — button clears nodes, marks, classes and inline styles.
- **Users missing one or both extensions**: button clears nodes and marks; class/style unset steps no-op safely (there''s nothing to clear). No TypeError.

### Testing

1. Create a Data Type using the TipTap Rich Text Editor.
2. Without enabling the `` `class` attributes `` or `` `style` attributes `` extensions, add "Clear Formatting" to the toolbar.
3. Apply formatting to a content item → click Clear Formatting → nodes and marks are cleared, no console errors.
4. Enable the `` `class` attributes `` and `` `style` attributes `` extensions, add classes/inline styles to content → click Clear Formatting → classes and inline styles are also cleared.