### PR TITLE
Enable single blocklist migration

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -187,8 +187,7 @@ public partial class UmbracoPlan : MigrationPlan
         To<V_17_4_0.FixLabelDataTypeDbTypeFromConfiguration>("{3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}");
 
         // To 18.0.0
-        // TODO (V18): Enable on 18 branch
-        ////To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");
+        To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -68,8 +68,8 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         IDataTypeService dataTypeService,
         ILogger<MigrateSingleBlockList> logger,
         ICoreScopeProvider coreScopeProvider,
-        SingleBlockListProcessor  singleBlockListProcessor,
-        IJsonSerializer  jsonSerializer,
+        SingleBlockListProcessor singleBlockListProcessor,
+        IJsonSerializer jsonSerializer,
         SingleBlockListConfigurationCache blockListConfigurationCache,
         IDataValueEditorFactory dataValueEditorFactory,
         IIOHelper ioHelper,
@@ -153,7 +153,7 @@ public class MigrateSingleBlockList : AsyncMigrationBase
                 _logger.LogInformation(
                     "No properties have been found to migrate for {propertyEditorAlias}",
                     propertyEditorAlias);
-                return;
+                continue;
             }
 
             updateItemsByPropertyEditorAlias[propertyEditorAlias] = updateItemsByPropertyType;

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -30,6 +30,7 @@ public class MigrateSingleBlockList : AsyncMigrationBase
     private readonly ILanguageService _languageService;
     private readonly IContentTypeService _contentTypeService;
     private readonly IMediaTypeService _mediaTypeService;
+    private readonly IMemberTypeService _memberTypeService;
     private readonly IDataTypeService _dataTypeService;
     private readonly ICoreScopeProvider _coreScopeProvider;
     private readonly SingleBlockListProcessor _singleBlockListProcessor;
@@ -48,6 +49,7 @@ public class MigrateSingleBlockList : AsyncMigrationBase
     /// <param name="languageService">Service for managing languages in Umbraco.</param>
     /// <param name="contentTypeService">Service for managing content types.</param>
     /// <param name="mediaTypeService">Service for managing media types.</param>
+    /// <param name="memberTypeService">Service for managing member types.</param>
     /// <param name="dataTypeService">Service for managing data types.</param>
     /// <param name="logger">The logger used for logging migration operations.</param>
     /// <param name="coreScopeProvider">Provides scope management for database operations.</param>
@@ -65,6 +67,7 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         ILanguageService languageService,
         IContentTypeService contentTypeService,
         IMediaTypeService mediaTypeService,
+        IMemberTypeService memberTypeService,
         IDataTypeService dataTypeService,
         ILogger<MigrateSingleBlockList> logger,
         ICoreScopeProvider coreScopeProvider,
@@ -82,6 +85,7 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         _languageService = languageService;
         _contentTypeService = contentTypeService;
         _mediaTypeService = mediaTypeService;
+        _memberTypeService = memberTypeService;
         _dataTypeService = dataTypeService;
         _logger = logger;
         _coreScopeProvider = coreScopeProvider;
@@ -111,9 +115,13 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         IEnumerable<IPropertyType> mediaPropertyTypes = allMediaTypes
             .SelectMany(ct => ct.PropertyTypes);
 
+        IMemberType[] allMemberTypes = _memberTypeService.GetAll().ToArray();
+        IEnumerable<IPropertyType> memberPropertyTypes = allMemberTypes
+            .SelectMany(mt => mt.PropertyTypes);
+
         // get all relevantPropertyTypes
         var relevantPropertyEditors =
-            contentPropertyTypes.Concat(mediaPropertyTypes).DistinctBy(pt => pt.Id)
+            contentPropertyTypes.Concat(mediaPropertyTypes).Concat(memberPropertyTypes).DistinctBy(pt => pt.Id)
                 .Where(pt => propertyEditorAliases.Contains(pt.PropertyEditorAlias))
                 .GroupBy(pt => pt.PropertyEditorAlias)
                 .ToDictionary(group => group.Key, group => group.ToArray());

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -165,7 +165,7 @@ public class MigrateSingleBlockList : AsyncMigrationBase
         string updateSql = $@"
 UPDATE umbracoDataType
 SET propertyEditorAlias = '{Constants.PropertyEditors.Aliases.SingleBlock}',
-    propertyEditorUiAlias = 'Umb.PropertyEditorUi.SingleBlock'
+    propertyEditorUiAlias = 'Umb.PropertyEditorUi.BlockSingle'
 WHERE nodeId IN (@0)";
         await Database.ExecuteAsync(updateSql, singleBlockListDataTypesIds);
 


### PR DESCRIPTION
### Description
This PR enables the single block migration that migrates any blocklists configured for single mode into the dedicated singleBlock propertyeditor instead.

### Changes since introduction of the migration
Retesting the migration surfaced a few issue which have been resolved
- incorrect frontend mismatch
- to aggresive early return
- not migrating single blocklists on member types

### Testing
- Create document/media/member types with blocklists configured in single block mode.
- Run the migration
- Make sure everything has migrated correctly