### PR TITLE
Elements: Contextualize variant blocks rendering for invariant content

### DIFF
--- a/src/Umbraco.Core/PublishedCache/IBlockElementService.cs
+++ b/src/Umbraco.Core/PublishedCache/IBlockElementService.cs
@@ -5,5 +5,5 @@ namespace Umbraco.Cms.Core.PublishedCache;
 
 public interface IBlockElementService
 {
-    Task<IPublishedElement?> BuildElementAsync(BlockItemData blockItemData, bool? preview = null);
+    Task<IPublishedElement?> BuildElementAsync(IPublishedElement owner, BlockItemData blockItemData, bool? preview = null);
 }

--- a/src/Umbraco.Core/PublishedCache/IBlockElementService.cs
+++ b/src/Umbraco.Core/PublishedCache/IBlockElementService.cs
@@ -3,7 +3,17 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Umbraco.Cms.Core.PublishedCache;
 
+/// <summary>
+/// A service for converting <see cref="BlockItemData"/> into <see cref="IPublishedElement"/>.
+/// </summary>
 public interface IBlockElementService
 {
+    /// <summary>
+    /// Creates an <see cref="IPublishedElement"/> instance from <see cref="BlockItemData"/>.
+    /// </summary>
+    /// <param name="owner">The <see cref="IPublishedElement"/> that contains the block property which is the origin to the <see cref="BlockItemData"/>.</param>
+    /// <param name="blockItemData">The <see cref="BlockItemData"/> containing the data to convert into an <see cref="IPublishedElement"/>.</param>
+    /// <param name="preview">Whether to perform the conversion for preview.</param>
+    /// <returns>The created <see cref="IPublishedElement"/>, or null if an element could not be created from the <see cref="BlockItemData"/>.</returns>
     Task<IPublishedElement?> BuildElementAsync(IPublishedElement owner, BlockItemData blockItemData, bool? preview = null);
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockEditorConverter.cs
@@ -94,7 +94,7 @@ public sealed class BlockEditorConverter
             Key = data.Key,
         };
 
-        return _blockElementService.BuildElementAsync(alignedData, preview).GetAwaiter().GetResult();
+        return _blockElementService.BuildElementAsync(owner, alignedData, preview).GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
@@ -1,6 +1,8 @@
-﻿using Umbraco.Cms.Core.Models.Blocks;
+﻿using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Infrastructure.HybridCache.Factories;
 using Umbraco.Extensions;
 
@@ -11,35 +13,72 @@ internal class BlockElementService : IBlockElementService
     private readonly IPublishedContentTypeCache _publishedContentTypeCache;
     private readonly IPublishedContentFactory _publishedContentFactory;
     private readonly IPublishedModelFactory _publishedModelFactory;
+    private readonly ILanguageService _languageService;
 
     public BlockElementService(
         IPublishedContentTypeCache publishedContentTypeCache,
         IPublishedContentFactory publishedContentFactory,
-        IPublishedModelFactory publishedModelFactory)
+        IPublishedModelFactory publishedModelFactory,
+        ILanguageService languageService)
     {
         _publishedContentTypeCache = publishedContentTypeCache;
         _publishedContentFactory = publishedContentFactory;
         _publishedModelFactory = publishedModelFactory;
+        _languageService = languageService;
     }
 
