### PR TITLE
Localization: Use invariant culture when parsing node paths (closes #22610)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Services/Entities/UserStartNodeEntitiesService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/Entities/UserStartNodeEntitiesService.cs
@@ -113,15 +113,23 @@ public class UserStartNodeEntitiesService : IUserStartNodeEntitiesService
         return ChildUserAccessEntities(children, userStartNodePaths);
     }
 
-    private static List<int> GetAllowedIds(string[] userStartNodePaths, int parentId)
+    /// <summary>
+    /// For each user start node path that contains <paramref name="parentId"/>, collects the ID of
+    /// the segment immediately after the parent and returns the distinct set. E.g. given paths
+    /// ["-1,2,3,4,5", "-1,2,3,9,10"] and a parent ID of 3, the returned "next child IDs" are [4, 9].
+    /// </summary>
+    /// <param name="userStartNodePaths">The user's start node paths (comma-delimited integer IDs).</param>
+    /// <param name="parentId">The parent ID to locate within each path.</param>
+    /// <returns>The distinct "next child IDs" across all paths that contain the parent.</returns>
+    /// <remarks>
+    /// Internal rather than private so it can be unit-tested directly.
+    /// </remarks>
+    internal static List<int> GetAllowedIds(string[] userStartNodePaths, int parentId)
     {
-        // If one or more of the user start nodes are descendants of the requested parent, find the "next child IDs" in those user start node paths
-        // that are the final entries in the path.
-        // E.g. given the user start node path "-1,2,3,4,5", if the requested parent ID is 3, the "next child ID" is 4.
-        var userStartNodePathIds = userStartNodePaths.Select(path => path.Split(Constants.CharArrays.Comma).Select(int.Parse).ToArray()).ToArray();
+        var userStartNodePathIds = userStartNodePaths.Select(path => path.GetIdsFromPath()).ToArray();
         return userStartNodePathIds
             .Where(ids => ids.Contains(parentId))
-            .Select(ids => ids[ids.IndexOf(parentId) + 1]) // Given the previous checks, the parent ID can never be the last in the user start node path, so this is safe
+            .Select(ids => ids[ids.IndexOf(parentId) + 1]) // Given the previous checks, the parent ID can never be the last in the user start node path, so this is safe.
             .Distinct()
             .ToList();
     }

--- a/src/Umbraco.Core/Extensions/StringExtensions.Parsing.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Parsing.cs
@@ -21,11 +21,16 @@ public static partial class StringExtensions
 #pragma warning restore IDE1006 // Naming Styles
 
     /// <summary>
-    /// Converts a path string to an array of node IDs in reverse order (deepest to shallowest).
+    /// Converts a path string to an array of node IDs, in path order (shallowest to deepest).
     /// </summary>
     /// <param name="path">The path string, expected as a comma-delimited collection of integers.</param>
-    /// <returns>An array of integers matching the provided path, in reverse order.</returns>
-    public static int[] GetIdsFromPathReversed(this string path)
+    /// <returns>An array of integers matching the provided path.</returns>
+    /// <remarks>
+    /// Parsing uses <see cref="CultureInfo.InvariantCulture"/> because paths persist the root
+    /// marker as ASCII "-1", which fails to parse under cultures whose
+    /// <see cref="NumberFormatInfo.NegativeSign"/> is not the ASCII hyphen-minus.
+    /// </remarks>
+    public static int[] GetIdsFromPath(this string path)
     {
         ReadOnlySpan<char> pathSpan = path.AsSpan();
 
@@ -44,14 +49,22 @@ public static partial class StringExtensions
             }
         }
 
-        var result = new int[nodeIds.Count];
-        var resultIndex = 0;
-        for (int i = nodeIds.Count - 1; i >= 0; i--)
-        {
-            result[resultIndex++] = nodeIds[i];
-        }
+        return [.. nodeIds];
+    }
 
