### PR TITLE
Migrations: Fix Label long-string data type dbType (closes #22553)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -184,6 +184,7 @@ public partial class UmbracoPlan : MigrationPlan
         To<V_17_4_0.AddContentVersionDateIndex>("{D4E5F6A7-B8C9-4D0E-A1F2-3B4C5D6E7F80}");
         To<V_17_4_0.AddDimensionsToSvg>("{72970B86-59D8-403C-B322-FFF43F9DB199}");
         To<V_17_4_0.AddExternalMemberTables>("{D7E8F9A0-B1C2-4D3E-A5F6-7890ABCDEF12}");
+        To<V_17_4_0.FixLabelDataTypeDbTypeFromConfiguration>("{3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}");
 
         // To 18.0.0
         // TODO (V18): Enable on 18 branch

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfiguration.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_4_0;
 /// <summary>
 /// Corrects the <see cref="IDataType.DatabaseType"/> for data types based on the <c>Umbraco.Label</c> property editor so it
 /// matches the configured value type, and relocates any existing property data from <c>varcharValue</c> to <c>textValue</c>
-/// for data types that move to <see cref="ValueStorageType.Ntext"/>.
+/// for Label data types whose storage type is <see cref="ValueStorageType.Ntext"/>.
 /// </summary>
 /// <remarks>
 /// Fixes https://github.com/umbraco/Umbraco-CMS/issues/22553. Before this migration, upgrading from older versions could
@@ -35,7 +35,7 @@ public class FixLabelDataTypeDbTypeFromConfiguration : AsyncMigrationBase
     /// <summary>
     /// Performs the migration: ensures each Label data type's <see cref="IDataType.DatabaseType"/> matches its configured
     /// <see cref="IConfigureValueType.ValueType"/>, then relocates any property data from <c>varcharValue</c> to
-    /// <c>textValue</c> for Label data types whose storage type is now <see cref="ValueStorageType.Ntext"/>.
+    /// <c>textValue</c> for Label data types whose storage type is <see cref="ValueStorageType.Ntext"/>.
     /// </summary>
     /// <remarks>
     /// Extracted into an internal static method to support integration testing.
@@ -44,7 +44,6 @@ public class FixLabelDataTypeDbTypeFromConfiguration : AsyncMigrationBase
     {
         IEnumerable<IDataType> dataTypes = await dataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.Label);
 
-        var movedToNtext = false;
         foreach (IDataType dataType in dataTypes)
         {
             var valueType = dataType.ConfigurationObject is IConfigureValueType configureValueType
@@ -57,22 +56,15 @@ public class FixLabelDataTypeDbTypeFromConfiguration : AsyncMigrationBase
                 continue;
             }
 
-            if (expected == ValueStorageType.Ntext && dataType.DatabaseType == ValueStorageType.Nvarchar)
-            {
-                movedToNtext = true;
-            }
-
             dataType.DatabaseType = expected;
             await dataTypeService.UpdateAsync(dataType, Constants.Security.SuperUserKey);
         }
 
-        if (movedToNtext is false)
-        {
-            return;
-        }
-
         // Relocate any property data that was previously written to varcharValue on a Label data type whose dbType is now Ntext.
