### PR TITLE
Code Tidy: Clean up obsoleted code scheduled for removal in Umbraco 18 (`IMemberGroupService`)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
+++ b/src/Umbraco.Core/PropertyEditors/ValueConverters/MemberGroupPickerValueConverter.cs
@@ -55,7 +55,7 @@ public class MemberGroupPickerValueConverter : PropertyValueConverterBase, IDeli
             return null;
         }
 
-        IEnumerable<IMemberGroup> memberGroups = _memberGroupService.GetByIds(memberGroupIds);
+        IEnumerable<IMemberGroup> memberGroups = _memberGroupService.GetByIdsAsync(memberGroupIds).GetAwaiter().GetResult();
         return memberGroups.Select(m => m.Name).ToArray();
     }
 }

--- a/src/Umbraco.Core/Services/IMemberGroupService.cs
+++ b/src/Umbraco.Core/Services/IMemberGroupService.cs
@@ -9,41 +9,11 @@ namespace Umbraco.Cms.Core.Services;
 public interface IMemberGroupService : IService
 {
     /// <summary>
-    ///     Gets all member groups.
-    /// </summary>
-    /// <returns>An enumerable collection of all <see cref="IMemberGroup"/> objects.</returns>
-    [Obsolete("Please use the asynchronous counterpart. Scheduled for removal in Umbraco 18.")]
-    IEnumerable<IMemberGroup> GetAll();
-
-    /// <summary>
-    ///     Gets a member group by its integer id.
-    /// </summary>
-    /// <param name="id">The integer id of the member group.</param>
-    /// <returns>The <see cref="IMemberGroup"/> if found; otherwise, <c>null</c>.</returns>
-    [Obsolete("Please use Guid instead of Int id. Scheduled for removal in Umbraco 18.")]
-    IMemberGroup? GetById(int id);
-
-    /// <summary>
-    ///     Gets multiple member groups by their integer ids.
-    /// </summary>
-    /// <param name="ids">An enumerable collection of integer ids.</param>
-    /// <returns>An enumerable collection of <see cref="IMemberGroup"/> objects.</returns>
-    [Obsolete("Please use the asynchronous counterpart. Scheduled for removal in Umbraco 18.")]
-    IEnumerable<IMemberGroup> GetByIds(IEnumerable<int> ids);
-
-    /// <summary>
     ///     Gets a member group by its name.
     /// </summary>
     /// <param name="name">The name of the member group.</param>
     /// <returns>The <see cref="IMemberGroup"/> if found; otherwise, <c>null</c>.</returns>
     IMemberGroup? GetByName(string? name);
-
-    /// <summary>
-    ///     Deletes a member group.
-    /// </summary>
-    /// <param name="memberGroup">The <see cref="IMemberGroup"/> to delete.</param>
-    [Obsolete("Please use the asynchronous counterpart. Scheduled for removal in Umbraco 18.")]
-    void Delete(IMemberGroup memberGroup);
 
     /// <summary>
     ///     Get a member group by name.
@@ -68,18 +38,7 @@ public interface IMemberGroupService : IService
     ///     The default implementation fetches all groups and filters in-memory. Implementations
     ///     backed by a query-capable store may provide a more efficient override.
     /// </remarks>
-    // TODO (V19): Remove default implementation.
-    async Task<IEnumerable<IMemberGroup>> GetAsync(IEnumerable<Guid> keys)
-    {
-        ICollection<Guid> keySet = keys as ICollection<Guid> ?? keys.ToArray();
-        if (keySet.Count == 0)
-        {
-            return [];
-        }
-
-        IEnumerable<IMemberGroup> all = await GetAllAsync();
-        return all.Where(x => keySet.Contains(x.Key));
-    }
+    Task<IEnumerable<IMemberGroup>> GetAsync(IEnumerable<Guid> keys);
 
     /// <summary>
     ///     Gets all member groups

--- a/src/Umbraco.Core/Services/MemberGroupService.cs
+++ b/src/Umbraco.Core/Services/MemberGroupService.cs
@@ -32,25 +32,7 @@ internal sealed class MemberGroupService : RepositoryService, IMemberGroupServic
         _memberGroupRepository = memberGroupRepository;
 
     /// <inheritdoc />
-    public IEnumerable<IMemberGroup> GetAll() => GetAllAsync().GetAwaiter().GetResult();
-
-    /// <inheritdoc />
-    public IEnumerable<IMemberGroup> GetByIds(IEnumerable<int> ids) => GetByIdsAsync(ids).GetAwaiter().GetResult();
-
-    /// <inheritdoc />
-    public IMemberGroup? GetById(int id)
-    {
-        using (ICoreScope scope = ScopeProvider.CreateCoreScope(autoComplete: true))
-        {
-            return _memberGroupRepository.Get(id);
-        }
-    }
-
-    /// <inheritdoc />
     public IMemberGroup? GetByName(string? name) => name is null ? null : GetByNameAsync(name).GetAwaiter().GetResult();
-
-    /// <inheritdoc />
-    public void Delete(IMemberGroup memberGroup) => DeleteAsync(memberGroup.Key).GetAwaiter().GetResult();
 
     /// <inheritdoc/>
     public Task<IMemberGroup?> GetByNameAsync(string name)

--- a/src/Umbraco.Core/Services/MemberService.cs
+++ b/src/Umbraco.Core/Services/MemberService.cs
@@ -1173,7 +1173,7 @@ namespace Umbraco.Cms.Core.Services
             {
                 foreach (IMemberGroup memberGroup in found)
                 {
-                    _memberGroupService.Delete(memberGroup);
+                    _memberGroupService.DeleteAsync(memberGroup.Key).GetAwaiter().GetResult();
                 }
             }
 

--- a/src/Umbraco.Infrastructure/Security/MemberRoleStore.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberRoleStore.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 
@@ -19,19 +21,31 @@ public class MemberRoleStore : IQueryableRoleStore<UmbracoIdentityRole>
         new() { Code = "IdentityMemberGroupNotFound", Description = "Member group not found" };
 
     private readonly IMemberGroupService _memberGroupService;
+    private readonly IIdKeyMap _idKeyMap;
 
     private bool _disposed;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Umbraco.Cms.Core.Security.MemberRoleStore"/> class.
+    /// Initializes a new instance of the <see cref="MemberRoleStore"/> class.
     /// </summary>
     /// <remarks>private const string genericIdentityErrorCode = "IdentityErrorUserStore";</remarks>
     /// <param name="memberGroupService">Service used to manage and retrieve member groups.</param>
     /// <param name="errorDescriber">Provides error messages for identity-related operations.</param>
-    public MemberRoleStore(IMemberGroupService memberGroupService, IdentityErrorDescriber errorDescriber)
+    /// <param name="idKeyMap">The cached id-to-key map used to resolve int role IDs to GUID keys.</param>
+    public MemberRoleStore(IMemberGroupService memberGroupService, IdentityErrorDescriber errorDescriber, IIdKeyMap idKeyMap)
     {
         _memberGroupService = memberGroupService ?? throw new ArgumentNullException(nameof(memberGroupService));
         ErrorDescriber = errorDescriber ?? throw new ArgumentNullException(nameof(errorDescriber));
+        _idKeyMap = idKeyMap ?? throw new ArgumentNullException(nameof(idKeyMap));
+    }
+
+    [Obsolete("Use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
+    public MemberRoleStore(IMemberGroupService memberGroupService, IdentityErrorDescriber errorDescriber)
+        : this(
+            memberGroupService,
+            errorDescriber,
+            StaticServiceProvider.Instance.GetRequiredService<IIdKeyMap>())
+    {
     }
 
     /// <summary>
@@ -79,7 +93,7 @@ public class MemberRoleStore : IQueryableRoleStore<UmbracoIdentityRole>
             return IdentityResult.Failed(_intParseError);
         }
 
-        IMemberGroup? memberGroup = _memberGroupService.GetById(roleId);
+        IMemberGroup? memberGroup = await GetMemberGroupByIdAsync(roleId);
         if (memberGroup != null)
         {
             if (MapToMemberGroup(role, memberGroup))
@@ -94,7 +108,7 @@ public class MemberRoleStore : IQueryableRoleStore<UmbracoIdentityRole>
     }
 
     /// <inheritdoc />
-    public Task<IdentityResult> DeleteAsync(UmbracoIdentityRole role, CancellationToken cancellationToken = default)
+    public async Task<IdentityResult> DeleteAsync(UmbracoIdentityRole role, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
@@ -109,17 +123,14 @@ public class MemberRoleStore : IQueryableRoleStore<UmbracoIdentityRole>
             throw new ArgumentException("The Id of the role is not an integer");
         }
 
-        IMemberGroup? memberGroup = _memberGroupService.GetById(roleId);
-        if (memberGroup != null)
+        IMemberGroup? memberGroup = await GetMemberGroupByIdAsync(roleId);
+        if (memberGroup == null)
         {
-            _memberGroupService.Delete(memberGroup);
-        }
-        else
-        {
-            return Task.FromResult(IdentityResult.Failed(_memberGroupNotFoundError));
+            return IdentityResult.Failed(_memberGroupNotFoundError);
         }
 
-        return Task.FromResult(IdentityResult.Success);
+        await _memberGroupService.DeleteAsync(memberGroup.Key);
+        return IdentityResult.Success;
     }
 
     /// <inheritdoc />
@@ -206,10 +217,24 @@ public class MemberRoleStore : IQueryableRoleStore<UmbracoIdentityRole>
         }
         else
         {
-            memberGroup = _memberGroupService.GetById(id);
+            memberGroup = await GetMemberGroupByIdAsync(id);
         }
 
         return memberGroup == null ? null : MapFromMemberGroup(memberGroup);
