### PR TITLE
Dictionary: Order SQL before `FetchOneToMany` to prevent duplicate items in collection view (closes #22640)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -157,7 +157,10 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
                         .WhereIn<DictionaryDto>(x => x.Parent, group);
 
                     ApplyFilterToQuery(sql, filter);
-                    sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+
+                    // FetchOneToMany only merges adjacent rows that share the same primary key,
+                    // so order by it to keep each dictionary item's translations contiguous.
+                    sql.OrderBy<DictionaryDto>(x => x.PrimaryKey);
 
                     return Database
                         .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
@@ -172,9 +175,9 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
 
             ApplyFilterToQuery(sql, filter);
 
-            // FetchOneToMany only merges adjacent rows that share the same primary key, so
-            // translations for the same dictionary item must be contiguous in the result set.
-            sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+            // FetchOneToMany only merges adjacent rows that share the same primary key,
+            // so order by it to keep each dictionary item's translations contiguous.
+            sql.OrderBy<DictionaryDto>(x => x.PrimaryKey);
 
             return Database
                 .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
@@ -256,7 +259,7 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
     {
         Sql<ISqlContext> sql = GetBaseQuery(false)
             .Where(GetBaseWhereClause(), new { id })
-            .OrderBy<DictionaryDto>(x => x.UniqueId);
+            .OrderBy<DictionaryDto>(x => x.PrimaryKey);
 
         DictionaryDto? dto = Database
             .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
@@ -374,7 +377,7 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             }
 
             // FetchOneToMany requires translations for the same dictionary item to be contiguous.
-            sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+            sql.OrderBy<DictionaryDto>(x => x.PrimaryKey);
 
             return Database
                 .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
@@ -464,7 +467,7 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
             }
 
             // FetchOneToMany requires translations for the same dictionary item to be contiguous.
-            sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+            sql.OrderBy<DictionaryDto>(x => x.PrimaryKey);
 
             return Database
                 .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
@@ -481,7 +484,7 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
         }
 
         // FetchOneToMany requires translations for the same dictionary item to be contiguous.
-        sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+        sql.OrderBy<DictionaryDto>(x => x.PrimaryKey);
 
         IDictionary<int, ILanguage> languageIsoCodeById = GetLanguagesById();
 
@@ -495,7 +498,9 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
         Sql<ISqlContext> sqlClause = GetBaseQuery(false);
         var translator = new SqlTranslator<IDictionaryItem>(sqlClause, query);
         Sql<ISqlContext> sql = translator.Translate();
-        sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+
+        // FetchOneToMany requires translations for the same dictionary item to be contiguous.
+        sql.OrderBy<DictionaryDto>(x => x.PrimaryKey);
 
         IDictionary<int, ILanguage> languageIsoCodeById = GetLanguagesById();
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DictionaryRepository.cs
@@ -172,6 +172,10 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
 
             ApplyFilterToQuery(sql, filter);
 
+            // FetchOneToMany only merges adjacent rows that share the same primary key, so
+            // translations for the same dictionary item must be contiguous in the result set.
+            sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+
             return Database
                 .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
                 .Select(dto => ConvertFromDto(dto, languageIsoCodeById))
@@ -369,6 +373,9 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
                 sql.WhereIn<DictionaryDto>(x => x.UniqueId, ids);
             }
 
+            // FetchOneToMany requires translations for the same dictionary item to be contiguous.
+            sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+
             return Database
                 .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
                 .Select(ConvertToEntity);
@@ -456,6 +463,9 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
                 sql.WhereIn<DictionaryDto>(x => x.Key, ids);
             }
 
+            // FetchOneToMany requires translations for the same dictionary item to be contiguous.
+            sql.OrderBy<DictionaryDto>(x => x.UniqueId);
+
             return Database
                 .FetchOneToMany<DictionaryDto>(x => x.LanguageTextDtos, sql)
                 .Select(ConvertToEntity);
@@ -469,6 +479,9 @@ internal sealed class DictionaryRepository : EntityRepositoryBase<int, IDictiona
         {
             sql.WhereIn<DictionaryDto>(x => x.PrimaryKey, ids);
         }
+
+        // FetchOneToMany requires translations for the same dictionary item to be contiguous.
+        sql.OrderBy<DictionaryDto>(x => x.UniqueId);
 
         IDictionary<int, ILanguage> languageIsoCodeById = GetLanguagesById();
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DictionaryRepositoryTest.cs
@@ -546,6 +546,65 @@ internal sealed class DictionaryRepositoryTest : UmbracoIntegrationTest
         }
     }
 
