### PR TITLE
Handle "broken" ancestor publish path in legacy routing

### DIFF
--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -1110,10 +1110,10 @@ public class DocumentUrlService : IDocumentUrlService
 
         foreach (Guid ancestorOrSelfKey in ancestorsOrSelfKeysArray)
         {
-            IEnumerable<Domain> domains = ancestorOrSelfKeyToDomains[ancestorOrSelfKey].WhereNotNull();
-            if (domains.Any())
+            Domain? domain = ancestorOrSelfKeyToDomains[ancestorOrSelfKey].WhereNotNull().FirstOrDefault();
+            if (domain is not null)
             {
-                foundDomain = domains.First();// What todo here that is better?
+                foundDomain = domain;
                 break;
             }
 
@@ -1121,10 +1121,11 @@ public class DocumentUrlService : IDocumentUrlService
             {
                 urlSegments.Add(segment);
             }
-
-            if (foundDomain is not null)
+            else
             {
-                break;
+                // There is no URL segment for this content key in the requested context.
+                // Exit early since the legacy route cannot be resolved.
+                return "#";
             }
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRouteBuilderPublishingTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRouteBuilderPublishingTests.cs
@@ -31,8 +31,8 @@ public class ApiContentRouteBuilderPublishingTests : ApiContentRouteBuilderTestB
 
         var root = new ContentBuilder()
             .WithContentType(contentType)
-            .WithCultureName("en-US", $"Root en-US")
-            .WithCultureName("da-DK", $"Root da-DK")
+            .WithCultureName("en-US", "Root en-US")
+            .WithCultureName("da-DK", "Root da-DK")
             .Build();
         ContentService.Save(root);
         ContentService.Publish(root, ["*"]);
@@ -40,8 +40,8 @@ public class ApiContentRouteBuilderPublishingTests : ApiContentRouteBuilderTestB
         var child = new ContentBuilder()
             .WithContentType(contentType)
             .WithParent(root)
-            .WithCultureName("en-US", $"Child en-US")
-            .WithCultureName("da-DK", $"Child da-DK")
+            .WithCultureName("en-US", "Child en-US")
+            .WithCultureName("da-DK", "Child da-DK")
             .Build();
         ContentService.Save(child);
         ContentService.Publish(child, ["*"]);
@@ -49,8 +49,8 @@ public class ApiContentRouteBuilderPublishingTests : ApiContentRouteBuilderTestB
         var grandchild = new ContentBuilder()
             .WithContentType(contentType)
             .WithParent(child)
-            .WithCultureName("en-US", $"Grandchild en-US")
-            .WithCultureName("da-DK", $"Grandchild da-DK")
+            .WithCultureName("en-US", "Grandchild en-US")
+            .WithCultureName("da-DK", "Grandchild da-DK")
             .Build();
         ContentService.Save(grandchild);
         ContentService.Publish(grandchild, ["*"]);
@@ -78,6 +78,67 @@ public class ApiContentRouteBuilderPublishingTests : ApiContentRouteBuilderTestB
         {
             Assert.IsNotNull(route);
             Assert.AreEqual("/child-da-dk/grandchild-da-dk/", route.Path);
+        }
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Can_Handle_Broken_Invariant_Publish_Path(bool breakPublishedPath)
+    {
+        SetRequestHost("localhost");
+
+        await GetRequiredService<ILanguageService>().CreateAsync(new Language("da-DK", "Danish"), Constants.Security.SuperUserKey);
+
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("theContentType")
+            .WithContentVariation(ContentVariation.Nothing)
+            .Build();
+        contentType.AllowedAsRoot = true;
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        contentType.AllowedContentTypes = [new() { Alias = contentType.Alias, Key = contentType.Key }];
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var root = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithName("Root")
+            .Build();
+        ContentService.Save(root);
+        ContentService.Publish(root, ["*"]);
+
+        var child = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithParent(root)
+            .WithName("Child")
+            .Build();
+        ContentService.Save(child);
+        ContentService.Publish(child, ["*"]);
+
+        var grandchild = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithParent(child)
+            .WithName("Grandchild")
+            .Build();
+        ContentService.Save(grandchild);
+        ContentService.Publish(grandchild, ["*"]);
+
+        if (breakPublishedPath)
+        {
+            ContentService.Unpublish(child);
+        }
+
+        SetVariationContext("en-US");
+
+        if (breakPublishedPath)
+        {
+            var publishedContent = ClearAndEnsureUmbracoContext().Content.GetById(grandchild.Key);
+            Assert.IsNull(publishedContent);
+        }
+        else
+        {
+            var publishedContent = GetPublishedContent(grandchild.Key);
+            var route = ApiContentRouteBuilder.Build(publishedContent);
+            Assert.IsNotNull(route);
+            Assert.AreEqual("/child/grandchild/", route.Path);
         }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRouteBuilderPublishingTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRouteBuilderPublishingTests.cs
@@ -1,0 +1,83 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.DeliveryApi.Request;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+public class ApiContentRouteBuilderPublishingTests : ApiContentRouteBuilderTestBase
+{
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Can_Handle_Broken_Variant_Publish_Path(bool breakPublishedPath)
+    {
+        SetRequestHost("localhost");
+
+        await GetRequiredService<ILanguageService>().CreateAsync(new Language("da-DK", "Danish"), Constants.Security.SuperUserKey);
+
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("theContentType")
+            .WithContentVariation(ContentVariation.Culture)
+            .Build();
+        contentType.AllowedAsRoot = true;
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        contentType.AllowedContentTypes = [new() { Alias = contentType.Alias, Key = contentType.Key }];
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var root = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithCultureName("en-US", $"Root en-US")
+            .WithCultureName("da-DK", $"Root da-DK")
+            .Build();
+        ContentService.Save(root);
+        ContentService.Publish(root, ["*"]);
+
+        var child = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithParent(root)
+            .WithCultureName("en-US", $"Child en-US")
+            .WithCultureName("da-DK", $"Child da-DK")
+            .Build();
+        ContentService.Save(child);
+        ContentService.Publish(child, ["*"]);
+
+        var grandchild = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithParent(child)
+            .WithCultureName("en-US", $"Grandchild en-US")
+            .WithCultureName("da-DK", $"Grandchild da-DK")
+            .Build();
+        ContentService.Save(grandchild);
+        ContentService.Publish(grandchild, ["*"]);
+
+        if (breakPublishedPath)
+        {
+            ContentService.Unpublish(child, "da-DK");
+        }
+
+        SetVariationContext("en-US");
+        var publishedContent = GetPublishedContent(grandchild.Key);
+        var route = ApiContentRouteBuilder.Build(publishedContent);
+        Assert.IsNotNull(route);
+        Assert.AreEqual("/child-en-us/grandchild-en-us/", route.Path);
+
+        SetVariationContext("da-DK");
+        publishedContent = GetPublishedContent(grandchild.Key);
+        route = ApiContentRouteBuilder.Build(publishedContent);
+
+        if (breakPublishedPath)
+        {
+            Assert.IsNull(route);
+        }
+        else
+        {
+            Assert.IsNotNull(route);
+            Assert.AreEqual("/child-da-dk/grandchild-da-dk/", route.Path);
+        }
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRouteBuilderTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/DeliveryApi/Request/ApiContentRouteBuilderTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Tests.Common.Testing;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.DeliveryApi.Request;
@@ -10,11 +11,15 @@ public abstract class ApiContentRouteBuilderTestBase : ApiContentRequestTestBase
 {
     protected IPublishedContent GetPublishedContent(Guid key)
     {
-        UmbracoContextAccessor.Clear();
-        var umbracoContext = UmbracoContextFactory.EnsureUmbracoContext().UmbracoContext;
-        var publishedContent = umbracoContext.Content?.GetById(key);
+        var publishedContent = ClearAndEnsureUmbracoContext().Content.GetById(key);
         Assert.IsNotNull(publishedContent);
 
         return publishedContent;
+    }
+
+    protected IUmbracoContext ClearAndEnsureUmbracoContext()
+    {
+        UmbracoContextAccessor.Clear();
+        return UmbracoContextFactory.EnsureUmbracoContext().UmbracoContext;
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -22,6 +22,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Mock)]
 internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithContent
 {
+    private const string SubSubPage1Key = "09376F1F-AF4E-4E5E-8DCF-074A5C8A81E7";
     private const string SubSubPage2Key = "48AE405E-5142-4EBE-929F-55EB616F51F2";
     private const string SubSubPage3Key = "AACF2979-3F53-4184-B071-BA34D3338497";
 
@@ -46,6 +47,15 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
 
         builder.UrlSegmentProviders().Insert<CustomUrlSegmentProvider1>();
         builder.UrlSegmentProviders().Insert<CustomUrlSegmentProvider2>();
+    }
+
+    public override void CreateTestData()
+    {
+        base.CreateTestData();
+
+        var subSubPage1 = ContentBuilder.CreateSimpleContent(ContentType, "Sub SUb Page 1", Subpage.Id);
+        subSubPage1.Key = new Guid(SubSubPage1Key);
+        ContentService.Save(subSubPage1, -1);
     }
 
     private abstract class CustomUrlSegmentProviderBase
@@ -361,12 +371,32 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
     [TestCase(SubPageKey, "en-US", ExpectedResult = "/text-page-1-custom")]  // Has non-terminating custom URL segment provider.
     [TestCase(SubPage2Key, "en-US", ExpectedResult = "/text-page-2-custom")] // Has terminating custom URL segment provider.
     [TestCase(SubPage3Key, "en-US", ExpectedResult = "/text-page-3")]
+    [TestCase(SubSubPage1Key, "en-US", ExpectedResult = "/text-page-1-custom/sub-sub-page-1")]
     public string? GetLegacyRouteFormat_Returns_Expected_Route(string documentKey, string culture)
     {
         ContentService.PublishBranch(Textpage, PublishBranchFilter.IncludeUnpublished, ["*"]);
         return DocumentUrlService.GetLegacyRouteFormat(Guid.Parse(documentKey), culture, false);
     }
 
+    [TestCase(TextpageKey, "en-US", "/")]
+    [TestCase(SubPageKey, "en-US", "/text-page-1-custom")]  // Has non-terminating custom URL segment provider.
+    [TestCase(SubPage2Key, "en-US", "/text-page-2-custom")] // Has terminating custom URL segment provider.
+    [TestCase(SubPage3Key, "en-US", "/text-page-3")]
+    [TestCase(SubSubPage1Key, "en-US", "/text-page-1-custom/sub-sub-page-1")]
+    public async Task GetLegacyRouteFormat_WithDomainBinding_Returns_Expected_Route(string documentKey, string culture, string expectedPath)
+    {
+        await DomainService.UpdateDomainsAsync(
+            Textpage.Key,
+            new()
+            {
+                Domains = [new() { DomainName = "/test", IsoCode = "en-US" }],
+                DefaultIsoCode = "en-US"
+            });
+
+        ContentService.PublishBranch(Textpage, PublishBranchFilter.IncludeUnpublished, ["*"]);
+        var route = DocumentUrlService.GetLegacyRouteFormat(Guid.Parse(documentKey), culture, false);
+        Assert.AreEqual($"{Textpage.Id}{expectedPath}", route);
+    }
 
     [Test]
     public async Task CreateOrUpdateUrlSegmentsWithDescendantsAsync_Does_Not_Throw_When_Content_Does_Not_Exist()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -53,7 +53,7 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
     {
         base.CreateTestData();
 
-        var subSubPage1 = ContentBuilder.CreateSimpleContent(ContentType, "Sub SUb Page 1", Subpage.Id);
+        var subSubPage1 = ContentBuilder.CreateSimpleContent(ContentType, "Sub Sub Page 1", Subpage.Id);
         subSubPage1.Key = new Guid(SubSubPage1Key);
         ContentService.Save(subSubPage1, -1);
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR fixes the "legacy" routing so it mimics the way routes were resolved and built in V13.

Why? Because at this time, a "broken" chain of ancestor publish state is simply ignored by the route building, which leads to invalid routes.

### The "legacy" routing?

The "legacy" route is the chain of default URL segments for a page, optionally prefixed with the ID of the root page, if there is a domain binding.

Given this page structure:

```
- Root [ID = 1001]
   - Child [ID = 1002]
      - Grandchild [ID = 1003]
```

With no domain binding on `Root`, the "legacy" path for `Grandchild` is `/child/grandchild/`.

If `Root` has a domain binding, the "legacy" path is prefixed with the ID of `Root` and becomes `1001/child/grandchild/`.

### So, what's wrong?

If `Child` is unpublished, `Grandchild` should not be routable. And this works fine for invariant pages.

The problem arise for culture variant pages. If the `Child` is culture variant, and is published in one or more cultures, but _not_ in the active rendering culture, the `DocumentUrlService` simply skips its URL segment ([here](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/Services/DocumentUrlService.cs#L1185)) and continues to the nearest ancestor. Effectively, the `Grandchild` "legacy" path is resolved as `/grandchild/` or `1001/grandchild/`, depending on the domain bindings. And this is obviously not a valid route for `Grandchild`.

### What's the impact?

The "legacy" route is actively used by the default URL provider when generating URLs ([here](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs#L191)). This means the wrongly resolved URLs flow directly into the Umbraco backoffice:

<img width="1225" height="513" alt="image" src="https://github.com/user-attachments/assets/db3066a5-b912-4114-a404-40f5be6d061f" />

The Delivery API relies on correct route resolving to figure out if a content item can be served. It uses the `IPublishedUrlProvider` to resolve routes for published content, and this in turn utilizes the URL providers. This causes variant content with a "broken" published ancestor chain to be served by the Delivery API - it should _not_ serve these content items (this is also how V13 works).

This issue has not been observed for templated rendering, though I suspect it will eventually cause similar trouble.

### Additional additions

I've added a few more tests for the `DocumentUrlService` to make sure it:

1. Resolves multi-level "legacy" routes correctly.
2. Prefixes domain bound routes with the ID of the root.

While these are not exhaustive, nor directly related to this issue, I felt it was worthwhile doing while I was investigating the root cause.

### Testing this PR

You need to create a culture variant structure like the one above, with the `Child` equivalent unpublished in one of the languages.

You'll also need the Delivery API enabled on your test site.

First and foremost, verify that backoffice UI does _not_ list any URLs for the `Grandchild` equivalent:

<img width="1225" height="513" alt="image" src="https://github.com/user-attachments/assets/2f7277e0-f875-4d43-913c-fa59eb62bc61" />

Next, request the `Grandchild` equivalent by ID using the Delivery API. It should yield the content for the culture(s) where the `Child` is published, and 404 for the culture(s) where `Child` is unpublished:

<img width="885" height="834" alt="image" src="https://github.com/user-attachments/assets/b642fd18-04c4-4765-8431-50fd9c0dd402" />
