### PR TITLE
State System: more tests, MD updates and a tiny bit more consistency

### DIFF
--- a/src/Umbraco.Web.UI.Client/CLAUDE.md
+++ b/src/Umbraco.Web.UI.Client/CLAUDE.md
@@ -9,7 +9,8 @@ TypeScript/Lit web components library for the Umbraco CMS backoffice. Published 
 - **[Manifests & Aliases](./docs/manifests.md)** - Manifest shape, alias conventions, alias constants, how aliases connect extensions, registration, registry operations, kind merging
 - **[Entities](./docs/entities.md)** - Entity types, entity context, how entityType connects workspaces/trees/actions/routing
 - **[Workspaces](./docs/workspaces.md)** - Workspace types, base classes, extension points, workspace contexts, save flow, routing
-- **[Core Primitives](./docs/core-primitives.md)** - UmbLitElement, observable state (UmbArrayState, UmbObjectState, etc.), Context API, controller lifecycle
+- **[Core Primitives](./docs/core-primitives.md)** - UmbLitElement, observable state, Context API, controller lifecycle
+- **[State System](./docs/state-system.md)** - `Umb*State` change-detection contract, per-type comparison semantics, `asObservablePart`, mute/unmute, observer-guard anti-patterns
 - **[Data Flow](./docs/data-flow.md)** - Data flow chain, data sources, tryExecute, generated API clients, stores, complete worked example
 - **[Repositories](./docs/repositories.md)** - Repository categories (detail, item, tree, collection, action-specific), file structure, naming, extension registration, data source delegation
 - **[Package Development](./docs/package-development.md)** - Package & module structure, folder structure conventions, localization, organizational rules
@@ -46,6 +47,7 @@ TypeScript/Lit web components library for the Umbraco CMS backoffice. Published 
 | Write or modify tests | [docs/testing.md](./docs/testing.md) |
 | Work with auth or security | [docs/security.md](./docs/security.md) + [docs/edge-cases.md](./docs/edge-cases.md) |
 | Scaffold a new package or module | [docs/package-development.md](./docs/package-development.md) |
+| Write or change observers / `Umb*State` usage | [docs/state-system.md](./docs/state-system.md) — states already deduplicate; do not add "is this a re-emit?" guards |
 
 This is not optional. Skipping these leads to convention violations that are caught in review.
 

--- a/src/Umbraco.Web.UI.Client/docs/core-primitives.md
+++ b/src/Umbraco.Web.UI.Client/docs/core-primitives.md
@@ -119,122 +119,25 @@ const label = this.localize.term('content_createBlueprintFrom');
 
 ## Observable State
 
-Reactive state containers built on RxJS `BehaviorSubject`. All state classes emit the current value immediately on subscription, then emit on every change.
+Reactive state containers built on RxJS `BehaviorSubject`. **All `Umb*State` classes only emit when the new value differs from the current value** — observers are not invoked on `setValue(x)` when the state already holds `x`. This means you do not need to write "is this a redundant re-emit?" guards inside observer callbacks.
 
-### State Types
-
-| Class | For | Change Detection |
-|-------|-----|-----------------|
-| `UmbStringState` | Strings | `!==` (reference) |
-| `UmbNumberState` | Numbers | `!==` (reference) |
-| `UmbBooleanState` | Booleans | `!==` (reference) |
-| `UmbObjectState` | Objects | JSON deep comparison + deep freeze |
-| `UmbArrayState` | Arrays | JSON deep comparison + deep freeze |
-| `UmbClassState` | Class instances | `.equal()` method on the class |
-| `UmbDeepState` | Any (base for Object/Array) | JSON deep comparison + deep freeze |
-
-### Basic Usage
+| Class | Holds | Comparison |
+|-------|-------|-----------|
+| `UmbStringState` / `UmbNumberState` / `UmbBooleanState` | Primitives | `===` |
+| `UmbObjectState` / `UmbArrayState` / `UmbDeepState` | Plain JSON data, deep-frozen | `JSON.stringify` deep compare |
+| `UmbClassState` | Class instance with `.equal()` | `oldValue.equal(newValue)` (when both non-null) |
+| `UmbBasicState` | Anything | `===` (reference) |
 
 ```typescript
 import { UmbStringState, UmbArrayState, UmbObjectState } from '@umbraco-cms/backoffice/observable-api';
 
-// Create state (private)
-#name = new UmbStringState('');
-#items = new UmbArrayState<MyItem>([], (item) => item.unique);
-#data = new UmbObjectState<MyModel | undefined>(undefined);
-
-// Expose as observable (public, read-only)
+// Private state, public read-only observable
+#name = new UmbStringState<string>('');
 readonly name = this.#name.asObservable();
-readonly items = this.#items.asObservable();
-readonly data = this.#data.asObservable();
-
-// Read current value
-const currentName = this.#name.getValue();
-
-// Update value
 this.#name.setValue('new name');
 ```
 
