### PR TITLE
Subscriber Server Role: Skip URL/alias persistence on subscribers with read-only databases (closes #22570)

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -307,7 +307,9 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
 
     /// <summary>
     /// Internal implementation that processes a single document without creating its own scope.
-    /// Caller must ensure a scope with write lock is active.
+    /// Caller must ensure a scope is active. A write lock on <see cref="Constants.Locks.DocumentUrlAliases"/>
+    /// is required whenever this method may perform database writes — i.e. on all server roles except
+    /// <see cref="ServerRole.Subscriber"/>, where persistence is skipped and the write lock is not taken.
     /// </summary>
     private async Task CreateOrUpdateAliasesInternalAsync(Guid documentKey)
     {

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -97,6 +97,30 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentUrlAliasService"/> class.
     /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
+    public DocumentUrlAliasService(
+        ILogger<DocumentUrlAliasService> logger,
+        IDocumentUrlAliasRepository documentUrlAliasRepository,
+        ICoreScopeProvider coreScopeProvider,
+        ILanguageService languageService,
+        IKeyValueService keyValueService,
+        IContentService contentService,
+        IDocumentNavigationQueryService documentNavigationQueryService)
+        : this(
+            logger,
+            documentUrlAliasRepository,
+            coreScopeProvider,
+            languageService,
+            keyValueService,
+            contentService,
+            documentNavigationQueryService,
+            StaticServiceProvider.Instance.GetRequiredService<IServerRoleAccessor>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentUrlAliasService"/> class.
+    /// </summary>
     public DocumentUrlAliasService(
         ILogger<DocumentUrlAliasService> logger,
         IDocumentUrlAliasRepository documentUrlAliasRepository,

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -150,7 +150,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     /// redundant at best, and blows up when the subscriber is configured against a read-only database connection.
     /// The in-memory cache is updated via deferred scope-context enlistments regardless of this flag.
     /// </remarks>
-    private bool SkipDatabaseWrites() => _serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber;
+    private bool SkipDatabaseWrites() => _serverRoleAccessor.CurrentServerRole is ServerRole.Subscriber;
 
     /// <inheritdoc/>
     public async Task InitAsync(bool forceEmpty, CancellationToken cancellationToken)

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -1,10 +1,13 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services.Navigation;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services;
@@ -39,6 +42,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     private readonly IKeyValueService _keyValueService;
     private readonly IContentService _contentService;
     private readonly IDocumentNavigationQueryService _documentNavigationQueryService;
+    private readonly IServerRoleAccessor _serverRoleAccessor;
 
     // Lookup: alias -> list of matching document keys (multiple docs can have same alias).
     private readonly ConcurrentDictionary<AliasCacheKey, List<Guid>> _aliasCache = new();
@@ -89,6 +93,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         public override int GetHashCode() => HashCode.Combine(NormalizedAlias, LanguageId ?? 0);
     }
 
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentUrlAliasService"/> class.
     /// </summary>
@@ -99,7 +104,8 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         ILanguageService languageService,
         IKeyValueService keyValueService,
         IContentService contentService,
-        IDocumentNavigationQueryService documentNavigationQueryService)
+        IDocumentNavigationQueryService documentNavigationQueryService,
+        IServerRoleAccessor serverRoleAccessor)
     {
         _logger = logger;
         _documentUrlAliasRepository = documentUrlAliasRepository;
@@ -108,7 +114,19 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         _keyValueService = keyValueService;
         _contentService = contentService;
         _documentNavigationQueryService = documentNavigationQueryService;
+        _serverRoleAccessor = serverRoleAccessor;
     }
+
+    /// <summary>
+    /// Indicates whether this instance should skip database writes for URL aliases.
+    /// </summary>
+    /// <remarks>
+    /// On a <see cref="ServerRole.Subscriber"/> the scheduling publisher has already persisted URL aliases to
+    /// the database before issuing the cache-refresh instruction that routed us here. Re-writing them locally is
+    /// redundant at best, and blows up when the subscriber is configured against a read-only database connection.
+    /// The in-memory cache is updated via deferred scope-context enlistments regardless of this flag.
+    /// </remarks>
+    private bool SkipDatabaseWrites() => _serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber;
 
     /// <inheritdoc/>
     public async Task InitAsync(bool forceEmpty, CancellationToken cancellationToken)
@@ -121,7 +139,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
 
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
 
-        if (ShouldRebuildAliases())
+        if (SkipDatabaseWrites() is false && ShouldRebuildAliases())
         {
             _logger.LogInformation("Rebuilding all document aliases.");
             await RebuildAllAliasesAsync();
@@ -229,7 +247,10 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     public async Task CreateOrUpdateAliasesAsync(Guid documentKey)
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        scope.WriteLock(Constants.Locks.DocumentUrlAliases);
+        if (SkipDatabaseWrites() is false)
+        {
+            scope.WriteLock(Constants.Locks.DocumentUrlAliases);
+        }
 
         await CreateOrUpdateAliasesInternalAsync(documentKey);
 
@@ -240,7 +261,10 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     public async Task CreateOrUpdateAliasesWithDescendantsAsync(Guid documentKey)
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        scope.WriteLock(Constants.Locks.DocumentUrlAliases);
+        if (SkipDatabaseWrites() is false)
+        {
+            scope.WriteLock(Constants.Locks.DocumentUrlAliases);
+        }
 
         // Get document and all descendants
         var documentKeys = new List<Guid> { documentKey };
@@ -276,17 +300,23 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         // Remove old aliases from cache (deferred until scope completes)
         RemoveFromCacheDeferred(_coreScopeProvider.Context!, documentKey);
 
-        // Save to database (handles insert/update/delete via diff) and add to cache
+        // Save to database (handles insert/update/delete via diff) and add to cache.
+        // On subscribers we skip the persistence — the publisher has already written the aliases — but the
+        // in-memory cache is still refreshed via the deferred enlistments so routing keeps working locally.
+        bool skipDatabaseWrites = SkipDatabaseWrites();
         if (aliases.Count > 0)
         {
-            _documentUrlAliasRepository.Save(aliases);
+            if (skipDatabaseWrites is false)
+            {
+                _documentUrlAliasRepository.Save(aliases);
+            }
 
             foreach (PublishedDocumentUrlAlias alias in aliases)
             {
                 AddToCacheDeferred(_coreScopeProvider.Context!, alias);
             }
         }
-        else
+        else if (skipDatabaseWrites is false)
         {
             // No aliases - delete any existing aliases for this document from the database
             _documentUrlAliasRepository.DeleteByDocumentKey(new[] { documentKey });
@@ -317,6 +347,12 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     /// <inheritdoc/>
     public async Task RebuildAllAliasesAsync()
     {
+        if (SkipDatabaseWrites())
+        {
+            _logger.LogDebug("Skipping document URL alias rebuild — the current server role does not persist aliases.");
+            return;
+        }
+
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
         scope.ReadLock(Constants.Locks.ContentTree);
 

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Core.Services;
@@ -44,6 +45,7 @@ public class DocumentUrlService : IDocumentUrlService
     private readonly IPublishStatusQueryService _publishStatusQueryService;
     private readonly IDomainCacheService _domainCacheService;
     private readonly IDefaultCultureAccessor _defaultCultureAccessor;
+    private readonly IServerRoleAccessor _serverRoleAccessor;
 
     private readonly ConcurrentDictionary<UrlCacheKey, UrlSegmentCache> _documentUrlCache = new();
     private readonly ConcurrentDictionary<string, int> _cultureToLanguageIdMap = new();
@@ -151,6 +153,7 @@ public class DocumentUrlService : IDocumentUrlService
         IDocumentNavigationQueryService documentNavigationQueryService,
         IPublishStatusQueryService publishStatusQueryService,
         IDomainCacheService domainCacheService)
+#pragma warning disable CS0618 // Type or member is obsolete
         :this(
             logger,
             documentUrlRepository,
@@ -168,6 +171,49 @@ public class DocumentUrlService : IDocumentUrlService
             publishStatusQueryService,
             domainCacheService,
             StaticServiceProvider.Instance.GetRequiredService<IDefaultCultureAccessor>())
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentUrlService"/> class.
+    /// </summary>
+    [Obsolete("Please use the constructor taking all parameters. Scheduled for removal in Umbraco 19.")]
+    public DocumentUrlService(
+        ILogger<DocumentUrlService> logger,
+        IDocumentUrlRepository documentUrlRepository,
+        IDocumentRepository documentRepository,
+        ICoreScopeProvider coreScopeProvider,
+        IOptions<GlobalSettings> globalSettings,
+        IOptions<WebRoutingSettings> webRoutingSettings,
+        UrlSegmentProviderCollection urlSegmentProviderCollection,
+        IContentService contentService,
+        IShortStringHelper shortStringHelper,
+        ILanguageService languageService,
+        IKeyValueService keyValueService,
+        IIdKeyMap idKeyMap,
+        IDocumentNavigationQueryService documentNavigationQueryService,
+        IPublishStatusQueryService publishStatusQueryService,
+        IDomainCacheService domainCacheService,
+        IDefaultCultureAccessor defaultCultureAccessor)
+        : this(
+            logger,
+            documentUrlRepository,
+            documentRepository,
+            coreScopeProvider,
+            globalSettings,
+            webRoutingSettings,
+            urlSegmentProviderCollection,
+            contentService,
+            shortStringHelper,
+            languageService,
+            keyValueService,
+            idKeyMap,
+            documentNavigationQueryService,
+            publishStatusQueryService,
+            domainCacheService,
+            defaultCultureAccessor,
+            StaticServiceProvider.Instance.GetRequiredService<IServerRoleAccessor>())
     {
     }
 
@@ -190,7 +236,8 @@ public class DocumentUrlService : IDocumentUrlService
         IDocumentNavigationQueryService documentNavigationQueryService,
         IPublishStatusQueryService publishStatusQueryService,
         IDomainCacheService domainCacheService,
-        IDefaultCultureAccessor defaultCultureAccessor)
+        IDefaultCultureAccessor defaultCultureAccessor,
+        IServerRoleAccessor serverRoleAccessor)
     {
         _logger = logger;
         _documentUrlRepository = documentUrlRepository;
@@ -208,6 +255,7 @@ public class DocumentUrlService : IDocumentUrlService
         _publishStatusQueryService = publishStatusQueryService;
         _domainCacheService = domainCacheService;
         _defaultCultureAccessor = defaultCultureAccessor;
+        _serverRoleAccessor = serverRoleAccessor;
     }
 
     /// <inheritdoc/>
@@ -221,7 +269,7 @@ public class DocumentUrlService : IDocumentUrlService
         }
 
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
-        if (ShouldRebuildUrls())
+        if (SkipDatabaseWrites() is false && ShouldRebuildUrls())
         {
             _logger.LogInformation("Rebuilding all document URLs.");
             await RebuildAllUrlsAsync();
@@ -278,6 +326,12 @@ public class DocumentUrlService : IDocumentUrlService
     /// <inheritdoc/>
     public async Task RebuildAllUrlsAsync()
     {
+        if (SkipDatabaseWrites())
+        {
+            _logger.LogDebug("Skipping document URL rebuild — the current server role does not persist URL segments.");
+            return;
+        }
+
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
         scope.ReadLock(Constants.Locks.ContentTree);
 
@@ -289,6 +343,17 @@ public class DocumentUrlService : IDocumentUrlService
 
         scope.Complete();
     }
+
+    /// <summary>
+    /// Indicates whether this instance should skip database writes for URL segments.
+    /// </summary>
+    /// <remarks>
+    /// On a <see cref="ServerRole.Subscriber"/> the scheduling publisher has already persisted URL segments to
+    /// the database before issuing the cache-refresh instruction that routed us here. Re-writing them locally is
+    /// redundant at best, and blows up when the subscriber is configured against a read-only database connection.
+    /// The in-memory cache is updated via deferred scope-context enlistments regardless of this flag.
+    /// </remarks>
+    private bool SkipDatabaseWrites() => _serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber;
 
     /// <summary>
     /// Converts a collection of <see cref="PublishedDocumentUrlSegment"/> to cache key-value pairs for caching purposes.
@@ -599,7 +664,7 @@ public class DocumentUrlService : IDocumentUrlService
             }
         }
 
