### PR TITLE
Prevent active tab changing on ctrl + click

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-header-sections.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-header-sections.element.ts
@@ -3,6 +3,8 @@ import type { UmbBackofficeContext } from '../backoffice.context.js';
 import { css, customElement, html, ifDefined, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { ManifestSection } from '@umbraco-cms/backoffice/section';
+import { ensureSlash } from '../../../packages/core/router/index.js';
+import { UUITabElement } from '../../../external/uui/index.js';
 
 @customElement('umb-backoffice-header-sections')
 export class UmbBackofficeHeaderSectionsElement extends UmbLitElement {
@@ -59,6 +61,7 @@ export class UmbBackofficeHeaderSectionsElement extends UmbLitElement {
 	#onSectionClick(event: PointerEvent, manifest: ManifestSection | undefined) {
 		// Let the browser handle the click if the Ctrl or Meta key is pressed
 		if (event.ctrlKey || event.metaKey) {
+			this.requestUpdate();
 			return;
 		}
 
@@ -100,22 +103,27 @@ export class UmbBackofficeHeaderSectionsElement extends UmbLitElement {
 		return html`
 			<uui-tab-group id="tabs" data-mark="section-links">
 				${repeat(
-					this._sections,
-					(section) => section.alias,
-					(section) => this.#renderItem(section),
-				)}
+			this._sections,
+			(section) => section.alias,
+			(section) => this.#renderItem(section),
+		)}
 			</uui-tab-group>
 		`;
 	}
 
 	#renderItem(manifest: ManifestSection) {
 		const label = this.localize.string(manifest?.meta.label || manifest?.name);
-		return html`<uui-tab
-			data-mark="section-link:${manifest.alias}"
-			.href=${this.#getSectionPath(manifest)}
-			label=${ifDefined(label)}
-			?active=${this._currentSectionAlias === manifest.alias}
-			@click=${(event: PointerEvent) => this.#onSectionClick(event, manifest)}></uui-tab>`;
+		const href = this.#getSectionPath(manifest)
+		const location = ensureSlash(window.location.pathname);
+		const compareHref = ensureSlash(href);
+		const isActive = location.includes(compareHref);
+		const tab = new UUITabElement();
+		tab.dataset.mark = `section-link:${manifest.alias}`;
+		tab.href = href;
+		tab.label = label;
+		tab.active = isActive;
+		tab.onclick = (event: PointerEvent) => this.#onSectionClick(event, manifest);
+		return tab;
 	}
 
 	static override readonly styles = [

--- a/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-header-sections.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/backoffice/components/backoffice-header-sections.element.ts
@@ -1,10 +1,10 @@
 import { UMB_BACKOFFICE_CONTEXT } from '../backoffice.context.js';
 import type { UmbBackofficeContext } from '../backoffice.context.js';
-import { css, customElement, html, ifDefined, repeat, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, repeat, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { ManifestSection } from '@umbraco-cms/backoffice/section';
-import { ensureSlash } from '../../../packages/core/router/index.js';
-import { UUITabElement } from '../../../external/uui/index.js';
+import { ensureSlash } from '@umbraco-cms/backoffice/router';
+import { UUITabElement } from '@umbraco-cms/backoffice/external/uui';
 
 @customElement('umb-backoffice-header-sections')
 export class UmbBackofficeHeaderSectionsElement extends UmbLitElement {


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #21040 

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
When opening a new browser tab via Ctrl + click, the current browser tab shows the opened tab link as active. I think the underlying issue is with UUI, Lit and the ActiveMixin as it would appear the browser may be applying the active attribute by itself as the _currentSectionAlias used previously for checking if a tab is active does not change, but the active status does.

This same issue doesn't appear to happen with menu items as they use the window.location to set their active status. This has been replicated here and on a ctrl click we can requestUpdate to make sure that this is respected.


<!-- Thanks for contributing to Umbraco CMS! -->
