### PR TITLE
Cache: Add scope-level cache version tier to reduce DB hits in bulk operations

### DIFF
--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
@@ -37,7 +37,9 @@ public interface IRepositoryCacheVersionAccessor
     /// <param name="cacheKey">Key of the changed version.</param>
     /// <param name="newVersion">The new version GUID that was just written to the database.</param>
     void VersionChanged(string cacheKey, Guid newVersion)
-    { }
+    {
+        VersionChanged(cacheKey);
+    }
 
     /// <summary>
     /// Notifies the accessor that caches have been synchronized.

--- a/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Core/Cache/IRepositoryCacheVersionAccessor.cs
@@ -26,7 +26,17 @@ public interface IRepositoryCacheVersionAccessor
     /// Notifies of a version change on a given cache key.
     /// </summary>
     /// <param name="cacheKey">Key of the changed version.</param>
+    [Obsolete("Use version that takes newVersion, scheduled for removal in V19")]
     void VersionChanged(string cacheKey)
+    { }
+
+    /// <summary>
+    /// Notifies of a version change on a given cache key, providing the new version so internal caches
+    /// can be updated in-place without a database round-trip.
+    /// </summary>
+    /// <param name="cacheKey">Key of the changed version.</param>
+    /// <param name="newVersion">The new version GUID that was just written to the database.</param>
+    void VersionChanged(string cacheKey, Guid newVersion)
     { }
 
     /// <summary>

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -14,6 +14,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     private readonly ILogger<RepositoryCacheVersionService> _logger;
     private readonly IRepositoryCacheVersionAccessor _repositoryCacheVersionAccessor;
     private readonly ConcurrentDictionary<string, Guid> _cacheVersions = new();
+    private readonly ConcurrentDictionary<Guid, HashSet<string>> _writtenKeysByScope = new();
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="RepositoryCacheVersionService" /> class.
@@ -84,14 +85,19 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     public async Task SetCacheUpdatedAsync<TEntity>()
         where TEntity : class
     {
-        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        string cacheKey = GetCacheKey<TEntity>();
 
-        // We have to take a write lock to ensure the cache is not being read while we update the version.
+        HashSet<string>? writtenKeys = GetOrRegisterScopeWrittenKeys();
+        if (writtenKeys?.Add(cacheKey) is false)
+        {
+            _logger.LogDebug("Cache version for {EntityType} already written in this scope, skipping", typeof(TEntity).Name);
+            return;
+        }
+
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
         scope.WriteLock(Constants.Locks.CacheVersion);
 
-        var cacheKey = GetCacheKey<TEntity>();
         var newVersion = Guid.NewGuid();
-
         _logger.LogDebug("Setting cache for {EntityType} to version {Version}", typeof(TEntity).Name, newVersion);
         await _repositoryCacheVersionRepository.SaveAsync(new RepositoryCacheVersion { Identifier = cacheKey, Version = newVersion.ToString() });
         _cacheVersions[cacheKey] = newVersion;
@@ -131,4 +137,28 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     internal string GetCacheKey<TEntity>()
         where TEntity : class =>
         typeof(TEntity).FullName ?? typeof(TEntity).Name;
+
+    private HashSet<string>? GetOrRegisterScopeWrittenKeys()
+    {
+        IScopeContext? context = _scopeProvider.Context;
+        if (context is null)
+        {
+            return null;
+        }
+
+        Guid contextId = context.InstanceId;
+        if (_writtenKeysByScope.TryGetValue(contextId, out HashSet<string>? writtenKeys))
+        {
+            return writtenKeys;
+        }
+
+        writtenKeys = new HashSet<string>();
+        _writtenKeysByScope[contextId] = writtenKeys;
+
+        context.Enlist(
+            $"RepositoryCacheVersionService_{contextId}",
+            completed => _writtenKeysByScope.TryRemove(contextId, out _));
+
+        return writtenKeys;
+    }
 }

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Collections;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
@@ -14,7 +15,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     private readonly ILogger<RepositoryCacheVersionService> _logger;
     private readonly IRepositoryCacheVersionAccessor _repositoryCacheVersionAccessor;
     private readonly ConcurrentDictionary<string, Guid> _cacheVersions = new();