-        if (toSave.Count > 0)
+        if (toSave.Count > 0 && SkipDatabaseWrites() is false)
         {
             scope.WriteLock(Constants.Locks.DocumentUrls);
             _documentUrlRepository.Save(toSave);

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -353,7 +353,7 @@ public class DocumentUrlService : IDocumentUrlService
     /// redundant at best, and blows up when the subscriber is configured against a read-only database connection.
     /// The in-memory cache is updated via deferred scope-context enlistments regardless of this flag.
     /// </remarks>
-    private bool SkipDatabaseWrites() => _serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber;
+    private bool SkipDatabaseWrites() => _serverRoleAccessor.CurrentServerRole is ServerRole.Subscriber;
 
     /// <summary>
     /// Converts a collection of <see cref="PublishedDocumentUrlSegment"/> to cache key-value pairs for caching purposes.

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -1,0 +1,684 @@
+using System.Data;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
+using Umbraco.Cms.Core.Sync;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
+
+[TestFixture]
+public class DocumentUrlAliasServiceTests
+{
+    /// <summary>
+    /// Creates a <see cref="DocumentUrlAliasService"/> wired up with mocked dependencies. The mocked
+    /// <see cref="IScopeContext"/> immediately executes deferred <c>Enlist</c> callbacks so that the
+    /// in-memory alias cache updates synchronously during the test.
+    /// </summary>
+    private static (DocumentUrlAliasService Service,
+        Mock<IDocumentUrlAliasRepository> AliasRepository,
+        Mock<IContentService> ContentService) CreateServiceWithMocks(
+            ServerRole serverRole = ServerRole.Single,
+            IEnumerable<ILanguage>? languages = null)
+    {
+        var effectiveLanguages = languages ?? Array.Empty<ILanguage>();
+
+        var loggerMock = Mock.Of<ILogger<DocumentUrlAliasService>>();
+        var aliasRepositoryMock = new Mock<IDocumentUrlAliasRepository>();
+        var contentServiceMock = new Mock<IContentService>();
+
+        var languageServiceMock = new Mock<ILanguageService>();
+        languageServiceMock.Setup(x => x.GetAllAsync()).ReturnsAsync(effectiveLanguages);
+        languageServiceMock.Setup(x => x.GetDefaultIsoCodeAsync()).ReturnsAsync("en-US");
+
+        // Return "1" (the service's CurrentRebuildValue constant) so ShouldRebuildAliases() returns false and
+        // InitAsync skips the rebuild side-effect in tests that call InitAsync.
+        var keyValueServiceMock = new Mock<IKeyValueService>();
+        keyValueServiceMock.Setup(x => x.GetValue(DocumentUrlAliasService.RebuildKey)).Returns("1");
+
+        var documentNavigationQueryServiceMock = Mock.Of<IDocumentNavigationQueryService>();
+
+        var serverRoleAccessorMock = new Mock<IServerRoleAccessor>();
+        serverRoleAccessorMock.Setup(x => x.CurrentServerRole).Returns(serverRole);
+
+        var scopeContextMock = new Mock<IScopeContext>();
+        scopeContextMock.Setup(x => x.Enlist<bool>(
+                It.IsAny<string>(),
+                It.IsAny<Func<bool>>(),
+                It.IsAny<Action<bool, bool>?>(),
+                It.IsAny<int>()))
+            .Returns((string _, Func<bool> creator, Action<bool, bool>? _, int _) => creator());
+
+        var coreScopeMock = new Mock<ICoreScope>();
+        coreScopeMock.Setup(x => x.Complete());
+
+        var coreScopeProviderMock = new Mock<ICoreScopeProvider>();
+        coreScopeProviderMock.Setup(x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher?>(),
+                It.IsAny<IScopedNotificationPublisher?>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(coreScopeMock.Object);
+        coreScopeProviderMock.Setup(x => x.Context).Returns(scopeContextMock.Object);
+
+        var service = new DocumentUrlAliasService(
+            loggerMock,
+            aliasRepositoryMock.Object,
+            coreScopeProviderMock.Object,
+            languageServiceMock.Object,
+            keyValueServiceMock.Object,
+            contentServiceMock.Object,
+            documentNavigationQueryServiceMock,
+            serverRoleAccessorMock.Object);
+
+        return (service, aliasRepositoryMock, contentServiceMock);
+    }
+
+    /// <summary>
+    /// Creates an invariant <see cref="IContent"/> mock whose alias property returns the supplied value when
+    /// looked up via <see cref="IContentBase.GetValue"/>.
+    /// </summary>
+    private static IContent CreateInvariantContentWithAlias(Guid documentKey, string? aliasValue)
+    {
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Variations).Returns(ContentVariation.Nothing);
+
+        // ExtractAliasesFromDocumentAsync probes Properties for the alias property to decide whether it
+        // varies by culture — an empty collection is sufficient for invariant content.
+        var propertyCollectionMock = new Mock<IPropertyCollection>();
+        propertyCollectionMock.Setup(x => x.GetEnumerator())
+            .Returns(() => Enumerable.Empty<IProperty>().GetEnumerator());
+
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.Key).Returns(documentKey);
+        contentMock.Setup(x => x.Trashed).Returns(false);
+        contentMock.Setup(x => x.Blueprint).Returns(false);
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+        contentMock.Setup(x => x.Properties).Returns(propertyCollectionMock.Object);
+        contentMock.Setup(x => x.GetValue<string>(
+                Constants.Conventions.Content.UrlAlias,
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<bool>()))
+            .Returns(aliasValue);
+
+        return contentMock.Object;
+    }
+
+    /// <summary>
+    /// Creates a variant <see cref="IContent"/> mock whose alias property itself varies by culture. The
+    /// <paramref name="aliasesByCulture"/> map supplies the alias value for each ISO culture code; cultures
+    /// not present in the map return null (simulating an unset value).
+    /// </summary>
+    private static IContent CreateVariantContentWithCultureVaryingAlias(
+        Guid documentKey,
+        IReadOnlyDictionary<string, string?> aliasesByCulture)
+    {
+        var contentTypeMock = new Mock<ISimpleContentType>();
+        contentTypeMock.Setup(x => x.Variations).Returns(ContentVariation.Culture);
+
+        var propertyTypeMock = new Mock<IPropertyType>();
+        propertyTypeMock.Setup(x => x.Variations).Returns(ContentVariation.Culture);
+
+        var aliasPropertyMock = new Mock<IProperty>();
+        aliasPropertyMock.Setup(x => x.Alias).Returns(Constants.Conventions.Content.UrlAlias);
+        aliasPropertyMock.Setup(x => x.PropertyType).Returns(propertyTypeMock.Object);
+
+        var propertyCollectionMock = new Mock<IPropertyCollection>();
+        propertyCollectionMock.Setup(x => x.GetEnumerator())
+            .Returns(() => new[] { aliasPropertyMock.Object }.AsEnumerable().GetEnumerator());
+
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.Key).Returns(documentKey);
+        contentMock.Setup(x => x.Trashed).Returns(false);
+        contentMock.Setup(x => x.Blueprint).Returns(false);
+        contentMock.Setup(x => x.ContentType).Returns(contentTypeMock.Object);
+        contentMock.Setup(x => x.Properties).Returns(propertyCollectionMock.Object);
+
+        foreach ((string culture, string? value) in aliasesByCulture)
+        {
+            contentMock.Setup(x => x.GetValue<string>(
+                    Constants.Conventions.Content.UrlAlias,
+                    culture,
+                    It.IsAny<string?>(),
+                    It.IsAny<bool>()))
+                .Returns(value);
+        }
+
+        return contentMock.Object;
+    }
+
+    /// <summary>
+    /// Creates a simple <see cref="ILanguage"/> mock.
+    /// </summary>
+    private static ILanguage CreateMockLanguage(int id, string isoCode)
+    {
+        var languageMock = new Mock<ILanguage>();
+        languageMock.Setup(x => x.Id).Returns(id);
+        languageMock.Setup(x => x.IsoCode).Returns(isoCode);
+        return languageMock.Object;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="DocumentUrlAliasService"/> pre-initialized with the supplied aliases loaded into
+    /// its in-memory cache via <see cref="DocumentUrlAliasService.InitAsync"/>. Useful for testing the public
+    /// lookup methods (<c>GetDocumentKeysByAliasAsync</c>, <c>GetAliasesAsync</c>, <c>HasAny</c>).
+    /// </summary>
+    private static async Task<DocumentUrlAliasService> CreateInitializedServiceWithAliases(
+        IEnumerable<PublishedDocumentUrlAlias> seededAliases,
+        IEnumerable<ILanguage> languages)
+    {
+        var (service, aliasRepositoryMock, _) = CreateServiceWithMocks(
+            serverRole: ServerRole.Single,
+            languages: languages);
+
+        aliasRepositoryMock.Setup(x => x.GetAll()).Returns(seededAliases);
+
+        await service.InitAsync(forceEmpty: false, CancellationToken.None);
+
+        return service;
+    }
+
+    #region CreateOrUpdateAliasesAsync Tests
+
+    /// <summary>
+    /// For invariant content the alias property value is stored once, with <c>NullableLanguageId = null</c>,
+    /// irrespective of how many languages are configured.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_InvariantContent_SavesAliasWithNullLanguageId()
+    {
+        // Arrange
+        var languages = new List<ILanguage>
+        {
+            CreateMockLanguage(1, "en-US"),
+            CreateMockLanguage(2, "fr-FR"),
+        };
+        var (service, aliasRepositoryMock, contentServiceMock) =
+            CreateServiceWithMocks(languages: languages);
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, "my-alias"));
+
+        List<PublishedDocumentUrlAlias>? savedAliases = null;
+        aliasRepositoryMock.Setup(x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()))
+            .Callback<IEnumerable<PublishedDocumentUrlAlias>>(aliases => savedAliases = aliases.ToList());
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        Assert.That(savedAliases, Is.Not.Null);
+        Assert.That(savedAliases, Has.Count.EqualTo(1));
+        Assert.That(savedAliases![0].DocumentKey, Is.EqualTo(documentKey));
+        Assert.That(savedAliases[0].NullableLanguageId, Is.Null);
+        Assert.That(savedAliases[0].Alias, Is.EqualTo("my-alias"));
+    }
+
+    /// <summary>
+    /// The alias property may contain multiple comma-separated aliases. Each must be persisted as its own
+    /// row sharing the same document key and (for invariant content) a null language id.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_InvariantContent_WithCommaSeparatedAliases_SavesOneRowPerAlias()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks();
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, "alias-one, alias-two, alias-three"));
+
+        List<PublishedDocumentUrlAlias>? savedAliases = null;
+        aliasRepositoryMock.Setup(x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()))
+            .Callback<IEnumerable<PublishedDocumentUrlAlias>>(aliases => savedAliases = aliases.ToList());
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        Assert.That(savedAliases, Is.Not.Null);
+        Assert.That(
+            savedAliases!.Select(x => x.Alias),
+            Is.EquivalentTo(new[] { "alias-one", "alias-two", "alias-three" }));
+        Assert.That(
+            savedAliases.All(x => x.NullableLanguageId is null),
+            Is.True,
+            "All rows from an invariant content must share a null language id.");
+    }
+
+    /// <summary>
+    /// Aliases must be normalized before persistence: trimmed, stripped of leading/trailing slashes, and
+    /// lowercased. This matches <c>IDocumentUrlAliasService.NormalizeAlias</c> so lookups round-trip.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_NormalizesAlias_BeforeSaving()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks();
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, "  /Some-Mixed-Case/  "));
+
+        List<PublishedDocumentUrlAlias>? savedAliases = null;
+        aliasRepositoryMock.Setup(x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()))
+            .Callback<IEnumerable<PublishedDocumentUrlAlias>>(aliases => savedAliases = aliases.ToList());
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        Assert.That(savedAliases, Is.Not.Null);
+        Assert.That(savedAliases, Has.Count.EqualTo(1));
+        Assert.That(savedAliases![0].Alias, Is.EqualTo("some-mixed-case"));
+    }
+
+    /// <summary>
+    /// For variant content whose alias property itself varies by culture, one row is saved per language —
+    /// each tagged with that language's id. Cultures with no alias value contribute no rows.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_VariantContent_WithVariantAliasProperty_SavesOneRowPerLanguage()
+    {
+        // Arrange
+        var languages = new List<ILanguage>
+        {
+            CreateMockLanguage(1, "en-US"),
+            CreateMockLanguage(2, "fr-FR"),
+        };
+        var (service, aliasRepositoryMock, contentServiceMock) =
+            CreateServiceWithMocks(languages: languages);
+
+        var documentKey = Guid.NewGuid();
+        var aliasesByCulture = new Dictionary<string, string?>
+        {
+            { "en-US", "english-alias" },
+            { "fr-FR", "alias-francais" },
+        };
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateVariantContentWithCultureVaryingAlias(documentKey, aliasesByCulture));
+
+        List<PublishedDocumentUrlAlias>? savedAliases = null;
+        aliasRepositoryMock.Setup(x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()))
+            .Callback<IEnumerable<PublishedDocumentUrlAlias>>(aliases => savedAliases = aliases.ToList());
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        Assert.That(savedAliases, Is.Not.Null);
+        Assert.That(savedAliases, Has.Count.EqualTo(2));
+
+        var english = savedAliases!.Single(x => x.NullableLanguageId == 1);
+        var french = savedAliases.Single(x => x.NullableLanguageId == 2);
+        Assert.That(english.Alias, Is.EqualTo("english-alias"));
+        Assert.That(french.Alias, Is.EqualTo("alias-francais"));
+    }
+
+    /// <summary>
+    /// When the document cannot be found the service must clear any existing cache entries for that key
+    /// (via the deferred <c>RemoveFromCacheDeferred</c>) and must not touch the repository.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_MissingDocument_DoesNotCallRepository()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks();
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey)).Returns((IContent?)null);
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never);
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Trashed content has no publicly-addressable URLs, so no aliases should be persisted (or deleted —
+    /// the deferred cache cleanup handles any previously-cached entries).
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_TrashedDocument_DoesNotCallRepository()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks();
+
+        var documentKey = Guid.NewGuid();
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.Key).Returns(documentKey);
+        contentMock.Setup(x => x.Trashed).Returns(true);
+        contentMock.Setup(x => x.Blueprint).Returns(false);
+        contentServiceMock.Setup(x => x.GetById(documentKey)).Returns(contentMock.Object);
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never);
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Blueprints are templates — they never resolve to a URL, so no aliases should be persisted for them.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_BlueprintDocument_DoesNotCallRepository()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks();
+
+        var documentKey = Guid.NewGuid();
+        var contentMock = new Mock<IContent>();
+        contentMock.Setup(x => x.Key).Returns(documentKey);
+        contentMock.Setup(x => x.Trashed).Returns(false);
+        contentMock.Setup(x => x.Blueprint).Returns(true);
+        contentServiceMock.Setup(x => x.GetById(documentKey)).Returns(contentMock.Object);
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never);
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// On a subscriber the scheduling publisher has already written the aliases, so the subscriber must not
+    /// re-persist them — doing so crashes on a read-only database (issue #22570). This covers the path where
+    /// the document has aliases and would otherwise hit <c>Save</c>.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_OnSubscriber_WithAliases_DoesNotCallSave()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks(ServerRole.Subscriber);
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, "my-alias"));
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never,
+            "Subscribers must not persist URL aliases — the publisher already has.");
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Regression guard for the subscriber guard: Single and SchedulingPublisher roles must still persist
+    /// URL aliases as they did before the fix.
+    /// </summary>
+    [TestCase(ServerRole.Single)]
+    [TestCase(ServerRole.SchedulingPublisher)]
+    public async Task CreateOrUpdateAliasesAsync_OnSingleOrPublisher_WithAliases_CallsSave(ServerRole role)
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks(role);
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, "my-alias"));
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Once,
+            $"The {role} role must continue to persist URL aliases.");
+    }
+
+    /// <summary>
+    /// Covers the alternate branch of the guard: when a document has no alias value the
+    /// <see cref="IDocumentUrlAliasRepository.DeleteByDocumentKey"/> path must also be skipped on subscribers.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_OnSubscriber_WithNoAliases_DoesNotCallDeleteByDocumentKey()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks(ServerRole.Subscriber);
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, aliasValue: null));
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never,
+            "Subscribers must not delete URL aliases.");
+    }
+
+    /// <summary>
+    /// Regression guard: the Single role must continue to delete stale aliases when a document no longer
+    /// has any alias value.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_OnSingle_WithNoAliases_CallsDeleteByDocumentKey()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks(ServerRole.Single);
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, aliasValue: null));
+
+        // Act
+        await service.CreateOrUpdateAliasesAsync(documentKey);
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region DeleteAliasesFromCacheAsync Tests
+
+    /// <summary>
+    /// <see cref="DocumentUrlAliasService.DeleteAliasesFromCacheAsync"/> only clears in-memory entries; it
+    /// must never issue database writes. This matches the documented contract and keeps the method safe to
+    /// call on subscribers.
+    /// </summary>
+    [Test]
+    public async Task DeleteAliasesFromCacheAsync_DoesNotCallRepository()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, _) = CreateServiceWithMocks();
+
+        // Act
+        await service.DeleteAliasesFromCacheAsync(new[] { Guid.NewGuid(), Guid.NewGuid() });
+
+        // Assert
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never);
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region RebuildAllAliasesAsync Tests
+
+    /// <summary>
+    /// <see cref="DocumentUrlAliasService.RebuildAllAliasesAsync"/> is a heavy, fully-writing operation.
+    /// On a subscriber it must short-circuit before touching the database at all.
+    /// </summary>
+    [Test]
+    public async Task RebuildAllAliasesAsync_OnSubscriber_IsNoOp()
+    {
+        // Arrange
+        var (service, aliasRepositoryMock, _) = CreateServiceWithMocks(ServerRole.Subscriber);
+
+        // Act
+        await service.RebuildAllAliasesAsync();
+
+        // Assert — none of the read or write side-effects should have fired.
+        aliasRepositoryMock.Verify(x => x.GetAllDocumentUrlAliases(), Times.Never);
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never);
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region Lookup Tests
+
+    /// <summary>
+    /// After the service is initialized from persisted aliases, looking up a document key by its alias must
+    /// return the matching document. Covers the common invariant-content lookup path.
+    /// </summary>
+    [Test]
+    public async Task GetDocumentKeysByAliasAsync_Returns_MatchingDocumentKey()
+    {
+        // Arrange
+        var documentKey = Guid.NewGuid();
+        var seeded = new[]
+        {
+            new PublishedDocumentUrlAlias
+            {
+                DocumentKey = documentKey,
+                NullableLanguageId = null,
+                Alias = "my-alias",
+            },
+        };
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+
+        var service = await CreateInitializedServiceWithAliases(seeded, languages);
+
+        // Act
+        var result = (await service.GetDocumentKeysByAliasAsync("my-alias", culture: null)).ToList();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(new[] { documentKey }));
+    }
+
+    /// <summary>
+    /// Lookups by alias are case-insensitive and tolerate leading slashes in the input (they are normalized
+    /// before lookup). Guards against regressions in <c>NormalizeAlias</c>.
+    /// </summary>
+    [Test]
+    public async Task GetDocumentKeysByAliasAsync_IsCaseInsensitive_AndTrimsSlashes()
+    {
+        // Arrange
+        var documentKey = Guid.NewGuid();
+        var seeded = new[]
+        {
+            new PublishedDocumentUrlAlias
+            {
+                DocumentKey = documentKey,
+                NullableLanguageId = null,
+                Alias = "my-alias",
+            },
+        };
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+
+        var service = await CreateInitializedServiceWithAliases(seeded, languages);
+
+        // Act
+        var result = (await service.GetDocumentKeysByAliasAsync("/My-Alias/", culture: null)).ToList();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(new[] { documentKey }));
+    }
+
+    /// <summary>
+    /// Given a document key, the service must return all aliases associated with it.
+    /// </summary>
+    [Test]
+    public async Task GetAliasesAsync_Returns_AliasesForDocument()
+    {
+        // Arrange
+        var documentKey = Guid.NewGuid();
+        var seeded = new[]
+        {
+            new PublishedDocumentUrlAlias { DocumentKey = documentKey, NullableLanguageId = null, Alias = "alias-one" },
+            new PublishedDocumentUrlAlias { DocumentKey = documentKey, NullableLanguageId = null, Alias = "alias-two" },
+        };
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+
+        var service = await CreateInitializedServiceWithAliases(seeded, languages);
+
+        // Act
+        var result = (await service.GetAliasesAsync(documentKey, culture: null)).ToList();
+
+        // Assert
+        Assert.That(result, Is.EquivalentTo(new[] { "alias-one", "alias-two" }));
+    }
+
+    /// <summary>
+    /// After initializing from a non-empty set of aliases, <see cref="DocumentUrlAliasService.HasAny"/>
+    /// should report that aliases exist. Initializing from an empty set must report the opposite.
+    /// </summary>
+    [Test]
+    public async Task HasAny_ReflectsWhetherAnyAliasesWereInitialized()
+    {
+        // Arrange
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+        var populatedService = await CreateInitializedServiceWithAliases(
+            new[]
+            {
+                new PublishedDocumentUrlAlias
+                {
+                    DocumentKey = Guid.NewGuid(),
+                    NullableLanguageId = null,
+                    Alias = "any",
+                },
+            },
+            languages);
+        var emptyService = await CreateInitializedServiceWithAliases(
+            Array.Empty<PublishedDocumentUrlAlias>(),
+            languages);
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.That(populatedService.HasAny(), Is.True);
+            Assert.That(emptyService.HasAny(), Is.False);
+        });
+    }
+
+    #endregion
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
 
