### PR TITLE
GroupId conditions - js error fix for undefined permission checks

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/conditions/group-id/group-id.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/conditions/group-id/group-id.condition.ts
@@ -18,6 +18,12 @@ export class UmbCurrentUserGroupCondition
 	}
 
 	#observeCurrentUser = async (currentUser: UmbCurrentUserModel) => {
+		// If currentUser is not yet available, return early to avoid errors
+		if (!currentUser) {
+			this.permitted = false;
+			return;
+		}
+
 		// Idea: This part could be refactored to become a shared util, to align these matching feature across conditions. [NL]
 		// Notice doing so it would be interesting to invistigate if it makes sense to combine some of these properties, to enable more specific matching. (But maybe it is only relevant for the combination of match + oneOf) [NL]
 		const { match, oneOf, allOf, noneOf } = this.config;


### PR DESCRIPTION
- Added check to `currentUser` to ensure a valid user exists before checking properties on it

### Prerequisites
- [x] I have added steps to test this contribution in the description below

Fixes #22648

### Description

`#observeCurrentUser` in `group-id.condition.ts` is called as an observer callback, which can fire before the current user model is set. When this happens, `currentUser` is `undefined`, causing a javascript console error when any of the `match`, `oneOf`, `allOf`, or `noneOf` checks attempt to access `currentUser.userGroupUniques`.

The fix adds an early return guard at the top of the method. If `currentUser` is not yet available, `this.permitted` is set to `false` and the method returns immediately, preventing the property access error. The condition should re-evaluate correctly once the user is fully loaded.

**To reproduce:**
1. Register a dashboard with a `Umb.Condition.CurrentUser.GroupId` condition using `oneOf` in `umbraco-package.json`, eg:
```json
    "extensions": [
        {
...
            "conditions": [
...
                {
                    "alias": "Umb.Condition.CurrentUser.GroupId",
                    "oneOf": [
                        "1234f6c8-7f9c-4b5b-8d5d-9e1e5a4fdcba",
                        "43215490-93cb-4003-9130-dd463660abcd"
                    ]
                }
...
            ]
        }
    ]
```
2. Load the Umbraco backoffice and navigate between CMS sections
3. Observe the error in the browser console: `TypeError: Cannot read properties of undefined (reading 'userGroupUniques')`

**To test the fix:**
1. Apply the change and rebuild
2. Register a dashboard with a `Umb.Condition.CurrentUser.GroupId` condition (using `match`, `oneOf`, `allOf`, or `noneOf`)
3. Load the backoffice — no console error should appear
4. Confirm the dashboard is shown/hidden correctly based on the current user's group membership