### PR TITLE
Current User: Reload when the current user or their groups change

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
@@ -106,53 +106,76 @@ describe('UmbCurrentUserContext', () => {
 				};
 			});
 
-			it('reloads when the current user entity is updated', () => {
+			const wait = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+			it('reloads when the current user entity is updated', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(1);
 			});
 
-			it('does not reload when a different user entity is updated', () => {
+			it('does not reload when a different user entity is updated', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: OTHER_USER_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
 			});
 
-			it('reloads when a user group the current user belongs to is updated', () => {
+			it('reloads when a user group the current user belongs to is updated', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityUpdatedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: CURRENT_USER_GROUP_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(1);
 			});
 
-			it('does not reload when a user group the current user does not belong to is updated', () => {
+			it('does not reload when a user group the current user does not belong to is updated', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityUpdatedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: OTHER_GROUP_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
 			});
 
-			it('does not reload for unrelated entity types', () => {
+			it('does not reload for unrelated entity types', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityUpdatedEvent({ entityType: UNRELATED_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
 			});
 
-			it('does not reload when unique is null for a user entity type', () => {
+			it('does not reload when unique is null for a user entity type', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: null }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
 			});
 
-			it('does not reload when unique is null for a user group entity type', () => {
+			it('does not reload when unique is null for a user group entity type', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityUpdatedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: null }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
+			});
+
+			it('collapses multiple rapid events into a single load', async () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
+				);
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: CURRENT_USER_GROUP_UNIQUE }),
+				);
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
+				);
+				await wait();
+				expect(loadCount).to.equal(1);
 			});
 		});
 
@@ -168,37 +191,43 @@ describe('UmbCurrentUserContext', () => {
 				};
 			});
 
