### PR TITLE
Backoffice: Stop UI filtering invariant document URLs by display culture (closes #22556)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
@@ -87,6 +87,14 @@ export class UmbDocumentUrlsDataResolver extends UmbControllerBase {
 	}
 
 	#getDataForCurrentCulture(): Array<UmbDocumentUrlModel> | undefined {
+		// If the local variant is invariant, the document doesn't vary by culture.
+		// URLs returned from the server carry the culture of the domain that produced
+		// them (e.g. "da") which intentionally differs from the backoffice's display
+		// culture, so filtering by culture would drop valid URLs.
+		if (this.#variantId?.isCultureInvariant()) {
+			return this.#data;
+		}
+
 		const culture = this.#getCurrentCulture();
 		// If there is no culture context (invariant data) we return all urls
 		return culture ? this.#data?.filter((x) => x.culture === culture) : this.#data;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/url/document-urls-data-resolver.ts
@@ -87,16 +87,15 @@ export class UmbDocumentUrlsDataResolver extends UmbControllerBase {
 	}
 
 	#getDataForCurrentCulture(): Array<UmbDocumentUrlModel> | undefined {
-		// If the local variant is invariant, the document doesn't vary by culture.
-		// URLs returned from the server carry the culture of the domain that produced
-		// them (e.g. "da") which intentionally differs from the backoffice's display
-		// culture, so filtering by culture would drop valid URLs.
+		// Invariant document: return all URLs. The server tags each URL with the
+		// culture of the domain that produced it.
 		if (this.#variantId?.isCultureInvariant()) {
 			return this.#data;
 		}
 
+		// Variant document: filter to the culture currently being viewed.
+		// If no culture can be resolved at all, fall back to returning everything.
 		const culture = this.#getCurrentCulture();
-		// If there is no culture context (invariant data) we return all urls
 		return culture ? this.#data?.filter((x) => x.culture === culture) : this.#data;
 	}
 }


### PR DESCRIPTION
## Description

This PR addresses https://github.com/umbraco/Umbraco-CMS/issues/22556 that shows missing URLs in the backoffice for for invariant content tagged with the originating domain's culture (e.g. `"da"`), that doesn't align with the globally selected application.

## Testomg

- [ ] Reproduce the reporter's setup: invariant `Domain` → `Language` (Da, En, De) → `Page` tree, with path-based domains on each language node.
- [ ] Open the Info tab on each of the three pages — Danish, English, and German pages should each show their URL without the "cannot be routed" message.
- [ ] Confirm a variant (multi-culture) document still filters URLs to the currently viewed culture.
