### PR TITLE
Published Content: Fix `Fallback.ToAncestors` with no match throwing exception at property level (closes #22759)

### DIFF
--- a/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
+++ b/src/Umbraco.Core/Models/PublishedContent/PublishedValueFallback.cs
@@ -74,6 +74,10 @@ public class PublishedValueFallback : IPublishedValueFallback
                     }
 
                     break;
+                case Fallback.Ancestors:
+                    // Ancestors fallback only applies at IPublishedContent level (tree-aware).
+                    // Skip silently here so chained fallbacks still work and direct element calls don't throw.
+                    continue;
                 default:
                     throw NotSupportedFallbackMethod(f, "property");
             }
@@ -127,6 +131,10 @@ public class PublishedValueFallback : IPublishedValueFallback
                     }
 
                     break;
+                case Fallback.Ancestors:
+                    // Ancestors fallback only applies at IPublishedContent level (tree-aware).
+                    // Skip silently here so chained fallbacks still work and direct element calls don't throw.
+                    continue;
                 default:
                     throw NotSupportedFallbackMethod(f, "element");
             }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/PublishedContent/PublishedContentFallbackTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/PublishedContent/PublishedContentFallbackTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -128,6 +128,52 @@ public class PublishedContentFallbackTests : UmbracoIntegrationTest
         VariationContextAccessor.VariationContext = new VariationContext(culture: "en-US", segment: null);
         var englishValue = publishedContent.Value<string>(PublishedValueFallback, "title");
         Assert.AreEqual(englishTitle, englishValue);
+    }
+
+    // Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22759.
+    // When a property exists on the content type but neither the requested node nor any ancestor holds a value, Value<T>
+    // with Fallback.ToAncestors should return default(T) — not throw NotSupportedException.
+    [Test]
+    public async Task Property_Value_With_Ancestors_Fallback_Returns_Default_When_No_Ancestor_Has_Value()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("theContentType")
+            .AddPropertyType()
+                .WithAlias("title")
+                .WithName("Title")
+                .WithDataTypeId(Constants.DataTypes.Textbox)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+                .WithValueStorageType(ValueStorageType.Nvarchar)
+                .Done()
+            .WithAllowAsRoot(true)
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        // Allow children of the same type so we can build a tree.
+        contentType.AllowedContentTypes = [new ContentTypeSort(contentType.Key, 0, contentType.Alias)];
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var parent = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithName("Parent")
+            .Build();
+        ContentService.Save(parent);
+        ContentService.Publish(parent, ["*"]);
+
+        var child = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithParent(parent)
+            .WithName("Child")
+            .Build();
+        ContentService.Save(child);
+        ContentService.Publish(child, ["*"]);
+
+        var publishedChild = GetPublishedContent(child.Key);
+
+        // NOTE: the TextStringValueConverter.ConvertIntermediateToObject() explicitly converts a null source value to an empty string
+        string? value = null;
+        Assert.DoesNotThrow(() => value = publishedChild.Value<string>(PublishedValueFallback, "title", fallback: Fallback.ToAncestors));
+        Assert.AreEqual(string.Empty, value);
     }
 
     private async Task<IPublishedContent> SetupSegmentedContentAsync(string? invariantTitle, string? segmentedTitle)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models.PublishedContent;
