### PR TITLE
Redirect URL Tracker: Remove ability to toggle from the UI

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
@@ -1,74 +1,30 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Models.RedirectUrlManagement;
-using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
 /// <summary>
-/// Controller for setting the redirect URL tracking status.
+/// Controller for setting the redirect URL tracking status. Retained for backwards compatibility only;
+/// the endpoint no longer modifies any configuration.
 /// </summary>
 [ApiVersion("1.0")]
+[Obsolete("This controller is deprecated and no longer modifies the configuration. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead. Scheduled for removal in Umbraco 19.")]
 public class SetStatusRedirectUrlManagementController : RedirectUrlManagementControllerBase
 {
-    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
-    private readonly IConfigManipulator _configManipulator;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="SetStatusRedirectUrlManagementController"/> class.
-    /// </summary>
-    /// <param name="backOfficeSecurityAccessor">The back office security accessor.</param>
-    /// <param name="configManipulator">The configuration manipulator.</param>
-    public SetStatusRedirectUrlManagementController(
-        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
-        IConfigManipulator configManipulator)
-    {
-        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
-        _configManipulator = configManipulator;
-    }
-
-    // TODO: Consider if we should even allow this, or only allow using the appsettings
-    // We generally don't want to edit the appsettings from our code.
-    // But maybe there is a valid use case for doing it on the fly.
-    /// <summary>
-    /// Sets the redirect URL tracking status.
+    /// Deprecated. Returns an OK response without modifying any configuration. To toggle redirect URL tracking,
+    /// set the <c>Umbraco:CMS:WebRouting:DisableRedirectUrlTracking</c> configuration key instead.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token for the HTTP request.</param>
-    /// <param name="status">The redirect status to set.</param>
-    /// <returns>An OK result if successful.</returns>
+    /// <param name="status">The redirect status (ignored).</param>
+    /// <returns>An OK result.</returns>
     [HttpPost("status")]
-    [EndpointSummary("Sets the redirect URL tracking status.")]
-    [EndpointDescription("Updates the redirect URL tracking configuration according to the provided status.")]
+    [EndpointSummary("Deprecated. No longer changes the redirect URL tracking status.")]
+    [EndpointDescription("This endpoint is deprecated and no longer modifies the configuration. To toggle redirect URL tracking, set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead.")]
     [MapToApiVersion("1.0")]
-    public async Task<IActionResult> SetStatus(CancellationToken cancellationToken, [FromQuery] RedirectStatus status)
-    {
-        // TODO: uncomment this when auth is implemented.
-        // var userIsAdmin = _backOfficeSecurityAccessor.BackOfficeSecurity?.CurrentUser?.IsAdmin();
-        // if (userIsAdmin is null or false)
-        // {
-        //     return Unauthorized();
-        // }
-
-        var enable = status switch
-        {
-            RedirectStatus.Enabled => true,
-            RedirectStatus.Disabled => false,
-            _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown redirect status")
-        };
-
-        // For now I'm not gonna change this to limit breaking, but it's weird to have a "disabled" switch,
-        // since you're essentially negating the boolean from the get go,
-        // it's much easier to reason with enabled = false == disabled.
-        await _configManipulator.SaveDisableRedirectUrlTrackingAsync(!enable);
-
-        // Taken from the existing implementation in RedirectUrlManagementController
-        // TODO this is ridiculous, but we need to ensure the configuration is reloaded, before this request is ended.
-        // otherwise we can read the old value in GetEnableState.
-        // The value is equal to JsonConfigurationSource.ReloadDelay
-        Thread.Sleep(250);
-
-        return Ok();
-    }
+    [Obsolete("This endpoint is deprecated and no longer modifies the configuration. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead. Scheduled for removal in Umbraco 19.")]
+    public Task<IActionResult> SetStatus(CancellationToken cancellationToken, [FromQuery] RedirectStatus status)
+        => Task.FromResult<IActionResult>(Ok());
 }

