### PR TITLE
Tiptap RTE: Ignore no-op transactions in onUpdate to prevent phantom dirty state (closes #22767)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/input-tiptap/input-tiptap.element.ts
@@ -223,7 +223,10 @@ export class UmbInputTiptapElement extends UmbFormControlMixin<string, typeof Um
 			onContentError: ({ error }) => {
 				console.error('contentError', [error.message, error.cause]);
 			},
-			onUpdate: ({ editor }) => {
+			onUpdate: ({ editor, transaction }) => {
+				// Tiptap also fires `update` for no-op transactions (e.g. setEditable),
+				// which would otherwise dirty the workspace with a phantom change.
+				if (!transaction.docChanged) return;
 				this.#value = editor.getHTML();
 				this._runValidators();
 				this.dispatchEvent(new UmbChangeEvent());


### PR DESCRIPTION
## Description

After creating a blank document with a Rich Text Editor property and clicking Save (without making any changes), the Discard Changes dialog appears spuriously when the workspace redirects from `/create` to `/edit/<id>`.

Fixes #22767.

This looks to be happening due to a toggle of the `readonly` property on `<umb-input-tiptap>` around save that's considered a meaningful update to content.

To fix I've guarded `onUpdate` with `if (!transaction.docChanged) return;`. Real user edits are always doc-changing transactions, so they are unaffected. Only the no-op transactions Tiptap emits for editor-state changes (like `setEditable`) are filtered out.

## Testing

- Create a Document Type with a Rich Text Editor property.
- Create new content based on it and leave the RTE blank.
- Click Save — the Discard Changes dialog should NOT appear.
- Type some content in the RTE, then navigate away without saving — the Discard Changes dialog SHOULD still appear.
- Save & Publish on a blank RTE — should continue to work as before