### PR TITLE
File-system Services: Complete child scopes on read-miss and validation-failure paths

### DIFF
--- a/src/Umbraco.Core/Services/FileServiceOperationBase.cs
+++ b/src/Umbraco.Core/Services/FileServiceOperationBase.cs
@@ -183,6 +183,9 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
         TEntity? entity = Repository.Get(path);
         if (entity is null)
         {
+            // Logical "no-op", not a transactional error. Complete the scope so an enclosing parent
+            // scope is not silently rolled back by this child failing to complete.
+            scope.Complete();
             return NotFound;
         }
 
@@ -190,6 +193,7 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
         DeletingNotification<TEntity> deletingNotification = DeletingNotification(entity, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(deletingNotification))
         {
+            scope.Complete();
             return CancelledByNotification;
         }
 
@@ -225,12 +229,16 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
             TOperationStatus validationResult = ValidateCreate(path);
             if (Success.Equals(validationResult) is false)
             {
+                // Logical "no-op", not a transactional error. Complete the scope so an enclosing parent
+                // scope is not silently rolled back by this child failing to complete.
+                scope.Complete();
                 return Attempt.FailWithStatus<TEntity?, TOperationStatus>(validationResult, default);
             }
         }
         catch (PathTooLongException exception)
         {
             _logger.LogError(exception, "The {EntityType} path was too long", EntityType);
+            scope.Complete();
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(PathTooLong, default);
         }
 
@@ -240,6 +248,7 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
         SavingNotification<TEntity> savingNotification = SavingNotification(entity, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
+            scope.Complete();
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(CancelledByNotification, default);
         }
 
@@ -267,6 +276,9 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
 
         if (entity is null)
         {
+            // Logical "no-op", not a transactional error. Complete the scope so an enclosing parent
+            // scope is not silently rolled back by this child failing to complete.
+            scope.Complete();
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(NotFound, default);
         }
 
@@ -276,6 +288,7 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
         SavingNotification<TEntity> savingNotification = SavingNotification(entity, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
+            scope.Complete();
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(CancelledByNotification, default);
         }
 
@@ -308,6 +321,9 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
 
         if (entity is null)
         {
+            // Logical "no-op", not a transactional error. Complete the scope so an enclosing parent
+            // scope is not silently rolled back by this child failing to complete.
+            scope.Complete();
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(NotFound, default);
         }
 
@@ -318,12 +334,14 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
             TOperationStatus validationResult = ValidateRename(newName, newPath);
             if (Success.Equals(validationResult) is false)
             {
+                scope.Complete();
                 return Attempt.FailWithStatus<TEntity?, TOperationStatus>(validationResult, default);
             }
         }
         catch (PathTooLongException exception)
         {
             _logger.LogError(exception, "The {EntityType} path was too long", EntityType);
+            scope.Complete();
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(PathTooLong, default);
         }
 
@@ -333,6 +351,7 @@ public abstract class FileServiceOperationBase<TRepository, TEntity, TOperationS
         SavingNotification<TEntity> savingNotification = SavingNotification(entity, eventMessages);
         if (await scope.Notifications.PublishCancelableAsync(savingNotification))
         {
+            scope.Complete();
             return Attempt.FailWithStatus<TEntity?, TOperationStatus>(CancelledByNotification, default);
         }
 

--- a/src/Umbraco.Core/Services/FileSystem/FolderServiceOperationBase.cs
+++ b/src/Umbraco.Core/Services/FileSystem/FolderServiceOperationBase.cs
@@ -84,6 +84,9 @@ internal abstract class FolderServiceOperationBase<TRepository, TFolderModel, TO
         TOperationStatus validateResult = ValidateCreate(name, path, parentPath);
         if (Success.Equals(validateResult) is false)
         {
+            // Validation failure is a logical "no-op", not a transactional error. Complete the scope so a parent
+            // scope (e.g. a package migration) is not silently rolled back by this child failing to complete.
+            scope.Complete();
             return Task.FromResult(Attempt.FailWithStatus<TFolderModel?, TOperationStatus>(validateResult, null));
         }
 
@@ -115,6 +118,9 @@ internal abstract class FolderServiceOperationBase<TRepository, TFolderModel, TO
         TOperationStatus validateResult = ValidateDelete(path);
         if (Success.Equals(validateResult) is false)
         {
+            // Validation failure is a logical "no-op", not a transactional error. Complete the scope so a parent
+            // scope is not silently rolled back by this child failing to complete.
+            scope.Complete();
             return Task.FromResult(validateResult);
         }
 
@@ -135,7 +141,9 @@ internal abstract class FolderServiceOperationBase<TRepository, TFolderModel, TO
     /// </returns>
     protected Task<TFolderModel?> HandleGetAsync(string path)
     {
-        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        // Use autoComplete because this is a read-only operation; there's nothing to roll back, and an
+        // un-completed child scope would silently roll back any enclosing parent scope (e.g. a package migration).
+        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
 
         // There's not much we can actually get when it's a folder, so it more a matter of ensuring the folder exists and returning a model.
         if (_repository.FolderExists(path) is false)
@@ -149,8 +157,6 @@ internal abstract class FolderServiceOperationBase<TRepository, TFolderModel, TO
             Path = path,
             ParentPath = GetParentFolderPath(path)
         };
