### PR TITLE
Accessibility: Added missing labels to number fields in the settings tab

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/settings/document-type-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/workspace/document-type/views/settings/document-type-workspace-view-settings.element.ts
@@ -177,6 +177,7 @@ export class UmbDocumentTypeWorkspaceViewSettingsElement extends UmbLitElement i
 										type="number"
 										id="versions-newer-than-days"
 										min="0"
+										label=${this.localize.term('contentTypeEditor_historyCleanupKeepAllVersionsNewerThanDays')}
 										placeholder="7"
 										.value=${this._keepAllVersionsNewerThanDays?.toString() ?? ''}
 										@change=${this.#onChangeKeepAllVersionsNewerThanDays}></uui-input>
@@ -192,6 +193,7 @@ export class UmbDocumentTypeWorkspaceViewSettingsElement extends UmbLitElement i
 										type="number"
 										id="latest-version-per-day-days"
 										min="0"
+										label=${this.localize.term('contentTypeEditor_historyCleanupKeepLatestVersionPerDayForDays')}
 										placeholder="90"
 										.value=${this._keepLatestVersionPerDayForDays?.toString() ?? ''}
 										@change=${this.#onChangeKeepLatestVersionPerDayForDays}></uui-input>


### PR DESCRIPTION
## Description

The two number input fields shown in the settings tab were both missing labels.

<img width="1192" height="685" alt="image" src="https://github.com/user-attachments/assets/4fcd73d1-c7d0-4688-8a54-c169d4dbc2f8" />

This caused the console warning `UUI-INPUT needs a label` to appear.

Added the same localized term used in the labels to the input fields.

<img width="600" height="381" alt="image" src="https://github.com/user-attachments/assets/028dfa72-3783-4068-b904-a78f81544a2e" />