### PR TITLE
Migrations: Add auto upgrade coordination for load-balanced setups

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
@@ -16,6 +16,7 @@ public class UnattendedSettings
     private const bool StaticInstallUnattended = false;
     private const bool StaticUpgradeUnattended = false;
     private const TelemetryLevel StaticTelemetryLevel = TelemetryLevel.Detailed;
+    private const string StaticMigrationClaimTimeout = "02:00:00";
 
     /// <summary>
     ///     Gets or sets a value indicating whether unattended installs are enabled.
@@ -53,7 +54,8 @@ public class UnattendedSettings
     ///     Only relevant in load-balanced deployments with <see cref="UpgradeUnattended"/> enabled.
     ///     Default is 2 hours, which should exceed the longest reasonable migration run time.
     /// </remarks>
-    public TimeSpan MigrationClaimTimeout { get; set; } = TimeSpan.FromHours(2);
+    [DefaultValue(StaticMigrationClaimTimeout)]
+    public TimeSpan MigrationClaimTimeout { get; set; } = TimeSpan.Parse(StaticMigrationClaimTimeout);
 
     /// <summary>
     ///     Gets or sets a value to use for creating a user with a name for Unattended Installs

--- a/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/UnattendedSettings.cs
@@ -46,6 +46,16 @@ public class UnattendedSettings
     public bool PackageMigrationsUnattended { get; set; } = true;
 
     /// <summary>
+    ///     Gets or sets the maximum time a migration leadership claim is considered valid before
+    ///     another server may take over. Protects against a leader crashing mid-migration.
+    /// </summary>
+    /// <remarks>
+    ///     Only relevant in load-balanced deployments with <see cref="UpgradeUnattended"/> enabled.
+    ///     Default is 2 hours, which should exceed the longest reasonable migration run time.
+    /// </remarks>
+    public TimeSpan MigrationClaimTimeout { get; set; } = TimeSpan.FromHours(2);
+
+    /// <summary>
     ///     Gets or sets a value to use for creating a user with a name for Unattended Installs
     /// </summary>
     public string? UnattendedUserName { get; set; } = null;

--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -36,6 +36,14 @@ public static partial class Constants
             ///     The key used to store the Umbraco pre-migrations upgrade plan state.
             /// </summary>
             public const string UmbracoUpgradePlanPremigrationsKey = KeyValuePrefix + UmbracoUpgradePlanPremigrationsName;
+
+            /// <summary>
+            ///     The key used to coordinate migration leadership across servers in a load-balanced
+            ///     environment. The value is either empty (no active leader) or
+            ///     <c>"{machineIdentifier}|{claimedAtUtc:O}"</c> when a server holds the claim,
+            ///     where <c>machineIdentifier</c> is the value returned by <see cref="Umbraco.Cms.Core.Factories.IMachineInfoFactory.GetMachineIdentifier"/>.
+            /// </summary>
+            public const string UpgradeLockKey = "Umbraco.Core.Upgrader.Lock";
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -94,6 +94,7 @@ public static partial class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<RuntimeUnattendedInstallNotification, UnattendedInstaller>();
         builder.AddNotificationAsyncHandler<RuntimeUnattendedUpgradeNotification, UnattendedUpgrader>();
         builder.AddNotificationAsyncHandler<RuntimePremigrationsUpgradeNotification, PremigrationUpgrader>();
+        builder.Services.AddSingleton<IMigrationCoordinator, MigrationCoordinator>();
         builder.Services.AddHostedService<UnattendedUpgradeBackgroundService>();
 
         // Database availability check.

--- a/src/Umbraco.Infrastructure/Install/IMigrationCoordinator.cs
+++ b/src/Umbraco.Infrastructure/Install/IMigrationCoordinator.cs
@@ -1,0 +1,24 @@
+namespace Umbraco.Cms.Infrastructure.Install;
+
+/// <summary>
+/// Coordinates migration leadership across servers in a load-balanced environment.
+/// </summary>
+internal interface IMigrationCoordinator
+{
+    /// <summary>
+    /// Attempts to become the migration leader, blocking until either this server wins the claim
+    /// or another server completes all migrations.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels the leadership wait loop.</param>
+    /// <returns>
+    /// <c>true</c> if this server is the migration leader and must call <see cref="ReleaseLeadership"/> after
+    /// running migrations; <c>false</c> if another server completed migrations and this server should skip them.
+    /// </returns>
+    Task<bool> TryBecomeLeaderAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Releases the migration leadership claim if it is still held by this instance.
+    /// Must be called in a <c>finally</c> block to ensure release even on failure.
+    /// </summary>
+    void ReleaseLeadership();
+}

