### PR TITLE
Backoffice QA: Add client-side tests for Webhook item, detail and collection repositories

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/collection/repository/webhook-collection.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/collection/repository/webhook-collection.repository.test.ts
@@ -1,0 +1,73 @@
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { useMockSet } from '@umbraco-cms/internal/mock-manager';
+import { UMB_WEBHOOK_ENTITY_TYPE } from '../../../entity.js';
+import { UmbWebhookCollectionRepository } from './webhook-collection.repository.js';
+
+@customElement('test-controller-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbWebhookCollectionRepository', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let repository: UmbWebhookCollectionRepository;
+
+	before(async () => {
+		await useMockSet('kitchenSink');
+	});
+
+	beforeEach(async () => {
+		hostElement = new UmbTestControllerHostElement();
+		repository = new UmbWebhookCollectionRepository(hostElement);
+		document.body.appendChild(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('Public API', () => {
+		describe('methods', () => {
+			it('has a requestCollection method', () => {
+				expect(repository).to.have.property('requestCollection').that.is.a('function');
+			});
+		});
+	});
+
+	describe('requestCollection', () => {
+		it('returns a collection of webhooks', async () => {
+			const { data, error } = await repository.requestCollection({ skip: 0, take: 3 });
+			expect(error).to.be.undefined;
+			expect(data).to.exist;
+			expect(data!.items).to.be.an('array').that.is.not.empty;
+			expect(data!.total).to.be.greaterThan(0);
+		});
+
+		it('returns items with the correct UmbWebhookDetailModel shape', async () => {
+			const { data } = await repository.requestCollection({ skip: 0, take: 1 });
+			const item = data!.items[0];
+			expect(item).to.have.property('unique').that.is.a('string');
+			expect(item).to.have.property('entityType').that.equals(UMB_WEBHOOK_ENTITY_TYPE);
+			expect(item).to.have.property('url').that.is.a('string');
+			expect(item).to.have.property('enabled').that.is.a('boolean');
+			expect(item).to.have.property('events').that.is.an('array');
+		});
+
+		it('respects the take filter', async () => {
+			const { data } = await repository.requestCollection({ skip: 0, take: 3 });
+			expect(data!.items).to.have.lengthOf(3);
+		});
+
+		it('respects the skip filter', async () => {
+			const { data: firstPage } = await repository.requestCollection({ skip: 0, take: 2 });
+			const { data: skipped } = await repository.requestCollection({ skip: 1, take: 2 });
+			expect(skipped!.items[0].unique).to.equal(firstPage!.items[1].unique);
+		});
+
+		it('returns the same total regardless of pagination', async () => {
+			const { data: firstPage } = await repository.requestCollection({ skip: 0, take: 3 });
+			const { data: secondPage } = await repository.requestCollection({ skip: 3, take: 3 });
+			expect(firstPage!.total).to.equal(secondPage!.total);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/detail/webhook-detail.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/detail/webhook-detail.repository.test.ts
@@ -1,0 +1,143 @@
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { useMockSet } from '@umbraco-cms/internal/mock-manager';
+import type { UmbWebhookDetailModel } from '../../../types.js';
+import { UMB_WEBHOOK_ENTITY_TYPE } from '../../../entity.js';
+import { UmbWebhookDetailRepository } from './webhook-detail.repository.js';
+import { UmbWebhookDetailStore } from './webhook-detail.store.js';
+
+@customElement('test-controller-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new UmbWebhookDetailStore(this);
+		new UmbNotificationContext(this);
+	}
+}
+
+describe('UmbWebhookDetailRepository', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let repository: UmbWebhookDetailRepository;
+
+	const webhookDetailModel: UmbWebhookDetailModel = {
+		entityType: UMB_WEBHOOK_ENTITY_TYPE,
+		unique: 'test-webhook-unique',
+		name: 'Test Webhook',
+		description: 'A test webhook',
+		url: 'https://example.com/webhook',
+		enabled: true,
+		headers: { 'X-Test': 'value' },
+		events: [{ alias: 'Umbraco.ContentPublish', eventName: 'Content Published', eventType: 'Content' }],
+		contentTypes: [],
+	};
+
+	before(async () => {
+		await useMockSet('kitchenSink');
+	});
+
+	beforeEach(async () => {
+		hostElement = new UmbTestControllerHostElement();
+		repository = new UmbWebhookDetailRepository(hostElement);
+		document.body.appendChild(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('Public API', () => {
+		describe('methods', () => {
+			it('has a createScaffold method', () => {
+				expect(repository).to.have.property('createScaffold').that.is.a('function');
+			});
+
+			it('has a create method', () => {
+				expect(repository).to.have.property('create').that.is.a('function');
+			});
+
+			it('has a requestByUnique method', () => {
+				expect(repository).to.have.property('requestByUnique').that.is.a('function');
+			});
+
+			it('has a save method', () => {
+				expect(repository).to.have.property('save').that.is.a('function');
+			});
+
+			it('has a delete method', () => {
+				expect(repository).to.have.property('delete').that.is.a('function');
+			});
+		});
+	});
+
+	describe('createScaffold', () => {
+		it('returns a scaffold with default values', async () => {
+			const { data } = await repository.createScaffold();
+			expect(data).to.exist;
+			expect(data!.entityType).to.equal(UMB_WEBHOOK_ENTITY_TYPE);
+			expect(data!.enabled).to.be.true;
+			expect(data!.url).to.equal('');
+			expect(data!.events).to.deep.equal([]);
+			expect(data!.contentTypes).to.deep.equal([]);
+		});
+
+		it('merges preset values into the scaffold', async () => {
+			const { data } = await repository.createScaffold({ name: 'Preset Webhook', url: 'https://preset.example.com' });
+			expect(data!.name).to.equal('Preset Webhook');
+			expect(data!.url).to.equal('https://preset.example.com');
+		});
+	});
+
+	describe('requestByUnique', () => {
+		it('returns data for a known unique', async () => {
+			const { data, error } = await repository.requestByUnique('webhook-named-id');
+			expect(error).to.be.undefined;
+			expect(data).to.exist;
+			expect(data!.unique).to.equal('webhook-named-id');
+			expect(data!.name).to.equal('Content Publisher');
+			expect(data!.entityType).to.equal(UMB_WEBHOOK_ENTITY_TYPE);
+		});
+
+		it('returns an error for an unknown unique', async () => {
+			const { data, error } = await repository.requestByUnique('non-existing-webhook-id');
+			expect(data).to.be.undefined;
+			expect(error).to.exist;
+		});
+	});
+
+	describe('create', () => {
+		it('creates a new webhook and returns it', async () => {
+			const { data, error } = await repository.create(webhookDetailModel);
+			expect(error).to.be.undefined;
+			expect(data).to.exist;
+			expect(data!.name).to.equal(webhookDetailModel.name);
+			expect(data!.url).to.equal(webhookDetailModel.url);
+			expect(data!.enabled).to.equal(webhookDetailModel.enabled);
+			expect(data!.entityType).to.equal(UMB_WEBHOOK_ENTITY_TYPE);
+		});
+	});
+
+	describe('save', () => {
+		it('updates an existing webhook', async () => {
+			const { data: created } = await repository.create(webhookDetailModel);
+			const updated = { ...created!, name: 'Updated Webhook', url: 'https://updated.example.com' };
+			const { data, error } = await repository.save(updated);
+			expect(error).to.be.undefined;
+			expect(data!.name).to.equal('Updated Webhook');
+			expect(data!.url).to.equal('https://updated.example.com');
+		});
+	});
+
+	describe('delete', () => {
+		it('deletes an existing webhook', async () => {
+			const { data: created } = await repository.create(webhookDetailModel);
+			const { error: deleteError } = await repository.delete(created!.unique);
+			expect(deleteError).to.be.undefined;
+
+			const { data, error: fetchError } = await repository.requestByUnique(created!.unique);
+			expect(data).to.be.undefined;
+			expect(fetchError).to.exist;
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/item/webhook-item.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/repository/item/webhook-item.repository.test.ts
@@ -1,0 +1,92 @@
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { useMockSet } from '@umbraco-cms/internal/mock-manager';
+import { UmbWebhookItemRepository } from './webhook-item.repository.js';
+import { UmbWebhookItemStore } from './webhook-item.store.js';
+import { UMB_WEBHOOK_ENTITY_TYPE } from '../../../entity.js';
+
+@customElement('test-controller-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new UmbWebhookItemStore(this);
+	}
+}
+
+describe('UmbWebhookItemRepository', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let repository: UmbWebhookItemRepository;
+
+	before(async () => {
+		await useMockSet('kitchenSink');
+	});
+
+	beforeEach(async () => {
+		hostElement = new UmbTestControllerHostElement();
+		repository = new UmbWebhookItemRepository(hostElement);
+		document.body.appendChild(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('Public API', () => {
+		describe('methods', () => {
+			it('has a requestItems method', () => {
+				expect(repository).to.have.property('requestItems').that.is.a('function');
+			});
+
+			it('has an items method', () => {
+				expect(repository).to.have.property('items').that.is.a('function');
+			});
+		});
+	});
+
+	describe('requestItems', () => {
+		it('returns data for a single known unique', async () => {
+			const { data } = await repository.requestItems(['webhook-named-id']);
+			expect(data).to.have.lengthOf(1);
+			expect(data![0].unique).to.equal('webhook-named-id');
+			expect(data![0].name).to.equal('Content Publisher');
+		});
+
+		it('returns data for multiple uniques', async () => {
+			const { data } = await repository.requestItems(['webhook-named-id', 'webhook-disabled-id']);
+			expect(data).to.have.lengthOf(2);
+			const uniques = data!.map((item) => item.unique);
+			expect(uniques).to.include.members(['webhook-named-id', 'webhook-disabled-id']);
+		});
+
+		it('returns items with the correct UmbWebhookItemModel shape', async () => {
+			const { data } = await repository.requestItems(['webhook-named-id']);
+			const item = data![0];
+			expect(item).to.have.property('unique').that.is.a('string');
+			expect(item).to.have.property('name');
+			expect(item).to.have.property('entityType').that.equals(UMB_WEBHOOK_ENTITY_TYPE);
+		});
+
+		it('returns an empty array for an unknown unique', async () => {
+			const { data } = await repository.requestItems(['non-existing-webhook-id']);
+			expect(data).to.be.empty;
+		});
+	});
+
+	describe('items', () => {
+		it('returns an observable that emits the requested items', async () => {
+			await repository.requestItems(['webhook-named-id']);
+			const observable = await repository.items(['webhook-named-id']);
+			expect(observable).to.exist;
+
+			await new Promise<void>((resolve) => {
+				observable!.subscribe((items) => {
+					if (items.length > 0) {
+						expect(items[0].unique).to.equal('webhook-named-id');
+						resolve();
+					}
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
### Description

Adds client-side tests for the three webhook repositories: item, detail, and collection.