### PR TITLE
Users: Show API users as active when approved (closes #22786)

### DIFF
--- a/src/Umbraco.Core/Models/Membership/User.cs
+++ b/src/Umbraco.Core/Models/Membership/User.cs
@@ -286,8 +286,10 @@ public class User : EntityBase, IUser, IProfile
                 return UserState.Disabled;
             }
 
-            // User is not disabled or locked and has never logged in before
-            if (LastLoginDate == default && IsApproved && IsLockedOut == false)
+            // User is not disabled or locked and has never logged in before.
+            // API users authenticate via client credentials and never set LastLoginDate, so the "never logged in"
+            // check does not apply to them — an approved, unlocked API user is considered Active.
+            if (Kind == UserKind.Default && LastLoginDate == default && IsApproved && IsLockedOut == false)
             {
                 return UserState.Inactive;
             }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/UserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/UserTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
@@ -58,7 +59,104 @@ public class UserTests
             .WithIsLockedOut(true)
             .WithComments("comments")
             .WithSessionTimeout(5)
-            .WithStartContentIds(new[] { 3 })
-            .WithStartMediaIds(new[] { 8 })
+            .WithStartContentIds([3])
+            .WithStartMediaIds([8])
             .Build();
+
+    [Test]
+    public void UserState_Is_Active_When_Approved_And_Has_Logged_In()
+    {
+        var user = CreateUser();
+        user.IsApproved = true;
+        user.IsLockedOut = false;
+        user.LastLoginDate = DateTime.UtcNow;
+
+        Assert.AreEqual(UserState.Active, user.UserState);
+    }
+
+    [Test]
+    public void UserState_Is_Inactive_When_Default_User_Has_Never_Logged_In()
+    {
+        var user = CreateUser();
+        user.IsApproved = true;
+        user.IsLockedOut = false;
+        user.LastLoginDate = null;
+
+        Assert.AreEqual(UserState.Inactive, user.UserState);
+    }
+
+    [Test]
+    public void UserState_Is_Disabled_When_Not_Approved()
+    {
+        var user = CreateUser();
+        user.IsApproved = false;
+        user.IsLockedOut = false;
+        user.LastLoginDate = DateTime.UtcNow;
+
+        Assert.AreEqual(UserState.Disabled, user.UserState);
+    }
+
+    [Test]
+    public void UserState_Is_LockedOut_When_Locked_Out()
+    {
+        var user = CreateUser();
+        user.IsApproved = true;
+        user.IsLockedOut = true;
+        user.LastLoginDate = DateTime.UtcNow;
+
+        Assert.AreEqual(UserState.LockedOut, user.UserState);
+    }
+
+    [Test]
+    public void UserState_Is_Invited_When_Not_Approved_And_Never_Logged_In_With_InvitedDate()
+    {
+        var user = CreateUser();
+        user.IsApproved = false;
+        user.IsLockedOut = false;
+        user.LastLoginDate = null;
+        user.InvitedDate = DateTime.UtcNow;
+
+        Assert.AreEqual(UserState.Invited, user.UserState);
+    }
+
+    [Test]
+    public void UserState_Is_Active_For_Api_User_That_Has_Never_Logged_In()
+    {
+        // API users authenticate via client credentials and never set LastLoginDate, so they should be considered
+        // Active when approved and not locked out — see https://github.com/umbraco/Umbraco-CMS/issues/22786.
+        var user = CreateUser();
+        user.Kind = UserKind.Api;
+        user.IsApproved = true;
+        user.IsLockedOut = false;
+        user.LastLoginDate = null;
+
+        Assert.AreEqual(UserState.Active, user.UserState);
+    }
+
+    [Test]
+    public void UserState_Is_Disabled_For_Api_User_That_Is_Not_Approved()
+    {
+        var user = CreateUser();
+        user.Kind = UserKind.Api;
+        user.IsApproved = false;
+        user.IsLockedOut = false;
+        user.LastLoginDate = null;
+
+        Assert.AreEqual(UserState.Disabled, user.UserState);
+    }
+
+    [Test]
+    public void UserState_Is_LockedOut_For_Api_User_That_Is_Locked_Out()
+    {
+        var user = CreateUser();
+        user.Kind = UserKind.Api;
+        user.IsApproved = true;
+        user.IsLockedOut = true;
+        user.LastLoginDate = null;
+
+        Assert.AreEqual(UserState.LockedOut, user.UserState);
+    }
+
+    private static User CreateUser() =>
+        new(new GlobalSettings(), "Test", "test@test.com", "test", "password");
 }


### PR DESCRIPTION
## Description

API users authenticate via the OpenIddict client-credentials flow and never go through the backoffice sign-in path, so `LastLoginDate` is never written for them. The `User.UserState` getter treats any approved, unlocked user with no `LastLoginDate` as `Inactive`, which meant every API user was permanently shown as Inactive in the backoffice.

To fix in this PR we now only set the "Inactive" state if the user is a default (i.e. not an API) user.

Fixes #22786

## Testing

### Automated

Unit tests in `UserTests` have been added to verify the logic of the calculation of the `UserState` value.

### Manual

- Create an API user via the backoffice; verify the status displays as **Active** immediately after creation.
- Disable the API user; verify status displays as **Disabled**. Re-enable; verify it returns to **Active** (and survives a page reload — the original symptom from the issue).
- Verify a backoffice user that has never logged in still displays as **Inactive**.