### PR TITLE
Add a constant for the "unroutable content" route

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/RedirectUrlPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/RedirectUrlPresentationFactory.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Api.Management.ViewModels;
 using Umbraco.Cms.Api.Management.ViewModels.RedirectUrlManagement;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Routing;
 
@@ -33,12 +34,12 @@ public class RedirectUrlPresentationFactory : IRedirectUrlPresentationFactory
     {
         var destinationUrl = source.ContentId > 0
             ? _publishedUrlProvider.GetUrl(source.ContentId, culture: source.Culture)
-            : "#";
+            : Constants.Routing.Unroutable;
 
         var originalUrl = _publishedUrlProvider.GetUrlFromRoute(source.ContentId, source.Url, source.Culture);
 
         // Even if the URL could not be extracted from the route, if we have a path as a the route for the original URL, we should display it.
-        if (originalUrl == "#" && source.Url.StartsWith('/'))
+        if (originalUrl == Constants.Routing.Unroutable && source.Url.StartsWith('/'))
         {
             originalUrl = source.Url;
         }

--- a/src/Umbraco.Core/Constants-Routing.cs
+++ b/src/Umbraco.Core/Constants-Routing.cs
@@ -12,6 +12,9 @@ public static partial class Constants
         /// </summary>
         public const string Unroutable = "#";
 
+        /// <summary>
+        ///     Represents the route returned when a URL provider throws an exception while resolving content.
+        /// </summary>
         public const string UrlProviderException = "#ex";
     }
 }

--- a/src/Umbraco.Core/Constants-Routing.cs
+++ b/src/Umbraco.Core/Constants-Routing.cs
@@ -11,5 +11,7 @@ public static partial class Constants
         ///     Represents the route of unroutable content.
         /// </summary>
         public const string Unroutable = "#";
+
+        public const string UrlProviderException = "#ex";
     }
 }

--- a/src/Umbraco.Core/Constants-Routing.cs
+++ b/src/Umbraco.Core/Constants-Routing.cs
@@ -1,0 +1,15 @@
+namespace Umbraco.Cms.Core;
+
+public static partial class Constants
+{
+    /// <summary>
+    ///     Defines routing constants.
+    /// </summary>
+    public static class Routing
+    {
+        /// <summary>
+        ///     Represents the route of unroutable content.
+        /// </summary>
+        public const string Unroutable = "#";
+    }
+}

--- a/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
@@ -108,7 +108,7 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
         var contentPath = _apiContentPathProvider.GetContentPath(content, culture);
 
         // in some scenarios the published content is actually routable, but due to the built-in handling of i.e. lacking culture setup
