### PR TITLE
Redirect Tracker: Prevent creation of redirects from unrouteable URLs (closes #22652, #22256)

### DIFF
--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -115,7 +115,7 @@ internal sealed class RedirectTracker : IRedirectTracker
                 try
                 {
                     var route = _publishedUrlProvider.GetUrl(publishedContent.Key, UrlMode.Relative, culture).TrimEnd(Constants.CharArrays.ForwardSlash);
-                    if (IsValidRoute(route))
+                    if (IsValidRoute(route) && HasPublishedUrlSegment(publishedContent.Key, culture))
                     {
                         StoreRoute(oldRoutes, publishedContent, culture, route, domainRootId.Value);
                     }
@@ -125,7 +125,7 @@ internal sealed class RedirectTracker : IRedirectTracker
                         foreach (string languageIsoCode in languageIsoCodes.Value)
                         {
                             route = GetUrl(publishedContent.Key, languageIsoCode);
-                            if (IsValidRoute(route))
+                            if (IsValidRoute(route) && HasPublishedUrlSegment(publishedContent.Key, languageIsoCode))
                             {
                                 StoreRoute(oldRoutes, publishedContent, languageIsoCode, route, domainRootId.Value);
                             }
@@ -322,6 +322,17 @@ internal sealed class RedirectTracker : IRedirectTracker
         route is not null
         && !route.StartsWith(Constants.Routing.Unroutable)
         && !route.StartsWith("err/");
+
+    // Only treat the resolved route as a valid "old URL" when the content actually has a
+    // published URL segment for this culture — i.e. it has been published before, so a redirect
+    // from its prior URL is meaningful. Without this gate, never-published content can have a
+    // misleading route captured (e.g. an ancestor's URL when the URL provider resolves drafts
+    // under an active preview cookie). See https://github.com/umbraco/Umbraco-CMS/issues/22256.
+    // Falls back to "true" during upgrades when the document URL service is not yet initialized,
+    // matching the fallback behaviour in HasUrlSegmentChanged.
+    private bool HasPublishedUrlSegment(Guid contentKey, string culture) =>
+        _documentUrlService.IsInitialized is false
+        || _documentUrlService.GetUrlSegment(contentKey, culture, isDraft: false) is not null;
 
     private void RemoveSelfReferencingRedirect(Guid contentKey, string route)
     {

--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -300,7 +300,7 @@ internal sealed class RedirectTracker : IRedirectTracker
                     newRoute = domainRootId + newRoute;
                 }
 
-                if (!IsValidRoute(newRoute) || oldRoute == newRoute)
+                if (!IsValidRoute(oldRoute) || !IsValidRoute(newRoute) || oldRoute == newRoute)
                 {
                     continue;
                 }
@@ -318,7 +318,10 @@ internal sealed class RedirectTracker : IRedirectTracker
         }
     }
 
-    private static bool IsValidRoute([NotNullWhen(true)] string? route) => route is not null && !route.StartsWith("err/");
+    private static bool IsValidRoute([NotNullWhen(true)] string? route) =>
+        route is not null
+        && route != Constants.Routing.Unroutable
+        && !route.StartsWith("err/");
 
     private void RemoveSelfReferencingRedirect(Guid contentKey, string route)
     {

--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -320,7 +320,7 @@ internal sealed class RedirectTracker : IRedirectTracker
 
     private static bool IsValidRoute([NotNullWhen(true)] string? route) =>
         route is not null
-        && route != Constants.Routing.Unroutable
+        && !route.StartsWith(Constants.Routing.Unroutable)
         && !route.StartsWith("err/");
 
     private void RemoveSelfReferencingRedirect(Guid contentKey, string route)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Routing/RedirectTrackerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Routing/RedirectTrackerTests.cs
@@ -47,7 +47,11 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
     {
         Dictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)> dict = [];
 
-        var redirectTracker = CreateRedirectTracker();
+        // CurrentPublishedSegment represents content that has been previously published.
+        var redirectTracker = CreateRedirectTracker(new RedirectTrackerSetupOptions
+        {
+            CurrentPublishedSegment = "test-page",
+        });
 
         redirectTracker.StoreOldRoute(_testPage, dict, isMove: true);
 
@@ -66,7 +70,11 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
     {
         Dictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)> dict = [];
 
-        var redirectTracker = CreateRedirectTracker(new RedirectTrackerSetupOptions { AssignDomain = true });
+        var redirectTracker = CreateRedirectTracker(new RedirectTrackerSetupOptions
+        {
+            AssignDomain = true,
+            CurrentPublishedSegment = "test-page",
+        });
 
         redirectTracker.StoreOldRoute(_testPage, dict, isMove: true);
 
@@ -152,6 +160,45 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
     }
 
     /// <summary>
+    /// Reproduces the scenario from <see href="https://github.com/umbraco/Umbraco-CMS/issues/22256">#22256</see>
+    /// (comment <c>4352606187</c>): when the preview cookie is active from a prior preview, a brand-new
+    /// sibling that is created and published causes a bogus redirect from its parent's URL to the
+    /// newly-published URL.
+    /// <para>
+    /// Mechanism: with the preview cookie active, the URL provider resolves URLs in draft mode via
+    /// <see cref="IDocumentUrlService.GetLegacyRouteFormat"/>. For never-published content, the
+    /// navigation query's ancestors-or-self lookup may return only the (published) ancestors, so
+    /// the route returned is actually the parent's URL — a real-looking value that passes
+    /// <c>IsValidRoute</c>. This is then captured as the "old route" for the new content, and on
+    /// publish a redirect is registered from <c>parent → child</c>.
+    /// </para>
+    /// <para>
+    /// We simulate this by mocking <see cref="IPublishedUrlProvider.GetUrl"/> to return the
+    /// parent's URL and leaving <see cref="IDocumentUrlService.GetUrlSegment"/>(<c>isDraft: false</c>)
+    /// returning <c>null</c>, which represents content that has never been published.
+    /// </para>
+    /// </summary>
+    [Test]
+    public void Does_Not_Store_Old_Route_For_Never_Published_Content_When_Url_Resolves_To_Ancestor()
+    {
+        Dictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)> dict = [];
+
+        // The URL provider returns the parent's URL ("/parent") because in draft mode (preview
+        // cookie active) the never-published draft isn't in the navigation tree, so ancestor
+        // resolution stops at the parent. CurrentPublishedSegment is intentionally not set, so
+        // the document URL service confirms there is no published segment for this content.
+        var redirectTracker = CreateRedirectTracker(new RedirectTrackerSetupOptions
+        {
+            RelativeUrl = "/parent",
+            DocumentUrlServiceInitialized = true,
+        });
+
+        redirectTracker.StoreOldRoute(_testPage, dict, isMove: false);
+
+        Assert.AreEqual(0, dict.Count, "Old route should not be stored for content that has no published URL.");
+    }
+
+    /// <summary>
     /// Verifies that when a domain includes a path prefix (e.g. "example.com/en/"), the stored
     /// route strips that prefix to avoid duplicating the culture segment.
     /// </summary>
