### PR TITLE
Templates: Update Umbraco extension template for OpenAPI route changes

### DIFF
--- a/templates/UmbracoExtension/Client/package.json
+++ b/templates/UmbracoExtension/Client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "watch": "tsc && vite build --watch",
     "build": "tsc && vite build",
-    "generate-client": "node scripts/generate-openapi.js https://localhost:44339/umbraco/swagger/umbracoextension/swagger.json"
+    "generate-client": "node scripts/generate-openapi.js https://localhost:44339/umbraco/openapi/umbracoextension.json"
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.85.2",

--- a/templates/UmbracoExtension/Client/scripts/generate-openapi.js
+++ b/templates/UmbracoExtension/Client/scripts/generate-openapi.js
@@ -5,11 +5,11 @@ import { createClient, defaultPlugins } from '@hey-api/openapi-ts';
 // Start notifying user we are generating the TypeScript client
 console.log(chalk.green("Generating OpenAPI client..."));
 
-const swaggerUrl = process.argv[2];
-if (swaggerUrl === undefined) {
+const openApiUrl = process.argv[2];
+if (openApiUrl === undefined) {
   console.error(chalk.red(`ERROR: Missing URL to OpenAPI spec`));
   console.error(`Please provide the URL to the OpenAPI spec as the first argument found in ${chalk.yellow('package.json')}`);
-  console.error(`Example: node generate-openapi.js ${chalk.yellow('https://localhost:44339/umbraco/swagger/REPLACE_ME/swagger.json')}`);
+  console.error(`Example: node generate-openapi.js ${chalk.yellow('https://localhost:44339/umbraco/openapi/REPLACE_ME.json')}`);
   process.exit();
 }
 
@@ -18,9 +18,9 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 // Start checking to see if we can connect to the OpenAPI spec
 console.log("Ensure your Umbraco instance is running");
-console.log(`Fetching OpenAPI definition from ${chalk.yellow(swaggerUrl)}`);
+console.log(`Fetching OpenAPI definition from ${chalk.yellow(openApiUrl)}`);
 
-fetch(swaggerUrl).then(async (response) => {
+fetch(openApiUrl).then(async (response) => {
   if (!response.ok) {
     console.error(chalk.red(`ERROR: OpenAPI spec returned with a non OK (200) response: ${response.status} ${response.statusText}`));
     console.error(`The URL to your Umbraco instance may be wrong or the instance is not running`);
@@ -32,7 +32,7 @@ fetch(swaggerUrl).then(async (response) => {
   console.log(`Calling ${chalk.yellow('hey-api')} to generate TypeScript client`);
 
   await createClient({
-    input: swaggerUrl,
+    input: openApiUrl,
     output: 'src/api',
     plugins: [
       ...defaultPlugins,

--- a/templates/UmbracoExtension/Composers/UmbracoExtensionApiComposer.cs
+++ b/templates/UmbracoExtension/Composers/UmbracoExtensionApiComposer.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi;
+using Umbraco.Cms.Api.Common.Attributes;
 using Umbraco.Cms.Api.Common.DependencyInjection;
 using Umbraco.Cms.Api.Management.OpenApi;
 using Umbraco.Cms.Core.Composing;
@@ -39,6 +40,12 @@ public class UmbracoExtensionApiComposer : IComposer
                     };
                     return Task.CompletedTask;
                 });
+
+                // Only include endpoints decorated with the `MapToApi` attribute for our own API.
+                options.ShouldInclude = apiDescription =>
+                    apiDescription.ActionDescriptor.EndpointMetadata
+                        .OfType<MapToApiAttribute>()
+                        .Any(attribute => attribute.ApiName == Constants.ApiName);
 
                 // Enable Umbraco authentication for the "Example" OpenAPI document
                 options.AddBackofficeSecurityRequirements();

--- a/templates/UmbracoExtension/Composers/UmbracoExtensionApiComposer.cs
+++ b/templates/UmbracoExtension/Composers/UmbracoExtensionApiComposer.cs
@@ -21,9 +21,9 @@ public class UmbracoExtensionApiComposer : IComposer
                 // https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-backoffice-api/versioning-your-api
                 // https://docs.umbraco.com/umbraco-cms/tutorials/creating-a-backoffice-api/access-policies
 
-                // Configure the Swagger generation options
-                // Add in a new Swagger API document solely for our own package that can be browsed via Swagger UI
-                // Along with having a generated swagger JSON file that we can use to auto generate a TypeScript client
+                // Configure the OpenAPI generation options
+                // Add in a new OpenAPI document solely for our own package that can be browsed via the OpenAPI UI
+                // Along with having a generated OpenAPI JSON file that we can use to auto generate a TypeScript client
                 options.AddDocumentTransformer((document, _, _) =>
                 {
                     document.Info = new OpenApiInfo
@@ -40,7 +40,7 @@ public class UmbracoExtensionApiComposer : IComposer
                     return Task.CompletedTask;
                 });
 
-                // Enable Umbraco authentication for the "Example" Swagger document
+                // Enable Umbraco authentication for the "Example" OpenAPI document
                 options.AddBackofficeSecurityRequirements();
 
                 // This is used to generate operation IDs in our OpenAPI JSON file so that the generated 

--- a/templates/UmbracoExtension/Directory.Packages.props
+++ b/templates/UmbracoExtension/Directory.Packages.props
@@ -11,5 +11,6 @@
     <PackageVersion Include="Umbraco.Cms.Api.Management" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
   </ItemGroup>
 </Project>

--- a/templates/UmbracoExtension/Umbraco.Extension.csproj
+++ b/templates/UmbracoExtension/Umbraco.Extension.csproj
@@ -25,6 +25,21 @@
     <PackageReference Include="Umbraco.Cms.Api.Management" />
     <PackageReference Include="Umbraco.Cms.Web.Common" />
     <PackageReference Include="Umbraco.Cms.Web.Website" />
+
+    <!--
+      Microsoft.AspNetCore.OpenApi is available transitively from the Umbraco packages above, but we
+      take a direct dependency here because extension code directly uses types from this package
+      (IOpenApiDocumentTransformer, IOpenApiOperationTransformer, etc.) and from Microsoft.OpenApi
+      (OpenApiInfo). Without a direct reference, this project's Microsoft.AspNetCore.OpenApi version
+      is determined solely by NuGet's transitive resolution, which can resolve to a different version
+      than the host site project (e.g. a newer patch). When that happens, the different
+      Microsoft.OpenApi versions can conflict at runtime, causing custom OpenAPI documents registered
+      by the extension to fail to appear.
+      Most other transitive dependencies don't have this problem because extension code doesn't use
+      their types directly - only Microsoft.AspNetCore.OpenApi / Microsoft.OpenApi types are
+      referenced in the composer.
+    -->
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
   <!--#endif -->
 
@@ -33,6 +48,8 @@
   <ItemGroup>
     <PackageReference Include="Umbraco.Cms.Api.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageReference Include="Umbraco.Cms.Api.Management" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
 
     <!--
       Microsoft.AspNetCore.OpenApi is available transitively from the Umbraco packages above, but we
@@ -48,8 +65,6 @@
       referenced in the composer.
     -->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageReference Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
   </ItemGroup>
   <!--#endif -->
 


### PR DESCRIPTION
## Summary

Follow-up to #21058 (the Microsoft.AspNetCore.OpenApi migration). The `UmbracoExtension` dotnet template was not updated as part of that PR, so a freshly scaffolded extension hits several issues against a v18 site.

This PR fixes:

- The `generate-client` URL in `Client/package.json` and the example URL in `Client/scripts/generate-openapi.js` to use the new `/umbraco/openapi/{name}.json` route. Also renames `swaggerUrl` to `openApiUrl`, updates the related log strings for consistency, and replaces outdated "Swagger" terminology in `UmbracoExtensionApiComposer.cs` comments.
- An explicit `ShouldInclude` predicate on `OpenApiOptions` in `UmbracoExtensionApiComposer.cs`, filtering by the `MapToApi` attribute that's already on the extension's controller base. Without it, Microsoft.AspNetCore.OpenApi's default predicate filters by `ApiExplorer.GroupName` matching the document name, which doesn't match for the template's setup, so the custom document was created but stayed empty (`paths: []`), making `npm run generate-client` produce an empty TypeScript SDK.
- A direct dependency on `Microsoft.AspNetCore.OpenApi` in the Central package management mode of the extension template (`Umbraco.Extension.csproj` and `Directory.Packages.props`). The PerProject mode already had this, but Central mode did not, so default Central scaffolds failed to build with the source-generator interceptors error.

## Testing

End-to-end test requires a running Umbraco 18 site with the extension loaded. Quickest path is to pack everything locally and scaffold a fresh site and extension from the updated templates:

1. From the repo root, pack the solution: `dotnet pack umbraco.sln -c Release -o ./packages`.
2. Install the templates from the local pack: `dotnet new install ./packages/Umbraco.Templates.18.0.0--*.nupkg`.
3. Create a scratch directory for the test project, then drop a `NuGet.config` in it that points at `<repo>/packages` alongside `nuget.org`.
4. From the scratch directory, scaffold the site: `dotnet new umbraco -n MyTestSite --development-database-type SQLite --friendly-name "Test Admin" --email admin@test.local --password "Test1234!@#"`.
5. Scaffold the extension: `dotnet new umbraco-extension -n MyTestExtension`.
6. In `MyTestExtension/Client/package.json`, set `@umbraco-cms/backoffice` to `^17.3.5` (no v18 release on npm yet) and update the URL in the `generate-client` script to match the port you'll run the site on (e.g. `https://localhost:44339`).
7. From `MyTestSite`: `dotnet add reference ../MyTestExtension/MyTestExtension.csproj`, then `dotnet build`, then `dotnet run --urls https://localhost:44339` (matching the port from step 6).
8. Confirm `https://localhost:44339/umbraco/openapi/mytestextension.json` returns 200 with the `ping` endpoint under `paths`, and `https://localhost:44339/umbraco/swagger/mytestextension/swagger.json` returns 404.
9. In `MyTestExtension/Client`, run `npm install`, `npm run generate-client`, `npm run build`. All three should succeed.