-        // the URL provider resolves the content URL as empty string or "#". since the Delivery API handles routing explicitly,
+        // the URL provider resolves the content URL as empty string or Constants.Routing.Unroutable. since the Delivery API handles routing explicitly,
         // we can perform fallback to the content route.
         if (IsInvalidContentPath(contentPath))
         {
@@ -131,7 +131,7 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
 
     private string ContentPreviewPath(IPublishedContent content) => $"{Constants.DeliveryApi.Routing.PreviewContentPathPrefix}{content.Key:D}{(_requestSettings.AddTrailingSlash ? "/" : string.Empty)}";
 
-    private static bool IsInvalidContentPath(string? path) => path.IsNullOrWhiteSpace() || "#".Equals(path);
+    private static bool IsInvalidContentPath(string? path) => path.IsNullOrWhiteSpace() || Constants.Routing.Unroutable.Equals(path);
 
     private IPublishedContent? GetRoot(IPublishedContent content, bool isPreview)
     {

--- a/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiContentRouteBuilder.cs
@@ -108,7 +108,7 @@ public sealed class ApiContentRouteBuilder : IApiContentRouteBuilder
         var contentPath = _apiContentPathProvider.GetContentPath(content, culture);
 
         // in some scenarios the published content is actually routable, but due to the built-in handling of i.e. lacking culture setup
-        // the URL provider resolves the content URL as empty string or Constants.Routing.Unroutable. since the Delivery API handles routing explicitly,
+        // the URL provider resolves the content URL as empty or unrouetable. since the Delivery API handles routing explicitly,
         // we can perform fallback to the content route.
         if (IsInvalidContentPath(contentPath))
         {

--- a/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByRedirectUrl.cs
@@ -88,8 +88,8 @@ public class ContentFinderByRedirectUrl : IContentFinder
         }
 
         IPublishedContent? content = umbracoContext.Content?.GetById(redirectUrl.ContentId);
-        var url = content == null ? "#" : content.Url(_publishedUrlProvider, redirectUrl.Culture);
-        if (url.StartsWith("#"))
+        var url = content == null ? Constants.Routing.Unroutable : content.Url(_publishedUrlProvider, redirectUrl.Culture);
+        if (url.StartsWith(Constants.Routing.Unroutable))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {

--- a/src/Umbraco.Core/Routing/IPublishedUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/IPublishedUrlProvider.cs
@@ -47,7 +47,7 @@ public interface IPublishedUrlProvider
     ///         If the published content is multi-lingual, gets the url for the specified culture or,
     ///         when no culture is specified, the current culture.
     ///     </para>
-    ///     <para>If the provider is unable to provide a url, it returns "#".</para>
+    ///     <para>If the provider is unable to provide a url, it returns <see cref="Constants.Routing.Unroutable"/>.</para>
     /// </remarks>
     string GetUrl(IPublishedContent content, UrlMode mode = UrlMode.Default, string? culture = null, Uri? current = null);
 

--- a/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
@@ -123,7 +123,7 @@ public class NewDefaultUrlProvider : IUrlProvider
 
             // although we are passing in culture here, if any node in this path is invariant, it ignores the culture anyways so this is ok
             var route = GetLegacyRouteFormatById(key, culture);
-            if (route == null || route == "#")
+            if (route == null || route == Constants.Routing.Unroutable)
             {
                 continue;
             }
@@ -184,7 +184,7 @@ public class NewDefaultUrlProvider : IUrlProvider
         var isDraft = _umbracoContextAccessor.GetRequiredUmbracoContext().InPreviewMode;
         if (isDraft is false && string.IsNullOrWhiteSpace(culture) is false && content.Cultures.Any() && content.IsInvariantOrHasCulture(culture) is false)
         {
-            route = "#";
+            route = Constants.Routing.Unroutable;
         }
         else
         {
@@ -206,7 +206,7 @@ public class NewDefaultUrlProvider : IUrlProvider
         UrlMode mode,
         string? culture)
     {
-        if (string.IsNullOrWhiteSpace(route) || route.Equals("#"))
+        if (string.IsNullOrWhiteSpace(route) || route.Equals(Constants.Routing.Unroutable))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {

--- a/src/Umbraco.Core/Routing/PublishedRouter.cs
+++ b/src/Umbraco.Core/Routing/PublishedRouter.cs
@@ -913,7 +913,7 @@ public class PublishedRouter : IPublishedRouter
         }
 
         var redirectId = request.PublishedContent.Value(_publishedValueFallback, Constants.Conventions.Content.Redirect, defaultValue: -1);
-        var redirectUrl = "#";
+        var redirectUrl = Constants.Routing.Unroutable;
         if (redirectId > 0)
         {
             redirectUrl = _publishedUrlProvider.GetUrl(redirectId);
@@ -931,7 +931,7 @@ public class PublishedRouter : IPublishedRouter
             }
         }
 
-        if (redirectUrl != "#")
+        if (redirectUrl != Constants.Routing.Unroutable)
         {
             request.SetRedirect(redirectUrl);
         }

--- a/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
+++ b/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
@@ -68,7 +68,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
             var url = _publishedUrlProvider.GetUrl(content.Key, culture: culture);
 
             // Handle "could not get URL"
-            if (url is Constants.Routing.Unroutable or "#ex")
+            if (url is Constants.Routing.Unroutable or Constants.Routing.UrlProviderException)
             {
                 // For invariant content, a missing URL just means there's no domain
                 // for this culture — not a problem worth reporting.

--- a/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
+++ b/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
@@ -68,7 +68,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
             var url = _publishedUrlProvider.GetUrl(content.Key, culture: culture);
 
             // Handle "could not get URL"
-            if (url is "#" or "#ex")
+            if (url is Constants.Routing.Unroutable or "#ex")
             {
                 // For invariant content, a missing URL just means there's no domain
                 // for this culture — not a problem worth reporting.

--- a/src/Umbraco.Core/Routing/UrlProvider.cs
+++ b/src/Umbraco.Core/Routing/UrlProvider.cs
@@ -112,13 +112,13 @@ namespace Umbraco.Cms.Core.Routing
         /// <para>The URL is absolute or relative depending on <c>mode</c> and on <c>current</c>.</para>
         /// <para>If the published content is multi-lingual, gets the URL for the specified culture or,
         /// when no culture is specified, the current culture.</para>
-        /// <para>If the provider is unable to provide a URL, it returns "#".</para>
+        /// <para>If the provider is unable to provide a URL, it returns <see cref="Constants.Routing.Unroutable"/>.</para>
         /// </remarks>
         public string GetUrl(IPublishedContent? content, UrlMode mode = UrlMode.Default, string? culture = null, Uri? current = null)
         {
             if (content == null || content.ContentType.ItemType == PublishedItemType.Element)
             {
-                return "#";
+                return Constants.Routing.Unroutable;
             }
 
             if (mode == UrlMode.Default)
@@ -144,7 +144,7 @@ namespace Umbraco.Cms.Core.Routing
 
             UrlInfo? url = _urlProviders.Select(provider => provider.GetUrl(content, mode, culture, current))
                 .FirstOrDefault(u => u is not null);
-            return url?.Url?.ToString() ?? "#"; // legacy wants this
+            return url?.Url?.ToString() ?? Constants.Routing.Unroutable; // legacy wants this
         }
 
         /// <inheritdoc />
@@ -155,7 +155,7 @@ namespace Umbraco.Cms.Core.Routing
             var url = provider == null
                 ? route // what else?
                 : provider.GetUrlFromRoute(route, id, umbracoContext.CleanedUmbracoUrl, Mode, culture)?.Url?.ToString();
-            return url ?? "#";
+            return url ?? Constants.Routing.Unroutable;
         }
 
         #endregion

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -183,7 +183,7 @@ public static class UrlProviderExtensions
 
     private static UrlInfo HandleCouldNotGetUrl(IContent content, string culture, IContentService contentService, ILocalizedTextService textService)
     {
-        // document has a published version yet its URL is Constants.Routing.Unroutable => a parent must be
+        // document has a published version yet its URL is unrouteable => a parent must be
         // unpublished, walk up the tree until we find it, and report.
         IContent? parent = content;
         do

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -146,7 +146,7 @@ public static class UrlProviderExtensions
             catch (Exception ex)
             {
                 logger.LogError(ex, "GetUrl exception.");
-                url = "#ex";
+                url = Constants.Routing.UrlProviderException;
             }
 
             switch (url)
@@ -157,7 +157,7 @@ public static class UrlProviderExtensions
                     break;
 
                 // deal with exceptions
-                case "#ex":
+                case Constants.Routing.UrlProviderException:
                     result.Add(UrlInfo.AsMessage(textService.Localize("content", "getUrlException"), UrlProviderAlias, culture));
                     break;
 

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -152,7 +152,7 @@ public static class UrlProviderExtensions
             switch (url)
             {
                 // deal with 'could not get the URL'
-                case "#":
+                case Constants.Routing.Unroutable:
                     result.Add(HandleCouldNotGetUrl(content, culture, contentService, textService));
                     break;
 
@@ -183,7 +183,7 @@ public static class UrlProviderExtensions
 
     private static UrlInfo HandleCouldNotGetUrl(IContent content, string culture, IContentService contentService, ILocalizedTextService textService)
     {
-        // document has a published version yet its URL is "#" => a parent must be
+        // document has a published version yet its URL is Constants.Routing.Unroutable => a parent must be
         // unpublished, walk up the tree until we find it, and report.
         IContent? parent = content;
         do

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -1137,17 +1137,17 @@ public class DocumentUrlService : IDocumentUrlService
 
         if (documentIdAttempt.Success is false)
         {
-            return "#";
+            return Constants.Routing.Unroutable;
         }
 
         if (_documentNavigationQueryService.TryGetAncestorsOrSelfKeys(documentKey, out IEnumerable<Guid> ancestorsOrSelfKeys) is false)
         {
-            return "#";
+            return Constants.Routing.Unroutable;
         }
 
         if (isDraft is false && string.IsNullOrWhiteSpace(culture) is false && _publishStatusQueryService.IsDocumentPublished(documentKey, culture) is false)
         {
-            return "#";
+            return Constants.Routing.Unroutable;
         }
 
         string cultureOrDefault = GetCultureOrDefault(culture);
@@ -1190,7 +1190,7 @@ public class DocumentUrlService : IDocumentUrlService
             {
                 // There is no URL segment for this content key in the requested context.
                 // Exit early since the legacy route cannot be resolved.
-                return "#";
+                return Constants.Routing.Unroutable;
             }
         }
 

--- a/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
+++ b/src/Umbraco.Web.Website/ActionResults/RedirectToUmbracoPageResult.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
@@ -97,7 +98,7 @@ public class RedirectToUmbracoPageResult : IKeepTempDataResult
 
             var result = _publishedUrlProvider.GetUrl(PublishedContent.Id);
 
-            if (result == "#")
+            if (result == Constants.Routing.Unroutable)
             {
                 throw new InvalidOperationException(
                     $"Could not route to entity with key {Key}, the NiceUrlProvider could not generate a URL");

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentRouteBuilderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/ContentRouteBuilderTests.cs
@@ -204,7 +204,7 @@ public class ContentRouteBuilderTests : DeliveryApiTests
 
     [TestCase("")]
     [TestCase(" ")]
-    [TestCase("#")]
+    [TestCase(Constants.Routing.Unroutable)]
     public void FallsBackToContentPathIfUrlProviderCannotResolveUrl(string resolvedUrl)
     {
         var result = GetUnRoutableRoute(resolvedUrl, "/the/content/route");
@@ -214,7 +214,7 @@ public class ContentRouteBuilderTests : DeliveryApiTests
 
     [TestCase("")]
     [TestCase(" ")]
-    [TestCase("#")]
+    [TestCase(Constants.Routing.Unroutable)]
     public void YieldsNullForUnRoutableContent(string contentPath)
     {
         var result = GetUnRoutableRoute(contentPath, contentPath);
@@ -438,7 +438,7 @@ public class ContentRouteBuilderTests : DeliveryApiTests
             var ancestorsOrSelf = content.AncestorsOrSelf(navigationQueryService, publishedContentStatusFilteringService).ToArray();
             return ancestorsOrSelf.All(c => c.IsPublished(culture))
                 ? string.Join("/", ancestorsOrSelf.Reverse().Skip(hideTopLevelNodeFromPath ? 1 : 0).Select(c => c.UrlSegment(variantContextAccessor, culture))).EnsureStartsWith("/")
-                : "#";
+                : Constants.Routing.Unroutable;
         }
 
         var publishedUrlProvider = new Mock<IPublishedUrlProvider>();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/NewDefaultUrlProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/NewDefaultUrlProviderTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -144,7 +145,7 @@ public class NewDefaultUrlProviderTests
     }
 
     /// <summary>
-    /// Verifies that the "#" route marker returns null (unpublished content).
+    /// Verifies that the <see cref="Constants.Routing.Unroutable"/> route marker returns null (unpublished content).
     /// </summary>
     [Test]
     public void Can_Return_Null_For_Hash_Route()
@@ -152,7 +153,7 @@ public class NewDefaultUrlProviderTests
         var ctx = new TestContext();
         var provider = ctx.CreateProvider();
 
-        var result = provider.GetUrlFromRoute("#", 123, _currentUri, UrlMode.Auto, null);
+        var result = provider.GetUrlFromRoute(Constants.Routing.Unroutable, 123, _currentUri, UrlMode.Auto, null);
 
         Assert.That(result, Is.Null);
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This is a bit of housekeeping. The string `"#"` is hardcoded all over the codebase as representing the route for "unroutable content". This PR replaces it with a constant.

**Update:** As per Claude's review comment I have also added a constant for URL provider exceptions.