### PR TITLE
Migrations: Align type attribute casing in locallink migration for integer-based legacy links (closes #22597)

### DIFF
--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -158,11 +158,13 @@ public sealed partial class HtmlLocalLinkParser
         }
     }
 
-    // under normal circumstances, the type attribute is preceded by a space
+    // Under normal circumstances, the type attribute is preceded by a space
     // to cover the rare occasion where it isn't, we first replace with a space and then without.
+    // Case-insensitive to tolerate historic mis-cased values written by the (now fixed) ConvertLocalLinks
+    // migration for Umbraco 15 (see #22597).
     private static string StripTypeAttributeFromTag(string tag, string type) =>
-        tag.Replace($" type=\"{type}\"", string.Empty)
-            .Replace($"type=\"{type}\"", string.Empty);
+        tag.Replace($" type=\"{type}\"", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace($"type=\"{type}\"", string.Empty, StringComparison.OrdinalIgnoreCase);
 
     private IEnumerable<LocalLinkTag> FindLocalLinkIds(string text)
     {
@@ -184,9 +186,11 @@ public sealed partial class HtmlLocalLinkParser
             // Find the culture attribute if it exists
             Match cultureMatch = _culturePattern.Match(linkTag.Value);
 
+            // Normalize the type to lower case to tolerate historic mis-cased values written by the (now fixed)
+            // ConvertLocalLinks migration (see #22597). Constants.UdiEntityType.* values are lower case.
             yield return new LocalLinkTag(
                 null,
-                new GuidUdi(typeMatch.Groups["type"].Value, guid),
+                new GuidUdi(typeMatch.Groups["type"].Value.ToLowerInvariant(), guid),
                 linkTag.Groups["locallink"].Value,
                 cultureMatch.Success ? cultureMatch.Groups["culture"].Value : null
             );

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextElementParser.cs
@@ -156,6 +156,10 @@ internal sealed class ApiRichTextElementParser : ApiRichTextParserBase, IApiRich
             type = "unknown";
         }
 
+        // Normalize the type to lower case to tolerate historic mis-cased values written by the (now fixed)
+        // ConvertLocalLinks migration for Umbraco 15 (see #22597). Constants.UdiEntityType.* values are lower case.
+        type = type.ToLowerInvariant();
+
         // Extract culture from attributes if present
         var culture = attributes.TryGetValue("data-culture", out object? cultureAttribute)
             ? cultureAttribute?.ToString()

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParser.cs
@@ -67,11 +67,13 @@ internal sealed class ApiRichTextMarkupParser : ApiRichTextParserBase, IApiRichT
         HtmlNode[] links = doc.DocumentNode.SelectNodes("//a")?.ToArray() ?? Array.Empty<HtmlNode>();
         foreach (HtmlNode link in links)
         {
+            // Normalize the type to lower case to tolerate historic mis-cased values written by the (now fixed)
+            // ConvertLocalLinks migration for Umbraco 15 (see #22597). Constants.UdiEntityType.* values are lower case.
             ReplaceLocalLinks(
                     contentCache,
                     mediaCache,
                 link.GetAttributeValue("href", string.Empty),
-                link.GetAttributeValue("type", "unknown"),
+                link.GetAttributeValue("type", "unknown").ToLowerInvariant(),
                 (route, content) =>
                 {
                     link.SetAttributeValue("href", $"{route.Path}{route.QueryString}");

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
@@ -135,17 +135,19 @@ public class LocalLinkProcessor
 
     private (Guid Key, string EntityType)? CreateIntBasedKeyType(int id)
     {
-        // very old data, best effort replacement
+        // very old data, best effort replacement.
+        // entity type must match the lowercase UDI entity type, which is what the tiptap RTE
+        // expects in the "type" attribute (and what the UDI-based branch above produces).
         Attempt<Guid> documentAttempt = _idKeyMap.GetKeyForId(id, UmbracoObjectTypes.Document);
         if (documentAttempt.Success)
         {
-            return (Key: documentAttempt.Result, EntityType: UmbracoObjectTypes.Document.ToString());
+            return (Key: documentAttempt.Result, EntityType: Constants.UdiEntityType.Document);
         }
 
         Attempt<Guid> mediaAttempt = _idKeyMap.GetKeyForId(id, UmbracoObjectTypes.Media);
         if (mediaAttempt.Success)
         {
-            return (Key: mediaAttempt.Result, EntityType: UmbracoObjectTypes.Media.ToString());
+            return (Key: mediaAttempt.Result, EntityType: Constants.UdiEntityType.Media);
         }
 
         return null;

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessorForFaultyLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessorForFaultyLinks.cs
@@ -72,17 +72,19 @@ public class LocalLinkProcessorForFaultyLinks
 
     private (Guid Key, string EntityType)? CreateIntBasedKeyType(int id)
     {
-        // very old data, best effort replacement
+        // very old data, best effort replacement.
+        // entity type must match the lowercase UDI entity type, which is what the tiptap RTE
+        // expects in the "type" attribute.
         Attempt<Guid> documentAttempt = _idKeyMap.GetKeyForId(id, UmbracoObjectTypes.Document);
         if (documentAttempt.Success)
         {
-            return (Key: documentAttempt.Result, EntityType: UmbracoObjectTypes.Document.ToString());
+            return (Key: documentAttempt.Result, EntityType: Constants.UdiEntityType.Document);
         }
 
         Attempt<Guid> mediaAttempt = _idKeyMap.GetKeyForId(id, UmbracoObjectTypes.Media);
         if (mediaAttempt.Success)
         {
-            return (Key: mediaAttempt.Result, EntityType: UmbracoObjectTypes.Media.ToString());
+            return (Key: mediaAttempt.Result, EntityType: Constants.UdiEntityType.Media);
         }
 
         return null;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/DeliveryApi/RichTextParserTests.cs
@@ -161,6 +161,31 @@ public class RichTextParserTests : PropertyValueConverterTests
         Assert.AreEqual(nameof(LinkType.Content), link.Attributes["linkType"]);
     }
 
+    // PascalCase type — historic mis-cased values written by the (now fixed) ConvertLocalLinks migration for Umbraco 15 (see #22597).
+    [Test]
+    public void ParseElement_CanParseContentLinkWithPascalCaseTypeAttribute()
+    {
+        var parser = CreateRichTextElementParser();
+
+        var element = parser.Parse($"<p><a href=\"/{{localLink:{_contentKey:N}}}\" type=\"Document\"></a></p>", RichTextBlockModel.Empty) as RichTextRootElement;
+        Assert.IsNotNull(element);
+        var link = element.Elements.OfType<RichTextGenericElement>().Single().Elements.Single() as RichTextGenericElement;
+        Assert.IsNotNull(link);
+        Assert.AreEqual("a", link.Tag);
+
+        Assert.IsNotNull(link.Attributes["route"]);
+        var route = link.Attributes["route"] as IApiContentRoute;
+        Assert.IsNotNull(route);
+        Assert.AreEqual("/some-content-path", route.Path);
+
+        Assert.IsNotNull(link.Attributes["destinationId"]);
+        Assert.IsNotNull(link.Attributes["destinationType"]);
+        Assert.IsNotNull(link.Attributes["linkType"]);
+        Assert.AreEqual(_contentKey, Guid.Parse((link.Attributes["destinationId"] as string)!));
+        Assert.AreEqual(_contentType, link.Attributes["destinationType"]);
+        Assert.AreEqual(nameof(LinkType.Content), link.Attributes["linkType"]);
+    }
+
     [Test]
     public void ParseElement_CanParseMediaLink()
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Templates/HtmlLocalLinkParserTests.cs
@@ -145,6 +145,14 @@ public class HtmlLocalLinkParserTests
         "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
         "<a type=\"custom\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>")]
 
+    // PascalCase type — historic mis-cased values written by the (now fixed) ConvertLocalLinks migration for Umbraco 15 (see #22597).
+    [TestCase(
+        "<a type=\"Document\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a href=\"/my-test-url\" title=\"world\">world</a>")]
+    [TestCase(
+        "<a type=\"Media\" href=\"/{localLink:9931BDE0-AAC3-4BAB-B838-909A7B47570E}\" title=\"world\">world</a>",
+        "<a href=\"/media/1001/my-image.jpg\" title=\"world\">world</a>")]
+
     // legacy
     [TestCase(
         "hello href=\"{localLink:1234}\" world ",

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/DeliveryApi/ApiRichTextMarkupParserTests.cs
@@ -83,6 +83,35 @@ public class ApiRichTextMarkupParserTests
         Assert.AreEqual(expectedOutput, parsedHtml);
     }
 
+    // PascalCase type — historic mis-cased values written by the (now fixed) ConvertLocalLinks migration for Umbraco 15 (see #22597).
+    [Test]
+    public void Can_Parse_LocalLinks_With_PascalCase_Type()
+    {
+        var key1 = Guid.Parse("eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f");
+        var data1 = new MockData()
+            .WithKey(key1)
+            .WithContentTypeAlias("someAlias")
+            .WithRoutePath("/self/")
+            .WithRouteStartPath("self");
+
+        var mockData = new Dictionary<Guid, MockData>
+        {
+            { key1, data1 },
+        };
+
+        var parser = BuildDefaultSut(mockData);
+
+        var html =
+            @"<p>Rich text outside of the blocks with a link to <a type=""Document"" href=""/{localLink:eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f}"" title=""itself"">itself</a></p>";
+
+        var expectedOutput =
+            $@"<p>Rich text outside of the blocks with a link to <a href=""/self/"" title=""itself"" data-destination-id=""{key1:D}"" data-destination-type=""someAlias"" data-start-item-path=""self"" data-start-item-id=""eed5fc6b-96fd-45a5-a0f1-b1adfb483c2f"" data-link-type=""{LinkType.Content}"">itself</a></p>";
+
+        var parsedHtml = parser.Parse(html);
+
+        Assert.AreEqual(expectedOutput, parsedHtml);
+    }
+
     [TestCase("#some-anchor")]
     [TestCase("?something=true")]
     [TestCase("#!some-hashbang")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
@@ -88,13 +88,13 @@ public class LocalLinkProcessorTests
         var result = processor.ProcessStringValue(input);
 
         Assert.AreEqual(
-            $@"<a href=""{{localLink:{documentKey}}}"" type=""Document"">link</a>",
+            $@"<a href=""{{localLink:{documentKey}}}"" type=""document"">link</a>",
             result);
     }
 
     /// <summary>
     /// Verifies that an integer-based link that resolves to media (not document)
-    /// is converted with the correct "Media" type attribute.
+    /// is converted with the correct "media" type attribute.
     /// </summary>
     [Test]
     public void ProcessStringValue_IntegerMediaLink_ConvertsToGuidWithType()
@@ -115,7 +115,7 @@ public class LocalLinkProcessorTests
         var result = processor.ProcessStringValue(input);
 
         Assert.AreEqual(
-            $@"<a href=""{{localLink:{mediaKey}}}"" type=""Media"">link</a>",
+            $@"<a href=""{{localLink:{mediaKey}}}"" type=""media"">link</a>",
             result);
     }
 
@@ -305,7 +305,7 @@ public class LocalLinkProcessorTests
         var result = processor.ProcessStringValue(input);
 
         Assert.AreEqual(
-            $@"<a href=""{{localLink:{documentKey}}}#anchor"" type=""Document"">link</a>",
+            $@"<a href=""{{localLink:{documentKey}}}#anchor"" type=""document"">link</a>",
             result);
     }
 
@@ -328,7 +328,7 @@ public class LocalLinkProcessorTests
         var result = processor.ProcessStringValue(input);
 
         Assert.AreEqual(
-            $@"<a href=""{{localLink:{documentKey}}}?page=2"" type=""Document"">link</a>",
+            $@"<a href=""{{localLink:{documentKey}}}?page=2"" type=""document"">link</a>",
             result);
     }
 


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/22597 reports a casing discrepancy in the `ConvertLocalLinks` migration between the legacy GUID UDI and integer formats.  The former emit "document"/"media" and the latter "Document"/"Media".  The former is expected (comparing to `Constants.UdiEntityType.*`).

The fix switches the integer branch to use `Constants.UdiEntityType.Document` (`"document"`) and `.Media` (`"media"`) so the two branches produce matching lowercase output.

## Testing

### Automated

`LocalLinkProcessorTests` are updated to reflect the change (they were previously incorrectly passing as they were asserting the incorrect case).

### Manual

To verify against a real database, I have used the following method.  Bear in mind it will replay all migrations since 15.  Doesn't do any harm, but don't run on anything important.

- Find a candidate RTE/TinyMCE property data row (the migration processes `current = 1` or `published = 1` versions):
```sql
SELECT
      pd.id                AS PropertyDataId,
      pd.versionId,
      pd.propertyTypeId,
      pt.alias             AS PropertyAlias,
      n.id                 AS NodeId,
      n.text               AS NodeName,
      dt.propertyEditorAlias,
      cv.[current]         AS IsCurrent,
      dv.published         AS IsPublished,
      LEN(pd.textValue)    AS TextLen,
      LEFT(pd.textValue, 500) AS TextPreview
  FROM umbracoPropertyData pd
  INNER JOIN cmsPropertyType    pt ON pt.id = pd.propertyTypeId
  INNER JOIN umbracoDataType    dt ON dt.nodeId = pt.dataTypeId
  INNER JOIN umbracoContentVersion cv ON cv.id = pd.versionId
  INNER JOIN umbracoNode        n  ON n.id = cv.nodeId
  LEFT  JOIN umbracoDocumentVersion dv ON dv.id = cv.id
  WHERE dt.propertyEditorAlias IN ('Umbraco.RichText', 'Umbraco.TinyMCE')
    AND (cv.[current] = 1 OR dv.published = 1)
    AND pd.textValue IS NOT NULL
  ORDER BY pd.id;
```

- Pick a real integer document ID for the legacy link to target (`IIdKeyMap.GetKeyForId` has to resolve it, so it must correspond to an actual node):
```sql
  SELECT TOP 5 id, [text] AS Name, [path]
  FROM umbracoNode
  WHERE nodeObjectType = 'C66BA18E-EAF3-4CFF-8A22-41B16D66A972'  -- Document
    AND trashed = 0
  ORDER BY id;
```

- Capture the current `textValue` of the property data row before overwriting it, so you can restore it afterwards:
```sql
SELECT pd.id, pd.textValue
FROM umbracoPropertyData pd
WHERE pd.id = @propertyDataId;
```

- Seed the legacy integer-form link into that row (keep the existing JSON shape, replace the markup):
```sql
DECLARE @propertyDataId int = 123;   -- from the first query above
DECLARE @docIntId int = 456;       -- from the second query above

UPDATE umbracoPropertyData
SET textValue = '{"markup":"<p>Legacy int link: <a href=\"/{localLink:' +
                CAST(@docIntId AS nvarchar(20)) +
                '}\" title=\"test\">click here</a></p>","blocks":null}'
WHERE id = @propertyDataId;
```

- Rewind the migration state so `ConvertLocalLinks` runs again on the seeded row. The state ID is taken from `UmbracoPlan.cs` — it's the state produced by the migration *before* `ConvertLocalLinks`:
```sql
UPDATE umbracoKeyValue
SET [value] = '37875E80-5CDD-42FF-A21A-7D4E3E23E0ED'
WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core';
```

- Start the site. Watch the log for `Migration starting for all properties of type: Umbraco.RichText`.

- Inspect the stored value after the migration runs. Expect `type="document"` (lowercase). Before the fix it was `type="Document"`. The href will contain the GUID for the target node (`umbracoNode.uniqueId`):
```sql
SELECT id, textValue
FROM umbracoPropertyData
WHERE id = @propertyDataId;
```

- Restore the original value if you want:
```sql
UPDATE umbracoPropertyData
SET textValue = '...'
WHERE id = @propertyDataId;
```