+    }
+
+    /// <summary>
+    ///     Resolves a member group by its integer id by mapping the id to its GUID key via the cached id-key map.
+    /// </summary>
+    private async Task<IMemberGroup?> GetMemberGroupByIdAsync(int id)
+    {
+        Attempt<Guid> keyAttempt = _idKeyMap.GetKeyForId(id, UmbracoObjectTypes.MemberGroup);
+        if (keyAttempt.Success is false)
+        {
+            return null;
+        }
+
+        return await _memberGroupService.GetAsync(keyAttempt.Result);
     }
 
     /// <inheritdoc />

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberRoleStoreTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Security/MemberRoleStoreTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -20,6 +21,7 @@ public class MemberRoleStoreTests
     }
 
     private Mock<IMemberGroupService> _mockMemberGroupService;
+    private Mock<IIdKeyMap> _mockIdKeyMap;
 
     private IdentityErrorDescriber ErrorDescriber => new();
 
@@ -30,9 +32,23 @@ public class MemberRoleStoreTests
     public MemberRoleStore CreateSut()
     {
         _mockMemberGroupService = new Mock<IMemberGroupService>();
+        _mockIdKeyMap = new Mock<IIdKeyMap>();
         return new MemberRoleStore(
             _mockMemberGroupService.Object,
-            ErrorDescriber);
+            ErrorDescriber,
+            _mockIdKeyMap.Object);
+    }
+
+    private void SetupIdToKey(int id, Guid key)
+    {
+        _mockIdKeyMap.Setup(x => x.GetKeyForId(id, UmbracoObjectTypes.MemberGroup))
+            .Returns(Attempt.Succeed(key));
+    }
+
+    private void SetupIdToKeyFailure(int id)
+    {
+        _mockIdKeyMap.Setup(x => x.GetKeyForId(id, UmbracoObjectTypes.MemberGroup))
+            .Returns(Attempt.Fail<Guid>());
     }
 
     [Test]