@@ -212,7 +213,8 @@ public class DocumentUrlServiceTests
     /// </summary>
     private static (DocumentUrlService Service, Mock<IDocumentUrlRepository> Repository) CreateDocumentUrlServiceWithMocks(
         UrlSegmentProviderCollection urlSegmentProviderCollection,
-        IEnumerable<ILanguage> languages)
+        IEnumerable<ILanguage> languages,
+        ServerRole serverRole = ServerRole.Single)
     {
         var loggerMock = Mock.Of<ILogger<DocumentUrlService>>();
         var documentUrlRepositoryMock = new Mock<IDocumentUrlRepository>();
@@ -230,6 +232,9 @@ public class DocumentUrlServiceTests
         var publishStatusQueryServiceMock = Mock.Of<IPublishStatusQueryService>();
         var domainCacheServiceMock = Mock.Of<IDomainCacheService>();
         var defaultCultureAccessorMock = Mock.Of<IDefaultCultureAccessor>();
+
+        var serverRoleAccessorMock = new Mock<IServerRoleAccessor>();
+        serverRoleAccessorMock.Setup(x => x.CurrentServerRole).Returns(serverRole);
 
         var scopeContextMock = new Mock<IScopeContext>();
         var coreScopeMock = new Mock<ICoreScope>();
@@ -263,7 +268,8 @@ public class DocumentUrlServiceTests
             documentNavigationQueryServiceMock,
             publishStatusQueryServiceMock,
             domainCacheServiceMock,
-            defaultCultureAccessorMock);
+            defaultCultureAccessorMock,
+            serverRoleAccessorMock.Object);
 
         return (service, documentUrlRepositoryMock);
     }