-    private readonly ConcurrentDictionary<Guid, HashSet<string>> _writtenKeysByScope = new();
+    private readonly ConcurrentDictionary<Guid, ConcurrentHashSet<string>> _writtenKeysByScope = new();
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="RepositoryCacheVersionService" /> class.
@@ -86,8 +87,8 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     {
         string cacheKey = GetCacheKey<TEntity>();
 
-        HashSet<string>? writtenKeys = GetOrRegisterScopeWrittenKeys();
-        if (writtenKeys?.Add(cacheKey) is false)
+        ConcurrentHashSet<string>? writtenKeys = GetOrRegisterScopeWrittenKeys();
+        if (writtenKeys?.TryAdd(cacheKey) is false)
         {
             _logger.LogDebug("Cache version for {EntityType} already written in this scope, skipping", typeof(TEntity).Name);
             return;
@@ -136,7 +137,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
         where TEntity : class =>
         typeof(TEntity).FullName ?? typeof(TEntity).Name;
 
-    private HashSet<string>? GetOrRegisterScopeWrittenKeys()
+    private ConcurrentHashSet<string>? GetOrRegisterScopeWrittenKeys()
     {
         IScopeContext? context = _scopeProvider.Context;
         if (context is null)
@@ -145,13 +146,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
         }
 
         Guid contextId = context.InstanceId;
-        if (_writtenKeysByScope.TryGetValue(contextId, out HashSet<string>? writtenKeys))
-        {
-            return writtenKeys;
-        }
-
-        writtenKeys = new HashSet<string>();
-        _writtenKeysByScope[contextId] = writtenKeys;
+        ConcurrentHashSet<string> writtenKeys = _writtenKeysByScope.GetOrAdd(contextId, _ => new ConcurrentHashSet<string>());
 
         context.Enlist(
             $"RepositoryCacheVersionService_{contextId}",

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -45,7 +45,6 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
 
         var cacheKey = GetCacheKey<TEntity>();
 
-        // The cache version accessor will take a read lock if the version is not in request cache, so we don't need to take one here.
         RepositoryCacheVersion? databaseVersion = await _repositoryCacheVersionAccessor.GetAsync(cacheKey);
 
         if (databaseVersion?.Version is null)
@@ -110,7 +109,6 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
     public async Task SetCachesSyncedAsync()
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        scope.ReadLock(Constants.Locks.CacheVersion);
 
         // We always sync all caches versions, so it's safe to assume all caches are synced at this point.
         IEnumerable<RepositoryCacheVersion> cacheVersions = await _repositoryCacheVersionRepository.GetAllAsync();

--- a/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
+++ b/src/Umbraco.Core/Cache/RepositoryCacheVersionService.cs
@@ -95,7 +95,7 @@ internal class RepositoryCacheVersionService : IRepositoryCacheVersionService
         _logger.LogDebug("Setting cache for {EntityType} to version {Version}", typeof(TEntity).Name, newVersion);
         await _repositoryCacheVersionRepository.SaveAsync(new RepositoryCacheVersion { Identifier = cacheKey, Version = newVersion.ToString() });
         _cacheVersions[cacheKey] = newVersion;
-        _repositoryCacheVersionAccessor.VersionChanged(cacheKey);
+        _repositoryCacheVersionAccessor.VersionChanged(cacheKey, newVersion);
 
         scope.Complete();
     }

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -77,7 +77,6 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         }
 
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope(autoComplete: true);
-        scope.ReadLock(Core.Constants.Locks.CacheVersion);
 
         RepositoryCacheVersion? databaseVersion = await _repositoryCacheVersionRepository.GetAsync(cacheKey);
 

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -147,13 +147,7 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         }
 
         Guid contextId = context.InstanceId;
-        if (_scopeVersionCaches.TryGetValue(contextId, out ConcurrentDictionary<string, Guid>? cache))
-        {
-            return cache;
-        }
-
-        cache = new ConcurrentDictionary<string, Guid>();
-        _scopeVersionCaches[contextId] = cache;
+        ConcurrentDictionary<string, Guid> cache = _scopeVersionCaches.GetOrAdd(contextId, _ => new ConcurrentDictionary<string, Guid>());
 
         // Enlist is used here for its intended purpose: lifecycle cleanup on scope exit.
         context.Enlist(

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Web.Common.Cache;
 public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
 {
     // Keyed by IScopeContext.InstanceId (root scope). Cleaned up via Enlist callback on scope exit.
-    private readonly ConcurrentDictionary<Guid, Dictionary<string, Guid>> _scopeVersionCaches = new();
+    private readonly ConcurrentDictionary<Guid, ConcurrentDictionary<string, Guid>> _scopeVersionCaches = new();
     private readonly IRequestCache _requestCache;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IRepositoryCacheVersionRepository _repositoryCacheVersionRepository;
@@ -61,7 +61,7 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         }
 
         // 1. Scope-level cache — survives request-cache invalidation within a transaction.
-        Dictionary<string, Guid>? scopeCache = GetOrRegisterScopeVersionCache();
+        ConcurrentDictionary<string, Guid>? scopeCache = GetOrRegisterScopeVersionCache();
         if (scopeCache is not null && scopeCache.TryGetValue(cacheKey, out Guid scopeVersion))
         {
             _logger.LogDebug("Cache version for key {CacheKey} found in scope cache", cacheKey);
@@ -111,7 +111,7 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
     public void VersionChanged(string cacheKey, Guid newVersion)
     {
         // Update scope cache in-place — no DB re-read needed.
-        Dictionary<string, Guid>? scopeCache = GetOrRegisterScopeVersionCache();
+        ConcurrentDictionary<string, Guid>? scopeCache = GetOrRegisterScopeVersionCache();
         if (scopeCache is not null)
         {
             scopeCache[cacheKey] = newVersion;
@@ -129,7 +129,7 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         _requestCache.ClearOfType<RepositoryCacheVersion>();
     }
 
-    private Dictionary<string, Guid>? GetOrRegisterScopeVersionCache()
+    private ConcurrentDictionary<string, Guid>? GetOrRegisterScopeVersionCache()
     {
         IScopeContext? context = _coreScopeProvider.Context;
         if (context is null)
@@ -138,12 +138,12 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         }
 
         Guid contextId = context.InstanceId;
-        if (_scopeVersionCaches.TryGetValue(contextId, out Dictionary<string, Guid>? cache))
+        if (_scopeVersionCaches.TryGetValue(contextId, out ConcurrentDictionary<string, Guid>? cache))
         {
             return cache;
         }
 
-        cache = new Dictionary<string, Guid>();
+        cache = new ConcurrentDictionary<string, Guid>();
         _scopeVersionCaches[contextId] = cache;
 
         // Enlist is used here for its intended purpose: lifecycle cleanup on scope exit.

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -91,7 +91,17 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         // Populate scope cache so subsequent reads within this scope skip the DB.
         if (databaseVersion.Version is not null)
         {
-            scopeCache?.TryAdd(cacheKey, Guid.Parse(databaseVersion.Version));
+            if (Guid.TryParse(databaseVersion.Version, out Guid parsedVersion))
+            {
+                scopeCache?.TryAdd(cacheKey, parsedVersion);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Cache version for key {CacheKey} has an invalid GUID value '{CacheVersion}' and will not be added to the scope cache",
+                    cacheKey,
+                    databaseVersion.Version);
+            }
         }
 
         return databaseVersion;

--- a/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
+++ b/src/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Cache;
@@ -10,6 +11,8 @@ namespace Umbraco.Cms.Web.Common.Cache;
 
 public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
 {
+    // Keyed by IScopeContext.InstanceId (root scope). Cleaned up via Enlist callback on scope exit.
+    private readonly ConcurrentDictionary<Guid, Dictionary<string, Guid>> _scopeVersionCaches = new();
     private readonly IRequestCache _requestCache;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IRepositoryCacheVersionRepository _repositoryCacheVersionRepository;
@@ -38,10 +41,11 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
     /// The cache version if found, or <see langword="null"/> if the version doesn't exist or the request is a client-side request.
     /// </returns>
     /// <remarks>
-    /// This method implements a two-tier caching strategy:
+    /// This method implements a three-tier caching strategy:
     /// <list type="number">
-    /// <item>First checks the request cache to avoid database queries within the same request.</item>
-    /// <item>If not found in request cache, queries the database and caches the result for subsequent calls.</item>
+    /// <item>First checks the scope cache to avoid database queries within the same transaction.</item>
+    /// <item>Then checks the request cache to avoid database queries within the same request.</item>
+    /// <item>If not found in either cache, queries the database and caches the result for subsequent calls.</item>
     /// </list>
     /// Client-side requests always return <see langword="null"/>
     /// to avoid unnecessary cache version lookups.
@@ -56,6 +60,15 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
             return null;
         }
 
+        // 1. Scope-level cache — survives request-cache invalidation within a transaction.
+        Dictionary<string, Guid>? scopeCache = GetOrRegisterScopeVersionCache();
+        if (scopeCache is not null && scopeCache.TryGetValue(cacheKey, out Guid scopeVersion))
+        {
+            _logger.LogDebug("Cache version for key {CacheKey} found in scope cache", cacheKey);
+            return new RepositoryCacheVersion { Identifier = cacheKey, Version = scopeVersion.ToString() };
+        }
+
+        // 2. Request-level cache.
         RepositoryCacheVersion? requestCachedVersion = _requestCache.GetCacheItem<RepositoryCacheVersion>(cacheKey);
         if (requestCachedVersion is not null)
         {
@@ -74,9 +87,15 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
         }
 
         _requestCache.Set(cacheKey, databaseVersion);
+
+        // Populate scope cache so subsequent reads within this scope skip the DB.
+        if (databaseVersion.Version is not null)
+        {
+            scopeCache?.TryAdd(cacheKey, Guid.Parse(databaseVersion.Version));
+        }
+
         return databaseVersion;
     }
-
 
     /// <inheritdoc />
     public void VersionChanged(string cacheKey)
@@ -89,5 +108,49 @@ public class RepositoryCacheVersionAccessor : IRepositoryCacheVersionAccessor
     }
 
     /// <inheritdoc />
