### PR TITLE
Modals: prevent indisposable modals from closing on navigation (closes #18652)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal-manager.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal-manager.context.ts
@@ -71,7 +71,7 @@ export class UmbModalManagerContext extends UmbContextBase {
 	#closeNoneRoutableModals() {
 		this.#modals
 			.getValue()
-			.filter((modal) => modal.router === null)
+			.filter((modal) => modal.router === null && modal.indisposable !== true)
 			.forEach((modal) => {
 				modal.forceResolve();
 			});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/context/modal.context.ts
@@ -56,6 +56,7 @@ export class UmbModalContext<
 	public readonly backdropBackground?: string;
 	public readonly router: IRouterSlot | null = null;
 	public readonly alias: string | UmbModalToken<ModalData, ModalValue>;
+	public readonly indisposable?: boolean;
 
 	#value;
 	public readonly value;
@@ -72,6 +73,7 @@ export class UmbModalContext<
 	) {
 		super(host);
 		this.key = args.modal?.key || UmbId.new();
+		this.indisposable = args.modal?.indisposable;
 		this.router = args.router ?? null;
 		this.alias = modalAlias;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/types.ts
@@ -45,4 +45,10 @@ export interface UmbModalConfig {
 	 * Set the title of the modal, this is used as Browser Title
 	 */
 	title?: string;
+
+	/**
+	 * Prevents the modal from automatically closing when backend routing or navigation occurs.
+	 * default false
+	 */
+	indisposable?: boolean;
 }


### PR DESCRIPTION

### Prerequisites
- [x] I have added steps to test this contribution in the description below

Fixes #18652

### Description
**The Issue:**
As reported in #18652, opening a modal from a Workspace context (e.g., during initialization) results in the modal closing almost immediately. This occurs because the final workspace routing events trigger the `UmbModalManager`'s automated navigation teardown logic (`#closeNoneRoutableModals`), which aggressively forces all non-routable modals to resolve.

### The Fix:
- Added an `indisposable?: boolean` flag to the `UmbModalConfig` interface.
- Updated `UmbModalContext` to expose and read this flag from `args.modal`.
- Updated the `UmbModalManagerContext` teardown logic to bypass any active modal that has `indisposable: true`.

This provides package developers a clean, official API to open critical modals during routing sequences without needing to rely on `setTimeout` hacks.

### Video Demonstration:
<img width="1734" height="876" alt="After_adding_fix" src="https://github.com/user-attachments/assets/2b92e687-15dc-46b7-8d65-dea0e7c036ba" />


### How to test:
1. Inject a modal open call into any workspace initialization (e.g., inside `firstUpdated()` of `workspace.element.ts` or a custom dashboard).
2. Pass the new flag in the config:
   ```typescript
   manager.open(this, UMB_CONFIRM_MODAL, {
       data: { headline: "Protected", content: "I should survive!" },
       modal: { indisposable: true }
   });

3. Load the workspace/route. The modal will safely remain open instead of being instantly destroyed by the router.
4. Verify the modal can still be manually closed via its UI (e.g., Cancel/Submit buttons).
5. Verify normal modals (without the flag) still close automatically when navigating away.

### Types of changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation (Release Notes).