### PR TITLE
Code Tidy: Remove obsolete `MoveEventInfo.NewParent`

### DIFF
--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -28,7 +28,7 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
     /// <param name="newParentId">The identifier of the new parent.</param>
     [Obsolete("Use the overload with the newParentKey parameter instead. Scheduled for removal in v19.")]
     public MoveEventInfo(TEntity entity, string originalPath, int newParentId)
-        : this(entity, originalPath, newParentId, null)
+        : this(entity, originalPath, null)
     {
     }
 

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -15,9 +15,8 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
     /// <param name="newParentKey">The unique identifier of the new parent.</param>
     [Obsolete("Use the overload without the newParentId parameter instead. Scheduled for removal in v19.")]
     public MoveEventInfo(TEntity entity, string originalPath, int newParentId, Guid? newParentKey)
-        : base(entity, originalPath)
+        : this(entity, originalPath, newParentKey)
     {
-        NewParentKey = newParentKey;
     }
 
     /// <summary>

--- a/src/Umbraco.Core/Events/MoveEventInfo.cs
+++ b/src/Umbraco.Core/Events/MoveEventInfo.cs
@@ -13,10 +13,10 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
     /// <param name="originalPath">The original path of the entity.</param>
     /// <param name="newParentId">The identifier of the new parent.</param>
     /// <param name="newParentKey">The unique identifier of the new parent.</param>
+    [Obsolete("Use the overload without the newParentId parameter instead. Scheduled for removal in v19.")]
     public MoveEventInfo(TEntity entity, string originalPath, int newParentId, Guid? newParentKey)
         : base(entity, originalPath)
     {
-        NewParentId = newParentId;
         NewParentKey = newParentKey;
     }
 
@@ -26,15 +26,23 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
     /// <param name="entity">The entity being moved.</param>
     /// <param name="originalPath">The original path of the entity.</param>
     /// <param name="newParentId">The identifier of the new parent.</param>
-    public MoveEventInfo(TEntity entity, string originalPath, int newParentId) : this(entity, originalPath, newParentId, null)
+    [Obsolete("Use the overload with the newParentKey parameter instead. Scheduled for removal in v19.")]
+    public MoveEventInfo(TEntity entity, string originalPath, int newParentId)
+        : this(entity, originalPath, newParentId, null)
     {
     }
 
     /// <summary>
-    ///     Gets or sets the identifier of the new parent.
+    ///     Initializes a new instance of the <see cref="MoveEventInfo{TEntity}" /> class.
     /// </summary>
-    [Obsolete("Please use NewParentKey instead. Scheduled for removal in Umbraco 18.")]
-    public int NewParentId { get; set; }
+    /// <param name="entity">The entity being moved.</param>
+    /// <param name="originalPath">The original path of the entity.</param>
+    /// <param name="newParentKey">The unique identifier of the new parent.</param>
+    public MoveEventInfo(TEntity entity, string originalPath, Guid? newParentKey)
+        : base(entity, originalPath)
+    {
+        NewParentKey = newParentKey;
+    }
 
     /// <summary>
     ///     Gets the unique identifier of the new parent.
@@ -57,7 +65,7 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
     /// </summary>
     /// <param name="other">The other instance to compare.</param>
     /// <returns><c>true</c> if the instances are equal; otherwise, <c>false</c>.</returns>
-    public bool Equals(MoveEventInfo<TEntity>? other) => NewParentId == other?.NewParentId && NewParentKey == other.NewParentKey && base.Equals(other);
+    public bool Equals(MoveEventInfo<TEntity>? other) => NewParentKey == other?.NewParentKey && base.Equals(other);
 
     /// <inheritdoc />
     public override int GetHashCode()
@@ -67,7 +75,7 @@ public class MoveEventInfo<TEntity> : MoveEventInfoBase<TEntity>
             var hashCode = Entity is not null
                 ? EqualityComparer<TEntity>.Default.GetHashCode(Entity)
                 : base.GetHashCode();
-            hashCode = (hashCode * 397) ^ NewParentId;
+            hashCode = (hashCode * 397) ^ NewParentKey.GetHashCode();
             hashCode = (hashCode * 397) ^ OriginalPath.GetHashCode();
             return hashCode;
         }

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1192,7 +1192,7 @@ public class ContentService : PublishableContentServiceBase<IContent>, IContentS
             }
 
             TryGetParentKey(parentId, out Guid? parentKey);
