### PR TITLE
Sort Children: Show loading state on Sort button (closes #22651)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -8,6 +8,7 @@ import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
+import type { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import type {
 	UmbTableColumn,
 	UmbTableConfig,
@@ -45,6 +46,9 @@ export class UmbSortChildrenOfModalElement<
 
 	@state()
 	private _sortable = false;
+
+	@state()
+	private _submitButtonState?: UUIButtonState;
 
 	protected _sortedUniques = new Set<string>();
 
@@ -143,13 +147,18 @@ export class UmbSortChildrenOfModalElement<
 			this.data.sortChildrenOfRepositoryAlias,
 		);
 
+		this._submitButtonState = 'waiting';
+
 		const { error } = await sortChildrenOfRepository.sortChildrenOf({
 			unique: this.data.unique,
 			sorting: this.#getSortOrderOfSortedItems(),
 		});
 
 		if (!error) {
+			this._submitButtonState = 'success';
 			this._submitModal();
+		} else {
+			this._submitButtonState = 'failed';
 		}
 	}
 
@@ -213,7 +222,13 @@ export class UmbSortChildrenOfModalElement<
 			<umb-body-layout headline=${this.localize.term('actions_sort')}>
 				${this._children.length === 0 ? this.#renderEmptyState() : this.#renderTable()}
 				<uui-button slot="actions" label=${this.localize.term('general_cancel')} @click="${this._rejectModal}"></uui-button>
-				<uui-button slot="actions" color="positive" look="primary" label=${this.localize.term('general_sort')} @click=${this.#onSubmit}></uui-button>
+				<uui-button
+					slot="actions"
+					color="positive"
+					look="primary"
+					label=${this.localize.term('general_sort')}
+					.state=${this._submitButtonState}
+					@click=${this.#onSubmit}></uui-button>
 			</umb-body-layout>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -139,6 +139,7 @@ export class UmbSortChildrenOfModalElement<
 	}
 
 	async #onSubmit(event: PointerEvent) {
+		if (this._submitButtonState === 'waiting') return;
 		event?.stopPropagation();
 		if (!this.data?.sortChildrenOfRepositoryAlias) throw new Error('sortChildrenOfRepositoryAlias is required');
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -143,23 +143,28 @@ export class UmbSortChildrenOfModalElement<
 		event?.stopPropagation();
 		if (!this.data?.sortChildrenOfRepositoryAlias) throw new Error('sortChildrenOfRepositoryAlias is required');
 
-		const sortChildrenOfRepository = await createExtensionApiByAlias<UmbSortChildrenOfRepository>(
-			this,
-			this.data.sortChildrenOfRepositoryAlias,
-		);
-
 		this._submitButtonState = 'waiting';
 
-		const { error } = await sortChildrenOfRepository.sortChildrenOf({
-			unique: this.data.unique,
-			sorting: this.#getSortOrderOfSortedItems(),
-		});
+		try {
+			const sortChildrenOfRepository = await createExtensionApiByAlias<UmbSortChildrenOfRepository>(
+				this,
+				this.data.sortChildrenOfRepositoryAlias,
+			);
 
-		if (!error) {
-			this._submitButtonState = 'success';
-			this._submitModal();
-		} else {
+			const { error } = await sortChildrenOfRepository.sortChildrenOf({
+				unique: this.data.unique,
+				sorting: this.#getSortOrderOfSortedItems(),
+			});
+
+			if (!error) {
+				this._submitButtonState = 'success';
+				this._submitModal();
+			} else {
+				this._submitButtonState = 'failed';
+			}
+		} catch (error) {
 			this._submitButtonState = 'failed';
+			throw error;
 		}
 	}
 


### PR DESCRIPTION
## Description

The "Sort Children" modal currently gives editors no visual feedback while the sort request is in flight. For parents with many children the await can take many seconds, which led editors to assume the action was hung and cancel it.

With this update, the "Sort" `uui-button` now reflects the in-flight state via `state="waiting"` (and transitions to `success`/`failed` based on the repository result), matching the pattern already used in `document-schedule-modal.element.ts`.

Fixes #22651

## Testing

- Right-click a parent with several children.
- Reorder at least one a child and click "Sort".
- Verify the Sort button shows a waiting spinner immediately and remains in that state until the request completes and the dialog closes.