### PR TITLE
Cherry-picked the missing constant for "unroutable"

### DIFF
--- a/src/Umbraco.Core/Constants-Routing.cs
+++ b/src/Umbraco.Core/Constants-Routing.cs
@@ -1,0 +1,20 @@
+namespace Umbraco.Cms.Core;
+
+public static partial class Constants
+{
+    /// <summary>
+    ///     Defines routing constants.
+    /// </summary>
+    public static class Routing
+    {
+        /// <summary>
+        ///     Represents the route of unroutable content.
+        /// </summary>
+        public const string Unroutable = "#";
+
+        /// <summary>
+        ///     Represents the route returned when a URL provider throws an exception while resolving content.
+        /// </summary>
+        public const string UrlProviderException = "#ex";
+    }
+}


### PR DESCRIPTION
### Description

This cherry-picks the routing constants introduced in https://github.com/umbraco/Umbraco-CMS/pull/22593 to 17.4.

These were originally intended for 17.5. However, https://github.com/umbraco/Umbraco-CMS/pull/22657, which was also created for 17.5, has been cherry-picked for 17.4, and it references one of the constants, causing the 17.4 build to fail.

I tried cherry-picking all of https://github.com/umbraco/Umbraco-CMS/pull/22593 to 17.4, as it is in essence just a replacement of all the hardcoded `"#"` values in the codebase, but the changes from https://github.com/umbraco/Umbraco-CMS/pull/22586 (also for 17.5) causes merge conflicts.

Adding the constants explicitly to 17.4 is preferable to including https://github.com/umbraco/Umbraco-CMS/pull/22586 in 17.4 as well. Hopefully we won't get too many merge conflicts when it's time to consolidate the 17.4 release branch with `main` 🤞 