### PR TITLE
Cache: Do not assume "published" when unpublishing a single culture

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Factories/CacheNodeFactory.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Factories/CacheNodeFactory.cs
@@ -17,11 +17,9 @@ internal sealed class CacheNodeFactory : ICacheNodeFactory
 
     public ContentCacheNode ToContentCacheNode(IContent content, bool preview)
     {
-
-
         ContentData contentData = GetContentData(
             content,
-            GetPublishedValue(content, preview),
+            preview is false,
             GetTemplateId(content, preview),
             content.PublishCultureInfos!.Values.Select(x => x.Culture).ToHashSet());
         return new ContentCacheNode
@@ -35,21 +33,6 @@ internal sealed class CacheNodeFactory : ICacheNodeFactory
             Data = contentData,
             IsDraft = preview,
         };
-    }
-
-    private static bool GetPublishedValue(IContent content, bool preview)
-    {
-        switch (content.PublishedState)
-        {
-            case PublishedState.Published:
-                return preview is false;
-            case PublishedState.Publishing:
-                return preview is false || content.Published; // The type changes after this operation
-            case PublishedState.Unpublished:
-            case PublishedState.Unpublishing:
-            default:
-                return false;
-        }
     }
 
     private static int? GetTemplateId(IContent content, bool preview)

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -56,31 +56,11 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     }
 
     /// <inheritdoc/>
-    public async Task RefreshContentAsync(ContentCacheNode contentCacheNode, PublishedState publishedState)
+    public async Task RefreshContentAsync(ContentCacheNode contentCacheNode)
     {
         IContentCacheDataSerializer serializer = _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
 
-        // We always cache draft and published separately, so we only want to cache drafts if the node is a draft type.
-        if (contentCacheNode.IsDraft)
-        {
-            await OnRepositoryRefreshed(serializer, contentCacheNode, true);
-
-            // If it's a draft node we don't need to worry about the published state.
-            return;
-        }
-
-        switch (publishedState)
-        {
-            case PublishedState.Publishing:
-                await OnRepositoryRefreshed(serializer, contentCacheNode, false);
-                break;
-            case PublishedState.Unpublishing:
-                Sql<ISqlContext> sql = Sql()
-                    .Delete<ContentNuDto>()
-                    .Where<ContentNuDto>(x => x.NodeId == contentCacheNode.Id && x.Published);
-                await Database.ExecuteAsync(sql);
-                break;
-        }
+        await OnRepositoryRefreshed(serializer, contentCacheNode, contentCacheNode.IsDraft);
     }
 
     /// <inheritdoc/>
@@ -88,6 +68,15 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     {
         IContentCacheDataSerializer serializer = _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
         await OnRepositoryRefreshed(serializer, contentCacheNode, true);
+    }
+
+    /// <inheritdoc/>
+    public async Task RemovePublishedContentAsync(int id)
+    {
+        Sql<ISqlContext> sql = Sql()
+            .Delete<ContentNuDto>()
+            .Where<ContentNuDto>(x => x.NodeId == id && x.Published);
+        await Database.ExecuteAsync(sql);
     }
 
     /// <inheritdoc/>

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/IDatabaseCacheRepository.cs
@@ -115,12 +115,17 @@ internal interface IDatabaseCacheRepository
     /// <summary>
     /// Refreshes the cache for the given document cache node.
     /// </summary>
-    Task RefreshContentAsync(ContentCacheNode contentCacheNode, PublishedState publishedState);
+    Task RefreshContentAsync(ContentCacheNode contentCacheNode);
 
     /// <summary>
     /// Refreshes the cache row for the given media cache node.
     /// </summary>
     Task RefreshMediaAsync(ContentCacheNode contentCacheNode);
+
+    /// <summary>
+    /// Removes the cache of published content for the given document.
+    /// </summary>
+    Task RemovePublishedContentAsync(int id);
 
     /// <summary>
     /// Rebuilds the caches for content, media and/or members based on the content type ids specified.

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -343,19 +343,17 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         // We have nodes seperate in the cache, cause 99% of the time, you are only using one
         // and thus we won't get too much data when retrieving from the cache.
         var draftCacheNode = _cacheNodeFactory.ToContentCacheNode(content, true);