+    /// <summary>
+    /// Verifies that <see cref="IDictionaryRepository.GetDictionaryItemDescendants"/> returns each
+    /// dictionary item exactly once when items have multiple translations.
+    /// </summary>
+    /// <remarks>
+    /// Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22640.
+    /// The underlying SQL left-joins cmsDictionary with cmsLanguageText (one row per
+    /// translation) and relies on NPoco's FetchOneToMany to collapse them back into a
+    /// single dictionary item. FetchOneToMany only merges adjacent rows that share the
+    /// same primary key, so the SQL must order rows such that translations for the same
+    /// dictionary item are contiguous. Without that ordering, items with multiple
+    /// translations get yielded multiple times.
+    /// </remarks>
+    [Test]
+    public async Task GetDictionaryItemDescendants_With_Multiple_Translations_Returns_Each_Item_Exactly_Once()
+    {
+        var languageService = GetRequiredService<ILanguageService>();
+        var languageDe = new Language("de-DE", "German (Germany)");
+        await languageService.CreateAsync(languageDe, Constants.Security.SuperUserKey);
+        var languageFr = new Language("fr-FR", "French (France)");
+        await languageService.CreateAsync(languageFr, Constants.Security.SuperUserKey);
+
+        var languageEn = await languageService.GetAsync("en-US");
+        var languageDk = await languageService.GetAsync("da-DK");
+
+        var dictionaryItemService = GetRequiredService<IDictionaryItemService>();
+        var additionalKeys = new[] { "Header", "Footer", "Sidebar", "Title", "Subtitle" };
+        foreach (var key in additionalKeys)
+        {
+            await dictionaryItemService.CreateAsync(
+                new DictionaryItem(key)
+                {
+                    Translations =
+                    [
+                        new DictionaryTranslation(languageEn, $"{key} (en)"),
+                        new DictionaryTranslation(languageDk, $"{key} (dk)"),
+                        new DictionaryTranslation(languageDe, $"{key} (de)"),
+                        new DictionaryTranslation(languageFr, $"{key} (fr)"),
+                    ],
+                },
+                Constants.Security.SuperUserKey);
+        }
+
+        using (ScopeProvider.CreateScope())
+        {
+            var repository = CreateRepository();
+
+            var results = repository.GetDictionaryItemDescendants(null).ToArray();
+
+            // 2 items from CreateTestData ("Read More", "Article") + the 5 items added above.
+            var expectedKeys = new[] { "Read More", "Article" }.Concat(additionalKeys).OrderBy(x => x).ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(results.Select(x => x.ItemKey).OrderBy(x => x), Is.EqualTo(expectedKeys));
+                Assert.That(results.Select(x => x.Key).Distinct().Count(), Is.EqualTo(results.Length), "Each dictionary item should appear exactly once.");
+            });
+        }
+    }
+
     [Test]
     public void GetDictionaryItemDescendants_WithValueSearch_Disabled_Does_Not_Return_Items_Matching_Only_Translation_Value()
     {


### PR DESCRIPTION
## Description

Fixes #22640

The dictionary collection view (translation dashboard) could show items duplicated once per translation, e.g., as shown in the linked issue, `Frontend.Articles.All` appearing four times when four languages had translations.

**Root cause** — `DictionaryRepository.GetDictionaryItemDescendants` (and three sister `PerformGetAll` methods) build a SQL that left-joins `cmsDictionary` to `cmsLanguageText` (one row per translation) and relies on NPoco's `FetchOneToMany` to collapse those rows back into a single dictionary item. `FetchOneToMany` walks the reader sequentially and only merges rows whose primary key matches the **immediately previous** row's PK — so the SQL must order rows such that translations for the same dictionary item are contiguous. With no `ORDER BY`, the optimiser could return interleaved rows, so each affected item gets yielded once per translation.

This is query plan optimizer dependent, which explains why it isn't always seen.  The reporter mentions that it's not seen on their staging environment, which may have less data and hence a different plan is selected. 

## Testing

### Automated

A regression test was added — `DictionaryRepositoryTest.GetDictionaryItemDescendants_With_Multiple_Translations_Returns_Each_Item_Exactly_Once` — that creates 5 dictionary items with 4 translations each on top of the existing fixture and asserts every item appears exactly once. The test passes both before and after the fix on LocalDb though (the optimiser happens to return rows in PK order at this scale), so it documents the contract and guards against regressions rather than reproducing the underlying bug.

### Manual

Open the Translation section in the backoffice on an instance with multiple languages and translated dictionary items; the table should show each item exactly once.