@@ -546,6 +552,94 @@ public class DocumentUrlServiceTests
         repositoryMock.Verify(x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlSegment>>()), Times.Never);
     }
 
+    /// <summary>
+    /// On a Subscriber the scheduling publisher has already persisted URL segments before publishing the
+    /// cache-refresh instruction, so the subscriber must not re-persist them. Re-writing blows up on
+    /// subscribers configured against a read-only database (issue #22570).
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateUrlSegmentsAsync_OnSubscriber_DoesNotCallRepositorySave()
+    {
+        // Arrange
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+
+        var urlSegmentProvider = CreateFixedSegmentProvider("test-segment");
+        var urlSegmentProviderCollection = new UrlSegmentProviderCollection(() => [urlSegmentProvider]);
+
+        var (service, repositoryMock) = CreateDocumentUrlServiceWithMocks(
+            urlSegmentProviderCollection, languages, ServerRole.Subscriber);
+
+        var contentMock = CreateMockContent(Guid.NewGuid(), variesByCulture: false, isPublished: true);
+
+        // Act
+        await service.CreateOrUpdateUrlSegmentsAsync([contentMock.Object]);
+
+        // Assert
+        repositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlSegment>>()),
+            Times.Never,
+            "Subscribers must not persist URL segments — the publisher already has.");
+    }
+
+    /// <summary>
+    /// Regression guard for the subscriber guard: Single and SchedulingPublisher roles must still persist
+    /// URL segments as they did before the fix.
+    /// </summary>
+    [TestCase(ServerRole.Single)]
+    [TestCase(ServerRole.SchedulingPublisher)]
+    public async Task CreateOrUpdateUrlSegmentsAsync_OnSingleOrPublisher_CallsRepositorySave(ServerRole role)
+    {
+        // Arrange
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+
+        var urlSegmentProvider = CreateFixedSegmentProvider("test-segment");
+        var urlSegmentProviderCollection = new UrlSegmentProviderCollection(() => [urlSegmentProvider]);
+
+        var (service, repositoryMock) = CreateDocumentUrlServiceWithMocks(
+            urlSegmentProviderCollection, languages, role);
+
+        var contentMock = CreateMockContent(Guid.NewGuid(), variesByCulture: false, isPublished: true);
+
+        // Act
+        await service.CreateOrUpdateUrlSegmentsAsync([contentMock.Object]);
+
+        // Assert
+        repositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlSegment>>()),
+            Times.Once,
+            $"The {role} role must continue to persist URL segments.");
+    }
+
+    /// <summary>
+    /// Even though a subscriber skips the database write, the in-memory URL cache must still be refreshed
+    /// so that URL resolution keeps working on the subscriber after the publisher renames a node. This
+    /// guards against over-zealous skipping of the deferred scope-context enlistments.
+    /// </summary>
+    [Test]
+    public async Task CreateOrUpdateUrlSegmentsAsync_OnSubscriber_StillPopulatesInMemoryCache()
+    {
+        // Arrange — initialize an empty subscriber service with immediate scope-context enlistment
+        // so deferred cache updates apply straight away.
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+        var service = await CreateInitializedDocumentUrlService(
+            segments: Array.Empty<PublishedDocumentUrlSegment>(),
+            languages: languages,
+            serverRole: ServerRole.Subscriber);
+
+        var documentKey = Guid.NewGuid();
+        var contentMock = CreateMockContent(documentKey, variesByCulture: false, isPublished: true);
+
+        // Act
+        await service.CreateOrUpdateUrlSegmentsAsync([contentMock.Object]);
+
+        // Assert — the in-memory lookup resolves even though we never wrote to the database.
+        var resolved = service.GetUrlSegment(documentKey, "en-US", isDraft: false);
+        Assert.AreEqual(
+            "test-segment",
+            resolved,
+            "Subscribers must still update the in-memory URL cache so routing keeps working locally.");
+    }
+
     #endregion
 
     #region GetUrlSegment Tests