@@ -81,10 +97,12 @@ public class MemberRoleStoreTests
         var fakeRole = _roleBuilder.WithName("fakeGroupName").WithId("777").Build();
         var fakeCancellationToken = CancellationToken.None;
 
+        var fakeKey = Guid.NewGuid();
         var mockMemberGroup = Mock.Of<IMemberGroup>(m =>
-            m.Name == "fakeGroupName" && m.CreatorId == 777);
+            m.Name == "fakeGroupName" && m.CreatorId == 777 && m.Key == fakeKey);
 
-        _mockMemberGroupService.Setup(x => x.GetById(777)).Returns(mockMemberGroup);
+        SetupIdToKey(777, fakeKey);
+        _mockMemberGroupService.Setup(x => x.GetAsync(fakeKey)).ReturnsAsync(mockMemberGroup);
         _mockMemberGroupService.Setup(x => x.UpdateAsync(mockMemberGroup));
 
         // act
@@ -93,7 +111,7 @@ public class MemberRoleStoreTests
         // assert
         Assert.IsTrue(identityResult.Succeeded);
         Assert.IsTrue(!identityResult.Errors.Any());
-        _mockMemberGroupService.Verify(x => x.GetById(777));
+        _mockMemberGroupService.Verify(x => x.GetAsync(fakeKey));
     }
 
     [Test]