-			it('reloads when a user group the current user belongs to is deleted', () => {
+			const wait = () => new Promise((resolve) => setTimeout(resolve, 200));
+
+			it('reloads when a user group the current user belongs to is deleted', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: CURRENT_USER_GROUP_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(1);
 			});
 
-			it('does not reload when a user group the current user does not belong to is deleted', () => {
+			it('does not reload when a user group the current user does not belong to is deleted', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: OTHER_GROUP_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
 			});
 
-			it('does not reload for unrelated entity types', () => {
+			it('does not reload for unrelated entity types', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityDeletedEvent({ entityType: UNRELATED_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
 			});
 
-			it('does not reload when unique is null for a user group entity type', () => {
+			it('does not reload when unique is null for a user group entity type', async () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: null }),
 				);
+				await wait();
 				expect(loadCount).to.equal(0);
 			});
 		});
 
 		describe('destroy', () => {
-			it('removes event listeners so events no longer trigger a reload', () => {
+			it('removes event listeners so events no longer trigger a reload', async () => {
 				let loadCount = 0;
 				const originalLoad = context.load.bind(context);
 				context.load = async () => {
@@ -215,6 +244,7 @@ describe('UmbCurrentUserContext', () => {
 					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: CURRENT_USER_GROUP_UNIQUE }),
 				);
 
+				await new Promise((resolve) => setTimeout(resolve, 200));
 				expect(loadCount).to.equal(0);
 			});
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
@@ -140,6 +140,20 @@ describe('UmbCurrentUserContext', () => {
 				);
 				expect(loadCount).to.equal(0);
 			});
+
+			it('does not reload when unique is null for a user entity type', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: null }),
+				);
+				expect(loadCount).to.equal(0);
+			});
+
+			it('does not reload when unique is null for a user group entity type', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: null }),
+				);
+				expect(loadCount).to.equal(0);
+			});
 		});
 
 		describe('entity deleted events', () => {
@@ -171,6 +185,13 @@ describe('UmbCurrentUserContext', () => {
 			it('does not reload for unrelated entity types', () => {
 				hostElement.actionEventContext.dispatchEvent(
 					new UmbEntityDeletedEvent({ entityType: UNRELATED_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
+				);
+				expect(loadCount).to.equal(0);
+			});
+
+			it('does not reload when unique is null for a user group entity type', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: null }),
 				);
 				expect(loadCount).to.equal(0);
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
@@ -1,0 +1,201 @@
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UmbActionEventContext } from '@umbraco-cms/backoffice/action';
+import { UmbEntityDeletedEvent, UmbEntityUpdatedEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_USER_ENTITY_TYPE } from '@umbraco-cms/backoffice/user';
+import { UMB_USER_GROUP_ENTITY_TYPE } from '@umbraco-cms/backoffice/user-group';
+import { useMockSet } from '@umbraco-cms/internal/mock-manager';
+import { UmbCurrentUserContext } from './current-user.context.js';
+import { UmbCurrentUserStore } from './repository/index.js';
+
+// Kitchen sink current user data
+const CURRENT_USER_UNIQUE = '1e70f841-c261-413b-abb2-2d68cdb96094';
+const CURRENT_USER_GROUP_UNIQUE = 'e5e7f6c8-7f9c-4b5b-8d5d-9e1e5a4f7e4d';
+const OTHER_USER_UNIQUE = 'not-the-current-user';
+const OTHER_GROUP_UNIQUE = 'not-a-group-the-user-is-in';
+const UNRELATED_ENTITY_TYPE = 'unrelated-entity-type';
+
+@customElement('umb-test-current-user-context-host')
+class UmbTestCurrentUserContextHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	currentUserContext = new UmbCurrentUserContext(this);
+	actionEventContext = new UmbActionEventContext(this);
+
+	constructor() {
+		super();
+		new UmbCurrentUserStore(this);
+		new UmbNotificationContext(this);
+	}
+
+	async init() {
+		await this.currentUserContext.load();
+	}
+}
+
+describe('UmbCurrentUserContext', () => {
+	let hostElement: UmbTestCurrentUserContextHostElement;
+	let context: UmbCurrentUserContext;
+
+	before(async () => {
+		await useMockSet('kitchenSink');
+	});
+
+	beforeEach(async () => {
+		hostElement = new UmbTestCurrentUserContextHostElement();
+		document.body.appendChild(hostElement);
+		context = hostElement.currentUserContext;
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('before load', () => {
+		it('getters return undefined', () => {
+			expect(context.getName()).to.be.undefined;
+			expect(context.getUnique()).to.be.undefined;
+			expect(context.getEmail()).to.be.undefined;
+		});
+	});
+
+	describe('after load', () => {
+		beforeEach(async () => {
+			await hostElement.init();
+		});
+
+		it('populates getters from the loaded user', () => {
+			expect(context.getName()).to.equal('Administrator');
+			expect(context.getUnique()).to.equal(CURRENT_USER_UNIQUE);
+			expect(context.getEmail()).to.equal('admin@example.com');
+			expect(context.getIsAdmin()).to.be.true;
+			expect(context.getLanguageIsoCode()).to.equal('en-US');
+		});
+
+		describe('isUserCurrentUser', () => {
+			it('returns true for the current user unique', async () => {
+				expect(await context.isUserCurrentUser(CURRENT_USER_UNIQUE)).to.be.true;
+			});
+
+			it('returns false for a different user unique', async () => {
+				expect(await context.isUserCurrentUser(OTHER_USER_UNIQUE)).to.be.false;
+			});
+		});
+
+		describe('isCurrentUserAdmin', () => {
+			it('returns true for an admin user', async () => {
+				expect(await context.isCurrentUserAdmin()).to.be.true;
+			});
+		});
+
+		describe('getAllowedSection', () => {
+			it('returns the sections the user has access to', () => {
+				expect(context.getAllowedSection()).to.be.an('array').that.is.not.empty;
+			});
+		});
+
+		describe('entity updated events', () => {
+			let loadCount: number;
+
+			beforeEach(() => {
+				loadCount = 0;
+				const originalLoad = context.load.bind(context);
+				context.load = async () => {
+					loadCount++;
+					return originalLoad();
+				};
+			});
+
+			it('reloads when the current user entity is updated', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
+				);
+				expect(loadCount).to.equal(1);
+			});
+
+			it('does not reload when a different user entity is updated', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: OTHER_USER_UNIQUE }),
+				);
+				expect(loadCount).to.equal(0);
+			});
+
+			it('reloads when a user group the current user belongs to is updated', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: CURRENT_USER_GROUP_UNIQUE }),
+				);
+				expect(loadCount).to.equal(1);
+			});
+
+			it('does not reload when a user group the current user does not belong to is updated', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: OTHER_GROUP_UNIQUE }),
+				);
+				expect(loadCount).to.equal(0);
+			});
+
+			it('does not reload for unrelated entity types', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UNRELATED_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
+				);
+				expect(loadCount).to.equal(0);
+			});
+		});
+
+		describe('entity deleted events', () => {
+			let loadCount: number;
+
+			beforeEach(() => {
+				loadCount = 0;
+				const originalLoad = context.load.bind(context);
+				context.load = async () => {
+					loadCount++;
+					return originalLoad();
+				};
+			});
+
+			it('reloads when a user group the current user belongs to is deleted', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: CURRENT_USER_GROUP_UNIQUE }),
+				);
+				expect(loadCount).to.equal(1);
+			});
+
+			it('does not reload when a user group the current user does not belong to is deleted', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: OTHER_GROUP_UNIQUE }),
+				);
+				expect(loadCount).to.equal(0);
+			});
+
+			it('does not reload for unrelated entity types', () => {
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityDeletedEvent({ entityType: UNRELATED_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
+				);
+				expect(loadCount).to.equal(0);
+			});
+		});
+
+		describe('destroy', () => {
+			it('removes event listeners so events no longer trigger a reload', () => {
+				let loadCount = 0;
+				const originalLoad = context.load.bind(context);
+				context.load = async () => {
+					loadCount++;
+					return originalLoad();
+				};
+
+				context.destroy();
+
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityUpdatedEvent({ entityType: UMB_USER_ENTITY_TYPE, unique: CURRENT_USER_UNIQUE }),
+				);
+				hostElement.actionEventContext.dispatchEvent(
+					new UmbEntityDeletedEvent({ entityType: UMB_USER_GROUP_ENTITY_TYPE, unique: CURRENT_USER_GROUP_UNIQUE }),
+				);
+
+				expect(loadCount).to.equal(0);
+			});
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
@@ -3,6 +3,7 @@ import { UmbCurrentUserRepository } from './repository/current-user.repository.j
 import { UMB_CURRENT_USER_CONTEXT } from './current-user.context.token.js';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { debounce } from '@umbraco-cms/backoffice/utils';
 import { filter, firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
 import { UMB_AUTH_CONTEXT } from '@umbraco-cms/backoffice/auth';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
@@ -73,6 +74,8 @@ export class UmbCurrentUserContext extends UmbContextBase {
 				.catch(() => undefined);
 		}
 	}
+
+	#loadDebounced = debounce(() => this.load(), 100);
 
 	/**
 	 * Checks if a user is the current user.
@@ -240,14 +243,14 @@ export class UmbCurrentUserContext extends UmbContextBase {
 
 		if (entityType === UMB_USER_GROUP_ENTITY_TYPE) {
 			if (this.#isInGroup(unique)) {
-				this.load();
+				this.#loadDebounced();
 			}
 			return;
 		}
 
 		const isCurrentUser = entityType === UMB_USER_ENTITY_TYPE && unique === this.#currentUser.getValue()?.unique;
 		if (isCurrentUser) {
-			this.load();
+			this.#loadDebounced();
 		}
 	};
 
@@ -256,7 +259,7 @@ export class UmbCurrentUserContext extends UmbContextBase {
 		const unique = event.getUnique();
 		if (!unique) return;
 		if (this.#isInGroup(unique)) {
-			this.load();
+			this.#loadDebounced();
 		}
 	};
 
@@ -284,6 +287,7 @@ export class UmbCurrentUserContext extends UmbContextBase {
 
 	override destroy(): void {
 		this.#removeActionEventListeners();
+		this.#loadDebounced.cancel();
 		super.destroy();
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
@@ -8,6 +8,10 @@ import { UMB_AUTH_CONTEXT } from '@umbraco-cms/backoffice/auth';
 import { UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 import { umbLocalizationRegistry } from '@umbraco-cms/backoffice/localization';
 import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbEntityDeletedEvent, UmbEntityUpdatedEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_USER_ENTITY_TYPE } from '@umbraco-cms/backoffice/user';
+import { UMB_USER_GROUP_ENTITY_TYPE } from '@umbraco-cms/backoffice/user-group';
 
 export class UmbCurrentUserContext extends UmbContextBase {
 	#currentUser = new UmbObjectState<UmbCurrentUserModel | undefined>(undefined);
@@ -32,6 +36,7 @@ export class UmbCurrentUserContext extends UmbContextBase {
 
 	#authContext?: typeof UMB_AUTH_CONTEXT.TYPE;
 	#currentUserRepository = new UmbCurrentUserRepository(this);
+	#actionEventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_CURRENT_USER_CONTEXT);
@@ -39,6 +44,12 @@ export class UmbCurrentUserContext extends UmbContextBase {
 		this.consumeContext(UMB_AUTH_CONTEXT, (instance) => {
 			this.#authContext = instance;
 			this.#observeIsAuthorized();
+		});
+
+		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (context) => {
+			this.#removeActionEventListeners();
+			this.#actionEventContext = context;
+			this.#addActionEventListeners();
 		});
 
 		this.observe(this.languageIsoCode, (currentLanguageIsoCode) => {
@@ -216,6 +227,64 @@ export class UmbCurrentUserContext extends UmbContextBase {
 	 */
 	getUserName(): string | undefined {
 		return this.#currentUser.getValue()?.userName;
+	}
+
+	#isInGroup(groupUnique: string): boolean {
+		return this.#currentUser.getValue()?.userGroupUniques.includes(groupUnique) ?? false;
+	}
+
+	#onEntityUpdatedEvent = (event: UmbEntityUpdatedEvent) => {
+		const entityType = event.getEntityType();
+		const unique = event.getUnique();
+		if (!unique) return;
+
+		if (entityType === UMB_USER_GROUP_ENTITY_TYPE) {
+			if (this.#isInGroup(unique)) {
+				this.load();
+			}
+			return;
+		}
+
+		const isCurrentUser = entityType === UMB_USER_ENTITY_TYPE && unique === this.#currentUser.getValue()?.unique;
+		if (isCurrentUser) {
+			this.load();
+		}
+	};
+
+	#onEntityDeletedEvent = (event: UmbEntityDeletedEvent) => {
+		if (event.getEntityType() !== UMB_USER_GROUP_ENTITY_TYPE) return;
+		const unique = event.getUnique();
+		if (!unique) return;
+		if (this.#isInGroup(unique)) {
+			this.load();
+		}
+	};
+
+	#addActionEventListeners(): void {
+		this.#actionEventContext?.addEventListener(
+			UmbEntityUpdatedEvent.TYPE,
+			this.#onEntityUpdatedEvent as unknown as EventListener,
+		);
+		this.#actionEventContext?.addEventListener(
+			UmbEntityDeletedEvent.TYPE,
+			this.#onEntityDeletedEvent as unknown as EventListener,
+		);
+	}
+
+	#removeActionEventListeners(): void {
+		this.#actionEventContext?.removeEventListener(
+			UmbEntityUpdatedEvent.TYPE,
+			this.#onEntityUpdatedEvent as unknown as EventListener,
+		);
+		this.#actionEventContext?.removeEventListener(
+			UmbEntityDeletedEvent.TYPE,
+			this.#onEntityDeletedEvent as unknown as EventListener,
+		);
+	}
+
+	override destroy(): void {
+		this.#removeActionEventListeners();
+		super.destroy();
 	}
 
 	#observeIsAuthorized() {


### PR DESCRIPTION
### Summary

`UmbCurrentUserContext` previously had no mechanism to react to changes made to the current user or their user groups from within the same session — for example, an admin editing the current user's profile or group memberships would not be reflected until a full page reload.

This PR subscribes the context to `UmbActionEventContext` and reloads the current user data when:

- The current user entity is updated
- A user group the current user belongs to is updated or deleted

Test Plan
- Manually update the current user in the User section.
- Manually add or remove a user group for the current user.
- Manually update the settings of a user group that the current user belongs to.
Verify that the update affects the back office without requiring a browser reload.
