### PR TITLE
Change Element migrations to a premigrations

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -189,7 +189,6 @@ public partial class UmbracoPlan : MigrationPlan
         // To 18.0.0
         // TODO (V18): Enable on 18 branch
         ////To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");
-        To<V_18_0_0.AddElements>("{E51033DE-B4F9-45F3-87B3-0E774B2939C2}");
         To<V_18_0_0.AddAllowedInLibraryToContentType>("{31C0D92A-49DD-47EC-B2A7-932A58FF224E}");
     }
 

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -189,7 +189,6 @@ public partial class UmbracoPlan : MigrationPlan
         // To 18.0.0
         // TODO (V18): Enable on 18 branch
         ////To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");
-        To<V_18_0_0.AddAllowedInLibraryToContentType>("{31C0D92A-49DD-47EC-B2A7-932A58FF224E}");
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
@@ -81,5 +81,8 @@ public class UmbracoPremigrationPlan : MigrationPlan
         To<V_17_0_0.AddCacheVersionDatabaseLock>("{1DC39DC7-A88A-4912-8E60-4FD36246E8D1}");
         To<V_17_0_0.AddRepositoryCacheVersionTable>("{A1B3F5D6-4C8B-4E7A-9F8C-1D2B3E4F5A6B}");
         To<V_17_0_0.AddLastSyncedTable>("{72894BCA-9FAD-4CC3-B0D0-D6CDA2FFA636}");
+
+        // To 18.0.0
+        To<V_18_0_0.AddElements>("{E51033DE-B4F9-45F3-87B3-0E774B2939C2}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPremigrationPlan.cs
@@ -84,5 +84,6 @@ public class UmbracoPremigrationPlan : MigrationPlan
 
         // To 18.0.0
         To<V_18_0_0.AddElements>("{E51033DE-B4F9-45F3-87B3-0E774B2939C2}");
+        To<V_18_0_0.AddAllowedInLibraryToContentType>("{31C0D92A-49DD-47EC-B2A7-932A58FF224E}");
     }
 }


### PR DESCRIPTION
### Description
While testing out the removal of obsolete migrations I noticed that with recent additions to notificationshandlers involving elements, the upgrade from 17 to 18 doesn't work anymore. This PR fixes this by moving the migrations that alters the DB to premigrations

### Testing
Create a project in 17.x, then upgrade to 18
Before: You get an error saying the Elements table does not exist
After: Upgrade succeeds