### PR TITLE
Accessibility: Added missing labels to code block copy button and embedded media URL input

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ar.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ar.ts
@@ -736,6 +736,7 @@ export default {
 		content: 'محتوى',
 		continue: 'متابعة',
 		copy: 'نسخ',
+		copied: 'تم النسخ!',
 		create: 'إنشاء',
 		cropSection: 'قسم الاقتصاص',
 		database: 'قاعدة بيانات',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
@@ -709,6 +709,7 @@ export default {
 		content: 'Sadržaj',
 		continue: 'Nastavi',
 		copy: 'Kopiraj',
+		copied: 'Kopirano!',
 		create: 'Kreiraj',
 		database: 'Baza podataka',
 		date: 'Datum',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
@@ -639,6 +639,7 @@ export default {
 		content: 'Obsah',
 		continue: 'Pokračovat',
 		copy: 'Kopírovat',
+		copied: 'Zkopírováno!',
 		create: 'Vytvořit',
 		database: 'Databáze',
 		date: 'Datum',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
@@ -747,6 +747,7 @@ export default {
 		content: 'Cynnwys',
 		continue: 'Bwrw ymlaen',
 		copy: 'Copïo',
+		copied: 'Wedi gopïo!',
 		create: 'Creu',
 		cropSection: 'Adran tocio',
 		database: 'Cronfa ddata',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -844,6 +844,7 @@ export default {
 		content: 'Indhold',
 		continue: 'Fortsæt',
 		copy: 'Kopiér',
+		copied: 'Kopieret!',
 		create: 'Opret',
 		cropSection: 'Beskær sektion',
 		database: 'Database',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -763,6 +763,7 @@ export default {
 		content: 'Inhalt',
 		continue: 'Weiter',
 		copy: 'Kopieren',
+		copied: 'Kopiert!',
 		create: 'Neu',
 		cropSection: 'Ausschnitte Bereich',
 		database: 'Datenbank',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -868,6 +868,7 @@ export default {
 		content: 'Content',
 		continue: 'Continue',
 		copy: 'Copy',
+		copied: 'Copied!',
 		create: 'Create',
 		database: 'Database',
 		date: 'Date',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/es.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/es.ts
@@ -477,6 +477,7 @@ export default {
 		constrainProportions: 'Mantener proporciones',
 		continue: 'Continuar',
 		copy: 'Copiar',
+		copied: '¡Copiado!',
 		create: 'Crear',
 		database: 'Base de datos',
 		date: 'Fecha',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
@@ -663,6 +663,7 @@ export default {
 		content: 'Contenu',
 		continue: 'Continuer',
 		copy: 'Copier',
+		copied: 'Copié !',
 		create: 'Créer',
 		database: 'Base de données',
 		date: 'Date',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/he.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/he.ts
@@ -262,6 +262,7 @@ export default {
 		constrainProportions: 'שמור על פרופורציות',
 		continue: 'המשך',
 		copy: 'העתק',
+		copied: 'הועתק!',
 		create: 'צור',
 		database: 'בסיס נתונים',
 		date: 'תאריך',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
@@ -711,6 +711,7 @@ export default {
 		content: 'Sadržaj',
 		continue: 'Nastavi',
 		copy: 'Kopiraj',
+		copied: 'Kopirano!',
 		create: 'Kreiraj',
 		database: 'Baza podataka',
 		date: 'Datum',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
@@ -721,6 +721,7 @@ export default {
 		content: 'Contenuto',
 		continue: 'Continua',
 		copy: 'Copia',
+		copied: 'Copiato!',
 		create: 'Crea',
 		cropSection: 'Selezione di ritaglio',
 		database: 'Database',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ja.ts
@@ -382,6 +382,7 @@ export default {
 		constrainProportions: '縦横比',
 		continue: '続行',
 		copy: 'コピー',
+		copied: 'コピーしました！',
 		create: '新規作成',
 		database: 'データベース',
 		date: '日付',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ko.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ko.ts
@@ -261,6 +261,7 @@ export default {
 		constrainProportions: '비율 맞추기',
 		continue: '계속',
 		copy: '복사',
+		copied: '복사됨!',
 		create: '생성',
 		database: '데이타베이스',
 		date: '날짜',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
@@ -455,6 +455,7 @@ export default {
 		content: 'Innhold',
 		continue: 'Fortsett',
 		copy: 'Kopier',
+		copied: 'Kopiert!',
 		create: 'Opprett',
 		cropSection: 'Utsnitt',
 		current: 'nåværende',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
@@ -679,6 +679,7 @@ export default {
 		content: 'Inhoud',
 		continue: 'Doorgaan',
 		copy: 'Kopiëren',
+		copied: 'Gekopieerd!',
 		create: 'Aanmaken',
 		cropSection: 'Sectie bijsnijden',
 		database: 'Database',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pl.ts
@@ -460,6 +460,7 @@ export default {
 		constrainProportions: 'Zachowaj proporcje',
 		continue: 'Kontynuuj',
 		copy: 'Kopiuj',
+		copied: 'Skopiowano!',
 		create: 'Utwórz',
 		database: 'Baza danych',
 		date: 'Data',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -831,6 +831,7 @@ export default {
 		content: 'Conteúdo',
 		continue: 'Continuar',
 		copy: 'Copiar',
+		copied: 'Copiado!',
 		create: 'Criar',
 		database: 'Base de dados',
 		date: 'Data',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ru.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ru.ts
@@ -506,6 +506,7 @@ export default {
 		constrainProportions: 'Сохранять пропорции',
 		continue: 'Далее',
 		copy: 'Копировать',
+		copied: 'Скопировано!',
 		create: 'Создать',
 		database: 'База данных',
 		date: 'Дата',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
@@ -489,6 +489,7 @@ export default {
 		content: 'Innehåll',
 		continue: 'Fortsätt',
 		copy: 'Kopiera',
+		copied: 'Kopierat!',
 		create: 'Skapa',
 		database: 'Databas',
 		date: 'Datum',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/tr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/tr.ts
@@ -653,6 +653,7 @@ export default {
 		content: 'İçerik',
 		continue: 'Devam et',
 		copy: 'Kopyala',
+		copied: 'Kopyalandı!',
 		create: 'Oluştur',
 		cropSection: 'Bölümü kırp',
 		database: 'Veritabanı',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/uk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/uk.ts
@@ -504,6 +504,7 @@ export default {
 		constrainProportions: 'Зберігати пропорції',
 		continue: 'Далі',
 		copy: 'Копіювати',
+		copied: 'Скопійовано!',
 		create: 'Створити',
 		database: 'База даних',
 		date: 'Дата',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
@@ -837,6 +837,7 @@ export default {
 		content: 'Nội dung',
 		continue: 'Tiếp tục',
 		copy: 'Sao chép',
+		copied: 'Đã sao chép!',
 		create: 'Tạo mới',
 		database: 'Cơ sở dữ liệu',
 		date: 'Ngày',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/zh-tw.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/zh-tw.ts
@@ -362,6 +362,7 @@ export default {
 		constrainProportions: '強制屬性',
 		continue: '繼續',
 		copy: '複製',
+		copied: '已複製！',
 		create: '創建',
 		database: '資料庫',
 		date: '時間',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/zh.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/zh.ts
@@ -365,6 +365,7 @@ export default {
 		constrainProportions: '强制属性',
 		continue: '继续',
 		copy: '复制',
+		copied: '已复制！',
 		create: '创建',
 		database: '数据库',
 		date: '时间',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -1,5 +1,7 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { css, customElement, html, property, state, when, LitElement } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, property, state, when } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 //TODO consider adding a highlight prop to the code block, that could spin up/access monaco instance and highlight the code
 
@@ -8,7 +10,7 @@ import { css, customElement, html, property, state, when, LitElement } from '@um
  *  @slot - the default slot where the full message resides
  */
 @customElement('umb-code-block')
-export class UmbCodeBlockElement extends LitElement {
+export class UmbCodeBlockElement extends UmbLitElement {
 	@property()
 	language = '';
 
@@ -17,6 +19,8 @@ export class UmbCodeBlockElement extends LitElement {
 
 	@state()
 	private _copyState: 'idle' | 'success' = 'idle';
+
+	readonly #localize = new UmbLocalizationController(this);
 
 	async copyCode() {
 		const text = this.textContent;
@@ -44,7 +48,7 @@ export class UmbCodeBlockElement extends LitElement {
 				${when(
 					this.copy,
 					() => html`
-						<uui-button color=${this._copyState === 'idle' ? 'default' : 'positive'} @click=${this.copyCode}>
+						<uui-button color=${this._copyState === 'idle' ? 'default' : 'positive'} .label=${this._copyState === 'idle' ? this.#localize.term('general_copy') : this.#localize.term('general_copied')} @click=${this.copyCode}>
 							${when(
 								this._copyState === 'idle',
 								() => html`<uui-icon name="copy"></uui-icon> <umb-localize key="general_copy">Copy</umb-localize>`,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -1,7 +1,6 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, customElement, html, property, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 
 //TODO consider adding a highlight prop to the code block, that could spin up/access monaco instance and highlight the code
 
@@ -20,7 +19,6 @@ export class UmbCodeBlockElement extends UmbLitElement {
 	@state()
 	private _copyState: 'idle' | 'success' = 'idle';
 
-	readonly #localize = new UmbLocalizationController(this);
 
 	async copyCode() {
 		const text = this.textContent;
@@ -48,7 +46,7 @@ export class UmbCodeBlockElement extends UmbLitElement {
 				${when(
 					this.copy,
 					() => html`
-						<uui-button color=${this._copyState === 'idle' ? 'default' : 'positive'} .label=${this._copyState === 'idle' ? this.#localize.term('general_copy') : this.#localize.term('general_copied')} @click=${this.copyCode}>
+						<uui-button color=${this._copyState === 'idle' ? 'default' : 'positive'} .label=${this._copyState === 'idle' ? this.localize.term('general_copy') : this.localize.term('general_copied')} @click=${this.copyCode}>
 							${when(
 								this._copyState === 'idle',
 								() => html`<uui-icon name="copy"></uui-icon> <umb-localize key="general_copy">Copy</umb-localize>`,

--- a/src/Umbraco.Web.UI.Client/src/packages/embedded-media/modal/embedded-media-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/embedded-media/modal/embedded-media-modal.element.ts
@@ -100,7 +100,7 @@ export class UmbEmbeddedMediaModalElement extends UmbModalBaseElement<
 				<uui-box>
 					<umb-property-layout label=${this.localize.term('general_url')} orientation="vertical">
 						<div slot="editor">
-							<uui-input id="url" .value=${this._url} @input=${this.#onUrlChange} required="true" ${umbFocus()}>
+							<uui-input id="url" label=${this.localize.term('general_retrieve')} .value=${this._url} @input=${this.#onUrlChange} required="true" ${umbFocus()}>
 								<uui-button
 									slot="append"
 									look="primary"

--- a/src/Umbraco.Web.UI.Client/src/packages/embedded-media/modal/embedded-media-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/embedded-media/modal/embedded-media-modal.element.ts
@@ -100,7 +100,7 @@ export class UmbEmbeddedMediaModalElement extends UmbModalBaseElement<
 				<uui-box>
 					<umb-property-layout label=${this.localize.term('general_url')} orientation="vertical">
 						<div slot="editor">
-							<uui-input id="url" label=${this.localize.term('general_retrieve')} .value=${this._url} @input=${this.#onUrlChange} required="true" ${umbFocus()}>
+							<uui-input id="url" label=${this.localize.term('general_url')} .value=${this._url} @input=${this.#onUrlChange} required="true" ${umbFocus()}>
 								<uui-button
 									slot="append"
 									look="primary"


### PR DESCRIPTION
## Description

Found more missing `label` attributes on UUI controls causing accessibility console warnings.

**Changes:**

- `code-block.element.ts` add localized `label` to the copy `uui-button` (`general_copy` / `general_copied`). Also migrated the element from `LitElement` to `UmbLitElement` to support `UmbLocalizationController`.
<img width="1317" height="236" alt="image" src="https://github.com/user-attachments/assets/980111a5-24b7-4aa0-9d5f-c02f710c9834" />


- `embedded-media-modal.element.ts` correct the `uui-input` label from `general_retrieve` (the retrieve button label) to `general_url`, which matches what the field actually represents.
<img width="991" height="464" alt="image" src="https://github.com/user-attachments/assets/efb261d6-592c-4cb7-a410-a925aef5aa49" />


## Testing

1. Open any page that renders a code block with the `copy` attribute (e.g. the query builder or template editor).
2. Open browser console: verify no `needs a 'label'` accessibility warning appears for the copy button.
3. Open the **Embed** modal (e.g. via the RTE embed option).
4. Open browser console: verify no `needs a 'label'` warning appears for the URL input.
