### PR TITLE
Open API: Skip operation ID generation for non-controller endpoints

### DIFF
--- a/src/Umbraco.Cms.Api.Common/OpenApi/UmbracoOperationIdTransformer.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/UmbracoOperationIdTransformer.cs
@@ -29,16 +29,23 @@ public class UmbracoOperationIdTransformer : IOpenApiOperationTransformer
         OpenApiOperationTransformerContext context,
         CancellationToken cancellationToken)
     {
-        operation.OperationId = GenerateOperationId(context);
+        var operationId = GenerateOperationId(context);
+        if (operationId is not null)
+        {
+            operation.OperationId = operationId;
+        }
+
         return Task.CompletedTask;
     }
 
-    private static string GenerateOperationId(OpenApiOperationTransformerContext context)
+    private static string? GenerateOperationId(OpenApiOperationTransformerContext context)
     {
         ApiDescription apiDescription = context.Description;
         if (apiDescription.ActionDescriptor is not ControllerActionDescriptor controllerActionDescriptor)
         {
-            throw new ArgumentException($"This handler operates only on {nameof(ControllerActionDescriptor)}.");
+            // Minimal APIs and other non-MVC endpoints don't carry a ControllerActionDescriptor; leave their
+            // operation ID untouched so the framework's default applies.
+            return null;
         }
 
         ApiVersion defaultVersion = context.ApplicationServices.GetRequiredService<IOptions<ApiVersioningOptions>>().Value.DefaultApiVersion;


### PR DESCRIPTION
## Summary

Fixes `UmbracoOperationIdTransformer` throwing `ArgumentException: This handler operates only on ControllerActionDescriptor` when an OpenAPI document includes minimal API (or any non-MVC) endpoints.

The transformer now returns `null` for non-`ControllerActionDescriptor` endpoints, leaving the operation ID untouched so the framework's default applies. Controller endpoints still get the Umbraco-style operation ID.

## Testing

Add a minimal API endpoint to `src/Umbraco.Web.UI/Program.cs`:

```csharp
app.MapGet("/api/minimal/ping", () => "pong");
```

Run the site and load `/umbraco/openapi/index.html`. Before the fix, the default document throws:

```
System.ArgumentException: This handler operates only on ControllerActionDescriptor.
   at Umbraco.Cms.Api.Common.OpenApi.UmbracoOperationIdTransformer.GenerateOperationId(...)
   at Umbraco.Cms.Api.Common.OpenApi.UmbracoOperationIdTransformer.TransformAsync(...)
```

After the fix, the document renders with the minimal API operation included (using the framework's default operation ID). Existing controller-based endpoints continue to use Umbraco's operation ID convention.
