### PR TITLE
Dependencies: Pin `System.Security.Cryptography.Xml` to resolve vulnerability warning (Umbraco 13)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,7 +87,7 @@
     <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- Examine brings in a vulnerable version of System.Security.Cryptography.Xml -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.2" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.6" />
     <!-- Both Dazinator.Extensions.FileProviders and MiniProfiler.AspNetCore.Mvc bring in a vulnerable version of System.Text.RegularExpressions -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- Both OpenIddict.AspNetCore, Npoco.SqlServer and Microsoft.EntityFrameworkCore.SqlServer bring in a vulnerable version of Microsoft.IdentityModel.JsonWebTokens -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,7 +87,7 @@
     <!-- Dazinator.Extensions.FileProviders brings in a vulnerable version of System.Net.Http -->
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <!-- Examine brings in a vulnerable version of System.Security.Cryptography.Xml -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <!-- Both Dazinator.Extensions.FileProviders and MiniProfiler.AspNetCore.Mvc bring in a vulnerable version of System.Text.RegularExpressions -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- Both OpenIddict.AspNetCore, Npoco.SqlServer and Microsoft.EntityFrameworkCore.SqlServer bring in a vulnerable version of Microsoft.IdentityModel.JsonWebTokens -->


### PR DESCRIPTION
### Description
There is a vulnerability found by Mend with a CVE score of 8.7 (high). The issue can be found in the [Mend vulnerability database](https://www.mend.io/vulnerability-database/CVE-2026-32203/) and can be simply be fixed by updating to the latest version (10.0.6) of the package.

**Description of the issue:**
"Stack-based buffer overflow in .NET and Visual Studio allows an unauthorized attacker to deny service over a network."

**Additional information:**
1. I emailed with security@umbraco.io and they said that they thought that the vulnerable package is loaded but never actually invoked. It was ok to make a pull request for this issue.
2. The problem will probably also exist in other branches / higher versions of Umbraco.CMS, since this also effects dotnet 10 (System.Security.Cryptography.Xml version < 10.0.6).



