### PR TITLE
Startup: Warn on misordered `Use*Endpoints calls` (closes #22718)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Extensions/UmbracoApplicationBuilder.BackOffice.cs
+++ b/src/Umbraco.Cms.Api.Management/Extensions/UmbracoApplicationBuilder.BackOffice.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Api.Management.Middleware;
@@ -58,15 +57,11 @@ public static partial class UmbracoApplicationBuilderExtensions
 
     private static void WarnIfWebsiteEndpointsAlreadyRegistered(IUmbracoEndpointBuilderContext app)
     {
-        bool dynamicRouteAlreadyRegistered = app.EndpointRouteBuilder.DataSources
-            .SelectMany(ds => ds.Endpoints)
-            .OfType<RouteEndpoint>()
-            .Any(e => string.Equals(
-                e.DisplayName,
-                Constants.Web.Routing.DynamicRoutePattern,
-                StringComparison.Ordinal));
-
-        if (dynamicRouteAlreadyRegistered is false)
+        // UseWebsiteEndpoints sets a flag in AppBuilder.Properties that we can read to determine
+        // if it has already been called. If it has, then we log a warning that the order of endpoint registration is wrong,
+        // which can lead to very confusing issues where the back office routes are shadowed by the front-end dynamic content
+        // route, resulting in blank pages and no errors.
+        if (app.AppBuilder.Properties.TryGetValue(Constants.Web.Routing.WebsiteEndpointsRegisteredKey, out object? flag) is false || flag is not true)
         {
             return;
         }

--- a/src/Umbraco.Cms.Api.Management/Extensions/UmbracoApplicationBuilder.BackOffice.cs
+++ b/src/Umbraco.Cms.Api.Management/Extensions/UmbracoApplicationBuilder.BackOffice.cs
@@ -14,6 +14,8 @@ namespace Umbraco.Extensions;
 /// </summary>
 public static partial class UmbracoApplicationBuilderExtensions
 {
+    private const string LoggerCategoryName = "Umbraco.Extensions.UmbracoApplicationBuilderExtensions";
+
     /// <summary>
     ///     Adds all required middleware to run the back office
     /// </summary>
@@ -60,7 +62,7 @@ public static partial class UmbracoApplicationBuilderExtensions
             .SelectMany(ds => ds.Endpoints)
             .OfType<RouteEndpoint>()
             .Any(e => string.Equals(
-                e.RoutePattern.RawText,
+                e.DisplayName,
                 Constants.Web.Routing.DynamicRoutePattern,
                 StringComparison.Ordinal));
 
@@ -69,11 +71,9 @@ public static partial class UmbracoApplicationBuilderExtensions
             return;
         }
 
-#pragma warning disable CS0436 // Type conflicts with imported type
         ILogger logger = app.ApplicationServices
             .GetRequiredService<ILoggerFactory>()
-            .CreateLogger(typeof(UmbracoApplicationBuilderExtensions).FullName!);
-#pragma warning restore CS0436 // Type conflicts with imported type
+            .CreateLogger(LoggerCategoryName);
 
         logger.LogWarning(
             "UseWebsiteEndpoints() appears to have been called before UseBackOfficeEndpoints() in the WithEndpoints configuration. " +

--- a/src/Umbraco.Cms.Api.Management/Extensions/UmbracoApplicationBuilder.BackOffice.cs
+++ b/src/Umbraco.Cms.Api.Management/Extensions/UmbracoApplicationBuilder.BackOffice.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Api.Management.Middleware;
 using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 
 namespace Umbraco.Extensions;
@@ -41,11 +44,41 @@ public static partial class UmbracoApplicationBuilderExtensions
             return app;
         }
 
+        WarnIfWebsiteEndpointsAlreadyRegistered(app);
+
         BackOfficeAreaRoutes backOfficeRoutes = app.ApplicationServices.GetRequiredService<BackOfficeAreaRoutes>();
         backOfficeRoutes.CreateRoutes(app.EndpointRouteBuilder);
 
         app.UseUmbracoPreviewEndpoints();
 
         return app;
+    }
+
+    private static void WarnIfWebsiteEndpointsAlreadyRegistered(IUmbracoEndpointBuilderContext app)
+    {
+        bool dynamicRouteAlreadyRegistered = app.EndpointRouteBuilder.DataSources
+            .SelectMany(ds => ds.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Any(e => string.Equals(
+                e.RoutePattern.RawText,
+                Constants.Web.Routing.DynamicRoutePattern,
+                StringComparison.Ordinal));
+
+        if (dynamicRouteAlreadyRegistered is false)
+        {
+            return;
+        }
+
+#pragma warning disable CS0436 // Type conflicts with imported type
+        ILogger logger = app.ApplicationServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(UmbracoApplicationBuilderExtensions).FullName!);
+#pragma warning restore CS0436 // Type conflicts with imported type
+
+        logger.LogWarning(
+            "UseWebsiteEndpoints() appears to have been called before UseBackOfficeEndpoints() in the WithEndpoints configuration. " +
+            "The required order is UseBackOfficeEndpoints() first, then UseWebsiteEndpoints(). " +
+            "With the order reversed the front-end dynamic content route shadows the backoffice routes, and Umbraco will appear to start with blank pages, broken static assets, and a non-functional install screen with no further errors. " +
+            "Update your Program.cs WithEndpoints callback to call UseBackOfficeEndpoints() first.");
     }
 }

