### PR TITLE
Distributed background jobs: Improve gracefull shutdown behaviour

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/DistributedBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/DistributedBackgroundJobHostedService.cs
@@ -97,7 +97,7 @@ public class DistributedBackgroundJobHostedService : BackgroundService
             {
                 try
                 {
-                    await RunRunnableJob();
+                    await RunRunnableJob(stoppingToken);
                 }
                 catch (Exception exception)
                 {
@@ -117,7 +117,7 @@ public class DistributedBackgroundJobHostedService : BackgroundService
         }
     }
 
-    private async Task RunRunnableJob()
+    private async Task RunRunnableJob(CancellationToken stoppingToken)
     {
         IDistributedBackgroundJob? job = await _distributedJobService.TryTakeRunnableAsync();
 
@@ -129,7 +129,7 @@ public class DistributedBackgroundJobHostedService : BackgroundService
 
         try
         {
-            await job.ExecuteAsync();
+            await job.ExecuteAsync(stoppingToken);
         }
         catch (Exception ex)
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/IDistributedBackgroundJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/IDistributedBackgroundJob.cs
@@ -20,4 +20,13 @@ public interface IDistributedBackgroundJob
     /// Run the job.
     /// </summary>
     Task ExecuteAsync();
+
+    /// <summary>
+    /// Run the job with a cancellation token that signals when the host is shutting down.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation delegates to <see cref="ExecuteAsync()"/>.
+    /// Override this method to respond to graceful shutdown.
+    /// </remarks>
+    Task ExecuteAsync(CancellationToken cancellationToken) => ExecuteAsync();
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DistributedJobRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DistributedJobRepository.cs
@@ -49,7 +49,7 @@ internal class DistributedJobRepository(IScopeAccessor scopeAccessor) : IDistrib
     {
         if (scopeAccessor.AmbientScope is null)
         {
-            return;
+            throw new InvalidOperationException("No scope, could not update distributed job");
         }
 
         DistributedJobDto dto = MapToDto(distributedBackgroundJob);


### PR DESCRIPTION
### Description
Improves distributed backgrounds jobs by not swallowing ambientscope errors and passing on the cancelationtoken to allow jobs to shut down gracefully.

### Testing
- existing tests still pass
- by introducing a long running task like below that consumes the cancelation token and then stopping the instance gracefully (stop in your IDE or Ctrl+C in cmd), the app should shut down pretty fast. The task should be marked as non running in the database when the app is shut down.

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Infrastructure.BackgroundJobs;

namespace Umbraco.Cms.Web.UI;

public class TestDistributedJob : IDistributedBackgroundJob
{
    private readonly ILogger<TestDistributedJob> _logger;

    public TestDistributedJob(ILogger<TestDistributedJob> logger)
    {
        _logger = logger;
        Period = TimeSpan.FromMinutes(3);
    }

    public async Task ExecuteAsync()
        => await ExecuteAsync(CancellationToken.None);

    public async Task ExecuteAsync(CancellationToken cancellationToken)
    {
        _logger.LogInformation("TestDistributedJob started");
        await Task.Delay(TimeSpan.FromMinutes(2), cancellationToken);
        _logger.LogInformation("TestDistributedJob finished");
    }

    public string Name => nameof(TestDistributedJob);
    public TimeSpan Period { get; }
}

public class TestDistributedJobComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.Services.AddSingleton<IDistributedBackgroundJob, TestDistributedJob>();
    }
}
```