### PR TITLE
Redirect Url Management: Implement workspace

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2362,6 +2362,8 @@ export default {
 		noRedirects: 'No redirects have been made',
 		noRedirectsDescription:
 			'When a published page gets renamed or moved a redirect will automatically be made to the new page.',
+		noRedirectsForSearch: 'No redirects matching this search criteria',
+		noRedirectsForSearchDescription: 'Double check your search for any error or spelling mistakes.',
 		redirectRemoved: 'Redirect URL removed.',
 		redirectRemoveError: 'Error removing redirect URL.',
 		redirectRemoveWarning: 'This will remove the redirect.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2364,7 +2364,7 @@ export default {
 			'When a published page gets renamed or moved a redirect will automatically be made to the new page.',
 		redirectRemoved: 'Redirect URL removed.',
 		redirectRemoveError: 'Error removing redirect URL.',
-		redirectRemoveWarning: 'This will remove the redirect',
+		redirectRemoveWarning: 'This will remove the redirect.',
 		confirmDisable: 'Are you sure you want to disable the URL tracker?',
 		disabledConfirm: 'URL tracker has now been disabled.',
 		disableError: 'Error disabling the URL tracker, more information can be found in your log file.',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -2,9 +2,10 @@ import type { UUIButtonState, UUIPaginationElement, UUIPaginationEvent } from '@
 import { css, html, nothing, customElement, state, query, property } from '@umbraco-cms/backoffice/external/lit';
 import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { RedirectUrlResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { RedirectManagementService, RedirectStatusModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { tryExecute } from '@umbraco-cms/backoffice/resources';
+import {
+	UmbDocumentRedirectManagementRepository,
+	type UmbDocumentRedirectUrlModel,
+} from '@umbraco-cms/backoffice/document';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 @customElement('umb-dashboard-redirect-management')
@@ -22,7 +23,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	private _total = 0;
 
 	@state()
-	private _redirectData?: RedirectUrlResponseModel[];
+	private _redirectData?: Array<UmbDocumentRedirectUrlModel>;
 
 	@state()
 	private _buttonState: UUIButtonState;
@@ -36,6 +37,8 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	@query('uui-pagination')
 	private _pagination?: UUIPaginationElement;
 
+	#repository = new UmbDocumentRedirectManagementRepository(this);
+
 	override connectedCallback() {
 		super.connectedCallback();
 		this.#getTrackerStatus();
@@ -43,21 +46,18 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	}
 
 	async #getTrackerStatus() {
-		const { data } = await tryExecute(this, RedirectManagementService.getRedirectManagementStatus());
-		if (data && data.status) this._trackerEnabled = data.status === RedirectStatusModel.ENABLED ? true : false;
+		const { data } = await this.#repository.requestStatus();
+		if (data) this._trackerEnabled = data.enabled;
 	}
 
 	// Fetch data
 	async #getRedirectData(filter: string | undefined = undefined) {
 		const skip = this.page * this.itemsPerPage - this.itemsPerPage;
-		const { data } = await tryExecute(
-			this,
-			RedirectManagementService.getRedirectManagement({ query: { filter, take: this.itemsPerPage, skip } }),
-		);
+		const { data } = await this.#repository.requestRedirects({ filter, take: this.itemsPerPage, skip });
 		if (!data) return;
 
-		this._total = data?.total;
-		this._redirectData = data?.items;
+		this._total = data.total;
+		this._redirectData = data.items;
 
 		if (filter !== undefined) this._buttonState = 'success';
 	}
@@ -70,8 +70,8 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	}
 
 	// Delete Redirect Action
-	async #onRequestDelete(data: RedirectUrlResponseModel) {
-		if (!data.id) return;
+	async #onRequestDelete(data: UmbDocumentRedirectUrlModel) {
+		if (!data.unique) return;
 
 		await umbConfirmModal(this, {
 			headline: 'Delete',
@@ -86,13 +86,13 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 			confirmLabel: 'Delete',
 		});
 
-		this.#redirectDelete(data.id!);
+		this.#redirectDelete(data.unique);
 	}
-	async #redirectDelete(id: string) {
-		const { error } = await tryExecute(this, RedirectManagementService.deleteRedirectManagementById({ path: { id } }));
+	async #redirectDelete(unique: string) {
+		const { error } = await this.#repository.delete(unique);
 		if (error) return;
 
-		this._redirectData = this._redirectData?.filter((x) => x.id !== id);
+		this._redirectData = this._redirectData?.filter((x) => x.unique !== unique);
 	}
 
 	// Search action
@@ -126,11 +126,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	}
 
 	async #trackerToggle() {
-		const status = this._trackerEnabled ? RedirectStatusModel.DISABLED : RedirectStatusModel.ENABLED;
-		const { error } = await tryExecute(
-			this,
-			RedirectManagementService.postRedirectManagementStatus({ query: { status } }),
-		);
+		const { error } = await this.#repository.setStatus(!this._trackerEnabled);
 		if (error) return;
 		this._trackerEnabled = !this._trackerEnabled;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -1,12 +1,20 @@