--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -119,6 +119,13 @@ public static partial class Constants
             ///     The dynamic route pattern used for Umbraco content routing.
             /// </summary>
             public const string DynamicRoutePattern = "/{**umbracoSlug}";
+
+            /// <summary>
+            ///     The key set on <see cref="Microsoft.AspNetCore.Builder.IApplicationBuilder.Properties"/> by
+            ///     <c>UseWebsiteEndpoints()</c> so that <c>UseBackOfficeEndpoints()</c> can detect when it has been
+            ///     called in the wrong order (back office endpoints must be registered first).
+            /// </summary>
+            public const string WebsiteEndpointsRegisteredKey = "Umbraco.Cms.Web.Website.WebsiteEndpointsRegistered";
         }
 
         /// <summary>

--- a/src/Umbraco.Web.Website/Extensions/UmbracoApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/Extensions/UmbracoApplicationBuilderExtensions.cs
@@ -40,6 +40,10 @@ public static class UmbracoApplicationBuilderExtensions
             return builder;
         }
 
+        // Flag this call so UseBackOfficeEndpoints can warn if it runs after us (which is the wrong order — the backoffice
+        // routes get shadowed by the dynamic content route registered below).
+        builder.AppBuilder.Properties[Constants.Web.Routing.WebsiteEndpointsRegisteredKey] = true;
+
         FrontEndRoutes surfaceRoutes = builder.ApplicationServices.GetRequiredService<FrontEndRoutes>();
         surfaceRoutes.CreateRoutes(builder.EndpointRouteBuilder);
 


### PR DESCRIPTION
## Description

This PR detects the silent misconfiguration described in #22718 where `UseWebsiteEndpoints()` is called before `UseBackOfficeEndpoints()` in the `WithEndpoints` callback in `Program.cs`. With that order reversed, the front-end dynamic content route (`{**slug}`) shadows the backoffice routes and Umbraco starts up with blank pages, broken static assets and a non-functional install screen, with no diagnostics in the log.

`UseBackOfficeEndpoints()` now inspects `IEndpointRouteBuilder.DataSources` for an already-registered `RouteEndpoint` matching `Constants.Web.Routing.DynamicRoutePattern`. If found, it emits a single `LogWarning` naming both methods, the required order, the user-visible symptoms, and where to fix it.

## Testing

Start up Umbraco as if for a new install (i.e. with no database configured).  It should start up normally and enter the installer flow.

Then restart having swapped the order of `UseBackOfficeEndpoints()` and `UseWebsiteEndpoints()` in `Program.cs`, i.e.:

```csharp
app.UseUmbraco()
    .WithMiddleware(u =>
    {
        u.UseBackOffice();
        u.UseWebsite();
    })
    .WithEndpoints(u =>
    {
        u.UseWebsiteEndpoints();
        u.UseBackOfficeEndpoints();
    });
```

You should see the following in the log (line breaks added for clarity):

```
[16:21:40 WRN] UseWebsiteEndpoints() appears to have been called before UseBackOfficeEndpoints() in the WithEndpoints configuration.
The required order is UseBackOfficeEndpoints() first, then UseWebsiteEndpoints().
With the order reversed the front-end dynamic content route shadows the backoffice routes, and Umbraco will appear to start with blank pages, broken static assets, and a non-functional install screen with no further errors.
Update your Program.cs WithEndpoints callback to call UseBackOfficeEndpoints() first.
```

Fixes #22718