+
+[TestFixture]
+public class PublishedValueFallbackTests
+{
+    // Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22759.
+    // PR #22219 caused PublishedContentExtensions.Value<T>(IPublishedContent, ...) to forward Fallback.ToAncestors into the property-level fallback
+    // when the property exists with no value and no ancestor holds a value either. The property-level fallback would explicitly throw NotSupportedException
+    // for the Ancestors code, breaking a common user scenario that worked silently in 17.3.x.
+    [Test]
+    public void TryGetValue_For_Property_With_Ancestors_Fallback_Does_Not_Throw_When_Property_Has_No_Value()
+    {
+        var fallback = CreateFallback();
+        var property = CreateEmptyProperty();
+
+        var result = fallback.TryGetValue<string>(property, culture: null, segment: null, Fallback.ToAncestors, defaultValue: null, out var value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(result);
+            Assert.IsNull(value);
+        });
+    }
+
+    [Test]
+    public void TryGetValue_For_Element_With_Ancestors_Fallback_Does_Not_Throw_When_Property_Has_No_Value()
+    {
+        var fallback = CreateFallback();
+        var element = CreateElementWithEmptyProperty(out _);
+
+        var result = fallback.TryGetValue<string>(element, "title", culture: null, segment: null, Fallback.ToAncestors, defaultValue: null, out var value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(result);
+            Assert.IsNull(value);
+        });
+    }
+
+    private static PublishedValueFallback CreateFallback() =>
+        new(
+            ServiceContext.CreatePartial(localizationService: Mock.Of<ILocalizationService>()),
+            Mock.Of<IVariationContextAccessor>(),
+            Mock.Of<IPropertyRenderingContextAccessor>());
+
+    private static IPublishedProperty CreateEmptyProperty()
+    {
+        var propertyType = new Mock<IPublishedPropertyType>();
+        propertyType.Setup(x => x.Variations).Returns(ContentVariation.Nothing);
+
+        var property = new Mock<IPublishedProperty>();
+        property.Setup(x => x.Alias).Returns("title");
+        property.Setup(x => x.PropertyType).Returns(propertyType.Object);
+        property.Setup(x => x.HasValue(It.IsAny<string?>(), It.IsAny<string?>())).Returns(false);
+
+        return property.Object;
+    }
+
+    private static IPublishedElement CreateElementWithEmptyProperty(out IPublishedProperty property)
+    {
+        property = CreateEmptyProperty();
+
+        var contentType = new Mock<IPublishedContentType>();
+        contentType.Setup(x => x.GetPropertyType("title")).Returns(property.PropertyType);
+
+        var element = new Mock<IPublishedElement>();
+        element.Setup(x => x.ContentType).Returns(contentType.Object);
+        element.Setup(x => x.GetProperty("title")).Returns(property);
+
+        return element.Object;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
@@ -12,10 +12,14 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models.PublishedContent;
 [TestFixture]
 public class PublishedValueFallbackTests
 {
-    // Regression test for https://github.com/umbraco/Umbraco-CMS/issues/22759.
-    // PR #22219 caused PublishedContentExtensions.Value<T>(IPublishedContent, ...) to forward Fallback.ToAncestors into the property-level fallback
-    // when the property exists with no value and no ancestor holds a value either. The property-level fallback would explicitly throw NotSupportedException
-    // for the Ancestors code, breaking a common user scenario that worked silently in 17.3.x.
+    /// <summary>
+    /// Regression test for <see href="https://github.com/umbraco/Umbraco-CMS/issues/22759">issue #22759</see>.
+    /// PR #22219 caused <c>PublishedContentExtensions.Value&lt;T&gt;(IPublishedContent, ...)</c> to forward
+    /// <see cref="Fallback.ToAncestors"/> into the property-level fallback when the property exists with no value
+    /// and no ancestor holds a value either. The property-level fallback would explicitly throw
+    /// <see cref="System.NotSupportedException"/> for the Ancestors code, breaking a common user scenario that
+    /// worked silently in 17.3.x.
+    /// </summary>
     [Test]
     public void TryGetValue_For_Property_With_Ancestors_Fallback_Does_Not_Throw_When_Property_Has_No_Value()
     {
@@ -31,6 +35,13 @@ public class PublishedValueFallbackTests
         });
     }
 
+    /// <summary>
+    /// Element-level counterpart to the property-level regression test for
+    /// <see href="https://github.com/umbraco/Umbraco-CMS/issues/22759">issue #22759</see>: directly invoking the
+    /// <see cref="IPublishedElement"/> overload with <see cref="Fallback.ToAncestors"/> must not throw when the
+    /// property has no value, since the Ancestors policy is tree-aware and only meaningful at
+    /// <see cref="IPublishedContent"/> level.
+    /// </summary>
     [Test]
     public void TryGetValue_For_Element_With_Ancestors_Fallback_Does_Not_Throw_When_Property_Has_No_Value()
     {
@@ -46,9 +57,51 @@ public class PublishedValueFallbackTests
         });
     }
 