-
-        scope.Complete();
 
         return Task.FromResult<TFolderModel?>(result);
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PartialViewServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PartialViewServiceTests.cs
@@ -6,7 +6,9 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.FileSystem;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Attributes;
@@ -19,6 +21,10 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 internal sealed class PartialViewServiceTests : UmbracoIntegrationTest
 {
     private IPartialViewService PartialViewService => GetRequiredService<IPartialViewService>();
+
+    private IPartialViewFolderService PartialViewFolderService => GetRequiredService<IPartialViewFolderService>();
+
+    private IKeyValueService KeyValueService => GetRequiredService<IKeyValueService>();
 
     /// <summary>
     /// Configures the runtime mode to Production for tests decorated with [ConfigureBuilder].
@@ -217,6 +223,55 @@ internal sealed class PartialViewServiceTests : UmbracoIntegrationTest
         Assert.AreEqual(PartialViewOperationStatus.NotAllowedInProductionMode, result.Status);
         Assert.IsTrue(partialViewFileSystem.FileExists(originalFileName), "Original file should still exist");
         Assert.IsFalse(partialViewFileSystem.FileExists("RenamedFile.cshtml"), "Renamed file should not exist");
+    }
+
+    [Test]
+    public async Task PartialViewFolderService_GetAsync_For_Missing_Folder_Does_Not_Roll_Back_Outer_Scope()
+    {
+        // Regression: FolderServiceOperationBase.HandleGetAsync used to open a scope without ever
+        // calling scope.Complete() when the folder didn't exist (early-return null path). When
+        // called inside an outer scope, the un-completed child propagated Completed=false up to
+        // the parent on dispose, silently rolling back the entire outer transaction including any
+        // unrelated writes made alongside it.
+        const string canaryKey = "Tests.PartialViewFolderService.OuterScopeCanary";
+
+        using (ICoreScope outer = ScopeProvider.CreateCoreScope())
+        {
+            // GetAsync against a path that does not exist takes the read-miss code path.
+            var result = await PartialViewFolderService.GetAsync("does-not-exist");
+            Assert.IsNull(result);
+
+            // Persist a canary in the same outer scope - this should survive scope.Complete().
+            KeyValueService.SetValue(canaryKey, "ok");
+            outer.Complete();
+        }
+
+        // If the outer scope was poisoned by the un-completed child, this returns null.
+        Assert.AreEqual("ok", KeyValueService.GetValue(canaryKey));
+    }
+
+    [Test]
+    public async Task PartialViewService_UpdateAsync_For_Missing_File_Does_Not_Roll_Back_Outer_Scope()
+    {
+        // Regression: FileServiceOperationBase.HandleUpdateAsync (and the other Handle* methods)
+        // used to open a scope and return early without calling scope.Complete() on validation
+        // failures (here: NotFound when Repository.Get returns null). When wrapped in an outer
+        // scope, the un-completed child rolled the parent transaction back.
+        const string canaryKey = "Tests.PartialViewService.OuterScopeCanary";
+
+        using (ICoreScope outer = ScopeProvider.CreateCoreScope())
+        {
+            var result = await PartialViewService.UpdateAsync(
+                "does-not-exist.cshtml",
+                new PartialViewUpdateModel { Content = string.Empty },
+                Constants.Security.SuperUserKey);
+            Assert.AreEqual(PartialViewOperationStatus.NotFound, result.Status);
+
+            KeyValueService.SetValue(canaryKey, "ok");
+            outer.Complete();
+        }
+
+        Assert.AreEqual("ok", KeyValueService.GetValue(canaryKey));
     }
 
     private void DeleteAllPartialViewFiles()


### PR DESCRIPTION
## Description

Methods on `FolderServiceOperationBase` and `FileServiceOperationBase` open a scope at the start of every method but only call `scope.Complete()` on the success path. Read-misses (`HandleGetAsync` returning null) and validation-failure early-returns leave the scope un-completed.

When the scope is the outermost (today's only caller pattern in v17) this is harmless — there's nothing transactional to roll back. But once a caller wraps these services in a parent scope, the un-completed child propagates `Completed=false` up via `ParentScope.ChildCompleted(...)` and silently rolls back the **entire enclosing transaction**, including any other writes the caller has made.

This fix:

- `HandleGetAsync` switches to `CreateCoreScope(autoComplete: true)` since it is read-only — there is nothing to roll back, and auto-complete-on-dispose makes it safe under any caller.
- `HandleCreateAsync` and `HandleDeleteAsync` call `scope.Complete()` before their validation-failure early-returns. A validation outcome (`AlreadyExists`, `ParentNotFound`, `InvalidName`, `NotEmpty`, etc.) is a logical "no-op" — we deliberately did not write — and shouldn't be conflated with a transactional rollback signal.

## Context

These are **latent bugs** discovered while working on https://github.com/umbraco/Umbraco-CMS/pull/22675 (v18, removing the obsoleted `IFileService`). That PR moves package install onto the per-domain file-system services and runs them inside the migration's outer scope. The result was that the migration would run, files/folders would land on disk, but the migration plan's own `umbracoKeyValue` row never persisted — `DetermineRuntimeLevel()` then kept seeing the plan as pending and looped the runtime in `Upgrading`.

The same fix is included in #22675; this PR ports it to `main` so we have the underlying issue fixed in 17 too.