### PR TITLE
Backoffice: Provide entity context via UMB_ENTITY_CONTEXT in menu components

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
@@ -1,7 +1,15 @@
-import { customElement, html, ifDefined, property, state, when } from '@umbraco-cms/backoffice/external/lit';
+import {
+	customElement,
+	html,
+	ifDefined,
+	property,
+	state,
+	when,
+} from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { ensureSlash } from '@umbraco-cms/backoffice/router';
 import { debounce } from '@umbraco-cms/backoffice/utils';
+import { UmbEntityContext } from '@umbraco-cms/backoffice/entity';
 
 /**
  * @element umb-menu-item-layout
@@ -12,7 +20,21 @@ import { debounce } from '@umbraco-cms/backoffice/utils';
 @customElement('umb-menu-item-layout')
 export class UmbMenuItemLayoutElement extends UmbLitElement {
 	@property({ type: String, attribute: 'entity-type' })
-	public entityType?: string;
+	set entityType(value: string | undefined) {
+		this.#entityType = value;
+		this.#entityContext.setEntityType(value);
+	}
+	get entityType(): string | undefined {
+		return this.#entityType;
+	}
+	#entityType?: string;
+
+	#entityContext = new UmbEntityContext(this);
+
+	constructor() {
+		super();
+		this.#entityContext.setUnique(null);
+	}
 
 	/**
 	 * The icon name for the icon to show in this menu item.
@@ -83,13 +105,7 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 				<umb-icon slot="icon" name=${this.iconName}></umb-icon>
 				${when(
 					this.entityType,
-					() => html`
-						<umb-entity-actions-bundle
-							slot="actions"
-							.entityType=${this.entityType}
-							.unique=${null}
-							.label=${this.label}></umb-entity-actions-bundle>
-					`,
+					() => html` <umb-entity-actions-bundle slot="actions" .label=${this.label}></umb-entity-actions-bundle> `,
 				)}
 				<slot></slot>
 			</uui-menu-item>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item-layout/menu-item-layout.element.ts
@@ -105,7 +105,7 @@ export class UmbMenuItemLayoutElement extends UmbLitElement {
 				<umb-icon slot="icon" name=${this.iconName}></umb-icon>
 				${when(
 					this.entityType,
-					() => html` <umb-entity-actions-bundle slot="actions" .label=${this.label}></umb-entity-actions-bundle> `,
+					() => html`<umb-entity-actions-bundle slot="actions" .label=${this.label}></umb-entity-actions-bundle>`,
 				)}
 				<slot></slot>
 			</uui-menu-item>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
@@ -1,22 +1,23 @@
 import { UmbSectionSidebarMenuElement } from '../section-sidebar-menu/section-sidebar-menu.element.js';
 import type { ManifestSectionSidebarAppMenuWithEntityActionsKind } from '../section-sidebar-menu/types.js';
-import { css, html, customElement, type PropertyValues, state } from '@umbraco-cms/backoffice/external/lit';
-import { UmbParentEntityContext } from '@umbraco-cms/backoffice/entity';
+import { css, html, customElement, type PropertyValues } from '@umbraco-cms/backoffice/external/lit';
+import { UmbEntityContext, UmbParentEntityContext } from '@umbraco-cms/backoffice/entity';
 
 @customElement('umb-section-sidebar-menu-with-entity-actions')
 export class UmbSectionSidebarMenuWithEntityActionsElement extends UmbSectionSidebarMenuElement<ManifestSectionSidebarAppMenuWithEntityActionsKind> {
-	@state()
-	private _unique = null;
-
-	@state()
-	private _entityType?: string | null;
-
+	#entityContext = new UmbEntityContext(this);
 	#parentContext = new UmbParentEntityContext(this);
+
+	constructor() {
+		super();
+		this.#entityContext.setUnique(null);
+	}
 
 	protected override updated(_changedProperties: PropertyValues<this>): void {
 		if (_changedProperties.has('manifest')) {
 			const entityType = this.manifest?.meta.entityType;
-			this.#parentContext.setParent(entityType ? { unique: this._unique, entityType } : undefined);
+			this.#entityContext.setEntityType(entityType);
+			this.#parentContext.setParent(entityType ? { unique: null, entityType } : undefined);
 		}
 	}
 
@@ -25,12 +26,7 @@ export class UmbSectionSidebarMenuWithEntityActionsElement extends UmbSectionSid
 		return html`
 			<div id="header">
 				<h3>${label}</h3>
-				<umb-entity-actions-bundle
-					slot="actions"
-					.unique=${this._unique}
-					.entityType=${this.manifest?.meta.entityType}
-					.label=${label}>
-				</umb-entity-actions-bundle>
+				<umb-entity-actions-bundle slot="actions" .label=${label}> </umb-entity-actions-bundle>
 			</div>
 		`;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/section-sidebar-menu-with-entity-actions/section-sidebar-menu-with-entity-actions.element.ts
@@ -26,7 +26,7 @@ export class UmbSectionSidebarMenuWithEntityActionsElement extends UmbSectionSid
 		return html`
 			<div id="header">
 				<h3>${label}</h3>
-				<umb-entity-actions-bundle slot="actions" .label=${label}> </umb-entity-actions-bundle>
+				<umb-entity-actions-bundle slot="actions" .label=${label}></umb-entity-actions-bundle>
 			</div>
 		`;
 	}


### PR DESCRIPTION
`umb-entity-actions-bundle` deprecated the `entityType` and `unique` properties in favour of consuming them via
`UMB_ENTITY_CONTEXT`. This PR fixes two of the components that were still passing those props directly, producing deprecation warnings in the console — most visibly on entity root items in the sidebar.