### PR TITLE
Document URL Aliases: De-duplicate repeated aliases to prevent upgrade failure

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -585,7 +585,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         }
 
         // Collapse duplicates that arise after normalization.
-        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var alias in rawValue.Split(',', StringSplitOptions.RemoveEmptyEntries))
         {
             var normalized = this.NormalizeAlias(alias);

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -584,10 +584,12 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
             yield break;
         }
 
+        // Collapse duplicates that arise after normalization.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (var alias in rawValue.Split(',', StringSplitOptions.RemoveEmptyEntries))
         {
             var normalized = this.NormalizeAlias(alias);
-            if (!string.IsNullOrEmpty(normalized))
+            if (string.IsNullOrEmpty(normalized) is false && seen.Add(normalized))
             {
                 yield return normalized;
             }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentUrlAliasRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentUrlAliasRepository.cs
@@ -37,8 +37,10 @@ internal class DocumentUrlAliasRepository : IDocumentUrlAliasRepository
     {
         IEnumerable<Guid> documentKeys = aliases.Select(x => x.DocumentKey).Distinct();
 
+        // DistinctBy guards against any caller passing duplicate (UniqueId, LanguageId, Alias) tuples.
         var dtoDictionary = aliases
             .Select(BuildDto)
+            .DistinctBy(x => (x.UniqueId, x.LanguageId, x.Alias))
             .ToDictionary(x => (x.UniqueId, x.LanguageId, x.Alias));
 
         var toDelete = new List<int>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -1133,4 +1133,98 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
     }
 
     #endregion
+
+    #region Duplicate Alias Handling Tests
+
+    // Regression for the 17.1 -> 17.2.x upgrade failure: umbracoUrlAlias property values whose
+    // tokens collide after normalization (literal dup, case-only, slash-only) produced two
+    // PublishedDocumentUrlAlias entries with the same (DocumentKey, LanguageId, Alias) tuple,
+    // which ToDictionary in Save() rejected with ArgumentException "An item with the same key
+    // has already been added".
+    [TestCase("foelelser, foelelser", "foelelser")]
+    [TestCase("UTM, utm", "utm")]
+    [TestCase("/foo/, foo", "foo")]
+    public void CreateOrUpdateAliasesAsync_Deduplicates_Normalization_Colliding_Aliases(string propertyValue, string expectedAlias)
+    {
+        var newPage = ContentBuilder.CreateSimpleContent(ContentType, "Duplicate Alias Page", RootPage.Id);
+        newPage.SetValue(Constants.Conventions.Content.UrlAlias, propertyValue);
+        ContentService.Save(newPage, -1);
+
+        Assert.DoesNotThrow(
+            () => ContentService.Publish(newPage, []),
+            "Publishing content with normalization-colliding tokens in umbracoUrlAlias should not throw.");
+
+        Assert.DoesNotThrowAsync(
+            () => DocumentUrlAliasService.CreateOrUpdateAliasesAsync(newPage.Key),
+            "CreateOrUpdateAliasesAsync should collapse duplicates, not throw.");
+
+        List<PublishedDocumentUrlAlias> stored;
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            stored = DocumentUrlAliasRepository.GetAll()
+                .Where(a => a.DocumentKey == newPage.Key)
+                .ToList();
+        }
+
+        Assert.That(stored, Has.Count.EqualTo(1), "Expected a single row after dedupe.");
+        Assert.That(stored[0].Alias, Is.EqualTo(expectedAlias));
+    }
+
+    [Test]
+    public void RebuildAllAliasesAsync_Deduplicates_Duplicates_From_Existing_Property_Data()
+    {
+        // Simulates the upgrade path: property data already contains "foelelser, foelelser" and
+        // RebuildAllAliasesAsync runs during InitAsync when the rebuild key changes.
+        var newPage = ContentBuilder.CreateSimpleContent(ContentType, "Rebuild Dup Page", RootPage.Id);
+        newPage.SetValue(Constants.Conventions.Content.UrlAlias, "foelelser, foelelser");
+        ContentService.Save(newPage, -1);
+
+        Assert.DoesNotThrow(() => ContentService.Publish(newPage, []));
+
+        Assert.DoesNotThrowAsync(
+            () => DocumentUrlAliasService.RebuildAllAliasesAsync(),
+            "Rebuild should collapse literal duplicates from existing property data, not throw.");
+
+        List<PublishedDocumentUrlAlias> stored;
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            stored = DocumentUrlAliasRepository.GetAll()
+                .Where(a => a.DocumentKey == newPage.Key)
+                .ToList();
+        }
+
+        Assert.That(stored, Has.Count.EqualTo(1));
+        Assert.That(stored[0].Alias, Is.EqualTo("foelelser"));
+    }
+
+    [Test]
+    public void DocumentUrlAliasRepository_Save_Silently_Dedupes_Duplicate_Input()
+    {
+        // Defensive: if a caller ever passes a list containing duplicate (DocumentKey, LanguageId, Alias)
+        // tuples, Save should collapse them rather than throwing ArgumentException from ToDictionary.
+        var documentKey = new Guid(PageWithNoAliasKey);
+        var duplicates = new List<PublishedDocumentUrlAlias>
+        {
+            new() { DocumentKey = documentKey, NullableLanguageId = null, Alias = "dup-test" },
+            new() { DocumentKey = documentKey, NullableLanguageId = null, Alias = "dup-test" },
+        };
+
+        using (ICoreScope scope = CoreScopeProvider.CreateCoreScope())
+        {
+            Assert.DoesNotThrow(() => DocumentUrlAliasRepository.Save(duplicates));
+            scope.Complete();
+        }
+
+        List<PublishedDocumentUrlAlias> stored;
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            stored = DocumentUrlAliasRepository.GetAll()
+                .Where(a => a.DocumentKey == documentKey && a.Alias == "dup-test")
+                .ToList();
+        }
+
+        Assert.That(stored, Has.Count.EqualTo(1));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Description

