### PR TITLE
Management API: Override document-level security on AllowAnonymous endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -16168,7 +16168,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/install/setup": {
@@ -16231,7 +16232,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/install/validate-database": {
@@ -16294,7 +16296,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/item/language": {
@@ -17555,7 +17558,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/collection/media": {
@@ -28356,7 +28360,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/profiling/status": {
@@ -30679,7 +30684,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/segment": {
@@ -30761,7 +30767,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/server/information": {
@@ -30823,7 +30830,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/server/troubleshooting": {
@@ -36862,7 +36870,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/user/invite/resend": {
@@ -37068,7 +37077,8 @@
               }
             }
           }
-        }
+        },
+        "security": []
       }
     },
     "/umbraco/management/api/v1/user/set-user-groups": {

--- a/src/Umbraco.Cms.Api.Management/OpenApi/Transformers/BackOfficeSecurityRequirementsTransformer.cs
+++ b/src/Umbraco.Cms.Api.Management/OpenApi/Transformers/BackOfficeSecurityRequirementsTransformer.cs
@@ -26,11 +26,20 @@ internal class BackOfficeSecurityRequirementsTransformer : IOpenApiOperationTran
         OpenApiOperationTransformerContext context,
         CancellationToken cancellationToken)
     {
-        if (context.Description.ActionDescriptor is not ControllerActionDescriptor description ||
-            description.MethodInfo.GetCustomAttributes(true).Any(x => x is AllowAnonymousAttribute) ||
+        if (context.Description.ActionDescriptor is not ControllerActionDescriptor description)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (description.MethodInfo.GetCustomAttributes(true).Any(x => x is AllowAnonymousAttribute) ||
             description.MethodInfo.DeclaringType?.GetCustomAttributes(true).Any(x => x is AllowAnonymousAttribute) ==
             true)
         {
+            // Explicitly clear security on anonymous operations so they override the document-level
+            // security requirement added below. Without this, OpenAPI consumers (including the
+            // generated backoffice SDK) treat these endpoints as authenticated and attach a Bearer
+            // token, which triggers a /token refresh before the user has logged in.
+            operation.Security = [];
             return Task.CompletedTask;
         }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/sdk.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/sdk.gen.ts
@@ -3756,12 +3756,6 @@ export class InstallService {
      */
     public static getInstallSettings<ThrowOnError extends boolean = true>(options?: Options<GetInstallSettingsData, ThrowOnError>) {
         return (options?.client ?? client).get<GetInstallSettingsResponses, GetInstallSettingsErrors, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/install/settings',
             ...options
         });
@@ -3774,12 +3768,6 @@ export class InstallService {
      */
     public static postInstallSetup<ThrowOnError extends boolean = true>(options: Options<PostInstallSetupData, ThrowOnError>) {
         return (options.client ?? client).post<PostInstallSetupResponses, PostInstallSetupErrors, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/install/setup',
             ...options,
             headers: {
@@ -3796,12 +3784,6 @@ export class InstallService {
      */
     public static postInstallValidateDatabase<ThrowOnError extends boolean = true>(options: Options<PostInstallValidateDatabaseData, ThrowOnError>) {
         return (options.client ?? client).post<PostInstallValidateDatabaseResponses, PostInstallValidateDatabaseErrors, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/install/validate-database',
             ...options,
             headers: {
@@ -4160,12 +4142,6 @@ export class ManifestService {
      */
     public static getManifestManifestPublic<ThrowOnError extends boolean = true>(options?: Options<GetManifestManifestPublicData, ThrowOnError>) {
         return (options?.client ?? client).get<GetManifestManifestPublicResponses, unknown, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/manifest/manifest/public',
             ...options
         });
@@ -6824,12 +6800,6 @@ export class PreviewService {
      */
     public static deletePreview<ThrowOnError extends boolean = true>(options?: Options<DeletePreviewData, ThrowOnError>) {
         return (options?.client ?? client).delete<DeletePreviewResponses, unknown, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/preview',
             ...options
         });
@@ -7482,12 +7452,6 @@ export class SecurityService {
      */
     public static postSecurityForgotPasswordVerify<ThrowOnError extends boolean = true>(options: Options<PostSecurityForgotPasswordVerifyData, ThrowOnError>) {
         return (options.client ?? client).post<PostSecurityForgotPasswordVerifyResponses, PostSecurityForgotPasswordVerifyErrors, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/security/forgot-password/verify',
             ...options,
             headers: {
@@ -7526,12 +7490,6 @@ export class ServerService {
      */
     public static getServerConfiguration<ThrowOnError extends boolean = true>(options?: Options<GetServerConfigurationData, ThrowOnError>) {
         return (options?.client ?? client).get<GetServerConfigurationResponses, unknown, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/server/configuration',
             ...options
         });
@@ -7562,12 +7520,6 @@ export class ServerService {
      */
     public static getServerStatus<ThrowOnError extends boolean = true>(options?: Options<GetServerStatusData, ThrowOnError>) {
         return (options?.client ?? client).get<GetServerStatusResponses, GetServerStatusErrors, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/server/status',
             ...options
         });
@@ -9120,12 +9072,6 @@ export class UserService {
      */
     public static postUserInviteCreatePassword<ThrowOnError extends boolean = true>(options: Options<PostUserInviteCreatePasswordData, ThrowOnError>) {
         return (options.client ?? client).post<PostUserInviteCreatePasswordResponses, PostUserInviteCreatePasswordErrors, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/user/invite/create-password',
             ...options,
             headers: {
@@ -9164,12 +9110,6 @@ export class UserService {
      */
     public static postUserInviteVerify<ThrowOnError extends boolean = true>(options: Options<PostUserInviteVerifyData, ThrowOnError>) {
         return (options.client ?? client).post<PostUserInviteVerifyResponses, PostUserInviteVerifyErrors, ThrowOnError>({
-            security: [
-                {
-                    scheme: 'bearer',
-                    type: 'http'
-                }
-            ],
             url: '/umbraco/management/api/v1/user/invite/verify',
             ...options,
             headers: {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsTransformerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/OpenApi/BackOfficeSecurityRequirementsTransformerTests.cs
@@ -109,7 +109,7 @@ public class BackOfficeSecurityRequirementsTransformerTests
     #region Operation Transformer Tests
 
     [Test]
-    public async Task TransformAsync_Operation_Skips_AllowAnonymous_Methods()
+    public async Task TransformAsync_Operation_Overrides_Security_For_AllowAnonymous_Methods()
     {
         // Arrange
         var operation = new OpenApiOperation();
@@ -134,13 +134,14 @@ public class BackOfficeSecurityRequirementsTransformerTests
         // Act
         await _transformer.TransformAsync(operation, context, CancellationToken.None);
 
-        // Assert - Should not add 401 response or security
+        // Assert - Should not add 401 response, and security must be an empty list to override document-level security
         Assert.IsFalse(operation.Responses?.ContainsKey(StatusCodes.Status401Unauthorized.ToString()) ?? false);
-        Assert.IsNull(operation.Security);
+        Assert.IsNotNull(operation.Security);
+        Assert.IsEmpty(operation.Security);
     }
 
     [Test]
-    public async Task TransformAsync_Operation_Skips_AllowAnonymous_Controllers()
+    public async Task TransformAsync_Operation_Overrides_Security_For_AllowAnonymous_Controllers()
     {
         // Arrange
         var operation = new OpenApiOperation();
@@ -165,9 +166,10 @@ public class BackOfficeSecurityRequirementsTransformerTests
         // Act
         await _transformer.TransformAsync(operation, context, CancellationToken.None);
 
-        // Assert - Should not add 401 response or security
+        // Assert - Should not add 401 response, and security must be an empty list to override document-level security
         Assert.IsFalse(operation.Responses?.ContainsKey(StatusCodes.Status401Unauthorized.ToString()) ?? false);
-        Assert.IsNull(operation.Security);
+        Assert.IsNotNull(operation.Security);
+        Assert.IsEmpty(operation.Security);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

On v18/dev, opening the backoffice on a freshly checked-out (uninstalled) project crashes the install screen — the very first request to `GET /umbraco/management/api/v1/server/status` returns a 500 (OpenIddict trying to resolve `UmbracoDbContext` with no connection string), and the backoffice fires `POST /umbraco/management/api/v1/security/back-office/token` before the user has even reached the install form.

Root cause: PR #21058 (switch to `Microsoft.AspNetCore.OpenApi`) caused the OpenAPI document to declare `security: [{ Backoffice-User: [] }]` at the document level. By the OpenAPI 3.x spec, that requirement is inherited by every operation that does not explicitly override it with its own `security` array — including the empty array `security: []`. `BackOfficeSecurityRequirementsTransformer` correctly skipped adding a security entry to operations on `[AllowAnonymous]` actions, but it never inserted the empty-array override, so the generated SDK (`sdk.gen.ts`) ended up declaring `security: [{ scheme: 'bearer', type: 'http' }]` on `getServerStatus`, `getServerConfiguration`, the install endpoints, etc. That in turn told `umbHttpClient`'s auth callback to call `#ensureTokenReady()` for those calls, which triggered the early `/token` refresh.

This branch is v17 (`main`) is not affected because `main`'s checked-in `sdk.gen.ts` predates the `Microsoft.AspNetCore.OpenApi` switch and contains no document-level security default.

## Changes

- `BackOfficeSecurityRequirementsTransformer`: when an operation's action method (or its declaring type) is `[AllowAnonymous]`, set `operation.Security = []` so the operation overrides the document-level `Backoffice-User` requirement.
- Regenerated `OpenApi.json`: 10 anonymous operations now carry `"security": []` (`/server/status`, `/server/configuration`, `/install/settings`, `/install/setup`, `/install/validate-database`, `/manifest/manifest/public`, `/preview` DELETE, `/security/forgot-password/verify`, `/user/invite/create-password`, `/user/invite/verify`).
- Regenerated `sdk.gen.ts`: matching `security: [...]` arrays removed from those 10 operations.

## Test plan

Reproduced and verified in a fresh worktree (`v18/dev`) with empty connection string:

- [x] Before fix: `GET /server/status` → 500, `POST /security/back-office/token` fires before the install screen renders, OpenIddict stack trace in console.
- [x] After fix: install screen loads cleanly. Network shows only `GET /server/status` (200), `GET /server/configuration` (200), `GET /manifest/manifest/public` (200), `GET /install/settings` (200). No `Authorization` header on those calls. No `/token` request.
- [x] End-to-end install + login flow still works (filled install form → completed install → logged in → landed on `/umbraco/section/content`).

Reported by @nielslyngsoe on Slack.