### PR TITLE
fix(media): restore drag-and-drop visual empty state in Media collect…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/default/collection-default.element.ts
@@ -102,7 +102,7 @@ export class UmbCollectionDefaultElement extends UmbLitElement {
 			? html`
 					<umb-body-layout header-transparent class=${this._hasItems ? 'has-items' : ''}>
 						<umb-router-slot id="router" .routes=${this._routes}></umb-router-slot>
-						${this.renderToolbar()} ${this._hasItems ? this.#renderContent() : this.#renderEmptyState()}
+						${this.renderToolbar()} ${this._hasItems ? this.#renderContent() : this.renderEmptyState()}
 					</umb-body-layout>
 				`
 			: nothing;
@@ -120,11 +120,7 @@ export class UmbCollectionDefaultElement extends UmbLitElement {
 		return html`<umb-collection-selection-actions slot="footer"></umb-collection-selection-actions>`;
 	}
 
-	#renderContent() {
-		return html`${this.renderPagination()} ${this.renderSelectionActions()}`;
-	}
-
-	#renderEmptyState() {
+	protected renderEmptyState() {
 		if (!this._initialLoadDone) return nothing;
 
 		return html`
@@ -132,6 +128,10 @@ export class UmbCollectionDefaultElement extends UmbLitElement {
 				<h4>${this.localize.string(this._emptyLabel)}</h4>
 			</div>
 		`;
+	}
+
+	#renderContent() {
+		return html`${this.renderPagination()} ${this.renderSelectionActions()}`;
 	}
 
 	static override styles = [

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/collection/media-collection.element.ts
@@ -2,7 +2,8 @@ import { UMB_MEDIA_ENTITY_TYPE, UMB_MEDIA_ROOT_ENTITY_TYPE } from '../entity.js'
 import { UMB_MEDIA_WORKSPACE_CONTEXT } from '../workspace/media-workspace.context-token.js';
 import type { UmbDropzoneMediaElement } from '../dropzone/index.js';
 import { UMB_MEDIA_COLLECTION_CONTEXT } from './media-collection.context-token.js';
-import { customElement, html, ref, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { customElement, html, ref, state, when, css } from '@umbraco-cms/backoffice/external/lit';
+import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbCollectionDefaultElement } from '@umbraco-cms/backoffice/collection';
 import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
@@ -98,6 +99,80 @@ export class UmbMediaCollectionElement extends UmbCollectionDefaultElement {
 				@progress=${this.#onProgress}></umb-dropzone-media>
 		`;
 	}
+
+	protected override renderEmptyState() {
+		return html`
+			<div class="media-empty-state">
+				
+				<span class="empty-state-title">
+					<umb-localize key="media_dragAndDropYourFilesIntoTheArea">
+						Drag and drop your file(s) into the area
+					</umb-localize>
+				</span>
+
+				<uui-icon name="icon-cloud-upload" class="empty-state-icon"></uui-icon>
+
+				<button 
+					type="button" 
+					class="empty-state-browse-btn"
+					@click=${() => this.#triggerFileBrowser()}>
+					<umb-localize key="media_orClickHereToChooseFiles">
+						- or click here to choose files
+					</umb-localize>
+				</button>
+
+			</div>
+		`;
+	}
+
+	#triggerFileBrowser() {
+		const dropzoneWrapper = this.shadowRoot?.querySelector('#dropzone');
+		const uuiDropzone = dropzoneWrapper?.shadowRoot?.querySelector('uui-file-dropzone');
+		const nativeInput = uuiDropzone?.shadowRoot?.querySelector('input[type="file"]') as HTMLInputElement;
+
+		if (nativeInput) nativeInput.click();
+	}
+
+	static override styles = [
+		UmbTextStyles,
+		css`
+			.media-empty-state {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				margin-top: 15vh; 
+				width: 100%;
+				gap: var(--uui-size-space-4);
+			}
+
+			.empty-state-title {
+				color: var(--uui-color-text-alt);
+				font-size: 1rem;
+			}
+
+			.empty-state-icon {
+				font-size: 7rem; 
+				color: var(--uui-color-border-standalone);
+				opacity: 0.3; 
+			}
+
+			.empty-state-browse-btn {
+				background: none;
+				border: none;
+				padding: 0;
+				color: var(--uui-color-interactive);
+				font-size: 1rem; 
+				cursor: pointer;
+				text-decoration: none;
+			}
+
+			.empty-state-browse-btn:hover {
+				text-decoration: underline;
+				color: var(--uui-color-interactive-emphasis);
+			}
+		`,
+	];
 }
 
 export default UmbMediaCollectionElement;


### PR DESCRIPTION
### Prerequisites
- [x] I have added steps to test this contribution in the description below

**Addresses the community feedback raised in Discussion #18035.**
Fixes #18332 

## Description
This PR restores the visual drag-and-drop hint in the Media section's empty state. This resolves a UX regression introduced during the Umbraco 14 backoffice rewrite, where editors were left with only the generic 'No items' text.

**Implementation:**
* Overrides `renderEmptyState` in `UmbMediaCollectionElement` so the fix applies uniformly across views.
* Replaces the text with a centered UI utilizing `<uui-icon name="icon-cloud-upload">`.
* Implements a shadow-DOM piercing click handler to reliably open the native OS file browser when the "click here" text is activated.
* Relies entirely on native UUI CSS variables (`--uui-color-border-standalone`, `--uui-color-interactive`) for out-of-the-box Dark Mode support, without hardcoded inline styles.
* Centers the layout seamlessly without triggering vertical scrollbars.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How to test?
1. Run the backoffice locally.
2. Navigate to the **Media** section.
3. Create a new folder and open it.
4. Verify the new visual empty state is vertically centered and no scrollbars appear.
5. Click the "- or click here to choose files" text and verify the OS file picker opens.
6. Drag and drop an image file directly into the area and verify the upload triggers successfully.
7. Switch to Dark Mode to verify the icon and text colors invert gracefully.

## Screenshots / Videos
<img width="1914" height="942" alt="media_demo" src="https://github.com/user-attachments/assets/690f9d96-04c7-4788-8f6e-8556c63838f2" />
