### PR TITLE
Performance: Use `GeneratedRegex` instead of generating at runtime in string extensions

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
@@ -19,6 +19,9 @@ public static partial class StringExtensions
     [GeneratedRegex(@"<[a-zA-Z/!][\s\S]*?>")]
     private static partial Regex StringHtmlRegex();
 
+    [GeneratedRegex(@"(?<extension>\.[^\.\?]+)(\?.*|$)")]
+    private static partial Regex GetFileExtensionRegex();
+
     /// <summary>
     /// Removes all whitespace characters including new lines, tabs, and spaces.
     /// </summary>
@@ -98,8 +101,7 @@ public static partial class StringExtensions
     public static string GetFileExtension(this string file)
     {
         // Find any characters between the last . and the start of a query string or the end of the string
-        const string pattern = @"(?<extension>\.[^\.\?]+)(\?.*|$)";
-        Match match = Regex.Match(file, pattern);
+        Match match = GetFileExtensionRegex().Match(file);
         return match.Success
             ? match.Groups["extension"].Value
             : string.Empty;

--- a/src/Umbraco.Core/Extensions/StringExtensions.Sanitization.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Sanitization.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Collections.Frozen;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
@@ -12,14 +13,15 @@ public static partial class StringExtensions
 {
 #pragma warning disable IDE1006 // Naming Styles (internal Guid is clearer without a _ prefix).
     /// <summary>
-    /// Provides a lazily initialized, compiled regular expression that matches one or more whitespace characters.
+    /// Compiled regular expression that matches one or more whitespace characters.
     /// </summary>
-    internal static readonly Lazy<Regex> Whitespace = new(() => new Regex(@"\s+", RegexOptions.Compiled));
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
 
     /// <summary>
     /// Provides a collection of JSON string representations that are considered empty objects or arrays.
     /// </summary>
-    internal static readonly string[] JsonEmpties = { "[]", "{}" };
+    internal static readonly FrozenSet<string> JsonEmpties = FrozenSet.ToFrozenSet(["[]", "{}"]);
 #pragma warning restore IDE1006 // Naming Styles
 
     private static readonly char[] _cleanForXssChars = "*?(){}[];:%<>/\\|&'\"".ToCharArray();
@@ -31,10 +33,8 @@ public static partial class StringExtensions
     /// Filters control characters but allows only properly-formed surrogate sequences.
     /// Hat-tip: http://stackoverflow.com/a/961504/5018.
     /// </remarks>
-    private static readonly Lazy<Regex> _invalidXmlChars = new(() =>
-        new Regex(
-            @"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]",
-            RegexOptions.Compiled));
+    [GeneratedRegex(@"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]")]
+    private static partial Regex InvalidXmlCharsRegex();
 
     /// <summary>
     /// Attempts to detect whether a string is JSON by checking for opening and closing brackets or braces.
@@ -62,7 +62,7 @@ public static partial class StringExtensions
     /// <param name="input">The string to check.</param>
     /// <returns><c>true</c> if the string is "[]" or "{}" (ignoring whitespace); otherwise, <c>false</c>.</returns>
     public static bool DetectIsEmptyJson(this string input) =>
-        JsonEmpties.Contains(Whitespace.Value.Replace(input, string.Empty));
+        JsonEmpties.Contains(WhitespaceRegex().Replace(input, string.Empty));
 
     /// <summary>
     /// Cleans a string to aid in preventing XSS attacks.
@@ -160,7 +160,7 @@ public static partial class StringExtensions
     /// <param name="text">The string to filter.</param>
     /// <returns>The string with invalid XML characters removed.</returns>
     public static string ToValidXmlString(this string text) =>
-        string.IsNullOrEmpty(text) ? text : _invalidXmlChars.Value.Replace(text, string.Empty);
+        string.IsNullOrEmpty(text) ? text : InvalidXmlCharsRegex().Replace(text, string.Empty);
 
     /// <summary>
     /// Turns a null-or-whitespace string into a null string.

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
@@ -17,7 +17,7 @@ internal static class ListExtensions
         items.Any(x => x.Suffix.HasValue);
 }
 
-internal sealed class SimilarNodeName
+internal sealed partial class SimilarNodeName
 {
     /// <summary>
     /// Gets or sets the unique identifier for this SimilarNodeName instance.
@@ -194,11 +194,14 @@ internal sealed class SimilarNodeName
         return current;
     }
 
-    internal sealed class StructuredName
+    internal sealed partial class StructuredName
     {
         internal const uint Initialsuffix = 1;
         private const string Spacecharacter = " ";
-        private const string Suffixedpattern = @"(.*) \(([1-9]\d*)\)$";
+
+        [GeneratedRegex(@"(.*) \(([1-9]\d*)\)$")]
+        private static partial Regex SuffixedPatternRegex();
+
         internal static readonly uint? _nosuffix = default;
 
         internal StructuredName(string? name)
@@ -210,8 +213,7 @@ internal sealed class SimilarNodeName
                 return;
             }
 
-            var rg = new Regex(Suffixedpattern);
-            MatchCollection matches = rg.Matches(name);
+            MatchCollection matches = SuffixedPatternRegex().Matches(name);
             if (matches.Count > 0)
             {
                 Match match = matches[0];

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/StringExtensionsTests.Sanitization.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/StringExtensionsTests.Sanitization.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
+
+[TestFixture]
+public partial class StringExtensionsTests
+{
+    [TestCase("[]", true)]
+    [TestCase("{}", true)]
+    [TestCase("  [ ]  ", true)]
+    [TestCase("{ \t\n }", true)]
+    [TestCase("[1]", false)]
+    [TestCase("{\"a\":1}", false)]
+    [TestCase("", false)]
+    [TestCase("null", false)]
+    [TestCase("[}", false)]
+    public void DetectIsEmptyJson_ReturnsExpected(string input, bool expected)
+    {
+        var result = input.DetectIsEmptyJson();
+        Assert.AreEqual(expected, result);
+    }
+
+    [TestCase("", "")] // empty short-circuits
+    [TestCase("hello", "hello")] // plain text preserved
+    [TestCase("tab\there\nlf\rcr", "tab\there\nlf\rcr")] // valid XML whitespace preserved
+    [TestCase("bad\u0000char", "badchar")] // NUL stripped
+    [TestCase("bell\u0007end", "bellend")] // BEL stripped
+    [TestCase("del\u007Fend", "delend")] // DEL stripped
+    [TestCase("emoji:\uD83D\uDE00!", "emoji:\uD83D\uDE00!")] // valid surrogate pair preserved
+    [TestCase("\uFEFFbom", "bom")] // BOM stripped
+    [TestCase("café", "café")] // unicode letters preserved
+    public void ToValidXmlString_RemovesInvalidCharacters(string input, string expected)
+    {
+        var result = input.ToValidXmlString();
+        Assert.AreEqual(expected, result);
+    }
+
+    // Lone surrogates cannot survive round-tripping through [TestCase] attribute arguments
+    // (stored as UTF-8 in metadata), so these cases must use method-body string literals.
+    [Test]
+    public void ToValidXmlString_StripsLoneSurrogates()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual("hi!", "hi\uD83D!".ToValidXmlString()); // lone high
+            Assert.AreEqual("hi!", "hi\uDE00!".ToValidXmlString()); // lone low
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -49,6 +49,9 @@
     <Compile Update="Umbraco.Core\Extensions\StringExtensionsTests.Manipulation.cs">
       <DependentUpon>StringExtensionsTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Core\Extensions\StringExtensionsTests.Sanitization.cs">
+      <DependentUpon>StringExtensionsTests.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- [x] I have added steps to test this contribution in the description below

Also replaced an array contains with a `FrozenSet`