### PR TITLE
Member surface controllers: Add XML documentation and unit test coverage

### DIFF
--- a/src/Umbraco.Web.Website/Controllers/UmbExternalLoginController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbExternalLoginController.cs
@@ -14,7 +14,6 @@ using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Persistence;
-using Umbraco.Cms.Web.Common.ActionsResults;
 using Umbraco.Cms.Web.Common.Filters;
 using Umbraco.Cms.Web.Common.Security;
 using Umbraco.Extensions;
@@ -22,6 +21,10 @@ using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 
 namespace Umbraco.Cms.Web.Website.Controllers;
 
+/// <summary>
+///     Surface controller that handles external (OAuth/OpenID) sign-in, sign-in callbacks, account
+///     linking and disassociation for members.
+/// </summary>
 [UmbracoMemberAuthorize]
 public class UmbExternalLoginController : SurfaceController
 {
@@ -31,6 +34,9 @@ public class UmbExternalLoginController : SurfaceController
     private readonly IOptions<SecuritySettings> _securitySettings;
     private readonly ITwoFactorLoginService _twoFactorLoginService;
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UmbExternalLoginController" /> class.
+    /// </summary>
     public UmbExternalLoginController(
         ILogger<UmbExternalLoginController> logger,
         IUmbracoContextAccessor umbracoContextAccessor,
@@ -81,8 +87,14 @@ public class UmbExternalLoginController : SurfaceController
     }
 
     /// <summary>
-    ///     Endpoint used my the login provider to call back to our solution.
+    ///     Endpoint used by the login provider to call back to our solution after an external sign-in attempt.
     /// </summary>
+    /// <param name="returnUrl">The URL to redirect to after a successful sign-in.</param>
+    /// <returns>
+    ///     A redirect to the return URL on success; a 400 response when no local member can be matched for
+    ///     a two-factor challenge; otherwise the current page with provider errors populated in
+    ///     <see cref="Controller.ViewData" />.
+    /// </returns>
     [HttpGet]
     [AllowAnonymous]
     public async Task<IActionResult> ExternalLoginCallback(string returnUrl)
@@ -192,6 +204,12 @@ public class UmbExternalLoginController : SurfaceController
         }
     }
 
+    /// <summary>
+    ///     Begins the flow that links an external login provider to the currently authenticated member's account.
+    /// </summary>
+    /// <param name="provider">The name of the external login provider.</param>
+    /// <param name="returnUrl">Optional URL to redirect to after the link callback completes.</param>
+    /// <returns>A challenge result that redirects to the external provider.</returns>
     [HttpPost]
     [ValidateAntiForgeryToken]
     public IActionResult LinkLogin(string provider, string? returnUrl = null)
@@ -214,6 +232,14 @@ public class UmbExternalLoginController : SurfaceController
         return Challenge(properties, provider);
     }
 
