### PR TITLE
Caching: Invalidate published content type cache for element types

### DIFF
--- a/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
+++ b/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
@@ -25,7 +25,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
     private readonly Dictionary<int, IPublishedContentType> _typesById = new();
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Umbraco.Cms.Core.PublishedCache.PublishedContentTypeCache"/> class.
+    /// Initializes a new instance of the <see cref="PublishedContentTypeCache"/> class.
     /// </summary>
     /// <remarks>default ctor</remarks>
     /// <param name="contentTypeService">The service used to manage content types. Typically injected as a dependency.</param>
@@ -47,23 +47,12 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
         _publishedContentTypeFactory = publishedContentTypeFactory;
     }
 
-    // for unit tests ONLY
-#pragma warning disable CS8618
-    internal PublishedContentTypeCache(
-        ILogger<PublishedContentTypeCache> logger,
-        IPublishedContentTypeFactory publishedContentTypeFactory)
-#pragma warning restore CS8618
-    {
-        _logger = logger;
-        _publishedContentTypeFactory = publishedContentTypeFactory;
-    }
-
     /// <summary>
     ///     Clears all cached content types.
     /// </summary>
     public void ClearAll()
     {
-        if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+        if (_logger.IsEnabled(LogLevel.Debug))
         {
             _logger.LogDebug("Clear all.");
         }
@@ -90,7 +79,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
     /// <param name="id">An identifier.</param>
     public void ClearContentType(int id)
     {
-        if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+        if (_logger.IsEnabled(LogLevel.Debug))
         {
             _logger.LogDebug("Clear content type w/id {ContentTypeId}", id);
         }
@@ -108,8 +97,20 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
             {
                 _lock.EnterWriteLock();
 
-                _typesByAlias.Remove(GetAliasKey(type));
+                // Multiple alias entries can point to the same type because Get(itemType, alias)
+                // keys by the *requested* itemType, which may not match the type's actual ItemType
+                // (e.g. Get(Content, alias) for an element type). Remove all of them.
+                var aliasKeysToRemove = _typesByAlias
+                    .Where(kvp => kvp.Value.Id == id)
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+                foreach (var aliasKey in aliasKeysToRemove)
+                {
+                    _typesByAlias.Remove(aliasKey);
+                }
+
                 _typesById.Remove(id);
+                _keyToIdMap.Remove(type.Key);
             }
             finally
             {
@@ -151,7 +152,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
     /// <returns>An enumerable of <see cref="IPublishedContentType"/> instances that were removed from the cache.</returns>
     public IEnumerable<IPublishedContentType> ClearByDataTypeId(int id)
     {
-        if (_logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+        if (_logger.IsEnabled(LogLevel.Debug))
         {
             _logger.LogDebug("Clear data type w/id {DataTypeId}.", id);
         }
@@ -167,10 +168,23 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
 
             toRemove = _typesById.Values
                 .Where(x => x.PropertyTypes.Any(xx => xx.DataType.Id == id)).ToArray();
+
+            var idsToRemove = toRemove.Select(x => x.Id).ToHashSet();
+
+            // See ClearContentType for why we scan _typesByAlias instead of using GetAliasKey(type).
+            var aliasKeysToRemove = _typesByAlias
+                .Where(kvp => idsToRemove.Contains(kvp.Value.Id))
+                .Select(kvp => kvp.Key)
+                .ToList();
+            foreach (var aliasKey in aliasKeysToRemove)
+            {
+                _typesByAlias.Remove(aliasKey);
+            }
+
             foreach (IPublishedContentType type in toRemove)
             {
-                _typesByAlias.Remove(GetAliasKey(type));
                 _typesById.Remove(type.Id);
+                _keyToIdMap.Remove(type.Key);
             }
         }
         finally
@@ -364,6 +378,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
         IContentTypeComposition? contentType = itemType switch
         {
             PublishedItemType.Content => _contentTypeService?.Get(alias),
+            PublishedItemType.Element => _contentTypeService?.Get(alias),
             PublishedItemType.Media => _mediaTypeService?.Get(alias),
             PublishedItemType.Member => _memberTypeService?.Get(alias),
             _ => throw new ArgumentOutOfRangeException(nameof(itemType)),
@@ -382,6 +397,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
         IContentTypeComposition? contentType = itemType switch
         {
             PublishedItemType.Content => _contentTypeService?.Get(id),
+            PublishedItemType.Element => _contentTypeService?.Get(id),
             PublishedItemType.Media => _mediaTypeService?.Get(id),
             PublishedItemType.Member => _memberTypeService?.Get(id),
             _ => throw new ArgumentOutOfRangeException(nameof(itemType)),

--- a/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
+++ b/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
@@ -63,6 +63,7 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
 
             _typesByAlias.Clear();
             _typesById.Clear();
+            _keyToIdMap.Clear();
         }
         finally
         {

--- a/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
+++ b/src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs
@@ -268,8 +268,22 @@ public class PublishedContentTypeCache : IPublishedContentTypeCache
             try
             {
                 _lock.EnterWriteLock();
+
+                // If a previous lookup under a different itemType prefix already cached this
+                // content type by id, reuse that instance so _typesById and every alias entry
+                // point at the same object.
+                if (_typesById.TryGetValue(type.Id, out IPublishedContentType? existing))
+                {
+                    type = existing;
+                }
+                else
+                {
+                    _typesById[type.Id] = type;
+                }
+
                 _keyToIdMap[type.Key] = type.Id;
-                return _typesByAlias[aliasKey] = _typesById[type.Id] = type;
+                _typesByAlias[aliasKey] = type;
+                return type;
             }
             finally
             {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/PublishedContentTypeCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/PublishedContentTypeCacheTests.cs
@@ -39,6 +39,7 @@ internal sealed class PublishedContentTypeCacheTests : UmbracoIntegrationTestWit
         var contentType = PublishedContentTypeCache.Get(PublishedItemType.Content, Textpage.ContentTypeKey);
         Assert.IsNotNull(contentType);
         Assert.AreEqual(1, ContentType.PropertyTypes.Count());
+
         // Update the content type
         var updateModel = ContentTypeUpdateHelper.CreateContentTypeUpdateModel(ContentType);
         updateModel.Properties = new List<ContentTypePropertyTypeModel>();
@@ -63,39 +64,76 @@ internal sealed class PublishedContentTypeCacheTests : UmbracoIntegrationTestWit
     }
 
     [Test]
-    public async Task Can_Get_Updated_Published_ElementType_By_Alias_Via_Content()
+    public async Task Can_Get_Updated_Published_ElementType_By_Alias_When_Looked_Up_As_Content()
     {
-        // Arrange — create an element type, prime the cache via Get(Content, alias).
+        // Arrange — create an element type and prime the cache via Get(Content, alias),
+        // exercising the case where the requested itemType differs from the type's actual ItemType.
         IContentType element = await CreateElementTypeAsync("myElementContent");
 
         IPublishedContentType initial = PublishedContentTypeCache.Get(PublishedItemType.Content, element.Alias);
         Assert.AreEqual(1, initial.PropertyTypes.Count());
 
-        // Act — add another property and save.
+        // Act — add a property and save; the save should invalidate the primed cache entry.
         await AddPropertyAndSaveAsync(element, "extra");
-
         IPublishedContentType updated = PublishedContentTypeCache.Get(PublishedItemType.Content, element.Alias);
 
-        // Assert — element types looked up via Content must invalidate on save.
+        // Assert
         Assert.AreEqual(2, updated.PropertyTypes.Count());
     }
 
     [Test]
-    public async Task Can_Get_Updated_Published_ElementType_By_Alias_Via_Element()
+    public async Task Can_Get_Updated_Published_ElementType_By_Alias_When_Looked_Up_As_Element()
     {
-        // Arrange — create an element type, prime the cache via Get(Element, alias).
+        // Arrange — create an element type and prime the cache via Get(Element, alias),
+        // the natural lookup shape for an element type.
         IContentType element = await CreateElementTypeAsync("myElementElement");
 
         IPublishedContentType initial = PublishedContentTypeCache.Get(PublishedItemType.Element, element.Alias);
         Assert.AreEqual(1, initial.PropertyTypes.Count());
 
-        // Act — add another property and save (also exercises CreatePublishedContentType(string)
-        // for PublishedItemType.Element on the post-clear cache miss).
+        // Act — add a property and save; the save should invalidate the primed cache entry, and
+        // the next Get must successfully resolve an element type via the alias overload.
         await AddPropertyAndSaveAsync(element, "extra");
-
         IPublishedContentType updated = PublishedContentTypeCache.Get(PublishedItemType.Element, element.Alias);
 
+        // Assert
         Assert.AreEqual(2, updated.PropertyTypes.Count());
+    }
+
+    [Test]
+    public async Task Can_Get_Published_ElementType_By_Id_When_Looked_Up_As_Element()
+    {
+        // Arrange — element type fetched on a cold cache via the int overload, exercising
+        // Element handling in Get(PublishedItemType, int).
+        IContentType element = await CreateElementTypeAsync("myElementById");
+
+        // Act
+        IPublishedContentType byId = PublishedContentTypeCache.Get(PublishedItemType.Element, element.Id);
+
+        // Assert
+        Assert.IsNotNull(byId);
+        Assert.AreEqual(PublishedItemType.Element, byId.ItemType);
+        Assert.AreEqual(element.Alias, byId.Alias);
+    }
+
+    [Test]
+    public async Task ClearByDataTypeId_Removes_Element_Type_Looked_Up_As_Content()
+    {
+        // Arrange — element type whose property uses a data type, primed via Get(Content, alias)
+        // so the alias-keyed entry uses the requested itemType prefix rather than the type's own.
+        IContentType element = await CreateElementTypeAsync("myDataTypeElement");
+        int dataTypeId = element.PropertyTypes.First().DataTypeId;
+
+        IPublishedContentType primed = PublishedContentTypeCache.Get(PublishedItemType.Content, element.Alias);
+        Assert.IsNotNull(primed);
+
+        // Act — clearing by data-type id must remove every alias-keyed entry pointing at the
+        // affected content type, regardless of which itemType prefix was used to insert it.
+        PublishedContentTypeCache.ClearByDataTypeId(dataTypeId);
+        IPublishedContentType after = PublishedContentTypeCache.Get(PublishedItemType.Content, element.Alias);
+
+        // Assert — a fresh instance signals the cache was invalidated rather than re-served.
+        Assert.IsFalse(ReferenceEquals(primed, after));
     }
 
     private async Task<IContentType> CreateElementTypeAsync(string alias)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/PublishedContentTypeCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/PublishedContentTypeCacheTests.cs
@@ -132,8 +132,10 @@ internal sealed class PublishedContentTypeCacheTests : UmbracoIntegrationTestWit
         PublishedContentTypeCache.ClearByDataTypeId(dataTypeId);
         IPublishedContentType after = PublishedContentTypeCache.Get(PublishedItemType.Content, element.Alias);
 
-        // Assert — a fresh instance signals the cache was invalidated rather than re-served.
+        // Assert — a fresh instance signals the cache was invalidated rather than re-served,
+        // and the freshly loaded type should be structurally equivalent to the one that was cached.
         Assert.IsFalse(ReferenceEquals(primed, after));
+        Assert.AreEqual(primed.PropertyTypes.Count(), after.PropertyTypes.Count());
     }
 
     private async Task<IContentType> CreateElementTypeAsync(string alias)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/PublishedContentTypeCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/PublishedContentTypeCacheTests.cs
@@ -1,9 +1,11 @@
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentTypeEditing;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.TestHelpers;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -17,6 +19,7 @@ internal sealed class PublishedContentTypeCacheTests : UmbracoIntegrationTestWit
     protected override void CustomTestSetup(IUmbracoBuilder builder) => builder.AddUmbracoHybridCache();
 
     private IPublishedContentTypeCache PublishedContentTypeCache => GetRequiredService<IPublishedContentTypeCache>();
+
     private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
 
     [Test]
@@ -57,5 +60,66 @@ internal sealed class PublishedContentTypeCacheTests : UmbracoIntegrationTestWit
 
         await ContentTypeService.DeleteAsync(contentType.Key, Constants.Security.SuperUserKey);
         Assert.Catch(() => PublishedContentTypeCache.Get(PublishedItemType.Content, ContentType.Key));
+    }
+
+    [Test]
+    public async Task Can_Get_Updated_Published_ElementType_By_Alias_Via_Content()
+    {
+        // Arrange — create an element type, prime the cache via Get(Content, alias).
+        IContentType element = await CreateElementTypeAsync("myElementContent");
+
+        IPublishedContentType initial = PublishedContentTypeCache.Get(PublishedItemType.Content, element.Alias);
+        Assert.AreEqual(1, initial.PropertyTypes.Count());
+
+        // Act — add another property and save.
+        await AddPropertyAndSaveAsync(element, "extra");
+
+        IPublishedContentType updated = PublishedContentTypeCache.Get(PublishedItemType.Content, element.Alias);
+
+        // Assert — element types looked up via Content must invalidate on save.
+        Assert.AreEqual(2, updated.PropertyTypes.Count());
+    }
+
+    [Test]
+    public async Task Can_Get_Updated_Published_ElementType_By_Alias_Via_Element()
+    {
+        // Arrange — create an element type, prime the cache via Get(Element, alias).
+        IContentType element = await CreateElementTypeAsync("myElementElement");
+
+        IPublishedContentType initial = PublishedContentTypeCache.Get(PublishedItemType.Element, element.Alias);
+        Assert.AreEqual(1, initial.PropertyTypes.Count());
+
+        // Act — add another property and save (also exercises CreatePublishedContentType(string)
+        // for PublishedItemType.Element on the post-clear cache miss).
+        await AddPropertyAndSaveAsync(element, "extra");
+
+        IPublishedContentType updated = PublishedContentTypeCache.Get(PublishedItemType.Element, element.Alias);
+
+        Assert.AreEqual(2, updated.PropertyTypes.Count());
+    }
+
+    private async Task<IContentType> CreateElementTypeAsync(string alias)
+    {
+        ContentTypeCreateModel createModel = ContentTypeEditingBuilder.CreateElementType(alias, alias);
+        var attempt = await ContentTypeEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(attempt.Success);
+        return attempt.Result!;
+    }
+
+    private async Task AddPropertyAndSaveAsync(IContentType element, string newPropertyAlias)
+    {
+        ContentTypeUpdateModel updateModel = ContentTypeUpdateHelper.CreateContentTypeUpdateModel(element);
+        var properties = updateModel.Properties.ToList();
+        properties.Add(new ContentTypePropertyTypeModel
+        {
+            Alias = newPropertyAlias,
+            Name = newPropertyAlias,
+            DataTypeKey = Constants.DataTypes.Guids.TextstringGuid,
+            ContainerKey = updateModel.Containers.First().Key,
+        });
+        updateModel.Properties = properties;
+
+        var updateAttempt = await ContentTypeEditingService.UpdateAsync(element, updateModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(updateAttempt.Success);
     }
 }


### PR DESCRIPTION
## Description

### The problem

When a back-office user saves an element type (`IContentType` with `IsElement == true`), code that looks the type up via `IPublishedContentTypeCache.Get(PublishedItemType.Content, alias)` continues to receive a stale `IPublishedContentType` until the application restarts. Document types do not exhibit this; subsequent saves of the same element type also do not refresh the cache (`Get(PublishedItemType.Element, alias)` does work correctly).

### Root cause

`PublishedContentTypeCache` keeps two dictionaries — `_typesByAlias` keyed by `"{prefix}:{alias}"` and `_typesById` keyed by id. Insert and clear used different rules to derive the prefix:

- `Get(PublishedItemType itemType, string alias)` stored the entry under `aliasKey` derived from the **caller's requested** `itemType` (e.g. `"c:{alias}"`).
- `ClearContentType(int id)` and `ClearByDataTypeId(int id)` removed using `GetAliasKey(type)` — derived from the **type's own** `ItemType` (e.g. `"e:{alias}"` for an element type, since `ContentTypeBaseExtensions.GetItemType()` returns `Element` when `IsElement == true`).

For an element type primed via `Get(Content, alias)`, the entry sat at `_typesByAlias["c:{alias}"]` while `ClearContentType` only attempted to remove `"e:{alias}"`. The alias entry was never cleared. `_typesById` *was* cleared, so subsequent clear calls early-returned and the stale alias entry persisted until process restart. Document types were unaffected because their requested `itemType` matches the type's own `itemType`.

### The fixes

In `src/Umbraco.Infrastructure/PublishedCache/PublishedContentTypeCache.cs`:

1. **`ClearContentType(int id)`** now scans `_typesByAlias` and removes every entry whose value matches `id`, instead of computing a single key. This handles the case where the same type may be reachable under multiple alias-key prefixes (e.g. both `"c:{alias}"` and `"e:{alias}"` for an element type if both lookup shapes have been primed).

2. **`ClearByDataTypeId(int id)`** got the same scan-and-remove pattern.

3. **`ClearContentType` and `ClearByDataTypeId`** now also remove the corresponding entry from `_keyToIdMap`, which was previously leaking across clears.

4. **`ClearAll()`** now also clears `_keyToIdMap` for consistency with the targeted clears.

5. A latent secondary defect was fixed in the same file: `CreatePublishedContentType(itemType, string alias)` and `CreatePublishedContentType(itemType, int id)` were missing the `PublishedItemType.Element` arm in their switch expressions (the Guid overload had it). Calling `Get(PublishedItemType.Element, alias)` or `Get(PublishedItemType.Element, id)` on a cache miss therefore threw `ArgumentOutOfRangeException`. Both overloads now handle `Element` consistently with the Guid overload.

### Considered but rejected

Should `Get(PublishedItemType.Content, alias)` return null for an element-type alias?

Decided not to do this, partly as it's behaviourally breaking. The current API is permissive by design. Get(itemType, alias) uses itemType as a routing hint (which service to consult, which alias-key prefix to use) — not as a filter. 

Also if the item is not found, returning null or throwing would be a binary breaking change. `IPublishedContentTypeCache.Get` returns non-nullable `IPublishedContentType`. 

## Testing

### Automated

`tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/PublishedContentTypeCacheTests.cs` is extended with four element-type tests that verify the fix.

### Manual

The handler below demonstrates the bug and the fix end-to-end. Drop it into a project that references `Umbraco.Cms.Core`, and register it via a composer (`builder.AddNotificationHandler<ContentTypeSavedNotification, ContentTypeSavedDiagnosticHandler>();`).

```csharp
using Microsoft.Extensions.Logging;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Models.PublishedContent;
using Umbraco.Cms.Core.Notifications;
using Umbraco.Cms.Core.PublishedCache;

public class ContentTypeSavedDiagnosticHandler : INotificationHandler<ContentTypeSavedNotification>
{
    private readonly IPublishedContentTypeCache _publishedContentTypeCache;
    private readonly ILogger<ContentTypeSavedDiagnosticHandler> _logger;

    public ContentTypeSavedDiagnosticHandler(
        IPublishedContentTypeCache publishedContentTypeCache,
        ILogger<ContentTypeSavedDiagnosticHandler> logger)
    {
        _publishedContentTypeCache = publishedContentTypeCache;
        _logger = logger;
    }

    public void Handle(ContentTypeSavedNotification notification)
    {
        foreach (IContentType saved in notification.SavedEntities)
        {
            LogLookup(saved, PublishedItemType.Content);
            if (saved.IsElement)
            {
                LogLookup(saved, PublishedItemType.Element);
            }
        }
    }

    private void LogLookup(IContentType saved, PublishedItemType itemType)
    {
        try
        {
            IPublishedContentType published = _publishedContentTypeCache.Get(itemType, saved.Alias);
            var propertyAliases = string.Join(",", published.PropertyTypes.Select(p => p.Alias));

            _logger.LogInformation(
                "ContentTypeSaved diagnostic: alias={Alias} id={Id} isElement={IsElement} " +
                "Get({ItemType},alias) -> ItemType={ResolvedItemType} {PropertyCount} props [{PropertyAliases}]",
                saved.Alias,
                saved.Id,
                saved.IsElement,
                itemType,
                published.ItemType,
                published.PropertyTypes.Count(),
                propertyAliases);
        }
        catch (Exception ex)
        {
            _logger.LogInformation(
                ex,
                "ContentTypeSaved diagnostic: alias={Alias} isElement={IsElement} Get({ItemType},alias) threw",
                saved.Alias,
                saved.IsElement,
                itemType);
        }
    }
}
```

#### Reproduction steps

1. Run the site with the handler registered.
2. In the back office, create an element type with one property (e.g. `testBlock` with property `text`) and save.
3. Add a second property (`text2`) and save.
4. Add a third property (`text3`) and save.

#### Expected log output **before** the fix

```
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Content,alias) -> ItemType=Element 1 props [text]
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Element,alias) -> ItemType=Element 1 props [text]
...
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Content,alias) -> ItemType=Element 1 props [text]              <- stale
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Element,alias) -> ItemType=Element 2 props [text,text2]
...
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Content,alias) -> ItemType=Element 1 props [text]              <- still stale
[INF] ContentTypeSaved diagnostic: alias=testBlock  id=4688 isElement=True Get(Element,alias) -> ItemType=Element 3 props [text,text2,text3]
```

The `Get(Content, alias)` line never moves past 1 property, no matter how many times the type is saved.

#### Expected log output **after** the fix

```
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Content,alias) -> ItemType=Element 1 props [text]
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Element,alias) -> ItemType=Element 1 props [text]
...
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Content,alias) -> ItemType=Element 2 props [text,text2]
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Element,alias) -> ItemType=Element 2 props [text,text2]
...
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Content,alias) -> ItemType=Element 3 props [text,text2,text3]
[INF] ContentTypeSaved diagnostic: alias=testBlock id=4688 isElement=True Get(Element,alias) -> ItemType=Element 3 props [text,text2,text3]
```

Both lookup shapes return the up-to-date property set on every save.

##  Workaround for downstream consumers (pre-fix)

If you're hitting this on a version that doesn't yet contain this fix, you can work around it from caller code — but only via the `Guid` overload, and only by routing `IsElement` to the right `PublishedItemType`:

```csharp
  public void Handle(ContentTypeSavedNotification notification)
  {
      foreach (IContentType saved in notification.SavedEntities)
      {
          PublishedItemType itemType = saved.IsElement
              ? PublishedItemType.Element
              : PublishedItemType.Content;

          // Use the Guid overload, not the alias or int overload.
          IPublishedContentType contentType = _publishedContentTypeCache.Get(itemType, saved.Key);

          // ...
      }
  }
```