### PR TITLE
Content: Ensure correct variant change tracking when unpublishing variant content

### DIFF
--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -468,6 +468,8 @@ public static class ContentRepositoryExtensions
             content.ClearPublishInfo(culture);
         }
 
+        // Following #22799 the explicit calls to `ClearPublishInfo` for each culture cause the unpublish in all cultures.
+        // `PublishCultureInfos` is set to null purely to retain previous behaviour at a property level.
         content.PublishCultureInfos = null;
     }
 

--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -454,7 +454,22 @@ public static class ContentRepositoryExtensions
     ///     Clears all publish culture information from the content item.
     /// </summary>
     /// <param name="content">The content item to clear publish information from.</param>
-    public static void ClearPublishInfos(this IContent content) => content.PublishCultureInfos = null;
+    public static void ClearPublishInfos(this IContent content)
+    {
+        if (content.PublishCultureInfos is null)
+        {
+            return;
+        }
+
+        // Pass each published culture through ClearPublishInfo([culture]) to ensure correct change tracking.
+        var cultures = content.PublishCultureInfos.Values.Select(c => c.Culture).ToArray();
+        foreach (var culture in cultures)
+        {
+            content.ClearPublishInfo(culture);
+        }
+
+        content.PublishCultureInfos = null;
+    }
 
     /// <summary>
     ///     Returns false if the culture is already unpublished

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -1670,9 +1670,7 @@ public class ContentService : RepositoryService, IContentService
         {
             // Determine cultures publishing/unpublishing which will be based on previous calls to content.PublishCulture and ClearPublishInfo
             culturesUnpublishing = content.GetCulturesUnpublishing();
-            culturesPublishing = variesByCulture
-                ? content.PublishCultureInfos?.Values.Where(x => x.IsDirty()).Select(x => x.Culture).ToList()
-                : null;
+            culturesPublishing = GetCulturesPublishing(content);
 
             // ensure that the document can be published, and publish handling events, business rules, etc
             publishResult = StrategyCanPublish(
@@ -1743,6 +1741,12 @@ public class ContentService : RepositoryService, IContentService
         // won't happen in a branch
         if (unpublishing)
         {
+            if (culturesUnpublishing is null)
+            {
+                culturesUnpublishing = content.GetCulturesUnpublishing();
+                culturesPublishing = GetCulturesPublishing(content);
+            }
+
             IContent? newest = GetById(content.Id); // ensure we have the newest version - in scope
             if (content.VersionId != newest?.VersionId)
             {
@@ -1805,12 +1809,13 @@ public class ContentService : RepositoryService, IContentService
                     var langs = GetLanguageDetailsForAuditEntry(allLangs, culturesUnpublishing);
                     Audit(AuditType.UnpublishVariant, userId, content.Id, $"Unpublished languages: {langs}", langs);
 
-                    if (publishResult == null)
+                    PublishResultType? publishResultType = publishResult?.Result ?? unpublishResult?.Result;
+                    if (publishResultType == null)
                     {
-                        throw new PanicException("publishResult == null - should not happen");
+                        throw new PanicException("publishResultType == null - should not happen");
                     }
 
-                    switch (publishResult.Result)
+                    switch (publishResultType)
                     {
                         case PublishResultType.FailedPublishMandatoryCultureMissing:
                             // Occurs when a mandatory culture was unpublished (which means we tried publishing the document without a mandatory culture)
@@ -2427,6 +2432,11 @@ public class ContentService : RepositoryService, IContentService
 
         return result;
     }
+
+    private IReadOnlyList<string>? GetCulturesPublishing(IContent content)
+        => content.ContentType.VariesByCulture()
+            ? content.PublishCultureInfos?.Values.Where(x => x.IsDirty()).Select(x => x.Culture).ToList()
+            : null;
 
     #endregion
 

--- a/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
+++ b/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
@@ -144,14 +144,14 @@ public PublishStatusService(
     {
         using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
         ISet<string> publishedCultures = await _publishStatusRepository.GetPublishStatusAsync(documentKey, cancellationToken);
-        _publishedCultures[documentKey] = publishedCultures;
+        UpdatePublishedCultures(documentKey, publishedCultures);
         scope.Complete();
     }
 
     /// <inheritdoc/>
     public Task RemoveAsync(Guid documentKey, CancellationToken cancellationToken)
     {
-        _publishedCultures.TryRemove(documentKey, out _);
+        RemovePublishedCultures(documentKey);
         return Task.CompletedTask;
     }
 
@@ -167,7 +167,22 @@ public PublishStatusService(
 
         foreach ((Guid documentKey, ISet<string> publishedCultures) in publishStatus)
         {
-            _publishedCultures[documentKey] = publishedCultures;
+            UpdatePublishedCultures(documentKey, publishedCultures);
         }
     }
+
+    private void UpdatePublishedCultures(Guid documentKey, ISet<string> publishedCultures)
+    {
+        if (publishedCultures.Any())
+        {
+            _publishedCultures[documentKey] = publishedCultures;
+        }
+        else
+        {
+            RemovePublishedCultures(documentKey);
+        }
+    }
+
+    private void RemovePublishedCultures(Guid documentKey)
+        => _publishedCultures.TryRemove(documentKey, out _);
 }

--- a/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
+++ b/src/Umbraco.Core/Services/PublishStatus/PublishStatusService.cs
@@ -173,7 +173,7 @@ public PublishStatusService(
 
     private void UpdatePublishedCultures(Guid documentKey, ISet<string> publishedCultures)
     {
-        if (publishedCultures.Any())
+        if (publishedCultures.Count > 0)
         {
             _publishedCultures[documentKey] = publishedCultures;
         }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTests.Query.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/PublishStatusServiceTests.Query.cs
@@ -181,4 +181,78 @@ internal sealed partial class PublishStatusServiceTests
         Assert.IsFalse(PublishStatusQueryService.HasPublishedAncestorPath(grandchild.Key, cultureToUnpublish));
         Assert.IsTrue(PublishStatusQueryService.HasPublishedAncestorPath(grandchild.Key, Constants.System.InvariantCulture));
     }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Fully_Unpublished_Culture_Variant_Document_Tracks_Unpublished_State_For_All_Cultures(bool unpublishAllCulturesAtOnce)
+    {
+        await GetRequiredService<ILanguageService>()
+            .CreateAsync(new Language("da-DK", "Danish"), Constants.Security.SuperUserKey);
+
+        var contentTypeKey = Guid.NewGuid();
+        var contentType = new ContentTypeBuilder()
+            .WithKey(contentTypeKey)
+            .WithAlias("variant")
+            .WithContentVariation(ContentVariation.Culture)
+            .WithAllowAsRoot(true)
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        contentType.AllowedContentTypes = [new ContentTypeSort(contentTypeKey, 1, "variant")];
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
+
+        IContent root = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithCultureName("en-US", "Root EN")
+            .WithCultureName("da-DK", "Root DA")
+            .Build();
+        ContentService.Save(root);
+
+        IContent child = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithCultureName("en-US", "Child EN")
+            .WithCultureName("da-DK", "Child DA")
+            .WithParent(root)
+            .Build();
+        ContentService.Save(child);
+
+        IContent grandchild = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithCultureName("en-US", "Grandchild EN")
+            .WithCultureName("da-DK", "Grandchild DA")
+            .WithParent(child)
+            .Build();
+        ContentService.Save(grandchild);
+
+        ContentService.PublishBranch(root, PublishBranchFilter.IncludeUnpublished, ["en-US", "da-DK"]);
+
+        // must refresh the child instance before unpublishing it, to reflect the state changes from the branch publish above
+        child = ContentService.GetById(child.Key)!;
+
+        if (unpublishAllCulturesAtOnce)
+        {
+            ContentService.Unpublish(child);
+        }
+        else
+        {
+            ContentService.Unpublish(child, "en-US");
+
+            // refresh again before unpublishing the last culture
+            child = ContentService.GetById(child.Key)!;
+            ContentService.Unpublish(child, "da-DK");
+        }
+
+        // refresh to get the latest state
+        child = ContentService.GetById(child.Key)!;
+        Assert.IsFalse(child.Published);
+        Assert.IsEmpty(child.PublishedCultures);
+        Assert.IsEmpty(child.PublishCultureInfos!);
+
+        Assert.IsFalse(PublishStatusQueryService.IsDocumentPublished(child.Key, "en-US"));
+        Assert.IsFalse(PublishStatusQueryService.IsDocumentPublished(child.Key, "da-DK"));
+        Assert.IsFalse(PublishStatusQueryService.IsDocumentPublished(child.Key, Constants.System.InvariantCulture));
+
+        Assert.IsFalse(PublishStatusQueryService.HasPublishedAncestorPath(grandchild.Key, "da-DK"));
+        Assert.IsFalse(PublishStatusQueryService.HasPublishedAncestorPath(grandchild.Key, "en-US"));
+        Assert.IsFalse(PublishStatusQueryService.HasPublishedAncestorPath(grandchild.Key, Constants.System.InvariantCulture));
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR addresses a couple of issues with our tracking of published status for variants, specifically tied to unpublishing variant content:

#### Invariant remains published after unpublishing cultures in turn

After unpublishing all cultures one at a time, the `IPublishStatusQueryService` still reports the now fully unpublished content as being published in the invariant culture.

#### Publish state tracking fails when unpublishing all cultures

When "bulk" unpublishing all cultures in a single operation (`IContentService.Unpublish()` with no culture specified), `IPublishStatusQueryService` continues to report all culture variants of the content as published.

### Testing this PR

The first issue can be reproduced using the backoffice, because this is exclusively how the backoffice works - it _only ever_ unpublishes specific cultures (likely this is also why this issue has remained undiscovered).

The second requires a bit of custom code to perform the unpublishing. I have used this controller:

```cs
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI.Controllers;

public class ReproduceIssuesController : Controller
{
    private readonly IContentService _contentService;

    public ReproduceIssuesController(IContentService contentService)
        => _contentService = contentService;

    [HttpGet("/repro/unpublish-variants-tracking")]
    public IActionResult Run(Guid id)
    {
        IContent? content = _contentService.GetById(id);
        if (content is null)
        {
            return NotFound("The content was not found.");
        }

        if (content.Published is false)
        {
            return BadRequest("The content was not published.");
        }

        if (content.ContentType.VariesByCulture() is false)
        {
            return BadRequest("The content type does not vary by culture.");
        }

        PublishResult result = _contentService.Unpublish(content);
        return result.Success
            ? Ok("Success.")
            : BadRequest($"Could not unpublish: {result.Result}");
    }
}
```

Now, given this content structure, where all pages are published in `en-US` and `da-DK`:

<img width="353" height="252" alt="image" src="https://github.com/user-attachments/assets/379451cc-1747-4c5a-a614-1452195eac0f" />

...and given this template:

```cshtml
@inject IContentService ContentService;
@inject IPublishStatusQueryService PublishStatusQueryService;
@using Umbraco.Cms.Core
@using Umbraco.Cms.Core.Services
@using Umbraco.Cms.Core.Services.Navigation
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@{
	Layout = null;
    var children = ContentService
        .GetPagedChildren(Model.Id, 0, 1000, out _)
        .ToArray();
}
<html>
<body>
<ul>
    @foreach (var child in children)
    {
        <li><b>@child.Name</b></li>
        <ul>
            <li>Is published (en-US): @PublishStatusQueryService.IsDocumentPublished(child.Key, "en-US")</li>
            <li>Is published (da-DK): @PublishStatusQueryService.IsDocumentPublished(child.Key, "da-DK")</li>
            <li>Is published (invariant): @PublishStatusQueryService.IsDocumentPublished(child.Key, Constants.System.InvariantCulture)</li>
        </ul>
    }
</ul>
</body>
</html>
```

...this is the initial rendering:

<img width="501" height="422" alt="image" src="https://github.com/user-attachments/assets/e95e8b5c-70bd-4b73-86dc-d095b7cd7c40" />

When unpublishing all cultures of "Child 1" from the backoffice, the output still claims that "Child 1" is published for the invariant culture:

<img width="501" height="422" alt="image" src="https://github.com/user-attachments/assets/711190cb-aef3-4080-b134-cacc965ff843" />

When unpublishing "Child 2" using the custom controller, the output continues to claim that "Child 2" is fully published:

<img width="501" height="422" alt="image" src="https://github.com/user-attachments/assets/3ea55e21-c1a2-425b-b8c8-770ff0d033b7" />

...when in fact it is not - which the backoffice correctly displays:

<img width="353" height="252" alt="image" src="https://github.com/user-attachments/assets/2c2873f3-cd79-4d6a-a5cf-a1c5e5952555" />
