### PR TITLE
Tests: Fix PublishedValueFallbackTests after ILocalizationService removal

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
@@ -99,9 +99,7 @@ public class PublishedValueFallbackTests
 
     private static PublishedValueFallback CreateFallback() =>
         new(
-#pragma warning disable CS0618 // Type or member is obsolete
-            ServiceContext.CreatePartial(localizationService: Mock.Of<ILocalizationService>()),
-#pragma warning restore CS0618 // Type or member is obsolete
+ServiceContext.CreatePartial(languageService: Mock.Of<ILanguageService>()),
             Mock.Of<IVariationContextAccessor>(),
             Mock.Of<IPropertyRenderingContextAccessor>());
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/PublishedContent/PublishedValueFallbackTests.cs
@@ -99,7 +99,7 @@ public class PublishedValueFallbackTests
 
     private static PublishedValueFallback CreateFallback() =>
         new(
-ServiceContext.CreatePartial(languageService: Mock.Of<ILanguageService>()),
+            ServiceContext.CreatePartial(languageService: Mock.Of<ILanguageService>()),
             Mock.Of<IVariationContextAccessor>(),
             Mock.Of<IPropertyRenderingContextAccessor>());
 


### PR DESCRIPTION
## Summary

- Replaces the removed `ILocalizationService` with `ILanguageService` in `PublishedValueFallbackTests`
- Updates the `ServiceContext.CreatePartial` call to use the `languageService:` parameter
- Removes the now-unnecessary `#pragma warning disable CS0618` suppression

`ILocalizationService` was removed as part of the v18 cleanup (PR #22677). The test was not updated accordingly, causing a build error on `main`.

## Test plan

- [x] `PublishedValueFallbackTests` — all 4 tests pass