--- a/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/RedirectUrlManagement/SetStatusRedirectUrlManagementController.cs
@@ -1,7 +1,9 @@
 using Asp.Versioning;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Models.RedirectUrlManagement;
+using Umbraco.Cms.Core.Security;
 
 namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 
@@ -13,6 +15,19 @@ namespace Umbraco.Cms.Api.Management.Controllers.RedirectUrlManagement;
 [Obsolete("This controller is deprecated and no longer modifies the configuration. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead. Scheduled for removal in Umbraco 19.")]
 public class SetStatusRedirectUrlManagementController : RedirectUrlManagementControllerBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetStatusRedirectUrlManagementController"/> class.
+    /// </summary>
+    /// <param name="backOfficeSecurityAccessor">Ignored. Retained for binary compatibility.</param>
+    /// <param name="configManipulator">Ignored. Retained for binary compatibility.</param>
+    public SetStatusRedirectUrlManagementController(
+#pragma warning disable IDE0060 // Remove unused parameter
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
+        IConfigManipulator configManipulator)
+#pragma warning restore IDE0060 // Remove unused parameter
+    {
+    }
+
     /// <summary>
     /// Deprecated. Returns an OK response without modifying any configuration. To toggle redirect URL tracking,
     /// set the <c>Umbraco:CMS:WebRouting:DisableRedirectUrlTracking</c> configuration key instead.

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -27860,8 +27860,8 @@
         "tags": [
           "Redirect Management"
         ],
-        "summary": "Sets the redirect URL tracking status.",
-        "description": "Updates the redirect URL tracking configuration according to the provided status.",
+        "summary": "Deprecated. No longer changes the redirect URL tracking status.",
+        "description": "This endpoint is deprecated and no longer modifies the configuration. To toggle redirect URL tracking, set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead.",
         "operationId": "PostRedirectManagementStatus",
         "parameters": [
           {
@@ -27907,6 +27907,7 @@
             }
           }
         },