-import type { UUIButtonState, UUIPaginationElement, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
-import { css, html, nothing, customElement, state, query, property } from '@umbraco-cms/backoffice/external/lit';
-import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import {
-	UmbDocumentRedirectManagementRepository,
-	type UmbDocumentRedirectUrlModel,
-} from '@umbraco-cms/backoffice/document';
+	css,
+	customElement,
+	html,
+	nothing,
+	property,
+	query,
+	repeat,
+	state,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
+import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
+import { UmbDocumentRedirectManagementRepository } from '@umbraco-cms/backoffice/document';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import type { UmbDocumentRedirectUrlModel } from '@umbraco-cms/backoffice/document';
+import type { UUIButtonState, UUIPaginationElement, UUIPaginationEvent } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-dashboard-redirect-management')
 export class UmbDashboardRedirectManagementElement extends UmbLitElement {
@@ -74,16 +82,16 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		if (!data.unique) return;
 
 		await umbConfirmModal(this, {
-			headline: 'Delete',
+			headline: '#general_delete',
 			content: html`
-				<div style="width:300px">
-					<p>${this.localize.term('redirectUrls_redirectRemoveWarning')}</p>
+				<p>${this.localize.term('redirectUrls_redirectRemoveWarning')}</p>
+				<p>
 					${this.localize.term('redirectUrls_originalUrl')}: <strong>${data.originalUrl}</strong><br />
 					${this.localize.term('redirectUrls_redirectedTo')}: <strong>${data.destinationUrl}</strong>
-				</div>
+				</p>
 			`,
 			color: 'danger',
-			confirmLabel: 'Delete',
+			confirmLabel: '#general_delete',
 		});
 
 		this.#redirectDelete(data.unique);
@@ -131,124 +139,141 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		this._trackerEnabled = !this._trackerEnabled;
 	}
 
-	// Renders
 	override render() {
-		return html` <div id="redirect-actions">
-				${this._trackerEnabled
-					? html`<div id="search-wrapper">
-								<uui-input
-									id="search"
-									placeholder="${this.localize.term('redirectUrls_originalUrl')}"
-									label="${this.localize.term('redirectUrls_originalUrl')}"
-									@keypress=${this.#onKeypress}></uui-input>
-								<uui-button
-									look="outline"
-									label="${this.localize.term('general_search')}"
-									@click=${this.#onSearch}
-									.state=${this._buttonState}>
-									${this.localize.term('general_search')}
-								</uui-button>
-							</div>
+		return html`
+			<div id="redirect-actions">
+				${when(
+					this._trackerEnabled,
+					() => html`
+						<div id="search-wrapper">
+							<uui-input
+								id="search"
+								label=${this.localize.term('redirectUrls_originalUrl')}
+								placeholder=${this.localize.term('redirectUrls_originalUrl')}
+								@keypress=${this.#onKeypress}></uui-input>
 							<uui-button
 								look="outline"
-								label="${this.localize.term('redirectUrls_disableUrlTracker')}"
-								@click=${this.#onRequestTrackerToggle}>
-								${this.localize.term('redirectUrls_disableUrlTracker')}
-							</uui-button>`
-					: html`<div></div>
-							<uui-button
-								look="outline"
-								color="positive"
-								label="${this.localize.term('redirectUrls_enableUrlTracker')}"
-								@click=${this.#onRequestTrackerToggle}>
-								${this.localize.term('redirectUrls_enableUrlTracker')}
-							</uui-button>`}
+								label=${this.localize.term('general_search')}
+								@click=${this.#onSearch}
+								.state=${this._buttonState}></uui-button>
+						</div>
+						<uui-button
+							look="outline"
+							label=${this.localize.term('redirectUrls_disableUrlTracker')}
+							@click=${this.#onRequestTrackerToggle}></uui-button>
+					`,
+					() => html`
+						<div></div>
+						<uui-button
+							color="positive"
+							look="outline"
+							label=${this.localize.term('redirectUrls_enableUrlTracker')}
+							@click=${this.#onRequestTrackerToggle}></uui-button>
+					`,
+				)}
 			</div>
-			${this._redirectData?.length
-				? html`<uui-box id="redirect-wrapper" style="--uui-box-default-padding:0">
-						${this._trackerEnabled ? '' : html`<div id="grey-out"></div>`} ${this.#renderTable()}
-					</uui-box>`
-				: this._filter !== undefined
-					? this.#renderZeroResults()
-					: this.#renderNoRedirects()}
-			${this.#renderPagination()}`;
+			${when(
+				this._redirectData?.length,
+				() => html`
+					<uui-box id="redirect-wrapper">
+						${when(!this._trackerEnabled, () => html`<div id="grey-out"></div>`)} ${this.#renderTable()}
+					</uui-box>
+				`,
+				() => (this._filter !== undefined ? this.#renderZeroResults() : this.#renderNoRedirects()),
+			)}
+			${this.#renderPagination()}
+		`;
 	}
 
 	#renderZeroResults() {
-		return html`<uui-box>
-			<strong>No redirects matching this search criteria</strong>
-			<p>Double check your search for any error or spelling mistakes.</p>
-		</uui-box>`;
+		return html`
+			<uui-box>
+				<strong>No redirects matching this search criteria</strong>
+				<p>Double check your search for any error or spelling mistakes.</p>
+			</uui-box>
+		`;
 	}
 
 	#renderNoRedirects() {
-		return html`<uui-box>
-			<strong>${this.localize.term('redirectUrls_noRedirects')}</strong>
-			<p>${this.localize.term('redirectUrls_noRedirectsDescription')}</p>
-		</uui-box>`;
+		return html`
+			<uui-box>
+				<strong>${this.localize.term('redirectUrls_noRedirects')}</strong>
+				<p>${this.localize.term('redirectUrls_noRedirectsDescription')}</p>
+			</uui-box>
+		`;
 	}
 
 	#renderTable() {
-		return html`<uui-table>
-			<uui-table-head>
-				<uui-table-head-cell style="width:10%;">${this.localize.term('redirectUrls_culture')}</uui-table-head-cell>
-				<uui-table-head-cell>${this.localize.term('redirectUrls_originalUrl')}</uui-table-head-cell>
-				<uui-table-head-cell style="width:10%;"></uui-table-head-cell>
-				<uui-table-head-cell>${this.localize.term('redirectUrls_redirectedTo')}</uui-table-head-cell>
-				<uui-table-head-cell style="width:10%;">${this.localize.term('general_actions')}</uui-table-head-cell>
-			</uui-table-head>
-			${this.#renderTableData()}
-		</uui-table>`;
+		return html`
+			<uui-table>
+				<uui-table-head>
+					<uui-table-head-cell style="width:10%;">${this.localize.term('redirectUrls_culture')}</uui-table-head-cell>
+					<uui-table-head-cell>${this.localize.term('redirectUrls_originalUrl')}</uui-table-head-cell>
+					<uui-table-head-cell style="width:10%;"></uui-table-head-cell>
+					<uui-table-head-cell>${this.localize.term('redirectUrls_redirectedTo')}</uui-table-head-cell>
+					<uui-table-head-cell style="width:10%;">${this.localize.term('general_actions')}</uui-table-head-cell>
+				</uui-table-head>
+				${this.#renderTableData()}
+			</uui-table>
+		`;
 	}
 
 	#renderTableData() {
-		return html`${this._redirectData?.map((data) => {
-			return html` <uui-table-row>
-				<uui-table-cell> ${data.culture || '*'} </uui-table-cell>
-				<uui-table-cell>
-					<a href="${data.originalUrl || '#'}" target="_blank">
-						<span>${data.originalUrl}</span>
-					</a>
-				</uui-table-cell>
-				<uui-table-cell>
-					<uui-icon name="icon-arrow-right"></uui-icon>
-				</uui-table-cell>
-				<uui-table-cell>
-					<a href="${data.destinationUrl || '#'}" target="_blank">
-						<span>${data.destinationUrl}</span>
-					</a>
-				</uui-table-cell>
-				<uui-table-cell>
-					<uui-action-bar style="justify-self: left;">
-						<uui-button
-							label="Delete"
-							look="secondary"
-							.disabled=${!this._trackerEnabled}
-							@click=${() => this.#onRequestDelete(data)}>
-							<uui-icon name="delete"></uui-icon>
-						</uui-button>
-					</uui-action-bar>
-				</uui-table-cell>
-			</uui-table-row>`;
-		})}`;
+		if (!this._redirectData?.length) return nothing;
+		return html`
+			${repeat(
+				this._redirectData,
+				(data) => data.unique,
+				(data) => html`
+					<uui-table-row>
+						<uui-table-cell>${data.culture || '*'}</uui-table-cell>
+						<uui-table-cell>
+							<a href=${data.originalUrl || '#'} target="_blank">
+								<span>${data.originalUrl}</span>
+							</a>
+						</uui-table-cell>
+						<uui-table-cell>
+							<uui-icon name="icon-arrow-right"></uui-icon>
+						</uui-table-cell>
+						<uui-table-cell>
+							<a href=${data.destinationUrl || '#'} target="_blank">
+								<span>${data.destinationUrl}</span>
+							</a>
+						</uui-table-cell>
+						<uui-table-cell>
+							<uui-action-bar>
+								<uui-button
+									label=${this.localize.term('general_delete')}
+									look="secondary"
+									.disabled=${!this._trackerEnabled}
+									@click=${() => this.#onRequestDelete(data)}>
+									<uui-icon name="delete"></uui-icon>
+								</uui-button>
+							</uui-action-bar>
+						</uui-table-cell>
+					</uui-table-row>
+				`,
+			)}
+		`;
 	}
 
 	#renderPagination() {
 		if (!this._total) return nothing;
 
 		const totalPages = Math.ceil(this._total / this.itemsPerPage);
-
 		if (totalPages <= 1) return nothing;
 
-		return html`<div class="pagination">
-			<uui-pagination
-				.total=${totalPages}
-				firstlabel=${this.localize.term('general_first')}
-				previouslabel=${this.localize.term('general_previous')}
-				nextlabel=${this.localize.term('general_next')}
-				lastlabel=${this.localize.term('general_last')}
-				@change=${this.#onPageChange}></uui-pagination>
-		</div>`;
+		return html`
+			<div class="pagination">
+				<uui-pagination
+					.total=${totalPages}
+					firstlabel=${this.localize.term('general_first')}
+					previouslabel=${this.localize.term('general_previous')}
+					nextlabel=${this.localize.term('general_next')}
+					lastlabel=${this.localize.term('general_last')}
+					@change=${this.#onPageChange}></uui-pagination>
+			</div>
+		`;
 	}
 
 	static override styles = [
@@ -272,15 +297,18 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 			}
 
 			#redirect-wrapper {
+				--uui-box-default-padding: 0;
+
 				position: relative;
 				display: block;
-			}
-			#redirect-wrapper #grey-out {
-				position: absolute;
-				inset: 0;
-				background-color: var(--uui-color-surface-alt);
-				opacity: 0.7;
-				z-index: 1;
+
+				#grey-out {
+					position: absolute;
+					inset: 0;
+					background-color: var(--uui-color-surface-alt);
+					opacity: 0.7;
+					z-index: 1;
+				}
 			}
 
 			uui-pagination {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -18,34 +18,34 @@ import type { UUIButtonState, UUIPaginationElement, UUIPaginationEvent } from '@
 
 @customElement('umb-dashboard-redirect-management')
 export class UmbDashboardRedirectManagementElement extends UmbLitElement {
+	#repository = new UmbDocumentRedirectManagementRepository(this);
+
+	@state()
+	private _buttonState: UUIButtonState;
+
+	@state()
+	private _redirectData?: Array<UmbDocumentRedirectUrlModel>;
+
+	@state()
+	private _total = 0;
+
+	@state()
+	private _trackerEnabled = true;
+
+	@state()
+	private _filter?: string;
+
 	@property({ type: Number, attribute: 'items-per-page' })
 	itemsPerPage = 20;
 
 	@property({ type: Number })
 	page = 1;
 
-	@state()
-	private _trackerEnabled = true;
-
-	@state()
-	private _total = 0;
-
-	@state()
-	private _redirectData?: Array<UmbDocumentRedirectUrlModel>;
-
-	@state()
-	private _buttonState: UUIButtonState;
-
-	@state()
-	private _filter?: string;
-
 	@query('#search')
 	private _search!: HTMLInputElement;
 
 	@query('uui-pagination')
 	private _pagination?: UUIPaginationElement;
-
-	#repository = new UmbDocumentRedirectManagementRepository(this);
 
 	override connectedCallback() {
 		super.connectedCallback();
@@ -58,7 +58,6 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		if (data) this._trackerEnabled = data.enabled;
 	}
 
-	// Fetch data
 	async #getRedirectData(filter: string | undefined = undefined) {
 		const skip = this.page * this.itemsPerPage - this.itemsPerPage;
 		const { data } = await this.#repository.requestRedirects({ filter, take: this.itemsPerPage, skip });
@@ -70,14 +69,12 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		if (filter !== undefined) this._buttonState = 'success';
 	}
 
-	// Pagination
 	#onPageChange(event: UUIPaginationEvent) {
 		if (this.page === event.target.current) return;
 		this.page = event.target.current;
 		this.#getRedirectData();
 	}
 
-	// Delete Redirect Action
 	async #onRequestDelete(data: UmbDocumentRedirectUrlModel) {
 		if (!data.unique) return;
 
@@ -103,10 +100,10 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		this._redirectData = this._redirectData?.filter((x) => x.unique !== unique);
 	}
 
-	// Search action
 	#onKeypress(e: KeyboardEvent) {
 		if (e.key === 'Enter') this.#onSearch();
 	}
+
 	#onSearch() {
 		this._buttonState = 'waiting';
 		this._filter = this._search?.value ?? '';
@@ -116,7 +113,6 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		this.#getRedirectData(this._search.value);
 	}
 
-	// Tracker disable/enable
 	async #onRequestTrackerToggle() {
 		if (!this._trackerEnabled) {
 			this.#trackerToggle();
@@ -188,8 +184,8 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 	#renderZeroResults() {
 		return html`
 			<uui-box>
-				<strong>No redirects matching this search criteria</strong>
-				<p>Double check your search for any error or spelling mistakes.</p>
+				<strong>${this.localize.term('redirectUrls_noRedirectsForSearch')}</strong>
+				<p>${this.localize.term('redirectUrls_noRedirectsForSearchDescription')}</p>
 			</uui-box>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/index.ts
@@ -11,6 +11,7 @@ export * from './modals/index.js';
 export * from './paths.js';
 export * from './publishing/index.js';
 export * from './recycle-bin/index.js';
+export * from './redirect-management/index.js';
 export * from './reference/index.js';
 export * from './repository/index.js';
 export * from './search/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/manifests.ts
@@ -12,6 +12,7 @@ import { manifests as previewManifests } from './preview/manifests.js';
 import { manifests as propertyEditorManifests } from './property-editors/manifests.js';
 import { manifests as publishingManifests } from './publishing/manifests.js';
 import { manifests as recycleBinManifests } from './recycle-bin/manifests.js';
+import { manifests as redirectManagementManifests } from './redirect-management/manifests.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
 import { manifests as rollbackManifests } from './rollback/manifests.js';
 import { manifests as searchProviderManifests } from './search/manifests.js';
@@ -40,6 +41,7 @@ export const manifests: Array<UmbExtensionManifest | UmbExtensionManifestKind> =
 	...propertyEditorManifests,
 	...publishingManifests,
 	...recycleBinManifests,
+	...redirectManagementManifests,
 	...repositoryManifests,
 	...rollbackManifests,
 	...searchProviderManifests,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/index.ts
@@ -1,0 +1,1 @@
+export * from './repository/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -11,6 +11,7 @@ import {
 	state,
 	when,
 } from '@umbraco-cms/backoffice/external/lit';
+import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
@@ -21,6 +22,7 @@ import { debounce } from '@umbraco-cms/backoffice/utils';
 @customElement('umb-document-redirect-management-workspace-info-app')
 export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLitElement {
 	#repository = new UmbDocumentRedirectManagementRepository(this);
+	#workspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
 
 	@state()
 	private _isNew = false;
@@ -37,7 +39,6 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	@state()
 	private _redirects: Array<UmbDocumentRedirectUrlModel> = [];
 
-	#documentWorkspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
 	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 
 	constructor() {
@@ -58,25 +59,23 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 		});
 
 		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (context) => {
-			this.#documentWorkspaceContext = context;
+			this.#workspaceContext = context;
+			if (context) {
+				this.observe(
+					observeMultiple([context.isNew, context.unique]),
+					([isNew, unique]) => {
+						this._isNew = isNew === true;
 
-			this.observe(
-				context?.isNew,
-				(isNew) => {
-					this._isNew = isNew === true;
-				},
-				'observeIsNew',
-			);
-
-			this.observe(
-				context?.unique,
-				(unique) => {
-					if (!unique || unique === this._unique) return;
-					this._unique = unique;
-					this.#requestRedirects();
-				},
-				'observeUnique',
-			);
+						if (unique && unique !== this._unique) {
+							this._unique = unique;
+							this.#requestRedirects();
+						}
+					},
+					'observeWorkspaceState',
+				);
+			} else {
+				this.removeUmbControllerByAlias('observeWorkspaceState');
+			}
 		});
 
 		this.#requestTrackerStatus();
@@ -104,8 +103,8 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	#debounceRequestRedirects = debounce(() => this.#requestRedirects(), 50);
 
 	#onReloadRequest = (event: UmbEntityActionEvent) => {
-		if (event.getUnique() !== this.#documentWorkspaceContext?.getUnique()) return;
-		if (event.getEntityType() !== this.#documentWorkspaceContext.getEntityType()) return;
+		if (event.getUnique() !== this.#workspaceContext?.getUnique()) return;
+		if (event.getEntityType() !== this.#workspaceContext.getEntityType()) return;
 		this.#debounceRequestRedirects();
 	};
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -13,6 +13,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { debounce } from '@umbraco-cms/backoffice/utils';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
 import {
@@ -126,11 +127,13 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 
 		return html`
 			<umb-workspace-info-app-layout headline="#redirectUrls_redirectUrlManagement">
-				${when(
-					this._loading,
-					() => this.#renderLoading(),
-					() => this.#renderContent(),
-				)}
+				<div id="content">
+					${when(
+						this._loading,
+						() => this.#renderLoading(),
+						() => this.#renderContent(),
+					)}
+				</div>
 			</umb-workspace-info-app-layout>
 		`;
 	}
@@ -178,7 +181,17 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	}
 
 	static override styles = [
+		UmbTextStyles,
 		css`
+			:host {
+				display: contents;
+			}
+
+			#content {
+				display: block;
+				padding: var(--uui-size-space-3) var(--uui-size-space-4);
+			}
+
 			#loader-container {
 				display: flex;
 				justify-content: center;
@@ -188,7 +201,6 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 
 			.panel-information {
 				display: block;
-				padding: var(--uui-size-space-3) var(--uui-size-space-4);
 				margin: var(--uui-size-space-2);
 			}
 
@@ -198,6 +210,7 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 				align-items: center;
 				gap: var(--uui-size-6);
 				padding: var(--uui-size-space-4) var(--uui-size-space-5);
+				margin: 0 calc(var(--uui-size-space-4) * -1);
 				cursor: pointer;
 				color: inherit;
 				text-decoration: none;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -111,6 +111,7 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 
 	#getTargetUrl(url: string | undefined) {
 		if (!url || url.length === 0) return url;
+		if (url.startsWith('/')) return url;
 		if (url.includes('.') && !url.includes('//')) return '//' + url;
 		return url;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -1,4 +1,6 @@
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '../../workspace/constants.js';
+import { UmbDocumentRedirectManagementRepository } from '../repository/index.js';
+import type { UmbDocumentRedirectUrlModel } from '../repository/index.js';
 import {
 	css,
 	customElement,
@@ -15,15 +17,11 @@ import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { debounce } from '@umbraco-cms/backoffice/utils';
-import { tryExecute } from '@umbraco-cms/backoffice/resources';
-import {
-	RedirectManagementService,
-	RedirectStatusModel,
-	type RedirectUrlResponseModel,
-} from '@umbraco-cms/backoffice/external/backend-api';
 
 @customElement('umb-document-redirect-management-workspace-info-app')
 export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLitElement {
+	#repository = new UmbDocumentRedirectManagementRepository(this);
+
 	@state()
 	private _isNew = false;
 
@@ -37,7 +35,7 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	private _loading = false;
 
 	@state()
-	private _redirects: Array<RedirectUrlResponseModel> = [];
+	private _redirects: Array<UmbDocumentRedirectUrlModel> = [];
 
 	#documentWorkspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
 	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
@@ -85,9 +83,9 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	}
 
 	async #requestTrackerStatus() {
-		const { data } = await tryExecute(this, RedirectManagementService.getRedirectManagementStatus());
-		if (data?.status) {
-			this._trackerEnabled = data.status === RedirectStatusModel.ENABLED;
+		const { data } = await this.#repository.requestStatus();
+		if (data) {
+			this._trackerEnabled = data.enabled;
 		}
 	}
 
@@ -97,10 +95,7 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 
 		this._loading = true;
 
-		const { data } = await tryExecute(
-			this,
-			RedirectManagementService.getRedirectManagementById({ path: { id: this._unique } }),
-		);
+		const { data } = await this.#repository.requestByDocumentUnique(this._unique);
 
 		this._redirects = data?.items ?? [];
 		this._loading = false;
@@ -149,13 +144,13 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 			</umb-localize>
 			${repeat(
 				this._redirects,
-				(redirect) => redirect.id,
+				(redirect) => redirect.unique,
 				(redirect) => this.#renderRedirect(redirect),
 			)}
 		`;
 	}
 
-	#renderRedirect(redirect: RedirectUrlResponseModel) {
+	#renderRedirect(redirect: UmbDocumentRedirectUrlModel) {
 		return html`
 			<a
 				class="redirect-item"

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -1,0 +1,231 @@
+import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from '../../workspace/constants.js';
+import {
+	css,
+	customElement,
+	html,
+	ifDefined,
+	nothing,
+	repeat,
+	state,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { debounce } from '@umbraco-cms/backoffice/utils';
+import { tryExecute } from '@umbraco-cms/backoffice/resources';
+import {
+	RedirectManagementService,
+	RedirectStatusModel,
+	type RedirectUrlResponseModel,
+} from '@umbraco-cms/backoffice/external/backend-api';
+
+@customElement('umb-document-redirect-management-workspace-info-app')
+export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLitElement {
+	@state()
+	private _isNew = false;
+
+	@state()
+	private _unique?: string;
+
+	@state()
+	private _trackerEnabled = true;
+
+	@state()
+	private _loading = false;
+
+	@state()
+	private _redirects: Array<RedirectUrlResponseModel> = [];
+
+	#documentWorkspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
+	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_ACTION_EVENT_CONTEXT, (context) => {
+			this.#eventContext = context;
+
+			this.#eventContext?.removeEventListener(
+				UmbRequestReloadStructureForEntityEvent.TYPE,
+				this.#onReloadRequest as unknown as EventListener,
+			);
+
+			this.#eventContext?.addEventListener(
+				UmbRequestReloadStructureForEntityEvent.TYPE,
+				this.#onReloadRequest as unknown as EventListener,
+			);
+		});
+
+		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (context) => {
+			this.#documentWorkspaceContext = context;
+
+			this.observe(
+				context?.isNew,
+				(isNew) => {
+					this._isNew = isNew === true;
+				},
+				'observeIsNew',
+			);
+
+			this.observe(
+				context?.unique,
+				(unique) => {
+					if (!unique || unique === this._unique) return;
+					this._unique = unique;
+					this.#requestRedirects();
+				},
+				'observeUnique',
+			);
+		});
+
+		this.#requestTrackerStatus();
+	}
+
+	async #requestTrackerStatus() {
+		const { data } = await tryExecute(this, RedirectManagementService.getRedirectManagementStatus());
+		if (data?.status) {
+			this._trackerEnabled = data.status === RedirectStatusModel.ENABLED;
+		}
+	}
+
+	async #requestRedirects() {
+		if (this._isNew) return;
+		if (!this._unique) return;
+
+		this._loading = true;
+
+		const { data } = await tryExecute(
+			this,
+			RedirectManagementService.getRedirectManagementById({ path: { id: this._unique } }),
+		);
+
+		this._redirects = data?.items ?? [];
+		this._loading = false;
+	}
+
+	#debounceRequestRedirects = debounce(() => this.#requestRedirects(), 50);
+
+	#onReloadRequest = (event: UmbEntityActionEvent) => {
+		if (event.getUnique() !== this.#documentWorkspaceContext?.getUnique()) return;
+		if (event.getEntityType() !== this.#documentWorkspaceContext.getEntityType()) return;
+		this.#debounceRequestRedirects();
+	};
+
+	#getTargetUrl(url: string | undefined) {
+		if (!url || url.length === 0) return url;
+		if (url.includes('.') && !url.includes('//')) return '//' + url;
+		return url;
+	}
+
+	override render() {
+		if (!this._trackerEnabled) return nothing;
+		if (this._isNew) return nothing;
+		if (!this._loading && this._redirects.length === 0) return nothing;
+
+		return html`
+			<umb-workspace-info-app-layout headline="#redirectUrls_redirectUrlManagement">
+				${when(
+					this._loading,
+					() => this.#renderLoading(),
+					() => this.#renderContent(),
+				)}
+			</umb-workspace-info-app-layout>
+		`;
+	}
+
+	#renderLoading() {
+		return html`<div id="loader-container"><uui-loader></uui-loader></div>`;
+	}
+
+	#renderContent() {
+		return html`
+			<p id="panel-information">
+				<umb-localize key="redirectUrls_panelInformation">
+					The following URLs redirect to this content item:
+				</umb-localize>
+			</p>
+			${repeat(
+				this._redirects,
+				(redirect) => redirect.id,
+				(redirect) => this.#renderRedirect(redirect),
+			)}
+		`;
+	}
+
+	#renderRedirect(redirect: RedirectUrlResponseModel) {
+		return html`
+			<a
+				class="redirect-item"
+				href=${ifDefined(this.#getTargetUrl(redirect.originalUrl))}
+				target="_blank"
+				rel="noopener">
+				<span>
+					${redirect.culture ? html`<span class="culture">${redirect.culture}</span>` : nothing}
+					<span>${redirect.originalUrl}</span>
+				</span>
+				<uui-icon name="icon-out"></uui-icon>
+			</a>
+		`;
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+
+		this.#eventContext?.removeEventListener(
+			UmbRequestReloadStructureForEntityEvent.TYPE,
+			this.#onReloadRequest as unknown as EventListener,
+		);
+	}
+
+	static override styles = [
+		css`
+			#loader-container {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				padding: var(--uui-size-space-2);
+			}
+
+			#panel-information {
+				margin: 0;
+				padding: var(--uui-size-space-4) var(--uui-size-space-5);
+				color: var(--uui-color-divider-emphasis);
+			}
+
+			.redirect-item {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				gap: var(--uui-size-6);
+				padding: var(--uui-size-space-4) var(--uui-size-space-5);
+				cursor: pointer;
+				color: inherit;
+				text-decoration: none;
+
+				&:hover {
+					background: var(--uui-color-divider);
+				}
+
+				& > span {
+					display: flex;
+					align-items: center;
+					gap: var(--uui-size-6);
+				}
+
+				.culture {
+					color: var(--uui-color-divider-emphasis);
+				}
+			}
+		`,
+	];
+}
+
+export default UmbDocumentRedirectManagementWorkspaceInfoAppElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-document-redirect-management-workspace-info-app': UmbDocumentRedirectManagementWorkspaceInfoAppElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -11,16 +11,16 @@ import {
 	state,
 	when,
 } from '@umbraco-cms/backoffice/external/lit';
+import { debounce } from '@umbraco-cms/backoffice/utils';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { debounce } from '@umbraco-cms/backoffice/utils';
+import type { UmbEntityActionEvent } from '@umbraco-cms/backoffice/entity-action';
 
 @customElement('umb-document-redirect-management-workspace-info-app')
 export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLitElement {
+	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
 	#repository = new UmbDocumentRedirectManagementRepository(this);
 	#workspaceContext?: typeof UMB_DOCUMENT_WORKSPACE_CONTEXT.TYPE;
 
@@ -28,18 +28,16 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	private _isNew = false;
 
 	@state()
-	private _unique?: string;
-
-	@state()
-	private _trackerEnabled = true;
-
-	@state()
 	private _loading = false;
 
 	@state()
 	private _redirects: Array<UmbDocumentRedirectUrlModel> = [];
 
-	#eventContext?: typeof UMB_ACTION_EVENT_CONTEXT.TYPE;
+	@state()
+	private _trackerEnabled = true;
+
+	@state()
+	private _unique?: string;
 
 	constructor() {
 		super();
@@ -175,7 +173,6 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	}
 
 	static override styles = [
-		UmbTextStyles,
 		css`
 			:host {
 				display: contents;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -141,11 +141,9 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 
 	#renderContent() {
 		return html`
-			<p id="panel-information">
-				<umb-localize key="redirectUrls_panelInformation">
-					The following URLs redirect to this content item:
-				</umb-localize>
-			</p>
+			<umb-localize class="panel-information" key="redirectUrls_panelInformation">
+				The following URLs redirect to this content item:
+			</umb-localize>
 			${repeat(
 				this._redirects,
 				(redirect) => redirect.id,
@@ -188,10 +186,10 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 				padding: var(--uui-size-space-2);
 			}
 
-			#panel-information {
-				margin: 0;
-				padding: var(--uui-size-space-4) var(--uui-size-space-5);
-				color: var(--uui-color-divider-emphasis);
+			.panel-information {
+				display: block;
+				padding: var(--uui-size-space-3) var(--uui-size-space-4);
+				margin: var(--uui-size-space-2);
 			}
 
 			.redirect-item {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -117,7 +117,6 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 
 	override render() {
 		if (!this._trackerEnabled) return nothing;
-		if (this._isNew) return nothing;
 		if (!this._loading && this._redirects.length === 0) return nothing;
 
 		return html`

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/document-redirect-management-workspace-info-app.element.ts
@@ -107,7 +107,7 @@ export class UmbDocumentRedirectManagementWorkspaceInfoAppElement extends UmbLit
 	};
 
 	#getTargetUrl(url: string | undefined) {
-		if (!url || url.length === 0) return url;
+		if (!url) return url;
 		if (url.startsWith('/')) return url;
 		if (url.includes('.') && !url.includes('//')) return '//' + url;
 		return url;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/manifests.ts
@@ -1,0 +1,25 @@
+import { UMB_DOCUMENT_WORKSPACE_ALIAS } from '../../workspace/constants.js';
+import {
+	UMB_WORKSPACE_CONDITION_ALIAS,
+	UMB_WORKSPACE_ENTITY_IS_NEW_CONDITION_ALIAS,
+} from '@umbraco-cms/backoffice/workspace';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'workspaceInfoApp',
+		name: 'Document Redirect Management Workspace Info App',
+		alias: 'Umb.WorkspaceInfoApp.Document.RedirectManagement',
+		element: () => import('./document-redirect-management-workspace-info-app.element.js'),
+		weight: 80,
+		conditions: [
+			{
+				alias: UMB_WORKSPACE_CONDITION_ALIAS,
+				match: UMB_DOCUMENT_WORKSPACE_ALIAS,
+			},
+			{
+				alias: UMB_WORKSPACE_ENTITY_IS_NEW_CONDITION_ALIAS,
+				match: false,
+			},
+		],
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/info-app/manifests.ts
@@ -10,7 +10,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		name: 'Document Redirect Management Workspace Info App',
 		alias: 'Umb.WorkspaceInfoApp.Document.RedirectManagement',
 		element: () => import('./document-redirect-management-workspace-info-app.element.js'),
-		weight: 80,
+		weight: 85,
 		conditions: [
 			{
 				alias: UMB_WORKSPACE_CONDITION_ALIAS,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/manifests.ts
@@ -1,0 +1,3 @@
+import { manifests as infoAppManifests } from './info-app/manifests.js';
+
+export const manifests: Array<UmbExtensionManifest> = [...infoAppManifests];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/manifests.ts
@@ -1,3 +1,4 @@
 import { manifests as infoAppManifests } from './info-app/manifests.js';
+import { manifests as repositoryManifests } from './repository/manifests.js';
 
-export const manifests: Array<UmbExtensionManifest> = [...infoAppManifests];
+export const manifests: Array<UmbExtensionManifest> = [...infoAppManifests, ...repositoryManifests];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_DOCUMENT_REDIRECT_MANAGEMENT_REPOSITORY_ALIAS = 'Umb.Repository.Document.RedirectManagement';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/constants.ts
@@ -1,1 +1,4 @@
+/**
+ * The extension alias for the document redirect management repository.
+ */
 export const UMB_DOCUMENT_REDIRECT_MANAGEMENT_REPOSITORY_ALIAS = 'Umb.Repository.Document.RedirectManagement';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.repository.ts
@@ -3,26 +3,60 @@ import { UmbDocumentRedirectManagementServerDataSource } from './document-redire
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 
+/**
+ * Repository for managing document redirect URLs.
+ * @class UmbDocumentRedirectManagementRepository
+ * @augments {UmbControllerBase}
+ */
 export class UmbDocumentRedirectManagementRepository extends UmbControllerBase implements UmbApi {
 	#dataSource = new UmbDocumentRedirectManagementServerDataSource(this);
 
+	/**
+	 * Gets the current redirect URL tracker status.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementRepository
+	 */
 	async requestStatus() {
 		return this.#dataSource.getStatus();
 	}
 
+	/**
+	 * Enables or disables the redirect URL tracker.
+	 * @param {boolean} enabled - Whether the tracker should be enabled.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementRepository
+	 */
 	async setStatus(enabled: boolean) {
 		return this.#dataSource.setStatus(enabled);
 	}
 
+	/**
+	 * Gets the redirects pointing to a specific document.
+	 * @param {string} unique - The document unique identifier.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementRepository
+	 */
 	async requestByDocumentUnique(unique: string) {
 		if (!unique) throw new Error('Unique is missing');
 		return this.#dataSource.getByDocumentUnique(unique);
 	}
 
+	/**
+	 * Gets a paginated, filtered list of redirects.
+	 * @param {UmbDocumentRedirectFilterArgs} [args] - Optional filter, skip and take arguments.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementRepository
+	 */
 	async requestRedirects(args: UmbDocumentRedirectFilterArgs = {}) {
 		return this.#dataSource.filter(args);
 	}
 
+	/**
+	 * Deletes a redirect by its unique identifier.
+	 * @param {string} unique - The redirect unique identifier.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementRepository
+	 */
 	async delete(unique: string) {
 		if (!unique) throw new Error('Unique is missing');
 		return this.#dataSource.delete(unique);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.repository.ts
@@ -1,0 +1,32 @@
+import type { UmbDocumentRedirectFilterArgs } from './types.js';
+import { UmbDocumentRedirectManagementServerDataSource } from './document-redirect-management.server.data-source.js';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+
+export class UmbDocumentRedirectManagementRepository extends UmbControllerBase implements UmbApi {
+	#dataSource = new UmbDocumentRedirectManagementServerDataSource(this);
+
+	async requestStatus() {
+		return this.#dataSource.getStatus();
+	}
+
+	async setStatus(enabled: boolean) {
+		return this.#dataSource.setStatus(enabled);
+	}
+
+	async requestByDocumentUnique(unique: string) {
+		if (!unique) throw new Error('Unique is missing');
+		return this.#dataSource.getByDocumentUnique(unique);
+	}
+
+	async requestRedirects(args: UmbDocumentRedirectFilterArgs = {}) {
+		return this.#dataSource.filter(args);
+	}
+
+	async delete(unique: string) {
+		if (!unique) throw new Error('Unique is missing');
+		return this.#dataSource.delete(unique);
+	}
+}
+
+export { UmbDocumentRedirectManagementRepository as api };

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -38,7 +38,6 @@ export class UmbDocumentRedirectManagementServerDataSource {
 
 		const model: UmbDocumentRedirectStatusModel = {
 			enabled: data.status === RedirectStatusModel.ENABLED,
-			userIsAdmin: data.userIsAdmin,
 		};
 
 		return { data: model };
@@ -66,8 +65,6 @@ export class UmbDocumentRedirectManagementServerDataSource {
 	 * @memberof UmbDocumentRedirectManagementServerDataSource
 	 */
 	async getByDocumentUnique(unique: string) {
-		if (!unique) throw new Error('Unique is missing');
-
 		const { data, error } = await tryExecute(
 			this.#host,
 			RedirectManagementService.getRedirectManagementById({ path: { id: unique } }),
@@ -79,7 +76,7 @@ export class UmbDocumentRedirectManagementServerDataSource {
 
 		return {
 			data: {
-				items: (data.items ?? []).map(mapRedirectUrl),
+				items: data.items.map(mapRedirectUrl),
 				total: data.total,
 			},
 		};
@@ -105,7 +102,7 @@ export class UmbDocumentRedirectManagementServerDataSource {
 
 		return {
 			data: {
-				items: (data.items ?? []).map(mapRedirectUrl),
+				items: data.items.map(mapRedirectUrl),
 				total: data.total,
 			},
 		};
@@ -118,7 +115,6 @@ export class UmbDocumentRedirectManagementServerDataSource {
 	 * @memberof UmbDocumentRedirectManagementServerDataSource
 	 */
 	async delete(unique: string) {
-		if (!unique) throw new Error('Unique is missing');
 		const { error } = await tryExecute(
 			this.#host,
 			RedirectManagementService.deleteRedirectManagementById({ path: { id: unique } }),

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -123,7 +123,5 @@ const mapRedirectUrl = (item: RedirectUrlResponseModel): UmbDocumentRedirectUrlM
 	unique: item.id,
 	originalUrl: item.originalUrl,
 	destinationUrl: item.destinationUrl,
-	created: item.created,
-	documentUnique: item.document.id,
 	culture: item.culture ?? null,
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -3,10 +3,10 @@ import type {
 	UmbDocumentRedirectStatusModel,
 	UmbDocumentRedirectUrlModel,
 } from './types.js';
+import { tryExecute } from '@umbraco-cms/backoffice/resources';
 import { RedirectManagementService, RedirectStatusModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { RedirectUrlResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { tryExecute } from '@umbraco-cms/backoffice/resources';
 
 /**
  * A data source for the Document Redirect Management feature that fetches data from the server.
@@ -52,7 +52,11 @@ export class UmbDocumentRedirectManagementServerDataSource {
 	 */
 	async setStatus(enabled: boolean) {
 		const status = enabled ? RedirectStatusModel.ENABLED : RedirectStatusModel.DISABLED;
-		return tryExecute(this.#host, RedirectManagementService.postRedirectManagementStatus({ query: { status } }));
+		const { error } = await tryExecute(
+			this.#host,
+			RedirectManagementService.postRedirectManagementStatus({ query: { status } }),
+		);
+		return { error };
 	}
 
 	/**
@@ -115,7 +119,11 @@ export class UmbDocumentRedirectManagementServerDataSource {
 	 */
 	async delete(unique: string) {
 		if (!unique) throw new Error('Unique is missing');
-		return tryExecute(this.#host, RedirectManagementService.deleteRedirectManagementById({ path: { id: unique } }));
+		const { error } = await tryExecute(
+			this.#host,
+			RedirectManagementService.deleteRedirectManagementById({ path: { id: unique } }),
+		);
+		return { error };
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -15,10 +15,20 @@ import { tryExecute } from '@umbraco-cms/backoffice/resources';
 export class UmbDocumentRedirectManagementServerDataSource {
 	#host: UmbControllerHost;
 
+	/**
+	 * Creates an instance of UmbDocumentRedirectManagementServerDataSource.
+	 * @param {UmbControllerHost} host - The controller host for this controller to be appended to.
+	 * @memberof UmbDocumentRedirectManagementServerDataSource
+	 */
 	constructor(host: UmbControllerHost) {
 		this.#host = host;
 	}
 
+	/**
+	 * Gets the current redirect URL tracker status.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementServerDataSource
+	 */
 	async getStatus() {
 		const { data, error } = await tryExecute(this.#host, RedirectManagementService.getRedirectManagementStatus());
 
@@ -34,11 +44,23 @@ export class UmbDocumentRedirectManagementServerDataSource {
 		return { data: model };
 	}
 
+	/**
+	 * Enables or disables the redirect URL tracker.
+	 * @param {boolean} enabled - Whether the tracker should be enabled.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementServerDataSource
+	 */
 	async setStatus(enabled: boolean) {
 		const status = enabled ? RedirectStatusModel.ENABLED : RedirectStatusModel.DISABLED;
 		return tryExecute(this.#host, RedirectManagementService.postRedirectManagementStatus({ query: { status } }));
 	}
 
+	/**
+	 * Gets the redirects pointing to a specific document.
+	 * @param {string} unique - The document unique identifier.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementServerDataSource
+	 */
 	async getByDocumentUnique(unique: string) {
 		if (!unique) throw new Error('Unique is missing');
 
@@ -59,6 +81,12 @@ export class UmbDocumentRedirectManagementServerDataSource {
 		};
 	}
 
+	/**
+	 * Gets a paginated, filtered list of redirects.
+	 * @param {UmbDocumentRedirectFilterArgs} args - Filter, skip and take arguments.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementServerDataSource
+	 */
 	async filter(args: UmbDocumentRedirectFilterArgs) {
 		const { data, error } = await tryExecute(
 			this.#host,
@@ -79,6 +107,12 @@ export class UmbDocumentRedirectManagementServerDataSource {
 		};
 	}
 
+	/**
+	 * Deletes a redirect by its unique identifier.
+	 * @param {string} unique - The redirect unique identifier.
+	 * @returns {*}
+	 * @memberof UmbDocumentRedirectManagementServerDataSource
+	 */
 	async delete(unique: string) {
 		if (!unique) throw new Error('Unique is missing');
 		return tryExecute(this.#host, RedirectManagementService.deleteRedirectManagementById({ path: { id: unique } }));

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -1,0 +1,95 @@
+import type {
+	UmbDocumentRedirectFilterArgs,
+	UmbDocumentRedirectStatusModel,
+	UmbDocumentRedirectUrlModel,
+} from './types.js';
+import { RedirectManagementService, RedirectStatusModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { RedirectUrlResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { tryExecute } from '@umbraco-cms/backoffice/resources';
+
+/**
+ * A data source for the Document Redirect Management feature that fetches data from the server.
+ * @class UmbDocumentRedirectManagementServerDataSource
+ */
+export class UmbDocumentRedirectManagementServerDataSource {
+	#host: UmbControllerHost;
+
+	constructor(host: UmbControllerHost) {
+		this.#host = host;
+	}
+
+	async getStatus() {
+		const { data, error } = await tryExecute(this.#host, RedirectManagementService.getRedirectManagementStatus());
+
+		if (error || !data) {
+			return { error };
+		}
+
+		const model: UmbDocumentRedirectStatusModel = {
+			enabled: data.status === RedirectStatusModel.ENABLED,
+			userIsAdmin: data.userIsAdmin,
+		};
+
+		return { data: model };
+	}
+
+	async setStatus(enabled: boolean) {
+		const status = enabled ? RedirectStatusModel.ENABLED : RedirectStatusModel.DISABLED;
+		return tryExecute(this.#host, RedirectManagementService.postRedirectManagementStatus({ query: { status } }));
+	}
+
+	async getByDocumentUnique(unique: string) {
+		if (!unique) throw new Error('Unique is missing');
+
+		const { data, error } = await tryExecute(
+			this.#host,
+			RedirectManagementService.getRedirectManagementById({ path: { id: unique } }),
+		);
+
+		if (error || !data) {
+			return { error };
+		}
+
+		return {
+			data: {
+				items: (data.items ?? []).map(mapRedirectUrl),
+				total: data.total,
+			},
+		};
+	}
+
+	async filter(args: UmbDocumentRedirectFilterArgs) {
+		const { data, error } = await tryExecute(
+			this.#host,
+			RedirectManagementService.getRedirectManagement({
+				query: { filter: args.filter, skip: args.skip, take: args.take },
+			}),
+		);
+
+		if (error || !data) {
+			return { error };
+		}
+
+		return {
+			data: {
+				items: (data.items ?? []).map(mapRedirectUrl),
+				total: data.total,
+			},
+		};
+	}
+
+	async delete(unique: string) {
+		if (!unique) throw new Error('Unique is missing');
+		return tryExecute(this.#host, RedirectManagementService.deleteRedirectManagementById({ path: { id: unique } }));
+	}
+}
+
+const mapRedirectUrl = (item: RedirectUrlResponseModel): UmbDocumentRedirectUrlModel => ({
+	unique: item.id,
+	originalUrl: item.originalUrl,
+	destinationUrl: item.destinationUrl,
+	created: item.created,
+	documentUnique: item.document.id,
+	culture: item.culture ?? null,
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/index.ts
@@ -1,0 +1,7 @@
+export { UmbDocumentRedirectManagementRepository } from './document-redirect-management.repository.js';
+export { UMB_DOCUMENT_REDIRECT_MANAGEMENT_REPOSITORY_ALIAS } from './constants.js';
+export type {
+	UmbDocumentRedirectFilterArgs,
+	UmbDocumentRedirectStatusModel,
+	UmbDocumentRedirectUrlModel,
+} from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/manifests.ts
@@ -1,0 +1,10 @@
+import { UMB_DOCUMENT_REDIRECT_MANAGEMENT_REPOSITORY_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'repository',
+		alias: UMB_DOCUMENT_REDIRECT_MANAGEMENT_REPOSITORY_ALIAS,
+		name: 'Document Redirect Management Repository',
+		api: () => import('./document-redirect-management.repository.js'),
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
@@ -13,7 +13,6 @@ export interface UmbDocumentRedirectUrlModel {
  */
 export interface UmbDocumentRedirectStatusModel {
 	enabled: boolean;
-	userIsAdmin: boolean;
 }
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Represents a single redirect URL associated with a document.
+ */
 export interface UmbDocumentRedirectUrlModel {
 	unique: string;
 	originalUrl: string;
@@ -7,11 +10,17 @@ export interface UmbDocumentRedirectUrlModel {
 	culture: string | null;
 }
 
+/**
+ * Represents the redirect URL tracker status.
+ */
 export interface UmbDocumentRedirectStatusModel {
 	enabled: boolean;
 	userIsAdmin: boolean;
 }
 
+/**
+ * Filter arguments for paginated redirect URL queries.
+ */
 export interface UmbDocumentRedirectFilterArgs {
 	filter?: string;
 	skip?: number;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
@@ -1,0 +1,19 @@
+export interface UmbDocumentRedirectUrlModel {
+	unique: string;
+	originalUrl: string;
+	destinationUrl: string;
+	created: string;
+	documentUnique: string;
+	culture: string | null;
+}
+
+export interface UmbDocumentRedirectStatusModel {
+	enabled: boolean;
+	userIsAdmin: boolean;
+}
+
+export interface UmbDocumentRedirectFilterArgs {
+	filter?: string;
+	skip?: number;
+	take?: number;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/types.ts
@@ -5,8 +5,6 @@ export interface UmbDocumentRedirectUrlModel {
 	unique: string;
 	originalUrl: string;
 	destinationUrl: string;
-	created: string;
-	documentUnique: string;
 	culture: string | null;
 }
 


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/22619

# Notes
It seems that when implementing the new backoffice, the "Redirect URL Management" workspace was missed. 
Here is how it looks in v13: 
<img width="2005" height="1255" alt="image" src="https://github.com/user-attachments/assets/d3c0c6b6-e753-4a7c-a107-a2157261d23b" />

This PR now remedies that, by implementing a "Redirect URL Management" workspace. 
All the backend endpoints was already implemented, so this was just a case of creating the workspace and using the endpoints 😁 

How it looks with the new workspace:
<img width="1825" height="1237" alt="image" src="https://github.com/user-attachments/assets/aac92b15-877a-48e3-9af6-bdbfb62b3f31" />

# How to test
- Create a document type with allowed as root.
- Create 2 documents from the document type, lets name the first "root", and the other "test"
- You should be able to navigate to `https://localhost:44339/test`
- Now rename the "Test" document to something else.
- Now there should be a "Redirect Url Management" with the old url displayed 💪 