@@ -163,7 +210,10 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
         // Domain configured as "example.com/en/" — GetUrl returns "/en/new-route".
         var redirectTracker = CreateRedirectTracker(new RedirectTrackerSetupOptions
         {
-            AssignDomain = true, DomainName = "example.com/en/", RelativeUrl = "/en/new-route",
+            AssignDomain = true,
+            DomainName = "example.com/en/",
+            RelativeUrl = "/en/new-route",
+            CurrentPublishedSegment = "test-page",
         });
 
         redirectTracker.StoreOldRoute(_testPage, dict, isMove: true);
@@ -292,6 +342,7 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
             ChildKey = childKey,
             ChildId = childId,
             OnGetUrlForChild = () => getUrlForChildCallCount++,
+            CurrentPublishedSegment = "test-page",
         });
 
         Dictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)> dict = [];
@@ -569,8 +620,11 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
         documentUrlService.SetupGet(x => x.IsInitialized).Returns(options.DocumentUrlServiceInitialized);
         if (options.CurrentPublishedSegment is not null)
         {
+            // Return the segment for any content key — represents content that has been
+            // previously published and therefore has a published URL segment. The redirect
+            // tracker uses GetUrlSegment(..., isDraft: false) as its "has been published" gate.
             documentUrlService
-                .Setup(x => x.GetUrlSegment(_testPage.Key, It.IsAny<string>(), false))
+                .Setup(x => x.GetUrlSegment(It.IsAny<Guid>(), It.IsAny<string>(), false))
                 .Returns(options.CurrentPublishedSegment);
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Routing/RedirectTrackerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Routing/RedirectTrackerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -122,6 +123,30 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
         Assert.AreEqual(1, redirects.Count());
         var redirect = redirects.First();
         Assert.AreEqual("/old-route", redirect.Url);
+    }
+
+    /// <summary>
+    /// Verifies that no redirect is created when the stored "old route" is the unroutable
+    /// indicator (<see cref="Constants.Routing.Unroutable"/>, "#"). This guards against the
+    /// scenario where content is previewed before being published for the first time: the
+    /// preview cookie causes the URL provider to return "#" for the not-yet-published content,
+    /// which would otherwise be tracked as a (bogus) redirect to the eventual published URL.
+    /// See https://github.com/umbraco/Umbraco-CMS/issues/22652.
+    /// </summary>
+    [Test]
+    public void Does_Not_Create_Redirect_For_Unroutable_Old_Route()
+    {
+        IDictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)> dict =
+            new Dictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)>
+            {
+                [(_testPage.Id, "en")] = (_testPage.Key, Constants.Routing.Unroutable),
+            };
+
+        var redirectTracker = CreateRedirectTracker();
+
+        redirectTracker.CreateRedirects(dict);
+
+        Assert.IsEmpty(RedirectUrlService.GetContentRedirectUrls(_testPage.Key));
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Routing/RedirectTrackerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Routing/RedirectTrackerTests.cs
@@ -126,20 +126,22 @@ public class RedirectTrackerTests : UmbracoIntegrationTestWithContent
     }
 
     /// <summary>