--- a/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
+++ b/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
@@ -46,7 +46,6 @@ internal sealed class MigrationCoordinator : IMigrationCoordinator
 
         while (cancellationToken.IsCancellationRequested is false)
         {
-            _leaderClaim = $"{machineIdentifier}|{DateTimeOffset.UtcNow:O}";
             if (TryClaimLeadership(machineIdentifier))
             {
                 _logger.LogInformation("This server claimed migration leadership.");
@@ -142,7 +141,8 @@ internal sealed class MigrationCoordinator : IMigrationCoordinator
 
         if (canClaim)
         {
-            _keyValueService.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, _leaderClaim!);
+            _leaderClaim = $"{machineIdentifier}|{DateTimeOffset.UtcNow:O}";
+            _keyValueService.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, _leaderClaim);
         }
 
         scope.Complete();

--- a/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
+++ b/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
@@ -43,10 +43,10 @@ internal sealed class MigrationCoordinator : IMigrationCoordinator
     public async Task<bool> TryBecomeLeaderAsync(CancellationToken cancellationToken)
     {
         var machineIdentifier = _machineInfoFactory.GetMachineIdentifier();
-        _leaderClaim = $"{machineIdentifier}|{DateTimeOffset.UtcNow:O}";
 
         while (cancellationToken.IsCancellationRequested is false)
         {
+            _leaderClaim = $"{machineIdentifier}|{DateTimeOffset.UtcNow:O}";
             if (TryClaimLeadership(machineIdentifier))
             {
                 _logger.LogInformation("This server claimed migration leadership.");
@@ -72,7 +72,15 @@ internal sealed class MigrationCoordinator : IMigrationCoordinator
                     return false;
                 default:
                     _logger.LogDebug("Waiting for migration leader to finish...");
-                    await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        return false;
+                    }
+
                     break;
             }
         }

--- a/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
+++ b/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
@@ -56,6 +56,10 @@ internal sealed class MigrationCoordinator : IMigrationCoordinator
             {
                 _runtimeState.DetermineRuntimeLevel();
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Could not determine runtime level during migration wait; will retry.");

--- a/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
+++ b/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Factories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.Install;
+
+/// <summary>
+/// Coordinates migration leadership across servers in a load-balanced environment.
+/// Exactly one server claims leadership, runs all migrations, then releases the claim.
+/// All other servers wait until the leader finishes, then proceed with per-server initialization.
+/// </summary>
+internal sealed class MigrationCoordinator : IMigrationCoordinator
+{
+    private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IKeyValueService _keyValueService;
+    private readonly IRuntimeState _runtimeState;
+    private readonly IMachineInfoFactory _machineInfoFactory;
+    private readonly IOptions<UnattendedSettings> _unattendedSettings;
+    private readonly ILogger<MigrationCoordinator> _logger;
+    private string? _leaderClaim;
+
+    public MigrationCoordinator(
+        ICoreScopeProvider scopeProvider,
+        IKeyValueService keyValueService,
+        IRuntimeState runtimeState,
+        IMachineInfoFactory machineInfoFactory,
+        IOptions<UnattendedSettings> unattendedSettings,
+        ILogger<MigrationCoordinator> logger)
+    {
+        _scopeProvider = scopeProvider;
+        _keyValueService = keyValueService;
+        _runtimeState = runtimeState;
+        _machineInfoFactory = machineInfoFactory;
+        _unattendedSettings = unattendedSettings;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> TryBecomeLeaderAsync(CancellationToken cancellationToken)
+    {
+        var machineIdentifier = _machineInfoFactory.GetMachineIdentifier();
+        _leaderClaim = $"{machineIdentifier}|{DateTimeOffset.UtcNow:O}";
+
+        while (cancellationToken.IsCancellationRequested is false)
+        {
+            if (TryClaimLeadership(machineIdentifier))
+            {
+                _logger.LogInformation("This server claimed migration leadership.");
+                return true;
+            }
+
+            try
+            {
+                _runtimeState.DetermineRuntimeLevel();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not determine runtime level during migration wait; will retry.");
+            }
+
+            switch (_runtimeState.Level)
+            {
+                case RuntimeLevel.Run:
+                    _logger.LogInformation("Migrations completed by another server; proceeding as follower.");
+                    return false;
+                case RuntimeLevel.BootFailed:
+                    _logger.LogError("Runtime entered BootFailed state while waiting for migrations.");
+                    return false;
+                default:
+                    _logger.LogDebug("Waiting for migration leader to finish...");
+                    await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public void ReleaseLeadership()
+    {
+        if (_leaderClaim is null)
+        {
+            return;
+        }
+
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        scope.WriteLock(Constants.Locks.KeyValues);
+
+        string? current = _keyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
+        if (current == _leaderClaim)
+        {
+            _keyValueService.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, string.Empty);
+        }
+
+        scope.Complete();
+        _leaderClaim = null;
+    }
+
+    private static bool IsStale(string claim, TimeSpan timeout)
+    {
+        var separatorIndex = claim.IndexOf('|');
+        return separatorIndex < 0
+               || !DateTimeOffset.TryParse(claim.AsSpan(separatorIndex + 1), out DateTimeOffset timestamp)
+               || DateTimeOffset.UtcNow - timestamp > timeout;
+    }
+
+    // Acquires WriteLock(KeyValues) so the read-then-write is serialized across all servers.
+    // Inner GetValue and SetValue calls create nested scopes that join the outer transaction;
+    // their internal WriteLock requests are no-ops because the lock is already held.
+    private bool TryClaimLeadership(string machineIdentifier)
+    {
+        TimeSpan timeout = _unattendedSettings.Value.MigrationClaimTimeout;
+
+        using ICoreScope scope = _scopeProvider.CreateCoreScope();
+        scope.WriteLock(Constants.Locks.KeyValues);
+
+        string? current = _keyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
+
+        bool canClaim = string.IsNullOrEmpty(current)
+            || IsStale(current, timeout)
+            || current.StartsWith(machineIdentifier + "|", StringComparison.Ordinal);
+
+        if (canClaim)
+        {
+            _keyValueService.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, _leaderClaim!);
+        }
+
+        scope.Complete();
+        return canClaim;
+    }
+}

--- a/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
+++ b/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
@@ -96,17 +96,24 @@ internal sealed class MigrationCoordinator : IMigrationCoordinator
             return;
         }
 
-        using ICoreScope scope = _scopeProvider.CreateCoreScope();
-        scope.WriteLock(Constants.Locks.KeyValues);
-
-        string? current = _keyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
-        if (current == _leaderClaim)
+        try
         {
-            _keyValueService.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, string.Empty);
-        }
+            using ICoreScope scope = _scopeProvider.CreateCoreScope();
+            scope.WriteLock(Constants.Locks.KeyValues);
 
-        scope.Complete();
-        _leaderClaim = null;
+            string? current = _keyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
+            if (current == _leaderClaim)
+            {
+                _keyValueService.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, string.Empty);
+            }
+
+            scope.Complete();
+            _leaderClaim = null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to release migration leadership; continuing shutdown because leadership release is best-effort.");
+        }
     }
 
     private static bool IsStale(string claim, TimeSpan timeout)

