### PR TITLE
Trees: Respect 'Ignore user start nodes' on expand (closes #22487)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.test.ts
@@ -1,6 +1,7 @@
 import { UmbTreeItemContextBase } from './tree-item-context-base.js';
+import { UmbDefaultTreeContext } from '../../default/default-tree.context.js';
 import { UMB_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
-import { expect } from '@open-wc/testing';
+import { aTimeout, expect } from '@open-wc/testing';
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
@@ -9,6 +10,10 @@ import type { UmbTreeItemModel, UmbTreeRootModel } from '../../types.js';
 class UmbTestTreeItemContext extends UmbTreeItemContextBase<UmbTreeItemModel, UmbTreeRootModel> {
 	constructor(host: UmbControllerHost) {
 		super(host);
+	}
+
+	public get testChildrenManager() {
+		return this._treeItemChildrenManager;
 	}
 }
 
@@ -75,6 +80,34 @@ describe('UmbTreeItemContextBase', () => {
 			context.setTreeItem(undefined);
 			expect(entityContext!.getEntityType()).to.be.undefined;
 			expect(entityContext!.getUnique()).to.be.null;
+		});
+	});
+
+	describe('Additional Request Args', () => {
+		it('forwards the tree context additional request args to the per-item children manager', async () => {
+			const treeContext = new UmbDefaultTreeContext(host);
+			treeContext.updateAdditionalRequestArgs({ dataType: { unique: 'test-data-type-id' } } as any);
+
+			context.setTreeItem(treeItem);
+			await aTimeout(0);
+
+			expect(context.testChildrenManager.getAdditionalRequestArgs()).to.deep.equal({
+				dataType: { unique: 'test-data-type-id' },
+			});
+		});
+
+		it('propagates later updates to the tree context additional request args', async () => {
+			const treeContext = new UmbDefaultTreeContext(host);
+
+			context.setTreeItem(treeItem);
+			await aTimeout(0);
+
+			treeContext.updateAdditionalRequestArgs({ dataType: { unique: 'updated-data-type-id' } } as any);
+			await aTimeout(0);
+
+			expect(context.testChildrenManager.getAdditionalRequestArgs()).to.deep.equal({
+				dataType: { unique: 'updated-data-type-id' },
+			});
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-base/tree-item-context-base.ts
@@ -272,6 +272,7 @@ export abstract class UmbTreeItemContextBase<
 			this.#observeIsSelectable();
 			this.#observeIsSelected();
 			this.#observeFoldersOnly();
+			this.#observeAdditionalRequestArgs();
 			this.#observeActive();
 		}).asPromise();
 	}
@@ -319,6 +320,19 @@ export abstract class UmbTreeItemContextBase<
 				this._treeItemChildrenManager.setFoldersOnly(foldersOnly ?? false);
 			},
 			'observeFoldersOnly',
+		);
+	}
+
+	#observeAdditionalRequestArgs() {
+		if (this.unique === undefined) return;
+
+		this.observe(
+			this.treeContext?.additionalRequestArgs,
+			(additionalRequestArgs) => {
+				if (!additionalRequestArgs) return;
+				this._treeItemChildrenManager.setAdditionalRequestArgs(additionalRequestArgs);
+			},
+			'observeAdditionalRequestArgs',
 		);
 	}
 


### PR DESCRIPTION
## Description

This PR fixes a content picker bug reported in https://github.com/umbraco/Umbraco-CMS/issues/22487 where expanding a node outside the user's start node returned no children, even when the data type had **Ignore user start nodes** enabled.

Root cause: the tree context's `additionalRequestArgs` (containing `dataType`) was only applied to the root children request. Each tree item's own `UmbTreeItemChildrenManager` never received it, so the request to the children endpoint omitted `dataTypeId` — the server then applied normal start-node filtering and returned nothing for nodes outside the user's start node.

Fix: `UmbTreeItemContextBase` now observes the tree context's `additionalRequestArgs` and forwards it to the per-item children manager.

## Testing
- Set up a user with a content start node restricted to a single branch (e.g. `Root > Test 1`).
- As an administrator, create content outside that branch with children (e.g. `Root > Test 2 > Test 2-1`).
- Configure a Content Picker data type with **Ignore user start nodes** enabled and use it on a document type the restricted user can edit.
- Log in as the restricted user, open a document with the picker, and expand `Test 2` — its children should appear.
