### PR TITLE
18.0-beta1: Elements: Show trashed folder ancestor names in breadcrumb (closes #22768)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/tree/element-recycle-bin-tree.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/recycle-bin/tree/element-recycle-bin-tree.server.data-source.ts
@@ -1,4 +1,5 @@
 import { UMB_ELEMENT_ENTITY_TYPE, UMB_ELEMENT_FOLDER_ENTITY_TYPE } from '../../entity.js';
+import { UmbElementVariantState } from '../../variant-state.js';
 import { UMB_ELEMENT_RECYCLE_BIN_ROOT_ENTITY_TYPE } from '../constants.js';
 import type { UmbElementRecycleBinTreeItemModel } from '../types.js';
 import type { UmbElementTreeItemVariantModel } from '../../tree/types.js';
@@ -86,15 +87,17 @@ const mapper = (item: ElementRecycleBinItemResponseModel): UmbElementRecycleBinT
 			icon: item.isFolder ? 'icon-folder' : (item.documentType?.icon ?? 'icon-document'),
 			collection: null,
 		},
-		variants: item.variants.map((variant): UmbElementTreeItemVariantModel => {
-			return {
-				name: variant.name,
-				culture: variant.culture || null,
-				segment: null, // TODO: add segment to the backend API?
-				state: variant.state,
-				flags: variant.flags,
-			};
-		}),
+		variants: item.isFolder
+			? [{ name: item.name, culture: null, segment: null, state: UmbElementVariantState.PUBLISHED, flags: [] }]
+			: item.variants.map((variant): UmbElementTreeItemVariantModel => {
+					return {
+						name: variant.name,
+						culture: variant.culture || null,
+						segment: null, // TODO: add segment to the backend API?
+						state: variant.state,
+						flags: variant.flags,
+					};
+				}),
 		// TODO: this is not correct. We need to get it from the variants. This is a temp solution. [LK]
 		name: item.isFolder ? item.name : item.variants[0]?.name,
 		isFolder: item.isFolder,


### PR DESCRIPTION
## Description

When an Element was opened from the recycle bin and had trashed folder ancestors, the workspace breadcrumb rendered each folder as `(Unknown)` instead of the folder name.

The fix updates `element-recycle-bin-tree.server.data-source.ts` to synthesize a single invariant variant from `item.name` for folder items, mirroring the existing branch in the regular Elements tree's mapper.

Fixes #22768

## Testing

- Create a folder hierarchy (e.g. `FolderA/FolderB/Element`) under Library > Elements, then move `FolderA` to the recycle bin.
- Open the trashed element from the recycle bin.
- Confirm the breadcrumb shows `Recycle Bin / FolderA / FolderB / Element` (no `(Unknown)` entries).
- Confirm the non-trashed Elements tree breadcrumbs still render correctly for elements inside folders.