### PR TITLE
Dependencies: Bump selected NuGet packages to latest versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,7 +367,16 @@ public interface IMyService
 
 ### Centralized Package Management
 
-**All NuGet package versions** are centralized in `Directory.Packages.props`. Individual projects do NOT specify versions.
+**NuGet package versions** are centralized in `Directory.Packages.props`. There are two `Directory.Packages.props` files in the source tree, with multi-level merging enabled so the test file inherits from the root:
+
+| File | Scope |
+|------|-------|
+| `Directory.Packages.props` (root) | Production source code packages — referenced by all `src/**` projects |
+| `tests/Directory.Packages.props` | Test-only packages (NUnit, Moq, Bogus, BenchmarkDotNet, etc.) — adds entries on top of the inherited root file |
+
+When updating dependencies, decide which file the package belongs in:
+- A package used only by test projects → `tests/Directory.Packages.props`
+- A package used by any production project (or by both production and tests) → root `Directory.Packages.props`
 
 ```xml
 <!-- Individual projects reference WITHOUT version -->
@@ -376,6 +385,8 @@ public interface IMyService
 <!-- Versions defined in Directory.Packages.props -->
 <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
 ```
+
+**Opt-out**: `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj` sets `<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>` and specifies versions inline (for `Microsoft.EntityFrameworkCore.Design`, `Microsoft.Build.Tasks.Core`, `Microsoft.ICU.ICU4C.Runtime`, etc.). Update those versions directly in that csproj when bumping. Two further `Directory.Packages.props` files exist under `templates/` for the project/extension templates and have their own version sets — keep `Microsoft.AspNetCore.OpenApi` aligned between the root file and `templates/UmbracoExtension/`.
 
 ### Build Configuration
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,31 +14,31 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
     <!-- When updating this version, also update templates/UmbracoExtension/Umbraco.Extension.csproj -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
-    <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <!-- Umbraco packages -->
   <ItemGroup>
@@ -46,8 +46,8 @@
   </ItemGroup>
   <!-- Third-party packages -->
   <ItemGroup>
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
     <PackageVersion Include="Examine" Version="3.7.1" />
     <PackageVersion Include="Examine.Core" Version="3.7.1" />
@@ -55,7 +55,7 @@
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
-    <PackageVersion Include="Markdig" Version="1.1.1" />
+    <PackageVersion Include="Markdig" Version="1.1.3" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
@@ -63,9 +63,9 @@
     <PackageVersion Include="ncrontab" Version="3.4.0" />
     <PackageVersion Include="NPoco" Version="6.2.0" />
     <PackageVersion Include="NPoco.SqlServer" Version="6.2.0" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="7.4.0" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.4.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.4.0" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.5.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
@@ -93,6 +93,6 @@
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- Examine (via Microsoft.AspNetCore.DataProtection 8.0.4) references a vulnerable version of the following: -->
     <!-- TODO: Remove this pinned dependency when Examine updates its Microsoft.AspNetCore.DataProtection reference. -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureDefaultApiOptions.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureDefaultApiOptions.cs
@@ -41,7 +41,7 @@ internal class ConfigureDefaultApiOptions : ConfigureUmbracoOpenApiOptionsBase
         }
 
         // Include endpoints not explicitly assigned to another document
-        ApiVersionMetadata apiVersionMetadata = apiDescription.ActionDescriptor.GetApiVersionMetadata();
+        ApiVersionMetadata apiVersionMetadata = apiDescription.ActionDescriptor.ApiVersionMetadata;
         return string.IsNullOrEmpty(apiVersionMetadata.Name);
     }
 }

--- a/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoOpenApiOptionsBase.cs
+++ b/src/Umbraco.Cms.Api.Common/Configuration/ConfigureUmbracoOpenApiOptionsBase.cs
@@ -120,7 +120,7 @@ internal abstract class ConfigureUmbracoOpenApiOptionsBase : IConfigureNamedOpti
             return true;
         }
 
