### PR TITLE
Code Tidy: Remove unused `publishedValueFallback` parameter from published content wrapper constructors

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentModel.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentModel.cs
@@ -16,7 +16,7 @@ public abstract class PublishedContentModel : PublishedContentWrapped
     /// <param name="content">The original content.</param>
     /// <param name="publishedValueFallback">the PublishedValueFallback</param>
     protected PublishedContentModel(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
-        : base(content, publishedValueFallback)
+        : base(content)
     {
     }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedContentWrapped.cs
@@ -26,8 +26,7 @@ public abstract class PublishedContentWrapped : PublishedElementWrapped<IPublish
     ///     with an <c>IPublishedContent</c> instance to wrap.
     /// </summary>
     /// <param name="content">The content to wrap.</param>
-    /// <param name="publishedValueFallback">The published value fallback.</param>
-    protected PublishedContentWrapped(IPublishedContent content, IPublishedValueFallback publishedValueFallback)
+    protected PublishedContentWrapped(IPublishedContent content)
         : base(content)
         => _content = content;
 

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedElementModel.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedElementModel.cs
@@ -18,7 +18,7 @@ public abstract class PublishedElementModel : PublishedElementWrapped
     /// <param name="content">The original content.</param>
     /// <param name="publishedValueFallback">The published value fallback.</param>
     protected PublishedElementModel(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
-        : base(content, publishedValueFallback)
+        : base(content)
     {
     }
 }

--- a/src/Umbraco.Core/Models/PublishedContent/PublishedElementWrapped.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedElementWrapped.cs
@@ -14,8 +14,7 @@ public abstract class PublishedElementWrapped : PublishedElementWrapped<IPublish
     ///     with an <c>IPublishedElement</c> instance to wrap.
     /// </summary>
     /// <param name="content">The content to wrap.</param>
-    /// <param name="publishedValueFallback">The published value fallback.</param>
-    protected PublishedElementWrapped(IPublishedElement content, IPublishedValueFallback publishedValueFallback)
+    protected PublishedElementWrapped(IPublishedElement content)
         : base(content)
     {
     }

--- a/src/Umbraco.Infrastructure/Models/MediaWithCrops.cs
+++ b/src/Umbraco.Infrastructure/Models/MediaWithCrops.cs
@@ -16,7 +16,7 @@ public class MediaWithCrops : PublishedContentWrapped
     /// <param name="publishedValueFallback">The published value fallback.</param>
     /// <param name="localCrops">The local crops.</param>
     public MediaWithCrops(IPublishedContent content, IPublishedValueFallback publishedValueFallback, ImageCropperValue localCrops)
-        : base(content, publishedValueFallback) =>
+        : base(content) =>
         LocalCrops = localCrops;
 
     /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/ContentModelBinderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ModelBinders/ContentModelBinderTests.cs
@@ -232,7 +232,7 @@ public class ContentModelBinderTests
     public class ContentType1 : PublishedContentWrapped
     {
         public ContentType1(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content, fallback)
+            : base(content)
         {
         }
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Views/UmbracoViewPageTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Views/UmbracoViewPageTests.cs
@@ -293,7 +293,7 @@ public class UmbracoViewPageTests
     public class ContentType1 : PublishedContentWrapped
     {
         public ContentType1(IPublishedContent content, IPublishedValueFallback fallback)
-            : base(content, fallback)
+            : base(content)
         {
         }
     }


### PR DESCRIPTION
## Description

Cleans up the unused `IPublishedValueFallback` parameter on `PublishedElementWrapped` and `PublishedContentWrapped` constructors. The fallback was accepted and immediately discarded — the wrapper base classes never used it.

Addresses the comment from https://github.com/umbraco/Umbraco-CMS/pull/22399#discussion_r3070917701.

## Testing

Build checks should pass - solution should build and test suite should complete without failures.