### PR TITLE
18.0-beta1: User Management: Invalidate cached element start nodes on user save and fix access summary display (closes #22770)

### DIFF
--- a/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/UserCacheRefresher.cs
@@ -78,8 +78,10 @@ public sealed class UserCacheRefresher : PayloadCacheRefresherBase<UserCacheRefr
             userCache.Result?.Clear(RepositoryCacheKeys.GetKey<IUser, int>(p.Id));
             userCache.Result?.ClearByKey(CacheKeys.UserContentStartNodePathsPrefix + p.Key);
             userCache.Result?.ClearByKey(CacheKeys.UserMediaStartNodePathsPrefix + p.Key);
+            userCache.Result?.ClearByKey(CacheKeys.UserElementStartNodePathsPrefix + p.Key);
             userCache.Result?.ClearByKey(CacheKeys.UserAllContentStartNodesPrefix + p.Key);
             userCache.Result?.ClearByKey(CacheKeys.UserAllMediaStartNodesPrefix + p.Key);
+            userCache.Result?.ClearByKey(CacheKeys.UserAllElementStartNodesPrefix + p.Key);
         }
     }
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/components/user-element-start-node/user-element-start-node.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/components/user-element-start-node/user-element-start-node.element.ts
@@ -55,12 +55,11 @@ export class UmbUserElementStartNodeElement extends UmbLitElement {
 			(item) => item.unique,
 			(item) => {
 				return html`
-					<!-- TODO: get correct variant name -->
 					<uui-ref-node
-						name=${item.variants[0]?.name}
+						name=${item.name}
 						?disabled=${this.readonly}
 						style="--uui-color-disabled-contrast: var(--uui-color-text)">
-						<uui-icon slot="icon" name="folder"></uui-icon>
+						<uui-icon slot="icon" name=${item.icon ?? 'icon-folder'}></uui-icon>
 					</uui-ref-node>
 				`;
 			},


### PR DESCRIPTION
## Description

Fixes #22770.

The user cache refresher was clearing the cached document and media start-node calculations on user save but missing the new element equivalents, so the Access summary kept rendering the pre-save (empty) result after assigning an element start node.

In addition the rendering of the selected folder wasn't correctly retrieving the variant name, and so once the caching issue was fixed we would see nothing displayed.  That's been updated too.

<img width="1106" height="652" alt="image" src="https://github.com/user-attachments/assets/80c1594c-98c5-49a8-ace5-6ff4a872368f" />

## Testing

- Edit an existing user, disable "Allow access to all elements", select a specific element start folder, and save.
- Click to another page and back again (it's a separate issue that the access summary doesn't update immediately, and is the same for documents and media).
- Confirm the access summary now shows the selected element start node.