### PR TITLE
Backoffice Mocks: Derive user language access from user groups

### DIFF
--- a/src/Umbraco.Web.UI.Client/mocks/db/user-group.db.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/user-group.db.ts
@@ -69,6 +69,22 @@ export class UmbUserGroupMockDB extends UmbEntityMockDbBase<UmbMockUserGroupMode
 		return Array.from(new Set(sections));
 	}
 
+	getHasAccessToAllLanguages(userGroupIds: Array<{ id: string }>): boolean {
+		return this.data
+			.filter((userGroup) => userGroupIds.map((reference) => reference.id).includes(userGroup.id))
+			.some((userGroup) => userGroup.hasAccessToAllLanguages);
+	}
+
+	getAllowedLanguages(userGroupIds: Array<{ id: string }>): string[] {
+		const languages = this.data
+			.filter((userGroup) => userGroupIds.map((reference) => reference.id).includes(userGroup.id))
+			.map((userGroup) => (userGroup.languages?.length ? userGroup.languages : []))
+			.flat();
+
+		// Remove duplicates
+		return Array.from(new Set(languages));
+	}
+
 	filter(options: UserGroupFilterOptions): PagedUserGroupResponseModel {
 		const allItems = this.getAll();
 

--- a/src/Umbraco.Web.UI.Client/mocks/db/user.db.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/user.db.ts
@@ -113,6 +113,12 @@ class UmbUserMockDB extends UmbEntityMockDbBase<UmbMockUserModel> {
 		const allowedSections = firstUser.userGroupIds?.length
 			? umbUserGroupMockDb.getAllowedSections(firstUser.userGroupIds)
 			: [];
+		const hasAccessToAllLanguages = firstUser.userGroupIds?.length
+			? umbUserGroupMockDb.getHasAccessToAllLanguages(firstUser.userGroupIds)
+			: false;
+		const languages = firstUser.userGroupIds?.length
+			? umbUserGroupMockDb.getAllowedLanguages(firstUser.userGroupIds)
+			: [];
 
 		return {
 			id: firstUser.id,
@@ -121,9 +127,9 @@ class UmbUserMockDB extends UmbEntityMockDbBase<UmbMockUserModel> {
 			userName: firstUser.email,
 			hasAccessToSensitiveData: true,
 			avatarUrls: [],
-			hasAccessToAllLanguages: true,
+			hasAccessToAllLanguages,
 			languageIsoCode: firstUser.languageIsoCode || null,
-			languages: [],
+			languages,
 			documentStartNodeIds: firstUser.documentStartNodeIds,
 			mediaStartNodeIds: firstUser.mediaStartNodeIds,
 			hasDocumentRootAccess: firstUser.hasDocumentRootAccess,


### PR DESCRIPTION
## Summary
- `hasAccessToAllLanguages` was hardcoded to `true` in the mock user DB, regardless of user group settings
- `languages` was hardcoded to `[]`, never reflecting the user's actual group-based language access
- Added `getHasAccessToAllLanguages` and `getAllowedLanguages` methods to `UmbUserGroupMockDB` and wired them up in the user mock