--- a/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
+++ b/src/Umbraco.Infrastructure/Install/MigrationCoordinator.cs
@@ -48,6 +48,28 @@ internal sealed class MigrationCoordinator : IMigrationCoordinator
         {
             if (TryClaimLeadership(machineIdentifier))
             {
+                // Re-check after claiming: the previous leader may have finished between our last
+                // DetermineRuntimeLevel call and our successful claim of the now-empty lock.
+                try
+                {
+                    _runtimeState.DetermineRuntimeLevel();
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return false;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not re-determine runtime level after claiming leadership; proceeding as leader.");
+                }
+
+                if (_runtimeState.Level == RuntimeLevel.Run)
+                {
+                    ReleaseLeadership();
+                    _logger.LogInformation("Migrations completed by another server; proceeding as follower.");
+                    return false;
+                }
+
                 _logger.LogInformation("This server claimed migration leadership.");
                 return true;
             }

--- a/src/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundService.cs
+++ b/src/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundService.cs
@@ -63,15 +63,17 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
 
         _logger.LogInformation("Unattended upgrade background service started.");
 
-        bool isLeader = await _coordinator.TryBecomeLeaderAsync(stoppingToken);
-
-        if (_runtimeState.Level == RuntimeLevel.BootFailed)
-        {
-            return;
-        }
+        bool isLeader = false;
 
         try
         {
+            isLeader = await _coordinator.TryBecomeLeaderAsync(stoppingToken);
+
+            if (_runtimeState.Level == RuntimeLevel.BootFailed)
+            {
+                return;
+            }
+
             if (isLeader)
             {
                 // Belt-and-suspenders for graceful shutdowns (e.g. Azure SIGTERM): release the claim

--- a/src/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundService.cs
+++ b/src/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundService.cs
@@ -24,6 +24,7 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
     private readonly IEventAggregator _eventAggregator;
     private readonly ComponentCollection _components;
     private readonly IHostApplicationLifetime _hostApplicationLifetime;
+    private readonly IMigrationCoordinator _coordinator;
     private readonly ILogger<UnattendedUpgradeBackgroundService> _logger;
 
     /// <summary>
@@ -33,18 +34,21 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
     /// <param name="eventAggregator">The event aggregator used to publish upgrade notifications.</param>
     /// <param name="components">The component collection to initialize after migration completes.</param>
     /// <param name="hostApplicationLifetime">The host application lifetime for registering started/stopped callbacks.</param>
+    /// <param name="coordinator">Coordinates migration leadership across servers in a load-balanced environment.</param>
     /// <param name="logger">The logger.</param>
     public UnattendedUpgradeBackgroundService(
         IRuntimeState runtimeState,
         IEventAggregator eventAggregator,
         ComponentCollection components,
         IHostApplicationLifetime hostApplicationLifetime,
+        IMigrationCoordinator coordinator,
         ILogger<UnattendedUpgradeBackgroundService> logger)
     {
         _runtimeState = runtimeState;
         _eventAggregator = eventAggregator;
         _components = components;
         _hostApplicationLifetime = hostApplicationLifetime;
+        _coordinator = coordinator;
         _logger = logger;
     }
 
@@ -59,9 +63,28 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
 
         _logger.LogInformation("Unattended upgrade background service started.");
 
+        bool isLeader = await _coordinator.TryBecomeLeaderAsync(stoppingToken);
+
+        if (_runtimeState.Level == RuntimeLevel.BootFailed)
+        {
+            return;
+        }
+
         try
         {
-            await RunMigrationsAsync(stoppingToken);
+            if (isLeader)
+            {
+                // Belt-and-suspenders for graceful shutdowns (e.g. Azure SIGTERM): release the claim
+                // as soon as the host begins stopping, even if a migration step is still blocking.
+                _hostApplicationLifetime.ApplicationStopping.Register(() => _coordinator.ReleaseLeadership());
+                await RunMigrationsAsync(stoppingToken);
+            }
+            else
+            {
+                // Follower: rebuild per-server in-memory navigation and publish status
+                // from the fully-migrated database.
+                await _eventAggregator.PublishAsync(new PostRuntimePremigrationsUpgradeNotification(), stoppingToken);
+            }
         }
         catch (Exception ex)
         {
@@ -69,14 +92,20 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
             _runtimeState.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, ex);
             return;
         }
+        finally
+        {
+            // Always release the claim — even on leader failure — so other servers
+            // can detect completion or take over.
+            if (isLeader)
+            {
+                _coordinator.ReleaseLeadership();
+            }
+        }
 
-        // Re-evaluate runtime level after migrations complete. This handles all result cases:
-        // - CoreUpgradeComplete / PackageMigrationComplete: confirms the new Run level.
-        // - NotRequired: another instance may have already run migrations; re-check to get Run level.
-        // - HasErrors: BootFailedException is set, so DetermineRuntimeLevel() returns early (no-op).
+        // For the leader: confirms migrations succeeded and level transitions to Run.
+        // For followers: level is already Run (set during TryBecomeLeaderAsync polling).
         DetermineRuntimeLevel();
 
-        // RunMigrationsAsync may have set BootFailed via a non-throwing error path (HasErrors result).
         if (_runtimeState.Level == RuntimeLevel.BootFailed)
         {
             return;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Factories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Install;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Install;
+
+[TestFixture]
+[Timeout(60000)]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class MigrationCoordinatorTests : UmbracoIntegrationTest
+{
+    private IKeyValueService KeyValueService => GetRequiredService<IKeyValueService>();
+
+    // Persistence
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenNoClaim_WritesClaimToDatabase()
+    {
+        var coordinator = CreateCoordinator("machine-a", CreateUpgradingRuntimeState().Object);
+
+        await coordinator.TryBecomeLeaderAsync(CancellationToken.None);
+
+        var claim = KeyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
+        Assert.That(claim, Does.StartWith("machine-a|"));
+    }
+
+    [Test]
+    public async Task ReleaseLeadership_AfterClaimingLeadership_ClearsKeyInDatabase()
+    {
+        var coordinator = CreateCoordinator("machine-a", CreateUpgradingRuntimeState().Object);
+        await coordinator.TryBecomeLeaderAsync(CancellationToken.None);
+
+        coordinator.ReleaseLeadership();
+
+        var claim = KeyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
+        Assert.That(claim, Is.Null.Or.Empty);
+    }
+
+    // Stale claim takeover
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenExistingClaimIsStale_TakesOverLeadership()
+    {
+        var staleTimestamp = DateTimeOffset.UtcNow.AddHours(-3).ToString("O");
+        KeyValueService.SetValue(
+            Constants.Conventions.Migrations.UpgradeLockKey,
+            $"crashed-server|{staleTimestamp}");
+
+        var coordinator = CreateCoordinator("machine-a", CreateUpgradingRuntimeState().Object, claimTimeout: TimeSpan.FromHours(2));
+        var result = await coordinator.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsTrue(result);
+        var claim = KeyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
+        Assert.That(claim, Does.StartWith("machine-a|"));
+    }
+
+    // Concurrent race — the core guarantee
+
+    [Test]
+    public void TryBecomeLeaderAsync_WhenTwoCoordinatorsRaceConcurrently_ExactlyOneWins()
+    {
+        // Both mocks start Upgrading and transition to Run on the first DetermineRuntimeLevel call.
+        // The coordinator that wins the claim returns true immediately without calling DetermineRuntimeLevel.
+        // The coordinator that loses calls DetermineRuntimeLevel once, sees Run, and returns false.
+        var runtimeState1 = CreateTransitioningRuntimeState();
+        var runtimeState2 = CreateTransitioningRuntimeState();
+
+        var coordinator1 = CreateCoordinator("machine-a", runtimeState1.Object);
+        var coordinator2 = CreateCoordinator("machine-b", runtimeState2.Object);
+
+        bool? result1 = null;
+        bool? result2 = null;
+        Exception? ex1 = null;
+        Exception? ex2 = null;
+
+        var gate = new ManualResetEventSlim(false);
+
+        var t1 = new Thread(() =>
+        {
+            try
+            {
+                gate.Wait();
+                result1 = coordinator1.TryBecomeLeaderAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                ex1 = ex;
+            }
+        });
+
+        var t2 = new Thread(() =>
+        {
+            try
+            {
+                gate.Wait();
+                result2 = coordinator2.TryBecomeLeaderAsync(CancellationToken.None).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                ex2 = ex;
+            }
+        });
+
+        // Suppress ambient scope from leaking into worker threads (matches LocksTests pattern).
+        using (ExecutionContext.SuppressFlow())
+        {
+            t1.Start();
+            t2.Start();
+        }
+
+        gate.Set();
+        t1.Join();
+        t2.Join();
+
+        Assert.IsNull(ex1, $"Coordinator 1 threw: {ex1}");
+        Assert.IsNull(ex2, $"Coordinator 2 threw: {ex2}");
+        Assert.IsNotNull(result1);
+        Assert.IsNotNull(result2);
+        Assert.AreNotEqual(result1, result2, "Exactly one coordinator should win leadership");
+
+        var winnerId = result1 == true ? "machine-a" : "machine-b";
+        var claim = KeyValueService.GetValue(Constants.Conventions.Migrations.UpgradeLockKey);
+        Assert.That(claim, Does.StartWith(winnerId + "|"));
+    }
+
+    private MigrationCoordinator CreateCoordinator(
+        string machineId,
+        IRuntimeState runtimeState,
+        TimeSpan? claimTimeout = null)
+    {
+        var machineInfoFactory = Mock.Of<IMachineInfoFactory>(
+            f => f.GetMachineIdentifier() == machineId);
+
+        var settings = Options.Create(new UnattendedSettings
+        {
+            MigrationClaimTimeout = claimTimeout ?? TimeSpan.FromHours(2),
+        });
+
+        return new MigrationCoordinator(
+            GetRequiredService<ICoreScopeProvider>(),
+            GetRequiredService<IKeyValueService>(),
+            runtimeState,
+            machineInfoFactory,
+            settings,
+            NullLogger<MigrationCoordinator>.Instance);
+    }
+
+    private static Mock<IRuntimeState> CreateUpgradingRuntimeState()
+    {
+        var mock = new Mock<IRuntimeState>();
+        mock.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+        return mock;
+    }
+
+    private static Mock<IRuntimeState> CreateTransitioningRuntimeState()
+    {
+        var mock = new Mock<IRuntimeState>();
+        mock.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+        mock.Setup(x => x.DetermineRuntimeLevel())
+            .Callback(() => mock.SetupGet(x => x.Level).Returns(RuntimeLevel.Run));
+        return mock;
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
@@ -71,9 +71,10 @@ internal sealed class MigrationCoordinatorTests : UmbracoIntegrationTest
     [Test]
     public void TryBecomeLeaderAsync_WhenTwoCoordinatorsRaceConcurrently_ExactlyOneWins()
     {
-        // Both mocks start Upgrading and transition to Run on the first DetermineRuntimeLevel call.
-        // The coordinator that wins the claim returns true immediately without calling DetermineRuntimeLevel.
-        // The coordinator that loses calls DetermineRuntimeLevel once, sees Run, and returns false.
+        // Both mocks start Upgrading. The winner calls DetermineRuntimeLevel once (post-claim check)
+        // and sees Upgrading — migrations haven't run yet, so it continues as leader and returns true.
+        // The loser calls DetermineRuntimeLevel twice: the first poll keeps Upgrading (5 s sleep),
+        // the second transitions to Run, and the loser returns false.
         var runtimeState1 = CreateTransitioningRuntimeState();
         var runtimeState2 = CreateTransitioningRuntimeState();
 
@@ -168,8 +169,19 @@ internal sealed class MigrationCoordinatorTests : UmbracoIntegrationTest
     {
         var mock = new Mock<IRuntimeState>();
         mock.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+
+        // The winner calls DetermineRuntimeLevel() once from the post-claim check and should
+        // still see Upgrading (migrations haven't run yet). The loser calls it from the poll
+        // loop — first call keeps Upgrading, so it sleeps once; second call transitions to Run.
+        int callCount = 0;
         mock.Setup(x => x.DetermineRuntimeLevel())
-            .Callback(() => mock.SetupGet(x => x.Level).Returns(RuntimeLevel.Run));
+            .Callback(() =>
+            {
+                if (Interlocked.Increment(ref callCount) >= 2)
+                {
+                    mock.SetupGet(x => x.Level).Returns(RuntimeLevel.Run);
+                }
+            });
         return mock;
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
@@ -36,8 +36,6 @@ public class MigrationCoordinatorTests
         SetupScopeProviderMock();
     }
 
-    // TryBecomeLeaderAsync — claim acquisition
-
     [Test]
     public async Task TryBecomeLeaderAsync_WhenClaimKeyIsEmpty_ClaimsLeadershipAndReturnsTrue()
     {
@@ -93,8 +91,6 @@ public class MigrationCoordinatorTests
                 It.Is<string>(v => v.StartsWith(TestMachineIdentifier + "|"))),
             Times.Once);
     }
-
-    // TryBecomeLeaderAsync — follower path
 
     [Test]
     public async Task TryBecomeLeaderAsync_WhenOtherMachineHoldsClaim_PollsUntilRunLevelAndReturnsFalse()
@@ -154,8 +150,6 @@ public class MigrationCoordinatorTests
         Assert.IsFalse(result);
     }
 
-    // TryBecomeLeaderAsync — cancellation
-
     [Test]
     public async Task TryBecomeLeaderAsync_WhenCancelledBeforeFirstIteration_ReturnsFalse()
     {
@@ -177,8 +171,6 @@ public class MigrationCoordinatorTests
                 It.IsAny<bool>()),
             Times.Never);
     }
-
-    // ReleaseLeadership
 
     [Test]
     public async Task ReleaseLeadership_WhenClaimMatchesDatabaseValue_ClearsKey()

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
@@ -93,6 +93,38 @@ public class MigrationCoordinatorTests
     }
 
     [Test]