+        "deprecated": true,
         "security": [
           {
             "Backoffice-User": [ ]

--- a/src/Umbraco.Core/Configuration/IConfigManipulator.cs
+++ b/src/Umbraco.Core/Configuration/IConfigManipulator.cs
@@ -36,6 +36,7 @@ public interface IConfigManipulator
     /// </summary>
     /// <param name="disable">The value to save.</param>
     /// <returns></returns>
+    [Obsolete("This method is no longer used by Umbraco. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead. Scheduled for removal in Umbraco 19.")]
     Task SaveDisableRedirectUrlTrackingAsync(bool disable);
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
+++ b/src/Umbraco.Infrastructure/Configuration/JsonConfigManipulator.cs
@@ -104,6 +104,7 @@ internal sealed class JsonConfigManipulator : IConfigManipulator
     }
 
     /// <inheritdoc />
+    [Obsolete("This method is no longer used by Umbraco. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead. Scheduled for removal in Umbraco 19.")]
     public async Task SaveDisableRedirectUrlTrackingAsync(bool disable)
         => await CreateOrUpdateConfigValueAsync(DisableRedirectUrlTrackingPath, disable);
 

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ar.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ar.ts
@@ -2025,6 +2025,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'تعطيل تتبع URL',
 		enableUrlTracker: 'تمكين تتبع URL',
+		urlTrackerEnabled: 'ممكّن',
+		urlTrackerDisabled: 'معطّل',
 		culture: 'الثقافة',
 		originalUrl: 'URL الأصلي',
 		redirectedTo: 'تم إعادة التوجيه إلى',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
@@ -1907,6 +1907,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Onemogući URL tragač',
 		enableUrlTracker: 'Omogući URL tragač',
+		urlTrackerEnabled: 'Omogućen',
+		urlTrackerDisabled: 'Onemogućen',
 		originalUrl: 'Originalni URL',
 		redirectedTo: 'Preusmjeri na',
 		redirectUrlManagement: 'Preusmjeravanje URL-ova',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
@@ -1735,6 +1735,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Zakázat sledování URL',
 		enableUrlTracker: 'Povolit sledování URL',
+		urlTrackerEnabled: 'Povoleno',
+		urlTrackerDisabled: 'Zakázáno',
 		culture: 'Jazyk',
 		originalUrl: 'Originální URL',
 		redirectedTo: 'Přesměrováno na',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
@@ -2087,6 +2087,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Analluogi olinydd URL',
 		enableUrlTracker: 'Galluogi olinydd URL',
+		urlTrackerEnabled: "Wedi'i alluogi",
+		urlTrackerDisabled: "Wedi'i analluogi",
 		culture: 'Diwylliant',
 		originalUrl: 'URL gwreiddiol',
 		redirectedTo: 'Ailgyfeirwyd I',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -2246,6 +2246,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Slå URL tracker fra',
 		enableUrlTracker: 'Slå URL tracker til',
+		urlTrackerEnabled: 'Aktiveret',
+		urlTrackerDisabled: 'Deaktiveret',
 		culture: 'Kultur',
 		originalUrl: 'Original URL',
 		redirectedTo: 'Viderestillet til',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -1912,6 +1912,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'URL-Änderungsaufzeichnung abschalten',
 		enableUrlTracker: 'URL-Änderungsaufzeichnung einschalten',
+		urlTrackerEnabled: 'Aktiviert',
+		urlTrackerDisabled: 'Deaktiviert',
 		culture: 'Kultur',
 		originalUrl: 'Original URL',
 		redirectedTo: 'Weiterleiten zu',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2359,7 +2359,11 @@ export default {
 	},
 	redirectUrls: {
 		disableUrlTracker: 'Disable URL tracker',
+		disableUrlTrackerInstruction:
+			'Redirect URL tracking is configured through application settings. To disable tracking, set the following configuration key to true:',
 		enableUrlTracker: 'Enable URL tracker',
+		enableUrlTrackerInstruction:
+			'Redirect URL tracking is configured through application settings. To enable tracking, set the following configuration key to false:',
 		originalUrl: 'Original URL',
 		redirectedTo: 'Redirected To',
 		redirectUrlManagement: 'Redirect URL Management',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2364,6 +2364,8 @@ export default {
 		enableUrlTracker: 'Enable URL tracker',
 		enableUrlTrackerInstruction:
 			'Redirect URL tracking is configured through application settings. To enable tracking, set the following configuration key to false:',
+		urlTrackerEnabled: 'Enabled',
+		urlTrackerDisabled: 'Disabled',
 		originalUrl: 'Original URL',
 		redirectedTo: 'Redirected To',
 		redirectUrlManagement: 'Redirect URL Management',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/es.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/es.ts
@@ -1436,6 +1436,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Desactivar URL tracker',
 		enableUrlTracker: 'Activar URL tracker',
+		urlTrackerEnabled: 'Activado',
+		urlTrackerDisabled: 'Desactivado',
 		originalUrl: 'URL Original',
 		redirectedTo: 'Redirigido a To',
 		noRedirects: 'No se ha creado ninguna redirección',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
@@ -1788,6 +1788,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Désactiver URL tracker',
 		enableUrlTracker: 'Activer URL tracker',
+		urlTrackerEnabled: 'Activé',
+		urlTrackerDisabled: 'Désactivé',
 		culture: 'Culture',
 		originalUrl: 'URL original',
 		redirectedTo: 'Redirigé Vers',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
@@ -1967,6 +1967,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Onemogući URL praćenje',
 		enableUrlTracker: 'Omogući URL praćenje',
+		urlTrackerEnabled: 'Omogućeno',
+		urlTrackerDisabled: 'Onemogućeno',
 		originalUrl: 'Originalni URL',
 		redirectedTo: 'Preusmjerno na',
 		redirectUrlManagement: 'Preusmjeravanje URL-ova',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
@@ -1997,6 +1997,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Disabilita tracciamento degli URL',
 		enableUrlTracker: 'Abilita tracciamento degli URL',
+		urlTrackerEnabled: 'Abilitato',
+		urlTrackerDisabled: 'Disabilitato',
 		culture: 'Cultura',
 		originalUrl: 'URL originale',
 		redirectedTo: 'Reindirizzato a',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
@@ -1856,6 +1856,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'URL tracker uitschakelen',
 		enableUrlTracker: 'URL tracker inschakelen',
+		urlTrackerEnabled: 'Ingeschakeld',
+		urlTrackerDisabled: 'Uitgeschakeld',
 		culture: 'Cultuur',
 		originalUrl: 'Originele URL',
 		redirectedTo: 'Doorgestuurd naar',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pl.ts
@@ -1281,6 +1281,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Wyłącz śledzenie URL',
 		enableUrlTracker: 'Włącz śledzenie URL',
+		urlTrackerEnabled: 'Włączone',
+		urlTrackerDisabled: 'Wyłączone',
 		originalUrl: 'Oryginalny URL',
 		redirectedTo: 'Przekierowane do',
 		noRedirects: 'Nie stworzono żadnych przekierowań',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -2286,6 +2286,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Desativar Monitorizador de URLs',
 		enableUrlTracker: 'Ativar Monitorizador de URLs',
+		urlTrackerEnabled: 'Ativado',
+		urlTrackerDisabled: 'Desativado',
 		originalUrl: 'URL Original',
 		redirectedTo: 'Redirecionado Para',
 		redirectUrlManagement: 'Gestão de URL de Redirecionamento',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ru.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ru.ts
@@ -988,6 +988,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Остановить отслеживание URL',
 		enableUrlTracker: 'Запустить отслеживание URL',
+		urlTrackerEnabled: 'Включено',
+		urlTrackerDisabled: 'Отключено',
 		originalUrl: 'Первоначальный URL',
 		redirectedTo: 'Перенаправлен в',
 		noRedirects: 'На данный момент нет ни одного перенаправления',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/tr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/tr.ts
@@ -1738,6 +1738,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'URL izleyiciyi devre dışı bırakın',
 		enableUrlTracker: 'URL izleyiciyi etkinleştir',
+		urlTrackerEnabled: 'Etkin',
+		urlTrackerDisabled: 'Devre Dışı',
 		originalUrl: 'Orijinal URL',
 		redirectedTo: 'Yönlendirildi',
 		redirectUrlManagement: 'URL Yönetimini Yeniden Yönlendir',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/uk.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/uk.ts
@@ -986,6 +986,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Зупинити відстеження URL',
 		enableUrlTracker: 'Запустити відстеження URL',
+		urlTrackerEnabled: 'Увімкнено',
+		urlTrackerDisabled: 'Вимкнено',
 		originalUrl: 'Початковий URL',
 		redirectedTo: 'Перенаправлено в',
 		noRedirects: 'На даний момент немає жодного перенаправлення',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
@@ -2290,6 +2290,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: 'Tắt theo dõi URL',
 		enableUrlTracker: 'Bật theo dõi URL',
+		urlTrackerEnabled: 'Đã bật',
+		urlTrackerDisabled: 'Đã tắt',
 		originalUrl: 'URL gốc',
 		redirectedTo: 'Chuyển hướng đến',
 		redirectUrlManagement: 'Quản lý URL chuyển hướng',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/zh-tw.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/zh-tw.ts
@@ -1042,6 +1042,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: '停止網址追蹤器',
 		enableUrlTracker: '啟動網址追蹤器',
+		urlTrackerEnabled: '已啟用',
+		urlTrackerDisabled: '已停用',
 		originalUrl: '原本網址',
 		redirectedTo: '轉址成',
 		noRedirects: '沒有任何轉址',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/zh.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/zh.ts
@@ -1054,6 +1054,8 @@ export default {
 	redirectUrls: {
 		disableUrlTracker: '禁用 URL 跟踪程序',
 		enableUrlTracker: '启用 URL 跟踪程序',
+		urlTrackerEnabled: '已启用',
+		urlTrackerDisabled: '已禁用',
 		originalUrl: '原始网址',
 		redirectedTo: '已重定向至',
 		noRedirects: '未进行重定向',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/sdk.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/sdk.gen.ts
@@ -6174,9 +6174,11 @@ export class RedirectManagementService {
     }
     
     /**
-     * Sets the redirect URL tracking status.
+     * Deprecated. No longer changes the redirect URL tracking status.
      *
-     * Updates the redirect URL tracking configuration according to the provided status.
+     * This endpoint is deprecated and no longer modifies the configuration. To toggle redirect URL tracking, set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead.
+     *
+     * @deprecated
      */
     public static postRedirectManagementStatus<ThrowOnError extends boolean = true>(options?: Options<PostRedirectManagementStatusData, ThrowOnError>) {
         return (options?.client ?? client).post<PostRedirectManagementStatusResponses, PostRedirectManagementStatusErrors, ThrowOnError>({

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -113,13 +113,14 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		this.#getRedirectData(this._search.value);
 	}
 
-	async #onConfigureTracker(enable: boolean) {
+	async #showTrackerInfo() {
+		const isEnabled = this._trackerEnabled;
 		await umbInfoModal(this, {
-			headline: enable ? '#redirectUrls_enableUrlTracker' : '#redirectUrls_disableUrlTracker',
+			headline: isEnabled ? '#redirectUrls_disableUrlTracker' : '#redirectUrls_enableUrlTracker',
 			content: html`
 				<p>
 					${this.localize.term(
-						enable ? 'redirectUrls_enableUrlTrackerInstruction' : 'redirectUrls_disableUrlTrackerInstruction',
+						isEnabled ? 'redirectUrls_disableUrlTrackerInstruction' : 'redirectUrls_enableUrlTrackerInstruction',
 					)}
 				</p>
 				<p><code>Umbraco:CMS:WebRouting:DisableRedirectUrlTracking</code></p>
@@ -145,20 +146,23 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 								@click=${this.#onSearch}
 								.state=${this._buttonState}></uui-button>
 						</div>
-						<uui-button
-							look="outline"
-							label=${this.localize.term('redirectUrls_disableUrlTracker')}
-							@click=${() => this.#onConfigureTracker(false)}></uui-button>
 					`,
-					() => html`
-						<div></div>
-						<uui-button
-							color="positive"
-							look="outline"
-							label=${this.localize.term('redirectUrls_enableUrlTracker')}
-							@click=${() => this.#onConfigureTracker(true)}></uui-button>
-					`,
+					() => html`<div></div>`,
 				)}
+				<uui-button
+					id="tracker-status"
+					compact
+					label=${this.localize.term(
+						this._trackerEnabled ? 'redirectUrls_urlTrackerEnabled' : 'redirectUrls_urlTrackerDisabled',
+					)}
+					@click=${this.#showTrackerInfo}>
+					<uui-tag look="outline" color="default">
+						<umb-localize
+							key=${this._trackerEnabled
+								? 'redirectUrls_urlTrackerEnabled'
+								: 'redirectUrls_urlTrackerDisabled'}></umb-localize>
+					</uui-tag>
+				</uui-button>
 			</div>
 			${when(
 				this._redirectData?.length,
@@ -277,6 +281,15 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 			#redirect-actions {
 				display: flex;
 				justify-content: space-between;
+			}
+
+			#tracker-status {
+				--uui-button-background-color: transparent;
+				--uui-button-background-color-hover: transparent;
+			}
+
+			uui-tag {
+				text-wrap: nowrap;
 			}
 
 			#search-wrapper {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -156,7 +156,8 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 						this._trackerEnabled ? 'redirectUrls_urlTrackerEnabled' : 'redirectUrls_urlTrackerDisabled',
 					)}
 					@click=${this.#showTrackerInfo}>
-					<uui-tag look="outline" color="default">
+					<uui-tag color="default">
+						<uui-icon name="icon-info"></uui-icon>
 						<umb-localize
 							key=${this._trackerEnabled
 								? 'redirectUrls_urlTrackerEnabled'
@@ -289,6 +290,9 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 			}
 
 			uui-tag {
+				display: inline-flex;
+				align-items: center;
+				gap: var(--uui-size-1);
 				text-wrap: nowrap;
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-redirect-management/dashboard-redirect-management.element.ts
@@ -9,7 +9,7 @@ import {
 	state,
 	when,
 } from '@umbraco-cms/backoffice/external/lit';
-import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
+import { umbConfirmModal, umbInfoModal } from '@umbraco-cms/backoffice/modal';
 import { UmbDocumentRedirectManagementRepository } from '@umbraco-cms/backoffice/document';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -113,26 +113,18 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 		this.#getRedirectData(this._search.value);
 	}
 
-	async #onRequestTrackerToggle() {
-		if (!this._trackerEnabled) {
-			this.#trackerToggle();
-			return;
-		}
-
-		await umbConfirmModal(this, {
-			headline: '#redirectUrls_disableUrlTracker',
-			content: '#redirectUrls_confirmDisable',
-			color: 'danger',
-			confirmLabel: '#actions_disable',
-		});
-
-		this.#trackerToggle();
-	}
-
-	async #trackerToggle() {
-		const { error } = await this.#repository.setStatus(!this._trackerEnabled);
-		if (error) return;
-		this._trackerEnabled = !this._trackerEnabled;
+	async #onConfigureTracker(enable: boolean) {
+		await umbInfoModal(this, {
+			headline: enable ? '#redirectUrls_enableUrlTracker' : '#redirectUrls_disableUrlTracker',
+			content: html`
+				<p>
+					${this.localize.term(
+						enable ? 'redirectUrls_enableUrlTrackerInstruction' : 'redirectUrls_disableUrlTrackerInstruction',
+					)}
+				</p>
+				<p><code>Umbraco:CMS:WebRouting:DisableRedirectUrlTracking</code></p>
+			`,
+		}).catch(() => undefined);
 	}
 
 	override render() {
@@ -156,7 +148,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 						<uui-button
 							look="outline"
 							label=${this.localize.term('redirectUrls_disableUrlTracker')}
-							@click=${this.#onRequestTrackerToggle}></uui-button>
+							@click=${() => this.#onConfigureTracker(false)}></uui-button>
 					`,
 					() => html`
 						<div></div>
@@ -164,7 +156,7 @@ export class UmbDashboardRedirectManagementElement extends UmbLitElement {
 							color="positive"
 							look="outline"
 							label=${this.localize.term('redirectUrls_enableUrlTracker')}
-							@click=${this.#onRequestTrackerToggle}></uui-button>
+							@click=${() => this.#onConfigureTracker(true)}></uui-button>
 					`,
 				)}
 			</div>

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.repository.ts
@@ -2,6 +2,7 @@ import type { UmbDocumentRedirectFilterArgs } from './types.js';
 import { UmbDocumentRedirectManagementServerDataSource } from './document-redirect-management.server.data-source.js';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * Repository for managing document redirect URLs.
@@ -25,8 +26,18 @@ export class UmbDocumentRedirectManagementRepository extends UmbControllerBase i
 	 * @param {boolean} enabled - Whether the tracker should be enabled.
 	 * @returns {*}
 	 * @memberof UmbDocumentRedirectManagementRepository
+	 * @deprecated Deprecated since v17. The backend endpoint is now a no-op; set the
+	 *   `Umbraco:CMS:WebRouting:DisableRedirectUrlTracking` configuration key instead.
+	 *   Scheduled for removal in Umbraco 19.
 	 */
 	async setStatus(enabled: boolean) {
+		new UmbDeprecation({
+			deprecated: 'UmbDocumentRedirectManagementRepository.setStatus()',
+			removeInVersion: '19.0.0',
+			solution:
+				'The backend endpoint is now a no-op. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead.',
+		}).warn();
+
 		return this.#dataSource.setStatus(enabled);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -7,6 +7,7 @@ import { tryExecute } from '@umbraco-cms/backoffice/resources';
 import { RedirectManagementService, RedirectStatusModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { RedirectUrlResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * A data source for the Document Redirect Management feature that fetches data from the server.
@@ -48,8 +49,18 @@ export class UmbDocumentRedirectManagementServerDataSource {
 	 * @param {boolean} enabled - Whether the tracker should be enabled.
 	 * @returns {*}
 	 * @memberof UmbDocumentRedirectManagementServerDataSource
+	 * @deprecated Deprecated since v17. The backend endpoint is now a no-op; set the
+	 *   `Umbraco:CMS:WebRouting:DisableRedirectUrlTracking` configuration key instead.
+	 *   Scheduled for removal in Umbraco 19.
 	 */
 	async setStatus(enabled: boolean) {
+		new UmbDeprecation({
+			deprecated: 'UmbDocumentRedirectManagementServerDataSource.setStatus()',
+			removeInVersion: '19.0.0',
+			solution:
+				'The backend endpoint is now a no-op. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead.',
+		}).warn();
+
 		const status = enabled ? RedirectStatusModel.ENABLED : RedirectStatusModel.DISABLED;
 		const { error } = await tryExecute(
 			this.#host,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/redirect-management/repository/document-redirect-management.server.data-source.ts
@@ -7,7 +7,6 @@ import { tryExecute } from '@umbraco-cms/backoffice/resources';
 import { RedirectManagementService, RedirectStatusModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { RedirectUrlResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * A data source for the Document Redirect Management feature that fetches data from the server.
@@ -54,13 +53,6 @@ export class UmbDocumentRedirectManagementServerDataSource {
 	 *   Scheduled for removal in Umbraco 19.
 	 */
 	async setStatus(enabled: boolean) {
-		new UmbDeprecation({
-			deprecated: 'UmbDocumentRedirectManagementServerDataSource.setStatus()',
-			removeInVersion: '19.0.0',
-			solution:
-				'The backend endpoint is now a no-op. Set the Umbraco:CMS:WebRouting:DisableRedirectUrlTracking configuration key instead.',
-		}).warn();
-
 		const status = enabled ? RedirectStatusModel.ENABLED : RedirectStatusModel.DISABLED;
 		const { error } = await tryExecute(
 			this.#host,


### PR DESCRIPTION
## Description

The backoffice toggle for redirect URL tracking writes to `appsettings.json` at runtime via the management API. This approach has several issues:

- Writes target the first JSON configuration source, but the *effective* value at runtime comes from the most-specific source (later overrides). When the value is set in `appsettings.{Environment}.json`, the toggle silently does nothing.
- It also won't have any effect if environment variables or some other configuration source is used.
- Authorization isn't correctly implemented on the controller.
- The update doesn't propagate across servers in a load-balanced install — as each server has its own files.

Some of these problems can't reasonably be resolved, so I think it's better to remove the runtime-write path and pointing users at the configuration key instead. 

I would suggest we remove the button completely for 18, but to make the removal less of a concern for the LTS I've kept the UI in place and replaced the action with a dialog that explains how to enable or disable the redirect tracker.

## Testing

Click the "Enable/Disable URL tracker" button and verify that an appropriate message is displayed.

<img width="3044" height="821" alt="image" src="https://github.com/user-attachments/assets/1cb951e2-8001-443b-b725-b5a318e9eded" />