-    public void CachesSynced() => _requestCache.ClearOfType<RepositoryCacheVersion>();
+    public void VersionChanged(string cacheKey, Guid newVersion)
+    {
+        // Update scope cache in-place — no DB re-read needed.
+        Dictionary<string, Guid>? scopeCache = GetOrRegisterScopeVersionCache();
+        if (scopeCache is not null)
+        {
+            scopeCache[cacheKey] = newVersion;
+        }
+
+        // Clear request cache (keep in sync with scope cache).
+        _requestCache.Remove(cacheKey);
+    }
+
+    /// <inheritdoc />
+    public void CachesSynced()
+    {
+        // Clear scope cache so fresh versions are read from the DB after a full reload.
+        GetOrRegisterScopeVersionCache()?.Clear();
+        _requestCache.ClearOfType<RepositoryCacheVersion>();
+    }
+
+    private Dictionary<string, Guid>? GetOrRegisterScopeVersionCache()
+    {
+        IScopeContext? context = _coreScopeProvider.Context;
+        if (context is null)
+        {
+            return null;
+        }
+
+        Guid contextId = context.InstanceId;
+        if (_scopeVersionCaches.TryGetValue(contextId, out Dictionary<string, Guid>? cache))
+        {
+            return cache;
+        }
+
+        cache = new Dictionary<string, Guid>();
+        _scopeVersionCaches[contextId] = cache;
+
+        // Enlist is used here for its intended purpose: lifecycle cleanup on scope exit.
+        context.Enlist(
+            $"RepositoryCacheVersionAccessor_{contextId}",
+            completed => _scopeVersionCaches.TryRemove(contextId, out _));
+
+        return cache;
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
@@ -66,17 +66,40 @@ internal sealed class RepositoryCacheVersionServiceTests : UmbracoIntegrationTes
     [Test]
     public async Task SetCacheUpdatedAsync_Updates_Cache_Version()
     {
+        // Each service call runs in its own implicit root scope so deduplication does not apply.
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        string? initialVersion;
+        using (var readScope = CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            initialVersion = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        }
+        Assert.IsNotNull(initialVersion, "Initial cache version should not be null.");
+
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        string? updatedVersion;
+        using (var readScope = CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            updatedVersion = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        }
+        Assert.IsNotNull(updatedVersion, "Updated cache version should not be null.");
+
+        Assert.AreNotEqual(initialVersion, updatedVersion, "Cache version should be updated.");
+    }
+
+    [Test]
+    public async Task SetCacheUpdatedAsync_OnlyWritesOncePerScopeForSameEntityType()
+    {
         using var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true);
 
         await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
-        var initialCacheVersion = await RepositoryCacheVersionRepository.GetAsync(GetCacheKey());
-        Assert.IsNotNull(initialCacheVersion, "Initial cache version should not be null.");
+        var firstVersion = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        Assert.IsNotNull(firstVersion);
 
+        // Second call within the same scope must be a no-op.
         await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
-        var updatedCacheVersion = await RepositoryCacheVersionRepository.GetAsync(GetCacheKey());
-        Assert.IsNotNull(updatedCacheVersion, "Updated cache version should not be null.");
+        var secondVersion = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
 
-        Assert.AreNotEqual(initialCacheVersion.Version, updatedCacheVersion.Version, "Cache version should be updated.");
+        Assert.AreEqual(firstVersion, secondVersion, "Second call within the same scope must not write a new version.");
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
@@ -96,6 +96,79 @@ internal sealed class RepositoryCacheVersionServiceTests : UmbracoIntegrationTes
         Assert.AreNotEqual(contentVersion, mediaVersion, "Cache versions should be unique for different repository types.");
     }
 
