### PR TITLE
System information: Adds `__uuiVersions` to sysinfo output

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
@@ -67,7 +67,10 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 		}
 		const uuiVersions = (window as { __uuiVersions?: string[] }).__uuiVersions;
 		if (uuiVersions) {
-			this.#serverKeyValues.push({ name: 'UI Library versions', data: JSON.stringify(uuiVersions) });
+			this.#serverKeyValues.push({
+				name: `UI Library version${uuiVersions.length > 1 ? 's' : ''}`,
+				data: uuiVersions.join(', '),
+			});
 		}
 
 		// User information

--- a/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
@@ -65,13 +65,12 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 		if (clientInformation) {
 			this.#serverKeyValues.push({ name: 'Umbraco client version', data: clientInformation.version });
 		}
-		const uuiVersions = (window as { __uuiVersions?: string[] }).__uuiVersions;
-		if (uuiVersions) {
-			this.#serverKeyValues.push({
-				name: `UI Library version${uuiVersions.length > 1 ? 's' : ''}`,
-				data: uuiVersions.join(', '),
-			});
-		}
+		const uuiVersions = globalThis.__uuiVersions;
+		const formattedUuiVersions = uuiVersions ? uuiVersions.join(', ') : 'Unknown';
+		this.#serverKeyValues.push({
+			name: `UI Library version${uuiVersions && uuiVersions.length > 1 ? 's' : ''}`,
+			data: formattedUuiVersions,
+		});
 
 		// User information
 		this.#serverKeyValues.push({});
@@ -206,5 +205,8 @@ export default UmbSysinfoElement;
 declare global {
 	interface HTMLElementTagNameMap {
 		'umb-sysinfo': UmbSysinfoElement;
+	}
+	interface Window {
+		__uuiVersions?: string[];
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/sysinfo/components/sysinfo.element.ts
@@ -65,6 +65,10 @@ export class UmbSysinfoElement extends UmbModalBaseElement {
 		if (clientInformation) {
 			this.#serverKeyValues.push({ name: 'Umbraco client version', data: clientInformation.version });
 		}
+		const uuiVersions = (window as { __uuiVersions?: string[] }).__uuiVersions;
+		if (uuiVersions) {
+			this.#serverKeyValues.push({ name: 'UI Library versions', data: JSON.stringify(uuiVersions) });
+		}
 
 		// User information
 		this.#serverKeyValues.push({});


### PR DESCRIPTION
## Description

By adding the global `__uuiVersions` to sysinfo, we can debug both which UUI version is loaded and also if more than one version is loaded simultaneously.