-    public Task<IPublishedElement?> BuildElementAsync(BlockItemData blockItemData, bool? preview = null)
+    public async Task<IPublishedElement?> BuildElementAsync(IPublishedElement owner, BlockItemData blockItemData, bool? preview = null)
     {
+        ILanguage[]? allLanguages = null;
+        ILanguage? defaultLanguage = null;
+
         // Only convert element types - content types will cause an exception when PublishedModelFactory creates the model
         IPublishedContentType? publishedContentType = _publishedContentTypeCache.Get(PublishedItemType.Element, blockItemData.ContentTypeKey);
         if (publishedContentType is null || publishedContentType.IsElement is false)
         {
-            return Task.FromResult<IPublishedElement?>(null);
+            return null;
         }
 
         var propertyData = new Dictionary<string, PropertyData[]>();
         foreach (IGrouping<string, BlockPropertyValue> properties in blockItemData.Values.GroupBy(value => value.Alias))
         {
-            propertyData[properties.Key] = properties.Select(property => new PropertyData
+            IPublishedPropertyType? propertyType = publishedContentType.GetPropertyType(properties.Key);
+            if (propertyType is null)
             {
-                Culture = property.Culture ?? string.Empty, // throws an error if there is no value
-                Segment = property.Segment ?? string.Empty, // throws an error if there is no value
-                Value = property.Value,
-            }).ToArray();
+                continue;
+            }
+
+            if (propertyType.VariesByCulture() && owner.ContentType.VariesByCulture() is false)
+            {
+                // Special case:
+                // The element property type varies by culture, but the owner element (e.g. the page) content type does not
+                // vary by culture. Since the created element is fully culture aware at render time, we need to replicate
+                // property values across all available languages, to make them available for rendering.
+
+                if (allLanguages is null)
+                {
+                    allLanguages = (await _languageService.GetAllAsync()).ToArray();
+                    defaultLanguage = allLanguages.Single(l => l.IsDefault);
+                }
+
+                BlockPropertyValue property = properties.FirstOrDefault(p => p.Culture.InvariantEquals(defaultLanguage!.IsoCode))
+                                              ?? properties.First();
+                propertyData[properties.Key] = allLanguages.Select(language => new PropertyData
+                {
+                    Culture = language.IsoCode,
+                    Segment = property.Segment ?? string.Empty, // throws an error if there is no value
+                    Value = property.Value,
+                }).ToArray();
+            }
+            else
+            {
+                propertyData[properties.Key] = properties.Select(property => new PropertyData
+                {
+                    Culture = property.Culture ?? string.Empty, // throws an error if there is no value
+                    Segment = property.Segment ?? string.Empty, // throws an error if there is no value
+                    Value = property.Value,
+                }).ToArray();
+            }
         }
 
         var published = preview is not true;
@@ -47,9 +86,11 @@ internal class BlockElementService : IBlockElementService
 
         const string name = "n/a";
 