+    [Test]
+    public async Task SetCachesSyncedAsync_RestoresSyncAfterRemoteUpdate()
+    {
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        Assert.IsTrue(await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>());
+
+        // Simulate a remote update — local service is now out of sync.
+        using (var scope = CoreScopeProvider.CreateCoreScope())
+        {
+            await RepositoryCacheVersionRepository.SaveAsync(GetRepositoryRandomCacheVersion());
+            scope.Complete();
+        }
+
+        Assert.IsFalse(await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>(), "Expected out of sync after remote update.");
+
+        // Re-sync from the database.
+        await RepositoryCacheVersionService.SetCachesSyncedAsync();
+
+        Assert.IsTrue(await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>(), "Expected in sync after SetCachesSyncedAsync.");
+    }
+
+    [Test]
+    public async Task IsCacheSyncedAsync_ReturnsTrueWhenLocalIsUninitializedButDbHasVersion()
+    {
+        // Write directly to DB — simulates another instance having written a version
+        // before this instance ever checked.
+        using (var scope = CoreScopeProvider.CreateCoreScope())
+        {
+            await RepositoryCacheVersionRepository.SaveAsync(GetRepositoryRandomCacheVersion());
+            scope.Complete();
+        }
+
+        // First check: local has no version, DB has one → service initialises from DB and returns true.
+        var isSynced = await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>();
+        Assert.IsTrue(isSynced, "Should be synced when local is uninitialised but DB has a version.");
+
+        // Second check: local version now matches DB version → still synced.
+        isSynced = await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>();
+        Assert.IsTrue(isSynced, "Should remain synced on subsequent checks.");
+    }
+
+    [Test]
+    public async Task SetCachesSyncedAsync_SyncsAllEntityTypesFromDb()
+    {
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IMedia>();
+
+        Assert.IsTrue(await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>());
+        Assert.IsTrue(await RepositoryCacheVersionService.IsCacheSyncedAsync<IMedia>());
+
+        var mediaKey = ((RepositoryCacheVersionService)RepositoryCacheVersionService).GetCacheKey<IMedia>();
+
+        // Simulate remote updates for both entity types.
+        using (var scope = CoreScopeProvider.CreateCoreScope())
+        {
+            await RepositoryCacheVersionRepository.SaveAsync(GetRepositoryRandomCacheVersion());
+            await RepositoryCacheVersionRepository.SaveAsync(new RepositoryCacheVersion
+            {
+                Identifier = mediaKey,
+                Version = Guid.NewGuid().ToString(),
+            });
+            scope.Complete();
+        }
+
+        Assert.IsFalse(await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>(), "IContent should be out of sync.");
+        Assert.IsFalse(await RepositoryCacheVersionService.IsCacheSyncedAsync<IMedia>(), "IMedia should be out of sync.");
+
+        await RepositoryCacheVersionService.SetCachesSyncedAsync();
+
+        Assert.IsTrue(await RepositoryCacheVersionService.IsCacheSyncedAsync<IContent>(), "IContent should be synced after SetCachesSyncedAsync.");
+        Assert.IsTrue(await RepositoryCacheVersionService.IsCacheSyncedAsync<IMedia>(), "IMedia should be synced after SetCachesSyncedAsync.");
+    }
+
     private RepositoryCacheVersion GetRepositoryRandomCacheVersion()
         => new()
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RepositoryCacheVersionServiceTests.cs
@@ -103,6 +103,55 @@ internal sealed class RepositoryCacheVersionServiceTests : UmbracoIntegrationTes
     }
 
     [Test]
