### PR TITLE
18.0-beta1: Recycle Bin: Fix empty action button in collection view (closes #22798)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/collection-action/empty-recycle-bin/empty-recycle-bin.collection-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/collection-action/empty-recycle-bin/empty-recycle-bin.collection-action.ts
@@ -7,7 +7,6 @@ import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/e
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UMB_COLLECTION_CONTEXT } from '@umbraco-cms/backoffice/collection';
 import { UMB_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/entity';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 /**
  * Collection action for emptying the recycle bin.
@@ -15,19 +14,19 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
  * @augments {UmbCollectionActionBase}
  */
 export class UmbEmptyRecycleBinCollectionAction extends UmbCollectionActionBase {
-	#manifest: ManifestCollectionActionEmptyRecycleBinKind;
 
-	constructor(host: UmbControllerHost, manifest: ManifestCollectionActionEmptyRecycleBinKind) {
-		super(host);
-		this.#manifest = manifest;
-	}
+	/**
+	 * The manifest for this action. Assigned by `umb-extension-with-api-slot` after construction.
+	 */
+	public manifest?: ManifestCollectionActionEmptyRecycleBinKind;
 
 	/**
 	 * Executes the action.
 	 * @memberof UmbEmptyRecycleBinCollectionAction
 	 */
 	async execute() {
-		if (!this.#manifest.meta.recycleBinRepositoryAlias) {
+		const recycleBinRepositoryAlias = this.manifest?.meta.recycleBinRepositoryAlias;
+		if (!recycleBinRepositoryAlias) {
 			throw new Error('Recycle Bin Repository Alias is not defined in the manifest meta');
 		}
 
@@ -40,7 +39,7 @@ export class UmbEmptyRecycleBinCollectionAction extends UmbCollectionActionBase 
 
 		const recycleBinRepository = await createExtensionApiByAlias<UmbRecycleBinRepository>(
 			this,
-			this.#manifest.meta.recycleBinRepositoryAlias,
+			recycleBinRepositoryAlias,
 		);
 
 		const { error } = await recycleBinRepository.requestEmpty();


### PR DESCRIPTION
## Description

Fixes #22798

As reported in the linked issue, clicking the **Empty Recycle Bin** button in the collection view of the Library - but also in Media and Content too - did nothing. The "Empty Recycle Bin" entity action in the action menu still worked.

### Cause

`UmbEmptyRecycleBinCollectionAction` read its manifest from a constructor argument:

```ts
constructor(host: UmbControllerHost, manifest: ManifestCollectionActionEmptyRecycleBinKind) {
    super(host);
    this.#manifest = manifest;
}
```

This worked when the action was instantiated by the old `umb-collection-action-button.element.ts`, which passed `[this._manifest]` as constructor args via `createExtensionApi`.

After #21974 ("Collection Action: Refactor to use extension-with-api-slot") the collection action bundle renders `<umb-extension-with-api-slot type="collectionAction">` with no `.apiArgs`, so the API is constructed as `new apiConstructor(element)` — manifest is `undefined`. On click, `execute()` threw `TypeError: Cannot read properties of undefined (reading 'meta')`, which was silently swallowed by the `try/catch` in `collection-action-button.element.ts` `_onClick`.

The bug affected all three sections that use the `emptyRecycleBin` collection action kind (Documents, Media, Elements), since they share this class.

### Fix

Read the manifest from the public `manifest` property that `UmbExtensionElementAndApiInitializer` assigns post-construction at `extension-element-and-api-initializer.controller.ts:165`:

```ts
public manifest?: ManifestCollectionActionEmptyRecycleBinKind;

async execute() {
    const recycleBinRepositoryAlias = this.manifest?.meta.recycleBinRepositoryAlias;
    ...
}
```

The follows the pattern already seen in `UmbDocumentSaveAndPreviewOptionWorkspaceAction` and `UmbTiptapToolbarElementApiBase`.

## Testing

- In Content, Media or Library, create and trash one or more items.
- Verify that they can be deleted via the **Empty Recycle Bin** entity action in the action menu (regression check).
- Verify that they can be deleted via the **Empty Recycle Bin** button on the recycle bin dashboards.