### PR TITLE
HttpClients: Deprecate unused `HttpClient` registered with certificate validation bypass

### DIFF
--- a/src/Umbraco.Core/Constants-HttpClients.cs
+++ b/src/Umbraco.Core/Constants-HttpClients.cs
@@ -13,6 +13,7 @@ public static partial class Constants
         /// <summary>
         ///     Name for http client which ignores certificate errors.
         /// </summary>
+        [Obsolete("Register a project specific named HttpClient with DangerousAcceptAnyServerCertificateValidator if this behavior is required. Scheduled for removal in Umbraco 19.")]
         public const string IgnoreCertificateErrors = "Umbraco:HttpClients:IgnoreCertificateErrors";
 
         /// <summary>

--- a/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -241,12 +241,15 @@ public static partial class UmbracoBuilderExtensions
     private static IUmbracoBuilder AddHttpClients(this IUmbracoBuilder builder)
     {
         builder.Services.AddHttpClient();
+        // TODO (V19): Remove this registration along with Constants.HttpClients.IgnoreCertificateErrors.
+        #pragma warning disable CS0618 // Type or member is obsolete
         builder.Services.AddHttpClient(Constants.HttpClients.IgnoreCertificateErrors)
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
             {
                 ServerCertificateCustomValidationCallback =
                     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
             });
+        #pragma warning restore CS0618 // Type or member is obsolete
         builder.Services.AddHttpClient(Constants.HttpClients.WebhookFiring, (services, client) =>
         {
             var productVersion = services.GetRequiredService<IUmbracoVersion>().SemanticVersion.ToSemanticStringWithoutBuild();


### PR DESCRIPTION
### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->

- Mark ServerCertificateCustomValidationCallback usage as obsolete due to security risk.
- Add TODO to remove in a future release.

This change is related to this [SonarQube issue.](https://sonarcloud.io/project/issues?impactSeverities=HIGH&impactSoftwareQualities=SECURITY&issueStatuses=OPEN%2CCONFIRMED&id=umbraco_Umbraco-CMS&open=AZ2amMtpk-l9ECQetFsl)
<!-- Thanks for contributing to Umbraco CMS! -->