-        // On large umbracoPropertyData tables the copy could exceed the default command timeout, so extend it here.
+        // This runs whenever any Ntext Label data type exists — including data types this migration did not touch
+        // (e.g. ones a user already re-saved as a workaround for #22553, leaving legacy rows behind in varcharValue).
+        // Idempotent thanks to the AND varcharValue IS NOT NULL guard. On large umbracoPropertyData tables the copy
+        // could exceed the default command timeout, so extend it here.
         EnsureLongCommandTimeout(database);
 
         var sql = $@"

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfiguration.cs
@@ -1,0 +1,94 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Persistence;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_4_0;
+
+/// <summary>
+/// Corrects the <see cref="IDataType.DatabaseType"/> for data types based on the <c>Umbraco.Label</c> property editor so it
+/// matches the configured value type, and relocates any existing property data from <c>varcharValue</c> to <c>textValue</c>
+/// for data types that move to <see cref="ValueStorageType.Ntext"/>.
+/// </summary>
+/// <remarks>
+/// Fixes https://github.com/umbraco/Umbraco-CMS/issues/22553. Before this migration, upgrading from older versions could
+/// leave a Label data type configured as Long String with <c>dbType = Nvarchar</c>, causing SQL truncation when saving
+/// content longer than 512 characters.
+/// </remarks>
+public class FixLabelDataTypeDbTypeFromConfiguration : AsyncMigrationBase
+{
+    private readonly IDataTypeService _dataTypeService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FixLabelDataTypeDbTypeFromConfiguration"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    /// <param name="dataTypeService">The service used to load and update data types.</param>
+    public FixLabelDataTypeDbTypeFromConfiguration(IMigrationContext context, IDataTypeService dataTypeService)
+        : base(context)
+        => _dataTypeService = dataTypeService;
+
+    /// <inheritdoc/>
+    protected override Task MigrateAsync() => ExecuteMigration(Database, _dataTypeService);
+
+    /// <summary>
+    /// Performs the migration: ensures each Label data type's <see cref="IDataType.DatabaseType"/> matches its configured
+    /// <see cref="IConfigureValueType.ValueType"/>, then relocates any property data from <c>varcharValue</c> to
+    /// <c>textValue</c> for Label data types whose storage type is now <see cref="ValueStorageType.Ntext"/>.
+    /// </summary>
+    /// <remarks>
+    /// Extracted into an internal static method to support integration testing.
+    /// </remarks>
+    internal static async Task ExecuteMigration(IUmbracoDatabase database, IDataTypeService dataTypeService)
+    {
+        IEnumerable<IDataType> dataTypes = await dataTypeService.GetByEditorAliasAsync(Constants.PropertyEditors.Aliases.Label);
+
+        var movedToNtext = false;
+        foreach (IDataType dataType in dataTypes)
+        {
+            var valueType = dataType.ConfigurationObject is IConfigureValueType configureValueType
+                ? configureValueType.ValueType
+                : ValueTypes.String;
+
+            ValueStorageType expected = ValueTypes.ToStorageType(valueType);
+            if (dataType.DatabaseType == expected)
+            {
+                continue;
+            }
+
+            if (expected == ValueStorageType.Ntext && dataType.DatabaseType == ValueStorageType.Nvarchar)
+            {
+                movedToNtext = true;
+            }
+
+            dataType.DatabaseType = expected;
+            await dataTypeService.UpdateAsync(dataType, Constants.Security.SuperUserKey);
+        }
+
+        if (movedToNtext is false)
+        {
+            return;
+        }
+
+        // Relocate any property data that was previously written to varcharValue on a Label data type whose dbType is now Ntext.
+        // On large umbracoPropertyData tables the copy could exceed the default command timeout, so extend it here.
+        EnsureLongCommandTimeout(database);
+
+        var sql = $@"
+UPDATE umbracoPropertyData
+SET textValue = varcharValue, varcharValue = NULL
+WHERE propertyTypeId IN (
+    SELECT id
+    FROM cmsPropertyType
+    WHERE dataTypeId IN (
+        SELECT nodeId
+        FROM umbracoDataType
+        WHERE propertyEditorAlias = '{Constants.PropertyEditors.Aliases.Label}'
+        AND dbType = '{nameof(ValueStorageType.Ntext)}'
+    )
+)
+AND varcharValue IS NOT NULL";
+        await database.ExecuteAsync(sql);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfigurationTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfigurationTest.cs
@@ -1,0 +1,231 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NPoco;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_4_0;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V17_4_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class FixLabelDataTypeDbTypeFromConfigurationTest : UmbracoIntegrationTest
+{
+    private IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
+
+    private PropertyEditorCollection PropertyEditors => GetRequiredService<PropertyEditorCollection>();
+
+    private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer
+        => GetRequiredService<IConfigurationEditorJsonSerializer>();
+
+    [Test]
+    public async Task Corrects_DbType_For_Label_Configured_As_LongString()
+    {
+        IDataType dataType = await CreateLabelDataType(ValueTypes.Text);
+        await SetDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+
+        await ExecuteMigration();
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
+    }
+
+    [Test]
+    public async Task Leaves_DbType_Unchanged_For_Label_Configured_As_String()
+    {
+        IDataType dataType = await CreateLabelDataType(ValueTypes.String);
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+
+        await ExecuteMigration();
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+    }
+
+    [Test]
+    public async Task Treats_Missing_ValueType_Config_As_String()
+    {
+        IDataType dataType = await CreateLabelDataType(valueType: null);
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+
+        await ExecuteMigration();
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+    }
+
+    [Test]
+    public async Task Is_Idempotent_When_DbType_Already_Correct()
+    {
+        IDataType dataType = await CreateLabelDataType(ValueTypes.Text);
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
+
+        await ExecuteMigration();
+        await ExecuteMigration();
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
+    }
+
+    [Test]
+    public async Task Relocates_VarcharValue_Content_To_TextValue_When_Moving_To_Ntext()
+    {
+        IDataType dataType = await CreateLabelDataType(ValueTypes.Text);
+        IContentType contentType = await CreateContentTypeWithLabelProperty(dataType);
+        IContent content = await CreateContent(contentType);
+
+        // Simulate the pre-migration state: dbType is Nvarchar, and the property value lives in varcharValue.
+        // (The Label editor is read-only so ContentEditingService does not persist a value for us; insert one directly.)
+        await SetDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+        var propertyTypeId = contentType.PropertyTypes.Single(pt => pt.Alias == "testLabel").Id;
+        await InsertPropertyDataVarcharValue(content.Id, propertyTypeId, "stored-as-varchar");
+
+        await ExecuteMigration();
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
+        await AssertPropertyDataMoved(propertyTypeId, expectedTextValue: "stored-as-varchar");
+    }
+
+    private async Task<IDataType> CreateLabelDataType(string? valueType)
+    {
+        var editor = PropertyEditors.First(e => e.Alias == Constants.PropertyEditors.Aliases.Label);
+        var dataType = new DataType(editor, ConfigurationEditorJsonSerializer)
+        {
+            Name = $"Test Label {valueType ?? "Default"}",
+            DatabaseType = valueType is null ? ValueStorageType.Nvarchar : ValueTypes.ToStorageType(valueType),
+        };
+
+        if (valueType is not null)
+        {
+            dataType.ConfigurationData = new Dictionary<string, object>
+            {
+                [Constants.PropertyEditors.ConfigurationKeys.DataValueType] = valueType,
+            };
+        }
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        return (await DataTypeService.GetAsync(dataType.Key))!;
+    }
+
+    private async Task<IContentType> CreateContentTypeWithLabelProperty(IDataType dataType)
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("migrationTestContentType")
+            .WithName("Migration Test Content Type")
+            .WithIsElement(false)
+            .AddPropertyType()
+                .WithAlias("testLabel")
+                .WithName("Test Label")
+                .WithDataTypeId(dataType.Id)
+                .Done()
+            .Build();
+        contentType.AllowedAsRoot = true;
+
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        return (await ContentTypeService.GetAsync(contentType.Key))!;
+    }
+
+    private async Task<IContent> CreateContent(IContentType contentType)
+    {
+        var createModel = new ContentCreateModel
+        {
+            Key = Guid.NewGuid(),
+            ContentTypeKey = contentType.Key,
+            ParentKey = Constants.System.RootKey,
+            Variants = [new VariantModel { Name = "Migration Test Content" }],
+            Properties =
+            [
+                new PropertyValueModel
+                {
+                    Alias = "testLabel",
+                    Value = "initial-value",
+                },
+            ],
+        };
+
+        var result = await ContentEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create content: {result.Status}");
+        return result.Result.Content!;
+    }
+
+    private async Task SetDbTypeInDatabase(int dataTypeId, ValueStorageType dbType)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+        await scope.Database.ExecuteAsync(
+            "UPDATE umbracoDataType SET dbType = @0 WHERE nodeId = @1",
+            dbType.ToString(),
+            dataTypeId);
+        scope.Complete();
+    }
+
+    private async Task InsertPropertyDataVarcharValue(int contentId, int propertyTypeId, string value)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+
+        // Find the current version for the content so the property data row is associated with real state.
+        var versionId = await scope.Database.ExecuteScalarAsync<int>(
+            "SELECT id FROM umbracoContentVersion WHERE nodeId = @0 AND [current] = 1",
+            contentId);
+
+        var propertyDataDto = new PropertyDataDto
+        {
+            VersionId = versionId,
+            PropertyTypeId = propertyTypeId,
+            LanguageId = null,
+            Segment = null,
+            VarcharValue = value,
+        };
+        await scope.Database.InsertAsync(propertyDataDto);
+
+        scope.Complete();
+    }
+
+    private async Task AssertDbTypeInDatabase(int dataTypeId, ValueStorageType expected)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+        var actual = await scope.Database.ExecuteScalarAsync<string>(
+            "SELECT dbType FROM umbracoDataType WHERE nodeId = @0",
+            dataTypeId);
+        scope.Complete();
+        Assert.AreEqual(expected.ToString(), actual);
+    }
+
+    private async Task AssertPropertyDataMoved(int propertyTypeId, string expectedTextValue)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+        Sql<ISqlContext> sql = scope.Database.SqlContext.Sql()
+            .Select<PropertyDataDto>()
+            .From<PropertyDataDto>()
+            .Where<PropertyDataDto>(x => x.PropertyTypeId == propertyTypeId);
+        var rows = await scope.Database.FetchAsync<PropertyDataDto>(sql);
+        scope.Complete();
+
+        Assert.IsNotEmpty(rows);
+        foreach (var row in rows)
+        {
+            Assert.AreEqual(expectedTextValue, row.TextValue);
+            Assert.IsNull(row.VarcharValue);
+        }
+    }
+
+    private async Task ExecuteMigration()
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+        await FixLabelDataTypeDbTypeFromConfiguration.ExecuteMigration(scope.Database, DataTypeService);
+        scope.Complete();
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfigurationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfigurationTests.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrad
 
 [TestFixture]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-internal sealed class FixLabelDataTypeDbTypeFromConfigurationTest : UmbracoIntegrationTest