-    /// Verifies that no redirect is created when the stored "old route" is the unroutable
-    /// indicator (<see cref="Constants.Routing.Unroutable"/>, "#"). This guards against the
+    /// Verifies that no redirect is created when the stored "old route" is one of the URL provider's
+    /// "could not resolve URL" indicators — <see cref="Constants.Routing.Unroutable"/> ("#") or
+    /// <see cref="Constants.Routing.UrlProviderException"/> ("#ex"). This guards against the
     /// scenario where content is previewed before being published for the first time: the
-    /// preview cookie causes the URL provider to return "#" for the not-yet-published content,
-    /// which would otherwise be tracked as a (bogus) redirect to the eventual published URL.
-    /// See https://github.com/umbraco/Umbraco-CMS/issues/22652.
+    /// preview cookie causes the URL provider to return one of these indicators for the
+    /// not-yet-published content, which would otherwise be tracked as a (bogus) redirect to the
+    /// eventual published URL. See https://github.com/umbraco/Umbraco-CMS/issues/22652.
     /// </summary>
-    [Test]
-    public void Does_Not_Create_Redirect_For_Unroutable_Old_Route()
+    [TestCase(Constants.Routing.Unroutable)]
+    [TestCase(Constants.Routing.UrlProviderException)]
+    public void Does_Not_Create_Redirect_For_Unroutable_Old_Route(string oldRoute)
     {
         IDictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)> dict =
             new Dictionary<(int ContentId, string Culture), (Guid ContentKey, string OldRoute)>
             {
-                [(_testPage.Id, "en")] = (_testPage.Key, Constants.Routing.Unroutable),
+                [(_testPage.Id, "en")] = (_testPage.Key, oldRoute),
             };
 
         var redirectTracker = CreateRedirectTracker();


### PR DESCRIPTION
## Description

