### PR TITLE
Update SupportsBlockLayoutAlias obsoletion timeframe

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockValue.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockValue.cs
@@ -55,7 +55,7 @@ public abstract class BlockValue
     /// <returns>
     ///     <c>true</c> if the specified block layout alias is supported; otherwise, <c>false</c>.
     /// </returns>
-    [Obsolete("Scheduled for removal in Umbraco 18.")]
+    [Obsolete("Scheduled for removal in Umbraco 19.")]
     public virtual bool SupportsBlockLayoutAlias(string alias) => alias.Equals(PropertyEditorAlias);
 }
 


### PR DESCRIPTION
### Description
This PR extends the obsoletion window of the SupportsBlockLayoutAlias to 19 while we come up with a plan for the edge case discovered in https://github.com/umbraco/Umbraco-CMS/pull/22707