-            var moveEventInfo = new MoveEventInfo<IContent>(content, content.Path, parentId, parentKey);
+            var moveEventInfo = new MoveEventInfo<IContent>(content, content.Path, parentKey);
 
             var movingNotification = new ContentMovingNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingNotification))

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1226,7 +1226,7 @@ public class ContentService : PublishableContentServiceBase<IContent>, IContentS
                 .Select(x =>
                 {
                     TryGetParentKey(x.Item1.ParentId, out Guid? itemParentKey);
-                    return new MoveEventInfo<IContent>(x.Item1, x.Item2, x.Item1.ParentId, itemParentKey);
+                    return new MoveEventInfo<IContent>(x.Item1, x.Item2, itemParentKey);
                 })
                 .ToArray();
 

--- a/src/Umbraco.Core/Services/ContentTypeServiceBase{TRepository,TItem}.cs
+++ b/src/Umbraco.Core/Services/ContentTypeServiceBase{TRepository,TItem}.cs
@@ -1136,7 +1136,7 @@ public abstract class ContentTypeServiceBase<TRepository, TItem> : ContentTypeSe
         var moveInfo = new List<MoveEventInfo<TItem>>();
         using (ICoreScope scope = ScopeProvider.CreateCoreScope())
         {
-            var moveEventInfo = new MoveEventInfo<TItem>(toMove, toMove.Path, containerId.Value);
+            var moveEventInfo = new MoveEventInfo<TItem>(toMove, toMove.Path, containerKey);
             MovingNotification<TItem> movingNotification = GetMovingNotification(moveEventInfo, eventMessages);
             if (scope.Notifications.PublishCancelable(movingNotification))
             {

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -177,7 +177,7 @@ namespace Umbraco.Cms.Core.Services.Implement
                     return Attempt.SucceedWithStatus(DataTypeOperationStatus.Success, toMove);
                 }
 
-                var moveEventInfo = new MoveEventInfo<IDataType>(toMove, toMove.Path, parentId, containerKey);
+                var moveEventInfo = new MoveEventInfo<IDataType>(toMove, toMove.Path, containerKey);
                 var movingDataTypeNotification = new DataTypeMovingNotification(moveEventInfo, eventMessages);
                 if (scope.Notifications.PublishCancelable(movingDataTypeNotification))
                 {

--- a/src/Umbraco.Core/Services/DictionaryItemService.cs
+++ b/src/Umbraco.Core/Services/DictionaryItemService.cs
@@ -294,7 +294,7 @@ internal sealed class DictionaryItemService : RepositoryService, IDictionaryItem
             dictionaryItem.ParentId = parentId;
 
             EventMessages eventMessages = EventMessagesFactory.Get();
-            var moveEventInfo = new MoveEventInfo<IDictionaryItem>(dictionaryItem, string.Empty, parent?.Id ?? Constants.System.Root, parentId);
+            var moveEventInfo = new MoveEventInfo<IDictionaryItem>(dictionaryItem, string.Empty, parentId);
             var movingNotification = new DictionaryItemMovingNotification(moveEventInfo, eventMessages);
             if (await scope.Notifications.PublishCancelableAsync(movingNotification))
             {

--- a/src/Umbraco.Core/Services/ElementContainerService.cs
+++ b/src/Umbraco.Core/Services/ElementContainerService.cs
@@ -181,12 +181,12 @@ internal sealed class ElementContainerService : EntityTypeContainerService<IElem
                 : EntityContainerOperationStatus.Success,
             (cont, eventMessages) =>
             {
-                var moveEventInfo = new MoveEventInfo<EntityContainer>(cont, originalPath, parentId, parentKey);
+                var moveEventInfo = new MoveEventInfo<EntityContainer>(cont, originalPath, parentKey);
                 return new EntityContainerMovingNotification(moveEventInfo, eventMessages);
             },
             (cont, eventMessages) =>
             {
-                var moveEventInfo = new MoveEventInfo<EntityContainer>(cont, originalPath, parentId, parentKey);
+                var moveEventInfo = new MoveEventInfo<EntityContainer>(cont, originalPath, parentKey);
                 return new EntityContainerMovedNotification(moveEventInfo, eventMessages);
             });
 

--- a/src/Umbraco.Core/Services/ElementEditingService.cs
+++ b/src/Umbraco.Core/Services/ElementEditingService.cs
@@ -316,12 +316,12 @@ internal sealed class ElementEditingService
             userKey,
             (elem, eventMessages) =>
             {
-                var moveEventInfo = new MoveEventInfo<IElement>(elem, originalPath, parentId, containerKey);
+                var moveEventInfo = new MoveEventInfo<IElement>(elem, originalPath, containerKey);
                 return new ElementMovingNotification(moveEventInfo, eventMessages);
             },
             (elem, eventMessages) =>
             {
-                var moveEventInfo = new MoveEventInfo<IElement>(elem, originalPath, parentId, containerKey);
+                var moveEventInfo = new MoveEventInfo<IElement>(elem, originalPath, containerKey);
                 return new ElementMovedNotification(moveEventInfo, eventMessages);
             });
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeRepositoryBase.cs
@@ -127,7 +127,7 @@ internal abstract class ContentTypeRepositoryBase<TEntity> : EntityRepositoryBas
         }
 
         // track moved entities