-        return result;
+    /// <summary>
+    /// Converts a path string to an array of node IDs in reverse order (deepest to shallowest).
+    /// </summary>
+    /// <param name="path">The path string, expected as a comma-delimited collection of integers.</param>
+    /// <returns>An array of integers matching the provided path, in reverse order.</returns>
+    /// <remarks>
+    /// See <see cref="GetIdsFromPath"/> for parsing semantics.
+    /// </remarks>
+    public static int[] GetIdsFromPathReversed(this string path)
+    {
+        int[] ids = path.GetIdsFromPath();
+        Array.Reverse(ids);
+        return ids;
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -389,7 +389,7 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
             // at this point the parent MUST exist - unless someone starts using this move method
             // e.g. for blueprints (which should be handled elsewhere).
             TContent parentContent = ContentService.GetById(parentKey.Value) ?? throw new InvalidOperationException("The content parent ID was validated, but the parent was not found");
-            if (parentContent.Path.Split(Constants.CharArrays.Comma).Select(int.Parse).Contains(content.Id) is true)
+            if (parentContent.Path.GetIdsFromPath().Contains(content.Id))
             {
                 return Attempt.FailWithStatus<TContent?, ContentEditingOperationStatus>(ContentEditingOperationStatus.ParentInvalid, content);
             }

--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -223,7 +223,7 @@ internal sealed class RedirectTracker : IRedirectTracker
     }
 
     private int GetNodeIdWithAssignedDomain(IPublishedContent entityContent) =>
-        entityContent.Path.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).Reverse()
+        entityContent.Path.GetIdsFromPathReversed()
             .FirstOrDefault(x => _domainCache.HasAssigned(x, includeWildcards: true));
 
     private string GetUrl(Guid contentKey, string languageIsoCode) =>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Move.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Move.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Globalization;
+using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services.OperationStatus;
@@ -195,5 +196,36 @@ public partial class ContentEditingServiceTests
         var result = await ContentEditingService.MoveAsync(root.Key, child.Key, Constants.Security.SuperUserKey);
         Assert.IsFalse(result.Success);
         Assert.AreEqual(ContentEditingOperationStatus.ParentInvalid, result.Status);
