### PR TITLE
Variant-Selector: improve visual alignment for segments (closes #22605)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -16,8 +16,8 @@ import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 
 @customElement('umb-workspace-split-view-variant-selector')
 export class UmbWorkspaceSplitViewVariantSelectorElement<
-	VariantOptionModelType extends
-		UmbEntityVariantOptionModel<UmbEntityVariantModel> = UmbEntityVariantOptionModel<UmbEntityVariantModel>,
+	VariantOptionModelType extends UmbEntityVariantOptionModel<UmbEntityVariantModel> =
+		UmbEntityVariantOptionModel<UmbEntityVariantModel>,
 > extends UmbLitElement {
 	@query('#popover')
 	private _popoverElement?: UUIPopoverContainerElement;
@@ -517,7 +517,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 
 		return html`
 			<div class="variant segment-variant ${this.#isVariantActive(variantId) ? 'selected' : ''}">
-				${notCreated ? nothing : html`<div class="expand-area"></div>`}
+				${notCreated || variantId.segment !== null ? nothing : html`<div class="expand-area"></div>`}
 				<button
 					class="switch-button ${notCreated ? 'add-mode' : ''} ${this.#isReadOnlyCulture(variantId.culture)
 						? 'readonly-mode'
@@ -713,11 +713,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 			}
 
 			.expand-area + .switch-button {
-				padding-left: var(--uui-size-space-3);
-			}
-
-			.segment-variant > .switch-button {
-				padding-left: var(--uui-size-space-6);
+				padding-left: var(--uui-size-space-1);
 			}
 
 			.switch-button:hover {
@@ -758,6 +754,14 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 			.switch-button.add-mode {
 				position: relative;
 				color: var(--uui-palette-dusty-grey-dark);
+				padding-left: var(--uui-size-space-4);
+			}
+
+			.segment-variant > .switch-button {
+				padding-left: var(--uui-size-space-6);
+			}
+			.segment-variant > .switch-button:not(.add-mode) {
+				padding-left: var(--uui-size-16);
 			}
 
 			.switch-button.add-mode:after {
@@ -783,7 +787,7 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 
 			.add-icon {
 				font-size: var(--uui-type-small-size);
-				margin-right: 21px;
+				margin-right: var(--uui-size-space-4);
 			}
 
 			.split-view {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-split-view/workspace-split-view-variant-selector.element.ts
@@ -517,7 +517,6 @@ export class UmbWorkspaceSplitViewVariantSelectorElement<
 
 		return html`
 			<div class="variant segment-variant ${this.#isVariantActive(variantId) ? 'selected' : ''}">
-				${notCreated || variantId.segment !== null ? nothing : html`<div class="expand-area"></div>`}
 				<button
 					class="switch-button ${notCreated ? 'add-mode' : ''} ${this.#isReadOnlyCulture(variantId.culture)
 						? 'readonly-mode'


### PR DESCRIPTION
Improves the variant selector alignment for segments, with this as the result:

<img width="532" height="468" alt="image" src="https://github.com/user-attachments/assets/4a908bc0-71a8-486a-83d9-7583f27b1e8d" />
