### PR TITLE
Fix the NullableLanguageId build errors after merge

### DIFF
--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -1205,8 +1205,8 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
         var documentKey = new Guid(PageWithNoAliasKey);
         var duplicates = new List<PublishedDocumentUrlAlias>
         {
-            new() { DocumentKey = documentKey, NullableLanguageId = null, Alias = "dup-test" },
-            new() { DocumentKey = documentKey, NullableLanguageId = null, Alias = "dup-test" },
+            new() { DocumentKey = documentKey, LanguageId = null, Alias = "dup-test" },
+            new() { DocumentKey = documentKey, LanguageId = null, Alias = "dup-test" },
         };
 
         using (ICoreScope scope = CoreScopeProvider.CreateCoreScope())

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -221,7 +221,7 @@ public class DocumentUrlAliasServiceTests
         Assert.That(savedAliases, Is.Not.Null);
         Assert.That(savedAliases, Has.Count.EqualTo(1));
         Assert.That(savedAliases![0].DocumentKey, Is.EqualTo(documentKey));
-        Assert.That(savedAliases[0].NullableLanguageId, Is.Null);
+        Assert.That(savedAliases[0].LanguageId, Is.Null);
         Assert.That(savedAliases[0].Alias, Is.EqualTo("my-alias"));
     }
 
@@ -252,7 +252,7 @@ public class DocumentUrlAliasServiceTests
             savedAliases!.Select(x => x.Alias),
             Is.EquivalentTo(new[] { "alias-one", "alias-two", "alias-three" }));
         Assert.That(
-            savedAliases.All(x => x.NullableLanguageId is null),
+            savedAliases.All(x => x.LanguageId is null),
             Is.True,
             "All rows from an invariant content must share a null language id.");
     }
@@ -320,8 +320,8 @@ public class DocumentUrlAliasServiceTests
         Assert.That(savedAliases, Is.Not.Null);
         Assert.That(savedAliases, Has.Count.EqualTo(2));
 
-        var english = savedAliases!.Single(x => x.NullableLanguageId == 1);
-        var french = savedAliases.Single(x => x.NullableLanguageId == 2);
+        var english = savedAliases!.Single(x => x.LanguageId == 1);
+        var french = savedAliases.Single(x => x.LanguageId == 2);
         Assert.That(english.Alias, Is.EqualTo("english-alias"));
         Assert.That(french.Alias, Is.EqualTo("alias-francais"));
     }
@@ -580,7 +580,7 @@ public class DocumentUrlAliasServiceTests
             new PublishedDocumentUrlAlias
             {
                 DocumentKey = documentKey,
-                NullableLanguageId = null,
+                LanguageId = null,
                 Alias = "my-alias",
             },
         };
@@ -609,7 +609,7 @@ public class DocumentUrlAliasServiceTests
             new PublishedDocumentUrlAlias
             {
                 DocumentKey = documentKey,
-                NullableLanguageId = null,
+                LanguageId = null,
                 Alias = "my-alias",
             },
         };
@@ -634,8 +634,8 @@ public class DocumentUrlAliasServiceTests
         var documentKey = Guid.NewGuid();
         var seeded = new[]
         {
-            new PublishedDocumentUrlAlias { DocumentKey = documentKey, NullableLanguageId = null, Alias = "alias-one" },
-            new PublishedDocumentUrlAlias { DocumentKey = documentKey, NullableLanguageId = null, Alias = "alias-two" },
+            new PublishedDocumentUrlAlias { DocumentKey = documentKey, LanguageId = null, Alias = "alias-one" },
+            new PublishedDocumentUrlAlias { DocumentKey = documentKey, LanguageId = null, Alias = "alias-two" },
         };
         var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
 
@@ -663,7 +663,7 @@ public class DocumentUrlAliasServiceTests
                 new PublishedDocumentUrlAlias
                 {
                     DocumentKey = Guid.NewGuid(),
-                    NullableLanguageId = null,
+                    LanguageId = null,
                     Alias = "any",
                 },
             },


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Fixes the build errors following the latest merge from `main` to `v18/dev`.