### PR TITLE
Delivery API: Fix broken discriminator mapping refs for polymorphic schemas

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
@@ -122,12 +122,48 @@ public sealed class ContentTypeSchemaTransformer : IOpenApiSchemaTransformer, IO
             return Task.CompletedTask;
         }
 
-        foreach (IOpenApiSchema componentsSchema in document.Components.Schemas.Values)
+        foreach ((var schemaId, IOpenApiSchema componentsSchema) in document.Components.Schemas)
         {
             ResolveSchemaReferences(document, componentsSchema);
+            FixAutoBuiltDiscriminatorMapping(document, schemaId, componentsSchema);
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Repairs broken discriminator mapping refs auto-built by the framework for polymorphic types.
+    /// </summary>
+    /// <remarks>
+    /// The framework prefixes each ref with the base schema id, but the derived schemas are
+    /// registered without that prefix. Stripping the prefix recovers the correct ref.
+    /// </remarks>
+    private static void FixAutoBuiltDiscriminatorMapping(OpenApiDocument document, string parentSchemaId, IOpenApiSchema schema)
+    {
+        if (schema is not OpenApiSchema concrete || concrete.Discriminator?.Mapping is not { } mapping)
+        {
+            return;
+        }
+
+        foreach ((var key, OpenApiSchemaReference currentRef) in mapping.ToList())
+        {
+            var targetId = currentRef.Reference.Id;
+            if (string.IsNullOrEmpty(targetId) || document.Components?.Schemas?.ContainsKey(targetId) == true)
+            {
+                continue;
+            }
+
+            if (targetId.StartsWith(parentSchemaId, StringComparison.Ordinal) is false)
+            {
+                continue;
+            }
+
+            var stripped = targetId[parentSchemaId.Length..];
+            if (document.Components?.Schemas?.ContainsKey(stripped) == true)
+            {
+                mapping[key] = new OpenApiSchemaReference(stripped, document);
+            }
+        }
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
@@ -140,7 +140,9 @@ public sealed class ContentTypeSchemaTransformer : IOpenApiSchemaTransformer, IO
     /// </remarks>
     private static void FixAutoBuiltDiscriminatorMapping(OpenApiDocument document, string parentSchemaId, IOpenApiSchema schema)
     {
-        if (schema is not OpenApiSchema concrete || concrete.Discriminator?.Mapping is not { } mapping)
+        if (schema is not OpenApiSchema concrete
+            || concrete.Discriminator?.Mapping is not { } mapping
+            || document.Components?.Schemas is not { } schemas)
         {
             return;
         }
@@ -148,7 +150,7 @@ public sealed class ContentTypeSchemaTransformer : IOpenApiSchemaTransformer, IO
         foreach ((var key, OpenApiSchemaReference currentRef) in mapping.ToList())
         {
             var targetId = currentRef.Reference.Id;
-            if (string.IsNullOrEmpty(targetId) || document.Components?.Schemas?.ContainsKey(targetId) == true)
+            if (string.IsNullOrEmpty(targetId) || schemas.ContainsKey(targetId))
             {
                 continue;
             }
@@ -159,7 +161,7 @@ public sealed class ContentTypeSchemaTransformer : IOpenApiSchemaTransformer, IO
             }
 
             var stripped = targetId[parentSchemaId.Length..];
-            if (document.Components?.Schemas?.ContainsKey(stripped) == true)
+            if (schemas.ContainsKey(stripped))
             {
                 mapping[key] = new OpenApiSchemaReference(stripped, document);
             }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/typed-schemas-with-sample-types.json
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/typed-schemas-with-sample-types.json
@@ -1268,6 +1268,16 @@
                 "type": "null"
               }
             ]
+          },
+          "polymorphicTest": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/IPolymorphicTestModel"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },
@@ -2092,6 +2102,27 @@
           }
         ]
       },
