### PR TITLE
Auth: Un-deprecate getLatestToken and route per-request fetches through it (closes #22647, #22816)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -428,19 +428,12 @@ export class UmbAuthContext extends UmbContextBase {
 	 *   const token = await authContext.getLatestToken();
 	 *   const result = await fetch('https://my-api.com', { headers: { Authorization: `Bearer ${token}` } });
 	 * ```
-	 * @deprecated Use {@link configureClient} for `@hey-api/openapi-ts` clients or {@link getOpenApiConfiguration} for manual fetch calls. With cookie-based auth this always returns `'[redacted]'`. Scheduled for removal in Umbraco 19.
 	 * @see {@link configureClient} for automatic token handling with `@hey-api/openapi-ts` clients.
 	 * @see {@link getOpenApiConfiguration} for manual fetch calls with cookie-based auth.
 	 * @memberof UmbAuthContext
 	 * @returns The latest token from the Management API
 	 */
 	async getLatestToken(): Promise<string> {
-		new UmbDeprecation({
-			deprecated: 'getLatestToken',
-			solution:
-				'Use configureClient for @hey-api/openapi-ts clients or getOpenApiConfiguration for manual fetch calls. With cookie-based auth this always returns "[redacted]".',
-			removeInVersion: '19.0.0',
-		}).warn();
 		await this.#ensureTokenReady();
 		return '[redacted]';
 	}
@@ -626,7 +619,7 @@ export class UmbAuthContext extends UmbContextBase {
 		return {
 			base: this.#serverUrl,
 			credentials: 'include',
-			token: () => Promise.resolve('[redacted]'),
+			token: this.getLatestToken.bind(this),
 		};
 	}
 
@@ -649,10 +642,7 @@ export class UmbAuthContext extends UmbContextBase {
 		client.setConfig({
 			baseUrl: this.#serverUrl,
 			credentials: 'include',
-			auth: async () => {
-				await this.#ensureTokenReady();
-				return '[redacted]';
-			},
+			auth: this.getLatestToken.bind(this),
 		});
 
 		// Controller self-registers on the host element via UmbControllerBase constructor,
@@ -731,7 +721,7 @@ export class UmbAuthContext extends UmbContextBase {
 		const request = new Request(this.#unlinkEndpoint, {
 			method: 'POST',
 			credentials: 'include',
-			headers: { 'Content-Type': 'application/json', Authorization: 'Bearer [redacted]' },
+			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${await this.getLatestToken()}` },
 			body: JSON.stringify({ loginProvider, providerKey }),
 		});
 