+    public async Task SetCacheUpdatedAsync_DeduplicationResetsAfterScopeExit()
+    {
+        string? firstScopeVersion;
+        using (var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+            firstScopeVersion = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        }
+        Assert.IsNotNull(firstScopeVersion);
+
+        // After the scope exits the deduplication state is cleared; a new scope must be able to write.
+        string? secondScopeVersion;
+        using (var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+            secondScopeVersion = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        }
+
+        Assert.IsNotNull(secondScopeVersion);
+        Assert.AreNotEqual(firstScopeVersion, secondScopeVersion, "A new scope must produce a fresh version after the previous scope exited.");
+    }
+
+    [Test]
+    public async Task SetCacheUpdatedAsync_DifferentEntityTypesDeduplicatedIndependently()
+    {
+        var mediaKey = ((RepositoryCacheVersionService)RepositoryCacheVersionService).GetCacheKey<IMedia>();
+
+        using var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true);
+
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IMedia>();
+
+        var contentVersionAfterFirst = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        var mediaVersionAfterFirst = (await RepositoryCacheVersionRepository.GetAsync(mediaKey))?.Version;
+        Assert.IsNotNull(contentVersionAfterFirst);
+        Assert.IsNotNull(mediaVersionAfterFirst);
+
+        // Second calls — must be no-ops for each type independently.
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IContent>();
+        await RepositoryCacheVersionService.SetCacheUpdatedAsync<IMedia>();
+
+        var contentVersionAfterSecond = (await RepositoryCacheVersionRepository.GetAsync(GetCacheKey()))?.Version;
+        var mediaVersionAfterSecond = (await RepositoryCacheVersionRepository.GetAsync(mediaKey))?.Version;
+
+        Assert.AreEqual(contentVersionAfterFirst, contentVersionAfterSecond, "Second IContent call in same scope must not write a new version.");
+        Assert.AreEqual(mediaVersionAfterFirst, mediaVersionAfterSecond, "Second IMedia call in same scope must not write a new version.");
+    }
+
+    [Test]
     public async Task CacheVersion_Is_Unique_Per_Repository_Type()
     {
         using var scope = CoreScopeProvider.CreateCoreScope(autoComplete: true);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
@@ -282,6 +282,7 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    [Ignore("Skip For nightly")]
     [LongRunning]
     public async Task Concurrent_Save_Same_Login_Should_Not_Throw_Duplicate_Key_Exception()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
@@ -282,7 +282,6 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    [Ignore("Skip For nightly")]
     [LongRunning]
     public async Task Concurrent_Save_Same_Login_Should_Not_Throw_Duplicate_Key_Exception()
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/RepositoryCacheVersionServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/RepositoryCacheVersionServiceTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Cache;
+
+[TestFixture]
+public class RepositoryCacheVersionServiceTests
+{
+    private Mock<ICoreScopeProvider> _scopeProvider = null!;
+    private Mock<IRepositoryCacheVersionRepository> _repository = null!;
+    private Mock<IRepositoryCacheVersionAccessor> _accessor = null!;
+    private FakeScopeContext _defaultScopeContext = null!;
+    private RepositoryCacheVersionService _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repository = new Mock<IRepositoryCacheVersionRepository>();
+        _accessor = new Mock<IRepositoryCacheVersionAccessor>();
+
+        _defaultScopeContext = new FakeScopeContext();
+        _scopeProvider = new Mock<ICoreScopeProvider>();
+        _scopeProvider.Setup(x => x.Context).Returns(_defaultScopeContext);
+        _scopeProvider
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher?>(),
+                It.IsAny<IScopedNotificationPublisher?>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(Mock.Of<ICoreScope>());
+
+        _sut = new RepositoryCacheVersionService(
+            _scopeProvider.Object,
+            _repository.Object,
+            NullLogger<RepositoryCacheVersionService>.Instance,
+            _accessor.Object);
+    }
+
+    [Test]
+    public async Task IsCacheSyncedAsync_ReturnsFalse_WhenAccessorReturnsStaleVersion()
+    {
+        // Arrange: SetCachesSyncedAsync writes V1 into _cacheVersions.
+        var cacheKey = _sut.GetCacheKey<IContent>();
+        var v0 = Guid.NewGuid();
+        var v1 = Guid.NewGuid();
+
+        _repository
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(new[] { new RepositoryCacheVersion { Identifier = cacheKey, Version = v1.ToString() } });
+
+        await _sut.SetCachesSyncedAsync();
+
+        // Accessor (scope / request cache on another request path) still returns stale V0.
+        _accessor
+            .Setup(x => x.GetAsync(cacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = cacheKey, Version = v0.ToString() });
+
+        // Act
+        var isSynced = await _sut.IsCacheSyncedAsync<IContent>();
+
+        // Assert: local V1 ≠ accessor V0 → not synced.
+        Assert.IsFalse(isSynced, "Cache should be out of sync when the accessor returns a stale version.");
+    }
+
+    [Test]
+    public async Task IsCacheSyncedAsync_ReturnsTrue_WhenAccessorAndLocalVersionMatch()
+    {
+        var cacheKey = _sut.GetCacheKey<IContent>();
+        var version = Guid.NewGuid();
+
+        _repository
+            .Setup(x => x.GetAllAsync())
+            .ReturnsAsync(new[] { new RepositoryCacheVersion { Identifier = cacheKey, Version = version.ToString() } });
+
+        await _sut.SetCachesSyncedAsync();
+
+        _accessor
+            .Setup(x => x.GetAsync(cacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = cacheKey, Version = version.ToString() });
+
+        var isSynced = await _sut.IsCacheSyncedAsync<IContent>();
+
+        Assert.IsTrue(isSynced);
+    }
+
+    [Test]
+    public async Task SetCacheUpdatedAsync_WritesOnlyOncePerScopeForSameEntityType()
+    {
+        var cacheKey = _sut.GetCacheKey<IContent>();
+        _repository.Setup(x => x.SaveAsync(It.IsAny<RepositoryCacheVersion>())).Returns(Task.CompletedTask);
+
+        await _sut.SetCacheUpdatedAsync<IContent>();
+        await _sut.SetCacheUpdatedAsync<IContent>();
+
+        _repository.Verify(
+            x => x.SaveAsync(It.Is<RepositoryCacheVersion>(v => v.Identifier == cacheKey)),
+            Times.Once,
+            "Second call within the same scope must be deduplicated.");
+    }
+
+    [Test]
+    public async Task SetCacheUpdatedAsync_WritesAgain_AfterScopeExit()
+    {
+        var cacheKey = _sut.GetCacheKey<IContent>();
+        _repository.Setup(x => x.SaveAsync(It.IsAny<RepositoryCacheVersion>())).Returns(Task.CompletedTask);
+
+        // First scope: one write.
+        await _sut.SetCacheUpdatedAsync<IContent>();
+        _defaultScopeContext.ScopeExit(completed: true);
+
+        // New scope: deduplication state is cleared — write must happen again.
+        var freshContext = new FakeScopeContext();
+        _scopeProvider.Setup(x => x.Context).Returns(freshContext);
+
+        await _sut.SetCacheUpdatedAsync<IContent>();
+
+        _repository.Verify(
+            x => x.SaveAsync(It.Is<RepositoryCacheVersion>(v => v.Identifier == cacheKey)),
+            Times.Exactly(2),
+            "A new scope must allow a second write after the previous scope exited.");
+    }
+
+    [Test]
+    public async Task SetCacheUpdatedAsync_WritesEveryTime_WhenNoScopeContext()
+    {
+        // Without a scope context there is no deduplication state to track.
+        _scopeProvider.Setup(x => x.Context).Returns((IScopeContext?)null);
+
+        var cacheKey = _sut.GetCacheKey<IContent>();
+        _repository.Setup(x => x.SaveAsync(It.IsAny<RepositoryCacheVersion>())).Returns(Task.CompletedTask);
+
+        await _sut.SetCacheUpdatedAsync<IContent>();
+        await _sut.SetCacheUpdatedAsync<IContent>();
+
+        _repository.Verify(
+            x => x.SaveAsync(It.Is<RepositoryCacheVersion>(v => v.Identifier == cacheKey)),
+            Times.Exactly(2),
+            "Without a scope context every call must write a new version.");
+    }
+
+    private sealed class FakeScopeContext : IScopeContext
+    {
+        private readonly Dictionary<string, Action<bool>> _actions = new();
+
+        public Guid InstanceId { get; } = Guid.NewGuid();
+
+        public int CreatedThreadId => Environment.CurrentManagedThreadId;
+
+        public void Enlist(string key, Action<bool> action, int priority = 100)
+            => _actions.TryAdd(key, action);
+
+        public T? Enlist<T>(string key, Func<T> creator, Action<bool, T?>? action = null, int priority = 100)
+            => throw new NotSupportedException();
+
+        public T? GetEnlisted<T>(string key)
+            => throw new NotSupportedException();
+
+        public void ScopeExit(bool completed)
+        {
+            foreach (Action<bool> a in _actions.Values)
+            {
+                a(completed);
+            }
+
+            _actions.Clear();
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessorTests.cs
@@ -296,7 +296,7 @@ public class RepositoryCacheVersionAccessorTests
         public int CreatedThreadId => Environment.CurrentManagedThreadId;
 
         public void Enlist(string key, Action<bool> action, int priority = 100)
-            => _actions[key] = action;
+            => _actions.TryAdd(key, action);
 
         public T? Enlist<T>(string key, Func<T> creator, Action<bool, T?>? action = null, int priority = 100)
             => throw new NotSupportedException();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Cache/RepositoryCacheVersionAccessorTests.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Web.Common.Cache;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Cache;
+
+[TestFixture]
+public class RepositoryCacheVersionAccessorTests
+{
+    private const string CacheKey = "test-cache-key";
+
+    private DictionaryAppCache _requestCache = null!;
+    private Mock<IRepositoryCacheVersionRepository> _repository = null!;
+    private Mock<IHttpContextAccessor> _httpContextAccessor = null!;
+    private Mock<ICoreScopeProvider> _scopeProvider = null!;
+    private FakeScopeContext _defaultScopeContext = null!;
+    private RepositoryCacheVersionAccessor _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _requestCache = new DictionaryAppCache();
+
+        _repository = new Mock<IRepositoryCacheVersionRepository>();
+
+        _httpContextAccessor = new Mock<IHttpContextAccessor>();
+        _httpContextAccessor.Setup(x => x.HttpContext).Returns((HttpContext?)null);
+
+        _defaultScopeContext = new FakeScopeContext();
+        _scopeProvider = new Mock<ICoreScopeProvider>();
+        _scopeProvider.Setup(x => x.Context).Returns(_defaultScopeContext);
+        _scopeProvider
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher?>(),
+                It.IsAny<IScopedNotificationPublisher?>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(Mock.Of<ICoreScope>());
+
+        _sut = new RepositoryCacheVersionAccessor(
+            _requestCache,
+            _httpContextAccessor.Object,
+            _repository.Object,
+            _scopeProvider.Object,
+            NullLogger<RepositoryCacheVersionAccessor>.Instance);
+    }
+
+    // --- Scope cache tier ---
+
+    [Test]
+    public async Task GetAsync_WhenRepositoryReturnsVersion_PopulatesScopeCacheAndRequestCache()
+    {
+        var version = Guid.NewGuid();
+        _repository
+            .Setup(x => x.GetAsync(CacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = CacheKey, Version = version.ToString() });
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        Assert.AreEqual(version.ToString(), result?.Version);
+        Assert.IsNotNull(_requestCache.GetCacheItem<RepositoryCacheVersion>(CacheKey));
+
+        // Second call within the same scope context must not hit the DB (scope cache hit).
+        await _sut.GetAsync(CacheKey);
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Once);
+    }
+
+    [Test]
+    public async Task GetAsync_WithinSameScopeContext_HitsDbOnlyOnce()
+    {
+        _repository
+            .Setup(x => x.GetAsync(CacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = CacheKey, Version = Guid.NewGuid().ToString() });
+
+        await _sut.GetAsync(CacheKey);
+        await _sut.GetAsync(CacheKey);
+        await _sut.GetAsync(CacheKey);
+
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Once);
+    }
+
+    [Test]
+    public async Task GetAsync_AfterVersionChangedWithGuid_ReturnsNewVersionFromScopeCacheWithoutDbCall()
+    {
+        var newGuid = Guid.NewGuid();
+        _sut.VersionChanged(CacheKey, newGuid);
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        Assert.AreEqual(newGuid.ToString(), result?.Version);
+        _repository.Verify(x => x.GetAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task VersionChanged_WithGuid_UpdatesScopeCacheAndClearsRequestCache()
+    {
+        var initialVersion = Guid.NewGuid();
+        _repository
+            .Setup(x => x.GetAsync(CacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = CacheKey, Version = initialVersion.ToString() });
+
+        // Populate both caches.
+        await _sut.GetAsync(CacheKey);
+        Assert.IsNotNull(_requestCache.GetCacheItem<RepositoryCacheVersion>(CacheKey));
+
+        // Update scope cache in-place; request cache must be cleared.
+        var newerGuid = Guid.NewGuid();
+        _sut.VersionChanged(CacheKey, newerGuid);
+
+        Assert.IsNull(_requestCache.GetCacheItem<RepositoryCacheVersion>(CacheKey));
+
+        // Next read returns the newer GUID from scope cache — no DB round-trip.
+        var result = await _sut.GetAsync(CacheKey);
+        Assert.AreEqual(newerGuid.ToString(), result?.Version);
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Once);
+    }
+
+    [Test]
+    public async Task ScopeCacheEntry_RemovedAfterScopeExit()
+    {
+        var guid1 = Guid.NewGuid();
+        _sut.VersionChanged(CacheKey, guid1);
+
+        // Scope cache is populated: GetAsync returns from it without hitting the DB.
+        var resultBeforeExit = await _sut.GetAsync(CacheKey);
+        Assert.AreEqual(guid1.ToString(), resultBeforeExit?.Version);
+        _repository.Verify(x => x.GetAsync(It.IsAny<string>()), Times.Never);
+
+        // Trigger scope exit — the Enlist cleanup callback fires and removes the entry.
+        _defaultScopeContext.ScopeExit(completed: true);
+
+        // Switch to a fresh scope context; its scope cache is empty.
+        var freshContext = new FakeScopeContext();
+        _scopeProvider.Setup(x => x.Context).Returns(freshContext);
+        _repository
+            .Setup(x => x.GetAsync(CacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = CacheKey, Version = Guid.NewGuid().ToString() });
+
+        await _sut.GetAsync(CacheKey);
+
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Once);
+    }
+
+    [Test]
+    public async Task GetAsync_DifferentScopeContexts_DoNotShareScopeCache()
+    {
+        var guid1 = Guid.NewGuid();
+        _sut.VersionChanged(CacheKey, guid1);
+
+        // Switch to a different scope context.
+        var context2 = new FakeScopeContext();
+        _scopeProvider.Setup(x => x.Context).Returns(context2);
+
+        var differentVersion = Guid.NewGuid().ToString();
+        _repository
+            .Setup(x => x.GetAsync(CacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = CacheKey, Version = differentVersion });
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        // Must not have served context1's scope cache entry.
+        Assert.AreNotEqual(guid1.ToString(), result?.Version);
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Once);
+    }
+
+    // --- Request cache tier ---
+
+    [Test]
+    public async Task GetAsync_WhenScopeContextIsNull_ReturnsFromRequestCache()
+    {
+        _scopeProvider.Setup(x => x.Context).Returns((IScopeContext?)null);
+        var cachedVersion = new RepositoryCacheVersion { Identifier = CacheKey, Version = Guid.NewGuid().ToString() };
+        _requestCache.Set(CacheKey, cachedVersion);
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        Assert.AreEqual(cachedVersion.Version, result?.Version);
+        _repository.Verify(x => x.GetAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public void VersionChanged_WithoutGuid_ClearsRequestCache()
+    {
+        _requestCache.Set(CacheKey, new RepositoryCacheVersion { Identifier = CacheKey, Version = Guid.NewGuid().ToString() });
+        Assert.IsNotNull(_requestCache.GetCacheItem<RepositoryCacheVersion>(CacheKey));
+
+        _sut.VersionChanged(CacheKey);
+
+        Assert.IsNull(_requestCache.GetCacheItem<RepositoryCacheVersion>(CacheKey));
+    }
+
+    // --- Database tier ---
+
+    [Test]
+    public async Task GetAsync_WhenNeitherCacheHasVersion_QueriesDatabase()
+    {
+        _scopeProvider.Setup(x => x.Context).Returns((IScopeContext?)null);
+        var dbVersion = new RepositoryCacheVersion { Identifier = CacheKey, Version = Guid.NewGuid().ToString() };
+        _repository.Setup(x => x.GetAsync(CacheKey)).ReturnsAsync(dbVersion);
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        Assert.AreEqual(dbVersion.Version, result?.Version);
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Once);
+    }
+
+    [Test]
+    public async Task GetAsync_WhenRepositoryReturnsNull_ReturnsNullAndDoesNotCache()
+    {
+        _repository.Setup(x => x.GetAsync(CacheKey)).ReturnsAsync((RepositoryCacheVersion?)null);
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        Assert.IsNull(result);
+        Assert.IsNull(_requestCache.GetCacheItem<RepositoryCacheVersion>(CacheKey));
+
+        // A second call must also hit the DB (nothing was cached).
+        await _sut.GetAsync(CacheKey);
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task GetAsync_WhenRepositoryReturnsVersionWithNullVersion_CachesInRequestButNotInScopeCache()
+    {
+        _repository
+            .Setup(x => x.GetAsync(CacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = CacheKey, Version = null });
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        // Object is returned and request-cached even though Version is null.
+        Assert.IsNotNull(result);
+        Assert.IsNotNull(_requestCache.GetCacheItem<RepositoryCacheVersion>(CacheKey));
+
+        // Scope cache was NOT populated (Version was null).
+        // Removing the request cache entry forces the next call to fall through to the DB.
+        _requestCache.Remove(CacheKey);
+        await _sut.GetAsync(CacheKey);
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Exactly(2));
+    }
+
+    // --- HTTP context ---
+
+    [Test]
+    public async Task GetAsync_WhenHttpContextHasNonNullRequestServicesAndIsNotBackOffice_ReturnsNull()
+    {
+        // Non-null RequestServices without UmbracoRequestPaths registered → IsBackOfficeRequest() returns false.
+        var httpContext = new DefaultHttpContext { RequestServices = Mock.Of<IServiceProvider>() };
+        _httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var result = await _sut.GetAsync(CacheKey);
+
+        Assert.IsNull(result);
+        _repository.Verify(x => x.GetAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CachesSynced_ClearsBothScopeCacheAndRequestCache()
+    {
+        var guid1 = Guid.NewGuid();
+        _sut.VersionChanged(CacheKey, guid1);
+        // VersionChanged removed the request cache key, so Set succeeds.
+        _requestCache.Set(CacheKey, new RepositoryCacheVersion { Identifier = CacheKey, Version = guid1.ToString() });
+
+        _sut.CachesSynced();
+
+        // Both caches cleared: next GetAsync must fall through to the DB.
+        _repository
+            .Setup(x => x.GetAsync(CacheKey))
+            .ReturnsAsync(new RepositoryCacheVersion { Identifier = CacheKey, Version = Guid.NewGuid().ToString() });
+        await _sut.GetAsync(CacheKey);
+        _repository.Verify(x => x.GetAsync(CacheKey), Times.Once);
+    }
+
+    private sealed class FakeScopeContext : IScopeContext
+    {
+        private readonly Dictionary<string, Action<bool>> _actions = new();
+
+        public Guid InstanceId { get; } = Guid.NewGuid();
+
+        public int CreatedThreadId => Environment.CurrentManagedThreadId;
+
+        public void Enlist(string key, Action<bool> action, int priority = 100)
+            => _actions[key] = action;
+
+        public T? Enlist<T>(string key, Func<T> creator, Action<bool, T?>? action = null, int priority = 100)
+            => throw new NotSupportedException();
+
+        public T? GetEnlisted<T>(string key)
+            => throw new NotSupportedException();
+
+        public void ScopeExit(bool completed)
+        {
+            foreach (Action<bool> a in _actions.Values)
+            {
+                a(completed);
+            }
+
+            _actions.Clear();
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

`EnsureCacheIsSynced()` is called before every repository read to detect when another load-balanced instance has invalidated the in-memory cache. It works by comparing a local GUID against a DB-stored version per entity type.

In bulk operations (e.g. 1 000 node imports in a loop), `SetCacheUpdatedAsync` was called on every write, each time taking a `WriteLock` + DB write, and `VersionChanged()` cleared the request cache so every subsequent read fell through to a new scope + DB query. The cost was O(N × M) DB hits per bulk operation.

## Solution

### 1. Write deduplication per scope

`SetCacheUpdatedAsync` now tracks which entity type keys have already been written within the current scope using a `ConcurrentDictionary<Guid, HashSet<string>>` keyed by `IScopeContext.InstanceId`. If the same entity type's version has already been written in the current scope, the call is a no-op — no `WriteLock`, no DB write, no version bump.

This means a bulk operation that saves 1 000 nodes of the same type takes the `WriteLock` and writes to the version table exactly **once per entity type per scope**, regardless of how many entities are saved.

### 2. Scope-level read cache tier

`RepositoryCacheVersionAccessor.GetAsync` now uses a three-tier lookup: **scope → request → DB**.

The scope cache is a `ConcurrentDictionary<string, Guid>` per root scope (`IScopeContext.InstanceId`), shared across all child scopes within the same transaction. When a version is read from DB it is stored in the scope cache, so subsequent reads within the same scope skip both the request cache lookup and the DB query entirely.

The new `VersionChanged(string cacheKey, Guid newVersion)` overload updates the scope cache **in-place** after a write rather than clearing it and forcing a re-read. Both scope and request caches are cleaned up via `IScopeContext.Enlist` on scope exit.

### 3. Removal of unnecessary ReadLocks

`ReadLock(Constants.Locks.CacheVersion)` has been removed from both `SetCachesSyncedAsync` and `GetAsync`. These locks were redundant for two reasons:

1. **READ COMMITTED already prevents dirty reads.** While a server holds the WriteLock, its write is inside an uncommitted transaction and is invisible to all other connections by definition — no lock on the reader side is needed.

2. **The WriteLock serializes all writers.** All servers acquire the WriteLock before writing a new cache version, so writes across servers are fully serialized. There is no concurrent-write state that a ReadLock could protect against.

In a load-balanced setup this matters in practice: `SetCacheUpdatedAsync` is called inside a larger outer transaction (e.g. saving content), so the WriteLock is held for the duration of that outer transaction. The background `DatabaseServerMessenger` can fire during this window and call `SetCachesSyncedAsync`, which previously blocked waiting for the ReadLock. Removing the ReadLocks eliminates this unnecessary contention.

The **WriteLock is unchanged** — it remains essential for serializing writes across servers.

## DB hits reduction

| Scenario | Before | After |
|---|---|---|
| 1 000 saves of same type in 1 outer scope | ~2 000 DB hits | ~1 write + ~1 read per entity type |
| Each save in its own scope, 2 reads per save | ~2 per save | ~1 per save (first read per entity type hits DB) |
| Another instance writes mid-scope | Detected per-operation | Detected at next scope boundary |
| Another instance writes before scope start | Detected at first scope read | Detected at first scope read (unchanged) |

## Changes

- `IRepositoryCacheVersionAccessor` — new `VersionChanged(string, Guid)` overload with default implementation (backwards compatible); old `VersionChanged(string)` overload marked `[Obsolete]`
- `RepositoryCacheVersionService` — write deduplication via `_writtenKeysByScope`; calls new `VersionChanged` overload in `SetCacheUpdatedAsync`; removed `ReadLock` from `SetCachesSyncedAsync`
- `RepositoryCacheVersionAccessor` — scope-level cache tier using `ConcurrentDictionary`; `VersionChanged(string, Guid)` updates scope cache in-place; `CachesSynced()` also clears scope cache; removed `ReadLock` from `GetAsync`
- New unit tests for all three cache tiers, HTTP context handling, and scope lifecycle cleanup
- New integration tests for `SetCachesSyncedAsync` and the fresh-instance sync path