+      "IPolymorphicTestModel": {
+        "required": [
+          "$type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PolymorphicTestModelChildAModel"
+          },
+          {
+            "$ref": "#/components/schemas/PolymorphicTestModelChildBModel"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "PolymorphicTestModelChildA": "#/components/schemas/PolymorphicTestModelChildAModel",
+            "PolymorphicTestModelChildB": "#/components/schemas/PolymorphicTestModelChildBModel"
+          }
+        }
+      },
       "LandingPageContentModel": {
         "required": [
           "contentType"
@@ -2188,6 +2219,41 @@
             "items": {
               "$ref": "#/components/schemas/IApiMediaWithCropsResponseModel"
             }
+          }
+        }
+      },
+      "PolymorphicTestModelChildAModel": {
+        "required": [
+          "$type",
+          "fieldA"
+        ],
+        "properties": {
+          "$type": {
+            "enum": [
+              "PolymorphicTestModelChildA"
+            ],
+            "type": "string"
+          },
+          "fieldA": {
+            "type": "string"
+          }
+        }
+      },
+      "PolymorphicTestModelChildBModel": {
+        "required": [
+          "$type",
+          "fieldB"
+        ],
+        "properties": {
+          "$type": {
+            "enum": [
+              "PolymorphicTestModelChildB"
+            ],
+            "type": "string"
+          },
+          "fieldB": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/Helpers/PolymorphicTestPropertyEditor.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/Helpers/PolymorphicTestPropertyEditor.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.DeliveryApi;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Api.Delivery.OpenApi.Helpers;
+
+/// <summary>
+/// Test-only property editor whose Delivery API value type is a polymorphic interface declared with
+/// <see cref="JsonDerivedTypeAttribute"/>. Used to verify that the OpenAPI schema generator correctly
+/// resolves auto-built discriminator mappings for polymorphic types reached via property walks.
+/// </summary>
+[HideFromTypeFinder]
+[DataEditor(EditorAlias)]
+internal sealed class PolymorphicTestPropertyEditor : DataEditor
+{
+    public const string EditorAlias = "Test.Polymorphic";
+
+    public PolymorphicTestPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
+        : base(dataValueEditorFactory)
+    {
+    }
+}
+
+[JsonDerivedType(typeof(PolymorphicTestModelChildA), nameof(PolymorphicTestModelChildA))]
+[JsonDerivedType(typeof(PolymorphicTestModelChildB), nameof(PolymorphicTestModelChildB))]
+internal interface IPolymorphicTestModel
+{
+}
+
+internal sealed class PolymorphicTestModelChildA : IPolymorphicTestModel
+{
+    public string FieldA { get; set; } = string.Empty;
+}
+
+internal sealed class PolymorphicTestModelChildB : IPolymorphicTestModel
+{
+    public int FieldB { get; set; }
+}
+
+[HideFromTypeFinder]
+internal sealed class PolymorphicTestPropertyValueConverter : PropertyValueConverterBase, IDeliveryApiPropertyValueConverter
+{
+    public override bool IsConverter(IPublishedPropertyType propertyType)
+        => propertyType.EditorAlias == PolymorphicTestPropertyEditor.EditorAlias;
+
+    public override Type GetPropertyValueType(IPublishedPropertyType propertyType) => typeof(IPolymorphicTestModel);
+
+    public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
+    public PropertyCacheLevel GetDeliveryApiPropertyCacheLevel(IPublishedPropertyType propertyType) => PropertyCacheLevel.Element;
+
+    public Type GetDeliveryApiPropertyValueType(IPublishedPropertyType propertyType) => typeof(IPolymorphicTestModel);
+
+    public object? ConvertIntermediateToDeliveryApiObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object? inter, bool preview, bool expanding) => null;
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTest.TypedSchemasWithSampleTypes.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTest.TypedSchemasWithSampleTypes.cs
@@ -116,5 +116,19 @@ internal sealed class OpenApiContractTestTypedSchemasWithSampleTypes : OpenApiCo
                 ["File"] = "FileMediaWithCropsModel",
                 ["video"] = "VideoMediaWithCropsModel",
             });
+
+        // Verify the polymorphic test schema (auto-built by the framework from [JsonDerivedType])
+        // has discriminator mapping refs that resolve to the actual derived schema ids. Regression
+        // coverage for the framework prefixing each ref with the base schema id even though the
+        // derived schemas are registered without that prefix.
+        AssertSchemaIsPolymorphicUnion(
+            openApiDocument,
+            "IPolymorphicTestModel",
+            "$type",
+            new Dictionary<string, string>
+            {
+                ["PolymorphicTestModelChildA"] = "PolymorphicTestModelChildAModel",
+                ["PolymorphicTestModelChildB"] = "PolymorphicTestModelChildBModel",
+            });
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTestBase.cs
@@ -2,12 +2,14 @@ using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Integration.Umbraco.Api.Delivery.OpenApi.Helpers;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Api.Delivery.OpenApi;
 
@@ -25,6 +27,18 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
     private PropertyEditorCollection PropertyEditorCollection => GetRequiredService<PropertyEditorCollection>();
 
     private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer => GetRequiredService<IConfigurationEditorJsonSerializer>();
+
+    /// <inheritdoc />
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        base.CustomTestSetup(builder);
+
+        // Register a test-only property editor whose Delivery API model is a polymorphic type
+        // declared with [JsonDerivedType]. Used to verify that the OpenAPI schema generator
+        // produces correctly-resolved discriminator mapping refs for framework auto-built unions.
+        builder.DataEditors().Add<PolymorphicTestPropertyEditor>();
+        builder.PropertyValueConverters().Append<PolymorphicTestPropertyValueConverter>();
+    }
 
     /// <summary>
     /// Asserts that the specified schema exists in the OpenAPI document.
@@ -80,17 +94,17 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
 
         var schema = schemas![schemaName]!;
 
