### PR TITLE
E2E: QA: Add .prettierrc.json to acceptance tests for formatting consistency

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/.prettierrc.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 200,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true,
+  "semi": true,
+  "bracketSpacing": false,
+  "endOfLine": "auto"
+}


### PR DESCRIPTION
Adds a `.prettierrc.json` to the acceptance tests so IDEs with the Prettier plugin format new edits to match the existing style (2 spaces, single quotes, `printWidth: 200`).
