### PR TITLE
Remove App Local ICU

### DIFF
--- a/src/Umbraco.Web.UI/CLAUDE.md
+++ b/src/Umbraco.Web.UI/CLAUDE.md
@@ -221,17 +221,7 @@ Razor compilation is disabled for InMemoryAuto mode (`RazorCompileOnBuild=false`
 
 ---
 
-## 6. ICU Globalization
-
-### App-Local ICU (csproj lines 39-40)
-
-Uses app-local ICU (`Microsoft.ICU.ICU4C.Runtime` v72.1.0.3) for consistent globalization across platforms.
-
-**Note**: Ensure ICU version matches between package reference and runtime option. Changes must also be made to `Umbraco.Templates`.
-
----
-
-## 7. Project-Specific Notes
+## 6. Project-Specific Notes
 
 ### Development vs Production
 
@@ -249,7 +239,6 @@ This project is for **development only**:
 Does NOT use central package management. Versions specified directly:
 - `Microsoft.EntityFrameworkCore.Design` - For EF Core migrations tooling
 - `Microsoft.Build.Tasks.Core` - Security fix for EFCore.Design dependency
-- `Microsoft.ICU.ICU4C.Runtime` - Globalization
 
 ### Umbraco Targets Import (csproj lines 19-20)
 

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <RootNamespace>Umbraco.Cms.Web.UI</RootNamespace>
     <IsPackable>false</IsPackable>
@@ -32,13 +32,6 @@
     Review for removal when Microsoft.EntityFrameworkCore.Design is updated to a newer version.
     -->
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="17.14.28" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Ensure the AppLocalIcu setting is the same as the referenced ICU package version and changes are also done to the template project! -->
-    <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/templates/UmbracoProject/Directory.Packages.props
+++ b/templates/UmbracoProject/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageVersion Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
     <!--#if (StarterKit != "None") -->
     <PackageVersion Include="STARTER_KIT_NAME" Version="STARTER_KIT_VERSION" />
     <!--#endif -->

--- a/templates/UmbracoProject/UmbracoProject.csproj
+++ b/templates/UmbracoProject/UmbracoProject.csproj
@@ -17,12 +17,6 @@
     <PackageReference Include="STARTER_KIT_NAME"/>
     <!--#endif -->
   </ItemGroup>
-
-  <ItemGroup>
-    <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime"/>
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
-  </ItemGroup>
   <!--#endif -->
 
   <!--#if (!UseCPM) -->
@@ -34,12 +28,6 @@
     <!--#if (StarterKit != "None") -->
     <PackageReference Include="STARTER_KIT_NAME" Version="STARTER_KIT_VERSION"/>
     <!--#endif -->
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3"/>
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
   </ItemGroup>
   <!--#endif -->
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #22758 

### Description

#### TL;DR using App Local ICU is unnecessary for the vast majority of modern workflows, and where it does matter Umbraco's default doesn't necessarily make sense.

Setting App Local ICU las currently causes as many problems as it solves. When building and deploying from modern Windows to older Windows environments it makes some sense, but that's less and less the case as time goes on so isn't an assumption that we should make.

Choosing the appropriate version to pin a local  ICU assembly at depends on the OS's being used to develop, build, and run Umbraco - which we don't know. So I don't think that it's appropriate to pin a version out of the box.

**App Local ICU doesn't work on macOS** at all as currently configured, and can't easily be made to work. This means that anyone developing on a mac is already using a different ICU version than what they are deploying to.

All modern Windows OS's use ICU and .NET 7+ uses the OS's ICU library out of the box. So for the vast majority of users developing in modern machines and deploying to Linux and Windows (2022+ Servers) this will "Just Work".

This _may_ cause problems/inconsistencies with developers deploying Umbraco to Windows Sever 2012/2016 (from any OS) BUT it makes more sense for that to be stipulated explicitly when that's the case and could just be a documentation piece.

If there are particular edge-case concerns that really need every environment to be using the exact same ICU assembly, then that should be up to implementers to configure what's right for them.