-        var cultureInfos = (publishedContentType.VariesByCulture()
-            ? blockItemData.Values.Select(value => value.Culture).WhereNotNull().Distinct()
-            : []).ToDictionary(
+        IEnumerable<string> cultures = publishedContentType.VariesByCulture()
+            ? propertyData.SelectMany(p => p.Value.Select(v => v.Culture)).WhereNotNull().Distinct()
+            : [];
+
+        var cultureInfos = cultures.ToDictionary(
             culture => culture,
             _ => new CultureVariation
             {
@@ -83,6 +124,6 @@ internal class BlockElementService : IBlockElementService
         };
 
         var result = _publishedContentFactory.ToIPublishedElement(contentCacheNode, draft);
-        return Task.FromResult(result.CreateModel(_publishedModelFactory));
+        return result.CreateModel(_publishedModelFactory);
     }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
@@ -85,7 +85,11 @@ internal class BlockElementService : IBlockElementService
         const string name = "n/a";
 
         IEnumerable<string> cultures = publishedContentType.VariesByCulture()
-            ? propertyData.SelectMany(p => p.Value.Select(v => v.Culture)).WhereNotNull().Distinct()
+            ? propertyData
+                .SelectMany(p => p.Value.Select(v => v.Culture))
+                .Where(c => c.IsNullOrWhiteSpace() is false)
+                .OfType<string>()
+                .Distinct()
             : [];
 
         var cultureInfos = cultures.ToDictionary(

--- a/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
@@ -8,6 +8,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
+/// <inheritdoc/>
 internal class BlockElementService : IBlockElementService
 {
     private readonly IPublishedContentTypeCache _publishedContentTypeCache;
@@ -27,6 +28,7 @@ internal class BlockElementService : IBlockElementService
         _languageService = languageService;
     }
 
+    /// <inheritdoc/>
     public async Task<IPublishedElement?> BuildElementAsync(IPublishedElement owner, BlockItemData blockItemData, bool? preview = null)
     {
         ILanguage[]? allLanguages = null;

--- a/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/BlockElementService.cs
@@ -55,13 +55,11 @@ internal class BlockElementService : IBlockElementService
                 // vary by culture. Since the created element is fully culture aware at render time, we need to replicate
                 // property values across all available languages, to make them available for rendering.
 
-                if (allLanguages is null)
-                {
-                    allLanguages = (await _languageService.GetAllAsync()).ToArray();
-                    defaultLanguage = allLanguages.Single(l => l.IsDefault);
-                }
+                allLanguages ??= (await _languageService.GetAllAsync()).ToArray();
+                defaultLanguage ??= allLanguages.SingleOrDefault(l => l.IsDefault)
+                                    ?? throw new InvalidOperationException("Could not find the default language.");
 
-                BlockPropertyValue property = properties.FirstOrDefault(p => p.Culture.InvariantEquals(defaultLanguage!.IsoCode))
+                BlockPropertyValue property = properties.FirstOrDefault(p => p.Culture.InvariantEquals(defaultLanguage.IsoCode))
                                               ?? properties.First();
                 propertyData[properties.Key] = allLanguages.Select(language => new PropertyData
                 {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Parsing.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.Parsing.cs
@@ -542,37 +542,45 @@ internal partial class BlockListElementLevelVariationTests
             true);
 
         SetVariationContext(culture, segment);
+        AssertBlockValues();
 
-        var publishedContent = GetPublishedContent(content.Key);
+        culture = culture == "en-US" ? "da-DK" : "en-US";
+        SetVariationContext(culture, segment);
+        AssertBlockValues();
 
-        var value = publishedContent.GetProperty("blocks")!.GetValue() as BlockListModel;
-        Assert.IsNotNull(value);
-        Assert.AreEqual(1, value.Count);
-
-        var blockListItem = value.First();
-        Assert.AreEqual(2, blockListItem.Content.Properties.Count());
-        Assert.Multiple(() =>
+        void AssertBlockValues()
         {
-            var invariantProperty = blockListItem.Content.Properties.First();
-            Assert.AreEqual("invariantText", invariantProperty.Alias);
-            Assert.AreEqual("This is invariant content text", invariantProperty.GetValue());
+            var publishedContent = GetPublishedContent(content.Key);
 
-            var variantProperty = blockListItem.Content.Properties.Last();
-            Assert.AreEqual("variantText", variantProperty.Alias);
-            Assert.AreEqual("This is variant content text", variantProperty.GetValue());
-        });
+            var value = publishedContent.GetProperty("blocks")!.GetValue() as BlockListModel;
+            Assert.IsNotNull(value);
+            Assert.AreEqual(1, value.Count);
 
-        Assert.AreEqual(2, blockListItem.Settings.Properties.Count());
-        Assert.Multiple(() =>
-        {
-            var invariantProperty = blockListItem.Settings.Properties.First();
-            Assert.AreEqual("invariantText", invariantProperty.Alias);
-            Assert.AreEqual("This is invariant settings text", invariantProperty.GetValue());
+            var blockListItem = value.First();
+            Assert.AreEqual(2, blockListItem.Content.Properties.Count());
+            Assert.Multiple(() =>
+            {
+                var invariantProperty = blockListItem.Content.Properties.First();
+                Assert.AreEqual("invariantText", invariantProperty.Alias);
+                Assert.AreEqual("This is invariant content text", invariantProperty.GetValue());
 
-            var variantProperty = blockListItem.Settings.Properties.Last();
-            Assert.AreEqual("variantText", variantProperty.Alias);
-            Assert.AreEqual("This is variant settings text", variantProperty.GetValue());
-        });
+                var variantProperty = blockListItem.Content.Properties.Last();
+                Assert.AreEqual("variantText", variantProperty.Alias);
+                Assert.AreEqual("This is variant content text", variantProperty.GetValue());
+            });
+
+            Assert.AreEqual(2, blockListItem.Settings.Properties.Count());
+            Assert.Multiple(() =>
+            {
+                var invariantProperty = blockListItem.Settings.Properties.First();
+                Assert.AreEqual("invariantText", invariantProperty.Alias);
+                Assert.AreEqual("This is invariant settings text", invariantProperty.GetValue());
+
+                var variantProperty = blockListItem.Settings.Properties.Last();
+                Assert.AreEqual("variantText", variantProperty.Alias);
+                Assert.AreEqual("This is variant settings text", variantProperty.GetValue());
+            });
+        }
     }
 
     [TestCase("en-US", null)]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListWithReusableContentTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListWithReusableContentTest.cs
@@ -660,30 +660,39 @@ internal class BlockListWithReusableContentTest : BlockEditorWithReusableContent
         PublishContent(content, ["*"]);
 
         SetVariationContext(culture, null);
+        AssertBlockValues();
 
-        var expectedReusableElementVariantText = culture == "en-US" ? "English" : "Danish";
-        var publishedContent = GetPublishedContent(content.Key);
-        var value = publishedContent.Value<BlockListModel>("blocks");
-        Assert.IsNotNull(value);
-        Assert.AreEqual(2, value.Count);
+        culture = culture == "en-US" ? "da-DK" : "en-US";
+        SetVariationContext(culture, null);
+        AssertBlockValues();
 
-        var blockListItem = value.First();
-        Assert.AreEqual(2, blockListItem.Content.Properties.Count());
-
-        Assert.Multiple(() =>
+        void AssertBlockValues()
         {
-            Assert.AreEqual(localElementKey, blockListItem.ContentKey);
-            Assert.AreEqual("The local invariant text", blockListItem.Content.Value<string>("invariantText"));
-            Assert.AreEqual($"The local variant text", blockListItem.Content.Value<string>("variantText"));
-        });
+            var expectedReusableElementVariantText = culture == "en-US" ? "English" : "Danish";
 
-        blockListItem = value.Last();
-        Assert.Multiple(() =>
-        {
-            Assert.AreEqual(reusableElementKey, blockListItem.ContentKey);
-            Assert.AreEqual("The reusable invariant text", blockListItem.Content.Value<string>("invariantText"));
-            Assert.AreEqual($"The reusable {expectedReusableElementVariantText} text", blockListItem.Content.Value<string>("variantText"));
-        });
+            var publishedContent = GetPublishedContent(content.Key);
+            var value = publishedContent.Value<BlockListModel>("blocks");
+            Assert.IsNotNull(value);
+            Assert.AreEqual(2, value.Count);
+
+            var blockListItem = value.First();
+            Assert.AreEqual(2, blockListItem.Content.Properties.Count());
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(localElementKey, blockListItem.ContentKey);
+                Assert.AreEqual("The local invariant text", blockListItem.Content.Value<string>("invariantText"));
+                Assert.AreEqual($"The local variant text", blockListItem.Content.Value<string>("variantText"));
+            });
+
+            blockListItem = value.Last();
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(reusableElementKey, blockListItem.ContentKey);
+                Assert.AreEqual("The reusable invariant text", blockListItem.Content.Value<string>("invariantText"));
+                Assert.AreEqual($"The reusable {expectedReusableElementVariantText} text", blockListItem.Content.Value<string>("variantText"));
+            });
+        }
     }
 
     [TestCase(true, true)]

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/PropertyValueLevelDetectionTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/PropertyValueLevelDetectionTests.cs
@@ -1,7 +1,9 @@
+using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
@@ -104,11 +106,17 @@ internal sealed class PropertyValueLevelDetectionTests : UmbracoIntegrationTestW
     [TestCase("somethingElse", false)]
     public async Task Can_Detect_Property_Value_At_All_Levels_For_Element(string titleValue, bool expectHasValue)
     {
+        var publishedContentTypeMock = new Mock<IPublishedContentType>();
+        publishedContentTypeMock.SetupGet(m => m.Variations).Returns(ContentVariation.Nothing);
+        var publishedContentMock = new Mock<IPublishedContent>();
+        publishedContentMock.SetupGet(m => m.ContentType).Returns(publishedContentTypeMock.Object);
+
         var elementType = ContentTypeBuilder.CreateSimpleContentType("umbElement");
         elementType.IsElement = true;
         await ContentTypeService.UpdateAsync(elementType, Constants.Security.SuperUserKey);
         var blockElementService = GetRequiredService<IBlockElementService>();
         var element = await blockElementService.BuildElementAsync(
+            publishedContentMock.Object,
             new BlockItemData(Guid.NewGuid(), elementType.Key, "umbElement")
             {
                 Values = [new BlockPropertyValue { Alias = "title", Value = titleValue, }]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockGridPropertyValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockGridPropertyValueConverterTests.cs
@@ -189,8 +189,8 @@ public class BlockGridPropertyValueConverterTests : BlockPropertyValueConverterT
         var blockElementServiceMock = new Mock<IBlockElementService>();
         var publishedContentTypeCache = GetPublishedContentTypeCache();
         blockElementServiceMock
-            .Setup(service => service.BuildElementAsync(It.IsAny<BlockItemData>(), It.IsAny<bool?>()))
-            .Returns<BlockItemData, bool?>((blockItemData, preview) =>
+            .Setup(service => service.BuildElementAsync(It.IsAny<IPublishedElement>(), It.IsAny<BlockItemData>(), It.IsAny<bool?>()))
+            .Returns<IPublishedElement, BlockItemData, bool?>((owner, blockItemData, preview) =>
             {
                 var publishedElementType = publishedContentTypeCache.Get(PublishedItemType.Element, blockItemData.ContentTypeKey);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListPropertyValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/BlockListPropertyValueConverterTests.cs
@@ -26,8 +26,8 @@ public class BlockListPropertyValueConverterTests : BlockPropertyValueConverterT
         var blockElementServiceMock = new Mock<IBlockElementService>();
         var publishedContentTypeCache = GetPublishedContentTypeCache();
         blockElementServiceMock
-            .Setup(service => service.BuildElementAsync(It.IsAny<BlockItemData>(), It.IsAny<bool?>()))
-            .Returns<BlockItemData, bool?>((blockItemData, preview) =>
+            .Setup(service => service.BuildElementAsync(It.IsAny<IPublishedElement>(), It.IsAny<BlockItemData>(), It.IsAny<bool?>()))
+            .Returns<IPublishedElement, BlockItemData, bool?>((owner, blockItemData, preview) =>
             {
                 var publishedElementType = publishedContentTypeCache.Get(PublishedItemType.Element, blockItemData.ContentTypeKey);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

We currently have issues contextualizing blocks of variant element types in an invariant context. While we have tests proving it works, these are actually false positives; it only works for the first request... then the cache takes over, and continues to serve the initially accessed variant for all requested languages.

This PR amends that shortcoming.

### Testing this PR

You'll need to use the Management API here, because block editors do not (yet) support the use of variant element types in invariant content:

<img width="844" height="234" alt="image" src="https://github.com/user-attachments/assets/5364dba2-cddb-4d86-9769-021b67abd272" />

1. Create an invariant and a variant element type.
2. Create elements of both types in the library.
3. Configure a block list data type to use both element types.
4. Create an invariant document type with a block list property using this data type.
5. Use the Management API to create and publish a document with a mix of blocks based on both invariant and variant element types.
6. Render the document in multiple languages and verify that the rendering contextualizes the element output correctly.

### Breaking change

This changes the signature of the public interface `IBlockElementService`, and that is a breaking change. Unfortunately, it is not possible to create any meaningful overload to retain backwards compatibility, because it would require either:

a. Handling a nullable `owner` parameter in the service implementation, which kinda defeats the purpose, or
b. New'ing up a `PublishedElement` instance to pass as default, which is a super complex entity, filled with a lot of inner workings.

Since `IBlockElementService` will be introduced in V18, and the [target PR](https://github.com/umbraco/Umbraco-CMS/pull/22448) for this PR is slated for V19, the impact of this breakage will be quite limited, so I think we should just accept it. Also, the target PR will probably be breaking in itself anyway 🤷 