-### UmbArrayState
-
-Requires a unique-key function for identity tracking. Provides rich array manipulation methods.
-
-```typescript
-#items = new UmbArrayState<MyItem>([], (item) => item.unique);
-
-// Append
-this.#items.appendOne(newItem);
-this.#items.append([item1, item2]);
-
-// Remove
-this.#items.removeOne('unique-id');
-this.#items.remove(['id1', 'id2']);
-
-// Update a single item (partial merge)
-this.#items.updateOne('unique-id', { name: 'Updated' });
-
-// Filter
-this.#items.filter((item) => item.active);
-
-// Sort
-this.#items.sortBy((a, b) => a.name.localeCompare(b.name));
-
-// Clear
-this.#items.clear();
-
-// Check existence
-this.#items.getHasOne('unique-id'); // boolean
-```
-
-### UmbObjectState
-
-```typescript
-#data = new UmbObjectState<MyModel>({ name: '', count: 0 });
-
-// Partial update (shallow merge)
-this.#data.update({ name: 'Updated' }); // count stays 0
-```
-
-### Derived Observables (asObservablePart)
-
-Create an observable that only emits when a specific derived value changes. Uses memoization to avoid unnecessary updates.
-
-```typescript
-// Only emits when the name changes, not when other properties change
-readonly name = this.#data.asObservablePart((data) => data?.name);
-
-// Count of items
-readonly itemCount = this.#items.asObservablePart((items) => items.length);
-
-// First item
-readonly firstItem = this.#items.asObservablePart((items) => items[0]);
-```
-
-### Deep Freeze
-
-`UmbDeepState`, `UmbObjectState`, and `UmbArrayState` deep-freeze their data. Attempting to mutate frozen data throws an error in development. This enforces immutable update patterns:
-
-```typescript
-// WRONG — throws TypeError in development
-const items = this.#items.getValue();
-items.push(newItem); // Frozen!
-
-// CORRECT — create new array
-this.#items.appendOne(newItem);
-// or
-this.#items.setValue([...this.#items.getValue(), newItem]);
-```
-
-### Mute/Unmute
-
-`UmbDeepState` (and its subclasses) support muting to batch multiple updates without emitting intermediate values:
-
-```typescript
-this.#data.mute();
-this.#data.update({ name: 'a' });
-this.#data.update({ count: 1 });
-this.#data.unmute(); // Single emission with both changes
-```
+For per-type comparison details, change-detection caveats (`UmbBasicState` holding objects, `UmbClassState` with `undefined`), `asObservablePart` memoization, mute/unmute, and the rationale for not writing emission guards in observers, see **[State System](./state-system.md)**.
 
 ---
 
@@ -350,6 +253,8 @@ this.observe(context.items, (items) => { ... }, '_observeItems');
 // Second call: destroys previous '_observeItems' observer, creates new one
 this.observe(context.items, (items) => { ... }, '_observeItems');
 ```
+
+
 
 ---
 

--- a/src/Umbraco.Web.UI.Client/docs/core-primitives.md
+++ b/src/Umbraco.Web.UI.Client/docs/core-primitives.md
@@ -51,9 +51,10 @@ this.observe(
 ```
 
 **Alias behavior:**
