### PR TITLE
Rich Text Editor: Mark as supports read only

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -251,7 +251,7 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 	}
 
 	#renderToolbar() {
-		if (!this.#hasToolbar) return;
+		if (!this.#hasToolbar || this.readonly) return;
 		return html`
 			<umb-tiptap-toolbar
 				data-mark="tiptap-toolbar"

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -112,6 +112,13 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 		await this.#loadEditor();
 	}
 
+	protected override updated(changedProperties: Map<string, unknown>) {
+		super.updated(changedProperties);
+		if (changedProperties.has('readonly')) {
+			this._editor?.setEditable(!this.readonly);
+		}
+	}
+
 	/**
 	 * Checks if the editor is empty.
 	 * @returns {boolean} returns true if the editor contains no markup
@@ -257,21 +264,19 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 				data-mark="tiptap-toolbar"
 				.toolbar=${this._toolbar}
 				.editor=${this._editor}
-				.configuration=${this.configuration}
-				?readonly=${this.readonly}>
+				.configuration=${this.configuration}>
 			</umb-tiptap-toolbar>
 		`;
 	}
 
 	#renderStatusbar() {
-		if (!this.#hasStatusbar) return;
+		if (!this.#hasStatusbar || this.readonly) return;
 		return html`
 			<umb-tiptap-statusbar
 				data-mark="tiptap-statusbar"
 				.statusbar=${this._statusbar}
 				.editor=${this._editor}
 				.configuration=${this.configuration}
-				?readonly=${this.readonly}
 				${umbDestroyOnDisconnect()}>
 			</umb-tiptap-statusbar>
 		`;
@@ -304,8 +309,6 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 			}
 
 			:host([readonly]) {
-				pointer-events: none;
-
 				#editor {
 					background-color: var(--uui-color-surface-alt);
 				}

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/statusbar/tiptap-statusbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/statusbar/tiptap-statusbar.element.ts
@@ -22,9 +22,6 @@ export class UmbTiptapStatusbarElement extends UmbLitElement {
 
 	#lookup: Map<string, unknown> = new Map();
 
-	@property({ type: Boolean, reflect: true })
-	readonly = false;
-
 	@property({ attribute: false })
 	editor?: Editor;
 
@@ -107,10 +104,6 @@ export class UmbTiptapStatusbarElement extends UmbLitElement {
 	}
 
 	static override readonly styles = css`
-		:host([readonly]) {
-			display: none;
-		}
-
 		:host {
 			--uui-button-height: var(--uui-size-layout-2);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar.element.ts
@@ -25,9 +25,6 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 
 	#lookup: Map<string, unknown> = new Map();
 
-	@property({ type: Boolean, reflect: true })
-	readonly = false;
-
 	@property({ attribute: false })
 	editor?: Editor;
 
@@ -100,11 +97,6 @@ export class UmbTiptapToolbarElement extends UmbLitElement {
 	}
 
 	static override readonly styles = css`
-		:host([readonly]) {
-			pointer-events: none;
-			background-color: var(--uui-color-surface-alt);
-		}
-
 		:host {
 			border-radius: var(--uui-border-radius);
 			border: 1px solid var(--uui-color-border);

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/property-editors/tiptap-rte/manifests.ts
@@ -12,6 +12,7 @@ export const manifests: Array<ManifestPropertyEditorUi> = [
 			propertyEditorSchemaAlias: 'Umbraco.RichText',
 			icon: 'icon-browser-window',
 			group: 'richContent',
+			supportsReadOnly: true,
 			settings: {
 				properties: [
 					{


### PR DESCRIPTION
Marks the TipTap Rich Text Editor as supporting read-only, as it does.

This enables users to copy content, which they should be allowed to in read-only mode.

This also hides the status bar, as that helps visually to indicate the read-only mode.


Test notes:

Make your use not able to edit a specific language, open a document with RTE on that Culture variant to see the read only mode.