-        ApiVersionMetadata apiVersionMetadata = apiDescription.ActionDescriptor.GetApiVersionMetadata();
+        ApiVersionMetadata apiVersionMetadata = apiDescription.ActionDescriptor.ApiVersionMetadata;
         return apiVersionMetadata.Name == ApiName;
     }
 }

--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -53,7 +53,7 @@ public static class UmbracoBuilderExtensions
             provider =>
             {
                 HttpContext? httpContext = provider.GetRequiredService<IHttpContextAccessor>().HttpContext;
-                ApiVersion? apiVersion = httpContext?.GetRequestedApiVersion();
+                ApiVersion? apiVersion = httpContext?.RequestedApiVersion;
                 if (apiVersion is null)
                 {
                     return provider.GetRequiredService<RequestContextOutputExpansionStrategyV2>();

--- a/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Json/DeliveryApiVersionAwareJsonConverterBase.cs
@@ -51,7 +51,7 @@ public abstract class DeliveryApiVersionAwareJsonConverterBase<T> : JsonConverte
     private int? GetApiVersion()
     {
         HttpContext? httpContext = _httpContextAccessor.HttpContext;
-        ApiVersion? apiVersion = httpContext?.GetRequestedApiVersion();
+        ApiVersion? apiVersion = httpContext?.RequestedApiVersion;
 
         return apiVersion?.MajorVersion;
     }

--- a/src/Umbraco.Cms.Api.Delivery/Routing/DeliveryApiItemsEndpointsMatcherPolicy.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Routing/DeliveryApiItemsEndpointsMatcherPolicy.cs
@@ -30,7 +30,7 @@ internal sealed class DeliveryApiItemsEndpointsMatcherPolicy : MatcherPolicy, IE
     public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
     {
         var hasIdQueryParameter = httpContext.Request.Query.ContainsKey("id");
-        ApiVersion? requestedApiVersion = httpContext.GetRequestedApiVersion();
+        ApiVersion? requestedApiVersion = httpContext.RequestedApiVersion;
         for (var i = 0; i < candidates.Count; i++)
         {
             CandidateState candidate = candidates[i];

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -34,10 +34,12 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="18.4.0" />
     <!--
     Added to align Microsoft.CodeAnalysis.* transitive versions brought in by Microsoft.EntityFrameworkCore.Design,
-    which otherwise pulls in Microsoft.CodeAnalysis.CSharp 5.3.0 alongside Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0,
-    resulting in a conflicting Microsoft.CodeAnalysis.Common version requirement (NU1107).
+    which otherwise pulls in Microsoft.CodeAnalysis.CSharp 5.3.0 alongside Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0
+    and Microsoft.CodeAnalysis.Workspaces.MSBuild 5.0.0, resulting in conflicting Microsoft.CodeAnalysis.Common /
+    Microsoft.CodeAnalysis.Workspaces.Common version requirements (NU1107 / NU1608).
     -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" PrivateAssets="all" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,12 +26,18 @@
 
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.7" />
     <!--
     Added the following direct dependency due to Microsoft.EntityFrameworkCore.Design having a dependency on an insecure version.
     Review for removal when Microsoft.EntityFrameworkCore.Design is updated to a newer version.
     -->
-    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="18.3.3" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="18.4.0" />
+    <!--
+    Added to align Microsoft.CodeAnalysis.* transitive versions brought in by Microsoft.EntityFrameworkCore.Design,
+    which otherwise pulls in Microsoft.CodeAnalysis.CSharp 5.3.0 alongside Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0,
+    resulting in a conflicting Microsoft.CodeAnalysis.Common version requirement (NU1107).
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/UmbracoExtension/Directory.Packages.props
+++ b/templates/UmbracoExtension/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="Umbraco.Cms.Api.Management" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
   </ItemGroup>
 </Project>

--- a/templates/UmbracoExtension/Umbraco.Extension.csproj
+++ b/templates/UmbracoExtension/Umbraco.Extension.csproj
@@ -64,7 +64,7 @@
       their types directly - only Microsoft.AspNetCore.OpenApi / Microsoft.OpenApi types are
       referenced in the composer.
     -->
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
   </ItemGroup>
   <!--#endif -->
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,12 +5,12 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="10.0.6" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.6" />
+    <PackageVersion Include="System.Data.Odbc" Version="10.0.7" />
+    <PackageVersion Include="System.Data.OleDb" Version="10.0.7" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Bumps NuGet dependencies across `Directory.Packages.props` (root and `tests/`), the templates, and the Web.UI project (which opts out of central package management) to the latest available versions per `dotnet-outdated`.

### Production source packages (`Directory.Packages.props`)
- `Asp.Versioning.Mvc` & `Asp.Versioning.Mvc.ApiExplorer`: 8.1.1 → **10.0.0** (major)
- `OpenIddict.Abstractions` / `AspNetCore` / `EntityFrameworkCore`: 7.4.0 → 7.5.0
- `Microsoft.Extensions.*`, `Microsoft.AspNetCore.OpenApi`, `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation`, `Microsoft.Data.Sqlite`, `Microsoft.EntityFrameworkCore.Sqlite/SqlServer`, `System.Security.Cryptography.Xml` (transitive pin): 10.0.6 → 10.0.7
- `Microsoft.CodeAnalysis.CSharp` (and `.Workspaces`, kept in lockstep): 5.0.0 → 5.3.0
- `System.Linq.Async`: 7.0.0 → 7.0.1
- `Markdig`: 1.1.1 → 1.1.3

### Test packages (`tests/Directory.Packages.props`)
- `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.Extensions.Logging.Debug`, `System.Data.Odbc`, `System.Data.OleDb`: 10.0.6 → 10.0.7
- `Microsoft.NET.Test.Sdk`: 18.4.0 → 18.5.1

### Web.UI (`src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`, CPM disabled)
- `Microsoft.EntityFrameworkCore.Design`: 10.0.6 → 10.0.7
- `Microsoft.Build.Tasks.Core`: 18.3.3 → 18.4.0
- Added explicit `Microsoft.CodeAnalysis.CSharp.Workspaces` 5.3.0 to resolve a NU1107 transitive conflict from `Microsoft.EntityFrameworkCore.Design 10.0.7` (which pulls in `CSharp 5.3.0` and `Workspaces 5.0.0` together, conflicting on `Microsoft.CodeAnalysis.Common`).

### Templates
- `templates/UmbracoExtension/Directory.Packages.props` and `Umbraco.Extension.csproj`: `Microsoft.AspNetCore.OpenApi` 10.0.6 → 10.0.7

### Excluded from this update
- **NUnit** and **NUnit3TestAdapter** — recent majors cause test failures on the CI pipelines.
- **JsonPatch.Net** — licensing change in the new major has not been accepted.

### Breaking changes handled with the `Asp.Versioning` v10 update

The 8.x → 10.x bump promotes several extension methods to extension properties. Updated five call sites:
- `ConfigureUmbracoOpenApiOptionsBase.cs` and `ConfigureDefaultApiOptions.cs` — `ActionDescriptor.GetApiVersionMetadata()` → `ActionDescriptor.ApiVersionMetadata`
- `DeliveryApiVersionAwareJsonConverterBase.cs`, `UmbracoBuilderExtensions.cs`, `DeliveryApiItemsEndpointsMatcherPolicy.cs` — `HttpContext.GetRequestedApiVersion()` → `HttpContext.RequestedApiVersion`

#### Documentation
- `CLAUDE.md` clarifies the centralized package management setup: the root vs `tests/` `Directory.Packages.props` split, the Web.UI opt-out, and the template duplicates.

### Testing

Build checks should pass - solution should build and test suite should complete without failures.

Solution should build and run locally without dependency warnings.