### PR TITLE
Blueprints: Fix creating documents from blueprints (closes #21996)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace.context.ts
@@ -241,11 +241,17 @@ export class UmbDocumentWorkspaceContext
 
 	async create(parent: UmbEntityModel, documentTypeUnique: string, blueprintUnique?: string) {
 		if (blueprintUnique) {
+			this.resetState();
+			this.loading.addState({ unique: 'blueprint-fetch' });
 			const blueprintRepository = new UmbDocumentBlueprintDetailRepository(this);
 			const { data } = await blueprintRepository.scaffoldByUnique(blueprintUnique);
 
-			if (!data) throw new Error('Blueprint data is missing');
+			if (!data) {
+				this.loading.removeState('blueprint-fetch');
+				throw new Error('Blueprint data is missing');
+			}
 
+			this.loading.removeState('blueprint-fetch');
 			return this.createScaffold({
 				parent,
 				preset: {


### PR DESCRIPTION
cherry-picked fix from https://github.com/umbraco/Umbraco-CMS/pull/22422

### Description
Fixes https://github.com/umbraco/Umbraco-CMS/issues/21996

### Testing
May be tricky to reproduce unless you want a copy of the database that shows the error, but it should be enough to verify that new documents can be created when selected from a list of blueprints, and you can successfully create one, scaffold it, then change your mind and create again from a different blueprint.