### PR TITLE
build(deps): bumps @umbraco-ui/uui from 2.0.0-alpha.1 to 2.0.0-rc.1

### DIFF
--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -3963,9 +3963,9 @@
 			"link": true
 		},
 		"node_modules/@umbraco-ui/uui": {
-			"version": "2.0.0-rc.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-2.0.0-rc.0.tgz",
-			"integrity": "sha512-Rj9qAKXtCJBFtEB/x260X1pYs30n/SANvQRt44ECgJwFjJtS/GaD3ALlumLi7gewSTNs6XDvDx5HxNLjFKbsRA==",
+			"version": "2.0.0-rc.1",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-2.0.0-rc.1.tgz",
+			"integrity": "sha512-qhKsTl11hq82GQWZEq/2f/D1UePjfN9DLet7MqastvEKFdwdgHM9cCu+2f3mlOcX/OHj5XiUwLVFoJanRgfJZg==",
 			"license": "MIT",
 			"dependencies": {
 				"culori": "^4.0.2",
@@ -16447,7 +16447,7 @@
 		"src/external/uui": {
 			"name": "@umbraco-backoffice/uui",
 			"dependencies": {
-				"@umbraco-ui/uui": "^2.0.0-rc.0"
+				"@umbraco-ui/uui": "^2.0.0-rc.1"
 			}
 		},
 		"src/libs/class-api": {

--- a/src/Umbraco.Web.UI.Client/package-lock.json
+++ b/src/Umbraco.Web.UI.Client/package-lock.json
@@ -3963,9 +3963,9 @@
 			"link": true
 		},
 		"node_modules/@umbraco-ui/uui": {
-			"version": "2.0.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-2.0.0-alpha.1.tgz",
-			"integrity": "sha512-WcBhB0t243yxTTVzdLJn+JAeGxWp7fyqUoctzhFDunvUvRu3dZk7uZF+eed+nZFb/tivZZ4pRBJ2FqcPXwBLNg==",
+			"version": "2.0.0-rc.0",
+			"resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-2.0.0-rc.0.tgz",
+			"integrity": "sha512-Rj9qAKXtCJBFtEB/x260X1pYs30n/SANvQRt44ECgJwFjJtS/GaD3ALlumLi7gewSTNs6XDvDx5HxNLjFKbsRA==",
 			"license": "MIT",
 			"dependencies": {
 				"culori": "^4.0.2",
@@ -16447,7 +16447,7 @@
 		"src/external/uui": {
 			"name": "@umbraco-backoffice/uui",
 			"dependencies": {
-				"@umbraco-ui/uui": "^2.0.0-alpha.1"
+				"@umbraco-ui/uui": "^2.0.0-rc.0"
 			}
 		},
 		"src/libs/class-api": {

--- a/src/Umbraco.Web.UI.Client/src/external/uui/package.json
+++ b/src/Umbraco.Web.UI.Client/src/external/uui/package.json
@@ -6,6 +6,6 @@
 		"build": "vite build"
 	},
 	"dependencies": {
-		"@umbraco-ui/uui": "^2.0.0-rc.0"
+		"@umbraco-ui/uui": "^2.0.0-rc.1"
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/external/uui/package.json
+++ b/src/Umbraco.Web.UI.Client/src/external/uui/package.json
@@ -6,6 +6,6 @@
 		"build": "vite build"
 	},
 	"dependencies": {
-		"@umbraco-ui/uui": "^2.0.0-alpha.1"
+		"@umbraco-ui/uui": "^2.0.0-rc.0"
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.test.ts
@@ -7,7 +7,7 @@ describe('UmbPersistentModalDialogElement', () => {
 
 	beforeEach(async () => {
 		element = await fixture(html`<umb-persistent-modal-dialog></umb-persistent-modal-dialog>`);
-		// `_openModal` defers `isOpen = true` via queueMicrotask
+		// `_openModal` defers `isOpen = true` via queueMicrotask.
 		await aTimeout(0);
 	});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.test.ts
@@ -1,0 +1,78 @@
+import { UmbPersistentModalDialogElement } from './persistent-modal-dialog.element.js';
+import { aTimeout, expect, fixture, html } from '@open-wc/testing';
+import { UUIModalDialogElement } from '@umbraco-cms/backoffice/external/uui';
+
+describe('UmbPersistentModalDialogElement', () => {
+	let element: UmbPersistentModalDialogElement;
+
+	beforeEach(async () => {
+		element = await fixture(html`<umb-persistent-modal-dialog></umb-persistent-modal-dialog>`);
+		// `_openModal` defers `isOpen = true` via queueMicrotask
+		await aTimeout(0);
+	});
+
+	afterEach(() => {
+		if (!element.isClosing) {
+			element.forceClose();
+		}
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbPersistentModalDialogElement);
+	});
+
+	it('extends UUIModalDialogElement', () => {
+		expect(element).to.be.instanceOf(UUIModalDialogElement);
+	});
+
+	it('auto-opens the dialog after first update', () => {
+		expect(element.isOpen).to.equal(true);
+		const dialog = element.shadowRoot?.querySelector('dialog');
+		expect(dialog?.open).to.equal(true);
+	});
+
+	it('prevents the Escape key from closing the dialog', () => {
+		const dialog = element.shadowRoot?.querySelector('dialog') as HTMLDialogElement;
+		const keydown = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true });
+		dialog.dispatchEvent(keydown);
+
+		expect(keydown.defaultPrevented).to.equal(true);
+		expect(element.isOpen).to.equal(true);
+	});
+
+	it('does not interfere with non-Escape keys', () => {
+		const dialog = element.shadowRoot?.querySelector('dialog') as HTMLDialogElement;
+		const keydown = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true, bubbles: true });
+		dialog.dispatchEvent(keydown);
+
+		expect(keydown.defaultPrevented).to.equal(false);
+	});
+
+	it('prevents the dialog cancel event from dismissing the modal', () => {
+		const dialog = element.shadowRoot?.querySelector('dialog') as HTMLDialogElement;
+		const cancelEvent = new Event('cancel', { cancelable: true });
+		dialog.dispatchEvent(cancelEvent);
+
+		expect(cancelEvent.defaultPrevented).to.equal(true);
+		expect(element.isOpen).to.equal(true);
+	});
+
+	it('closes when forceClose is called', () => {
+		element.forceClose();
+		expect(element.isOpen).to.equal(false);
+		expect(element.isClosing).to.equal(true);
+	});
+
+	it('removes the listeners after forceClose', () => {
+		const dialog = element.shadowRoot?.querySelector('dialog') as HTMLDialogElement;
+		element.forceClose();
+
+		const keydown = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true });
+		dialog.dispatchEvent(keydown);
+		expect(keydown.defaultPrevented).to.equal(false);
+
+		const cancelEvent = new Event('cancel', { cancelable: true });
+		dialog.dispatchEvent(cancelEvent);
+		expect(cancelEvent.defaultPrevented).to.equal(false);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.ts
@@ -14,13 +14,9 @@ export class UmbPersistentModalDialogElement extends UUIModalDialogElement {
 		this.#abortController = new AbortController();
 		const signal = this.#abortController.signal;
 
-		this._popoverElement?.showPopover();
-		if (!this._popoverElement?.hasAttribute('tabindex')) {
-			this._popoverElement?.setAttribute('tabindex', '-1');
-		}
-		this._popoverElement?.addEventListener('cancel', (e) => e.preventDefault(), { signal });
-		document.addEventListener('keydown', this._onKeyDown, { signal });
-		document.addEventListener('focus', this._onFocus, true);
+		this._dialogElement?.showModal();
+		this._dialogElement?.addEventListener('keydown', (e) => e.key === 'Escape' && e.preventDefault(), { signal });
+		this._dialogElement?.addEventListener('cancel', (e) => e.preventDefault(), { signal });
 
 		// Defer isOpen to avoid scheduling a Lit update during firstUpdated
 		queueMicrotask(() => {
@@ -30,23 +26,8 @@ export class UmbPersistentModalDialogElement extends UUIModalDialogElement {
 
 	override forceClose(): void {
 		this.#abortController?.abort();
-		document.removeEventListener('keydown', this._onKeyDown);
-		document.removeEventListener('focus', this._onFocus, true);
 		super.forceClose();
 	}
-
-	private readonly _onKeyDown = (e: KeyboardEvent) => {
-		if (e.key === 'Escape') {
-			e.preventDefault();
-		}
-	};
-
-	private readonly _onFocus = (e: FocusEvent) => {
-		if (this.index !== 0) return;
-		if (!this._popoverElement?.contains(e.target as Node)) {
-			this._popoverElement?.focus();
-		}
-	};
 }
 
 export default UmbPersistentModalDialogElement;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.ts
@@ -14,9 +14,13 @@ export class UmbPersistentModalDialogElement extends UUIModalDialogElement {
 		this.#abortController = new AbortController();
 		const signal = this.#abortController.signal;
 
-		this._dialogElement?.showModal();
-		this._dialogElement?.addEventListener('keydown', (e) => e.key === 'Escape' && e.preventDefault(), { signal });
-		this._dialogElement?.addEventListener('cancel', (e) => e.preventDefault(), { signal });
+		this._popoverElement?.showPopover();
+		if (!this._popoverElement?.hasAttribute('tabindex')) {
+			this._popoverElement?.setAttribute('tabindex', '-1');
+		}
+		this._popoverElement?.addEventListener('keydown', (e) => e.key === 'Escape' && e.preventDefault(), { signal });
+		this._popoverElement?.addEventListener('cancel', (e) => e.preventDefault(), { signal });
+		document.addEventListener('focus', this._onFocus, true);
 
 		// Defer isOpen to avoid scheduling a Lit update during firstUpdated
 		queueMicrotask(() => {
@@ -28,6 +32,13 @@ export class UmbPersistentModalDialogElement extends UUIModalDialogElement {
 		this.#abortController?.abort();
 		super.forceClose();
 	}
+
+	private readonly _onFocus = (e: FocusEvent) => {
+		if (this.index !== 0) return;
+		if (!this._popoverElement?.contains(e.target as Node)) {
+			this._popoverElement?.focus();
+		}
+	};
 }
 
 export default UmbPersistentModalDialogElement;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/modal/component/persistent-modal-dialog.element.ts
@@ -18,8 +18,8 @@ export class UmbPersistentModalDialogElement extends UUIModalDialogElement {
 		if (!this._popoverElement?.hasAttribute('tabindex')) {
 			this._popoverElement?.setAttribute('tabindex', '-1');
 		}
-		this._popoverElement?.addEventListener('keydown', (e) => e.key === 'Escape' && e.preventDefault(), { signal });
 		this._popoverElement?.addEventListener('cancel', (e) => e.preventDefault(), { signal });
+		document.addEventListener('keydown', this._onKeyDown, { signal });
 		document.addEventListener('focus', this._onFocus, true);
 
 		// Defer isOpen to avoid scheduling a Lit update during firstUpdated
@@ -30,8 +30,16 @@ export class UmbPersistentModalDialogElement extends UUIModalDialogElement {
 
 	override forceClose(): void {
 		this.#abortController?.abort();
+		document.removeEventListener('keydown', this._onKeyDown);
+		document.removeEventListener('focus', this._onFocus, true);
 		super.forceClose();
 	}
+
+	private readonly _onKeyDown = (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+		}
+	};
 
 	private readonly _onFocus = (e: FocusEvent) => {
 		if (this.index !== 0) return;


### PR DESCRIPTION
## Description

Bumps @umbraco-ui/uui to the newly released rc.1.

rc.0 briefly switched the modal element from `<dialog>`/`showModal()` to the Popover API (UUI #1363), and `UmbPersistentModalDialogElement` was patched to override the new behavior. That PR was reverted in rc.1, so the persistent modal is back to its pre-rc.0 implementation (using `_dialogElement` + `cancel`/`keydown` listeners).

Also adds unit tests for `UmbPersistentModalDialogElement` covering:
- auto-open
- ESC keydown is prevented (modal stays open)
- non-Escape keys pass through
- dialog `cancel` event is prevented
- `forceClose()` closes the modal and tears down listeners