### PR TITLE
User Permission: Re-export fallback condition config type and global augmentation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/user-permission/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user-permission/types.ts
@@ -1,5 +1,6 @@
 export type * from './user-granular-permission.extension.js';
 export type * from './entity-user-permission.extension.js';
+export type * from './fallback-permission-condition/types.js';
 export interface UmbUserPermissionModel {
 	$type: string;
 	userPermissionType?: string;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

The public `@umbraco-cms/backoffice/user-permission` subpath re-exports `./fallback-permission-condition/constants.js` (so consumers can use `UMB_FALLBACK_USER_PERMISSION_CONDITION_ALIAS`) but does *not* re-export `./fallback-permission-condition/types.js`. As a result, consumers can import the alias constant but not the matching `UmbFallbackUserPermissionConditionConfig` type, and — more importantly — the `declare global` augmentation on `UmbExtensionConditionConfigMap` declared in that same file never reaches consumers' TypeScript projects. Authoring a manifest with this alias therefore can't be typed without resorting to `as any`.

This PR adds a one-line `export type * from './fallback-permission-condition/types.js'` to `packages/user/user-permission/types.ts`, matching the existing pattern already used for `user-granular-permission.extension.js` and `entity-user-permission.extension.js` in that file. No behaviour changes.

### How to test

See [Extension Conditions](https://docs.umbraco.com/umbraco-cms/customizing/extending-overview/extension-conditions) for context. In a TypeScript project that imports `@umbraco-cms/backoffice` at this build, register a manifest that gates on the fallback user-permission condition:

```ts
import { UMB_FALLBACK_USER_PERMISSION_CONDITION_ALIAS } from "@umbraco-cms/backoffice/user-permission";
import type { ManifestEntityAction } from "@umbraco-cms/backoffice/entity-action";

const manifest: ManifestEntityAction = {
  type: "entityAction",
  alias: "Example.EntityAction.RestrictedAction",
  name: "Restricted action",
  api: () => import("./restricted-action.js"),
  forEntityTypes: ["document"],
  conditions: [
    {
      alias: UMB_FALLBACK_USER_PERMISSION_CONDITION_ALIAS,
      allOf: ["Umb.Permission.Foo"],
    },
  ],
};
```

- **Before this PR**: the `declare global` augmentation never reaches the consumer, so `UmbExtensionConditionConfig` (the union derived from `UmbExtensionConditionConfigMap`) doesn't include `UmbFallbackUserPermissionConditionConfig`. TS doesn't recognise `allOf` on the entry whose alias is `Umb.Condition.UserPermission.Fallback` — authors have to fall back to `as any` to compile.
- **After this PR**: the union includes the config, so narrowing on `alias` resolves the entry to `UmbFallbackUserPermissionConditionConfig` and `allOf`/`oneOf` are type-checked.

### Context

Surfaced while working on the Umbraco Deploy NPM package (part of the upcoming 17.1.0 release). Deploy currently has to mirror this exact augmentation locally as a workaround (and avoid `as any` warnings from eslint). Once this lands and flows through to Deploy's consumed CMS version, that local mirror can be removed. @AndyButland Would be great of this can be included in v18 💪🏻