@@ -843,7 +833,7 @@ export class UmbAuthContext extends UmbContextBase {
 		const request = await fetch(`${this.#linkKeyEndpoint}?provider=${provider}`, {
 			credentials: 'include',
 			headers: {
-				Authorization: 'Bearer [redacted]',
+				Authorization: `Bearer ${await this.getLatestToken()}`,
 				'Content-Type': 'application/json',
 			},
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/auth.context.ts
@@ -18,7 +18,7 @@ import {
 } from '@umbraco-cms/backoffice/external/rxjs';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import type { UmbBackofficeExtensionRegistry } from '@umbraco-cms/backoffice/extension-registry';
-import type { umbHttpClient } from '@umbraco-cms/backoffice/http-client';
+import type { UmbApiClient, umbHttpClient } from '@umbraco-cms/backoffice/http-client';
 import { isTestEnvironment, UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
@@ -71,6 +71,12 @@ export class UmbAuthContext extends UmbContextBase {
 
 	// Track clients that have been configured to prevent duplicate interceptor binding
 	#configuredClients = new WeakSet();
+
+	// Lazily initialised on the first configureClient() call. Owns the singleton
+	// UmbAuthSignalerContext provided on the host (`<umb-app>`), so we MUST share
+	// one instance across every client we configure — instantiating a new controller
+	// per call would re-provide the signaler and stack listeners.
+	#interceptorController?: UmbApiInterceptorController;
 
 	// Endpoint URLs
 	#linkEndpoint;
@@ -162,20 +168,25 @@ export class UmbAuthContext extends UmbContextBase {
 		this.#channel.onmessage = (evt: MessageEvent) => {
 			switch (evt.data?.type) {
 				case 'authorized': {
-					// Set session locally — do NOT call #updateSession which would re-broadcast
-					const accessTokenExpiresAt = evt.data.issuedAt + evt.data.expiresIn;
-					const expiresAt = evt.data.issuedAt + evt.data.expiresIn * TOKEN_EXPIRY_MULTIPLIER;
-					this.#session.setValue({ accessTokenExpiresAt, expiresAt });
-					this.#isAuthorized.setValue(true);
+					// Apply locally — do NOT call #updateSession which would re-broadcast.
+					this.#setSessionLocally(evt.data.expiresIn, evt.data.issuedAt);
 					this.#authorizationSignal.next();
 					break;
 				}
 				case 'sessionUpdate':
-					this.#session.setValue({
-						accessTokenExpiresAt: evt.data.accessTokenExpiresAt,
-						expiresAt: evt.data.expiresAt,
-					});
-					this.#isAuthorized.setValue(true);
+					// Peer broadcast already-computed timestamps, so set the session
+					// directly. We still go through the `#inSessionUpdateCallback` guard
+					// so observers triggered re-entrantly skip a redundant /token call.
+					this.#inSessionUpdateCallback = true;
+					try {
+						this.#session.setValue({
+							accessTokenExpiresAt: evt.data.accessTokenExpiresAt,
+							expiresAt: evt.data.expiresAt,
+						});
+						this.#isAuthorized.setValue(true);
+					} finally {
+						this.#inSessionUpdateCallback = false;
+					}
 					break;
 				case 'sessionCleared':
 					this.#session.setValue(undefined);
@@ -216,6 +227,9 @@ export class UmbAuthContext extends UmbContextBase {
 	}
 
 	override destroy(): void {
+		// Tear down any in-flight popup auth flow so its window-level message listener
+		// and the closed-poll interval don't leak past this context's lifetime.
+		this.#popupCleanup?.();
 		super.destroy();
 		this.#channel.close();
 	}
@@ -232,7 +246,7 @@ export class UmbAuthContext extends UmbContextBase {
 		redirect?: boolean,
 		usernameHint?: string,
 		manifest?: ManifestAuthProvider,
-	) {
+	): Promise<void> {
 		const redirectUrl = await this.#client.buildAuthorizationUrl(identityProvider, usernameHint);
 
 		if (redirect) {
@@ -279,22 +293,25 @@ export class UmbAuthContext extends UmbContextBase {
 		window.addEventListener('message', pkceHandler);
 
 		// Wait for the popup to complete via BroadcastChannel.
-		// Resolves when authorized; also resolves (no-op) if the popup is closed/cancelled.
+		// The Promise resolves once cleanup runs — whether triggered by an `authorized`
+		// broadcast, the popup being closed/cancelled, a new auth flow superseding this
+		// one, or the auth context being destroyed. resolve() is parked inside cleanup
+		// so every termination path is observable to the awaiter.
 		return new Promise<void>((resolve) => {
 			const cleanup = () => {
 				clearInterval(closedPoll);
 				this.#channel.removeEventListener('message', handler);
 				window.removeEventListener('message', pkceHandler);
 				this.#popupCleanup = undefined;
+				resolve();
 			};
 			this.#popupCleanup = cleanup;
 
 			const handler = (evt: MessageEvent) => {
 				if (evt.data?.type === 'authorized') {
-					cleanup();
 					this.#client.clearPkceState();
 					this.#authWindowProxy?.close();
-					resolve();
+					cleanup();
 				}
 			};
 			this.#channel.addEventListener('message', handler);
@@ -302,9 +319,8 @@ export class UmbAuthContext extends UmbContextBase {
 			// Poll for popup closed (user cancelled or closed the window)
 			const closedPoll = setInterval(() => {
 				if (this.#authWindowProxy?.closed) {
-					cleanup();
 					this.#client.clearPkceState();
-					resolve();
+					cleanup();
 				}
 			}, 500);
 		});
@@ -324,29 +340,31 @@ export class UmbAuthContext extends UmbContextBase {
 			return null;
 		}
 
-		// Try to get PKCE state — first from the parent window (popup flow), then from sessionStorage (redirect flow)
+		// Try to get PKCE state. Check sessionStorage first — it's synchronous and covers
+		// the redirect flow (where the same tab navigated to the IDP and back). Only fall
+		// back to asking window.opener if sessionStorage didn't have a matching entry.
+		// The previous order hung for the full opener-postMessage timeout whenever
+		// `oauth_complete` happened to load with a non-OAuth window.opener (which is set
+		// for ANY window.open target, not only OAuth popups).
 		let codeVerifier: string | undefined;
 
-		if (window.opener) {
-			// Popup flow: request code_verifier from parent via postMessage
-			codeVerifier = await this.#requestCodeVerifierFromOpener(state);
-		}
-
-		if (!codeVerifier) {
-			// Redirect flow: read from sessionStorage
-			const pkceData = sessionStorage.getItem('umb:pkce');
-			if (pkceData) {
-				try {
-					const parsed = JSON.parse(pkceData);
-					if (parsed.state === state) {
-						codeVerifier = parsed.codeVerifier;
-						sessionStorage.removeItem('umb:pkce');
-					}
-				} catch {
-					// Ignore parse errors
+		const pkceData = sessionStorage.getItem('umb:pkce');
+		if (pkceData) {
+			try {
+				const parsed = JSON.parse(pkceData);
+				if (parsed.state === state) {
+					codeVerifier = parsed.codeVerifier;
 					sessionStorage.removeItem('umb:pkce');
 				}
+			} catch {
+				// Ignore parse errors
+				sessionStorage.removeItem('umb:pkce');
 			}
+		}
+
+		if (!codeVerifier && window.opener) {
+			// Popup flow: request code_verifier from parent via postMessage.
+			codeVerifier = await this.#requestCodeVerifierFromOpener(state);
 		}
 
 		if (!codeVerifier) {
@@ -527,14 +545,11 @@ export class UmbAuthContext extends UmbContextBase {
 			return;
 		}
 		if (!navigator.locks) return;
-		const state = await navigator.locks.query();
-		if (state.held?.some((l) => l.name === 'umb:token-refresh')) {
-			// A refresh is in progress in another tab — queue behind it so we send
-			// requests with the new cookie rather than the soon-to-be-revoked one.
-			await navigator.locks.request('umb:token-refresh', async () => {
-				// No-op: we only need to wait for the ongoing refresh to finish.
-			});
-		}
+		// Always queue behind the refresh lock with a no-op callback. If the lock is
+		// free we acquire it immediately and resolve; if a peer tab holds it we wait
+		// behind that holder. This avoids a race window where querying the lock state
+		// could return "free" microseconds before another tab acquires it.
+		await navigator.locks.request('umb:token-refresh', () => Promise.resolve());
 	}
 
 	/**
@@ -624,18 +639,28 @@ export class UmbAuthContext extends UmbContextBase {
 	}
 
 	/**
-	 * Configures a `@hey-api/openapi-ts` client for authenticated API calls.
-	 * Sets baseUrl, credentials, auth header, and binds the default response
-	 * interceptors (401 retry, error handling, notifications).
+	 * Configures a `@hey-api/openapi-ts` generated client for authenticated API calls.
+	 *
+	 * Sets `baseUrl`, `credentials`, and the `auth` callback (cookie-based with
+	 * automatic token refresh via {@link getLatestToken}), and binds the default
+	 * response interceptors (401 retry, problem-details error notifications, etc.)
+	 * to the client.
+	 *
+	 * The same auth context owns a single {@link UmbApiInterceptorController} for
+	 * the lifetime of the host (`<umb-app>`), so it's safe to call this method for
+	 * multiple clients (the core's {@link umbHttpClient} *and* an extension's own
+	 * generated client) without registering duplicate auth-signaler contexts.
+	 *
 	 * @example
 	 * ```js
 	 * const authContext = await this.getContext(UMB_AUTH_CONTEXT);
 	 * authContext.configureClient(myClient);
 	 * // Now myClient automatically includes auth headers and interceptors
 	 * ```
-	 * @param client A `@hey-api/openapi-ts` client instance.
+	 * @param client A `@hey-api/openapi-ts` client instance — either {@link umbHttpClient}
+	 * or one regenerated by an extension package against its own OpenAPI document.
 	 */
-	configureClient(client: typeof umbHttpClient) {
+	configureClient(client: UmbApiClient): void {
 		if (this.#configuredClients.has(client)) return;
 		this.#configuredClients.add(client);
 
@@ -645,10 +670,14 @@ export class UmbAuthContext extends UmbContextBase {
 			auth: this.getLatestToken.bind(this),
 		});
 
-		// Controller self-registers on the host element via UmbControllerBase constructor,
-		// so the anonymous reference is intentional — lifecycle is managed by the host.
-		// Note: _host must be a proper UmbControllerHost (element host) for correct cleanup.
-		new UmbApiInterceptorController(this._host).bindDefaultInterceptors(client);
+		// Lazy single instance — see #interceptorController field comment. Controller
+		// self-registers on the host element via UmbControllerBase, so its lifecycle is
+		// managed by the host. `_host` must be a proper UmbControllerHost.
+		this.#interceptorController ??= new UmbApiInterceptorController(this._host);
+		// Each generated client is structurally identical but TypeScript treats them as
+		// distinct generic instantiations. Cast at the boundary; the controller's own
+		// signature stays strictly typed against `umbHttpClient`.
+		this.#interceptorController.bindDefaultInterceptors(client as unknown as typeof umbHttpClient);
 	}
 
 	/**
@@ -728,8 +757,11 @@ export class UmbAuthContext extends UmbContextBase {
 		const result = await fetch(request);
 
 		if (!result.ok) {
-			const error = await result.json();
-			throw error;
+			// Wrap the parsed body in a real Error so consumers using `instanceof Error`
+			// or expecting a stack trace get sane behaviour. The original problem-details
+			// payload is exposed on `.cause` for callers that want the structured fields.
+			const detail = await result.json().catch(() => undefined);
+			throw new Error(`Failed to unlink login (${result.status} ${result.statusText})`, { cause: detail });
 		}
 
 		await this.signOut();
@@ -808,10 +840,13 @@ export class UmbAuthContext extends UmbContextBase {
 				return;
 			}
 
+			// Short timeout: a real OAuth popup parent responds within milliseconds. Any
+			// longer is just a hang for the unrelated-opener case (e.g. an arbitrary
+			// `window.open(...)` target that incidentally landed on `oauth_complete`).
 			const timeout = setTimeout(() => {
 				window.removeEventListener('message', handler);
 				resolve(undefined);
-			}, 5000);
+			}, 1500);
 
 			const handler = (evt: MessageEvent) => {
 				if (evt.origin !== window.location.origin) return;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/http-client/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/http-client/index.ts
@@ -32,3 +32,29 @@ client.setConfig({
  * ```
  */
 export { client as umbHttpClient };
+
+/**
+ * Structural type representing any `@hey-api/openapi-ts` generated client.
+ *
+ * Each call to the generator produces a fully-bound `Client<RequestFn, Config, …>`
+ * tied to that document's specific operation/options shapes, so the backoffice's
+ * own `umbHttpClient` and the client in an extension package's `Client/src/api/`
+ * are structurally identical but not assignable to each other under TypeScript's
+ * variance rules. Use `UmbApiClient` on APIs (such as `UmbAuthContext.configureClient`)
+ * that need to accept either.
+ *
+ * The shape only covers what those APIs touch — `setConfig`, `request`, and the
+ * three interceptor middlewares — so callers retain meaningful autocomplete on the
+ * concrete client they pass in, while we keep the public surface flexible.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any -- bivariant escape hatch: see jsdoc above */
+export type UmbApiClient = {
+	setConfig: (config: any) => any;
+	request: (options: any) => any;
+	interceptors: {
+		request: { use: (fn: any) => unknown; eject: (fn: any) => unknown };
+		response: { use: (fn: any) => unknown; eject: (fn: any) => unknown };
+		error: { use: (fn: any) => unknown; eject: (fn: any) => unknown };
+	};
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/templates/UmbracoExtension/Client/src/entrypoints/entrypoint.ts
+++ b/templates/UmbracoExtension/Client/src/entrypoints/entrypoint.ts
@@ -2,9 +2,24 @@ import type {
   UmbEntryPointOnInit,
   UmbEntryPointOnUnload,
 } from "@umbraco-cms/backoffice/extension-api";
+import { UMB_AUTH_CONTEXT } from "@umbraco-cms/backoffice/auth";
+import { client } from "../api/client.gen.js";
 
 // load up the manifests here
-export const onInit: UmbEntryPointOnInit = (_host, _extensionRegistry) => {
+export const onInit: UmbEntryPointOnInit = async (host, _extensionRegistry) => {
+  // Wire the generated API client into the backoffice auth context.
+  // configureClient() sets baseUrl + credentials, attaches the auth callback
+  // (cookie-based, with automatic token refresh) and binds the default
+  // response interceptors (401 retry, error notifications, etc.).
+  // The framework awaits onInit, so resolving the context here ensures the
+  // client is fully configured before any element in this extension can use it.
+  const authContext = await host.getContext(UMB_AUTH_CONTEXT);
+  if (!authContext) {
+    console.warn("UMB_AUTH_CONTEXT not available — extension API client will not be authenticated");
+    return;
+  }
+  authContext.configureClient(client);
+
   console.log("Hello from my extension 🎉");
 };
 


### PR DESCRIPTION
## Summary

Fixes #22647

Since version 17.3, `getLatestToken()` had been limited in functionality, but that turned out to be a behavioral breaking change, because certain guides/tutorials/older dotnet templates advised to use this method. In the spirit of keeping this functionality working, because it is not limiting us in any way, we have decided to un-deprecate this method and actually make it work again. You can use it for any fetch clients (hey-api, ky, axios, etc), although it is advisable to use `getOpenApiConfiguration` instead, because that will also give you the base URL and cookie configuration. 

If you follow the dotnet template and generate the API client with `@hey-api/openapi-ts`, you should use `configureClient()` instead. This PR includes a change to the dotnet template that enables its usage:

```ts
import type {
  UmbEntryPointOnInit,
  UmbEntryPointOnUnload,
} from "@umbraco-cms/backoffice/extension-api";
import { UMB_AUTH_CONTEXT } from "@umbraco-cms/backoffice/auth";
import { client } from "../api/client.gen.js";

export const onInit: UmbEntryPointOnInit = async (host, _extensionRegistry) => {
  const authContext = await host.getContext(UMB_AUTH_CONTEXT);
  if (!authContext) {
    console.warn("UMB_AUTH_CONTEXT not available — extension API client will not be authenticated");
    return;
  }
  authContext.configureClient(client);
}
```

## Changes

- Removes the `@deprecated` JSDoc tag and the `UmbDeprecation.warn()` call.
- `configureClient`'s `auth` callback and `getOpenApiConfiguration`'s `token` callback both delegate to `getLatestToken.bind(this)` — single implementation, single gate.
- `unlinkLogin` and `#makeLinkTokenRequest` previously sent a hard-coded `Authorization: Bearer [redacted]` header. Replaced with `Bearer ${await this.getLatestToken()}` so those fetches participate in the refresh coordination rather than firing with a possibly-stale cookie.
- Wires the `UmbracoExtension` template's entrypoint to call `authContext.configureClient(client)`. The framework awaits `onInit`, so this guarantees the API client is fully configured before any element in the extension can hit it. (Same change is going out on v18 in #22735.)

### Minor changes discovered while working on this

- `configureClient(client)` now accepts a new structural **`UmbApiClient`** type exported from `@umbraco-cms/backoffice/http-client`. Each `@hey-api/openapi-ts` generation produces a fully-bound `Client<…>`; the backoffice's `umbHttpClient` and an extension's regenerated client are structurally identical but TS treats them as distinct generic instantiations. The widened parameter lets extensions wire their own client without `as never` casts at call sites. `bindDefaultInterceptors` keeps its strict `typeof umbHttpClient` parameter (preserving autocomplete inside interceptor callbacks); the cast happens once, internally.
- The auth context now holds a **single** `UmbApiInterceptorController`, lazy-initialised on first `configureClient()` call. Previously each call instantiated a new controller, which re-provided the `UmbAuthSignalerContext` on the host and stacked listeners — visible the moment an extension also called `configureClient`. One controller for the lifetime of the host, all configured clients share it.
- `completeAuthorizationRequest` checks `sessionStorage` before asking `window.opener` for the PKCE verifier. The previous order hung for the full postMessage timeout whenever `oauth_complete` loaded with a non-OAuth `window.opener` (which is set for *any* `window.open` target). The opener postMessage timeout is also dropped from 5s to 1.5s.
- The cross-tab `'authorized'` BroadcastChannel handler now routes through `#setSessionLocally` so the timestamp math stays in one place. The `'sessionUpdate'` handler still applies pre-computed timestamps directly (peer broadcast already did the math) but does so inside the `#inSessionUpdateCallback` guard, so a synchronous `session$` observer can no longer trigger a spurious `/token` refresh on top of a peer's update.
- `#ensureTokenReady` drops its query-then-request pattern. Now always queues behind the `umb:token-refresh` lock with a no-op callback — eliminates the race window between `query()` and `request()`.
- `destroy()` invokes `#popupCleanup` before tearing down so an in-flight popup flow's window-level message listener and closed-poll interval don't leak past the context's lifetime. The cleanup helper itself now resolves the popup-flow Promise — every termination path (authorized, popup closed, superseded, destroyed) is observable to the awaiter instead of hanging forever.
- `makeAuthorizationRequest` is annotated `Promise<void>`.
- `unlinkLogin` wraps the parsed problem-details payload in a real `Error` (with the original payload exposed on `.cause`) so callers using `instanceof Error` or expecting a stack trace get sane behaviour.

## Test plan

- [x] `npm run test` — the auth-context test suite (23 tests) passes
- [x] No new TS or lint errors in changed files
- [ ] Scaffold a fresh extension via `dotnet new umbraco-extension --include-example true`, run it, and verify the dashboard's three buttons work — the entrypoint now wires `configureClient(client)` instead of relying on the inherited `umbHttpClient` config copy

## Backport

Self-contained. I'll cherry-pick this manually to `release/17.4.0` and `release/18.0` after it lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)