+        await _databaseCacheRepository.RefreshContentAsync(draftCacheNode);
 
-        await _databaseCacheRepository.RefreshContentAsync(draftCacheNode, content.PublishedState);
-
-        if (content.PublishedState is PublishedState.Publishing or PublishedState.Unpublishing)
+        if (content.PublishedState is PublishedState.Publishing)
         {
             var publishedCacheNode = _cacheNodeFactory.ToContentCacheNode(content, false);
-
-            await _databaseCacheRepository.RefreshContentAsync(publishedCacheNode, content.PublishedState);
-
-            if (content.PublishedState == PublishedState.Unpublishing)
-            {
-                await ClearPublishedCacheAsync(publishedCacheNode.Key);
-            }
+            await _databaseCacheRepository.RefreshContentAsync(publishedCacheNode);
+        }
+        else if (content.PublishedState is PublishedState.Unpublishing)
+        {
+            await _databaseCacheRepository.RemovePublishedContentAsync(content.Id);
+            await ClearPublishedCacheAsync(content.Key);
         }
 
         scope.Complete();

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVariantsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVariantsTests.cs
@@ -38,6 +38,8 @@ internal sealed class DocumentHybridCacheVariantsTests : UmbracoIntegrationTest
 
     private IPublishedContentCache PublishedContentHybridCache => GetRequiredService<IPublishedContentCache>();
 
+    private IContentPublishingService ContentPublishingService => GetRequiredService<IContentPublishingService>();
+
     private IContent VariantPage { get; set; }
 
     protected override void CustomTestSetup(IUmbracoBuilder builder)
@@ -118,6 +120,83 @@ internal sealed class DocumentHybridCacheVariantsTests : UmbracoIntegrationTest
         Assert.AreEqual(updatedInvariantTitle, textPage.Value(_invariantTitleAlias, string.Empty, string.Empty));
         Assert.AreEqual(updatedVariantTitle, textPage.Value(_variantTitleAlias, _englishIsoCode));
         Assert.AreEqual(_variantTitleName, textPage.Value(_variantTitleAlias, _danishIsoCode));
