### PR TITLE
Build pipeline: Add manual approval gate to NuGet release

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -897,9 +897,10 @@ stages:
   - stage: Deploy_NuGet
     displayName: NuGet release
     dependsOn: Deploy_MyGet
-    # Run on MyGet success or failure (but not when MyGet was skipped — i.e. only in a release context).
+    # Run only when Deploy_MyGet actually ran (succeeded or failed) — not when it was skipped due to an upstream test failure.
+    # Inspect Deploy_MyGet's direct result rather than succeeded()/failed(), which are transitive across the full ancestor graph.
     # Approval is required every run via the WaitForApproval job below.
-    condition: and(or(succeeded(), failed()), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.nuGetDeploy}}))
+    condition: and(in(dependencies.Deploy_MyGet.result, 'Succeeded', 'SucceededWithIssues', 'Failed'), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.nuGetDeploy}}))
     jobs:
       - job: WaitForApproval
         displayName: Wait for manual approval

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -897,12 +897,26 @@ stages:
   - stage: Deploy_NuGet
     displayName: NuGet release
     dependsOn: Deploy_MyGet
-    condition: and(succeeded(), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.nuGetDeploy}}))
+    # Run on MyGet success or failure (but not when MyGet was skipped — i.e. only in a release context).
+    # Approval is required every run via the WaitForApproval job below.
+    condition: and(or(succeeded(), failed()), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.nuGetDeploy}}))
     jobs:
-      - job:
+      - job: WaitForApproval
+        displayName: Wait for manual approval
+        pool: server
+        timeoutInMinutes: 4320 # 3 days
+        steps:
+          - task: ManualValidation@0
+            displayName: Manual approval to push to NuGet
+            inputs:
+              notifyUsers: ''
+              instructions: 'Approve to push the NuGet release. Use this to override a MyGet pre-release failure caused by an upstream issue.'
+              onTimeout: 'reject'
+      - job: Push
+        displayName: Push to NuGet
+        dependsOn: WaitForApproval
         pool:
           vmImage: "windows-latest" # NuGetCommand@2 is no longer supported on Ubuntu 24.04 so we'll use windows until an alternative is available.
-        displayName: Push to NuGet
         steps:
           - checkout: none
           - task: DownloadPipelineArtifact@2

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -910,7 +910,7 @@ stages:
             displayName: Manual approval to push to NuGet
             inputs:
               notifyUsers: ''
-              instructions: 'Approve to push the NuGet release. Use this to override a MyGet pre-release failure caused by an upstream issue.'
+              instructions: 'Approve to push the NuGet release.'
               onTimeout: 'reject'
       - job: Push
         displayName: Push to NuGet


### PR DESCRIPTION
## Description

### Context

The MyGet pre-release feed is currently failing to publish due to an upstream issue. Because the `Deploy_NuGet` stage in `build/azure-pipelines.yml` previously depended on `Deploy_MyGet` succeeding (implicit `succeeded()`), a MyGet failure blocks the NuGet release.

### Solution

Restructure the `Deploy_NuGet` stage so it can run regardless of whether `Deploy_MyGet` succeeded or failed, gated behind a manual approval gate using the `ManualValidation@0` task.

Two changes to the `Deploy_NuGet` stage in `build/azure-pipelines.yml`:

1. **Loosened stage condition** — replaced the implicit `succeeded()` with `or(succeeded(), failed())` so the stage starts whether `Deploy_MyGet` succeeded or failed. The release-context gate (`PublicRelease=True OR nuGetDeploy=true`) is unchanged, so the stage is still skipped on non-release runs and when MyGet itself was skipped.

2. **New `WaitForApproval` server job** — agentless job using `ManualValidation@0` runs first. It pauses the pipeline; a reviewer clicks **Resume** in the Azure DevOps UI to proceed, or **Reject** to cancel. Timeout is 3 days, defaulting to reject. The existing push job is renamed to `Push` and now `dependsOn: WaitForApproval`, so it only runs after approval.

`Deploy_Npm` continues to use `succeeded()` against `Deploy_NuGet`, so a rejected/timed-out approval cleanly skips the npm release as well.

### Tradeoff

Every release run now requires a click before NuGet push — even when MyGet succeeded. Once the upstream MyGet issue is resolved, this stage can be reverted (see below).

### Rollback

When the MyGet upstream issue is resolved, revert `build/azure-pipelines.yml` to its previous shape — restore the implicit `succeeded()` condition and collapse the two jobs back into a single push job:

```yaml
  - stage: Deploy_NuGet
    displayName: NuGet release
    dependsOn: Deploy_MyGet
    condition: and(succeeded(), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.nuGetDeploy}}))
    jobs:
      - job:
        pool:
          vmImage: "windows-latest" # NuGetCommand@2 is no longer supported on Ubuntu 24.04 so we'll use windows until an alternative is available.
        displayName: Push to NuGet
        steps:
          - checkout: none
          - task: DownloadPipelineArtifact@2
            displayName: Download nupkg
            inputs:
              artifact: nupkg
              path: $(Build.ArtifactStagingDirectory)/nupkg
          - task: NuGetCommand@2
            displayName: NuGet push
            inputs:
              command: "push"
              packagesToPush: $(Build.ArtifactStagingDirectory)/**/*.nupkg
              nuGetFeedType: "external"
              publishFeedCredentials: "NuGet - Umbraco.*"
```

The simplest way to do this is `git revert` on the merge commit produced from this PR, which restores the pre-existing single-job structure exactly.