@@ -556,7 +650,8 @@ public class DocumentUrlServiceTests
     /// </summary>
     private static async Task<DocumentUrlService> CreateInitializedDocumentUrlService(
         IEnumerable<PublishedDocumentUrlSegment> segments,
-        IEnumerable<ILanguage> languages)
+        IEnumerable<ILanguage> languages,
+        ServerRole serverRole = ServerRole.Single)
     {
         var urlSegmentProvider = CreateFixedSegmentProvider("test-segment");
         var urlSegmentProviderCollection = new UrlSegmentProviderCollection(() => [urlSegmentProvider]);
@@ -608,6 +703,9 @@ public class DocumentUrlServiceTests
             .Returns(coreScopeMock.Object);
         coreScopeProviderMock.Setup(x => x.Context).Returns(scopeContextMock.Object);
 
+        var serverRoleAccessorMock = new Mock<IServerRoleAccessor>();
+        serverRoleAccessorMock.Setup(x => x.CurrentServerRole).Returns(serverRole);
+
         var service = new DocumentUrlService(
             loggerMock,
             documentUrlRepositoryMock.Object,
@@ -624,7 +722,8 @@ public class DocumentUrlServiceTests
             documentNavigationQueryServiceMock,
             publishStatusQueryServiceMock,
             domainCacheServiceMock,
-            defaultCultureAccessorMock);
+            defaultCultureAccessorMock,
+            serverRoleAccessorMock.Object);
 
         await service.InitAsync(forceEmpty: false, CancellationToken.None);
 


