### PR TITLE
Nightly Pipeline: Skip E2E and Integration stages when Build fails

### DIFF
--- a/build/nightly-E2E-test-pipelines.yml
+++ b/build/nightly-E2E-test-pipelines.yml
@@ -117,7 +117,7 @@ stages:
   - stage: Integration
     displayName: Integration Tests
     dependsOn: Build
-    condition: ${{ eq(parameters.skipIntegrationTests, false) }}
+    condition: and(succeeded(), ${{ eq(parameters.skipIntegrationTests, false) }})
     jobs:
       # Integration Tests (SQLite)
       - job:
@@ -319,8 +319,8 @@ stages:
 
   - stage: DefaultConfigE2E
     displayName: Default Config E2E Tests
-    dependsOn: Integration
-    condition: always()
+    dependsOn: [Build, Integration]
+    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues')
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       # Enable console logging in Release mode
@@ -500,8 +500,8 @@ stages:
 
   - stage: AdditionalConfigE2E
     displayName: Additional Config E2E Tests
-    dependsOn: DefaultConfigE2E
-    condition: always()
+    dependsOn: [Build, DefaultConfigE2E]
+    condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues')
     variables:
       npm_config_cache: $(Pipeline.Workspace)/.npm_e2e
       ASPNETCORE_URLS: https://localhost:44331


### PR DESCRIPTION
The nightly E2E pipeline's Integration, DefaultConfigE2E, and AdditionalConfigE2E stages had conditions that bypassed the default `succeeded()` dependency check, so they ran even when the Build stage failed or was cancelled — producing confusing failures against missing or stale build artifacts.

 This change gates each stage on `Build`'s result while preserving the independent `skip*` parameters (skipping Integration no longer cascades into skipping E2E).