### PR TITLE
Color Picker: Refresh stored label when data type label changes (closes #22741)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
@@ -58,6 +58,7 @@ export class UmbPropertyEditorUIColorPickerElement
 		const match = this._swatches.find((swatch) => swatch.value === this.value!.value);
 		if (match && match.label !== this.value.label) {
 			super.value = match;
+			// Dispatch outside of user interaction so the refreshed label is persisted on the next save.
 			this.dispatchEvent(new UmbChangeEvent());
 		}
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
@@ -55,7 +55,9 @@ export class UmbPropertyEditorUIColorPickerElement
 
 	#syncLabelFromSwatches() {
 		if (!this.value || this._swatches.length === 0) return;
-		const match = this._swatches.find((swatch) => swatch.value === this.value!.value);
+		// Compare case-insensitively to match legacy/inconsistently-cased stored values (e.g. "#FF0000" vs "#ff0000").
+		const targetValue = this.value.value.toLowerCase();
+		const match = this._swatches.find((swatch) => swatch.value.toLowerCase() === targetValue);
 		if (match && match.label !== this.value.label) {
 			super.value = match;
 			// Dispatch outside of user interaction so the refreshed label is persisted on the next save.

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.element.ts
@@ -20,6 +20,7 @@ export class UmbPropertyEditorUIColorPickerElement
 	@property({ type: Object })
 	public override set value(value: UmbSwatchDetails | undefined) {
 		super.value = value ? this.#ensureHashPrefix(value) : undefined;
+		this.#syncLabelFromSwatches();
 	}
 	public override get value(): UmbSwatchDetails | undefined {
 		return super.value;
@@ -49,6 +50,16 @@ export class UmbPropertyEditorUIColorPickerElement
 
 		const swatches = config?.getValueByAlias<Array<UmbSwatchDetails>>('items') ?? [];
 		this._swatches = swatches.map((swatch) => this.#ensureHashPrefix(swatch));
+		this.#syncLabelFromSwatches();
+	}
+
+	#syncLabelFromSwatches() {
+		if (!this.value || this._swatches.length === 0) return;
+		const match = this._swatches.find((swatch) => swatch.value === this.value!.value);
+		if (match && match.label !== this.value.label) {
+			super.value = match;
+			this.dispatchEvent(new UmbChangeEvent());
+		}
 	}
 
 	#ensureHashPrefix(swatch: UmbSwatchDetails): UmbSwatchDetails {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/color-picker/property-editor-ui-color-picker.test.ts
@@ -1,6 +1,8 @@
 import { UmbPropertyEditorUIColorPickerElement } from './property-editor-ui-color-picker.element.js';
 import { expect, fixture, html } from '@open-wc/testing';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 describe('UmbPropertyEditorUIColorPickerElement', () => {
 	let element: UmbPropertyEditorUIColorPickerElement;
@@ -11,6 +13,65 @@ describe('UmbPropertyEditorUIColorPickerElement', () => {
 
 	it('is defined with its own instance', () => {
 		expect(element).to.be.instanceOf(UmbPropertyEditorUIColorPickerElement);
+	});
+
+	describe('label sync', () => {
+		const swatches = [
+			{ value: '#28802a', label: 'Green' },
+			{ value: '#ff0000', label: 'Red' },
+		];
+
+		const configWith = (items: Array<{ value: string; label: string }>) =>
+			new UmbPropertyEditorConfigCollection([{ alias: 'items', value: items }]);
+
+		it('updates value.label and emits a single change event when config label differs from stored label', async () => {
+			let changeCount = 0;
+			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);
+
+			element.config = configWith(swatches);
+			element.value = { value: '#28802a', label: 'Forest' };
+			await element.updateComplete;
+
+			expect(element.value?.label).to.equal('Green');
+			expect(element.value?.value).to.equal('#28802a');
+			expect(changeCount).to.equal(1);
+		});
+
+		it('refreshes a stale label even when the stored hex casing differs from the swatch', async () => {
+			let changeCount = 0;
+			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);
+
+			element.config = configWith(swatches);
+			element.value = { value: '#28802A', label: 'Forest' };
+			await element.updateComplete;
+
+			expect(element.value?.label).to.equal('Green');
+			expect(changeCount).to.equal(1);
+		});
+
+		it('does not emit a change event when labels already match', async () => {
+			let changeCount = 0;
+			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);
+
+			element.config = configWith(swatches);
+			element.value = { value: '#28802a', label: 'Green' };
+			await element.updateComplete;
+
+			expect(element.value?.label).to.equal('Green');
+			expect(changeCount).to.equal(0);
+		});
+
+		it('does not emit a change event when no swatch matches the stored value', async () => {
+			let changeCount = 0;
+			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);
+
+			element.config = configWith(swatches);
+			element.value = { value: '#000000', label: 'Black' };
+			await element.updateComplete;
+
+			expect(element.value?.label).to.equal('Black');
+			expect(changeCount).to.equal(0);
+		});
 	});
 
 	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {


### PR DESCRIPTION
## Description

When the label of a colour in a Color Picker data type is changed, content already using that colour does not pick up the new label on the next publish.  Looking at the stored property data, I can see the old label is still stored.  This explains why the delivery API serves the out of data value.

Looking at the linked issue history, it seems the previous (AngularJS) editor handled this in Umbraco 13; but the new one does not.

Root cause: the property data is a compound object `{ value, label }`.  The property editor UI receives `value` (saved data with the old label) and `config` (current swatches with the new label) on independent setters, but never reconciles them. Without user interaction with the swatch, no change event fires and the stale label is re-persisted.

Fix: in `property-editor-ui-color-picker.element.ts`, after either setter runs, look up the matching swatch by hex value. If the swatch's label differs from the stored value's label, replace the value and dispatch `UmbChangeEvent` so the corrected label is persisted on the next save.

Fixes #22741

## Testing

- Create a Color Picker data type with two colours: labels "first" and "second".
- Create a doc type with the data type and a content node, select the "first" colour, save & publish.
- Edit the data type and change the "first" label to "third", save.
- Open the same content node and click "Save and publish" without touching the swatch.
- Query the database using `select top 100 * from umbracoPropertyData order by id desc`.  Look at the `varcharValue` field that will contain a value like: `{ "label": "third", "value": "#514c94" }`.  Before this PR it would have `{ "label": "first", "value": "#514c94" }`
- Verify fresh selections still save correctly.