### PR TITLE
Routing: Ensure `IPublishedContent.UrlSegment` respects `umbracoUrlName` (closes #22655)

### DIFF
--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -75,41 +75,29 @@ public static class PublishedContentExtensions
     [Obsolete("Please use GetUrlSegment() on IDocumentUrlService instead. Scheduled for removal in Umbraco 18.")]
     public static string? UrlSegment(this IPublishedContent content, IVariationContextAccessor? variationContextAccessor, string? culture = null)
     {
-        if (content == null)
+        ArgumentNullException.ThrowIfNull(content);
+
+        // The obsolete accessor only meaningfully applies to documents — the documented replacement is
+        // IDocumentUrlService, and media/members never had user-facing URL segments.
+        if (content.ItemType != PublishedItemType.Content)
         {
-            throw new ArgumentNullException(nameof(content));
+            return null;
         }
 
         string effectiveCulture = content.ContentType.VariesByCulture() is false
             ? string.Empty
             : culture ?? variationContextAccessor?.VariationContext?.Culture ?? string.Empty;
 
-        // Delegate to IDocumentUrlService so this obsolete accessor agrees with IPublishedContent.Url(),
-        // which routes through the same service. Skip for variant content with no resolved culture —
-        // the service would do a fruitless ILanguageService.GetAsync("") lookup before falling through
-        // to a null result, which is the same answer the legacy Cultures lookup below produces.
-        if (content.ItemType == PublishedItemType.Content
-            && (content.ContentType.VariesByCulture() is false || effectiveCulture.Length != 0))
+        // Variant content with no resolved culture has no associated segment; avoid an unnecessary
+        // ILanguageService.GetAsync("") lookup inside the service.
+        if (content.ContentType.VariesByCulture() && effectiveCulture.Length == 0)
         {
-            IDocumentUrlService? documentUrlService = StaticServiceProvider.Instance?.GetService<IDocumentUrlService>();
-            if (documentUrlService is not null && documentUrlService.IsInitialized)
-            {
-                var isDraft = content.IsDraft(effectiveCulture.Length == 0 ? null : effectiveCulture);
-                return documentUrlService.GetUrlSegment(content.Key, effectiveCulture, isDraft);
-            }
+            return null;
         }
 
-        // Fallback for media/members or when the service is not available (e.g. during boot).
-        if (content.ContentType.VariesByCulture() is false)
-        {
-            return content.Cultures.TryGetValue(string.Empty, out PublishedCultureInfo? invariantInfos)
-                ? invariantInfos.UrlSegment
-                : null;
-        }
-
-        return effectiveCulture.Length != 0 && content.Cultures.TryGetValue(effectiveCulture, out PublishedCultureInfo? infos)
-            ? infos.UrlSegment
-            : null;
+        IDocumentUrlService documentUrlService = StaticServiceProvider.Instance.GetRequiredService<IDocumentUrlService>();
+        var isDraft = content.IsDraft(effectiveCulture.Length == 0 ? null : effectiveCulture);
+        return documentUrlService.GetUrlSegment(content.Key, effectiveCulture, isDraft);
     }
 
     #endregion

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -95,7 +95,17 @@ public static class PublishedContentExtensions
             return null;
         }
 
-        IDocumentUrlService documentUrlService = StaticServiceProvider.Instance.GetRequiredService<IDocumentUrlService>();
+        // Use IDocumentUrlService to get the URL segment, aligning with the non-obsolete recommended approach.
+        // Fall back to in-memory lookup if the static service provider isn't initialised (e.g. unit tests that
+        // don't bootstrap DI). In production it is always populated.
+        IDocumentUrlService? documentUrlService = StaticServiceProvider.Instance?.GetService<IDocumentUrlService>();
+        if (documentUrlService is null)
+        {
+            return content.Cultures.TryGetValue(effectiveCulture, out PublishedCultureInfo? infos)
+                ? infos.UrlSegment
+                : null;
+        }
+
         var isDraft = content.IsDraft(effectiveCulture.Length == 0 ? null : effectiveCulture);
         return documentUrlService.GetUrlSegment(content.Key, effectiveCulture, isDraft);
     }

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -80,22 +80,31 @@ public static class PublishedContentExtensions
             throw new ArgumentNullException(nameof(content));
         }
 
