### PR TITLE
Elements: Disable inaccessible parent folders in element tree

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/folder/tree/element-folder-tree-item.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/folder/tree/element-folder-tree-item.context.ts
@@ -13,6 +13,7 @@ export class UmbElementFolderTreeItemContext extends UmbDefaultTreeItemContext<
 
 	// TODO: Move to API
 	readonly isTrashed = this._treeItem.asObservablePart((item) => item?.isTrashed ?? false);
+	readonly noAccess = this._treeItem.asObservablePart((item) => item?.noAccess ?? false);
 
 	constructor(host: UmbControllerHost) {
 		super(host);

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/folder/tree/element-folder-tree-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/folder/tree/element-folder-tree-item.element.ts
@@ -1,0 +1,23 @@
+import type { UmbElementFolderTreeItemModel } from '../types.js';
+import type { UmbElementFolderTreeItemContext } from './element-folder-tree-item.context.js';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbTreeItemElementBase } from '@umbraco-cms/backoffice/tree';
+
+@customElement('umb-element-folder-tree-item')
+export class UmbElementFolderTreeItemElement extends UmbTreeItemElementBase<
+	UmbElementFolderTreeItemModel,
+	UmbElementFolderTreeItemContext
+> {
+	public override set api(value: UmbElementFolderTreeItemContext | undefined) {
+		this.observe(value?.noAccess, (noAccess) => (this._noAccess = noAccess ?? false));
+		super.api = value;
+	}
+}
+
+export { UmbElementFolderTreeItemElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-element-folder-tree-item': UmbElementFolderTreeItemElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/folder/tree/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/folder/tree/manifests.ts
@@ -3,9 +3,9 @@ import type { ManifestTreeItem } from '@umbraco-cms/backoffice/tree';
 
 const treeItem: ManifestTreeItem = {
 	type: 'treeItem',
-	kind: 'default',
 	alias: 'Umb.TreeItem.ElementFolder',
 	name: 'Element Folder Tree Item',
+	element: () => import('./element-folder-tree-item.element.js'),
 	api: () => import('./element-folder-tree-item.context.js'),
 	forEntityTypes: [UMB_ELEMENT_FOLDER_ENTITY_TYPE],
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/tree/element-recycle-bin-tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/tree/element-recycle-bin-tree.server.data-source.ts
@@ -79,6 +79,7 @@ const mapper = (item: ElementRecycleBinItemResponseModel): UmbElementRecycleBinT
 		entityType: item.isFolder ? UMB_ELEMENT_FOLDER_ENTITY_TYPE : UMB_ELEMENT_ENTITY_TYPE,
 		icon: item.isFolder ? 'icon-folder' : (item.documentType?.icon ?? 'icon-document'),
 		isTrashed: true,
+		noAccess: false,
 		hasChildren: item.hasChildren,
 		documentType: {
 			unique: item.documentType?.id ?? '',

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/tree/element.tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/tree/element.tree.server.data-source.ts
@@ -65,6 +65,7 @@ export class UmbElementTreeServerDataSource
 			entityType: item.isFolder ? UMB_ELEMENT_FOLDER_ENTITY_TYPE : UMB_ELEMENT_ENTITY_TYPE,
 			hasChildren: item.hasChildren,
 			isTrashed: false,
+			noAccess: item.noAccess,
 			isFolder: item.isFolder,
 			documentType: {
 				unique: item.documentType?.id ?? '',

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/tree/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/tree/types.ts
@@ -15,6 +15,7 @@ export type { UmbElementTreeRepository } from './element-tree.repository.js';
 export interface UmbElementTreeItemModel extends Omit<UmbTreeItemModel, 'flags'>, UmbEntityWithFlags {
 	entityType: UmbElementEntityType | UmbElementFolderEntityType;
 	isTrashed: boolean;
+	noAccess: boolean;
 	documentType: {
 		unique: string;
 		icon: string;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The backend flags ancestor folders above a configured element start node with `noAccess` so they render as breadcrumbs. The element folder tree item used `kind: 'default'`, which doesn't observe `noAccess`, so those parent folders were enabled and clickable in the Library section tree.

Replaced the folder tree item with a small custom element that observes `noAccess` and forwards it to the base class, which already handles disabling the row.

<img width="287" height="213" alt="image" src="https://github.com/user-attachments/assets/3a6bdb1a-bf41-4a2c-9ce5-41cd834b4231" />

### Testing

Configure a user group whose element start node is `Library Root > Parent Folder > Child Folder`. Sign in and open the Library section. `Parent Folder` and any ancestors above `Child Folder` should appear greyed out and unclickable, while `Child Folder` and its contents stay interactive. Switch the start node back to the root and confirm no folders are greyed out.