When a content node was previewed before being published, publishing it (or, in some cases, publishing a *different* never-published node afterwards) created an unwanted entry in the URL Tracker (Redirect URL Management) pointing at the newly-published URL.

Two distinct manifestations have been observed (the first I can replicate, the second I haven't been able to):

1. **Redirect from `#`** — preview the node, close the preview tab without clicking *exit preview* (leaves the preview cookie active), then publish. The published URL provider resolves the draft to `"#"` (`Constants.Routing.Unroutable`), which was being stored as the "old route" and registered as a bogus `# → /real-url` redirect.
2. **Redirect from the parent's URL** — once the preview cookie is active for any prior page, *every* subsequent first-time publish in that backoffice session can create a redirect from the parent node's URL to the new child's URL. Reproduction: preview any page, then create a sibling/child, save it, then save & publish — observe the redirect appearing from the parent. Reported in [#22256 (comment)](https://github.com/umbraco/Umbraco-CMS/issues/22256#issuecomment-4352606187).

### Root cause

Both paths share the same underlying issue: with the preview cookie active, `IPublishedUrlProvider.GetUrl()` resolves URLs via `IDocumentUrlService.GetLegacyRouteFormat(..., isDraft: true)`. For never-published content, `GetLegacyRouteFormat` walks ancestors-or-self and either:

- returns `"#"` (when no segment can be resolved), or
- returns a partial route assembled from the *published* ancestors only (when the never-published draft itself isn't yet in the navigation tree) — i.e. **the parent's URL**.

`RedirectTracker.StoreOldRoute` would capture whatever the URL provider returned, but if the content had never been published, there's nothing to redirect from, so no route should be captured.

### Fix

Two changes in `RedirectTracker`:

1. **`IsValidRoute` rejects unroutable indicators.** It now returns `false` for routes starting with `Constants.Routing.Unroutable` (`"#"`).

2. **New `HasPublishedUrlSegment` gate in `StoreOldRoute`.** Before storing a captured route, verify the content actually has a published URL segment in `IDocumentUrlService` for the given culture. If `GetUrlSegment(key, culture, isDraft: false)` returns `null`, the content has never been published — there is no "old URL", so no route is stored.

Resolves #22652 and #22256.

## Testing

### Automated

Two new integration tests in `RedirectTrackerTests`:

- `Does_Not_Create_Redirect_For_Unroutable_Old_Route` — covers the `#` and `#ex` cases at the `CreateRedirects` boundary.
- `Does_Not_Store_Old_Route_For_Never_Published_Content_When_Url_Resolves_To_Ancestor` — covers the parent-URL leakage at the `StoreOldRoute` boundary, with the URL provider mocked to return a parent-style URL and `IDocumentUrlService.GetUrlSegment(..., isDraft: false)` returning `null`.

A few existing tests were updated to set `CurrentPublishedSegment` so they accurately represent already-published content (matching the new gate's expectation).

```
dotnet test tests/Umbraco.Tests.Integration --filter "FullyQualifiedName~RedirectTrackerTests"
```

### Manual

**Scenario 1 — preview-then-publish (originally reported in #22652):**

1. Create a new content node and click **Save and preview**.
2. Close the preview browser tab — **do not** use the *exit preview* button (this leaves the preview cookie in place).
3. Publish the content.
4. Repeat steps 1–3 for a child node beneath the first.
5. Open *Settings → Redirect URL Management*.

**Before the fix:** at least one entry redirecting from `#` to the newly-published URL.
**After the fix:** no entries are listed.

**Scenario 2 — sibling created after a stale preview cookie (reported in [#22256 (comment)](https://github.com/umbraco/Umbraco-CMS/issues/22256#issuecomment-4352606187)):**

1. Click **Save and preview** on any page; close the preview tab without clicking *exit preview*.
2. Create a new node under an already-published parent.
3. **Save** the node.
4. **Save and publish** the node.
5. Open *Settings → Redirect URL Management*.

**Before the fix:** an entry redirecting from the parent's URL to the newly-published URL.
**After the fix:** no entries are listed.