### PR DESCRIPTION
## Description

On a load-balanced Umbraco setup with one `SchedulingPublisher` and one or more `Subscriber` instances pointed at a **read-only** database connection, the subscriber crashes whenever it processes a cache-refresh instruction written by the publisher:

> `Failed to update database because the database is read-only.`

The stack trace originates inside `SqlServerDistributedLockingMechanism` → `DocumentUrlRepository.Save` / `DocumentUrlAliasRepository.Save`, reached via `ContentCacheRefresher.HandleRouting` invoking `IDocumentUrlService.CreateOrUpdateUrlSegmentsAsync` and `IDocumentUrlAliasService.CreateOrUpdateAliasesAsync`. 

These writes are **redundant** on a subscriber — the scheduling publisher has already persisted the same URL segments and aliases before broadcasting the cache instruction.

Reported in: https://github.com/umbraco/Umbraco-CMS/issues/22570

## Fix

Inject `IServerRoleAccessor` into `DocumentUrlService` and `DocumentUrlAliasService` and guard every DB-mutating call path so it is skipped when `CurrentServerRole == ServerRole.Subscriber`. In-memory cache updates continue to happen via the existing `scope.Enlist` deferred actions, so URL and alias resolution on the subscriber keeps working after a publish on the main instance. The approach mirrors the existing pattern in `IndexingRebuilderService`.