+internal sealed class FixLabelDataTypeDbTypeFromConfigurationTests : UmbracoIntegrationTest
 {
     private IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
 
@@ -98,6 +98,26 @@ internal sealed class FixLabelDataTypeDbTypeFromConfigurationTest : UmbracoInteg
 
         await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
         await AssertPropertyDataMoved(propertyTypeId, expectedTextValue: "stored-as-varchar");
+    }
+
+    [Test]
+    public async Task Leaves_Existing_TextValue_Untouched_When_Moving_To_Ntext()
+    {
+        // Scenario A: an upgraded v13 database already has the value in textValue (because v13 stored
+        // Long-String Label values there). Only the dbType is wrong; the relocation UPDATE must leave
+        // the textValue row alone — its AND varcharValue IS NOT NULL guard is what protects it.
+        IDataType dataType = await CreateLabelDataType(ValueTypes.Text);
+        IContentType contentType = await CreateContentTypeWithLabelProperty(dataType);
+        IContent content = await CreateContent(contentType);
+
+        await SetDbTypeInDatabase(dataType.Id, ValueStorageType.Nvarchar);
+        var propertyTypeId = contentType.PropertyTypes.Single(pt => pt.Alias == "testLabel").Id;
+        await InsertPropertyDataTextValue(content.Id, propertyTypeId, "stored-as-textvalue");
+
+        await ExecuteMigration();
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
+        await AssertPropertyDataMoved(propertyTypeId, expectedTextValue: "stored-as-textvalue");
     }
 
     private async Task<IDataType> CreateLabelDataType(string? valueType)
