### PR TITLE
Documents: Present blueprint options from collection view Create button (closes #22529)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
@@ -1,9 +1,12 @@
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '../../workspace/constants.js';
 import { UMB_CREATE_DOCUMENT_WORKSPACE_PATH_PATTERN } from '../../paths.js';
 import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_ROOT_ENTITY_TYPE } from '../../entity.js';
+import { UMB_DOCUMENT_CREATE_OPTIONS_MODAL } from '../../entity-actions/create/constants.js';
 import { css, customElement, html, property, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbDocumentTypeStructureRepository } from '@umbraco-cms/backoffice/document-type';
+import { UmbDocumentBlueprintItemRepository } from '@umbraco-cms/backoffice/document-blueprint';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import type { ManifestCollectionAction } from '@umbraco-cms/backoffice/collection';
 import type { UmbAllowedDocumentTypeModel } from '@umbraco-cms/backoffice/document-type';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
@@ -26,6 +29,7 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 	manifest?: ManifestCollectionAction;
 
 	#documentTypeStructureRepository = new UmbDocumentTypeStructureRepository(this);
+	#documentBlueprintItemRepository = new UmbDocumentBlueprintItemRepository(this);
 
 	constructor() {
 		super();
@@ -72,6 +76,35 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 		});
 	}
 
+	async #onSelect(item: UmbAllowedDocumentTypeModel) {
+		if (!item.unique) {
+			throw new Error('Item unique is missing');
+		}
+
+		const createUrl = this.#getCreateUrl(item);
+
+		const { data } = await this.#documentBlueprintItemRepository.requestItemsByDocumentType(item.unique);
+
+		if (!data?.length) {
+			history.pushState(null, '', createUrl);
+			return;
+		}
+
+		await umbOpenModal(this, UMB_DOCUMENT_CREATE_OPTIONS_MODAL, {
+			data: {
+				parent: {
+					unique: this._documentUnique ?? null,
+					entityType: this._documentUnique ? UMB_DOCUMENT_ENTITY_TYPE : UMB_DOCUMENT_ROOT_ENTITY_TYPE,
+				},
+				documentType: this._documentTypeUnique ? { unique: this._documentTypeUnique } : null,
+				preselectedDocumentType: {
+					unique: item.unique,
+					icon: item.icon ?? undefined,
+				},
+			},
+		});
+	}
+
 	override render() {
 		return this._allowedDocumentTypes.length !== 1 ? this.#renderDropdown() : this.#renderCreateButton();
 	}
@@ -89,7 +122,7 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 			this.localize.string(item.name);
 
 		return html`
-			<uui-button color="default" href=${this.#getCreateUrl(item)} label=${label} look="outline"></uui-button>
+			<uui-button color="default" label=${label} look="outline" @click=${() => this.#onSelect(item)}></uui-button>
 		`;
 	}
 
@@ -115,7 +148,7 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 							this._allowedDocumentTypes,
 							(item) => item.unique,
 							(item) => html`
-								<uui-menu-item label=${this.localize.string(item.name)} href=${this.#getCreateUrl(item)}>
+								<uui-menu-item label=${this.localize.string(item.name)} @click-label=${() => this.#onSelect(item)}>
 									<umb-icon slot="icon" name=${item.icon ?? 'icon-document'}></umb-icon>
 								</uui-menu-item>
 							`,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/collection/action/create-document-collection-action.element.ts
@@ -76,6 +76,19 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 		});
 	}
 
+	#onClick(event: MouseEvent, item: UmbAllowedDocumentTypeModel) {
+		// Let modified/non-primary clicks (open in new tab, new window, etc.) use native link navigation.
+		if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+			return;
+		}
+		// Cancel native anchor navigation and stop the window-level router-slot click handler
+		// (see core/router/router-slot/util/anchor.ts) from SPA-navigating before we can decide
+		// whether to open the blueprint picker.
+		event.preventDefault();
+		event.stopPropagation();
+		this.#onSelect(item);
+	}
+
 	async #onSelect(item: UmbAllowedDocumentTypeModel) {
 		if (!item.unique) {
 			throw new Error('Item unique is missing');
@@ -100,6 +113,7 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 				preselectedDocumentType: {
 					unique: item.unique,
 					icon: item.icon ?? undefined,
+					blueprints: data,
 				},
 			},
 		});
@@ -122,7 +136,12 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 			this.localize.string(item.name);
 
 		return html`
-			<uui-button color="default" label=${label} look="outline" @click=${() => this.#onSelect(item)}></uui-button>
+			<uui-button
+				color="default"
+				href=${this.#getCreateUrl(item)}
+				label=${label}
+				look="outline"
+				@click=${(event: MouseEvent) => this.#onClick(event, item)}></uui-button>
 		`;
 	}
 