Reports on [the forum](https://forum.umbraco.com/t/error-in-documenturlalias-repository-when-upgrading-from-17-1-to-17-2-x/7578) show to 17.2.x could fail to boot with `System.ArgumentException: An item with the same key has already been added. Key: (<guid>, <langId>, <alias>)` thrown from `DocumentUrlAliasRepository.Save`.

This happens when an `umbracoUrlAlias` property value contains tokens that collide after normalization — a literal duplicate (`"foelelser, foelelser"`), a case-only difference (`"UTM, utm"`), or a slash-only difference (`"/foo/, foo"`) — because `NormalizeAliases` produced two `PublishedDocumentUrlAlias` entries with the same `(DocumentKey, LanguageId, Alias)` tuple, which `ToDictionary` then rejected.

This PR contains fixes for this issue:

- Primary fix: `NormalizeAliases` now collapses duplicates via a `HashSet<string>` while iterating, so at most one entry is produced per normalized value. 
- Defensive fix: `DocumentUrlAliasRepository.Save` now passes incoming aliases through `DistinctBy((UniqueId, LanguageId, Alias))` before building the dictionary, so any future caller passing dirty input gets a clean upsert rather than a cryptic `ArgumentException`. The unique index `IX_umbracoDocumentUrlAlias_Unique` remains the final backstop at the DB level.

## Testing

### Automated

New regression tests in have been added in `DocumentUrlAliasServiceTests` that previously failed and now pass after the fix is in place.

### Manual

Prepare an `umbracoUrlAlias` property on a document type and create a page based on that type.

Populate the alias as e.g. "abc, ABC"

Verify the alias cache via:

```sql
SELECT * FROM umbracoDocumentUrlAlias
```

You should expect one record for the document.

Stop the application

Trigger a rebuild of the URL alias cache on start up via running:

```sql
UPDATE umbracoKeyValue SET [value] = 'force-rebuild' WHERE [key] = 'UmbracoUrlAliasGeneration';
```

And then restart the application.

Verify the alias cache again.