### PR TITLE
Code Tidy: Remove unused obsoleted `InstalledPackage` mapping

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
@@ -22,8 +22,6 @@ public class PackageViewModelMapDefinition : IMapDefinition
         mapper.Define<PackageDefinition, PackageDefinitionResponseModel>(
             (_, _) => new PackageDefinitionResponseModel { Name = string.Empty, PackagePath = string.Empty },
             Map);
-        mapper.Define<InstalledPackage, PackageMigrationStatusResponseModel>(
-            (_, _) => new PackageMigrationStatusResponseModel { PackageName = string.Empty }, Map);
     }
 
     // Umbraco.Code.MapAll -Id -PackageId -PackagePath
@@ -64,17 +62,5 @@ public class PackageViewModelMapDefinition : IMapDefinition
         target.Scripts = source.Scripts;
         target.Languages = source.Languages;
         target.DictionaryItems = source.DictionaryItems;
-    }
-
-    // Umbraco.Code.MapAll
-    [Obsolete("Please use the IPackagePresentationFactory instead. Scheduled for removal in Umbraco 18.")]
-    private static void Map(InstalledPackage source, PackageMigrationStatusResponseModel target, MapperContext context)
-    {
-        if (source.PackageName is not null)
-        {
-            target.PackageName = source.PackageName;
-        }
-
-        target.HasPendingMigrations = source.HasPendingMigrations;
     }
 }

--- a/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
@@ -6,14 +6,13 @@ using Umbraco.Cms.Core.Packaging;
 namespace Umbraco.Cms.Api.Management.Mapping.Package;
 
 /// <summary>
-/// Provides mapping configuration for converting package data to and from the <see cref="PackageViewModel"/>.
+/// Provides mapping configuration for converting package data to and from the <see cref="PackageDefinitionResponseModel"/>.
 /// </summary>
 public class PackageViewModelMapDefinition : IMapDefinition
 {
     /// <summary>
     /// Configures the object-object mappings for package-related models used in the management API.
-    /// This includes mappings between <see cref="PackageModelBase"/>, <see cref="PackageDefinition"/>,
-    /// <see cref="PackageDefinitionResponseModel"/>, <see cref="InstalledPackage"/>, and <see cref="PackageMigrationStatusResponseModel"/>.
+    /// This includes mappings between <see cref="PackageModelBase"/>, <see cref="PackageDefinition"/>, and <see cref="PackageDefinitionResponseModel"/>.
     /// </summary>
     /// <param name="mapper">The <see cref="IUmbracoMapper"/> instance used to register the mappings.</param>
     public void DefineMaps(IUmbracoMapper mapper)


### PR DESCRIPTION
### Description
Removed the obsoleted InstalledPackage → PackageMigrationStatusResponseModel mapper registration and Map method from PackageViewModelMapDefinition. The current code already uses its replacement `IPackagePresentationFactory.CreatePackageMigrationStatusResponseModel(PagedModel<InstalledPackage> installedPackages)`