-- If omitted and callback exists: auto-generated hash of the callback function
-- If `null`: no alias (controller cannot be replaced by alias)
-- If provided: explicit string/symbol for later reference
+
+- If omitted and callback exists: auto-generated hash of the callback function — guards against accidental duplicate subscriptions when the same `observe(...)` line runs more than once
+- If `null`: no alias — use this when the call site is one-shot (e.g., set up once in a constructor and never invoked again). Intentional; not a missing-alias smell.
+- If provided: explicit string/symbol — re-running the same `observe(...)` line replaces the existing controller with the same alias, and you can remove it actively via `removeUmbControllerByAlias('_observeItems')`
 
 ### Retrieve a Context
 

--- a/src/Umbraco.Web.UI.Client/docs/state-system.md
+++ b/src/Umbraco.Web.UI.Client/docs/state-system.md
@@ -1,0 +1,73 @@
+# State System
+
+Reactive state containers built on RxJS `BehaviorSubject`. The canonical way to hold and expose mutable data in contexts, controllers, and elements.
+
+For the broader observable lifecycle (`this.observe(...)`, controller cleanup, `observeMultiple`), see [core-primitives.md](./core-primitives.md).
+
+---
+
+
+## State Types
+
+| Class | Holds | Comparison |
+|-------|-------|-----------|
+| `UmbStringState` / `UmbNumberState` / `UmbBooleanState` | Primitives | `===` |
+| `UmbObjectState` / `UmbArrayState` / `UmbDeepState` | Plain JSON data, deep-frozen | `JSON.stringify` deep compare |
+| `UmbClassState` | Class instance with `.equal()` | `===` first, falling back to `oldValue.equal(newValue)` |
+| `UmbBasicState` | Anything | `===` |
+
+`UmbObjectState`/`UmbArrayState`/`UmbDeepState` deep-freeze their value — mutate by replacing, never in place. Use `UmbClassState` for class instances; `JSON.stringify` strips prototypes.
+
+Comparison determines whether a new value differs from the current one — subscribers are only notified when it does, so observer callbacks don't need their own re-emit guards.
+
+---
+
+## Standard Pattern
+
+Private state, public observable, immutable updates:
+
+```typescript
+#name = new UmbStringState<string>('');
+#items = new UmbArrayState<MyItem>([], (item) => item.unique);
+#data = new UmbObjectState<MyModel | undefined>(undefined);
+
+readonly name = this.#name.asObservable();
+readonly items = this.#items.asObservable();
+readonly data = this.#data.asObservable();
+
+this.#name.setValue('new name');
+this.#data.update({ count: 1 }); // shallow merge
+this.#items.appendOne(newItem);
+```
+
+---
+
+## `asObservablePart`
+
+Available on every state class. Project to a sub-value with its own deduplication layer:
+
+```typescript
+readonly name = this.#data.asObservablePart((data) => data?.name);
+readonly itemCount = this.#items.asObservablePart((items) => items.length);
+```
+
+Default memoization handles both objects (deep-equal via JSON) and primitives (`===`). Pass a custom memoization function as the second arg when the default is too coarse or too fine.
+
+---
+
+## Mute / Unmute (UmbDeepState only)
+
+Batch multiple writes into a single emission:
+
+```typescript
+this.#data.mute();
+this.#data.update({ name: 'a' });
+this.#data.update({ count: 1 });
+this.#data.unmute(); // single emission
+```
+
+Available on `UmbDeepState`, `UmbObjectState`, `UmbArrayState`. `getMutePromise()` resolves on the next `unmute`.
+
+---
+
+All state classes are imported from `@umbraco-cms/backoffice/observable-api`.

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/basic-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/basic-state.ts
@@ -1,4 +1,8 @@
+import type { MappingFunction } from '../types/mapping-function.type.js';
+import type { MemoizationFunction } from '../types/memoization-function.type.js';
+import { createObservablePart } from '../utils/create-observable-part.function.js';
 import { BehaviorSubject, type Observable } from '@umbraco-cms/backoffice/external/rxjs';