@@ -188,6 +208,27 @@ internal sealed class FixLabelDataTypeDbTypeFromConfigurationTest : UmbracoInteg
             LanguageId = null,
             Segment = null,
             VarcharValue = value,
+        };
+        await scope.Database.InsertAsync(propertyDataDto);
+
+        scope.Complete();
+    }
+
+    private async Task InsertPropertyDataTextValue(int contentId, int propertyTypeId, string value)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+
+        var versionId = await scope.Database.ExecuteScalarAsync<int>(
+            "SELECT id FROM umbracoContentVersion WHERE nodeId = @0 AND [current] = 1",
+            contentId);
+
+        var propertyDataDto = new PropertyDataDto
+        {
+            VersionId = versionId,
+            PropertyTypeId = propertyTypeId,
+            LanguageId = null,
+            Segment = null,
+            TextValue = value,
         };
         await scope.Database.InsertAsync(propertyDataDto);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfigurationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/FixLabelDataTypeDbTypeFromConfigurationTests.cs
@@ -101,6 +101,27 @@ internal sealed class FixLabelDataTypeDbTypeFromConfigurationTests : UmbracoInte
     }
 
     [Test]
+    public async Task Relocates_VarcharValue_Content_When_Label_Is_Already_Ntext()
+    {
+        // Covers the workaround scenario: a user manually re-saved the Label data type after upgrading,
+        // so dbType is already Ntext, but any content saved before that re-save is still stuck in
+        // varcharValue. The migration's relocation step must run regardless of whether this run
+        // transitioned the data type, and must move those legacy rows into textValue.
+        IDataType dataType = await CreateLabelDataType(ValueTypes.Text);
+        IContentType contentType = await CreateContentTypeWithLabelProperty(dataType);
+        IContent content = await CreateContent(contentType);
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
+        var propertyTypeId = contentType.PropertyTypes.Single(pt => pt.Alias == "testLabel").Id;
+        await InsertPropertyDataVarcharValue(content.Id, propertyTypeId, "legacy-varchar");
+
+        await ExecuteMigration();
+
+        await AssertDbTypeInDatabase(dataType.Id, ValueStorageType.Ntext);
+        await AssertPropertyDataMoved(propertyTypeId, expectedTextValue: "legacy-varchar");
+    }
+
+    [Test]
     public async Task Leaves_Existing_TextValue_Untouched_When_Moving_To_Ntext()
     {
         // Scenario A: an upgraded v13 database already has the value in textValue (because v13 stored


### PR DESCRIPTION
## Description

#22553 is a re-report of #21853. [PR #21914](https://github.com/umbraco/Umbraco-CMS/pull/21914) fixed the backoffice create/update path for `Umbraco.Label` data types so that the configured value type (`umbracoDataValueType`) now correctly drives `DatabaseType`. That fix does not touch databases that were upgraded from pre-17.4 versions: `umbracoDataType.dbType` stays `Nvarchar` for Label data types configured as Long String, and any attempt to save content > 512 characters still fails with:

```
String or binary data would be truncated in table '...', column 'varcharValue'.
```

until the user manually re-saves the data type.

This PR adds a V17.4 migration, `FixLabelDataTypeDbTypeFromConfiguration`, that:

1. Iterates every `Umbraco.Label` data type, derives the expected `ValueStorageType` from the configured `umbracoDataValueType` via `IConfigureValueType` → `ValueTypes.ToStorageType`, and corrects `umbracoDataType.dbType` when it disagrees.
2. For rows that transition `Nvarchar → Ntext`, moves any existing content from `varcharValue` into `textValue` in `umbracoPropertyData`.

The migration is scoped to `Umbraco.Label` — the only in-tree editor whose configuration implements `IConfigureValueType` — to keep the blast radius tight for custom editors that may rely on their current `dbType`.

## Testing

### Automated

New integration tests in `FixLabelDataTypeDbTypeFromConfigurationTest` covers the migration step functionality.

```bash
dotnet test --filter "FullyQualifiedName~FixLabelDataTypeDbTypeFromConfigurationTest"
```

### Manual

The Label property editor is read-only in the backoffice, so property values can't be created through the UI — the steps below seed them via SQL.  Testing with SQL Server.

#### 1. Set up via the backoffice

- **Settings → Data Types → Create**: choose **Label**, set **Value type = Long String**, save. Post-#21914 this is created with `dbType = Ntext`; step 5 breaks it back to `Nvarchar` to simulate the pre-17.4 state.
- **Settings → Document Types**: add (or reuse) a doc type with a property of alias `myLabel` using the new Label data type.
- **Content**: create **two** documents of that doc type (each gives a distinct `versionId` so both scenarios below can be seeded in one run). Save — you can't enter a value; Label is read-only.

#### 2. Grab the IDs you'll need

```sql
-- Label data type + property type(s) using it
SELECT dt.nodeId AS dataTypeId, n.[text] AS dataTypeName,
       dt.dbType, dt.config,
       pt.id AS propertyTypeId, pt.[Alias] AS propertyAlias
FROM umbracoDataType dt
INNER JOIN umbracoNode n ON dt.nodeId = n.id
LEFT JOIN cmsPropertyType pt ON pt.dataTypeId = dt.nodeId
WHERE dt.propertyEditorAlias = 'Umbraco.Label'
  AND dt.config LIKE '%"umbracoDataValueType":"TEXT"%';

-- Current versions of the two documents you created (filter by your doc type alias)
SELECT cv.id AS versionId, n.[text] AS docName
FROM umbracoContentVersion cv
INNER JOIN umbracoNode n ON cv.nodeId = n.id
INNER JOIN umbracoContent c ON c.nodeId = n.id
INNER JOIN cmsContentType ct ON ct.nodeId = c.contentTypeId
WHERE cv.[current] = 1
  AND ct.[Alias] = '<yourDocTypeAlias>';
```

Note the `propertyTypeId` and both `versionId` values.

#### 3. Seed property data for both scenarios

```sql
-- Scenario A (pristine v13 state): data already in textValue. Only the dbType fix matters.
INSERT INTO umbracoPropertyData (versionId, propertyTypeId, languageId, segment, textValue)
VALUES (<versionId1>, <propertyTypeId>, NULL, NULL, N'A: value stored in textValue by v13');

-- Scenario B (post-upgrade short-save state): data in varcharValue. Exercises the column-relocation step.
INSERT INTO umbracoPropertyData (versionId, propertyTypeId, languageId, segment, varcharValue)
VALUES (<versionId2>, <propertyTypeId>, NULL, NULL, N'B: value stored in varcharValue post-upgrade');
```

#### 4. Break the `dbType`

```sql
UPDATE umbracoDataType
SET dbType = 'Nvarchar'
WHERE propertyEditorAlias = 'Umbraco.Label'
  AND config LIKE '%"umbracoDataValueType":"TEXT"%';
```

#### 5. Rewind the migration state so the new migration runs again

The migration pipeline records each reached state in `umbracoKeyValue` under `Umbraco.Core.Upgrader.State+Umbraco.Core`. Once the migration has run on this database it won't run again. Rewind to the previous state (the GUID of `AddExternalMemberTables`, which is the 17.4 step immediately before the new one):

```sql
UPDATE umbracoKeyValue
SET [value] = '{D7E8F9A0-B1C2-4D3E-A5F6-7890ABCDEF12}'
WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core';
```

#### 6. Verify the broken state before running the migration

```sql
-- Expect: dbType = Nvarchar; row A has textValue set; row B has varcharValue set.
SELECT dt.dbType,
       pd.id AS propertyDataId, pd.versionId,
       pd.varcharValue, pd.textValue
FROM umbracoPropertyData pd
INNER JOIN cmsPropertyType pt ON pd.propertyTypeId = pt.id
INNER JOIN umbracoDataType dt ON pt.dataTypeId = dt.nodeId
WHERE dt.propertyEditorAlias = 'Umbraco.Label'
  AND dt.config LIKE '%"umbracoDataValueType":"TEXT"%'
ORDER BY pd.id;
```

#### 7. Run the migration

Restart the site — the upgrade pipeline runs on startup and will execute `FixLabelDataTypeDbTypeFromConfiguration`.

#### 8. Verify the fix

```sql
SELECT dt.dbType,
       pd.id AS propertyDataId, pd.versionId,
       pd.varcharValue, pd.textValue
FROM umbracoPropertyData pd
INNER JOIN cmsPropertyType pt ON pd.propertyTypeId = pt.id
INNER JOIN umbracoDataType dt ON pt.dataTypeId = dt.nodeId
WHERE dt.propertyEditorAlias = 'Umbraco.Label'
  AND dt.config LIKE '%"umbracoDataValueType":"TEXT"%'
ORDER BY pd.id;
```

Expected:

| dbType | row | varcharValue | textValue |
|---|---|---|---|
| Ntext | A | NULL | `A: value stored in textValue by v13` (unchanged) |
| Ntext | B | NULL | `B: value stored in varcharValue post-upgrade` (relocated) |
