### PR TITLE
Delivery API: Drop $type discriminator from response payloads

### DIFF
--- a/src/Umbraco.Core/Models/DeliveryApi/IApiContent.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/IApiContent.cs
@@ -1,11 +1,8 @@
-using System.Text.Json.Serialization;
-
 namespace Umbraco.Cms.Core.Models.DeliveryApi;
 
 /// <summary>
 ///     Represents content in the Delivery API.
 /// </summary>
-[JsonDerivedType(typeof(ApiContent), nameof(ApiContent))]
 public interface IApiContent : IApiElement
 {
     /// <summary>

--- a/src/Umbraco.Core/Models/DeliveryApi/IApiContentResponse.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/IApiContentResponse.cs
@@ -1,11 +1,8 @@
-using System.Text.Json.Serialization;
-
 namespace Umbraco.Cms.Core.Models.DeliveryApi;
 
 /// <summary>
 ///     Represents a content response in the Delivery API that includes culture-specific routes.
 /// </summary>
-[JsonDerivedType(typeof(ApiContentResponse), nameof(ApiContentResponse))]
 public interface IApiContentResponse : IApiContent
 {
     /// <summary>

--- a/src/Umbraco.Core/Models/DeliveryApi/IApiContentResponse.cs
+++ b/src/Umbraco.Core/Models/DeliveryApi/IApiContentResponse.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Umbraco.Cms.Core.Models.DeliveryApi;
 
 /// <summary>
@@ -8,5 +10,6 @@ public interface IApiContentResponse : IApiContent
     /// <summary>
     ///     Gets the culture-specific routes for the content, keyed by culture code.
     /// </summary>
+    [JsonPropertyOrder(100)]
     IDictionary<string, IApiContentRoute> Cultures { get; }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/default.json
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/default.json
@@ -1157,45 +1157,36 @@
     "schemas": {
       "IApiContentResponseModel": {
         "required": [
-          "$type"
-        ],
-        "type": "object",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/IApiContentResponseModelApiContentResponseModel"
-          }
-        ],
-        "discriminator": {
-          "propertyName": "$type",
-          "mapping": {
-            "ApiContentResponse": "#/components/schemas/IApiContentResponseModelApiContentResponseModel"
-          }
-        }
-      },
-      "IApiContentResponseModelApiContentResponseModel": {
-        "required": [
           "contentType",
-          "name",
+          "cultures",
           "createDate",
           "updateDate",
           "route",
           "id",
-          "properties",
-          "cultures",
-          "$type"
+          "properties"
         ],
+        "type": "object",
         "properties": {
-          "$type": {
-            "enum": [
-              "ApiContentResponse"
-            ],
-            "type": "string"
-          },
           "contentType": {
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cultures": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "$ref": "#/components/schemas/IApiContentRouteModel"
+            }
           },
           "name": {
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "createDate": {
             "type": "string",
@@ -1213,13 +1204,10 @@
             "format": "uuid"
           },
           "properties": {
-            "type": "object"
-          },
-          "cultures": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/IApiContentRouteModel"
-            }
+            "type": [
+              "null",
+              "object"
+            ]
           }
         }
       },

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/default.json
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/default.json
@@ -1158,12 +1158,12 @@
       "IApiContentResponseModel": {
         "required": [
           "contentType",
-          "cultures",
           "createDate",
           "updateDate",
           "route",
           "id",
-          "properties"
+          "properties",
+          "cultures"
         ],
         "type": "object",
         "properties": {
@@ -1172,15 +1172,6 @@
               "null",
               "string"
             ]
-          },
-          "cultures": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": {
-              "$ref": "#/components/schemas/IApiContentRouteModel"
-            }
           },
           "name": {
             "type": [
@@ -1208,6 +1199,15 @@
               "null",
               "object"
             ]
+          },
+          "cultures": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "$ref": "#/components/schemas/IApiContentRouteModel"
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

In v18, Delivery API responses started carrying a `$type` discriminator field that was not present in v17, and the OpenAPI spec started declaring a `discriminator` block on the generic content schemas. The regression was introduced in #21058 (adoption of `Microsoft.AspNetCore.OpenApi`) when `[JsonDerivedType]` attributes were added to `IApiContent` and `IApiContentResponse`.

This PR removes those attributes so the responses match v17.

## What changed

- Removed `[JsonDerivedType(typeof(...))]` from `IApiContent` and `IApiContentResponse`. Without registered derived types, `System.Text.Json` does not configure polymorphism, so `$type` is not emitted and the OpenAPI generator does not produce a `discriminator` block.
- Added `[JsonPropertyOrder(100)]` to `IApiContentResponse.Cultures` so collection endpoints (where the static element type is the interface) keep `cultures` last in the payload, matching the existing concrete-class attribute and the `[JsonPropertyOrder(-100)]` pattern on `IApiElement.ContentType`.
- Regenerated the Delivery API OpenAPI contract snapshot used by the integration tests.

## Why this approach

Two alternatives were considered:

1. Drop only the discriminator name (`[JsonDerivedType(typeof(ApiContent))]` with no second arg). This produced a malformed OpenAPI spec — `$type` was partially configured, inconsistently between the generic schema and its mapping.
2. Remove the attributes entirely (chosen). Out of the box `IApiContent` / `IApiContentResponse` and their concrete types are 1:1, so polymorphism adds nothing for default consumers. Anyone who genuinely needs polymorphic responses can still register derived types via `ContentJsonTypeResolverBase`, which configures the discriminator correctly. The existing `OpenApiCustomDerivedTypeTest.OpenApiDocument_ContainsCustomDerivedTypeInDiscriminator` integration test continues to pass and proves this extension path is intact.

## Wire-level impact

The regression was endpoint-shape dependent:

- **Single-item endpoints** (`/item/{path}`, `/item/{id}`) return `Ok(concrete)`. System.Text.Json used the runtime type, so `$type` was never on the wire — but the OpenAPI spec required it. After the fix, the spec matches reality.
- **Collection endpoints** (`/content`, `/items`) return `PagedViewModel<IApiContentResponse>` / `IEnumerable<IApiContentResponse>`. System.Text.Json saw the interface as the static element type and emitted `$type` per item. After the fix, no `$type`.

## Testing

1. Run an Umbraco instance with the Delivery API enabled.
2. Create and publish a content node.
3. `GET /umbraco/delivery/api/v2/content/item/<path>` — confirm the response body contains no `$type` field.
4. `GET /umbraco/delivery/api/v2/content?take=10` — confirm none of the entries in `items[]` contain a `$type` field.
5. `GET /umbraco/openapi/delivery.json` — confirm the `IApiContentResponseModel` schema no longer has a `discriminator` block or a `$type` required property.