+import { strictEqualityMemoization } from '../utils/strict-equality-memoization.function.js';
 
 /**
  * @class UmbBasicState
@@ -22,6 +26,20 @@ export class UmbBasicState<T> {
 	 */
 	public asObservable(): Observable<T> {
 		return this._subject.asObservable();
+	}
+
+	/**
+	 * @function asObservablePart
+	 * @param {(mappable: T) => R} mappingFunction - Method to return the part for this Observable to return.
+	 * @param {(previousResult: R, currentResult: R) => boolean} [memoizationFunction] - Method to compare if the data has changed. Should return true when data is identical.
+	 * @returns {Observable<R>}
+	 * @description - Creates an Observable from this State that emits a derived value, deduplicated against its previous emission.
+	 */
+	public asObservablePart<ReturnType>(
+		mappingFunction: MappingFunction<T, ReturnType>,
+		memoizationFunction?: MemoizationFunction<ReturnType>,
+	): Observable<ReturnType> {
+		return createObservablePart(this._subject, mappingFunction, memoizationFunction ?? strictEqualityMemoization);
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/boolean-state.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/boolean-state.test.ts
@@ -1,0 +1,132 @@
+import { UmbBooleanState } from './boolean-state.js';
+import { expect } from '@open-wc/testing';
+
+describe('UmbBooleanState', () => {
+	it('initial value is reflected on subscription', (done) => {
+		const state = new UmbBooleanState(false);
+		state.asObservable().subscribe((value) => {
+			expect(value).to.be.false;
+			done();
+		});
+	});
+
+	it('getValue returns the current value', () => {
+		const state = new UmbBooleanState(true);
+		expect(state.getValue()).to.be.true;
+		state.setValue(false);
+		expect(state.getValue()).to.be.false;
+	});
+
+	it('does not fire a change when going from false to false', () => {
+		const state = new UmbBooleanState(false);
+		let amountOfCallbacks = 0;
+
+		state.asObservable().subscribe(() => {
+			amountOfCallbacks++;
+		});
+
+		// Initial subscription emits once.
+		expect(amountOfCallbacks).to.equal(1);
+
+		state.setValue(false);
+		state.setValue(false);
+		state.setValue(false);
+
+		expect(amountOfCallbacks).to.equal(1);
+	});
+
+	it('does not fire a change when going from true to true', () => {
+		const state = new UmbBooleanState(true);
+		let amountOfCallbacks = 0;
+
+		state.asObservable().subscribe(() => {
+			amountOfCallbacks++;
+		});
+
+		expect(amountOfCallbacks).to.equal(1);
+
+		state.setValue(true);
+		state.setValue(true);
+
+		expect(amountOfCallbacks).to.equal(1);
+	});
+
+	it('fires a change when going from false to true', (done) => {
+		const state = new UmbBooleanState(false);
+		let amountOfCallbacks = 0;
+
+		state.asObservable().subscribe((value) => {
+			amountOfCallbacks++;
+			if (amountOfCallbacks === 1) {
+				expect(value).to.be.false;
+			}
+			if (amountOfCallbacks === 2) {
+				expect(value).to.be.true;
+				done();
+			}
+		});
+
+		state.setValue(true);
+	});
+
+	it('fires a change when going from true to false', (done) => {
+		const state = new UmbBooleanState(true);
+		let amountOfCallbacks = 0;
+
+		state.asObservable().subscribe((value) => {
+			amountOfCallbacks++;
+			if (amountOfCallbacks === 1) {
+				expect(value).to.be.true;
+			}
+			if (amountOfCallbacks === 2) {
+				expect(value).to.be.false;
+				done();
+			}
+		});
+
+		state.setValue(false);
+	});
+
+	it('only fires once when toggled then set back to the same value in a row', () => {
+		const state = new UmbBooleanState(false);
+		const emitted: Array<boolean> = [];
+
+		state.asObservable().subscribe((value) => {
+			emitted.push(value as boolean);
+		});
+
+		state.setValue(true);
+		state.setValue(true);
+		state.setValue(false);
+		state.setValue(false);
+
+		expect(emitted).to.deep.equal([false, true, false]);
+	});
+
+	it('replays the latest value to late subscribers', (done) => {
+		const state = new UmbBooleanState(false);
+		state.setValue(true);
+
+		state.asObservable().subscribe((value) => {
+			expect(value).to.be.true;
+			done();
+		});
+	});
+
+	it('does not emit after destroy', () => {
+		const state = new UmbBooleanState(false);
+		let amountOfCallbacks = 0;
+
+		state.asObservable().subscribe(() => {
+			amountOfCallbacks++;
+		});
+
+		expect(amountOfCallbacks).to.equal(1);
+
+		state.destroy();
+
+		// Setting after destroy must not throw and must not emit.
+		expect(() => state.setValue(true)).to.not.throw();
+		expect(amountOfCallbacks).to.equal(1);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
@@ -37,6 +37,9 @@ export class UmbClassState<T extends UmbClassStateData | undefined> extends UmbB
 		if (!this._subject) return;
 		const oldValue = this._subject.getValue();
 
+		// Do a strict compare first, to avoid reacting on the same instance or going from undefined to undefined.
+		if (data === oldValue) return;
+		// Then if the new data has an equal method, use it to compare with the old value.
 		if (data && oldValue?.equal(data)) return;
 		this._subject.next(data);
 	}

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
@@ -1,3 +1,4 @@
+import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import type { MappingFunction } from '../types/mapping-function.type.js';
 import type { MemoizationFunction } from '../types/memoization-function.type.js';
 import type { UmbClassStateData } from '../utils/class-equal-memoization.function.js';
@@ -21,10 +22,10 @@ export class UmbClassState<T extends UmbClassStateData | undefined> extends UmbB
 	 * @returns {Observable<unknown>} - an observable.
 	 * @description - Creates an Observable from this State.
 	 */
-	asObservablePart<ReturnType>(
+	override asObservablePart<ReturnType>(
 		mappingFunction: MappingFunction<T, ReturnType>,
 		memoizationFunction?: MemoizationFunction<ReturnType>,
-	) {
+	): Observable<ReturnType> {
 		return createObservablePart(this._subject, mappingFunction, memoizationFunction);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
@@ -40,7 +40,7 @@ export class UmbClassState<T extends UmbClassStateData | undefined> extends UmbB
 
 		// Do a strict compare first, to avoid reacting on the same instance or going from undefined to undefined.
 		if (data === oldValue) return;
-		// Then if the new data has an equal method, use it to compare with the old value.
+		// Then if the current value has an equal method, use it to compare with the incoming value.
 		if (data && oldValue?.equal(data)) return;
 		this._subject.next(data);
 	}

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/class-state.ts
@@ -18,7 +18,7 @@ export class UmbClassState<T extends UmbClassStateData | undefined> extends UmbB
 	/**
 	 * @function createObservablePart
 	 * @param {(mappable: UmbClassStateData | undefined) => unknown} mappingFunction - Method to return the part for this Observable to return.
-	 * @param {(previousResult: unknown, currentResult: unknown) => boolean} [memoizationFunction] - Method to Compare if the data has changed. Should return true when data is different.
+	 * @param {(previousResult: unknown, currentResult: unknown) => boolean} [memoizationFunction] - Method to compare two results. Should return true when data is the same (unchanged), preventing unnecessary emissions.
 	 * @returns {Observable<unknown>} - an observable.
 	 * @description - Creates an Observable from this State.
 	 */

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.test.ts
@@ -50,4 +50,45 @@ describe('UmbDeepState', () => {
 		subject.setValue({ key: 'change_this_first_should_not_trigger_update', another: 'myValue' });
 		subject.setValue({ key: 'some', another: 'myNewValue' });
 	});
+
+	describe('getMutePromise', () => {
+		it('returns false immediately when state is not muted', async () => {
+			const result = await subject.getMutePromise();
+			expect(result).to.be.false;
+		});
+
+		it('resolves with true when unmute is called', async () => {
+			subject.mute();
+			const promise = subject.getMutePromise();
+			subject.unmute();
+			const result = await promise;
+			expect(result).to.be.true;
+		});
+
+		it('resolves with true when unmute is called even if no emission occurs', async () => {
+			subject.mute();
+			const promise = subject.getMutePromise();
+			// setValue to the same content — unmute will not emit, but the promise must still resolve
+			subject.setValue({ key: 'some', another: 'myValue' });
+			subject.unmute();
+			const result = await promise;
+			expect(result).to.be.true;
+		});
+
+		it('resolves all concurrent callers on unmute', async () => {
+			subject.mute();
+			const promises = [subject.getMutePromise(), subject.getMutePromise(), subject.getMutePromise()];
+			subject.unmute();
+			const results = await Promise.all(promises);
+			expect(results).to.deep.equal([true, true, true]);
+		});
+
+		it('resolves with false when state is destroyed while muted', async () => {
+			subject.mute();
+			const promise = subject.getMutePromise();
+			subject.destroy();
+			const result = await promise;
+			expect(result).to.be.false;
+		});
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
@@ -5,7 +5,6 @@ import type { MemoizationFunction } from '../types/memoization-function.type.js'
 import { jsonStringComparison } from '../utils/json-string-comparison.function.js';
 import { UmbBasicState } from './basic-state.js';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
-import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * @class UmbDeepState

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
@@ -4,6 +4,7 @@ import type { MappingFunction } from '../types/mapping-function.type.js';
 import type { MemoizationFunction } from '../types/memoization-function.type.js';
 import { jsonStringComparison } from '../utils/json-string-comparison.function.js';
 import { UmbBasicState } from './basic-state.js';
+import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 
 /**
  * @class UmbDeepState
@@ -27,10 +28,10 @@ export class UmbDeepState<T> extends UmbBasicState<T> {
 	 * @returns {Observable<R>}
 	 * @description - Creates an Observable from this State.
 	 */
-	asObservablePart<ReturnType>(
+	override asObservablePart<ReturnType>(
 		mappingFunction: MappingFunction<T, ReturnType>,
 		memoizationFunction?: MemoizationFunction<ReturnType>,
-	) {
+	): Observable<ReturnType> {
 		return createObservablePart(this._subject, mappingFunction, memoizationFunction ?? jsonStringComparison);
 	}
 
@@ -80,24 +81,24 @@ export class UmbDeepState<T> extends UmbBasicState<T> {
 	 * @description - Check if the state is muted.
 	 * @returns {boolean} - Returns true if the state is muted.
 	 */
-	isMuted() {
-		return this.#mute;
+	isMuted(): boolean {
+		return this.#mute ?? false;
 	}
 
 	/**
 	 * @function getMutePromise
 	 * @description - Get a promise which resolves when the mute is unset.
-	 * @returns {Promise<void>}
+	 * @returns {Promise<boolean>} - Returns a promise which resolves to true if the state was muted and is now unmuted, or false if the state was not muted.
 	 */
-	getMutePromise() {
-		return new Promise<void>((resolve) => {
+	getMutePromise(): Promise<boolean> {
+		return new Promise<boolean>((resolve) => {
 			if (!this.#mute) {
-				resolve();
+				resolve(false);
 				return;
 			}
 			const subscription = this._subject.subscribe(() => {
 				subscription.unsubscribe();
-				resolve();
+				resolve(true);
 			});
 		});
 	}

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
@@ -25,7 +25,7 @@ export class UmbDeepState<T> extends UmbBasicState<T> {
 	/**
 	 * @function createObservablePart
 	 * @param {(mappable: T) => R} mappingFunction - Method to return the part for this Observable to return.
-	 * @param {(previousResult: R, currentResult: R) => boolean} [memoizationFunction] - Method to Compare if the data has changed. Should return true when data is different.
+	 * @param {(previousResult: R, currentResult: R) => boolean} [memoizationFunction] - Method to compare two results. Should return true when data is the same (unchanged), preventing unnecessary emissions.
 	 * @returns {Observable<R>}
 	 * @description - Creates an Observable from this State.
 	 */

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/deep-state.ts
@@ -5,6 +5,7 @@ import type { MemoizationFunction } from '../types/memoization-function.type.js'
 import { jsonStringComparison } from '../utils/json-string-comparison.function.js';
 import { UmbBasicState } from './basic-state.js';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * @class UmbDeepState
@@ -15,6 +16,7 @@ import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 export class UmbDeepState<T> extends UmbBasicState<T> {
 	#mute?: boolean;
 	#value: T;
+	#muteResolvers?: Array<(value: boolean) => void>;
 
 	constructor(initialData: T) {
 		super(deepFreeze(initialData));
@@ -74,6 +76,12 @@ export class UmbDeepState<T> extends UmbBasicState<T> {
 		if (!jsonStringComparison(this.#value, this._subject.getValue())) {
 			this._subject?.next(this.#value);
 		}
+		// Resolve any pending mute promises — independent of whether an emission occurred. [NL]
+		if ((this.#muteResolvers?.length ?? 0) > 0) {
+			const resolvers = this.#muteResolvers!;
+			this.#muteResolvers = [];
+			resolvers.forEach((resolve) => resolve(true));
+		}
 	}
 
 	/**
@@ -91,15 +99,21 @@ export class UmbDeepState<T> extends UmbBasicState<T> {
 	 * @returns {Promise<boolean>} - Returns a promise which resolves to true if the state was muted and is now unmuted, or false if the state was not muted.
 	 */
 	getMutePromise(): Promise<boolean> {
+		if (!this.#mute) {
+			return Promise.resolve(false);
+		}
 		return new Promise<boolean>((resolve) => {
-			if (!this.#mute) {
-				resolve(false);
-				return;
-			}
-			const subscription = this._subject.subscribe(() => {
-				subscription.unsubscribe();
-				resolve(true);
-			});
+			(this.#muteResolvers ??= []).push(resolve);
 		});
+	}
+
+	override destroy(): void {
+		// Drain any pending mute promises so awaiters don't hang. [NL]
+		if ((this.#muteResolvers?.length ?? 0) > 0) {
+			const resolvers = this.#muteResolvers!;
+			this.#muteResolvers = [];
+			resolvers.forEach((resolve) => resolve(false));
+		}
+		super.destroy();
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/string-state.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/states/string-state.ts
@@ -1,5 +1,3 @@
-import type { MappingFunction, MemoizationFunction } from '../types/index.js';
-import { createObservablePart, strictEqualityMemoization } from '../utils/index.js';
 import { UmbBasicState } from './basic-state.js';
 
 /**
@@ -10,12 +8,5 @@ import { UmbBasicState } from './basic-state.js';
 export class UmbStringState<T> extends UmbBasicState<T | string> {
 	constructor(initialData: T | string) {
 		super(initialData);
-	}
-
-	asObservablePart<ReturnType>(
-		mappingFunction: MappingFunction<T | string, ReturnType>,
-		memoizationFunction?: MemoizationFunction<ReturnType>,
-	) {
-		return createObservablePart(this._subject, mappingFunction, memoizationFunction ?? strictEqualityMemoization);
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/libs/observable-api/utils/create-observable-part.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/observable-api/utils/create-observable-part.function.ts
@@ -8,7 +8,7 @@ import { distinctUntilChanged, map, shareReplay } from '@umbraco-cms/backoffice/
  * @function createObservablePart
  * @param {Observable<T>} source - RxJS Subject to use for this Observable.
  * @param {(mappable: T) => R} mappingFunction - Method to return the part for this Observable to return.
- * @param {(previousResult: R, currentResult: R) => boolean} [memoizationFunction] - Method to Compare if the data has changed. Should return true when data is different.
+ * @param {(previousResult: R, currentResult: R) => boolean} [memoizationFunction] - Method to compare two results. Should return true when data is the same (unchanged), preventing unnecessary emissions.
  * @returns {Observable<T>}
  * @description - Creates a RxJS Observable from RxJS Subject.
  * @example <caption>Example create a Observable for part of the data Subject.</caption>


### PR DESCRIPTION
Added a few more details to the MD files to improve Claude's knowledge about our state system.

With a focus on: when subscripers are notified, and when an observation needs an alias.

Also added some unit tests and aligned the ability to make an observable part across all umb*State classes.