+    /// <summary>
+    /// The property/element-level handling of <see cref="Fallback.Ancestors"/> is a <c>continue</c> rather than a
+    /// short-circuit return. This test locks that in: a chained policy of Ancestors then DefaultValue should skip
+    /// Ancestors at the property level and resolve via DefaultValue.
+    /// </summary>
+    [Test]
+    public void TryGetValue_For_Property_With_Chained_Ancestors_Then_DefaultValue_Resolves_Via_Default_Value()
+    {
+        var fallback = CreateFallback();
+        var property = CreateEmptyProperty();
+
+        var result = fallback.TryGetValue<string>(property, culture: null, segment: null, Fallback.To(Fallback.Ancestors, Fallback.DefaultValue), defaultValue: "fallback-default", out var value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(result);
+            Assert.AreEqual("fallback-default", value);
+        });
+    }
+
+    /// <summary>
+    /// Element-level counterpart to the property-level chained-fallback test: confirms that
+    /// <see cref="Fallback.Ancestors"/> falls through to a subsequent <see cref="Fallback.DefaultValue"/> rather
+    /// than short-circuiting the chain at element level.
+    /// </summary>
+    [Test]
+    public void TryGetValue_For_Element_With_Chained_Ancestors_Then_DefaultValue_Resolves_Via_Default_Value()
+    {
+        var fallback = CreateFallback();
+        var element = CreateElementWithEmptyProperty(out _);
+
+        var result = fallback.TryGetValue<string>(element, "title", culture: null, segment: null, Fallback.To(Fallback.Ancestors, Fallback.DefaultValue), defaultValue: "fallback-default", out var value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(result);
+            Assert.AreEqual("fallback-default", value);
+        });
+    }
+
     private static PublishedValueFallback CreateFallback() =>
         new(
+#pragma warning disable CS0618 // Type or member is obsolete
             ServiceContext.CreatePartial(localizationService: Mock.Of<ILocalizationService>()),
+#pragma warning restore CS0618 // Type or member is obsolete
             Mock.Of<IVariationContextAccessor>(),
             Mock.Of<IPropertyRenderingContextAccessor>());
 


### PR DESCRIPTION
## Description

This PR restores the pre-17.4 behaviour of `IPublishedContent.Value<T>(..., fallback: Fallback.ToAncestors)` when neither the requested node nor any ancestor holds a value. Previously returned `default(T)` silently in 17.3.x; 17.4.0-rc throws `System.NotSupportedException: Fallback PublishedValueFallback does not support fallback code '3' at property level.`.

Fixes #22759.

### How the issue came about

The throw at `PublishedValueFallback.TryGetValue<T>(IPublishedProperty …)` is long-standing — a defensive guard for when an ancestor-level fallback policy is supplied at a level (property/element) that can't walk the tree. It was previously unreachable from the standard `IPublishedContent.Value<T>` extension path.

PR #22219 (\"Block Grid: Apply language fallback to block elements within layouts\") changed `PublishedContentExtensions.Value<T>(IPublishedContent …)` so it forwards the caller's `fallback` argument into the property-level `IPublishedProperty.Value<T>` call:

```csharp
// before
return property == null ? default : property.Value<T>(publishedValueFallback, culture, segment);

// after
return property == null ? default : property.Value<T>(publishedValueFallback, culture, segment, fallback);
```

The intent was to ensure `EnterFallbackScope(fallback)` (introduced in the same PR for Block Grid rendering) sees the active fallback policy. The unintended consequence: on the \"no-value\" path, when content-level fallback returned nothing and the requested fallback was `Fallback.ToAncestors`, the property-level `TryGetValue` was now invoked with `Fallback.Ancestors` (code 3) and hit the long-standing `default: throw` arm.

The exception only fires when the ancestor walk actually finds nothing — if any ancestor holds a value, the content-level overload returns at the earlier branch and the throw is bypassed.

### Resolution

Treat `Fallback.Ancestors` as a no-op at property and element level rather than throwing. The Ancestors policy is tree-aware and only meaningful on `IPublishedContent`; reaching it via `IPublishedProperty` / `IPublishedElement` should silently skip rather than throw, so chained fallbacks still work and direct callers don't break.

## Testing

### Automated

New unit tests and an integration test have been added that fail showing the issue before this fix is applied, and pass afterward.

### Manual

- Create a text string property with the alias `someProperty` on a document type that is allowed under itself.
- Create a couple of levels of this document but don't populate the property.
- In the template add the following code.
- Render a child document.

Before the fix you'd get an exception thrown.

Now you'll get an empty string rendered.

```cshtml
@{
    var value = Model.Value<string>("someProperty", fallback: Fallback.ToAncestors);
}
<div>Value: @value</div>
```
