### PR TITLE
Localization: Honor DefaultUILanguage on initial load (closes #22808)

### DIFF
--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
@@ -21,7 +21,7 @@
     var backOfficeAssetsPath = BackOfficePathGenerator.BackOfficeAssetsPath;
     var loginLogoImageAlternative = Url.RouteUrl(BackOfficeGraphicsController.LoginLogoAlternativeRouteName, new {Version= "1"});
 }<!doctype html>
-<html lang="@GlobalSettings.Value.DefaultUILanguage">
+<html lang="en">
 
 <head>
     <meta charset="UTF-8" />

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoBackOffice/Index.cshtml
@@ -61,7 +61,7 @@
         <p>Here are the <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener" style="text-decoration: underline;">instructions how to enable JavaScript in your web browser</a>.</p>
     </div>
 </noscript>
-<umb-app @(SecuritySettings.Value.KeepUserLoggedIn ? "keep-user-logged-in" : "")></umb-app>
+<umb-app lang="@GlobalSettings.Value.DefaultUILanguage" @(SecuritySettings.Value.KeepUserLoggedIn ? "keep-user-logged-in" : "")></umb-app>
 
 @if (isDebug)
 {

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -35,7 +35,7 @@
 }
 
 <!DOCTYPE html>
-<html lang="@GlobalSettings.Value.DefaultUILanguage">
+<html lang="en">
 <head>
     <meta charset="UTF-8"/>
     <base href="@backOfficePath.EnsureEndsWith('/')" />

--- a/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
+++ b/src/Umbraco.Cms.StaticAssets/umbraco/UmbracoLogin/Index.cshtml
@@ -83,6 +83,7 @@
 </noscript>
 
 <umb-auth
+    lang="@GlobalSettings.Value.DefaultUILanguage"
     return-url="@backOfficePath"
     logo-image="@loginLogoImage"
     logo-image-alternative="@loginLogoImageAlternative"

--- a/src/Umbraco.Web.UI.Client/docs/package-development.md
+++ b/src/Umbraco.Web.UI.Client/docs/package-development.md
@@ -99,6 +99,16 @@ No hardcoded UI-facing strings. All user-visible text must go through the locali
 
 For step-by-step instructions on adding localization keys and using them in elements or controllers, use the `general-add-localization` skill.
 
