### PR TITLE
Accessibility: Added missing labels to add property and create new collection

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
@@ -206,6 +206,7 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 					<uui-textarea
 						id="description-input"
 						data-mark="input:entity-description"
+						label="${this.localize.term('general_description')}"
 						slot="editor"
 						name="description"
 						@input=${this.#onDescriptionChange}
@@ -217,6 +218,7 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 					<umb-data-type-flow-input
 						slot="editor"
 						id="data-type-input"
+						label="${this.localize.term('general_propertyEditor')}"
 						.value=${this._data?.dataType?.unique ?? ''}
 						@change=${this.#onDataTypeIdChange}
 						required
@@ -329,6 +331,7 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 					id="mandatory"
 					.checked=${this._data?.validation?.mandatory ?? false}
 					slot="editor"
+					label=${this.localize.term('validation_fieldIsMandatory')}
 					><umb-localize key="validation_fieldIsMandatory">Field is mandatory</umb-localize></uui-toggle
 				></umb-property-layout
 			>
@@ -352,6 +355,7 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 		return html`<umb-property-layout orientation="vertical" label=${this.localize.term('validation_customValidation')}
 				><uui-select
 					slot="editor"
+					label=${this.localize.term('validation_customValidation')}
 					@change=${this.#onCustomValidationChange}
 					.options=${this._customValidationOptions}></uui-select
 			></umb-property-layout>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-with-alias/input-with-alias.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-with-alias/input-with-alias.element.ts
@@ -122,7 +122,7 @@ export class UmbInputWithAliasElement extends UmbFormControlMixin<string, typeof
 	}
 
 	override render() {
-		const nameLabel = this.label ?? this.localize.term('placeholders_entername');
+		const nameLabel = this.label || this.localize.term('placeholders_entername');
 		const aliasLabel = this.localize.term('placeholders_enterAlias');
 
 		return html`

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-data-type-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/modals/data-type-picker-flow/data-type-picker-flow-data-type-picker-modal.element.ts
@@ -95,7 +95,7 @@ export class UmbDataTypePickerFlowDataTypePickerModalElement extends UmbModalBas
 
 	#renderCreate() {
 		return html`
-			<uui-button id="create-button" look="placeholder" @click=${this.#handleCreate}>
+			<uui-button id="create-button" look="placeholder" label=${this.localize.term('contentTypeEditor_availableEditors')} @click=${this.#handleCreate}>
 				<div class="content">
 					<uui-icon name="icon-add" class="icon"></uui-icon>
 					<umb-localize key="contentTypeEditor_availableEditors">Create new</umb-localize>


### PR DESCRIPTION
## Description

I found more missing labels.

Add missing `label` attributes to UUI form controls to resolve accessibility console warnings when adding a property to a document type.

**Changes:**
- `input-with-alias.element.ts` — use `||` instead of `??` so empty string label falls through to localized placeholder
- `property-workspace-view-settings.element.ts` — add `label` to `uui-select` (validation) and `uui-toggle` (mandatory)
- `data-type-picker-flow-data-type-picker-modal.element.ts` — add `label` to create `uui-button`

## Testing

1. Add a new property to a document type.
2. Open browser console — verify no `needs a 'label'` warnings appear.
3. Click through to the Structure → Add collection flow and verify no warnings there either.
