### PR TITLE
Typeloader: Comply with public obsoletion by making the Properties internal

### DIFF
--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -58,16 +58,14 @@ public sealed class TypeLoader
     ///         assemblies
     ///         for example.
     ///     </para>
-    ///     <para>This is for unit tests.</para>
-    /// </remarks>
-    // internal for tests
+///     <para>Marked as internal as used only for unit tests.</para>
+/// </remarks>
     internal IEnumerable<Assembly> AssembliesToScan => _assemblies ??= TypeFinder.AssembliesToScan;
 
     /// <summary>
     ///     Gets the type lists.
     /// </summary>
-    /// <remarks>For unit tests.</remarks>
-    // internal for tests
+/// <remarks>Marked as internal as used only for unit tests.</remarks>
     internal IEnumerable<TypeList> TypeLists => _types.Values;
 
     #region Get Assembly Attributes

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -58,14 +58,14 @@ public sealed class TypeLoader
     ///         assemblies
     ///         for example.
     ///     </para>
-///     <para>Marked as internal as used only for unit tests.</para>
-/// </remarks>
+    ///     <para>Marked as internal as used only for unit tests.</para>
+    /// </remarks>
     internal IEnumerable<Assembly> AssembliesToScan => _assemblies ??= TypeFinder.AssembliesToScan;
 
     /// <summary>
     ///     Gets the type lists.
     /// </summary>
-/// <remarks>Marked as internal as used only for unit tests.</remarks>
+    /// <remarks>Marked as internal as used only for unit tests.</remarks>
     internal IEnumerable<TypeList> TypeLists => _types.Values;
 
     #region Get Assembly Attributes

--- a/src/Umbraco.Core/Composing/TypeLoader.cs
+++ b/src/Umbraco.Core/Composing/TypeLoader.cs
@@ -49,7 +49,7 @@ public sealed class TypeLoader
     public ITypeFinder TypeFinder { get; }
 
     /// <summary>
-    ///     Gets or sets the set of assemblies to scan.
+    ///     Gets the set of assemblies to scan.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -61,16 +61,14 @@ public sealed class TypeLoader
     ///     <para>This is for unit tests.</para>
     /// </remarks>
     // internal for tests
-    [Obsolete("Scheduled for removal in Umbraco 18.")]
-    public IEnumerable<Assembly> AssembliesToScan => _assemblies ??= TypeFinder.AssembliesToScan;
+    internal IEnumerable<Assembly> AssembliesToScan => _assemblies ??= TypeFinder.AssembliesToScan;
 
     /// <summary>
     ///     Gets the type lists.
     /// </summary>
     /// <remarks>For unit tests.</remarks>
     // internal for tests
-    [Obsolete("Scheduled for removal in Umbraco 18.")]
-    public IEnumerable<TypeList> TypeLists => _types.Values;
+    internal IEnumerable<TypeList> TypeLists => _types.Values;
 
     #region Get Assembly Attributes
 


### PR DESCRIPTION
###
The Properties that were marked obsolete were also noted to be internal for testing. So this PR removes the obsoletion tag and makes them actually internal.