-        // invariant has invariant value (whatever the requested culture)
-        if (!content.ContentType.VariesByCulture())
+        string effectiveCulture = content.ContentType.VariesByCulture() is false
+            ? string.Empty
+            : culture ?? variationContextAccessor?.VariationContext?.Culture ?? string.Empty;
+
+        // Delegate to IDocumentUrlService so this obsolete accessor agrees with IPublishedContent.Url(),
+        // which routes through the same service.
+        if (content.ItemType == PublishedItemType.Content)
+        {
+            IDocumentUrlService? documentUrlService = StaticServiceProvider.Instance?.GetService<IDocumentUrlService>();
+            if (documentUrlService is not null && documentUrlService.IsInitialized)
+            {
+                var isDraft = content.IsDraft(effectiveCulture.Length == 0 ? null : effectiveCulture);
+                return documentUrlService.GetUrlSegment(content.Key, effectiveCulture, isDraft);
+            }
+        }
+
+        // Fallback for media/members or when the service is not available (e.g. during boot).
+        if (content.ContentType.VariesByCulture() is false)
         {
             return content.Cultures.TryGetValue(string.Empty, out PublishedCultureInfo? invariantInfos)
                 ? invariantInfos.UrlSegment
                 : null;
         }
 
-        // handle context culture for variant
-        if (culture == null)
-        {
-            culture = variationContextAccessor?.VariationContext?.Culture ?? string.Empty;
-        }
-
-        // get
-        return culture != string.Empty && content.Cultures.TryGetValue(culture, out PublishedCultureInfo? infos)
+        return effectiveCulture.Length != 0 && content.Cultures.TryGetValue(effectiveCulture, out PublishedCultureInfo? infos)
             ? infos.UrlSegment
             : null;
     }

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -96,10 +96,11 @@ public static class PublishedContentExtensions
         }
 
         // Use IDocumentUrlService to get the URL segment, aligning with the non-obsolete recommended approach.
-        // Fall back to in-memory lookup if the static service provider isn't initialised (e.g. unit tests that
-        // don't bootstrap DI). In production it is always populated.
+        // Fall back to in-memory lookup when the service isn't usable — either DI hasn't been bootstrapped
+        // (unit tests) or the service hasn't been initialised (integration tests not running full Umbraco
+        // startup). In production both hold.
         IDocumentUrlService? documentUrlService = StaticServiceProvider.Instance?.GetService<IDocumentUrlService>();