+    /// <summary>
+    ///     Endpoint used by the login provider to call back after an account-linking attempt.
+    /// </summary>
+    /// <param name="returnUrl">The URL to redirect to after a successful link.</param>
+    /// <returns>
+    ///     A redirect to the return URL on success; otherwise the current page with provider errors
+    ///     populated in <see cref="Controller.ViewData" />.
+    /// </returns>
     [HttpGet]
     public async Task<IActionResult> ExternalLinkLoginCallback(string returnUrl)
     {
@@ -262,6 +288,16 @@ public class UmbExternalLoginController : SurfaceController
     private IActionResult RedirectToLocal(string returnUrl) =>
         Url.IsLocalUrl(returnUrl) ? Redirect(returnUrl) : RedirectToCurrentUmbracoPage();
 
+    /// <summary>
+    ///     Removes the link between the authenticated member and an external login provider.
+    /// </summary>
+    /// <param name="provider">The name of the external login provider to unlink.</param>
+    /// <param name="providerKey">The provider-assigned key identifying the external login.</param>
+    /// <param name="returnUrl">Optional URL to redirect to on success.</param>
+    /// <returns>
+    ///     A redirect to the return URL on success; otherwise the current page with identity errors
+    ///     added to ModelState.
+    /// </returns>
     [HttpPost]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Disassociate(string provider, string providerKey, string? returnUrl = null)

--- a/src/Umbraco.Web.Website/Controllers/UmbLoginController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbLoginController.cs
@@ -18,6 +18,9 @@ using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 
 namespace Umbraco.Cms.Web.Website.Controllers;
 
+/// <summary>
+///     Surface controller that handles member login from the Login snippet.
+/// </summary>
 public class UmbLoginController : SurfaceController
 {
     private readonly IMemberManager _memberManager;
@@ -26,6 +29,9 @@ public class UmbLoginController : SurfaceController
     private readonly IDocumentNavigationQueryService _navigationQueryService;
     private readonly IPublishedContentStatusFilteringService _publishedContentStatusFilteringService;
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UmbLoginController" /> class.
+    /// </summary>
     public UmbLoginController(
         IUmbracoContextAccessor umbracoContextAccessor,
         IUmbracoDatabaseFactory databaseFactory,
@@ -47,6 +53,14 @@ public class UmbLoginController : SurfaceController
         _publishedContentStatusFilteringService = publishedContentStatusFilteringService;
     }
 
+    /// <summary>
+    ///     Handles the login form post.
+    /// </summary>
+    /// <param name="model">The posted login model.</param>
+    /// <returns>
+    ///     A redirect to the specified (or current) page on success; otherwise the current page with
+    ///     validation errors or two-factor provider information populated in <see cref="Controller.ViewData" />.
+    /// </returns>
     [HttpPost]
     [ValidateAntiForgeryToken]
     [ValidateUmbracoFormRouteString]
@@ -113,10 +127,7 @@ public class UmbLoginController : SurfaceController
         return CurrentUmbracoPage();
     }
 
-    /// <summary>
-    ///     We pass in values via encrypted route values so they cannot be tampered with and merge them into the model for use
-    /// </summary>
-    /// <param name="model"></param>
+    // Route values carry encrypted, tamper-proof overrides for the posted model (see ValidateUmbracoFormRouteString).
     private void MergeRouteValuesToModel(LoginModel model)
     {
         if (RouteData.Values.TryGetValue(nameof(LoginModel.RedirectUrl), out var redirectUrl) && redirectUrl != null)

--- a/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbLoginStatusController.cs
@@ -13,11 +13,17 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Website.Controllers;
 
+/// <summary>
+///     Surface controller that handles member logout from the Login Status snippet.
+/// </summary>
 [UmbracoMemberAuthorize]
 public class UmbLoginStatusController : SurfaceController
 {
     private readonly IMemberSignInManager _signInManager;
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UmbLoginStatusController" /> class.
+    /// </summary>
     public UmbLoginStatusController(
         IUmbracoContextAccessor umbracoContextAccessor,
         IUmbracoDatabaseFactory databaseFactory,
@@ -29,6 +35,13 @@ public class UmbLoginStatusController : SurfaceController
         : base(umbracoContextAccessor, databaseFactory, services, appCaches, profilingLogger, publishedUrlProvider)
         => _signInManager = signInManager;
 
+    /// <summary>
+    ///     Handles the logout form post, signing the current member out if they are authenticated.
+    /// </summary>
+    /// <param name="model">The posted model, optionally containing a redirect URL.</param>
+    /// <returns>
+    ///     A redirect to the supplied local URL when provided; otherwise a redirect to the current Umbraco page.
+    /// </returns>
     [HttpPost]
     [AllowAnonymous]
     [ValidateAntiForgeryToken]
@@ -61,10 +74,7 @@ public class UmbLoginStatusController : SurfaceController
         return RedirectToCurrentUmbracoPage();
     }
 
-    /// <summary>
-    ///     We pass in values via encrypted route values so they cannot be tampered with and merge them into the model for use
-    /// </summary>
-    /// <param name="model"></param>
+    // Route values carry encrypted, tamper-proof overrides for the posted model (see ValidateUmbracoFormRouteString).
     private void MergeRouteValuesToModel(PostRedirectModel model)
     {
         if (RouteData.Values.TryGetValue(nameof(PostRedirectModel.RedirectUrl), out var redirectUrl) && redirectUrl is not null)

--- a/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbProfileController.cs
@@ -15,6 +15,10 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Website.Controllers;
 
+/// <summary>
+///     Surface controller that handles updates to the profile of the currently authenticated member,
+///     posted from the Edit Profile snippet.
+/// </summary>
 [UmbracoMemberAuthorize]
 public class UmbProfileController : SurfaceController
 {
@@ -23,6 +27,9 @@ public class UmbProfileController : SurfaceController
     private readonly IMemberTypeService _memberTypeService;
     private readonly ICoreScopeProvider _scopeProvider;
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UmbProfileController" /> class.
+    /// </summary>
     public UmbProfileController(
         IUmbracoContextAccessor umbracoContextAccessor,
         IUmbracoDatabaseFactory databaseFactory,
@@ -42,6 +49,14 @@ public class UmbProfileController : SurfaceController
         _scopeProvider = scopeProvider;
     }
 
+    /// <summary>
+    ///     Handles the profile update form post for the currently authenticated member.
+    /// </summary>
+    /// <param name="model">The posted profile model.</param>
+    /// <returns>
+    ///     A redirect to the supplied local URL (or the current page) on success; otherwise the current
+    ///     page with validation errors added to ModelState.
+    /// </returns>
     [HttpPost]
     [ValidateAntiForgeryToken]
     [ValidateUmbracoFormRouteString]
@@ -80,10 +95,7 @@ public class UmbProfileController : SurfaceController
         return RedirectToCurrentUmbracoPage();
     }
 
-    /// <summary>
-    ///     We pass in values via encrypted route values so they cannot be tampered with and merge them into the model for use
-    /// </summary>
-    /// <param name="model"></param>
+    // Route values carry encrypted, tamper-proof overrides for the posted model (see ValidateUmbracoFormRouteString).
     private void MergeRouteValuesToModel(ProfileModel model)
     {
         if (RouteData.Values.TryGetValue(nameof(ProfileModel.RedirectUrl), out var redirectUrl) && redirectUrl != null)

--- a/src/Umbraco.Web.Website/Controllers/UmbRegisterController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbRegisterController.cs
@@ -16,6 +16,9 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Website.Controllers;
 
+/// <summary>
+///     Surface controller that handles member registration from the Register Member snippet.
+/// </summary>
 public class UmbRegisterController : SurfaceController
 {
     private readonly IMemberManager _memberManager;
@@ -23,6 +26,9 @@ public class UmbRegisterController : SurfaceController
     private readonly IMemberSignInManager _memberSignInManager;
     private readonly ICoreScopeProvider _scopeProvider;
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UmbRegisterController" /> class.
+    /// </summary>
     public UmbRegisterController(
         IMemberManager memberManager,
         IMemberService memberService,
@@ -42,6 +48,15 @@ public class UmbRegisterController : SurfaceController
         _scopeProvider = scopeProvider;
     }
 
+    /// <summary>
+    ///     Handles the registration form post, creating a new member and signing them in when
+    ///     <see cref="RegisterModel.AutomaticLogIn" /> is set.
+    /// </summary>
+    /// <param name="model">The posted registration model.</param>
+    /// <returns>
+    ///     A redirect to the supplied local URL (or the current page) on success; otherwise the current
+    ///     page with validation errors added to ModelState.
+    /// </returns>
     [HttpPost]
     [ValidateAntiForgeryToken]
     [ValidateUmbracoFormRouteString]
@@ -73,10 +88,7 @@ public class UmbRegisterController : SurfaceController
         return CurrentUmbracoPage();
     }
 
-    /// <summary>
-    ///     We pass in values via encrypted route values so they cannot be tampered with and merge them into the model for use
-    /// </summary>
-    /// <param name="model"></param>
+    // Route values carry encrypted, tamper-proof overrides for the posted model (see ValidateUmbracoFormRouteString).
     private void MergeRouteValuesToModel(RegisterModel model)
     {
         if (RouteData.Values.TryGetValue(nameof(RegisterModel.RedirectUrl), out var redirectUrl) && redirectUrl != null)
@@ -111,11 +123,6 @@ public class UmbRegisterController : SurfaceController
         }
     }
 
-    /// <summary>
-    ///     Registers a new member.
-    /// </summary>
-    /// <param name="model">Register member model.</param>
-    /// <returns>Result of registration operation.</returns>
     private async Task<IdentityResult> RegisterMemberAsync(RegisterModel model)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();

--- a/src/Umbraco.Web.Website/Controllers/UmbTwoFactorLoginController.cs
+++ b/src/Umbraco.Web.Website/Controllers/UmbTwoFactorLoginController.cs
@@ -16,6 +16,10 @@ using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 
 namespace Umbraco.Cms.Web.Website.Controllers;
 
+/// <summary>
+///     Surface controller that handles two-factor authentication flows for members, including provider
+///     listing, code verification, and setup/disable operations.
+/// </summary>
 [UmbracoMemberAuthorize]
 public class UmbTwoFactorLoginController : SurfaceController
 {
@@ -24,6 +28,9 @@ public class UmbTwoFactorLoginController : SurfaceController
     private readonly IMemberSignInManager _memberSignInManager;
     private readonly ITwoFactorLoginService _twoFactorLoginService;
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="UmbTwoFactorLoginController" /> class.
+    /// </summary>
     public UmbTwoFactorLoginController(
         ILogger<UmbTwoFactorLoginController> logger,
         IUmbracoContextAccessor umbracoContextAccessor,
@@ -50,9 +57,12 @@ public class UmbTwoFactorLoginController : SurfaceController
     }
 
     /// <summary>
-    ///     Used to retrieve the 2FA providers for code submission
+    ///     Retrieves the list of two-factor provider names valid for the member currently in the 2FA flow.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>
+    ///     An <see cref="ObjectResult" /> containing the list of enabled provider names, or
+    ///     <see cref="NotFoundResult" /> when no member is in the 2FA flow.
+    /// </returns>
     [AllowAnonymous]
     public async Task<ActionResult<IEnumerable<string>>> Get2FAProviders()
     {
@@ -67,6 +77,15 @@ public class UmbTwoFactorLoginController : SurfaceController
         return new ObjectResult(userFactors);
     }
 
+    /// <summary>
+    ///     Verifies a two-factor authentication code for the member currently in the 2FA flow.
+    /// </summary>
+    /// <param name="model">The submitted two-factor code and provider details.</param>
+    /// <param name="returnUrl">Optional URL to redirect to on successful verification.</param>
+    /// <returns>
+    ///     A redirect to the return URL on success; <see cref="NotFoundResult" /> when no member is in
+    ///     the 2FA flow; otherwise the current page with validation errors added to ModelState.
+    /// </returns>
     [AllowAnonymous]
     public async Task<IActionResult> Verify2FACode(Verify2FACodeModel model, string? returnUrl = null)
     {
@@ -110,6 +129,18 @@ public class UmbTwoFactorLoginController : SurfaceController
         return CurrentUmbracoPage();
     }
 
+    /// <summary>
+    ///     Validates a two-factor setup code and, on success, persists the two-factor login for the
+    ///     currently authenticated member.
+    /// </summary>
+    /// <param name="providerName">The name of the two-factor provider being configured.</param>
+    /// <param name="secret">The shared secret generated during setup.</param>
+    /// <param name="code">The code the member has entered to verify the setup.</param>
+    /// <param name="returnUrl">Optional URL to redirect to on success.</param>
+    /// <returns>
+    ///     A redirect to the return URL on success; otherwise the current page with a validation error
+    ///     added to ModelState.
+    /// </returns>
     [HttpPost]
     public async Task<IActionResult> ValidateAndSaveSetup(
         string providerName,
@@ -138,6 +169,14 @@ public class UmbTwoFactorLoginController : SurfaceController
         return RedirectToLocal(returnUrl);
     }
 
+    /// <summary>
+    ///     Disables a two-factor provider for the currently authenticated member.
+    /// </summary>
+    /// <param name="providerName">The name of the two-factor provider to disable.</param>
+    /// <param name="returnUrl">Optional URL to redirect to on success.</param>
+    /// <returns>
+    ///     A redirect to the return URL on success; otherwise the current page.
+    /// </returns>
     [HttpPost]
     public async Task<IActionResult> Disable(string providerName, string? returnUrl = null)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/SurfaceControllerTestHelpers.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/SurfaceControllerTestHelpers.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Routing;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
+
+/// <summary>
+///     Shared test infrastructure for exercising SurfaceController subclasses.
+/// </summary>
+internal static class SurfaceControllerTestHelpers
+{
+    /// <summary>
+    ///     Configures the <see cref="ControllerBase.ControllerContext" />, URL helper, TempData provider and the
+    ///     <see cref="UmbracoRouteValues" /> feature required for a Surface controller under test.
+    /// </summary>
+    public static void ConfigureControllerContext(
+        Controller controller,
+        bool isAuthenticated = false,
+        IPublishedContent? currentPage = null,
+        string? userIdClaim = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        ClaimsPrincipal user;
+        if (isAuthenticated)
+        {
+            var claims = new List<Claim>();
+            if (userIdClaim is not null)
+            {
+                claims.Add(new Claim(ClaimTypes.NameIdentifier, userIdClaim));
+                claims.Add(new Claim(ClaimTypes.Name, userIdClaim));
+            }
+
+            user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        }
+        else
+        {
+            user = new ClaimsPrincipal(new ClaimsIdentity());
+        }
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider,
+            User = user,
+        };
+
+        // Provide a routed request feature so CurrentPage/RedirectToCurrentUmbracoPage can resolve.
+        var publishedRequestBuilder = new PublishedRequestBuilder(new Uri("http://localhost/"), Mock.Of<IFileService>());
+        if (currentPage is not null)
+        {
+            publishedRequestBuilder.SetPublishedContent(currentPage);
+        }
+
+        var routeValues = new UmbracoRouteValues(publishedRequestBuilder.Build(), null);
+        httpContext.Features.Set(routeValues);
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext, RouteData = actionContext.RouteData };
+        controller.Url = new UrlHelper(actionContext);
+        controller.TempData = new TempDataDictionary(httpContext, new NullTempDataProvider());
+    }
+
+    private sealed class NullTempDataProvider : ITempDataProvider
+    {
+        public IDictionary<string, object?> LoadTempData(HttpContext context) => new Dictionary<string, object?>();
+
+        public void SaveTempData(HttpContext context, IDictionary<string, object?> values)
+        {
+            // No-op for unit tests.
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/SurfaceControllerTestHelpers.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/SurfaceControllerTestHelpers.cs
@@ -22,6 +22,15 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
 /// </summary>
 internal static class SurfaceControllerTestHelpers
 {
+    // Shared across tests: the registrations are static (logging only) and IServiceProvider is safe for concurrent
+    // resolution, so reusing a single instance avoids accumulating disposable provider state across large test runs.
+    private static readonly Lazy<ServiceProvider> SharedServiceProvider = new(() =>
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        return services.BuildServiceProvider();
+    });
+
     /// <summary>
     ///     Configures the <see cref="ControllerBase.ControllerContext" />, URL helper, TempData provider and the
     ///     <see cref="UmbracoRouteValues" /> feature required for a Surface controller under test.
@@ -32,10 +41,6 @@ internal static class SurfaceControllerTestHelpers
         IPublishedContent? currentPage = null,
         string? userIdClaim = null)
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        ServiceProvider serviceProvider = services.BuildServiceProvider();
-
         ClaimsPrincipal user;
         if (isAuthenticated)
         {
@@ -55,7 +60,7 @@ internal static class SurfaceControllerTestHelpers
 
         var httpContext = new DefaultHttpContext
         {
-            RequestServices = serviceProvider,
+            RequestServices = SharedServiceProvider.Value,
             User = user,
         };
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbExternalLoginControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbExternalLoginControllerTests.cs
@@ -1,0 +1,391 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Web.Common.Security;
+using Umbraco.Cms.Web.Website.ActionResults;
+using Umbraco.Cms.Web.Website.Controllers;
+using Umbraco.Extensions;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
+
+[TestFixture]
+public class UmbExternalLoginControllerTests
+{
+    private Mock<IMemberManager> _memberManagerMock = null!;
+    private Mock<IMemberSignInManager> _signInManagerMock = null!;
+    private Mock<ITwoFactorLoginService> _twoFactorLoginServiceMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _memberManagerMock = new Mock<IMemberManager>();
+        _signInManagerMock = new Mock<IMemberSignInManager>();
+        _twoFactorLoginServiceMock = new Mock<ITwoFactorLoginService>();
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_NoLoginInfo_ReturnsCurrentPageWithError()
+    {
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync((ExternalLoginInfo?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.Contains("Invalid response from the login provider", errors!.Errors.ToList());
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_Success_RedirectsToReturnUrl()
+    {
+        var loginInfo = CreateLoginInfo();
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(SignInResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/after", redirect!.Url);
+        _signInManagerMock.Verify(x => x.UpdateExternalAuthenticationTokensAsync(loginInfo), Times.Once);
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_Success_WithNonLocalReturnUrl_FallsBackToCurrentPage()
+    {
+        var loginInfo = CreateLoginInfo();
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(SignInResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("https://evil.com");
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task ExternalLinkLoginCallback_Success_WithNonLocalReturnUrl_FallsBackToCurrentPage()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), Id = "1" };
+        var loginInfo = CreateLoginInfo();
+        _memberManagerMock.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        _memberManagerMock.Setup(x => x.GetUserIdAsync(user)).ReturnsAsync("1");
+        _signInManagerMock.Setup(x => x.GetExternalLoginInfoAsync("1")).ReturnsAsync(loginInfo);
+        _memberManagerMock.Setup(x => x.AddLoginAsync(user, loginInfo)).ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLinkLoginCallback("https://evil.com");
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task Disassociate_Success_WithNonLocalReturnUrl_FallsBackToCurrentPage()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), Id = "1" };
+        _memberManagerMock.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(user);
+        _memberManagerMock
+            .Setup(x => x.RemoveLoginAsync(user, "Provider", "key"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController(userIdClaim: "1");
+
+        IActionResult result = await controller.Disassociate("Provider", "key", "https://evil.com");
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_TwoFactorRequired_UnknownLocalUser_ReturnsBadRequest()
+    {
+        var loginInfo = CreateLoginInfo();
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(SignInResult.TwoFactorRequired);
+        _memberManagerMock
+            .Setup(x => x.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey))
+            .ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_TwoFactorRequired_PopulatesProviderNames()
+    {
+        var loginInfo = CreateLoginInfo();
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(SignInResult.TwoFactorRequired);
+        _memberManagerMock
+            .Setup(x => x.FindByLoginAsync(loginInfo.LoginProvider, loginInfo.ProviderKey))
+            .ReturnsAsync(user);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.GetEnabledTwoFactorProviderNamesAsync(user.Key))
+            .ReturnsAsync(["AppAuth"]);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ViewData.TryGetTwoFactorProviderNames(out var names));
+        Assert.That(names, Is.EquivalentTo(new[] { "AppAuth" }));
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_LockedOut_ReturnsCurrentPageWithError()
+    {
+        var loginInfo = CreateLoginInfo();
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(SignInResult.LockedOut);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.That(errors!.Errors.Single(), Does.Contain("is locked out"));
+    }
+
+    [Test]
+    public async Task ExternalLoginCallback_Failed_ReturnsCurrentPageWithError()
+    {
+        var loginInfo = CreateLoginInfo();
+        _signInManagerMock
+            .Setup(x => x.GetExternalLoginInfoAsync(It.IsAny<string?>()))
+            .ReturnsAsync(loginInfo);
+        _signInManagerMock
+            .Setup(x => x.ExternalLoginSignInAsync(loginInfo, false, It.IsAny<bool>()))
+            .ReturnsAsync(SignInResult.Failed);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.That(errors!.Errors.Single(), Does.Contain("has not been linked to an account"));
+    }
+
+    [Test]
+    public async Task ExternalLinkLoginCallback_NoLocalUser_ReturnsCurrentPageWithError()
+    {
+        _memberManagerMock
+            .Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+            .ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLinkLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.Contains("Local user does not exist", errors!.Errors.ToList());
+    }
+
+    [Test]
+    public async Task ExternalLinkLoginCallback_NoExternalInfo_ReturnsCurrentPageWithError()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), Id = "1" };
+        _memberManagerMock.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        _memberManagerMock.Setup(x => x.GetUserIdAsync(user)).ReturnsAsync("1");
+        _signInManagerMock.Setup(x => x.GetExternalLoginInfoAsync("1")).ReturnsAsync((ExternalLoginInfo?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLinkLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.Contains("An error occurred, could not get external login info", errors!.Errors.ToList());
+    }
+
+    [Test]
+    public async Task ExternalLinkLoginCallback_Success_RedirectsToReturnUrl()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), Id = "1" };
+        var loginInfo = CreateLoginInfo();
+        _memberManagerMock.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        _memberManagerMock.Setup(x => x.GetUserIdAsync(user)).ReturnsAsync("1");
+        _signInManagerMock.Setup(x => x.GetExternalLoginInfoAsync("1")).ReturnsAsync(loginInfo);
+        _memberManagerMock.Setup(x => x.AddLoginAsync(user, loginInfo)).ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLinkLoginCallback("/after");
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/after", redirect!.Url);
+        _signInManagerMock.Verify(x => x.UpdateExternalAuthenticationTokensAsync(loginInfo), Times.Once);
+    }
+
+    [Test]
+    public async Task ExternalLinkLoginCallback_AddLoginFails_ReturnsCurrentPageWithErrors()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), Id = "1" };
+        var loginInfo = CreateLoginInfo();
+        _memberManagerMock.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(user);
+        _memberManagerMock.Setup(x => x.GetUserIdAsync(user)).ReturnsAsync("1");
+        _signInManagerMock.Setup(x => x.GetExternalLoginInfoAsync("1")).ReturnsAsync(loginInfo);
+        _memberManagerMock
+            .Setup(x => x.AddLoginAsync(user, loginInfo))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Already linked" }));
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ExternalLinkLoginCallback("/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        var errors = controller.ViewData.GetExternalSignInProviderErrors();
+        Assert.IsNotNull(errors);
+        Assert.Contains("Already linked", errors!.Errors.ToList());
+    }
+
+    [Test]
+    public async Task Disassociate_Success_RedirectsToReturnUrl()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), Id = "1" };
+        _memberManagerMock.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(user);
+        _memberManagerMock
+            .Setup(x => x.RemoveLoginAsync(user, "Provider", "key"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController(userIdClaim: "1");
+
+        IActionResult result = await controller.Disassociate("Provider", "key", "/after");
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/after", redirect!.Url);
+        _signInManagerMock.Verify(x => x.SignInAsync(user, false, null), Times.Once);
+    }
+
+    [Test]
+    public async Task Disassociate_RemoveLoginFails_ReturnsCurrentPageWithModelErrors()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), Id = "1" };
+        _memberManagerMock.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(user);
+        _memberManagerMock
+            .Setup(x => x.RemoveLoginAsync(user, "Provider", "key"))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Cannot remove last login" }));
+
+        var controller = CreateController(userIdClaim: "1");
+
+        IActionResult result = await controller.Disassociate("Provider", "key", "/after");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState[string.Empty]!.Errors.Any(e => e.ErrorMessage == "Cannot remove last login"));
+    }
+
+    [Test]
+    public async Task Disassociate_NoUserIdClaim_ReturnsCurrentPage()
+    {
+        var controller = CreateController();
+
+        IActionResult result = await controller.Disassociate("Provider", "key");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _memberManagerMock.Verify(x => x.RemoveLoginAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Disassociate_UserNotFound_ReturnsCurrentPage()
+    {
+        _memberManagerMock.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController(userIdClaim: "1");
+
+        IActionResult result = await controller.Disassociate("Provider", "key");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _memberManagerMock.Verify(x => x.RemoveLoginAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    private static ExternalLoginInfo CreateLoginInfo()
+    {
+        var identity = new ClaimsIdentity(
+            new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, "ext-1"),
+                new Claim(ClaimTypes.Email, "ext@example.com"),
+                new Claim(ClaimTypes.Name, "External User"),
+            },
+            "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+        return new ExternalLoginInfo(principal, "TestProvider", "ext-1", "Test Provider");
+    }
+
+    private UmbExternalLoginController CreateController(string? userIdClaim = null)
+    {
+        var controller = new UmbExternalLoginController(
+            NullLogger<UmbExternalLoginController>.Instance,
+            new TestUmbracoContextAccessor(),
+            null!,
+            ServiceContext.CreatePartial(),
+            AppCaches.Disabled,
+            Mock.Of<IProfilingLogger>(),
+            Mock.Of<IPublishedUrlProvider>(),
+            _signInManagerMock.Object,
+            _memberManagerMock.Object,
+            _twoFactorLoginServiceMock.Object,
+            Options.Create(new SecuritySettings()));
+
+        SurfaceControllerTestHelpers.ConfigureControllerContext(controller, isAuthenticated: true, userIdClaim: userIdClaim);
+
+        return controller;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbLoginControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbLoginControllerTests.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
+using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Tests.UnitTests.TestHelpers.Objects;
+using Umbraco.Cms.Web.Common.Models;
+using Umbraco.Cms.Web.Common.Security;
+using Umbraco.Cms.Web.Website.ActionResults;
+using Umbraco.Cms.Web.Website.Controllers;
+using Umbraco.Extensions;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
+
+[TestFixture]
+public class UmbLoginControllerTests
+{
+    private Mock<IMemberSignInManager> _signInManagerMock = null!;
+    private Mock<IMemberManager> _memberManagerMock = null!;
+    private Mock<ITwoFactorLoginService> _twoFactorLoginServiceMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _signInManagerMock = new Mock<IMemberSignInManager>();
+        _memberManagerMock = new Mock<IMemberManager>();
+        _twoFactorLoginServiceMock = new Mock<ITwoFactorLoginService>();
+    }
+
+    [Test]
+    public async Task HandleLogin_InvalidModelState_ReturnsCurrentPage()
+    {
+        var controller = CreateController();
+        controller.ModelState.AddModelError("loginModel", "invalid");
+
+        IActionResult result = await controller.HandleLogin(new LoginModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _signInManagerMock.Verify(
+            x => x.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task HandleLogin_Success_WithLocalRedirectUrl_RedirectsAndSetsSuccessTempData()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleLogin(new LoginModel
+        {
+            Username = "user",
+            Password = "pass",
+            RedirectUrl = "/after-login",
+        });
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/after-login", redirect!.Url);
+        Assert.AreEqual(true, controller.TempData["LoginSuccess"]);
+    }
+
+    [Test]
+    public async Task HandleLogin_Success_NoRedirectUrl_RedirectsToCurrentUmbracoUrl()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleLogin(new LoginModel { Username = "user", Password = "pass" });
+
+        Assert.IsInstanceOf<RedirectToUmbracoUrlResult>(result);
+        Assert.AreEqual(true, controller.TempData["LoginSuccess"]);
+    }
+
+    [Test]
+    public async Task HandleLogin_Success_WithNonLocalRedirectUrl_FallsBackToAncestorUrl()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.Success);
+
+        var currentPage = new Mock<IPublishedContent>();
+        currentPage.Setup(x => x.Level).Returns(1);
+        currentPage.Setup(x => x.Id).Returns(1234);
+        currentPage.Setup(x => x.ContentType).Returns(Mock.Of<IPublishedContentType>(t => t.ItemType == PublishedItemType.Content));
+
+        var publishedUrlProvider = new Mock<IPublishedUrlProvider>();
+        publishedUrlProvider
+            .Setup(x => x.GetUrl(currentPage.Object, UrlMode.Default, null, null))
+            .Returns("/root-page");
+
+        var controller = CreateController(currentPage.Object, publishedUrlProvider.Object);
+
+        IActionResult result = await controller.HandleLogin(new LoginModel
+        {
+            Username = "user",
+            Password = "pass",
+            RedirectUrl = "https://evil.com",
+        });
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/root-page", redirect!.Url);
+    }
+
+    [Test]
+    public async Task HandleLogin_RedirectUrlFromRouteData_OverridesModelValue()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.Success);
+
+        var controller = CreateController();
+        controller.RouteData.Values[nameof(LoginModel.RedirectUrl)] = "/from-route";
+
+        IActionResult result = await controller.HandleLogin(new LoginModel
+        {
+            Username = "user",
+            Password = "pass",
+            RedirectUrl = "/from-model",
+        });
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/from-route", redirect!.Url);
+    }
+
+    [Test]
+    public async Task HandleLogin_TwoFactorRequired_WithKnownUser_PopulatesProviderNames()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid(), UserName = "user" };
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.TwoFactorRequired);
+        _memberManagerMock.Setup(x => x.FindByNameAsync("user")).ReturnsAsync(user);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.GetEnabledTwoFactorProviderNamesAsync(user.Key))
+            .ReturnsAsync(["UmbracoMemberAppAuthenticator"]);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleLogin(new LoginModel { Username = "user", Password = "pass" });
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ViewData.TryGetTwoFactorProviderNames(out var providerNames));
+        Assert.That(providerNames, Is.EquivalentTo(new[] { "UmbracoMemberAppAuthenticator" }));
+    }
+
+    [Test]
+    public async Task HandleLogin_TwoFactorRequired_WithUnknownUser_ReturnsBadRequest()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.TwoFactorRequired);
+        _memberManagerMock.Setup(x => x.FindByNameAsync("user")).ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleLogin(new LoginModel { Username = "user", Password = "pass" });
+
+        Assert.IsInstanceOf<BadRequestObjectResult>(result);
+    }
+
+    [Test]
+    public async Task HandleLogin_LockedOut_AddsModelError()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.LockedOut);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleLogin(new LoginModel { Username = "user", Password = "pass" });
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["loginModel"]!.Errors.Any(e => e.ErrorMessage == "Member is locked out"));
+    }
+
+    [Test]
+    public async Task HandleLogin_NotAllowed_AddsModelError()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "pass", false, true))
+            .ReturnsAsync(SignInResult.NotAllowed);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleLogin(new LoginModel { Username = "user", Password = "pass" });
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["loginModel"]!.Errors.Any(e => e.ErrorMessage == "Member is not allowed"));
+    }
+
+    [Test]
+    public async Task HandleLogin_Failed_AddsInvalidCredentialsModelError()
+    {
+        _signInManagerMock
+            .Setup(x => x.PasswordSignInAsync("user", "wrong", false, true))
+            .ReturnsAsync(SignInResult.Failed);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleLogin(new LoginModel { Username = "user", Password = "wrong" });
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["loginModel"]!.Errors
+            .Any(e => e.ErrorMessage == "Invalid username or password"));
+    }
+
+    private UmbLoginController CreateController(
+        IPublishedContent? currentPage = null,
+        IPublishedUrlProvider? publishedUrlProvider = null)
+    {
+        var umbracoContextAccessor = new TestUmbracoContextAccessor();
+        TestUmbracoContextFactory.Create(umbracoContextAccessor).EnsureUmbracoContext();
+
+        var controller = new UmbLoginController(
+            umbracoContextAccessor,
+            null!,
+            ServiceContext.CreatePartial(),
+            AppCaches.Disabled,
+            Mock.Of<IProfilingLogger>(),
+            publishedUrlProvider ?? Mock.Of<IPublishedUrlProvider>(),
+            _signInManagerMock.Object,
+            _memberManagerMock.Object,
+            _twoFactorLoginServiceMock.Object,
+            Mock.Of<IDocumentNavigationQueryService>(),
+            Mock.Of<IPublishedContentStatusFilteringService>());
+
+        SurfaceControllerTestHelpers.ConfigureControllerContext(controller, currentPage: currentPage);
+
+        return controller;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbLoginStatusControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbLoginStatusControllerTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Web.Common.Models;
+using Umbraco.Cms.Web.Common.Security;
+using Umbraco.Cms.Web.Website.ActionResults;
+using Umbraco.Cms.Web.Website.Controllers;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
+
+[TestFixture]
+public class UmbLoginStatusControllerTests
+{
+    private Mock<IMemberSignInManager> _signInManagerMock = null!;
+
+    [SetUp]
+    public void SetUp() => _signInManagerMock = new Mock<IMemberSignInManager>();
+
+    [Test]
+    public async Task HandleLogout_InvalidModelState_ReturnsCurrentPage()
+    {
+        var controller = CreateController();
+        controller.ModelState.AddModelError("logoutModel", "invalid");
+
+        IActionResult result = await controller.HandleLogout(new PostRedirectModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _signInManagerMock.Verify(x => x.SignOutAsync(), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleLogout_WhenAuthenticated_SignsOutAndRedirectsToCurrentPage()
+    {
+        var controller = CreateController(isAuthenticated: true);
+
+        IActionResult result = await controller.HandleLogout(new PostRedirectModel());
+
+        _signInManagerMock.Verify(x => x.SignOutAsync(), Times.Once);
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+        Assert.AreEqual(true, controller.TempData["LogoutSuccess"]);
+    }
+
+    [Test]
+    public async Task HandleLogout_WhenNotAuthenticated_DoesNotSignOut()
+    {
+        var controller = CreateController(isAuthenticated: false);
+
+        IActionResult result = await controller.HandleLogout(new PostRedirectModel());
+
+        _signInManagerMock.Verify(x => x.SignOutAsync(), Times.Never);
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+        Assert.AreEqual(true, controller.TempData["LogoutSuccess"]);
+    }
+
+    [Test]
+    public async Task HandleLogout_WithLocalRedirectUrl_RedirectsToThatUrl()
+    {
+        var controller = CreateController(isAuthenticated: true);
+
+        IActionResult result = await controller.HandleLogout(new PostRedirectModel { RedirectUrl = "/goodbye" });
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/goodbye", redirect!.Url);
+    }
+
+    [Test]
+    public async Task HandleLogout_WithNonLocalRedirectUrl_RedirectsToCurrentPage()
+    {
+        var controller = CreateController(isAuthenticated: true);
+
+        IActionResult result = await controller.HandleLogout(new PostRedirectModel { RedirectUrl = "https://evil.com" });
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task HandleLogout_RedirectUrlFromRouteData_OverridesModelValue()
+    {
+        var controller = CreateController(isAuthenticated: true);
+        controller.RouteData.Values[nameof(PostRedirectModel.RedirectUrl)] = "/from-route";
+
+        IActionResult result = await controller.HandleLogout(new PostRedirectModel { RedirectUrl = "/from-model" });
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/from-route", redirect!.Url);
+    }
+
+    private UmbLoginStatusController CreateController(bool isAuthenticated = false)
+    {
+        var controller = new UmbLoginStatusController(
+            new TestUmbracoContextAccessor(),
+            null!,
+            ServiceContext.CreatePartial(),
+            AppCaches.Disabled,
+            Mock.Of<IProfilingLogger>(),
+            Mock.Of<IPublishedUrlProvider>(),
+            _signInManagerMock.Object);
+
+        SurfaceControllerTestHelpers.ConfigureControllerContext(controller, isAuthenticated);
+
+        return controller;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbProfileControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbProfileControllerTests.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Web.Website.ActionResults;
+using Umbraco.Cms.Web.Website.Controllers;
+using Umbraco.Cms.Web.Website.Models;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
+
+[TestFixture]
+public class UmbProfileControllerTests
+{
+    private Mock<IMemberManager> _memberManagerMock = null!;
+    private Mock<IMemberService> _memberServiceMock = null!;
+    private Mock<IMemberTypeService> _memberTypeServiceMock = null!;
+    private Mock<ICoreScopeProvider> _scopeProviderMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _memberManagerMock = new Mock<IMemberManager>();
+        _memberServiceMock = new Mock<IMemberService>();
+        _memberTypeServiceMock = new Mock<IMemberTypeService>();
+        _scopeProviderMock = new Mock<ICoreScopeProvider>();
+        _scopeProviderMock
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<System.Data.IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<global::Umbraco.Cms.Core.Events.IEventDispatcher>(),
+                It.IsAny<global::Umbraco.Cms.Core.Events.IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(Mock.Of<ICoreScope>());
+    }
+
+    [Test]
+    public async Task HandleUpdateProfile_InvalidModelState_ReturnsCurrentPage()
+    {
+        var controller = CreateController();
+        controller.ModelState.AddModelError("profileModel", "invalid");
+
+        IActionResult result = await controller.HandleUpdateProfile(CreateModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _memberManagerMock.Verify(x => x.UpdateAsync(It.IsAny<MemberIdentityUser>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleUpdateProfile_NoCurrentMember_RedirectsToCurrentPage()
+    {
+        _memberManagerMock
+            .Setup(x => x.GetUserAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>()))
+            .ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleUpdateProfile(CreateModel());
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+        _memberManagerMock.Verify(x => x.UpdateAsync(It.IsAny<MemberIdentityUser>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleUpdateProfile_UpdateFails_AddsModelErrors()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _memberManagerMock
+            .Setup(x => x.GetUserAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>()))
+            .ReturnsAsync(user);
+        _memberManagerMock
+            .Setup(x => x.UpdateAsync(user))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Invalid email" }));
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleUpdateProfile(CreateModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["profileModel"]!.Errors.Any(e => e.ErrorMessage == "Invalid email"));
+    }
+
+    [Test]
+    public async Task HandleUpdateProfile_Success_NoRedirectUrl_RedirectsToCurrentPage()
+    {
+        SetupSuccessfulUpdate(out _);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleUpdateProfile(CreateModel());
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+        Assert.AreEqual(true, controller.TempData["FormSuccess"]);
+    }
+
+    [Test]
+    public async Task HandleUpdateProfile_Success_WithLocalRedirectUrl_RedirectsToUrl()
+    {
+        SetupSuccessfulUpdate(out _);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleUpdateProfile(CreateModel(redirectUrl: "/profile-saved"));
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/profile-saved", redirect!.Url);
+    }
+
+    [Test]
+    public async Task HandleUpdateProfile_Success_WithNonLocalRedirectUrl_FallsBackToCurrentPage()
+    {
+        SetupSuccessfulUpdate(out _);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleUpdateProfile(CreateModel(redirectUrl: "https://evil.com"));
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task HandleUpdateProfile_Success_CopiesEditableFieldsToIdentityUser()
+    {
+        SetupSuccessfulUpdate(out var user);
+
+        var controller = CreateController();
+
+        await controller.HandleUpdateProfile(new ProfileModel
+        {
+            Name = "Updated Name",
+            Email = "updated@example.com",
+            UserName = "updated-username",
+            Comments = "Updated comments",
+        });
+
+        Assert.AreEqual("Updated Name", user.Name);
+        Assert.AreEqual("updated@example.com", user.Email);
+        Assert.AreEqual("updated-username", user.UserName);
+        Assert.AreEqual("Updated comments", user.Comments);
+    }
+
+    private static ProfileModel CreateModel(string? redirectUrl = null) =>
+        new()
+        {
+            Email = "member@example.com",
+            Name = "Member",
+            UserName = "member",
+            RedirectUrl = redirectUrl,
+        };
+
+    private void SetupSuccessfulUpdate(out MemberIdentityUser user)
+    {
+        user = new MemberIdentityUser
+        {
+            Key = Guid.NewGuid(),
+            Email = "old@example.com",
+            Name = "Old",
+            UserName = "old",
+        };
+        _memberManagerMock
+            .Setup(x => x.GetUserAsync(It.IsAny<System.Security.Claims.ClaimsPrincipal>()))
+            .ReturnsAsync(user);
+        _memberManagerMock
+            .Setup(x => x.UpdateAsync(It.IsAny<MemberIdentityUser>()))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var member = new Mock<IMember>();
+        member.Setup(x => x.ContentTypeId).Returns(1234);
+        member.Setup(x => x.Properties).Returns(new PropertyCollection());
+        _memberServiceMock.Setup(x => x.GetById(It.IsAny<Guid>())).Returns(member.Object);
+
+        var memberType = new Mock<IMemberType>();
+        _memberTypeServiceMock.Setup(x => x.Get(It.IsAny<int>())).Returns(memberType.Object);
+    }
+
+    private UmbProfileController CreateController()
+    {
+        var controller = new UmbProfileController(
+            new TestUmbracoContextAccessor(),
+            null!,
+            ServiceContext.CreatePartial(),
+            AppCaches.Disabled,
+            Mock.Of<IProfilingLogger>(),
+            Mock.Of<IPublishedUrlProvider>(),
+            _memberManagerMock.Object,
+            _memberServiceMock.Object,
+            _memberTypeServiceMock.Object,
+            _scopeProviderMock.Object);
+
+        SurfaceControllerTestHelpers.ConfigureControllerContext(controller, isAuthenticated: true);
+
+        return controller;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbRegisterControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbRegisterControllerTests.cs
@@ -1,0 +1,258 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Web.Common.Security;
+using Umbraco.Cms.Web.Website.ActionResults;
+using Umbraco.Cms.Web.Website.Controllers;
+using Umbraco.Cms.Web.Website.Models;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
+
+[TestFixture]
+public class UmbRegisterControllerTests
+{
+    private Mock<IMemberManager> _memberManagerMock = null!;
+    private Mock<IMemberService> _memberServiceMock = null!;
+    private Mock<IMemberSignInManager> _signInManagerMock = null!;
+    private Mock<ICoreScopeProvider> _scopeProviderMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _memberManagerMock = new Mock<IMemberManager>();
+        _memberServiceMock = new Mock<IMemberService>();
+        _signInManagerMock = new Mock<IMemberSignInManager>();
+        _scopeProviderMock = new Mock<ICoreScopeProvider>();
+        _scopeProviderMock
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<System.Data.IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<global::Umbraco.Cms.Core.Events.IEventDispatcher>(),
+                It.IsAny<global::Umbraco.Cms.Core.Events.IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(Mock.Of<ICoreScope>());
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_InvalidModelState_ReturnsCurrentPage()
+    {
+        var controller = CreateController();
+        controller.ModelState.AddModelError("registerModel", "invalid");
+
+        IActionResult result = await controller.HandleRegisterMember(new RegisterModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _memberManagerMock.Verify(
+            x => x.CreateAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_Success_WithLocalRedirectUrl_RedirectsAndSetsSuccessTempData()
+    {
+        SetupSuccessfulMemberCreation();
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "new@example.com",
+            Password = "Password1",
+            Name = "New Member",
+            AutomaticLogIn = false,
+            RedirectUrl = "/welcome",
+        });
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/welcome", redirect!.Url);
+        Assert.AreEqual(true, controller.TempData["FormSuccess"]);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_Success_NoRedirectUrl_RedirectsToCurrentUmbracoPage()
+    {
+        SetupSuccessfulMemberCreation();
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "new@example.com",
+            Password = "Password1",
+            Name = "New Member",
+            AutomaticLogIn = false,
+        });
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_Success_WithNonLocalRedirectUrl_FallsBackToCurrentPage()
+    {
+        SetupSuccessfulMemberCreation();
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "new@example.com",
+            Password = "Password1",
+            Name = "New Member",
+            AutomaticLogIn = false,
+            RedirectUrl = "https://evil.com/phish",
+        });
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_Success_WithAutomaticLogIn_SignsInTheNewMember()
+    {
+        SetupSuccessfulMemberCreation();
+
+        var controller = CreateController();
+
+        await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "new@example.com",
+            Password = "Password1",
+            Name = "New Member",
+            AutomaticLogIn = true,
+        });
+
+        _signInManagerMock.Verify(x => x.SignInAsync(It.IsAny<MemberIdentityUser>(), false, null), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_Success_WithoutAutomaticLogIn_DoesNotSignIn()
+    {
+        SetupSuccessfulMemberCreation();
+
+        var controller = CreateController();
+
+        await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "new@example.com",
+            Password = "Password1",
+            Name = "New Member",
+            AutomaticLogIn = false,
+        });
+
+        _signInManagerMock.Verify(x => x.SignInAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<bool>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_IdentityError_AddsModelError()
+    {
+        _memberManagerMock
+            .Setup(x => x.CreateAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<string>()))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Password too short" }));
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "new@example.com",
+            Password = "x",
+            Name = "New Member",
+        });
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["registerModel"]!.Errors
+            .Any(e => e.ErrorMessage == "Password too short"));
+        _memberServiceMock.Verify(x => x.Save(It.IsAny<IMember>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_UsesEmailAsName_WhenNameIsEmpty()
+    {
+        SetupSuccessfulMemberCreation();
+
+        MemberIdentityUser? createdUser = null;
+        _memberManagerMock
+            .Setup(x => x.CreateAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<string>()))
+            .Callback<MemberIdentityUser, string>((user, _) => createdUser = user)
+            .ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController();
+
+        await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "fallback@example.com",
+            Password = "Password1",
+            Name = string.Empty,
+        });
+
+        Assert.IsNotNull(createdUser);
+        Assert.AreEqual("fallback@example.com", createdUser!.Name);
+    }
+
+    [Test]
+    public async Task HandleRegisterMember_RegistersWithConfiguredMemberType()
+    {
+        SetupSuccessfulMemberCreation();
+
+        MemberIdentityUser? createdUser = null;
+        _memberManagerMock
+            .Setup(x => x.CreateAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<string>()))
+            .Callback<MemberIdentityUser, string>((user, _) => createdUser = user)
+            .ReturnsAsync(IdentityResult.Success);
+
+        var controller = CreateController();
+
+        await controller.HandleRegisterMember(new RegisterModel
+        {
+            Email = "alias@example.com",
+            Password = "Password1",
+            Name = "Alias Member",
+            MemberTypeAlias = "customMemberType",
+        });
+
+        Assert.AreEqual("customMemberType", createdUser!.MemberTypeAlias);
+    }
+
+    private void SetupSuccessfulMemberCreation()
+    {
+        _memberManagerMock
+            .Setup(x => x.CreateAsync(It.IsAny<MemberIdentityUser>(), It.IsAny<string>()))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var member = new Mock<IMember>();
+        member.Setup(x => x.Properties).Returns(new PropertyCollection());
+        _memberServiceMock.Setup(x => x.GetById(It.IsAny<Guid>())).Returns(member.Object);
+    }
+
+    private UmbRegisterController CreateController()
+    {
+        var controller = new UmbRegisterController(
+            _memberManagerMock.Object,
+            _memberServiceMock.Object,
+            new TestUmbracoContextAccessor(),
+            null!,
+            ServiceContext.CreatePartial(),
+            AppCaches.Disabled,
+            Mock.Of<IProfilingLogger>(),
+            Mock.Of<IPublishedUrlProvider>(),
+            _signInManagerMock.Object,
+            _scopeProviderMock.Object);
+
+        SurfaceControllerTestHelpers.ConfigureControllerContext(controller);
+
+        return controller;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbTwoFactorLoginControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbTwoFactorLoginControllerTests.cs
@@ -225,6 +225,7 @@ public class UmbTwoFactorLoginControllerTests
         IActionResult result = await controller.ValidateAndSaveSetup("Provider", "secret", "123456");
 
         Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["code"]!.Errors.Any(e => e.ErrorMessage == "Invalid Code"));
         _twoFactorLoginServiceMock.Verify(x => x.SaveAsync(It.IsAny<TwoFactorLogin>()), Times.Never);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbTwoFactorLoginControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Controllers/UmbTwoFactorLoginControllerTests.cs
@@ -1,0 +1,338 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
+using Umbraco.Cms.Web.Common.Security;
+using Umbraco.Cms.Web.Website.ActionResults;
+using Umbraco.Cms.Web.Website.Controllers;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Controllers;
+
+[TestFixture]
+public class UmbTwoFactorLoginControllerTests
+{
+    private Mock<IMemberManager> _memberManagerMock = null!;
+    private Mock<IMemberSignInManager> _signInManagerMock = null!;
+    private Mock<ITwoFactorLoginService> _twoFactorLoginServiceMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _memberManagerMock = new Mock<IMemberManager>();
+        _signInManagerMock = new Mock<IMemberSignInManager>();
+        _twoFactorLoginServiceMock = new Mock<ITwoFactorLoginService>();
+    }
+
+    [Test]
+    public async Task Get2FAProviders_NoUserInFlow_ReturnsNotFound()
+    {
+        _signInManagerMock
+            .Setup(x => x.GetTwoFactorAuthenticationUserAsync())
+            .ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController();
+
+        ActionResult<IEnumerable<string>> result = await controller.Get2FAProviders();
+
+        Assert.IsInstanceOf<NotFoundResult>(result.Result);
+    }
+
+    [Test]
+    public async Task Get2FAProviders_ReturnsProviderList()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _signInManagerMock
+            .Setup(x => x.GetTwoFactorAuthenticationUserAsync())
+            .ReturnsAsync(user);
+        _memberManagerMock
+            .Setup(x => x.GetValidTwoFactorProvidersAsync(user))
+            .ReturnsAsync(["ProviderA", "ProviderB"]);
+
+        var controller = CreateController();
+
+        ActionResult<IEnumerable<string>> result = await controller.Get2FAProviders();
+
+        var objectResult = result.Result as ObjectResult;
+        Assert.IsNotNull(objectResult);
+        Assert.That((IList<string>)objectResult!.Value!, Is.EquivalentTo(new[] { "ProviderA", "ProviderB" }));
+    }
+
+    [Test]
+    public async Task Verify2FACode_NoUserInFlow_ReturnsNotFound()
+    {
+        _signInManagerMock
+            .Setup(x => x.GetTwoFactorAuthenticationUserAsync())
+            .ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Verify2FACode(CreateVerifyModel(), "/return");
+
+        Assert.IsInstanceOf<NotFoundResult>(result);
+    }
+
+    [Test]
+    public async Task Verify2FACode_Success_RedirectsToLocalUrl()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _signInManagerMock
+            .Setup(x => x.GetTwoFactorAuthenticationUserAsync())
+            .ReturnsAsync(user);
+        _signInManagerMock
+            .Setup(x => x.TwoFactorSignInAsync("Provider", "123456", false, false))
+            .ReturnsAsync(SignInResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Verify2FACode(CreateVerifyModel(), "/after-2fa");
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/after-2fa", redirect!.Url);
+    }
+
+    [Test]
+    public async Task Verify2FACode_Success_WithNonLocalReturnUrl_FallsBackToCurrentPage()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _signInManagerMock
+            .Setup(x => x.GetTwoFactorAuthenticationUserAsync())
+            .ReturnsAsync(user);
+        _signInManagerMock
+            .Setup(x => x.TwoFactorSignInAsync("Provider", "123456", false, false))
+            .ReturnsAsync(SignInResult.Success);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Verify2FACode(CreateVerifyModel(), "https://evil.com");
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task ValidateAndSaveSetup_Success_WithNonLocalReturnUrl_FallsBackToCurrentPage()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _memberManagerMock.Setup(x => x.GetCurrentMemberAsync()).ReturnsAsync(user);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.ValidateTwoFactorSetup("Provider", "secret", "123456"))
+            .Returns(true);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ValidateAndSaveSetup("Provider", "secret", "123456", "https://evil.com");
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task Disable_Success_WithNonLocalReturnUrl_FallsBackToCurrentPage()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _memberManagerMock.Setup(x => x.GetCurrentMemberAsync()).ReturnsAsync(user);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.DisableAsync(user.Key, "Provider"))
+            .ReturnsAsync(true);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Disable("Provider", "https://evil.com");
+
+        Assert.IsInstanceOf<RedirectToUmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task Verify2FACode_LockedOut_AddsModelError()
+    {
+        SetupVerifyFailure(SignInResult.LockedOut);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Verify2FACode(CreateVerifyModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["Code"]!.Errors.Any(e => e.ErrorMessage == "Member is locked out"));
+    }
+
+    [Test]
+    public async Task Verify2FACode_NotAllowed_AddsModelError()
+    {
+        SetupVerifyFailure(SignInResult.NotAllowed);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Verify2FACode(CreateVerifyModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["Code"]!.Errors.Any(e => e.ErrorMessage == "Member is not allowed"));
+    }
+
+    [Test]
+    public async Task Verify2FACode_Failed_AddsInvalidCodeModelError()
+    {
+        SetupVerifyFailure(SignInResult.Failed);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Verify2FACode(CreateVerifyModel());
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["Code"]!.Errors.Any(e => e.ErrorMessage == "Invalid code"));
+    }
+
+    [Test]
+    public async Task ValidateAndSaveSetup_InvalidCode_AddsModelError()
+    {
+        _memberManagerMock
+            .Setup(x => x.GetCurrentMemberAsync())
+            .ReturnsAsync(new MemberIdentityUser { Key = Guid.NewGuid() });
+        _twoFactorLoginServiceMock
+            .Setup(x => x.ValidateTwoFactorSetup("Provider", "secret", "000000"))
+            .Returns(false);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ValidateAndSaveSetup("Provider", "secret", "000000");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        Assert.IsTrue(controller.ModelState["code"]!.Errors.Any(e => e.ErrorMessage == "Invalid Code"));
+        _twoFactorLoginServiceMock.Verify(x => x.SaveAsync(It.IsAny<TwoFactorLogin>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ValidateAndSaveSetup_NoCurrentMember_AddsModelError()
+    {
+        _memberManagerMock
+            .Setup(x => x.GetCurrentMemberAsync())
+            .ReturnsAsync((MemberIdentityUser?)null);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.ValidateTwoFactorSetup("Provider", "secret", "123456"))
+            .Returns(true);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ValidateAndSaveSetup("Provider", "secret", "123456");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _twoFactorLoginServiceMock.Verify(x => x.SaveAsync(It.IsAny<TwoFactorLogin>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ValidateAndSaveSetup_Success_SavesAndRedirects()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _memberManagerMock.Setup(x => x.GetCurrentMemberAsync()).ReturnsAsync(user);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.ValidateTwoFactorSetup("Provider", "secret", "123456"))
+            .Returns(true);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.ValidateAndSaveSetup("Provider", "secret", "123456", "/done");
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/done", redirect!.Url);
+        _twoFactorLoginServiceMock.Verify(
+            x => x.SaveAsync(It.Is<TwoFactorLogin>(t =>
+                t.Confirmed &&
+                t.Secret == "secret" &&
+                t.ProviderName == "Provider" &&
+                t.UserOrMemberKey == user.Key)),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Disable_WhenServiceDisables_RedirectsToReturnUrl()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _memberManagerMock.Setup(x => x.GetCurrentMemberAsync()).ReturnsAsync(user);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.DisableAsync(user.Key, "Provider"))
+            .ReturnsAsync(true);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Disable("Provider", "/settings");
+
+        var redirect = result as RedirectResult;
+        Assert.IsNotNull(redirect);
+        Assert.AreEqual("/settings", redirect!.Url);
+    }
+
+    [Test]
+    public async Task Disable_WhenServiceRefuses_ReturnsCurrentPage()
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _memberManagerMock.Setup(x => x.GetCurrentMemberAsync()).ReturnsAsync(user);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.DisableAsync(user.Key, "Provider"))
+            .ReturnsAsync(false);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Disable("Provider");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+    }
+
+    [Test]
+    public async Task Disable_NoCurrentMember_ReturnsCurrentPage()
+    {
+        _memberManagerMock.Setup(x => x.GetCurrentMemberAsync()).ReturnsAsync((MemberIdentityUser?)null);
+
+        var controller = CreateController();
+
+        IActionResult result = await controller.Disable("Provider");
+
+        Assert.IsInstanceOf<UmbracoPageResult>(result);
+        _twoFactorLoginServiceMock.Verify(x => x.DisableAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
+
+    private void SetupVerifyFailure(SignInResult failure)
+    {
+        var user = new MemberIdentityUser { Key = Guid.NewGuid() };
+        _signInManagerMock
+            .Setup(x => x.GetTwoFactorAuthenticationUserAsync())
+            .ReturnsAsync(user);
+        _signInManagerMock
+            .Setup(x => x.TwoFactorSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(failure);
+        _twoFactorLoginServiceMock
+            .Setup(x => x.GetEnabledTwoFactorProviderNamesAsync(user.Key))
+            .ReturnsAsync(["Provider"]);
+    }
+
+    private static Verify2FACodeModel CreateVerifyModel() =>
+        new() { Provider = "Provider", Code = "123456" };
+
+    private UmbTwoFactorLoginController CreateController()
+    {
+        var controller = new UmbTwoFactorLoginController(
+            NullLogger<UmbTwoFactorLoginController>.Instance,
+            new TestUmbracoContextAccessor(),
+            null!,
+            ServiceContext.CreatePartial(),
+            AppCaches.Disabled,
+            Mock.Of<IProfilingLogger>(),
+            Mock.Of<IPublishedUrlProvider>(),
+            _signInManagerMock.Object,
+            _memberManagerMock.Object,
+            _twoFactorLoginServiceMock.Object);
+
+        SurfaceControllerTestHelpers.ConfigureControllerContext(controller, isAuthenticated: true);
+
+        return controller;
+    }
+}


### PR DESCRIPTION
## Description

This PR is purely related to code documentation and test coverage improvement.  There are no changes to production code.

I've added XML documentation and unit tests for the the six member-operation surface controllers in `Umbraco.Web.Website.Controllers`.

## Testing

Verify that the build checks, which will include the new unit tests, pass.