+    public async Task TryBecomeLeaderAsync_WhenLeaderFinishedBetweenPollAndClaim_ReleasesClaimAndReturnsFalse()
+    {
+        // Simulate TOCTOU: lock is empty (leader released between our last DetermineRuntimeLevel and our claim).
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns((string?)null);
+
+        // DetermineRuntimeLevel transitions level to Run (leader already finished).
+        _runtimeStateMock.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+        _runtimeStateMock
+            .Setup(x => x.DetermineRuntimeLevel())
+            .Callback(() => _runtimeStateMock.SetupGet(x => x.Level).Returns(RuntimeLevel.Run));
+
+        string? capturedClaim = null;
+        _keyValueServiceMock
+            .Setup(x => x.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, It.IsAny<string>()))
+            .Callback<string, string>((_, v) => capturedClaim = v);
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns(() => capturedClaim);
+
+        var sut = CreateSut();
+        var result = await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsFalse(result);
+        // The claim was written then cleared by ReleaseLeadership.
+        _keyValueServiceMock.Verify(
+            x => x.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, string.Empty),
+            Times.Once);
+    }
+
+    [Test]
     public async Task TryBecomeLeaderAsync_WhenOtherMachineHoldsClaim_PollsUntilRunLevelAndReturnsFalse()
     {
         var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O");

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/MigrationCoordinatorTests.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Factories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Install;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Install;
+
+[TestFixture]
+public class MigrationCoordinatorTests
+{
+    private const string TestMachineIdentifier = "test-machine";
+    private const string OtherMachineIdentifier = "other-machine";
+
+    private Mock<ICoreScopeProvider> _scopeProviderMock = null!;
+    private Mock<IKeyValueService> _keyValueServiceMock = null!;
+    private Mock<IRuntimeState> _runtimeStateMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _scopeProviderMock = new Mock<ICoreScopeProvider>();
+        _keyValueServiceMock = new Mock<IKeyValueService>();
+        _runtimeStateMock = new Mock<IRuntimeState>();
+
+        SetupScopeProviderMock();
+    }
+
+    // TryBecomeLeaderAsync — claim acquisition
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenClaimKeyIsEmpty_ClaimsLeadershipAndReturnsTrue()
+    {
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns((string?)null);
+
+        var sut = CreateSut();
+        var result = await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsTrue(result);
+        _keyValueServiceMock.Verify(
+            x => x.SetValue(
+                Constants.Conventions.Migrations.UpgradeLockKey,
+                It.Is<string>(v => v.StartsWith(TestMachineIdentifier + "|"))),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenClaimIsStale_ClaimsLeadershipAndReturnsTrue()
+    {
+        var staleTimestamp = DateTimeOffset.UtcNow.AddHours(-3).ToString("O");
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns($"{OtherMachineIdentifier}|{staleTimestamp}");
+
+        var sut = CreateSut(claimTimeout: TimeSpan.FromHours(2));
+        var result = await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsTrue(result);
+        _keyValueServiceMock.Verify(
+            x => x.SetValue(
+                Constants.Conventions.Migrations.UpgradeLockKey,
+                It.Is<string>(v => v.StartsWith(TestMachineIdentifier + "|"))),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenClaimBelongsToSameMachine_ReclaimsAndReturnsTrue()
+    {
+        var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O");
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns($"{TestMachineIdentifier}|{recentTimestamp}");
+
+        var sut = CreateSut();
+        var result = await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsTrue(result);
+        _keyValueServiceMock.Verify(
+            x => x.SetValue(
+                Constants.Conventions.Migrations.UpgradeLockKey,
+                It.Is<string>(v => v.StartsWith(TestMachineIdentifier + "|"))),
+            Times.Once);
+    }
+
+    // TryBecomeLeaderAsync — follower path
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenOtherMachineHoldsClaim_PollsUntilRunLevelAndReturnsFalse()
+    {
+        var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O");
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns($"{OtherMachineIdentifier}|{recentTimestamp}");
+
+        _runtimeStateMock.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+        _runtimeStateMock
+            .Setup(x => x.DetermineRuntimeLevel())
+            .Callback(() => _runtimeStateMock.SetupGet(x => x.Level).Returns(RuntimeLevel.Run));
+
+        var sut = CreateSut();
+        var result = await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenOtherMachineHoldsClaim_PollsUntilBootFailedAndReturnsFalse()
+    {
+        var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O");
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns($"{OtherMachineIdentifier}|{recentTimestamp}");
+
+        _runtimeStateMock.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+        _runtimeStateMock
+            .Setup(x => x.DetermineRuntimeLevel())
+            .Callback(() => _runtimeStateMock.SetupGet(x => x.Level).Returns(RuntimeLevel.BootFailed));
+
+        var sut = CreateSut();
+        var result = await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenDetermineRuntimeLevelThrows_LogsWarningAndReturnsFalseWhenRunDetected()
+    {
+        var recentTimestamp = DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O");
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns($"{OtherMachineIdentifier}|{recentTimestamp}");
+
+        // Level returns Run so the switch exits without sleeping; DetermineRuntimeLevel still throws.
+        _runtimeStateMock.SetupGet(x => x.Level).Returns(RuntimeLevel.Run);
+        _runtimeStateMock
+            .Setup(x => x.DetermineRuntimeLevel())
+            .Throws(new InvalidOperationException("db gone"));
+
+        var sut = CreateSut();
+        var result = await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        Assert.IsFalse(result);
+    }
+
+    // TryBecomeLeaderAsync — cancellation
+
+    [Test]
+    public async Task TryBecomeLeaderAsync_WhenCancelledBeforeFirstIteration_ReturnsFalse()
+    {
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sut = CreateSut();
+        var result = await sut.TryBecomeLeaderAsync(cts.Token);
+
+        Assert.IsFalse(result);
+        _scopeProviderMock.Verify(
+            x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher>(),
+                It.IsAny<IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    // ReleaseLeadership
+
+    [Test]
+    public async Task ReleaseLeadership_WhenClaimMatchesDatabaseValue_ClearsKey()
+    {
+        string? capturedClaim = null;
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns(() => capturedClaim);
+        _keyValueServiceMock
+            .Setup(x => x.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, It.IsAny<string>()))
+            .Callback<string, string>((_, v) => capturedClaim = v);
+
+        var sut = CreateSut();
+        await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        sut.ReleaseLeadership();
+
+        _keyValueServiceMock.Verify(
+            x => x.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, string.Empty),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task ReleaseLeadership_WhenDatabaseValueDiffersFromLeaderClaim_DoesNotClearKey()
+    {
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns((string?)null);
+
+        var sut = CreateSut();
+        await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        // Another server has since taken over the claim.
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns($"{OtherMachineIdentifier}|{DateTimeOffset.UtcNow:O}");
+
+        sut.ReleaseLeadership();
+
+        _keyValueServiceMock.Verify(
+            x => x.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, string.Empty),
+            Times.Never);
+    }
+
+    [Test]
+    public void ReleaseLeadership_WhenCalledBeforeTryBecomeLeaderAsync_DoesNothing()
+    {
+        var sut = CreateSut();
+        sut.ReleaseLeadership();
+
+        _scopeProviderMock.Verify(
+            x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher>(),
+                It.IsAny<IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task ReleaseLeadership_WhenCalledTwice_IsIdempotent()
+    {
+        string? capturedClaim = null;
+        _keyValueServiceMock
+            .Setup(x => x.GetValue(Constants.Conventions.Migrations.UpgradeLockKey))
+            .Returns(() => capturedClaim);
+        _keyValueServiceMock
+            .Setup(x => x.SetValue(Constants.Conventions.Migrations.UpgradeLockKey, It.IsAny<string>()))
+            .Callback<string, string>((_, v) => capturedClaim = v);
+
+        var sut = CreateSut();
+        await sut.TryBecomeLeaderAsync(CancellationToken.None);
+
+        sut.ReleaseLeadership(); // Clears claim, sets _leaderClaim = null.
+        sut.ReleaseLeadership(); // _leaderClaim is null — returns immediately, no scope created.
+
+        // TryBecomeLeaderAsync: 1 scope, first ReleaseLeadership: 1 scope, second: 0 scopes.
+        _scopeProviderMock.Verify(
+            x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher>(),
+                It.IsAny<IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()),
+            Times.Exactly(2));
+    }
+
+    private MigrationCoordinator CreateSut(
+        string machineIdentifier = TestMachineIdentifier,
+        TimeSpan? claimTimeout = null)
+    {
+        var machineInfoFactory = Mock.Of<IMachineInfoFactory>(
+            f => f.GetMachineIdentifier() == machineIdentifier);
+
+        var settings = Options.Create(new UnattendedSettings
+        {
+            MigrationClaimTimeout = claimTimeout ?? TimeSpan.FromMinutes(5),
+        });
+
+        return new MigrationCoordinator(
+            _scopeProviderMock.Object,
+            _keyValueServiceMock.Object,
+            _runtimeStateMock.Object,
+            machineInfoFactory,
+            settings,
+            NullLogger<MigrationCoordinator>.Instance);
+    }
+
+    private void SetupScopeProviderMock() =>
+        _scopeProviderMock
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher>(),
+                It.IsAny<IScopedNotificationPublisher>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(Mock.Of<ICoreScope>());
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundServiceTests.cs
@@ -232,19 +232,32 @@ public class UnattendedUpgradeBackgroundServiceTests
     private static UnattendedUpgradeBackgroundService CreateSut(
         IRuntimeState runtimeState,
         IEventAggregator eventAggregator,
-        IHostApplicationLifetime? hostApplicationLifetime = null)
+        IHostApplicationLifetime? hostApplicationLifetime = null,
+        IMigrationCoordinator? coordinator = null)
     {
         var components = new ComponentCollection(
             () => Enumerable.Empty<IAsyncComponent>(),
             Mock.Of<IProfilingLogger>(),
             NullLogger<ComponentCollection>.Instance);
 
+        // Default coordinator acts as the migration leader so existing tests cover the leader path.
+        coordinator ??= CreateLeaderCoordinator();
+
         return new UnattendedUpgradeBackgroundService(
             runtimeState,
             eventAggregator,
             components,
             hostApplicationLifetime ?? CreateMockLifetime().Object,
+            coordinator,
             NullLogger<UnattendedUpgradeBackgroundService>.Instance);
+    }
+
+    private static IMigrationCoordinator CreateLeaderCoordinator()
+    {
+        var mock = new Mock<IMigrationCoordinator>();
+        mock.Setup(x => x.TryBecomeLeaderAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return mock.Object;
     }
 
     private static Mock<IRuntimeState> CreateMockRuntimeState(


### PR DESCRIPTION
## Summary

In load-balanced deployments with `UpgradeUnattended: true`, every server previously entered `RunMigrationsAsync()` concurrently. Schema-altering SQL (ALTER TABLE, CREATE INDEX, etc.) would fail on all-but-one server because the object already existed, causing `BootFailed` on every server except the first to finish.

- Introduces `IMigrationCoordinator` / `MigrationCoordinator` — a claim-based coordinator that uses an entry in `umbracoKeyValue` (serialised by `WriteLock(Constants.Locks.KeyValues)`) to elect exactly one migration leader per upgrade
- The leader runs the full migration sequence; followers wait until the leader finishes, then perform their own per-server in-memory rebuild (`PostRuntimePremigrationsUpgradeNotification`) and component initialisation
- `ReleaseLeadership()` is called in both the `finally` block and an `ApplicationStopping` callback (belt-and-suspenders for graceful Azure SIGTERM restarts)
- Stale claims (default 2-hour timeout, configurable via `UnattendedSettings.MigrationClaimTimeout`) are taken over automatically as a last resort for hard crashes
- Adds 11 unit tests (state machine logic) and 4 integration tests (real DB write/read, stale claim takeover, concurrent race verifying `WriteLock` serialisation)

## Test plan
Add some mock upgrades to UmbracoPlan, PreMigrationPlan, etc...

  1. Point two Umbraco instances at the same database with a pending migration and `UpgradeUnattended: true`
  2. Give each instance a distinct identity by setting a different `Umbraco:Hosting:SiteName` in each instance's `appsettings.json` — this is what `IMachineInfoFactory.GetMachineIdentifier()` uses to distinguish servers on the same machine
  3. **Important**: start each instance with **Ctrl+F5** in Rider (Run without debugging), not F5. Stopping with F5 sends SIGKILL, which bypasses the graceful shutdown and prevents `ApplicationStopping` from releasing the migration leadership claim
  4. Start both instances simultaneously and verify: only one runs migrations, the other waits and initialises normally, and both reach `Run`

I tried some different scenarios like:

* Slow migration, leader stops halfway through -> Follower gets elected 
* Happy Path with slow migration -> Leader finishes, follower starts normally
* Exception happens -> Leader crashes, follower attempts, follower crashes, expected
* Leader dies with SIGKILL -> leadership isn't released, this is expected, but because the leader identity remains the same, it's elected after a reboot