### PR TITLE
User management: Improved error message when deleting active user (closes #22669)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -63,6 +63,10 @@ public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerB
                 .WithTitle("Cannot delete user")
                 .WithDetail("The user cannot be deleted.")
                 .Build()),
+            UserOperationStatus.CannotDeleteUserHasLoggedIn => BadRequest(problemDetailsBuilder
+                .WithTitle("Cannot delete user")
+                .WithDetail("This user has logged in and may be referenced by audit logs or content history. Disable the user instead of deleting them.")
+                .Build()),
             UserOperationStatus.CannotDisableSelf => BadRequest(problemDetailsBuilder
                 .WithTitle("Cannot disable")
                 .WithDetail("A user cannot disable itself.")

--- a/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/User/UserOrCurrentUserControllerBase.cs
@@ -63,7 +63,7 @@ public abstract class UserOrCurrentUserControllerBase : ManagementApiControllerB
                 .WithTitle("Cannot delete user")
                 .WithDetail("The user cannot be deleted.")
                 .Build()),
-            UserOperationStatus.CannotDeleteUserHasLoggedIn => BadRequest(problemDetailsBuilder
+            UserOperationStatus.CannotDeleteUserWithLoginHistory => BadRequest(problemDetailsBuilder
                 .WithTitle("Cannot delete user")
                 .WithDetail("This user has logged in and may be referenced by audit logs or content history. Disable the user instead of deleting them.")
                 .Build()),

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -91,6 +91,11 @@ public enum UserOperationStatus
     CannotDelete,
 
     /// <summary>
+    ///     The operation failed because the user has logged in before, and therefore might be referenced in audit logs etc.
+    /// </summary>
+    CannotDeleteUserHasLoggedIn,
+
+    /// <summary>
     ///     The operation failed because the current user cannot disable themselves.
     /// </summary>
     CannotDisableSelf,

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -91,11 +91,6 @@ public enum UserOperationStatus
     CannotDelete,
 
     /// <summary>
-    ///     The operation failed because the user has logged in before, and therefore might be referenced in audit logs etc.
-    /// </summary>
-    CannotDeleteUserHasLoggedIn,
-
-    /// <summary>
     ///     The operation failed because the current user cannot disable themselves.
     /// </summary>
     CannotDisableSelf,
@@ -201,4 +196,9 @@ public enum UserOperationStatus
     ///     <c>ApplicationUrlDetection</c> to <c>FirstRequest</c> or <c>EveryRequest</c>.
     /// </summary>
     ApplicationUrlNotConfigured,
+
+    /// <summary>
+    ///     The operation failed because the user has logged in before, and therefore might be referenced in audit logs etc.
+    /// </summary>
+    CannotDeleteUserHasLoggedIn,
 }

--- a/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
+++ b/src/Umbraco.Core/Services/OperationStatus/UserOperationStatus.cs
@@ -198,7 +198,7 @@ public enum UserOperationStatus
     ApplicationUrlNotConfigured,
 
     /// <summary>
-    ///     The operation failed because the user has logged in before, and therefore might be referenced in audit logs etc.
+    ///     The operation failed because the user has login history, and therefore might be referenced in audit logs etc.
     /// </summary>
-    CannotDeleteUserHasLoggedIn,
+    CannotDeleteUserWithLoginHistory,
 }

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1508,7 +1508,7 @@ internal partial class UserService : RepositoryService, IUserService
             // the Id is associated with audit trails, versions etc. and can't be removed.
             if (user.LastLoginDate is not null && user.LastLoginDate != default(DateTime))
             {
-                return UserOperationStatus.CannotDelete;
+                return UserOperationStatus.CannotDeleteUserHasLoggedIn;
             }
 
             user.IsApproved = false;

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -1508,7 +1508,7 @@ internal partial class UserService : RepositoryService, IUserService
             // the Id is associated with audit trails, versions etc. and can't be removed.
             if (user.LastLoginDate is not null && user.LastLoginDate != default(DateTime))
             {
-                return UserOperationStatus.CannotDeleteUserHasLoggedIn;
+                return UserOperationStatus.CannotDeleteUserWithLoginHistory;
             }
 
             user.IsApproved = false;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Delete.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Delete.cs
@@ -37,7 +37,7 @@ internal sealed partial class UserServiceCrudTests
         userService.Save(createdUser);
 
         var result = await userService.DeleteAsync(Constants.Security.SuperUserKey, createdUser.Key);
-        Assert.AreEqual(UserOperationStatus.CannotDeleteUserHasLoggedIn, result);
+        Assert.AreEqual(UserOperationStatus.CannotDeleteUserWithLoginHistory, result);
 
         // Asset that it is in fact not deleted
         var postDeletedUser = await userService.GetAsync(createdUser.Key);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Delete.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Delete.cs
@@ -37,7 +37,7 @@ internal sealed partial class UserServiceCrudTests
         userService.Save(createdUser);
 
         var result = await userService.DeleteAsync(Constants.Security.SuperUserKey, createdUser.Key);
-        Assert.AreEqual(UserOperationStatus.CannotDelete, result);
+        Assert.AreEqual(UserOperationStatus.CannotDeleteUserHasLoggedIn, result);
 
         // Asset that it is in fact not deleted
         var postDeletedUser = await userService.GetAsync(createdUser.Key);


### PR DESCRIPTION
Closes #22669

### Description
This PR adds a better error message when deleting a user who has previously logged in.

Before this change, when deleting a user who has logged in, the error message was a generic "Cannot delete user". This change adds some more detail as to why the user cannot be deleted and suggests disabling the user instead.

### Testing
I have tested this manually with 2 users:
* One user who has never logged in (Deletes fine)
* One user who **has** logged in (Does not delete, but gets the new error message)

<!-- Thanks for contributing to Umbraco CMS! -->