+### Active language
+
+The active language is driven by the shell elements `<umb-app>` and `<umb-auth>`, not by `<html lang>`:
+
+- Razor sets `lang` on the shell element from `GlobalSettings.DefaultUILanguage`. The shell reads its own `lang` on connect and calls `umbLocalizationRegistry.loadLanguage(this.lang)`.
+- After login, `current-user.context` calls `loadLanguage(user.languageIsoCode)` and the shell mirrors the new value back onto its own `lang` attribute via `umbLocalizationRegistry.currentLanguage`.
+- `<html lang>` is the static `"en"` for the noscript fallback text. Don't conflate it with the dynamic UI language.
+
+If you're adding a new shell-like element (rare — most code lives inside `<umb-app>`), give it a `lang` attribute and the same subscribe-and-mirror pattern. For everything else, just use `this.localize` and the inherited context resolves the rest.
+
 ---
 
 ## Conventions & Rules

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -213,9 +213,6 @@ export class UmbAppElement extends UmbLitElement {
 	override connectedCallback(): void {
 		super.connectedCallback();
 
-		// Keep the host's `lang` attribute in sync with the active locale so that
-		// `myApp.lang` always reflects the source of truth (the registry observable),
-		// not a stale snapshot of <html lang> taken at construction time.
 		this.observe(umbLocalizationRegistry.currentLanguage, (lang) => {
 			if (lang) this.lang = lang;
 		});

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -27,6 +27,7 @@ import {
 import { redirectToStoredPath } from '@umbraco-cms/backoffice/utils';
 import { umbHttpClient } from '@umbraco-cms/backoffice/http-client';
 import { UmbViewContext } from '@umbraco-cms/backoffice/view';
+import { umbLocalizationRegistry } from '@umbraco-cms/backoffice/localization';
 
 import './app-logo.element.js';
 import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
@@ -211,6 +212,14 @@ export class UmbAppElement extends UmbLitElement {
 
 	override connectedCallback(): void {
 		super.connectedCallback();
+
+		// Keep the host's `lang` attribute in sync with the active locale so that
+		// `myApp.lang` always reflects the source of truth (the registry observable),
+		// not a stale snapshot of <html lang> taken at construction time.
+		this.observe(umbLocalizationRegistry.currentLanguage, (lang) => {
+			if (lang) this.lang = lang;
+		});
+
 		this.#setup();
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -213,6 +213,11 @@ export class UmbAppElement extends UmbLitElement {
 	override connectedCallback(): void {
 		super.connectedCallback();
 
+		// The host's `lang` attribute is set by Razor from GlobalSettings.DefaultUILanguage.
+		// Use it as the initial active language; current-user.context overrides it after login.
+		if (this.lang) {
+			umbLocalizationRegistry.loadLanguage(this.lang);
+		}
 		this.observe(umbLocalizationRegistry.currentLanguage, (lang) => {
 			if (lang) this.lang = lang;
 		});

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -503,6 +503,32 @@ describe('UmbLocalizationController', () => {
 });
 
 describe('UmbLocalizationManager.setActiveLanguage', () => {
+	function createCountingController() {
+		let updates = 0;
+		const host = {
+			getHostElement: () => {
+				const el = document.createElement('div') as HTMLElement & { requestUpdate?: () => void };
+				el.requestUpdate = () => {
+					updates++;
+				};
+				return el;
+			},
+			addUmbController: () => {},
+			removeUmbController: () => {},
+			hasUmbController: () => false,
+			getUmbControllers: () => [],
+			removeUmbControllerByAlias: () => {},
+		} satisfies UmbControllerHost;
+		const controller = new UmbLocalizationController(host);
+		controller.hostConnected();
+		return {
+			controller,
+			get updates() {
+				return updates;
+			},
+		};
+	}
+
 	beforeEach(() => {
 		umbLocalizationManager.registerManyLocalizations([english, danish, danishRegional]);
 		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
@@ -520,55 +546,22 @@ describe('UmbLocalizationManager.setActiveLanguage', () => {
 		expect(umbLocalizationManager.documentDirection).to.equal('ltr');
 	});
 
-	it('notifies connected controllers when the language changes', async () => {
-		let updates = 0;
-		const host = {
-			getHostElement: () => {
-				const el = document.createElement('div') as HTMLElement & { requestUpdate?: () => void };
-				el.requestUpdate = () => {
-					updates++;
-				};
-				return el;
-			},
-			addUmbController: () => {},
-			removeUmbController: () => {},
-			hasUmbController: () => false,
-			getUmbControllers: () => [],
-			removeUmbControllerByAlias: () => {},
-		} satisfies UmbControllerHost;
-		const controller = new UmbLocalizationController(host);
-		controller.hostConnected();
+	it('does not notify consumers on its own — callers must follow up with notifyLanguageChanged()', () => {
+		const probe = createCountingController();
 
-		updates = 0;
 		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
 
-		expect(updates, 'expected the controller to receive a documentUpdate').to.equal(1);
-		controller.destroy();
+		expect(probe.updates).to.equal(0);
+		probe.controller.destroy();
 	});
 
-	it('is a no-op when called with the same language and direction', async () => {
-		let updates = 0;
-		const host = {
-			getHostElement: () => {
-				const el = document.createElement('div') as HTMLElement & { requestUpdate?: () => void };
-				el.requestUpdate = () => {
-					updates++;
-				};
-				return el;
-			},
-			addUmbController: () => {},
-			removeUmbController: () => {},
-			hasUmbController: () => false,
-			getUmbControllers: () => [],
-			removeUmbControllerByAlias: () => {},
-		} satisfies UmbControllerHost;
-		const controller = new UmbLocalizationController(host);
-		controller.hostConnected();
+	it('notifyLanguageChanged() flushes pending updates to connected controllers', () => {
+		const probe = createCountingController();
 
-		updates = 0;
-		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
+		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
+		umbLocalizationManager.notifyLanguageChanged();
 
-		expect(updates, 'expected no update when nothing changes').to.equal(0);
-		controller.destroy();
+		expect(probe.updates).to.equal(1);
+		probe.controller.destroy();
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -546,20 +546,10 @@ describe('UmbLocalizationManager.setActiveLanguage', () => {
 		expect(umbLocalizationManager.documentDirection).to.equal('ltr');
 	});
 
-	it('does not notify consumers on its own — callers must follow up with notifyLanguageChanged()', () => {
+	it('notifies connected controllers when the language changes', () => {
 		const probe = createCountingController();
 
 		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
-
-		expect(probe.updates).to.equal(0);
-		probe.controller.destroy();
-	});
-
-	it('notifyLanguageChanged() flushes pending updates to connected controllers', () => {
-		const probe = createCountingController();
-
-		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
-		umbLocalizationManager.notifyLanguageChanged();
 
 		expect(probe.updates).to.equal(1);
 		probe.controller.destroy();

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -83,8 +83,7 @@ describe('UmbLocalizationController', () => {
 
 	beforeEach(async () => {
 		umbLocalizationManager.registerManyLocalizations([english, danish, danishRegional]);
-		document.documentElement.lang = initialLanguage;
-		document.documentElement.dir = 'ltr';
+		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
 		await aTimeout(0);
 		const host = {
 			getHostElement: () => document.createElement('div'),
@@ -107,7 +106,7 @@ describe('UmbLocalizationController', () => {
 	});
 
 	it('should update the language when the language changes', async () => {
-		document.documentElement.lang = danishRegional.$code;
+		umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 		await aTimeout(0);
 		expect(controller.lang()).to.equal(danishRegional.$code);
 	});
@@ -117,7 +116,7 @@ describe('UmbLocalizationController', () => {
 	});
 
 	it('should update the dir when the dir changes', async () => {
-		document.documentElement.dir = 'rtl';
+		umbLocalizationManager.setActiveLanguage(initialLanguage, 'rtl');
 		await aTimeout(0);
 		expect(controller.dir()).to.equal('rtl');
 	});
@@ -129,7 +128,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should update the term when the language changes', async () => {
 			// Change language
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			expect(controller.term('close')).to.equal('Luk');
@@ -137,7 +136,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should provide a secondary term when the term is not found on the regional language', async () => {
 			// Load Danish
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			expect(controller.term('notOnRegional')).to.equal('Not on regional');
@@ -145,7 +144,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should provide a fallback term from the fallback language when the term is not found on primary or secondary', async () => {
 			// Load Danish
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			expect(controller.term('close')).to.equal('Luk'); // Primary
@@ -225,7 +224,7 @@ describe('UmbLocalizationController', () => {
 			expect(controller.date(new Date(2020, 11, 31))).to.equal('12/31/2020');
 
 			// Switch browser to Danish
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			expect(controller.date(new Date(2020, 11, 31))).to.equal('31.12.2020');
@@ -258,7 +257,7 @@ describe('UmbLocalizationController', () => {
 			const enResult = controller.dateTime(date);
 
 			// Switch browser to Danish
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			const daResult = controller.dateTime(date);
@@ -280,7 +279,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should update the number when the language changes', async () => {
 			// Switch browser to Danish
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			expect(controller.number(123456.789)).to.equal('123.456,789');
@@ -300,7 +299,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should update the relative time when the language changes', async () => {
 			// Switch browser to Danish
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			expect(controller.relativeTime(2, 'days')).to.equal('om 2 dage');
@@ -380,7 +379,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should handle the three-tier fallback before using defaultValue', async () => {
 			// Switch to Danish regional
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			// Primary (da-dk) has 'close'
@@ -401,7 +400,7 @@ describe('UmbLocalizationController', () => {
 			expect(controller.termOrDefault('close', 'X')).to.equal('Close');
 
 			// Switch to Danish
-			document.documentElement.lang = danishRegional.$code;
+			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
 			await aTimeout(0);
 
 			expect(controller.termOrDefault('close', 'X')).to.equal('Luk');
@@ -500,5 +499,76 @@ describe('UmbLocalizationController', () => {
 			await elementUpdated(element);
 			expect(element.localize.string('testing #close')).to.equal('testing Luk');
 		});
+	});
+});
+
+describe('UmbLocalizationManager.setActiveLanguage', () => {
+	beforeEach(() => {
+		umbLocalizationManager.registerManyLocalizations([english, danish, danishRegional]);
+		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
+	});
+
+	afterEach(() => {
+		umbLocalizationManager.localizations.clear();
+		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
+	});
+
+	it('updates the active language and direction', () => {
+		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
+
+		expect(umbLocalizationManager.documentLanguage).to.equal('da-dk');
+		expect(umbLocalizationManager.documentDirection).to.equal('ltr');
+	});
+
+	it('notifies connected controllers when the language changes', async () => {
+		let updates = 0;
+		const host = {
+			getHostElement: () => {
+				const el = document.createElement('div') as HTMLElement & { requestUpdate?: () => void };
+				el.requestUpdate = () => {
+					updates++;
+				};
+				return el;
+			},
+			addUmbController: () => {},
+			removeUmbController: () => {},
+			hasUmbController: () => false,
+			getUmbControllers: () => [],
+			removeUmbControllerByAlias: () => {},
+		} satisfies UmbControllerHost;
+		const controller = new UmbLocalizationController(host);
+		controller.hostConnected();
+
+		updates = 0;
+		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
+
+		expect(updates, 'expected the controller to receive a documentUpdate').to.equal(1);
+		controller.destroy();
+	});
+
+	it('is a no-op when called with the same language and direction', async () => {
+		let updates = 0;
+		const host = {
+			getHostElement: () => {
+				const el = document.createElement('div') as HTMLElement & { requestUpdate?: () => void };
+				el.requestUpdate = () => {
+					updates++;
+				};
+				return el;
+			},
+			addUmbController: () => {},
+			removeUmbController: () => {},
+			hasUmbController: () => false,
+			getUmbControllers: () => [],
+			removeUmbControllerByAlias: () => {},
+		} satisfies UmbControllerHost;
+		const controller = new UmbLocalizationController(host);
+		controller.hostConnected();
+
+		updates = 0;
+		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
+
+		expect(updates, 'expected no update when nothing changes').to.equal(0);
+		controller.destroy();
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.controller.test.ts
@@ -83,7 +83,8 @@ describe('UmbLocalizationController', () => {
 
 	beforeEach(async () => {
 		umbLocalizationManager.registerManyLocalizations([english, danish, danishRegional]);
-		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
+		umbLocalizationManager.documentLanguage = initialLanguage;
+		umbLocalizationManager.documentDirection = 'ltr';
 		await aTimeout(0);
 		const host = {
 			getHostElement: () => document.createElement('div'),
@@ -106,7 +107,7 @@ describe('UmbLocalizationController', () => {
 	});
 
 	it('should update the language when the language changes', async () => {
-		umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+		umbLocalizationManager.documentLanguage = danishRegional.$code;
 		await aTimeout(0);
 		expect(controller.lang()).to.equal(danishRegional.$code);
 	});
@@ -116,7 +117,7 @@ describe('UmbLocalizationController', () => {
 	});
 
 	it('should update the dir when the dir changes', async () => {
-		umbLocalizationManager.setActiveLanguage(initialLanguage, 'rtl');
+		umbLocalizationManager.documentDirection = 'rtl';
 		await aTimeout(0);
 		expect(controller.dir()).to.equal('rtl');
 	});
@@ -128,7 +129,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should update the term when the language changes', async () => {
 			// Change language
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			expect(controller.term('close')).to.equal('Luk');
@@ -136,7 +137,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should provide a secondary term when the term is not found on the regional language', async () => {
 			// Load Danish
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			expect(controller.term('notOnRegional')).to.equal('Not on regional');
@@ -144,7 +145,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should provide a fallback term from the fallback language when the term is not found on primary or secondary', async () => {
 			// Load Danish
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			expect(controller.term('close')).to.equal('Luk'); // Primary
@@ -224,7 +225,7 @@ describe('UmbLocalizationController', () => {
 			expect(controller.date(new Date(2020, 11, 31))).to.equal('12/31/2020');
 
 			// Switch browser to Danish
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			expect(controller.date(new Date(2020, 11, 31))).to.equal('31.12.2020');
@@ -257,7 +258,7 @@ describe('UmbLocalizationController', () => {
 			const enResult = controller.dateTime(date);
 
 			// Switch browser to Danish
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			const daResult = controller.dateTime(date);
@@ -279,7 +280,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should update the number when the language changes', async () => {
 			// Switch browser to Danish
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			expect(controller.number(123456.789)).to.equal('123.456,789');
@@ -299,7 +300,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should update the relative time when the language changes', async () => {
 			// Switch browser to Danish
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			expect(controller.relativeTime(2, 'days')).to.equal('om 2 dage');
@@ -379,7 +380,7 @@ describe('UmbLocalizationController', () => {
 
 		it('should handle the three-tier fallback before using defaultValue', async () => {
 			// Switch to Danish regional
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			// Primary (da-dk) has 'close'
@@ -400,7 +401,7 @@ describe('UmbLocalizationController', () => {
 			expect(controller.termOrDefault('close', 'X')).to.equal('Close');
 
 			// Switch to Danish
-			umbLocalizationManager.setActiveLanguage(danishRegional.$code, 'ltr');
+			umbLocalizationManager.documentLanguage = danishRegional.$code;
 			await aTimeout(0);
 
 			expect(controller.termOrDefault('close', 'X')).to.equal('Luk');
@@ -502,56 +503,3 @@ describe('UmbLocalizationController', () => {
 	});
 });
 
-describe('UmbLocalizationManager.setActiveLanguage', () => {
-	function createCountingController() {
-		let updates = 0;
-		const host = {
-			getHostElement: () => {
-				const el = document.createElement('div') as HTMLElement & { requestUpdate?: () => void };
-				el.requestUpdate = () => {
-					updates++;
-				};
-				return el;
-			},
-			addUmbController: () => {},
-			removeUmbController: () => {},
-			hasUmbController: () => false,
-			getUmbControllers: () => [],
-			removeUmbControllerByAlias: () => {},
-		} satisfies UmbControllerHost;
-		const controller = new UmbLocalizationController(host);
-		controller.hostConnected();
-		return {
-			controller,
-			get updates() {
-				return updates;
-			},
-		};
-	}
-
-	beforeEach(() => {
-		umbLocalizationManager.registerManyLocalizations([english, danish, danishRegional]);
-		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
-	});
-
-	afterEach(() => {
-		umbLocalizationManager.localizations.clear();
-		umbLocalizationManager.setActiveLanguage(initialLanguage, 'ltr');
-	});
-
-	it('updates the active language and direction', () => {
-		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
-
-		expect(umbLocalizationManager.documentLanguage).to.equal('da-dk');
-		expect(umbLocalizationManager.documentDirection).to.equal('ltr');
-	});
-
-	it('notifies connected controllers when the language changes', () => {
-		const probe = createCountingController();
-
-		umbLocalizationManager.setActiveLanguage('da-dk', 'ltr');
-
-		expect(probe.updates).to.equal(1);
-		probe.controller.destroy();
-	});
-});

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -14,7 +14,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 */
 import type { UmbLocalizationController } from './localization.controller.js';
 import type { UmbLocalizationEntry } from './types/localization.js';
-import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 export type FunctionParams<T> = T extends (...args: infer U) => string ? U : [];
 
@@ -107,25 +106,6 @@ export class UmbLocalizationManager {
 		}
 		this.#changedKeys.clear();
 	}
-
-	/**
-	 * @deprecated Use {@link setActiveLanguage} + {@link notifyLanguageChanged} instead — this method
-	 * previously read `document.documentElement.lang`/`dir` and propagated to consumers; that responsibility
-	 * now lives in `UmbLocalizationRegistry`. Scheduled for removal in Umbraco 20.
-	 */
-	updateAll = () => {
-		new UmbDeprecation({
-			deprecated: 'UmbLocalizationManager.updateAll',
-			solution:
-				'Call setActiveLanguage(lang, dir) and notifyLanguageChanged() explicitly. The active language is now driven by UmbLocalizationRegistry.loadLanguage() rather than mutations to document.documentElement.lang.',
-			removeInVersion: '20.0.0',
-		}).warn();
-		this.setActiveLanguage(
-			document.documentElement.lang || navigator.language,
-			(document.documentElement.dir as 'ltr' | 'rtl') || 'ltr',
-		);
-		this.notifyLanguageChanged();
-	};
 
 	#updateChangedKeys = () => {
 		this.#requestUpdateChangedKeysId = undefined;

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -37,6 +37,13 @@ export class UmbLocalizationManager {
 	#requestUpdateChangedKeysId?: number = undefined;
 
 	localizations: Map<string, UmbLocalizationSetBase> = new Map();
+
+	/**
+	 * The currently active language and direction. Read-only from a consumer perspective —
+	 * to change the active language, call `umbLocalizationRegistry.loadLanguage(locale)`.
+	 * The fields stay publicly writable for the registry's pipeline; consumers writing here
+	 * directly will only sync the field without loading the matching dictionaries.
+	 */
 	documentDirection: 'ltr' | 'rtl' = (document.documentElement.dir as 'ltr' | 'rtl') || 'ltr';
 	documentLanguage = document.documentElement.lang || navigator.language;
 

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -79,29 +79,6 @@ export class UmbLocalizationManager {
 		translations.map(this.#registerLocalizationBind);
 	}
 
-	/**
-	 * Updates the active language and direction, and tells all connected controllers to re-render.
-	 * Use after dictionaries have been registered for the new language; for a silent sync of the
-	 * fields (e.g., before translations have loaded), assign `documentLanguage`/`documentDirection`
-	 * directly.
-	 * @param {string} language - the language code to set as active; falls back to {@link UMB_DEFAULT_LOCALIZATION_CULTURE} when empty.
-	 * @param {'ltr' | 'rtl'} [direction] - the direction associated with the language (defaults to `'ltr'`).
-	 */
-	setActiveLanguage(language: string, direction: 'ltr' | 'rtl' = 'ltr') {
-		this.documentLanguage = language || UMB_DEFAULT_LOCALIZATION_CULTURE;
-		this.documentDirection = direction;
-
-		this.connectedControllers.forEach((ctrl) => {
-			ctrl.documentUpdate();
-		});
-
-		if (this.#requestUpdateChangedKeysId) {
-			cancelAnimationFrame(this.#requestUpdateChangedKeysId);
-			this.#requestUpdateChangedKeysId = undefined;
-		}
-		this.#changedKeys.clear();
-	}
-
 	#updateChangedKeys = () => {
 		this.#requestUpdateChangedKeysId = undefined;
 

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -111,14 +111,14 @@ export class UmbLocalizationManager {
 	/**
 	 * @deprecated Use {@link setActiveLanguage} + {@link notifyLanguageChanged} instead — this method
 	 * previously read `document.documentElement.lang`/`dir` and propagated to consumers; that responsibility
-	 * now lives in `UmbLocalizationRegistry`. Scheduled for removal in Umbraco 19.
+	 * now lives in `UmbLocalizationRegistry`. Scheduled for removal in Umbraco 20.
 	 */
 	updateAll = () => {
 		new UmbDeprecation({
 			deprecated: 'UmbLocalizationManager.updateAll',
 			solution:
 				'Call setActiveLanguage(lang, dir) and notifyLanguageChanged() explicitly. The active language is now driven by UmbLocalizationRegistry.loadLanguage() rather than mutations to document.documentElement.lang.',
-			removeInVersion: '19.0.0',
+			removeInVersion: '20.0.0',
 		}).warn();
 		this.setActiveLanguage(
 			document.documentElement.lang || navigator.language,

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -32,25 +32,16 @@ export const UMB_DEFAULT_LOCALIZATION_CULTURE = 'en';
 
 export class UmbLocalizationManager {
 	connectedControllers = new Set<UmbLocalizationController<UmbLocalizationSetBase>>();
-	#documentElementObserver: MutationObserver;
 
 	#changedKeys: Set<UmbLocalizationSetKey> = new Set();
 	#requestUpdateChangedKeysId?: number = undefined;
 
 	localizations: Map<string, UmbLocalizationSetBase> = new Map();
-	documentDirection = document.documentElement.dir || 'ltr';
+	documentDirection: 'ltr' | 'rtl' = (document.documentElement.dir as 'ltr' | 'rtl') || 'ltr';
 	documentLanguage = document.documentElement.lang || navigator.language;
 
 	get fallback(): UmbLocalizationSet | undefined {
 		return this.localizations.get(UMB_DEFAULT_LOCALIZATION_CULTURE) as UmbLocalizationSet;
-	}
-
-	constructor() {
-		this.#documentElementObserver = new MutationObserver(this.updateAll);
-		this.#documentElementObserver.observe(document.documentElement, {
-			attributes: true,
-			attributeFilter: ['dir', 'lang'],
-		});
 	}
 
 	appendConsumer(consumer: UmbLocalizationController<UmbLocalizationSetBase>) {
@@ -88,18 +79,26 @@ export class UmbLocalizationManager {
 		translations.map(this.#registerLocalizationBind);
 	}
 
-	/** Updates all localized elements that are currently connected */
-	updateAll = () => {
-		const newDir = document.documentElement.dir || 'ltr';
-		const newLang = document.documentElement.lang || navigator.language;
+	/**
+	 * Sets the active language and direction and notifies all connected controllers.
+	 * This is the single channel through which the manager learns of a language change;
+	 * callers should not write to `document.documentElement.lang` for this purpose.
+	 * @param {string} language The language code to set as active.
+	 * @param {'ltr' | 'rtl'} [direction] The direction associated with the language.
+	 */
+	setActiveLanguage(language: string, direction: 'ltr' | 'rtl' = 'ltr', options?: { silent?: boolean }) {
+		const newLang = language || UMB_DEFAULT_LOCALIZATION_CULTURE;
+		const changed = this.documentLanguage !== newLang || this.documentDirection !== direction;
 
-		if (this.documentDirection === newDir && this.documentLanguage === newLang) return;
-
-		// The document direction or language did changed, so lets move on:
-		this.documentDirection = newDir;
 		this.documentLanguage = newLang;
+		this.documentDirection = direction;
 
-		// Check if there was any changed.
+		// When `silent` is set, callers want to update the fields without notifying consumers.
+		// This is used by the registry to set the active language synchronously when it changes,
+		// so controllers can pick up the new language on their next render, while deferring the
+		// `documentUpdate` notification until translations have actually loaded.
+		if (options?.silent || !changed) return;
+
 		this.connectedControllers.forEach((ctrl) => {
 			ctrl.documentUpdate();
 		});
@@ -109,7 +108,26 @@ export class UmbLocalizationManager {
 			this.#requestUpdateChangedKeysId = undefined;
 		}
 		this.#changedKeys.clear();
-	};
+	}
+
+	/**
+	 * Explicitly notify all connected controllers that the active language or its translations
+	 * have changed. Use this after registering or loading a new set of translations, when the
+	 * `documentLanguage`/`documentDirection` fields may not have changed but the underlying
+	 * dictionaries did. Tests around the unrelated key-change debounce still rely on the
+	 * documentUpdate path being the canonical "force-rerender" channel.
+	 */
+	notifyLanguageChanged() {
+		this.connectedControllers.forEach((ctrl) => {
+			ctrl.documentUpdate();
+		});
+
+		if (this.#requestUpdateChangedKeysId) {
+			cancelAnimationFrame(this.#requestUpdateChangedKeysId);
+			this.#requestUpdateChangedKeysId = undefined;
+		}
+		this.#changedKeys.clear();
+	}
 
 	#updateChangedKeys = () => {
 		this.#requestUpdateChangedKeysId = undefined;

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -80,42 +80,20 @@ export class UmbLocalizationManager {
 	}
 
 	/**
-	 * Sets the active language and direction and notifies all connected controllers.
-	 * This is the single channel through which the manager learns of a language change;
-	 * callers should not write to `document.documentElement.lang` for this purpose.
-	 * @param {string} language The language code to set as active.
-	 * @param {'ltr' | 'rtl'} [direction] The direction associated with the language.
+	 * Updates the active language and direction on the manager without notifying consumers.
+	 * Pair this with {@link notifyLanguageChanged} when consumers should react.
+	 * @param {string} language - the language code to set as active; falls back to {@link UMB_DEFAULT_LOCALIZATION_CULTURE} when empty.
+	 * @param {'ltr' | 'rtl'} [direction] - the direction associated with the language (defaults to `'ltr'`).
 	 */
-	setActiveLanguage(language: string, direction: 'ltr' | 'rtl' = 'ltr', options?: { silent?: boolean }) {
-		const newLang = language || UMB_DEFAULT_LOCALIZATION_CULTURE;
-		const changed = this.documentLanguage !== newLang || this.documentDirection !== direction;
-
-		this.documentLanguage = newLang;
+	setActiveLanguage(language: string, direction: 'ltr' | 'rtl' = 'ltr') {
+		this.documentLanguage = language || UMB_DEFAULT_LOCALIZATION_CULTURE;
 		this.documentDirection = direction;
-
-		// When `silent` is set, callers want to update the fields without notifying consumers.
-		// This is used by the registry to set the active language synchronously when it changes,
-		// so controllers can pick up the new language on their next render, while deferring the
-		// `documentUpdate` notification until translations have actually loaded.
-		if (options?.silent || !changed) return;
-
-		this.connectedControllers.forEach((ctrl) => {
-			ctrl.documentUpdate();
-		});
-
-		if (this.#requestUpdateChangedKeysId) {
-			cancelAnimationFrame(this.#requestUpdateChangedKeysId);
-			this.#requestUpdateChangedKeysId = undefined;
-		}
-		this.#changedKeys.clear();
 	}
 
 	/**
-	 * Explicitly notify all connected controllers that the active language or its translations
-	 * have changed. Use this after registering or loading a new set of translations, when the
-	 * `documentLanguage`/`documentDirection` fields may not have changed but the underlying
-	 * dictionaries did. Tests around the unrelated key-change debounce still rely on the
-	 * documentUpdate path being the canonical "force-rerender" channel.
+	 * Tells all connected controllers to re-render against the current active language and
+	 * dictionaries. Use after a batch of {@link registerLocalization} or {@link setActiveLanguage}
+	 * calls to flush the result in one go.
 	 */
 	notifyLanguageChanged() {
 		this.connectedControllers.forEach((ctrl) => {

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -80,22 +80,17 @@ export class UmbLocalizationManager {
 	}
 
 	/**
-	 * Updates the active language and direction on the manager without notifying consumers.
-	 * Pair this with {@link notifyLanguageChanged} when consumers should react.
+	 * Updates the active language and direction, and tells all connected controllers to re-render.
+	 * Use after dictionaries have been registered for the new language; for a silent sync of the
+	 * fields (e.g., before translations have loaded), assign `documentLanguage`/`documentDirection`
+	 * directly.
 	 * @param {string} language - the language code to set as active; falls back to {@link UMB_DEFAULT_LOCALIZATION_CULTURE} when empty.
 	 * @param {'ltr' | 'rtl'} [direction] - the direction associated with the language (defaults to `'ltr'`).
 	 */
 	setActiveLanguage(language: string, direction: 'ltr' | 'rtl' = 'ltr') {
 		this.documentLanguage = language || UMB_DEFAULT_LOCALIZATION_CULTURE;
 		this.documentDirection = direction;
-	}
 
-	/**
-	 * Tells all connected controllers to re-render against the current active language and
-	 * dictionaries. Use after a batch of {@link registerLocalization} or {@link setActiveLanguage}
-	 * calls to flush the result in one go.
-	 */
-	notifyLanguageChanged() {
 		this.connectedControllers.forEach((ctrl) => {
 			ctrl.documentUpdate();
 		});

--- a/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/localization-api/localization.manager.ts
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 */
 import type { UmbLocalizationController } from './localization.controller.js';
 import type { UmbLocalizationEntry } from './types/localization.js';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 export type FunctionParams<T> = T extends (...args: infer U) => string ? U : [];
 
@@ -106,6 +107,25 @@ export class UmbLocalizationManager {
 		}
 		this.#changedKeys.clear();
 	}
+
+	/**
+	 * @deprecated Use {@link setActiveLanguage} + {@link notifyLanguageChanged} instead — this method
+	 * previously read `document.documentElement.lang`/`dir` and propagated to consumers; that responsibility
+	 * now lives in `UmbLocalizationRegistry`. Scheduled for removal in Umbraco 19.
+	 */
+	updateAll = () => {
+		new UmbDeprecation({
+			deprecated: 'UmbLocalizationManager.updateAll',
+			solution:
+				'Call setActiveLanguage(lang, dir) and notifyLanguageChanged() explicitly. The active language is now driven by UmbLocalizationRegistry.loadLanguage() rather than mutations to document.documentElement.lang.',
+			removeInVersion: '19.0.0',
+		}).warn();
+		this.setActiveLanguage(
+			document.documentElement.lang || navigator.language,
+			(document.documentElement.dir as 'ltr' | 'rtl') || 'ltr',
+		);
+		this.notifyLanguageChanged();
+	};
 
 	#updateChangedKeys = () => {
 		this.#requestUpdateChangedKeysId = undefined;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
@@ -1,6 +1,7 @@
 import { UmbLocalizationRegistry } from './localization.registry.js';
 import { aTimeout, expect } from '@open-wc/testing';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { umbLocalizationManager } from '@umbraco-cms/backoffice/localization-api';
 import type { ManifestLocalization } from '../extensions/localization.extension.js';
 
 //#region Localizations
@@ -250,5 +251,53 @@ describe('UmbLocalizeController', () => {
 		// Check that both the regional and the base language is loaded.
 		expect(registry.localizations.has(danishRegional.meta.culture), 'expected "da-dk" to be present').to.be.true;
 		expect(registry.localizations.has(danish.meta.culture), 'expected "da" to be present').to.be.true;
+	});
+});
+
+describe('UmbLocalizationRegistry initialization', () => {
+	// The fixture extensions are registered when the suite above runs; they are global
+	// to the extension registry, so they are already available here too.
+
+	const originalLang = document.documentElement.lang;
+	const originalDir = document.documentElement.dir;
+	let registry: UmbLocalizationRegistry;
+
+	afterEach(() => {
+		registry?.destroy();
+		umbLocalizationManager.localizations.clear();
+		document.documentElement.lang = originalLang;
+		document.documentElement.dir = originalDir;
+	});
+
+	it('honors document.documentElement.lang on construction', async () => {
+		// Simulate Razor having rendered <html lang="@DefaultUILanguage"> with "da-dk".
+		document.documentElement.lang = 'da-dk';
+
+		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+		await aTimeout(0);
+
+		expect(registry.localizations.has('da-dk'), 'expected the configured locale to be loaded').to.be.true;
+		expect(document.documentElement.lang, 'expected <html lang> to reflect the configured locale').to.equal('da-dk');
+	});
+
+	it('always loads the English fallback dictionary alongside the active language', async () => {
+		document.documentElement.lang = 'da-dk';
+
+		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+		await aTimeout(0);
+
+		// The active language is loaded.
+		expect(registry.localizations.has('da-dk'), 'expected active "da-dk" to be loaded').to.be.true;
+		// The fallback ("en") is loaded so that missing-key lookups can still resolve via fallback.
+		expect(registry.localizations.has('en'), 'expected fallback "en" to be loaded').to.be.true;
+	});
+
+	it('falls back to the default culture when document.documentElement.lang is empty', async () => {
+		document.documentElement.lang = '';
+
+		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+		await aTimeout(0);
+
+		expect(registry.localizations.has('en'), 'expected default "en" to be loaded').to.be.true;
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.test.ts
@@ -142,8 +142,8 @@ describe('UmbLocalizeController', () => {
 		expect(registry.localizations.size).to.equal(3, 'Should have registered the 3rd language (da)');
 	});
 
-	it('should set the document language and direction', async () => {
-		expect(document.documentElement.lang).to.equal(english.meta.culture);
+	it('should set the manager language and document direction', async () => {
+		expect(umbLocalizationManager.documentLanguage).to.equal(english.meta.culture);
 		expect(document.documentElement.dir).to.equal(english.meta.direction);
 	});
 
@@ -205,15 +205,15 @@ describe('UmbLocalizeController', () => {
 	});
 
 	it('should be able to switch to the fallback language', async () => {
-		// Verify that the document language and direction is set correctly to the default language
-		expect(document.documentElement.lang).to.equal(english.meta.culture);
+		// Verify that the manager language and document direction is set correctly to the default language
+		expect(umbLocalizationManager.documentLanguage).to.equal(english.meta.culture);
 		expect(document.documentElement.dir).to.equal(english.meta.direction);
 
 		// Switch to the fallback language, which is the UK version of English
 		registry.loadLanguage('en');
 		await aTimeout(0);
 
-		expect(document.documentElement.lang).to.equal('en');
+		expect(umbLocalizationManager.documentLanguage).to.equal('en');
 		expect(document.documentElement.dir).to.equal('ltr');
 
 		const current = registry.localizations.get(englishUk.meta.culture);
@@ -223,7 +223,7 @@ describe('UmbLocalizeController', () => {
 		registry.loadLanguage('en-us');
 		await aTimeout(0);
 
-		expect(document.documentElement.lang).to.equal('en-us');
+		expect(umbLocalizationManager.documentLanguage).to.equal('en-us');
 		expect(document.documentElement.dir).to.equal('ltr');
 
 		const newCurrent = registry.localizations.get(english.meta.culture);
@@ -257,45 +257,40 @@ describe('UmbLocalizeController', () => {
 describe('UmbLocalizationRegistry initialization', () => {
 	// The fixture extensions are registered when the suite above runs; they are global
 	// to the extension registry, so they are already available here too.
-
-	const originalLang = document.documentElement.lang;
-	const originalDir = document.documentElement.dir;
 	let registry: UmbLocalizationRegistry;
 
 	afterEach(() => {
 		registry?.destroy();
 		umbLocalizationManager.localizations.clear();
-		document.documentElement.lang = originalLang;
-		document.documentElement.dir = originalDir;
 	});
 
-	it('honors document.documentElement.lang on construction', async () => {
-		// Simulate Razor having rendered <html lang="@DefaultUILanguage"> with "da-dk".
-		document.documentElement.lang = 'da-dk';
-
+	it('loads the language a host element passes via loadLanguage()', async () => {
 		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+		registry.loadLanguage('da-dk');
 		await aTimeout(0);
 
-		expect(registry.localizations.has('da-dk'), 'expected the configured locale to be loaded').to.be.true;
-		expect(document.documentElement.lang, 'expected <html lang> to reflect the configured locale').to.equal('da-dk');
+		expect(registry.localizations.has('da-dk'), 'expected the requested locale to be loaded').to.be.true;
 	});
 
 	it('always loads the English fallback dictionary alongside the active language', async () => {
-		document.documentElement.lang = 'da-dk';
-
 		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+		registry.loadLanguage('da-dk');
 		await aTimeout(0);
 
-		// The active language is loaded.
 		expect(registry.localizations.has('da-dk'), 'expected active "da-dk" to be loaded').to.be.true;
-		// The fallback ("en") is loaded so that missing-key lookups can still resolve via fallback.
 		expect(registry.localizations.has('en'), 'expected fallback "en" to be loaded').to.be.true;
 	});
 
-	it('falls back to the default culture when document.documentElement.lang is empty', async () => {
-		document.documentElement.lang = '';
-
+	it('starts on the default culture when no host has called loadLanguage', async () => {
 		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+		await aTimeout(0);
+
+		expect(registry.localizations.has('en'), 'expected default "en" to be loaded').to.be.true;
+	});
+
+	it('falls back to the default culture when loadLanguage is called with empty or invalid input', async () => {
+		registry = new UmbLocalizationRegistry(umbExtensionsRegistry);
+		registry.loadLanguage('');
 		await aTimeout(0);
 
 		expect(registry.localizations.has('en'), 'expected default "en" to be loaded').to.be.true;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -41,8 +41,8 @@ function addOrUpdateDictionary(
  * Returns the canonical form of the given locale, or the default culture if the input is empty or
  * cannot be canonicalised. `Intl.getCanonicalLocales` throws RangeError for malformed input so we
  * intentionally swallow it here — a misconfigured DefaultUILanguage should fall back, not crash.
- * @param {string} locale The locale to canonicalise.
- * @returns {string} The canonical locale, or the default culture if invalid.
+ * @param {string} locale - the locale to canonicalise.
+ * @returns {string} the canonical locale, or the default culture if invalid.
  */
 function toCanonicalLocale(locale: string): string {
 	if (!locale) return UMB_DEFAULT_LOCALIZATION_CULTURE;
@@ -51,6 +51,16 @@ function toCanonicalLocale(locale: string): string {
 	} catch {
 		return UMB_DEFAULT_LOCALIZATION_CULTURE;
 	}
+}
+
+/**
+ * Returns the lowercase BCP-47 base name (`language[-region]`) of a locale tag.
+ * E.g. `'en-US'` → `'en-us'`, `'da-DK'` → `'da-dk'`.
+ * @param {string} locale - the locale to extract the base name from.
+ * @returns {string} the lowercase base name of the locale.
+ */
+function baseLocaleOf(locale: string): string {
+	return new Intl.Locale(locale).baseName.toLowerCase();
 }
 
 export class UmbLocalizationRegistry {
@@ -77,20 +87,16 @@ export class UmbLocalizationRegistry {
 				filter((currentLanguage) => !!currentLanguage),
 				// Use distinctUntilChanged to avoid unnecessary re-renders when the language hasn't changed
 				distinctUntilChanged(),
-				// Synchronously mirror the active language to the document and manager (silently).
-				// This must happen synchronously so that any controller rendering between now and
-				// translations finishing loading sees the requested language — otherwise the first
-				// render of a fresh element after `loadLanguage(...)` would use the previous language.
-				// We don't fire `documentUpdate` here because translations are still loading; that
-				// happens once the dictionaries are in place (see `#setBrowserLanguage`).
+				// Mirror the active language onto the document and the manager synchronously, so a
+				// fresh element rendering between now and the async translation load picks up the
+				// requested language. Direction is set further down once we know which dictionary
+				// won; consumers are notified there too.
 				tap((currentLanguage) => {
-					const newLang = new Intl.Locale(currentLanguage).baseName.toLowerCase();
+					const newLang = baseLocaleOf(currentLanguage);
 					if (document.documentElement.lang.toLowerCase() !== newLang) {
 						document.documentElement.lang = newLang;
 					}
-					umbLocalizationManager.setActiveLanguage(newLang, umbLocalizationManager.documentDirection, {
-						silent: true,
-					});
+					umbLocalizationManager.setActiveLanguage(newLang, umbLocalizationManager.documentDirection);
 				}),
 				// Switch to the extensions registry to get the current language and the extensions for that language
 				// Note: This also cancels the previous subscription if the language changes
@@ -186,26 +192,17 @@ export class UmbLocalizationRegistry {
 	#setBrowserLanguage(locale: Intl.Locale, translations: UmbLocalizationSetBase[]) {
 		const newLang = locale.baseName.toLowerCase();
 
-		// Resolve direction from the best-matching translation: regional match wins, else
-		// language-only match, else default to 'ltr'.
+		// Regional match wins, then language-only match, then default to LTR.
 		const reverseTranslations = translations.slice().reverse();
-		const directMatch = reverseTranslations.find((t) => t.$code.toLowerCase() === newLang);
 		const bestMatch =
-			directMatch ?? reverseTranslations.find((t) => t.$code.toLowerCase() === locale.language.toLowerCase());
+			reverseTranslations.find((t) => t.$code.toLowerCase() === newLang) ??
+			reverseTranslations.find((t) => t.$code.toLowerCase() === locale.language.toLowerCase());
 		const direction: 'ltr' | 'rtl' = bestMatch?.$dir ?? 'ltr';
 
-		// Lang was already mirrored synchronously in the upstream `tap` so the manager and the
-		// document attribute are in sync. Update the direction now that we know which dictionary
-		// won (the language code alone does not tell us LTR vs RTL).
 		if (document.documentElement.dir !== direction) {
 			document.documentElement.dir = direction;
 		}
-		if (umbLocalizationManager.documentDirection !== direction) {
-			umbLocalizationManager.setActiveLanguage(newLang, direction, { silent: true });
-		}
-
-		// Translations are now available — tell connected controllers that the active language's
-		// dictionaries have changed so they re-render with the freshly loaded terms.
+		umbLocalizationManager.setActiveLanguage(newLang, direction);
 		umbLocalizationManager.notifyLanguageChanged();
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -94,13 +94,11 @@ export class UmbLocalizationRegistry {
 				distinctUntilChanged(),
 				// Mirror the active language onto the manager synchronously, so a fresh element
 				// rendering between now and the async translation load picks up the requested
-				// language. Direction is set further down once we know which dictionary won;
-				// consumers are notified there too.
+				// language. We're not calling setActiveLanguage here because translations aren't
+				// loaded yet — we don't want to notify consumers to re-render with a fallback.
+				// Direction and the actual re-render happen below once dictionaries are in place.
 				tap((currentLanguage) => {
-					umbLocalizationManager.setActiveLanguage(
-						baseLocaleOf(currentLanguage),
-						umbLocalizationManager.documentDirection,
-					);
+					umbLocalizationManager.documentLanguage = baseLocaleOf(currentLanguage);
 				}),
 				// Switch to the extensions registry to get the current language and the extensions for that language
 				// Note: This also cancels the previous subscription if the language changes
@@ -207,7 +205,6 @@ export class UmbLocalizationRegistry {
 			document.documentElement.dir = direction;
 		}
 		umbLocalizationManager.setActiveLanguage(newLang, direction);
-		umbLocalizationManager.notifyLanguageChanged();
 	}
 
 	#arraysEqual(a: string[], b: string[]) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -7,6 +7,7 @@ import {
 	map,
 	of,
 	switchMap,
+	tap,
 } from '@umbraco-cms/backoffice/external/rxjs';
 import { hasDefaultExport, loadManifestPlainJs } from '@umbraco-cms/backoffice/extension-api';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
@@ -36,10 +37,24 @@ function addOrUpdateDictionary(
 	}
 }
 
+/**
+ * Returns the canonical form of the given locale, or the default culture if the input is empty or
+ * cannot be canonicalised. `Intl.getCanonicalLocales` throws RangeError for malformed input so we
+ * intentionally swallow it here — a misconfigured DefaultUILanguage should fall back, not crash.
+ * @param {string} locale The locale to canonicalise.
+ * @returns {string} The canonical locale, or the default culture if invalid.
+ */
+function toCanonicalLocale(locale: string): string {
+	if (!locale) return UMB_DEFAULT_LOCALIZATION_CULTURE;
+	try {
+		return Intl.getCanonicalLocales(locale)[0] ?? UMB_DEFAULT_LOCALIZATION_CULTURE;
+	} catch {
+		return UMB_DEFAULT_LOCALIZATION_CULTURE;
+	}
+}
+
 export class UmbLocalizationRegistry {
-	#currentLanguage = new UmbStringState(
-		document.documentElement.lang !== '' ? document.documentElement.lang : UMB_DEFAULT_LOCALIZATION_CULTURE,
-	);
+	#currentLanguage = new UmbStringState(toCanonicalLocale(document.documentElement.lang));
 	readonly currentLanguage = this.#currentLanguage.asObservable();
 
 	/**
@@ -62,18 +77,36 @@ export class UmbLocalizationRegistry {
 				filter((currentLanguage) => !!currentLanguage),
 				// Use distinctUntilChanged to avoid unnecessary re-renders when the language hasn't changed
 				distinctUntilChanged(),
+				// Synchronously mirror the active language to the document and manager (silently).
+				// This must happen synchronously so that any controller rendering between now and
+				// translations finishing loading sees the requested language — otherwise the first
+				// render of a fresh element after `loadLanguage(...)` would use the previous language.
+				// We don't fire `documentUpdate` here because translations are still loading; that
+				// happens once the dictionaries are in place (see `#setBrowserLanguage`).
+				tap((currentLanguage) => {
+					const newLang = new Intl.Locale(currentLanguage).baseName.toLowerCase();
+					if (document.documentElement.lang.toLowerCase() !== newLang) {
+						document.documentElement.lang = newLang;
+					}
+					umbLocalizationManager.setActiveLanguage(newLang, umbLocalizationManager.documentDirection, {
+						silent: true,
+					});
+				}),
 				// Switch to the extensions registry to get the current language and the extensions for that language
 				// Note: This also cancels the previous subscription if the language changes
 				switchMap((currentLanguage) => {
 					return extensionRegistry.byType('localization').pipe(
-						// Filter the extensions to only those that match the current language
+						// Filter the extensions to those matching the current language; we also always
+						// include the default culture so the manager has it available as a key-level
+						// fallback when the active language is missing a translation.
 						map((extensions) => {
 							locale = new Intl.Locale(currentLanguage);
-							return extensions.filter(
-								(ext) =>
-									ext.meta.culture.toLowerCase() === locale!.baseName.toLowerCase() ||
-									ext.meta.culture.toLowerCase() === locale!.language.toLowerCase(),
-							);
+							const baseName = locale.baseName.toLowerCase();
+							const language = locale.language.toLowerCase();
+							return extensions.filter((ext) => {
+								const culture = ext.meta.culture.toLowerCase();
+								return culture === UMB_DEFAULT_LOCALIZATION_CULTURE || culture === baseName || culture === language;
+							});
 						}),
 					);
 				}),
@@ -118,9 +151,6 @@ export class UmbLocalizationRegistry {
 			)
 			// Subscribe to the observable to trigger the loading of translations
 			.subscribe();
-
-		// Always register the fallback language (en) to ensure there is always at least one language available
-		this.loadLanguage(UMB_DEFAULT_LOCALIZATION_CULTURE);
 	}
 
 	#loadExtension = async (extension: ManifestLocalization) => {
@@ -154,36 +184,29 @@ export class UmbLocalizationRegistry {
 	};
 
 	#setBrowserLanguage(locale: Intl.Locale, translations: UmbLocalizationSetBase[]) {
-		// Set the document language
 		const newLang = locale.baseName.toLowerCase();
-		if (document.documentElement.lang.toLowerCase() !== newLang) {
-			document.documentElement.lang = newLang;
-		}
 
-		// We need to find the direction of the new language, so we look for the best match
-		// If the new language is not found, we default to 'ltr'
+		// Resolve direction from the best-matching translation: regional match wins, else
+		// language-only match, else default to 'ltr'.
 		const reverseTranslations = translations.slice().reverse();
-
-		// Look for a direct match first
 		const directMatch = reverseTranslations.find((t) => t.$code.toLowerCase() === newLang);
-		if (directMatch) {
-			document.documentElement.dir = directMatch.$dir;
-			return;
+		const bestMatch =
+			directMatch ?? reverseTranslations.find((t) => t.$code.toLowerCase() === locale.language.toLowerCase());
+		const direction: 'ltr' | 'rtl' = bestMatch?.$dir ?? 'ltr';
+
+		// Lang was already mirrored synchronously in the upstream `tap` so the manager and the
+		// document attribute are in sync. Update the direction now that we know which dictionary
+		// won (the language code alone does not tell us LTR vs RTL).
+		if (document.documentElement.dir !== direction) {
+			document.documentElement.dir = direction;
+		}
+		if (umbLocalizationManager.documentDirection !== direction) {
+			umbLocalizationManager.setActiveLanguage(newLang, direction, { silent: true });
 		}
 
-		// If no direct match, look for a match with the language code only
-		const langOnlyDirectMatch = reverseTranslations.find(
-			(t) => t.$code.toLowerCase() === locale.language.toLowerCase(),
-		);
-		if (langOnlyDirectMatch) {
-			document.documentElement.dir = langOnlyDirectMatch.$dir;
-			return;
-		}
-
-		// If no match is found, default to 'ltr'
-		if (document.documentElement.dir !== 'ltr') {
-			document.documentElement.dir = 'ltr';
-		}
+		// Translations are now available — tell connected controllers that the active language's
+		// dictionaries have changed so they re-render with the freshly loaded terms.
+		umbLocalizationManager.notifyLanguageChanged();
 	}
 
 	#arraysEqual(a: string[], b: string[]) {
@@ -196,11 +219,10 @@ export class UmbLocalizationRegistry {
 
 	/**
 	 * Load a language from the extension registry.
-	 * @param {string} locale The locale to load.
+	 * @param {string} locale The locale to load. Invalid or empty input falls back to the default culture.
 	 */
 	loadLanguage(locale: string) {
-		const canonicalLocale = Intl.getCanonicalLocales(locale)[0];
-		this.#currentLanguage.setValue(canonicalLocale);
+		this.#currentLanguage.setValue(toCanonicalLocale(locale));
 	}
 
 	destroy() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -94,9 +94,8 @@ export class UmbLocalizationRegistry {
 				distinctUntilChanged(),
 				// Mirror the active language onto the manager synchronously, so a fresh element
 				// rendering between now and the async translation load picks up the requested
-				// language. We're not calling setActiveLanguage here because translations aren't
-				// loaded yet — we don't want to notify consumers to re-render with a fallback.
-				// Direction and the actual re-render happen below once dictionaries are in place.
+				// language on its first render. Direction and the actual consumer notification
+				// happen below, once the dictionaries are in place.
 				tap((currentLanguage) => {
 					umbLocalizationManager.documentLanguage = baseLocaleOf(currentLanguage);
 				}),
@@ -204,7 +203,13 @@ export class UmbLocalizationRegistry {
 		if (document.documentElement.dir !== direction) {
 			document.documentElement.dir = direction;
 		}
-		umbLocalizationManager.setActiveLanguage(newLang, direction);
+		// Write the active language and direction onto the manager, then tell every connected
+		// controller to re-render against the freshly loaded dictionaries. Inlined here because
+		// it's the only place this happens — no need for another public method on the manager
+		// that we'd just have to retire when the manager and registry get merged.
+		umbLocalizationManager.documentLanguage = newLang;
+		umbLocalizationManager.documentDirection = direction;
+		umbLocalizationManager.connectedControllers.forEach((ctrl) => ctrl.documentUpdate());
 	}
 
 	#arraysEqual(a: string[], b: string[]) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -54,8 +54,9 @@ function toCanonicalLocale(locale: string): string {
 }
 
 /**
- * Returns the lowercase BCP-47 base name (`language[-region]`) of a locale tag.
- * E.g. `'en-US'` → `'en-us'`, `'da-DK'` → `'da-dk'`.
+ * Returns the lowercase BCP-47 base name (`language[-script][-region]`) of a locale tag, e.g.
+ * `'en-US'` → `'en-us'`, `'zh-Hant-TW'` → `'zh-hant-tw'`. The input is expected to already be
+ * a canonical locale (use {@link toCanonicalLocale} first if it might not be).
  * @param {string} locale - the locale to extract the base name from.
  * @returns {string} the lowercase base name of the locale.
  */

--- a/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/localization/registry/localization.registry.ts
@@ -65,7 +65,11 @@ function baseLocaleOf(locale: string): string {
 }
 
 export class UmbLocalizationRegistry {
-	#currentLanguage = new UmbStringState(toCanonicalLocale(document.documentElement.lang));
+	// The active language is driven by the consuming host element (<umb-app>, <umb-auth>) via
+	// `loadLanguage()` — Razor sets `lang="@DefaultUILanguage"` on those, the element passes
+	// it through on connect, and current-user.context takes over after login. The default here
+	// is just the bootstrap value before any host has connected.
+	#currentLanguage = new UmbStringState(UMB_DEFAULT_LOCALIZATION_CULTURE);
 	readonly currentLanguage = this.#currentLanguage.asObservable();
 
 	/**
@@ -88,16 +92,15 @@ export class UmbLocalizationRegistry {
 				filter((currentLanguage) => !!currentLanguage),
 				// Use distinctUntilChanged to avoid unnecessary re-renders when the language hasn't changed
 				distinctUntilChanged(),
-				// Mirror the active language onto the document and the manager synchronously, so a
-				// fresh element rendering between now and the async translation load picks up the
-				// requested language. Direction is set further down once we know which dictionary
-				// won; consumers are notified there too.
+				// Mirror the active language onto the manager synchronously, so a fresh element
+				// rendering between now and the async translation load picks up the requested
+				// language. Direction is set further down once we know which dictionary won;
+				// consumers are notified there too.
 				tap((currentLanguage) => {
-					const newLang = baseLocaleOf(currentLanguage);
-					if (document.documentElement.lang.toLowerCase() !== newLang) {
-						document.documentElement.lang = newLang;
-					}
-					umbLocalizationManager.setActiveLanguage(newLang, umbLocalizationManager.documentDirection);
+					umbLocalizationManager.setActiveLanguage(
+						baseLocaleOf(currentLanguage),
+						umbLocalizationManager.documentDirection,
+					);
 				}),
 				// Switch to the extensions registry to get the current language and the extensions for that language
 				// Note: This also cancels the previous subscription if the language changes

--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -2,6 +2,7 @@ import { html, customElement, property, ifDefined } from '@umbraco-cms/backoffic
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { InputType, UUIFormLayoutItemElement } from '@umbraco-cms/backoffice/external/uui';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { umbLocalizationRegistry } from '@umbraco-cms/backoffice/localization';
 
 import { UMB_AUTH_CONTEXT, UmbAuthContext } from './contexts/index.js';
 import { UmbSlimBackofficeController } from './controllers/index.js';
@@ -121,7 +122,7 @@ const createFormLayoutPasswordItem = (
 	label: HTMLLabelElement,
 	input: HTMLInputElement,
 	showPasswordToggle: HTMLSpanElement,
-	requiredMessageKey: string
+	requiredMessageKey: string,
 ) => {
 	const formLayoutItem = document.createElement('uui-form-layout-item') as UUIFormLayoutItemElement;
 	const errorId = input.getAttribute('aria-errormessage') || input.id + '-error';
@@ -228,6 +229,17 @@ export default class UmbAuthElement extends UmbLitElement {
 		});
 	}
 
+	override connectedCallback() {
+		super.connectedCallback();
+
+		// Mirror the active locale onto the host element so that downstream components can
+		// resolve their `lang` from the closest ancestor with one set, rather than relying
+		// on a side-effect read of <html lang>.
+		this.observe(umbLocalizationRegistry.currentLanguage, (lang) => {
+			if (lang) this.lang = lang;
+		});
+	}
+
 	async firstUpdated() {
 		// Bind the (slim) Backoffice controller to this element so that we can use utilities from the Backoffice app.
 		await new UmbSlimBackofficeController(this).register(this);
@@ -235,10 +247,34 @@ export default class UmbAuthElement extends UmbLitElement {
 		// Register the main package for Umbraco.Auth
 		umbExtensionsRegistry.registerMany(extensions);
 
+		// Now that localization extensions are registered, prefer the visitor's browser language
+		// over the configured DefaultUILanguage if we actually have a translation for it. The
+		// pipeline matches `baseName` then `language`, so 'fr-CA' falls through to 'fr' and then
+		// 'en' automatically when no specific extension exists.
+		this.#loadPreferredLanguage();
+
 		// Wait for localization to be ready before loading the form
 		await this.#waitForLocalization();
 
 		this.#initializeForm();
+	}
+
+	#loadPreferredLanguage() {
+		const preferred = navigator.language;
+		if (!preferred) return;
+
+		const cultures = new Set(
+			umbExtensionsRegistry.getByType('localization').map((ext) => ext.meta.culture.toLowerCase()),
+		);
+
+		const preferredLower = preferred.toLowerCase();
+		const languageLower = preferredLower.split('-')[0];
+
+		// Only override the DefaultUILanguage if we actually have a matching translation.
+		// Otherwise we leave the registry on whatever <html lang> set it to.
+		if (cultures.has(preferredLower) || cultures.has(languageLower)) {
+			umbLocalizationRegistry.loadLanguage(preferred);
+		}
 	}
 
 	async #waitForLocalization(): Promise<void> {
@@ -311,13 +347,13 @@ export default class UmbAuthElement extends UmbLitElement {
 		const usernameLayoutItem = createFormLayoutItem(
 			usernameLabel,
 			usernameInput,
-			this.usernameIsEmail ? 'login_requiredEmailValidationMessage' : 'login_requiredUsernameValidationMessage'
+			this.usernameIsEmail ? 'login_requiredEmailValidationMessage' : 'login_requiredUsernameValidationMessage',
 		);
 		const passwordLayoutItem = createFormLayoutPasswordItem(
 			passwordLabel,
 			passwordInput,
 			passwordShowPasswordToggleItem,
-			'login_requiredPasswordValidationMessage'
+			'login_requiredPasswordValidationMessage',
 		);
 		const style = document.createElement('style');
 		style.innerHTML = authStyles;

--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -260,19 +260,25 @@ export default class UmbAuthElement extends UmbLitElement {
 	}
 
 	#loadPreferredLanguage() {
-		const preferred = navigator.language;
-		if (!preferred) return;
-
 		const cultures = new Set(
 			umbExtensionsRegistry.getByType('localization').map((ext) => ext.meta.culture.toLowerCase()),
 		);
 
-		const preferredLower = preferred.toLowerCase();
-		const languageLower = preferredLower.split('-')[0];
+		// If the configured DefaultUILanguage already has a matching translation, respect the
+		// admin's choice. Only fall back to the visitor's browser language when the configured
+		// default has no translation available — that's the case where the visitor would otherwise
+		// see English regardless of what the admin configured.
+		const configured = document.documentElement.lang.toLowerCase();
+		const configuredLanguage = configured.split('-')[0];
+		if (configured && (cultures.has(configured) || cultures.has(configuredLanguage))) {
+			return;
+		}
 
-		// Only override the DefaultUILanguage if we actually have a matching translation.
-		// Otherwise we leave the registry on whatever <html lang> set it to.
-		if (cultures.has(preferredLower) || cultures.has(languageLower)) {
+		const preferred = navigator.language;
+		if (!preferred) return;
+		const preferredLower = preferred.toLowerCase();
+		const preferredLanguage = preferredLower.split('-')[0];
+		if (cultures.has(preferredLower) || cultures.has(preferredLanguage)) {
 			umbLocalizationRegistry.loadLanguage(preferred);
 		}
 	}

--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -232,6 +232,11 @@ export default class UmbAuthElement extends UmbLitElement {
 	override connectedCallback() {
 		super.connectedCallback();
 
+		// The host's `lang` attribute is set by Razor from GlobalSettings.DefaultUILanguage.
+		// Use it as the initial active language; current-user.context overrides it after login.
+		if (this.lang) {
+			umbLocalizationRegistry.loadLanguage(this.lang);
+		}
 		this.observe(umbLocalizationRegistry.currentLanguage, (lang) => {
 			if (lang) this.lang = lang;
 		});
@@ -244,36 +249,10 @@ export default class UmbAuthElement extends UmbLitElement {
 		// Register the main package for Umbraco.Auth
 		umbExtensionsRegistry.registerMany(extensions);
 
-		this.#applyPreferredLanguage();
-
 		// Wait for localization to be ready before loading the form
 		await this.#waitForLocalization();
 
 		this.#initializeForm();
-	}
-
-	/**
-	 * Respect the admin's configured DefaultUILanguage when a translation for it is available,
-	 * otherwise fall back to the visitor's `navigator.language` if we have a translation for that.
-	 * Without this, a visitor whose browser is set to English would override an admin's explicit
-	 * `DefaultUILanguage` configuration.
-	 */
-	#applyPreferredLanguage() {
-		const cultures = new Set(
-			umbExtensionsRegistry.getByType('localization').map((ext) => ext.meta.culture.toLowerCase()),
-		);
-		const hasMatch = (tag: string) => {
-			const lower = tag.toLowerCase();
-			return cultures.has(lower) || cultures.has(lower.split('-')[0]);
-		};
-
-		const configured = document.documentElement.lang;
-		if (configured && hasMatch(configured)) return;
-
-		const preferred = navigator.language;
-		if (preferred && hasMatch(preferred)) {
-			umbLocalizationRegistry.loadLanguage(preferred);
-		}
 	}
 
 	async #waitForLocalization(): Promise<void> {

--- a/src/Umbraco.Web.UI.Login/src/auth.element.ts
+++ b/src/Umbraco.Web.UI.Login/src/auth.element.ts
@@ -232,9 +232,6 @@ export default class UmbAuthElement extends UmbLitElement {
 	override connectedCallback() {
 		super.connectedCallback();
 
-		// Mirror the active locale onto the host element so that downstream components can
-		// resolve their `lang` from the closest ancestor with one set, rather than relying
-		// on a side-effect read of <html lang>.
 		this.observe(umbLocalizationRegistry.currentLanguage, (lang) => {
 			if (lang) this.lang = lang;
 		});
@@ -247,11 +244,7 @@ export default class UmbAuthElement extends UmbLitElement {
 		// Register the main package for Umbraco.Auth
 		umbExtensionsRegistry.registerMany(extensions);
 
-		// Now that localization extensions are registered, prefer the visitor's browser language
-		// over the configured DefaultUILanguage if we actually have a translation for it. The
-		// pipeline matches `baseName` then `language`, so 'fr-CA' falls through to 'fr' and then
-		// 'en' automatically when no specific extension exists.
-		this.#loadPreferredLanguage();
+		this.#applyPreferredLanguage();
 
 		// Wait for localization to be ready before loading the form
 		await this.#waitForLocalization();
@@ -259,26 +252,26 @@ export default class UmbAuthElement extends UmbLitElement {
 		this.#initializeForm();
 	}
 
-	#loadPreferredLanguage() {
+	/**
+	 * Respect the admin's configured DefaultUILanguage when a translation for it is available,
+	 * otherwise fall back to the visitor's `navigator.language` if we have a translation for that.
+	 * Without this, a visitor whose browser is set to English would override an admin's explicit
+	 * `DefaultUILanguage` configuration.
+	 */
+	#applyPreferredLanguage() {
 		const cultures = new Set(
 			umbExtensionsRegistry.getByType('localization').map((ext) => ext.meta.culture.toLowerCase()),
 		);
+		const hasMatch = (tag: string) => {
+			const lower = tag.toLowerCase();
+			return cultures.has(lower) || cultures.has(lower.split('-')[0]);
+		};
 
-		// If the configured DefaultUILanguage already has a matching translation, respect the
-		// admin's choice. Only fall back to the visitor's browser language when the configured
-		// default has no translation available — that's the case where the visitor would otherwise
-		// see English regardless of what the admin configured.
-		const configured = document.documentElement.lang.toLowerCase();
-		const configuredLanguage = configured.split('-')[0];
-		if (configured && (cultures.has(configured) || cultures.has(configuredLanguage))) {
-			return;
-		}
+		const configured = document.documentElement.lang;
+		if (configured && hasMatch(configured)) return;
 
 		const preferred = navigator.language;
-		if (!preferred) return;
-		const preferredLower = preferred.toLowerCase();
-		const preferredLanguage = preferredLower.split('-')[0];
-		if (cultures.has(preferredLower) || cultures.has(preferredLanguage)) {
+		if (preferred && hasMatch(preferred)) {
 			umbLocalizationRegistry.loadLanguage(preferred);
 		}
 	}


### PR DESCRIPTION
Fixes #22808.

The backoffice already respects a logged-in user's language preference. This PR fixes the gap **before login** (or when the user has no language set) — the configured `DefaultUILanguage` was silently overridden to `en` at startup.

## What changed

- Razor now sets `lang` on `<umb-app>` and `<umb-auth>` from `DefaultUILanguage`. The element reads its own `lang` on connect and tells the registry to load it. This scopes the language to the host element rather than the document — important for future scenarios where two backoffices might share the same document (e.g. Umbraco Cloud).
- `<html lang>` is now a static `"en"` — that's the language of the noscript fallback text, which is the only static content on the page. The dynamic UI's language lives on the host element.
- `UmbLocalizationRegistry` no longer forces `en` in its constructor; the active language comes from whichever host element connects.
- The implicit `MutationObserver` on `document.documentElement` is removed. The registry's pipeline writes directly to the manager's existing fields and notifies controllers inline — no new public methods on the manager.
- The `en` dictionary is always loaded alongside the active language so missing-key lookups can fall back gracefully.

## Test plan

- [x] Existing tests refactored, new tests added; `npm test` passes (83 tests).
- [x] Manual browser test: `DefaultUILanguage="da-DK"` + English browser → login renders in Danish; logging in as an English user → backoffice in English. `<umb-app>.lang` and `<umb-auth>.lang` reflect the active language.
- [ ] Cherry-pick to `v17/dev` after merge.