@@ -105,10 +123,12 @@ public class MemberRoleStoreTests
         var fakeRole = _roleBuilder.WithName("fakeGroup777").WithId("777").Build();
         var fakeCancellationToken = CancellationToken.None;
 
+        var fakeKey = Guid.NewGuid();
         var mockMemberGroup = Mock.Of<IMemberGroup>(m =>
-            m.Name == "fakeGroupName" && m.CreatorId == 777);
+            m.Name == "fakeGroupName" && m.CreatorId == 777 && m.Key == fakeKey);
 
-        _mockMemberGroupService.Setup(x => x.GetById(777)).Returns(mockMemberGroup);
+        SetupIdToKey(777, fakeKey);
+        _mockMemberGroupService.Setup(x => x.GetAsync(fakeKey)).ReturnsAsync(mockMemberGroup);
         _mockMemberGroupService.Setup(x => x.UpdateAsync(mockMemberGroup));
 
         // act
@@ -118,7 +138,7 @@ public class MemberRoleStoreTests
         Assert.IsTrue(identityResult.Succeeded);
         Assert.IsTrue(!identityResult.Errors.Any());
         _mockMemberGroupService.Verify(x => x.UpdateAsync(It.IsAny<IMemberGroup>()));
-        _mockMemberGroupService.Verify(x => x.GetById(777));
+        _mockMemberGroupService.Verify(x => x.GetAsync(fakeKey));
     }
 
     [Test]
@@ -129,6 +149,8 @@ public class MemberRoleStoreTests
         var fakeRole = _roleBuilder.WithTestName("777").Build();
         var fakeCancellationToken = CancellationToken.None;
 
+        SetupIdToKeyFailure(777);
+
         // act
         var identityResult = await sut.UpdateAsync(fakeRole, fakeCancellationToken);
 
@@ -136,7 +158,6 @@ public class MemberRoleStoreTests
         Assert.IsTrue(identityResult.Succeeded == false);
         Assert.IsTrue(identityResult.Errors.Any(x =>
             x.Code == "IdentityMemberGroupNotFound" && x.Description == "Member group not found"));
-        _mockMemberGroupService.Verify(x => x.GetById(777));
     }
 
     [Test]
@@ -181,10 +202,12 @@ public class MemberRoleStoreTests
         var fakeRole = _roleBuilder.WithTestName("777").Build();
         var fakeCancellationToken = CancellationToken.None;
 
+        var fakeKey = Guid.NewGuid();
         var mockMemberGroup = Mock.Of<IMemberGroup>(m =>
-            m.Name == "fakeGroupName" && m.CreatorId == 77);
+            m.Name == "fakeGroupName" && m.CreatorId == 77 && m.Key == fakeKey);
 
-        _mockMemberGroupService.Setup(x => x.GetById(777)).Returns(mockMemberGroup);
+        SetupIdToKey(777, fakeKey);
+        _mockMemberGroupService.Setup(x => x.GetAsync(fakeKey)).ReturnsAsync(mockMemberGroup);
 
         // act
         var identityResult = await sut.DeleteAsync(fakeRole, fakeCancellationToken);
@@ -192,8 +215,8 @@ public class MemberRoleStoreTests
         // assert
         Assert.IsTrue(identityResult.Succeeded);
         Assert.IsTrue(!identityResult.Errors.Any());
-        _mockMemberGroupService.Verify(x => x.GetById(777));
-        _mockMemberGroupService.Verify(x => x.Delete(mockMemberGroup));
+        _mockMemberGroupService.Verify(x => x.GetAsync(fakeKey));
+        _mockMemberGroupService.Verify(x => x.DeleteAsync(fakeKey));
         _mockMemberGroupService.VerifyNoOtherCalls();
     }
 
@@ -223,8 +246,7 @@ public class MemberRoleStoreTests
         var fakeRole = _roleBuilder.WithTestName("777").Build();
         var fakeCancellationToken = CancellationToken.None;
 