+    }
+
+    [TestCase("en-US")]
+    [TestCase("da-DK")]
+    public async Task Can_Get_Draft_For_Unpublished_Culture(string cultureToUnpublish)
+    {
+        // Arrange
+        var publishAttempt = await ContentPublishingService.PublishBranchAsync(VariantPage.Key, [_englishIsoCode, _danishIsoCode], PublishBranchFilter.All, Constants.Security.SuperUserKey, false);
+        Assert.IsTrue(publishAttempt.Success);
+        Assert.That(publishAttempt.Result.SucceededItems.Count(), Is.EqualTo(1));
+
+        var publishedPage = await PublishedContentHybridCache.GetByIdAsync(VariantPage.Id, false);
+        Assert.IsNotNull(publishedPage);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(publishedPage.IsPublished(_englishIsoCode));
+            Assert.IsTrue(publishedPage.IsPublished(_danishIsoCode));
+
+            Assert.AreEqual(2, publishedPage.Cultures.Count);
+            CollectionAssert.AreEqual(new[] { _englishIsoCode, _danishIsoCode }, publishedPage.Cultures.Keys);
+            CollectionAssert.AreEqual(new[] { _englishIsoCode, _danishIsoCode }, publishedPage.Cultures.Values.Select(v => v.Name));
+
+            Assert.AreEqual(_variantTitleName, publishedPage.Value<string>(_variantTitleAlias, _englishIsoCode));
+            Assert.AreEqual(_variantTitleName, publishedPage.Value<string>(_variantTitleAlias, _danishIsoCode));
+        });
+
+        var draftPage = await PublishedContentHybridCache.GetByIdAsync(VariantPage.Id, true);
+        Assert.IsNotNull(draftPage);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(draftPage.IsPublished(_englishIsoCode));
+            Assert.IsTrue(draftPage.IsPublished(_danishIsoCode));
+
+            Assert.AreEqual(2, draftPage.Cultures.Count);
+            CollectionAssert.AreEqual(new[] { _englishIsoCode, _danishIsoCode }, draftPage.Cultures.Keys);
+            CollectionAssert.AreEqual(new[] { _englishIsoCode, _danishIsoCode }, draftPage.Cultures.Values.Select(v => v.Name));
+
+            Assert.AreEqual(_variantTitleName, draftPage.Value<string>(_variantTitleAlias, _englishIsoCode));
+            Assert.AreEqual(_variantTitleName, draftPage.Value<string>(_variantTitleAlias, _danishIsoCode));
+        });
+
+        // Act
+        var unpublishAttempt = await ContentPublishingService.UnpublishAsync(VariantPage.Key, new HashSet<string> { cultureToUnpublish }, Constants.Security.SuperUserKey);
+        Assert.IsTrue(unpublishAttempt.Success);
+
+        // Assert
+        var expectedPublishedCulture = cultureToUnpublish == _danishIsoCode ? _englishIsoCode : _danishIsoCode;
+
+        publishedPage = await PublishedContentHybridCache.GetByIdAsync(VariantPage.Id, false);
+        Assert.IsNotNull(publishedPage);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(publishedPage.IsPublished(expectedPublishedCulture));
+            Assert.IsFalse(publishedPage.IsPublished(cultureToUnpublish));
+
+            Assert.AreEqual(1, publishedPage.Cultures.Count);
+            Assert.AreEqual(expectedPublishedCulture, publishedPage.Cultures.Single().Key);
+            Assert.AreEqual(expectedPublishedCulture, publishedPage.Cultures.Single().Value.Name);
+
+            Assert.AreEqual(_variantTitleName, publishedPage.Value<string>(_variantTitleAlias, expectedPublishedCulture));
+            Assert.IsEmpty(publishedPage.Value<string>(_variantTitleAlias, cultureToUnpublish));
+        });
+
+        draftPage = await PublishedContentHybridCache.GetByIdAsync(VariantPage.Id, true);
+        Assert.IsNotNull(draftPage);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(draftPage.IsPublished(expectedPublishedCulture));
+            Assert.IsFalse(draftPage.IsPublished(cultureToUnpublish));
+
+            Assert.AreEqual(2, draftPage.Cultures.Count);
+            CollectionAssert.AreEqual(new[] { _englishIsoCode, _danishIsoCode }, draftPage.Cultures.Keys);
+            CollectionAssert.AreEqual(new[] { _englishIsoCode, _danishIsoCode }, draftPage.Cultures.Values.Select(v => v.Name));
+
+            Assert.AreEqual(_variantTitleName, draftPage.Value<string>(_variantTitleAlias, _englishIsoCode));
+            Assert.AreEqual(_variantTitleName, draftPage.Value<string>(_variantTitleAlias, _danishIsoCode));
+        });
     }
 
     private async Task CreateTestData()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

A strange behavior was found while reviewing #22622: Unpublishing a single culture variant seems to make it "somewhat disappear" from preview mode.

Upon further investigation, this is a distinct fault, hence a dedicated PR to fix it.

Here's a screencast of the issue:

[unpublish-single-culture.webm](https://github.com/user-attachments/assets/5fb569a3-ef00-4cf3-badb-8bda6fa3b6a4)

_Note: The strangely orphaned "Grandchild 2 - DA" at the end of the screencast is what #22622 aims to fix._

This _only_ affects variant content.

The root cause is that when a content item is unpublishing a single culture among multiple, published cultures, the tracked `PublishedState` of the content item is not `PublishedState.Unpublishing`, as you might expect, but `PublishedState.Publishing`. This causes [`CacheNodeFactory.GetPublishedValue()`](https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.PublishedCache.HybridCache/Factories/CacheNodeFactory.cs#L40) to misinterpret the intent of the current operation, and ultimately it ends up forcefully populating a `ContentCacheNode` with _published_ data, when it was intended to populate it with _draft_ data. Since the culture variant has already been flagged as unpublished, the result is a quite empty looking `ContentCacheNode`, which explains the subsequent empty rendering.

If you subsequently makes a change to the culture and save it, the `ContentCacheNode` is regenerated and correctly populated for draft (preview) rendering.

### Testing this PR

Verify that preview continues to work, when unpublishing culture variants of already-published content.