-        var oneOf = schema["oneOf"]?.AsArray();
-        Assert.That(oneOf, Is.Not.Null, $"Schema '{schemaName}' has no 'oneOf' entries.");
+        var unionEntries = schema["oneOf"]?.AsArray() ?? schema["anyOf"]?.AsArray();
+        Assert.That(unionEntries, Is.Not.Null, $"Schema '{schemaName}' has no 'oneOf' or 'anyOf' entries.");
 
-        var oneOfRefs = oneOf!
+        var unionRefs = unionEntries!
             .Select(entry => entry?["$ref"]?.GetValue<string>())
             .Where(value => value is not null)
             .ToHashSet();
         foreach (var expectedSchemaName in expectedDiscriminatorMapping.Values)
         {
             var expectedRef = $"#/components/schemas/{expectedSchemaName}";
-            Assert.That(oneOfRefs, Contains.Item(expectedRef), $"Schema '{schemaName}' 'oneOf' is missing reference to '{expectedSchemaName}'.");
+            Assert.That(unionRefs, Contains.Item(expectedRef), $"Schema '{schemaName}' union is missing reference to '{expectedSchemaName}'.");
         }
 
         var discriminator = schema["discriminator"];
@@ -151,6 +165,11 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
         // Create a block list data type that allows the test element
         var blockListDataType = await CreateBlockListDataTypeAsync(testElement);
 
+        // Create a data type backed by the polymorphic test property editor (Delivery API model
+        // declared with [JsonDerivedType]). Used to verify that the OpenAPI generator produces
+        // discriminator mapping refs that match the registered schema names.
+        var polymorphicDataType = await CreatePolymorphicTestDataTypeAsync();
+
         // Create a composition type that exposes shared SEO metadata properties
         var seoMetadataComposition = new ContentTypeBuilder()
             .WithAlias("seoMetadata")
@@ -198,6 +217,11 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
                     .WithAlias("relatedArticles")
                     .WithName("Related Articles")
                     .WithDataTypeId(contentPickerDataType!.Id)
+                    .Done()
+                .AddPropertyType()
+                    .WithAlias("polymorphicTest")
+                    .WithName("Polymorphic Test")
+                    .WithDataTypeId(polymorphicDataType.Id)
                     .Done()
                 .Done()
             .Build();
@@ -293,6 +317,24 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
                 },
             },
             Name = "Content Blocks",
+            DatabaseType = ValueStorageType.Ntext,
+            ParentId = Constants.System.Root,
+            CreateDate = DateTime.UtcNow,
+        };
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        return dataType;
+    }
+
+    private async Task<IDataType> CreatePolymorphicTestDataTypeAsync()
+    {
+        var editor = PropertyEditorCollection[PolymorphicTestPropertyEditor.EditorAlias]
+                     ?? throw new InvalidOperationException(
+                         $"Property editor '{PolymorphicTestPropertyEditor.EditorAlias}' was not registered.");
+
+        var dataType = new DataType(editor, ConfigurationEditorJsonSerializer)
+        {
+            Name = "Polymorphic Test",
             DatabaseType = ValueStorageType.Ntext,
             ParentId = Constants.System.Root,
             CreateDate = DateTime.UtcNow,


### PR DESCRIPTION
## Summary

`Microsoft.AspNetCore.OpenApi`'s `MapPolymorphismOptionsToDiscriminator` builds each `discriminator.mapping` ref as `callback(base) + callback(derived)`, but our typed-schema flow in `ContentTypeSchemaTransformer` registers derived schemas without the base prefix. The auto-built mapping refs end up pointing at non-existent schemas (e.g. `IRichTextElementModelRichTextRootElementModel`), which crashes strict client generators like orval.

The fix strips the base schema id from the front of each broken ref, recovering the registration key the derived schema actually uses. Generalized - works for any `[JsonDerivedType]` interface, not just `IRichTextElement`. Implemented inside the existing document transformer; no new transformer added.

## Testing

Start an Umbraco instance with the Delivery API, RichTextOutputAsJson and GenerateContentTypeSchemas enabled in appsettings.
```json
{
  ...
  "Umbraco": {
    "CMS": {
      ...
      "DeliveryApi": {
        "Enabled": true,
        "PublicAccess": true,
        "RichTextOutputAsJson": true,
        "OpenApi": {
          "GenerateContentTypeSchemas": true
        }
      },
      ...
    }
  }
}

```
Add a document type that includes a richtext property and create some content.  
Fetch the spec at `https://<host>/umbraco/openapi/delivery.json`, find the `IRichTextElementModel` schema in `components.schemas`, and confirm each `discriminator.mapping` value references an existing schema id (e.g. `RichTextRootElementModel`), not the broken concat form (`IRichTextElementModelRichTextRootElementModel`). Optionally feed the spec into a strict client generator like orval and confirm it generates without crashing.