-        var moveInfo = new List<MoveEventInfo<TEntity>> { new(moving, moving.Path, parentId, parentKey) };
+        var moveInfo = new List<MoveEventInfo<TEntity>> { new(moving, moving.Path, parentKey) };
 
         // get the level delta (old pos to new pos)
         var levelDelta = container == null

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Events/MoveEventInfoTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Events/MoveEventInfoTests.cs
@@ -28,28 +28,27 @@ public class MoveEventInfoTests
     [Test]
     public void Can_Equate_Move_Event_Infos_Parent_Key_Null()
     {
-        var moveEvent = new MoveEventInfo<string>("entity", "path", 123, null);
-        var moveEventTwo = new MoveEventInfo<string>("entity", "path", 123, null);
+        var moveEvent = new MoveEventInfo<string>("entity", "path",  null);
+        var moveEventTwo = new MoveEventInfo<string>("entity", "path",  null);
         Assert.IsTrue(moveEvent.Equals(moveEventTwo));
     }
 
     [Test]
     public void Can_Equate_Move_Event_Infos_All_Params_Null_Or_Empty()
     {
-        var moveEvent = new MoveEventInfo<string>(string.Empty, string.Empty, 0, null);
-        var moveEventTwo = new MoveEventInfo<string>(string.Empty, string.Empty, 0, null);
+        var moveEvent = new MoveEventInfo<string>(string.Empty, string.Empty, null);
+        var moveEventTwo = new MoveEventInfo<string>(string.Empty, string.Empty, null);
         Assert.IsTrue(moveEvent.Equals(moveEventTwo));
     }
 
-    [TestCase(123, "entity", "", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
-    [TestCase(123, "", "path", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
-    [TestCase(12, "entity", "path", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
-    [TestCase(123, "entity", "path", "C6D6EA3E-C2B0-483F-B772-2F4D8BBF5027", false)]
-    [TestCase(123, "entity", "path", "063897F1-194A-4C42-B406-CA80DBC12968", true)]
-    public void Can_Equate_Move_Event_Infos(int parentId, string entity, string originalPath, Guid parentKey, bool expectedResult)
+    [TestCase("entity", "", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
+    [TestCase("", "path", "063897F1-194A-4C42-B406-CA80DBC12968", false)]
+    [TestCase("entity", "path", "C6D6EA3E-C2B0-483F-B772-2F4D8BBF5027", false)]
+    [TestCase("entity", "path", "063897F1-194A-4C42-B406-CA80DBC12968", true)]
+    public void Can_Equate_Move_Event_Infos(string entity, string originalPath, Guid parentKey, bool expectedResult)
     {
-        var moveEvent = new MoveEventInfo<string>(entity, originalPath, parentId, parentKey);
-        var moveEventTwo = new MoveEventInfo<string>("entity", "path", 123, new Guid("063897F1-194A-4C42-B406-CA80DBC12968"));
+        var moveEvent = new MoveEventInfo<string>(entity, originalPath, parentKey);
+        var moveEventTwo = new MoveEventInfo<string>("entity", "path",  new Guid("063897F1-194A-4C42-B406-CA80DBC12968"));
         Assert.AreEqual(expectedResult, moveEvent.Equals(moveEventTwo));
     }
 }


### PR DESCRIPTION
### Description
- Removed the obsoleted property
- Updated Equals and GetHashCode to only use the NewParentKey
  The GetHashCode is not used directly anywhere so the change should not cause any issues with already persisted data.
- Added constructor that only uses the NewParentKey
- Obsoleted irrelevant constructors
- Updated code that now uses the obsoleted constructors