### PR TITLE
Log Viewer: Updated the saved log viewer searches for new installs to reference `Umbraco.Cms` instead of `Umbraco.Core`.

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -52,8 +52,8 @@ internal sealed class DatabaseDataCreator
         },
         new()
         {
-            Name = "Find all logs that are from the namespace 'Umbraco.Core'",
-            Query = "StartsWith(SourceContext, 'Umbraco.Core')",
+            Name = "Find all logs that are within the namespace 'Umbraco.Cms'",
+            Query = "StartsWith(SourceContext, 'Umbraco.Cms')",
         },
         new()
         {

--- a/src/Umbraco.Web.UI.Client/mocks/data/sets/default/log-viewer.data.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/data/sets/default/log-viewer.data.ts
@@ -21,8 +21,8 @@ export const savedSearches: Array<SavedLogSearchResponseModel> = [
 		query: 'Has(Duration) and Duration > 1000',
 	},
 	{
-		name: "Find all logs that are from the namespace 'Umbraco.Core'",
-		query: "StartsWith(SourceContext, 'Umbraco.Core')",
+		name: "Find all logs that are within the namespace 'Umbraco.Cms'",
+		query: "StartsWith(SourceContext, 'Umbraco.Cms')",
 	},
 	{
 		name: 'Find all logs that use a specific log message template',

--- a/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/log-viewer.data.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/log-viewer.data.ts
@@ -21,8 +21,8 @@ export const savedSearches: Array<SavedLogSearchResponseModel> = [
 		query: 'Has(Duration) and Duration > 1000',
 	},
 	{
-		name: "Find all logs that are from the namespace 'Umbraco.Core'",
-		query: "StartsWith(SourceContext, 'Umbraco.Core')",
+		name: "Find all logs that are within the namespace 'Umbraco.Cms'",
+		query: "StartsWith(SourceContext, 'Umbraco.Cms')",
 	},
 ];
 

--- a/src/Umbraco.Web.UI.Client/mocks/tools/sqlite-to-mock/generate-supporting-files.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/tools/sqlite-to-mock/generate-supporting-files.ts
@@ -423,8 +423,8 @@ export const savedSearches: Array<SavedLogSearchResponseModel> = [
 		query: 'Has(Duration) and Duration > 1000',
 	},
 	{
-		name: "Find all logs that are from the namespace 'Umbraco.Core'",
-		query: "StartsWith(SourceContext, 'Umbraco.Core')",
+		name: "Find all logs that are within the namespace 'Umbraco.Cms'",
+		query: "StartsWith(SourceContext, 'Umbraco.Cms')",
 	},
 ];
 

--- a/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/log-viewer/workspace/logviewer-workspace.context.ts
@@ -197,8 +197,8 @@ export class UmbLogViewerWorkspaceContext extends UmbContextBase implements UmbW
 						query: 'Has(Duration) and Duration > 1000',
 					},
 					{
-						name: "Find all logs that are from the namespace 'Umbraco.Core'",
-						query: "StartsWith(SourceContext, 'Umbraco.Core')",
+						name: "Find all logs that are within the namespace 'Umbraco.Cms'",
+						query: "StartsWith(SourceContext, 'Umbraco.Cms')",
 					},
 					{
 						name: 'Find all logs that use a specific log message template',


### PR DESCRIPTION
## Description

As noted in the linked issue, the current namespace we include in the default set of saved searches is out of date, and returns no results.

I've updated it for a search of the current Umbraco root namespace (no longer using just the "Core" project), which seems a reasonable default and a useful search that someone might want to do ("find me all logs from the CMS").

Fixes #22842.

## Testing

Install a new instance of Umbraco and verify that you see this "Saved search" in the log viewer:

<img width="816" height="545" alt="image" src="https://github.com/user-attachments/assets/8c3b6a15-19d6-4caa-b472-6f92c0f681b7" />

And that it generates some results:

<img width="1511" height="549" alt="image" src="https://github.com/user-attachments/assets/6922558f-7c2c-4197-a662-443238ade538" />



