### PR TITLE
bug(#22607) Add Directory.Packages.props and update restore command

### DIFF
--- a/templates/UmbracoProject/Dockerfile
+++ b/templates/UmbracoProject/Dockerfile
@@ -8,7 +8,9 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["UmbracoProject/UmbracoProject.csproj", "UmbracoProject/"]
+#if (UseCPM)
 COPY ["UmbracoProject/Directory.Packages.props", "UmbracoProject/"]
+#endif
 RUN dotnet restore "UmbracoProject/"
 COPY . .
 WORKDIR "/src/UmbracoProject"

--- a/templates/UmbracoProject/Dockerfile
+++ b/templates/UmbracoProject/Dockerfile
@@ -8,7 +8,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["UmbracoProject/UmbracoProject.csproj", "UmbracoProject/"]
-RUN dotnet restore "UmbracoProject/UmbracoProject.csproj"
+COPY ["UmbracoProject/Directory.Packages.props", "UmbracoProject/"]
+RUN dotnet restore "UmbracoProject/"
 COPY . .
 WORKDIR "/src/UmbracoProject"
 RUN dotnet build "UmbracoProject.csproj" -c $BUILD_CONFIGURATION -o /app/build


### PR DESCRIPTION
Updated Dockerfile to include Directory.Packages.props and modified restore command to resolve docker build errors during dotnet restore step. Resolves issue #22607

