### PR TITLE
Dependencies: Pin `System.Security.Cryptography.Xml` to resolve vulnerability warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,5 +88,8 @@
     <!-- Markdown references vulnerable version of the following: -->
     <!-- TODO (V19): Remove these pinned dependencies when the Markdown dependency is removed. -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <!-- Examine (via Microsoft.AspNetCore.DataProtection 8.0.4) references a vulnerable version of the following: -->
+    <!-- TODO: Remove this pinned dependency when Examine updates its Microsoft.AspNetCore.DataProtection reference. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Resolves `NU1903` build warnings about a high-severity vulnerability in `System.Security.Cryptography.Xml 8.0.0` (GHSA-w3x6-4m5h-cxqf and GHSA-37gx-xxp4-5rgx — denial of service via uncontrolled resource consumption / infinite loop in `EncryptedXml`, CVSS 7.5).

The vulnerable package is pulled in transitively via:

```
Examine (3.7.1)
  └── Microsoft.AspNetCore.DataProtection (8.0.4)
      └── System.Security.Cryptography.Xml (8.0.0)
```

Examine 3.7.1 is the latest stable release, and there is no updated direct dependency we can bump to clear the warning upstream. Following the existing pattern in `Directory.Packages.props` for transitive pins (e.g. `System.Net.Http`, `System.Private.Uri`, `System.Text.RegularExpressions`), this adds a pinned version of `System.Security.Cryptography.Xml` at `10.0.6` — the patched version for the 10.x line per the advisories, and matching the `10.0.6` version used for other `Microsoft.Extensions.*` packages already in the file.

A `TODO` is included to remove the pin when Examine updates its `Microsoft.AspNetCore.DataProtection` reference to a non-vulnerable version.