+    }
+
+    /// <summary>
+    /// Regression test for <see href="https://github.com/umbraco/Umbraco-CMS/issues/22610"/>:
+    /// restoring a content item from the recycle bin under Arabic culture failed because the
+    /// parent path's "-1" root marker could not be parsed under ar-EG's
+    /// <see cref="NumberFormatInfo.NegativeSign"/> (U+061C + hyphen).
+    /// </summary>
+    [Test]
+    public async Task Can_Restore_From_Recycle_Bin_Under_Arabic_Culture()
+    {
+        var contentType = await CreateTextPageContentTypeAsync();
+        (IContent root, IContent child) = await CreateRootAndChildAsync(contentType);
+
+        var moveToRecycleBinResult = await ContentEditingService.MoveToRecycleBinAsync(child.Key, Constants.Security.SuperUserKey);
+        Assert.IsTrue(moveToRecycleBinResult.Success);
+
+        var savedCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("ar-EG");
+
+            var result = await ContentEditingService.RestoreAsync(child.Key, root.Key, Constants.Security.SuperUserKey);
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = savedCulture;
+        }
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Move.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Move.cs
@@ -218,6 +218,14 @@ public partial class ContentEditingServiceTests
         {
             CultureInfo.CurrentCulture = new CultureInfo("ar-EG");
 
+            // Sanity-check that the runtime's culture data actually triggers the bug. If a future
+            // ICU/NLS update reverts ar-EG's NegativeSign to a plain ASCII hyphen, this test would
+            // silently pass without exercising anything; skip rather than give false confidence.
+            Assume.That(
+                CultureInfo.CurrentCulture.NumberFormat.NegativeSign,
+                Is.Not.EqualTo("-"),
+                "ar-EG NegativeSign is plain ASCII hyphen on this host; cannot reproduce #22610.");
+
             var result = await ContentEditingService.RestoreAsync(child.Key, root.Key, Constants.Security.SuperUserKey);
 
             Assert.IsTrue(result.Success);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/UserStartNodeEntitiesServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Services/UserStartNodeEntitiesServiceTests.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Services.Entities;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Services;
+
+[TestFixture]
+public class UserStartNodeEntitiesServiceTests
+{
+    [Test]
+    public void GetAllowedIds_Returns_Next_Child_Ids_For_Paths_Containing_Parent()
+    {
+        string[] startNodePaths = ["-1,2,3,4,5", "-1,2,3,9,10"];
+
+        var allowed = UserStartNodeEntitiesService.GetAllowedIds(startNodePaths, parentId: 3);
+
+        CollectionAssert.AreEquivalent(new[] { 4, 9 }, allowed);
+    }
+
+    [Test]
+    public void GetAllowedIds_Returns_Empty_When_No_Path_Contains_Parent()
+    {
+        string[] startNodePaths = ["-1,2,3,4,5"];
+
+        var allowed = UserStartNodeEntitiesService.GetAllowedIds(startNodePaths, parentId: 99);
+
+        Assert.IsEmpty(allowed);
+    }
+
+    // Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22610: under cultures whose
+    // NumberFormatInfo.NegativeSign is not the ASCII hyphen-minus, int.Parse("-1") with no
+    // IFormatProvider throws because the parser uses CultureInfo.CurrentCulture. Start-node paths
+    // persist the root marker as ASCII "-1".
+    [Test]
+    public void GetAllowedIds_Parses_Root_Marker_Under_Culture_With_Non_Ascii_Negative_Sign()
+    {
+        var savedCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            // Mirrors ar-EG's NegativeSign under ICU (U+061C ARABIC LETTER MARK + ASCII hyphen).
+            // Using an explicit clone keeps the test deterministic regardless of which ICU version
+            // is installed on the test host.
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NegativeSign = "؜-";
+            CultureInfo.CurrentCulture = culture;
+
+            string[] startNodePaths = ["-1,2,3,4,5"];
+
+            var allowed = UserStartNodeEntitiesService.GetAllowedIds(startNodePaths, parentId: 3);
+
+            CollectionAssert.AreEqual(new[] { 4 }, allowed);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = savedCulture;
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -438,6 +438,31 @@ public class StringExtensionsTests
         }
     }
 
+    [TestCase("#")]
+    [TestCase("")]
+    [TestCase("123")]
+    [TestCase("abc")]
+    [TestCase("-")]
+    [TestCase("+")]
+    [TestCase("؜-")] // ar-EG's NegativeSign under ICU (U+061C ARABIC LETTER MARK + ASCII hyphen)
+    public void GetIdsFromPath_And_Reversed_Parse_Root_Marker_Under_Culture_With_Different_Negative_Sign(string negativeSign)
+    {
+        var savedCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NegativeSign = negativeSign;
+            CultureInfo.CurrentCulture = culture;
+
+            CollectionAssert.AreEqual(new[] { -1, 1234, 5678 }, "-1,1234,5678".GetIdsFromPath());
+            CollectionAssert.AreEqual(new[] { 5678, 1234, -1 }, "-1,1234,5678".GetIdsFromPathReversed());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = savedCulture;
+        }
+    }
+
     [TestCase(null, null)]
     [TestCase("", "")]
     [TestCase("*", "*")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/ShortStringHelper/StringExtensionsTests.cs
@@ -391,12 +391,51 @@ public class StringExtensionsTests
 
     [TestCase(null, "")]
     [TestCase("", "")]
+    [TestCase("1,2,3,4,5", "1,2,3,4,5")]
+    [TestCase("1,2,x,4,5", "1,2,4,5")]
+    [TestCase("-1,1234,5678", "-1,1234,5678")]
+    public void GetIdsFromPath_ReturnsExpectedResult(string input, string expected)
+    {
+        var ids = input.GetIdsFromPath();
+        Assert.AreEqual(expected, string.Join(",", ids.Select(i => i.ToString(CultureInfo.InvariantCulture))));
+    }
+
+    [TestCase(null, "")]
+    [TestCase("", "")]
     [TestCase("1,2,3,4,5", "5,4,3,2,1")]
     [TestCase("1,2,x,4,5", "5,4,2,1")]
+    [TestCase("-1,1234,5678", "5678,1234,-1")]
     public void GetIdsFromPathReversed_ReturnsExpectedResult(string input, string expected)
     {
         var ids = input.GetIdsFromPathReversed();
-        Assert.AreEqual(expected, string.Join(",", ids));
+        Assert.AreEqual(expected, string.Join(",", ids.Select(i => i.ToString(CultureInfo.InvariantCulture))));
+    }
+
+    // Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22610: under cultures whose
+    // NumberFormatInfo.NegativeSign is not the ASCII hyphen-minus (e.g. ar-EG under ICU, where
+    // NegativeSign is U+061C followed by a hyphen), int.Parse("-1") with no IFormatProvider throws
+    // because the parser uses CultureInfo.CurrentCulture. Content paths persist the root marker
+    // as ASCII "-1", so the path-id parsers must use invariant culture.
+    [Test]
+    public void GetIdsFromPath_And_Reversed_Parse_Root_Marker_Under_Culture_With_Non_Ascii_Negative_Sign()
+    {
+        var savedCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            // Mirrors ar-EG's NegativeSign under ICU (U+061C ARABIC LETTER MARK + ASCII hyphen).
+            // Using an explicit clone keeps the test deterministic regardless of which ICU version
+            // is installed on the test host.
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NegativeSign = "؜-";
+            CultureInfo.CurrentCulture = culture;
+
+            CollectionAssert.AreEqual(new[] { -1, 1234, 5678 }, "-1,1234,5678".GetIdsFromPath());
+            CollectionAssert.AreEqual(new[] { 5678, 1234, -1 }, "-1,1234,5678".GetIdsFromPathReversed());
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = savedCulture;
+        }
     }
 
     [TestCase(null, null)]