@@ -148,7 +167,10 @@ export class UmbCreateDocumentCollectionActionElement extends UmbLitElement {
 							this._allowedDocumentTypes,
 							(item) => item.unique,
 							(item) => html`
-								<uui-menu-item label=${this.localize.string(item.name)} @click-label=${() => this.#onSelect(item)}>
+								<uui-menu-item
+									label=${this.localize.string(item.name)}
+									href=${this.#getCreateUrl(item)}
+									@click=${(event: MouseEvent) => this.#onClick(event, item)}>
 									<umb-icon slot="icon" name=${item.icon ?? 'icon-document'}></umb-icon>
 								</uui-menu-item>
 							`,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -49,8 +49,15 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 	override async firstUpdated() {
 		const parentUnique = this.data?.parent.unique;
 		const documentTypeUnique = this.data?.documentType?.unique || null;
+		const preselectedDocumentType = this.data?.preselectedDocumentType;
 
-		this.#retrieveAllowedDocumentTypesOf(documentTypeUnique, parentUnique || null);
+		if (preselectedDocumentType?.unique) {
+			this.#documentTypeIcon = preselectedDocumentType.icon ?? '';
+			await this.#onSelectDocumentType(preselectedDocumentType.unique);
+			this._loading = false;
+		} else {
+			this.#retrieveAllowedDocumentTypesOf(documentTypeUnique, parentUnique || null);
+		}
 
 		if (parentUnique) {
 			this.#retrieveHeadline(parentUnique);
@@ -111,7 +118,10 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 			throw new Error('Document type unique is not defined');
 		}
 		this.#documentTypeUnique = documentTypeUnique;
-		this.#documentTypeIcon = this._allowedDocumentTypes.find((dt) => dt.unique === documentTypeUnique)?.icon ?? '';
+		const matchedDocumentType = this._allowedDocumentTypes.find((dt) => dt.unique === documentTypeUnique);
+		if (matchedDocumentType) {
+			this.#documentTypeIcon = matchedDocumentType.icon ?? '';
+		}
 
 		const { data } = await this.#documentBlueprintItemRepository.requestItemsByDocumentType(documentTypeUnique);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -52,8 +52,19 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 		const preselectedDocumentType = this.data?.preselectedDocumentType;
 
 		if (preselectedDocumentType?.unique) {
+			this.#documentTypeUnique = preselectedDocumentType.unique;
 			this.#documentTypeIcon = preselectedDocumentType.icon ?? '';
-			await this.#onSelectDocumentType(preselectedDocumentType.unique);
+			if (preselectedDocumentType.blueprints) {
+				this._availableBlueprints = preselectedDocumentType.blueprints;
+			} else {
+				const { data } = await this.#documentBlueprintItemRepository.requestItemsByDocumentType(
+					preselectedDocumentType.unique,
+				);
+				this._availableBlueprints = data ?? [];
+			}
+			if (!this._availableBlueprints.length) {
+				this.#onNavigate(preselectedDocumentType.unique);
+			}
 			this._loading = false;
 		} else {
 			this.#retrieveAllowedDocumentTypesOf(documentTypeUnique, parentUnique || null);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.token.ts
@@ -1,3 +1,4 @@
+import type { UmbDocumentBlueprintItemBaseModel } from '@umbraco-cms/backoffice/document-blueprint';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
@@ -9,6 +10,7 @@ export interface UmbDocumentCreateOptionsModalData {
 	preselectedDocumentType?: {
 		unique: string;
 		icon?: string;
+		blueprints?: Array<UmbDocumentBlueprintItemBaseModel>;
 	} | null;
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.token.ts
@@ -6,6 +6,10 @@ export interface UmbDocumentCreateOptionsModalData {
 	documentType: {
 		unique: string;
 	} | null;
+	preselectedDocumentType?: {
+		unique: string;
+		icon?: string;
+	} | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
## Description

Fixes a reported regression from Umbraco 13 (https://github.com/umbraco/Umbraco-CMS/issues/22529): when creating a document from the **Create** button of a list/collection view, available blueprints for the selected document type are no longer offered — the user is taken straight to a blank editor. The same user flow from the tree's create action does presents the blueprint picker correctly.

This PR brings back the behaviour by having the collection action look up blueprints for the document type the user picks and, when any exist, open the existing create-options dialog in a mode that jumps straight to blueprint selection (Blank + each available blueprint). When no blueprints exist, navigation happens directly as before.

## Testing

- [ ] Collection view on a document type whose allowed child has blueprints → clicking **Create** shows the Blank/Blueprint picker.
- [ ] Selecting **Blank** navigates to an empty new document.
- [ ] Selecting a blueprint navigates to a new document pre-filled from that blueprint.
- [ ] Collection view on a document type whose allowed child has no blueprints → clicking **Create** goes straight to an empty new document (unchanged).
- [ ] Collection view with multiple allowed child types → dropdown lists each; picking one with blueprints opens the picker, picking one without navigates directly.
- [ ] Tree create action (blueprint picker modal) continues to work as before.