-        if (documentUrlService is null)
+        if (documentUrlService is null || documentUrlService.IsInitialized is false)
         {
             return content.Cultures.TryGetValue(effectiveCulture, out PublishedCultureInfo? infos)
                 ? infos.UrlSegment

--- a/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
+++ b/src/Umbraco.Core/Extensions/PublishedContentExtensions.cs
@@ -85,8 +85,11 @@ public static class PublishedContentExtensions
             : culture ?? variationContextAccessor?.VariationContext?.Culture ?? string.Empty;
 
         // Delegate to IDocumentUrlService so this obsolete accessor agrees with IPublishedContent.Url(),
-        // which routes through the same service.
-        if (content.ItemType == PublishedItemType.Content)
+        // which routes through the same service. Skip for variant content with no resolved culture —
+        // the service would do a fruitless ILanguageService.GetAsync("") lookup before falling through
+        // to a null result, which is the same answer the legacy Cultures lookup below produces.
+        if (content.ItemType == PublishedItemType.Content
+            && (content.ContentType.VariesByCulture() is false || effectiveCulture.Length != 0))
         {
             IDocumentUrlService? documentUrlService = StaticServiceProvider.Instance?.GetService<IDocumentUrlService>();
             if (documentUrlService is not null && documentUrlService.IsInitialized)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -155,7 +155,7 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
             .WithSupportsPublishing(true)
             .Build();
         ContentType.AddPropertyType(urlNameProperty);
-        ContentTypeService.Save(ContentType);
+        await ContentTypeService.UpdateAsync(ContentType, Constants.Security.SuperUserKey);
 
         var page = ContentBuilder.CreateSimpleContent(ContentType, "Find a Park", Textpage.Id);
         page.SetValue(Constants.Conventions.Content.UrlName, "park");
@@ -177,7 +177,7 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
             .WithSupportsPublishing(true)
             .Build();
         ContentType.AddPropertyType(urlNameProperty);
-        ContentTypeService.Save(ContentType);
+        await ContentTypeService.UpdateAsync(ContentType, Constants.Security.SuperUserKey);
 
         var page = ContentBuilder.CreateSimpleContent(ContentType, "Find a Park", Textpage.Id);
         page.SetValue(Constants.Conventions.Content.UrlName, "park");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
@@ -27,6 +28,8 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
     private const string SubSubPage3Key = "AACF2979-3F53-4184-B071-BA34D3338497";
 
     private IDocumentUrlService DocumentUrlService => GetRequiredService<IDocumentUrlService>();
+
+    private IPublishedContentCache PublishedContentCache => GetRequiredService<IPublishedContentCache>();
 
     private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
 
@@ -143,7 +146,56 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
 
     }
 
-    //TODO test with the urlsegment property value!
+    [Test]
+    public async Task GetUrlSegment_Respects_UmbracoUrlName_Property()
+    {
+        var urlNameProperty = new PropertyTypeBuilder()
+            .WithAlias(Constants.Conventions.Content.UrlName)
+            .WithName("Url Name")
+            .WithSupportsPublishing(true)
+            .Build();
+        ContentType.AddPropertyType(urlNameProperty);
+        ContentTypeService.Save(ContentType);
+
+        var page = ContentBuilder.CreateSimpleContent(ContentType, "Find a Park", Textpage.Id);
+        page.SetValue(Constants.Conventions.Content.UrlName, "park");
+        ContentService.Save(page);
+        ContentService.Publish(page, ["*"]);
+
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+        var actual = DocumentUrlService.GetUrlSegment(page.Key, isoCode, isDraft: false);
+
+        Assert.AreEqual("park", actual);
+    }
+
+    [Test]
+    public async Task PublishedContent_UrlSegment_Agrees_With_DocumentUrlService_When_UmbracoUrlName_Set()
+    {
+        var urlNameProperty = new PropertyTypeBuilder()
+            .WithAlias(Constants.Conventions.Content.UrlName)
+            .WithName("Url Name")
+            .WithSupportsPublishing(true)
+            .Build();
+        ContentType.AddPropertyType(urlNameProperty);
+        ContentTypeService.Save(ContentType);
+
+        var page = ContentBuilder.CreateSimpleContent(ContentType, "Find a Park", Textpage.Id);
+        page.SetValue(Constants.Conventions.Content.UrlName, "park");
+        ContentService.Save(page);
+        ContentService.Publish(page, ["*"]);
+
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+        var serviceSegment = DocumentUrlService.GetUrlSegment(page.Key, isoCode, isDraft: false);
+
+        var published = await PublishedContentCache.GetByIdAsync(page.Key);
+        Assert.IsNotNull(published);
+#pragma warning disable CS0618 // Type or member is obsolete
+        var publishedSegment = published!.UrlSegment;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        Assert.AreEqual("park", serviceSegment);
+        Assert.AreEqual(serviceSegment, publishedSegment);
+    }
 
     [Test]
     public async Task GetUrlSegment_For_Document_With_Parent_Deleted_Does_Not_Have_Url_Segment()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -187,7 +187,7 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
         var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
         var serviceSegment = DocumentUrlService.GetUrlSegment(page.Key, isoCode, isDraft: false);
 
-        var published = await PublishedContentCache.GetByIdAsync(page.Key);
+        var published = await PublishedContentCache.GetByIdAsync(page.Key, preview: false);
         Assert.IsNotNull(published);
 #pragma warning disable CS0618 // Type or member is obsolete
         var publishedSegment = published!.UrlSegment;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -149,21 +149,19 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
     [Test]
     public async Task GetUrlSegment_Respects_UmbracoUrlName_Property()
     {
-        var urlNameProperty = new PropertyTypeBuilder()
-            .WithAlias(Constants.Conventions.Content.UrlName)
-            .WithName("Url Name")
-            .WithSupportsPublishing(true)
-            .Build();
-        ContentType.AddPropertyType(urlNameProperty);
-        await ContentTypeService.UpdateAsync(ContentType, Constants.Security.SuperUserKey);
+        var contentType = await CreateInvariantContentTypeWithUrlNameAsync("invariantWithUrlName");
 
-        var page = ContentBuilder.CreateSimpleContent(ContentType, "Find a Park", Textpage.Id);
-        page.SetValue(Constants.Conventions.Content.UrlName, "park");
-        ContentService.Save(page);
-        ContentService.Publish(page, ["*"]);
+        var content = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithName("Find a Park")
+            .Build();
+        content.SetValue(Constants.Conventions.Content.UrlName, "park");
+        ContentService.Save(content);
+        var publishResult = ContentService.Publish(content, ["*"]);
+        Assert.IsTrue(publishResult.Success, $"Publish failed: {publishResult.Result}");
 
         var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
-        var actual = DocumentUrlService.GetUrlSegment(page.Key, isoCode, isDraft: false);
+        var actual = DocumentUrlService.GetUrlSegment(content.Key, isoCode, isDraft: false);
 
         Assert.AreEqual("park", actual);
     }
@@ -171,23 +169,21 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
     [Test]
     public async Task PublishedContent_UrlSegment_Agrees_With_DocumentUrlService_When_UmbracoUrlName_Set()
     {
-        var urlNameProperty = new PropertyTypeBuilder()
-            .WithAlias(Constants.Conventions.Content.UrlName)
-            .WithName("Url Name")
-            .WithSupportsPublishing(true)
-            .Build();
-        ContentType.AddPropertyType(urlNameProperty);
-        await ContentTypeService.UpdateAsync(ContentType, Constants.Security.SuperUserKey);
+        var contentType = await CreateInvariantContentTypeWithUrlNameAsync("invariantWithUrlNameAgree");
 
-        var page = ContentBuilder.CreateSimpleContent(ContentType, "Find a Park", Textpage.Id);
-        page.SetValue(Constants.Conventions.Content.UrlName, "park");
-        ContentService.Save(page);
-        ContentService.Publish(page, ["*"]);
+        var content = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithName("Find a Park")
+            .Build();
+        content.SetValue(Constants.Conventions.Content.UrlName, "park");
+        ContentService.Save(content);
+        var publishResult = ContentService.Publish(content, ["*"]);
+        Assert.IsTrue(publishResult.Success, $"Publish failed: {publishResult.Result}");
 
         var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
-        var serviceSegment = DocumentUrlService.GetUrlSegment(page.Key, isoCode, isDraft: false);
+        var serviceSegment = DocumentUrlService.GetUrlSegment(content.Key, isoCode, isDraft: false);
 
-        var published = await PublishedContentCache.GetByIdAsync(page.Key, preview: false);
+        var published = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
         Assert.IsNotNull(published);
 #pragma warning disable CS0618 // Type or member is obsolete
         var publishedSegment = published!.UrlSegment;
@@ -195,6 +191,33 @@ internal sealed class DocumentUrlServiceTests : UmbracoIntegrationTestWithConten
 
         Assert.AreEqual("park", serviceSegment);
         Assert.AreEqual(serviceSegment, publishedSegment);
+    }
+
+    private async Task<IContentType> CreateInvariantContentTypeWithUrlNameAsync(string alias)
+    {
+        var template = TemplateBuilder.CreateTextPageTemplate($"{alias}Template", $"{alias} Template");
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        var contentType = new ContentTypeBuilder()
+            .WithAlias(alias)
+            .WithName(alias)
+            .WithAllowAsRoot(true)
+            .WithDefaultTemplateId(template.Id)
+            .AddPropertyGroup()
+                .WithAlias("content")
+                .WithName("Content")
+                .WithSortOrder(1)
+                .WithSupportsPublishing(true)
+                .AddPropertyType()
+                    .WithAlias(Constants.Conventions.Content.UrlName)
+                    .WithName("Url Name")
+                    .WithVariations(ContentVariation.Nothing)
+                    .WithSortOrder(1)
+                    .Done()
+                .Done()
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        return contentType;
     }
 
     [Test]


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/22655 provides a report that the obsolete `UrlSegment` property, which is supported via an also obsolete extension method, can return different values than would be expected when comparing to the `IPublishedContent.Url()` value.

In my tests, I couldn't replicate it, but it seems like it could occur due to caching issues.

To ensure they align, I've delegated the extension method to `IDocumentUrlService.GetUrlSegment(...)`, which is the documented replacement (per the `[Obsolete]` message). So both now read from the same source and will stay in sync. 

Whilst here, I've replaced a `TODO` placeholder in `DocumentUrlServiceTests` with two new tests: one asserting `IDocumentUrlService.GetUrlSegment` honours `umbracoUrlName`, and one asserting `IPublishedContent.UrlSegment` agrees with it.

> Note: there is a bit of ceremony in the extension method now to safely service locate and use the `IDocumentUrlService`; necessary to avoid failing tests that haven't bootstrapped all of the Umbraco initialization.  I think this is reasonable for the purposes we have here: ensuring that an obsolete code path is aligned with the non-obsolete one.

## Testing

### Automated

Verify new integration tests pass.

## Manual testing

Drop the following into a template. Replace the GUID with the key of the document you want to inspect.  It should have a `umbracoUrlName` that you can populate and erase to check the effect.

```cshtml
@using Umbraco.Cms.Core
@using Umbraco.Cms.Core.Models.PublishedContent
@using Umbraco.Cms.Core.Services
@using Microsoft.AspNetCore.Mvc.Rendering
@inject IDocumentUrlService DocumentUrlService
@inject ILanguageService LanguageService
@{
    Layout = null;
    var key = new Guid("REPLACE-WITH-NODE-GUID");
    var node = Umbraco.Content(key);
    var defaultIso = (await LanguageService.GetDefaultLanguageAsync())?.IsoCode ?? "en-US";
    string? serviceSegment = node is null ? null : DocumentUrlService.GetUrlSegment(node.Key, defaultIso, isDraft: false);
}

@if (node is null)
{
    <p>No content found for GUID @key.</p>
}
else
{
    <h1>@node.Name</h1>
    <table border="1" cellpadding="6">
        <tr><th>Accessor</th><th>Value</th></tr>
        <tr><td><code>node.Url()</code></td><td>@node.Url()</td></tr>
@{
        var legacySegment = node.UrlSegment;
}
        <tr><td><code>node.UrlSegment</code> (obsolete)</td><td>@legacySegment</td></tr>
        <tr><td><code>IDocumentUrlService.GetUrlSegment(...)</code></td><td>@serviceSegment</td></tr>
        <tr><td><code>node.Value("umbracoUrlName")</code></td><td>@node.Value("umbracoUrlName")</td></tr>
        <tr><td><code>node.Name</code></td><td>@node.Name</td></tr>
    </table>
}
</body>
</html>
```

Verify that you see the expected agreement between the different ways of rendering the URL segment.