-        var mockMemberGroup = Mock.Of<IMemberGroup>(m =>
-            m.Name == "fakeGroupName" && m.CreatorId == 77);
+        SetupIdToKeyFailure(777);
 
         // act
         var identityResult = await sut.DeleteAsync(fakeRole, fakeCancellationToken);
@@ -233,7 +255,6 @@ public class MemberRoleStoreTests
         Assert.IsTrue(identityResult.Succeeded == false);
         Assert.IsTrue(identityResult.Errors.Any(x =>
             x.Code == "IdentityMemberGroupNotFound" && x.Description == "Member group not found"));
-        _mockMemberGroupService.Verify(x => x.GetById(777));
         _mockMemberGroupService.VerifyNoOtherCalls();
     }
 
@@ -244,11 +265,13 @@ public class MemberRoleStoreTests
         var sut = CreateSut();
         var fakeRole = _roleBuilder.WithName("fakeGroupName").WithId("777").Build();
         var fakeRoleId = 777;
+        var fakeKey = Guid.NewGuid();
 
         IMemberGroup fakeMemberGroup = _groupBuilder.WithName("fakeGroupName").WithCreatorId(123).WithId(777)
-            .WithKey(Guid.NewGuid()).Build();
+            .WithKey(fakeKey).Build();
 
-        _mockMemberGroupService.Setup(x => x.GetById(fakeRoleId)).Returns(fakeMemberGroup);
+        SetupIdToKey(fakeRoleId, fakeKey);
+        _mockMemberGroupService.Setup(x => x.GetAsync(fakeKey)).ReturnsAsync(fakeMemberGroup);
 
         // act
         IdentityRole actual = await sut.FindByIdAsync(fakeRole.Id);
@@ -256,7 +279,7 @@ public class MemberRoleStoreTests
         // assert
         Assert.AreEqual(fakeRole.Name, actual.Name);
         Assert.AreEqual(fakeRole.Id, actual.Id);
-        _mockMemberGroupService.Verify(x => x.GetById(fakeRoleId));
+        _mockMemberGroupService.Verify(x => x.GetAsync(fakeKey));
         _mockMemberGroupService.VerifyNoOtherCalls();
     }
 
@@ -311,11 +334,13 @@ public class MemberRoleStoreTests
         var fakeRole = _roleBuilder.WithName("fakeGroupName").WithId("777").Build();
 
         var fakeRoleId = 777;
+        var fakeKey = Guid.NewGuid();
 
         IMemberGroup fakeMemberGroup = _groupBuilder.WithName("fakeGroupName").WithCreatorId(123).WithId(777)
-            .WithKey(Guid.NewGuid()).Build();
+            .WithKey(fakeKey).Build();
 
-        _mockMemberGroupService.Setup(x => x.GetById(fakeRoleId)).Returns(fakeMemberGroup);
+        SetupIdToKey(fakeRoleId, fakeKey);
+        _mockMemberGroupService.Setup(x => x.GetAsync(fakeKey)).ReturnsAsync(fakeMemberGroup);
 
         // act
         IdentityRole actual = await sut.FindByIdAsync(fakeRoleId.ToString());
@@ -323,7 +348,7 @@ public class MemberRoleStoreTests
         // assert
         Assert.AreEqual(fakeRole.Name, actual.Name);
         Assert.AreEqual(fakeRole.Id, actual.Id);
-        _mockMemberGroupService.Verify(x => x.GetById(fakeRoleId));
+        _mockMemberGroupService.Verify(x => x.GetAsync(fakeKey));
         _mockMemberGroupService.VerifyNoOtherCalls();
     }
 


### PR DESCRIPTION
## Description

This is a further PR that removes obsolete members scheduled for removal in Umbraco 18, deleting the obsolete members from `IMemberGroupService`. All callers updated to non-obsolete equivalents.

### Obsoletions removed

#### `IMemberGroupService` / `MemberGroupService`
- `IEnumerable<IMemberGroup> GetAll()` → use `GetAllAsync()`
- `IMemberGroup? GetById(int id)` → use `GetAsync(Guid key)` (after id→key conversion)
- `IEnumerable<IMemberGroup> GetByIds(IEnumerable<int> ids)` → use `GetByIdsAsync(IEnumerable<int> ids)`
- `void Delete(IMemberGroup memberGroup)` → use `DeleteAsync(Guid key)`

## Testing

Build checks should pass - solution should build and test suite should complete without failures.