### PR DESCRIPTION
## Description

#22610 reports that restoring a content item from the recycle bin under an Arabic backoffice user language (`ar-EG`) failed with `FormatException: The input string '-1' was not in a correct format.` The exception originated in `ContentEditingServiceBase.HandleMoveAsync`, where the parent's `Path` was split on commas and each segment passed to `int.Parse(string)` with no `IFormatProvider`.

We've had this issue a few times before - mostly as I recall with the "Swedish -1" - and I couldn't replicate this myself (possibly not an issue on Windows?).  That said, the code reveals the issue and we need the same fix as in other, previous cases.

`int.Parse(string)` uses `NumberFormatInfo.CurrentInfo`, i.e. `CultureInfo.CurrentCulture.NumberFormat`. Under .NET's ICU globalization, several cultures define a `NegativeSign` that is **not** the ASCII hyphen-minus.

Every Umbraco content `Path` begins with `-1` (the root) using the literal ASCII hyphen, so `int.Parse("-1")` fails when the request runs under one of these cultures.

As well as in the specific case, I found two other places where we do similar operations on the `Path` and needed the same fix.  To do that I've moved the operations into shared helper methods, which can be unit tested.

The new helpers use `int.TryParse` (silently skip non-numeric segments), where the original inline calls used `int.Parse` (throw). For real Umbraco paths — which are always well-formed comma-delimited integers — this is equivalent. So there's no change in behaviour in practice. 

## Testing

### Automated

Unit tests are added for the new helpers and the `GetAllowedIds` method on `UserStartNodeEntitiesService` (which was made internal to allow this.

A single integration test is added for the specific reported case, verifying that a restore from the recycle bin will occur without error under Arabic culture.

### Manual

See issue report but note that I haven't been able to replicate on Windows.  I think the test coverage and the fact we've seen and dealt with this same issue before in the same way should suffice if the reviewer can't either.