### PR TITLE
Backoffice: Fix typedoc UI API docs generation

### DIFF
--- a/src/Umbraco.Web.UI.Client/tsconfig.typedoc.json
+++ b/src/Umbraco.Web.UI.Client/tsconfig.typedoc.json
@@ -1,0 +1,5 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["src/**/*.ts", "index.ts"],
+	"exclude": ["src/**/*.test.ts", "src/**/*.stories.ts"]
+}

--- a/src/Umbraco.Web.UI.Client/typedoc.config.js
+++ b/src/Umbraco.Web.UI.Client/typedoc.config.js
@@ -19,4 +19,5 @@ for (const [key, value] of Object.entries(packageJsonExports || {})) {
 export default {
 	entryPoints,
 	out: 'ui-api',
+	tsconfig: './tsconfig.typedoc.json',
 };


### PR DESCRIPTION
## Summary

The `Generate API Docs` CI step (`npm run generate:ui-api-docs` in `src/Umbraco.Web.UI.Client/`) has been failing on `release/18.0` since the TypeScript 5.9.3 → 6.0.3 bump in #22591. typedoc aborts with 3284 errors before emitting anything, so the v18 UI API docs are not being published to blob storage.

### Root cause

typedoc passes the tsconfig to the TypeScript compiler. Under TS 6 + `moduleResolution: "bundler"` + no explicit `types` field, `@types/mocha` (and other `@types/*`) is no longer auto-included the way it was in TS 5. The main `tsconfig.json` `include` covers `src/**/*.ts`, `examples/**/*.ts`, `e2e/**/*.ts`, etc., so every `.test.ts` file gets pulled into the program and fails to resolve `describe` / `it` / `beforeEach` — typedoc treats this as a fatal program error and exits with code 3.

Reproduced locally with plain `npx tsc --noEmit` against the same tsconfig — same 3284 errors. Confirmed typedoc 0.28.19 (latest) explicitly declares peer support for TS 6.0.x, so upgrading typedoc would not help.

### Fix

Point typedoc at a dedicated `tsconfig.typedoc.json` that:
- `extends` the main `tsconfig.json` (so paths, lib, strict, etc. stay in sync)
- narrows `include` to `src/**/*.ts` + `index.ts` (entry points all come from `package.json` exports under `src/`, so we don't need `mocks/`, `e2e/`, `apps/`, `storybook/`, `examples/` in the program)
- excludes `src/**/*.test.ts` and `src/**/*.stories.ts` — noise that isn't part of the public API surface

Two files touched, six lines added. No change to the main `tsconfig.json`, `package.json`, or the docs entry-point list.

## Test plan

- [x] `cd src/Umbraco.Web.UI.Client && npm run generate:ui-api-docs` exits 0
- [x] 6533 HTML files generated under `src/Umbraco.Web.UI.Client/ui-api/` (classes, interfaces, modules, functions, enums, types)
- [x] `Found 0 errors and 1669 warnings` — warnings are pre-existing broken `{@link …}` cross-references in source comments, not caused by this PR
- [ ] CI `Build js API Reference` job goes green on `release/18.0`