### PR TITLE
Backoffice: Preserve prerelease tag when hoisting peer dependencies

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/publish/cleanse-pkg.js
+++ b/src/Umbraco.Web.UI.Client/devops/publish/cleanse-pkg.js
@@ -22,17 +22,20 @@ const looseVersionRange = (version) => {
 		return version;
 	}
 
-	const major = minVersion.major;
-	const minor = minVersion.minor;
-	const patch = minVersion.patch;
+	const { major, minor, patch, prerelease } = minVersion;
 
-	// For pre-release (0.x.y), always use floor at current version and ceiling at 1.0.0
+	// Preserve any prerelease tag in the floor so a range built from e.g. ^2.0.0-rc.1
+	// stays satisfiable by 2.0.0-rc.1 rather than demanding a non-existent ^2.0.0 stable.
+	const prereleaseSuffix = prerelease.length ? `-${prerelease.join('.')}` : '';
+	const floor = `${major}.${minor}.${patch}${prereleaseSuffix}`;
+
+	// For 0.x.y, always use floor at current version and ceiling at 1.0.0
 	if (major === 0) {
-		return `>=${major}.${minor}.${patch} <1.0.0`;
+		return `>=${floor} <1.0.0`;
 	}
 
 	// Exact version without caret, add caret (e.g., 3.16.0 -> ^3.16.0 and ^3.16.0 -> ^3.16.0 and ~3.16.0 -> ^3.16.0)
-	return `^${major}.${minor}.${patch}`;
+	return `^${floor}`;
 };
 
 // Rename dependencies to peerDependencies with looser version ranges


### PR DESCRIPTION
## Summary

The publish-time cleanse step that rewrites workspace `dependencies` into the published `peerDependencies` of `@umbraco-cms/backoffice` was stripping the prerelease suffix from version ranges. `^2.0.0-rc.1` (the version `@umbraco-backoffice/uui` declares for `@umbraco-ui/uui`) was being collapsed to `^2.0.0`, which no published `@umbraco-ui/uui` version satisfies — only `2.0.0-rc.0`/`-rc.1` are on npm so far. The result was that `@umbraco-cms/backoffice@18.0.0-beta1`+ (which is what extension developers are installing) listed an unresolvable peer dep and `npm install` failed:

> Can't update extensions to `@umbraco-cms/backoffice@18.0.0-beta1` because it depends on `@umbraco-ui/uui@2.0.0` and that's not published.

Cause: `looseVersionRange()` in `devops/publish/cleanse-pkg.js` read `semver.minVersion(...).major/minor/patch` and discarded the `.prerelease` array when rebuilding the range string.

Fix: include the prerelease suffix when present, so `^2.0.0-rc.1` round-trips as `^2.0.0-rc.1` and accepts `2.0.0-rc.1`, future RCs/betas, and the eventual stable 2.x.

Verified with semver semantics:

```text
^2.0.0-rc.1 → ^2.0.0-rc.1     (was: ^2.0.0)
^3.3.1      → ^3.3.1          (unchanged)
^0.85.0     → >=0.85.0 <1.0.0 (unchanged)

satisfies('2.0.0-rc.1', '^2.0.0-rc.1') → true
satisfies('2.0.0',      '^2.0.0-rc.1') → true
satisfies('2.0.1',      '^2.0.0-rc.1') → true
satisfies('3.0.0',      '^2.0.0-rc.1') → false
```

The only workspace currently affected is `src/external/uui` (`@umbraco-ui/uui@^2.0.0-rc.1`). All other external workspace deps already use stable ranges and produce the same output as before.

## Test plan

- [ ] Cherry-pick to `release/18.0` so the fix lands in the next 18.0.0-beta/rc package
- [ ] Run `npm run build:for:cms` and `npm pack` in `src/Umbraco.Web.UI.Client`, inspect the `peerDependencies` of the resulting tarball — `@umbraco-ui/uui` should be `^2.0.0-rc.1`, not `^2.0.0`
- [ ] `npm install @umbraco-cms/backoffice@<new-build>` in an extension project resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)