## Testing

### Automated

Unit tests have been added to verify the new behaviour, as well as update `DocumentUrlAliasServiceTests` to have the same level of coverage that `DocumentUrlServiceTests` shows.

### Manual

This is how the fix was verified end-to-end in a running instance. It forces the current instance into `ServerRole.Subscriber` and invokes both rebuild entrypoints at startup, so you can observe the new `Skipping…` debug logs and confirm `InitAsync` still populates the in-memory cache.

1. Add `src/Umbraco.Web.UI/Custom/ForceSubscriberComposer.cs`:

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Sync;

namespace Umbraco.Cms.Web.UI.Custom;

// Manual-test scaffolding for issue #22570.
// Forces this instance into ServerRole.Subscriber so we can observe that
// DocumentUrlService / DocumentUrlAliasService skip their database writes
// (without needing an actual load-balanced setup with a read-only SQL login).
// Remove before committing — this is diagnostic only.
public sealed class ForceSubscriberComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Services.AddUnique<IServerRoleAccessor, ForcedSubscriberRoleAccessor>();
        builder.Services.AddHostedService<ForceSubscriberStartupProbe>();
    }

    private sealed class ForcedSubscriberRoleAccessor : IServerRoleAccessor
    {
        public ServerRole CurrentServerRole => ServerRole.Subscriber;
    }

    private sealed class ForceSubscriberStartupProbe : IHostedService
    {
        private readonly IServiceProvider _serviceProvider;
        private readonly ILogger<ForceSubscriberStartupProbe> _logger;

        public ForceSubscriberStartupProbe(
            IServiceProvider serviceProvider,
            ILogger<ForceSubscriberStartupProbe> logger)
        {
            _serviceProvider = serviceProvider;
            _logger = logger;
        }

        public async Task StartAsync(CancellationToken cancellationToken)
        {
            using IServiceScope scope = _serviceProvider.CreateScope();
            IServerRoleAccessor roleAccessor = scope.ServiceProvider.GetRequiredService<IServerRoleAccessor>();
            _logger.LogInformation(
                "[22570-probe] Resolved IServerRoleAccessor.CurrentServerRole = {Role} (expected Subscriber).",
                roleAccessor.CurrentServerRole);

            IDocumentUrlService urlService = scope.ServiceProvider.GetRequiredService<IDocumentUrlService>();
            IDocumentUrlAliasService aliasService = scope.ServiceProvider.GetRequiredService<IDocumentUrlAliasService>();

            try
            {
                _logger.LogInformation("[22570-probe] Calling IDocumentUrlService.RebuildAllUrlsAsync() — should be a no-op on Subscriber.");
                await urlService.RebuildAllUrlsAsync();

                _logger.LogInformation("[22570-probe] Calling IDocumentUrlAliasService.RebuildAllAliasesAsync() — should be a no-op on Subscriber.");
                await aliasService.RebuildAllAliasesAsync();

                _logger.LogInformation("[22570-probe] Both rebuild calls returned without throwing.");
            }
            catch (Exception ex)
            {
                _logger.LogError(ex, "[22570-probe] Rebuild threw — fix is not effective.");
            }
        }

        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
    }
}
```

2. Temporarily bump log levels for the two services so the debug lines surface. In `src/Umbraco.Web.UI/appsettings.Development.json`, under `Serilog.MinimumLevel.Override`, add:

```json
"Umbraco.Cms.Core.Services.DocumentUrlService": "Debug",
"Umbraco.Cms.Core.Services.DocumentUrlAliasService": "Debug"
```

3. Run `dotnet run --project src/Umbraco.Web.UI`.

4. Expected console output shortly after boot:

```
[INF] Caching document URLs.
[INF] Cached N document URLs.
[INF] Caching document aliases.
[INF] Cached N document aliases.
[INF] [22570-probe] Resolved IServerRoleAccessor.CurrentServerRole = Subscriber (expected Subscriber).
[INF] [22570-probe] Calling IDocumentUrlService.RebuildAllUrlsAsync() — should be a no-op on Subscriber.
[DBG] Skipping document URL rebuild — the current server role does not persist URL segments.
[INF] [22570-probe] Calling IDocumentUrlAliasService.RebuildAllAliasesAsync() — should be a no-op on Subscriber.
[DBG] Skipping document URL alias rebuild — the current server role does not persist aliases.
[INF] [22570-probe] Both rebuild calls returned without throwing.
```
