### PR TITLE
Revert fix for making block editors read-only in trashed documents which causes a regression in certain multi-lingual block editing scenarios (closes #22472, re-opens #21973) 

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -582,7 +582,6 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	}
 
 	#renderEditAction() {
-		if (this._isReadOnly) return nothing;
 		return html`
 			${when(
 				this._showContentEdit && this._workspaceEditContentPath,
@@ -616,7 +615,6 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	}
 
 	#renderEditSettingsAction() {
-		if (this._isReadOnly) return nothing;
 		return html`
 			${this._hasSettings && this._workspaceEditSettingsPath
 				? html`

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/block-list-entry/block-list-entry.element.ts
@@ -455,7 +455,6 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 	}
 
 	#renderEditContentAction() {
-		if (this._isReadOnly) return nothing;
 		return this._showContentEdit && this._workspaceEditContentPath
 			? html`<uui-button
 					label="edit"
@@ -479,7 +478,6 @@ export class UmbBlockListEntryElement extends UmbLitElement implements UmbProper
 	}
 
 	#renderEditSettingsAction() {
-		if (this._isReadOnly) return nothing;
 		return html`
 			${this._hasSettings && this._workspaceEditSettingsPath
 				? html`<uui-button

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -371,7 +371,6 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	#renderEditAction() {
-		if (this._isReadOnly) return nothing;
 		return this._showContentEdit && this._workspaceEditContentPath
 			? html`<uui-button
 					label="edit"
@@ -394,7 +393,6 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	#renderEditSettingsAction() {
-		if (this._isReadOnly) return nothing;
 		return html`
 			${this._hasSettings && this._workspaceEditSettingsPath
 				? html`<uui-button

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/block-single-entry/block-single-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/block-single-entry/block-single-entry.element.ts
@@ -441,7 +441,6 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 	}
 
 	#renderEditContentAction() {
-		if (this._isReadOnly) return nothing;
 		return this._showContentEdit && this._workspaceEditContentPath
 			? html`<uui-button
 					label="edit"
@@ -464,7 +463,6 @@ export class UmbBlockSingleEntryElement extends UmbLitElement implements UmbProp
 	}
 
 	#renderEditSettingsAction() {
-		if (this._isReadOnly) return nothing;
 		return html`
 			${this._hasSettings && this._workspaceEditSettingsPath
 				? html`<uui-button

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -212,12 +212,8 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 					};
 
 					this.readOnlyGuard?.addRule(rule);
-					this.content.propertyWriteGuard.addRule({ unique, permitted: false });
-					this.settings.propertyWriteGuard.addRule({ unique, permitted: false });
 				} else {
 					this.readOnlyGuard?.removeRule(unique);
-					this.content.propertyWriteGuard.removeRule(unique);
-					this.settings.propertyWriteGuard.removeRule(unique);
 				}
 			},
 			'observeIsReadOnly',

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/manifests.ts
@@ -26,10 +26,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 				alias: 'Umb.Condition.BlockWorkspaceIsExposed',
 				match: false,
 			},
-			{
-				alias: 'Umb.Condition.BlockWorkspaceIsReadOnly',
-				match: false,
-			},
 		],
 	},
 	{
@@ -50,10 +46,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 			},
 			{
 				alias: 'Umb.Condition.BlockWorkspaceIsExposed',
-			},
-			{
-				alias: 'Umb.Condition.BlockWorkspaceIsReadOnly',
-				match: false,
 			},
 		],
 	},


### PR DESCRIPTION
Reverts parts of https://github.com/umbraco/Umbraco-CMS/pull/21982

To enable users to access Blocks as in 17.2, this will generall fix: https://github.com/umbraco/Umbraco-CMS/issues/22472

But there is a follow-up PR https://github.com/umbraco/Umbraco-CMS/pull/22522 which takes care of all permissions cases.

Meaning, are you unhappy with the revert in this PR, then upgrade to 17.4, where this will be working as expected in all cases.

Test-notes, read the issue.