### PR TITLE
Integration tests: Tolerate deadlocks in concurrent external login test

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -351,9 +352,10 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
 
     private static bool IsDeadlockException(Exception ex)
     {
+        const int DeadlockVictimErrorNumber = 1205;
         for (Exception? current = ex; current is not null; current = current.InnerException)
         {
-            if (current.Message.Contains("deadlock", StringComparison.OrdinalIgnoreCase))
+            if (current is SqlException sqlException && sqlException.Number == DeadlockVictimErrorNumber)
             {
                 return true;
             }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ExternalLoginServiceTests.cs
@@ -295,7 +295,7 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
         UserService.Save(user);
 
         const int NumberOfConcurrentOperations = 10;
-        var exceptions = new ConcurrentBag<Exception>();
+        var unexpectedExceptions = new ConcurrentBag<Exception>();
         var providerKey = Guid.NewGuid().ToString("N");
 
         // Barrier ensures all threads start the Save operation at the same time,
@@ -318,9 +318,18 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
                         var login = new ExternalLogin("TestProvider", providerKey);
                         ExternalLoginService.Save(user.Key, [login]);
                     }
+                    catch (Exception ex) when (IsDeadlockException(ex))
+                    {
+                        // Deadlock victim (SQL Server error 1205) — tolerated.
+                        // The 10-way Barrier is intentionally more aggressive than any realistic
+                        // production scenario, and SQL Server's UPDLOCK hint does not prevent phantom
+                        // inserts under READ COMMITTED. This test is about the duplicate-key race
+                        // handler, not deadlock resilience, so we swallow deadlocks here — the final
+                        // assertion still confirms at least one save succeeded.
+                    }
                     catch (Exception ex)
                     {
-                        exceptions.Add(ex);
+                        unexpectedExceptions.Add(ex);
                     }
                 }));
             }
@@ -330,11 +339,26 @@ internal sealed class ExternalLoginServiceTests : UmbracoIntegrationTest
         await Task.WhenAll(tasks);
 
         // Assert
-        var exceptionDetails = exceptions.Select(e =>
+        var exceptionDetails = unexpectedExceptions.Select(e =>
             $"Type: {e.GetType().FullName}, Message: {e.Message}, Inner: {e.InnerException?.GetType().FullName}: {e.InnerException?.Message}");
-        Assert.IsEmpty(exceptions, $"Expected no duplicate key exceptions but got {exceptions.Count}:\n{string.Join("\n", exceptionDetails)}");
+        Assert.IsEmpty(
+            unexpectedExceptions,
+            $"Expected no duplicate key exceptions but got {unexpectedExceptions.Count}:\n{string.Join("\n", exceptionDetails)}");
 
         var logins = ExternalLoginService.GetExternalLogins(user.Key).ToList();
         Assert.AreEqual(1, logins.Count, "Should have exactly one login");
+    }
+
+    private static bool IsDeadlockException(Exception ex)
+    {
+        for (Exception? current = ex; current is not null; current = current.InnerException)
+        {
+            if (current.Message.Contains("deadlock", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Description

This PR is fixing a flaky integration test - `Concurrent_Save_Same_Login_Should_Not_Throw_Duplicate_Key_Exception` - that intermittently fails on CI with SQL Server error 1205 (deadlock victim).

I've taken the view that the test is intentionally more aggressive than any realistic production scenario - multiple concurrent logins with the same account - so it's reasonable to fix the test rather than attempt to fix the potential issue in the production code.

Since the test's purpose is to exercise the duplicate-key race handler (not to assert deadlock resilience), it will now tolerate deadlock exceptions in the test and only fail on unexpected exceptions. 