### PR TITLE
fix: user shows wrong state on enabling user #22786

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/enable/enable-user.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/enable/enable-user.repository.ts
@@ -1,18 +1,20 @@
-import { UmbUserRepositoryBase } from '../user-repository-base.js';
-import { UmbUserItemRepository } from '../item/index.js';
-import { UmbEnableUserServerDataSource } from './enable-user.server.data-source.js';
-import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { UserStateModel } from '@umbraco-cms/backoffice/external/backend-api';
+import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
+import { UmbUserServerDataSource } from '../detail/user-detail.server.data-source.js';
+import { UmbUserItemRepository } from '../item/index.js';
+import { UmbUserRepositoryBase } from '../user-repository-base.js';
+import { UmbEnableUserServerDataSource } from './enable-user.server.data-source.js';
 
 export class UmbEnableUserRepository extends UmbUserRepositoryBase {
 	#enableSource: UmbEnableUserServerDataSource;
 	#localize = new UmbLocalizationController(this);
 	#userItemRepository = new UmbUserItemRepository(this);
+	#detailSource: UmbUserServerDataSource;
 
 	constructor(host: UmbControllerHost) {
 		super(host);
 		this.#enableSource = new UmbEnableUserServerDataSource(host);
+		this.#detailSource = new UmbUserServerDataSource(host);
 	}
 
 	async enable(ids: Array<string>) {
@@ -25,10 +27,12 @@ export class UmbEnableUserRepository extends UmbUserRepositoryBase {
 			const { data: items } = await this.#userItemRepository.requestItems(ids);
 			if (!items) throw new Error('Could not load user item');
 
-			// TODO: get state from item when available
-			ids.forEach((id) => {
-				this.detailStore?.updateItem(id, { state: UserStateModel.ACTIVE });
-			});
+			await Promise.all(ids.map(async (id) => {
+				const { data: detail } = await this.#detailSource.read(id);
+				if (detail) {
+					this.detailStore?.append(detail);
+				}
+			}));
 
 			let message = this.#localize.term('speechBubbles_enableUsersSuccess', items.length);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #22786

### Description
When enabling a previously disabled user who has never logged in, the UI shows their state as "Active" before reverting to "Inactive" on page refresh. This happens because the enable repository optimistically sets the state to [UserStateModel.ACTIVE](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html), but the correct state depends on server-side factors (like whether the user has ever logged in / exchanged a token).

#### Root cause: The [UmbEnableUserRepository](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) uses [this.detailStore?.updateItem(id, { state: UserStateModel.ACTIVE })](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which assumes an enabled user is always Active. However, the backend calculates state as:

- Active = approved + has logged in at least once
- Inactive = approved + never logged in ([LastLoginDate == default](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
#### Fix: Replace the optimistic [ACTIVE](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) state update with a server call to fetch the actual user detail (including the correct computed state), then update the store with the real data.

#### How to test
1. Go to Users section in the backoffice
2. Create a new user (do NOT log in with it)
3. Note the user shows as Inactive (correct - never logged in)
4. Use the dropdown action to Disable the user → state shows "Disabled"
5. Use the dropdown action to Enable the user

#### Before fix: State says "Active" then shows "Inactive" on refresh (if you see user mismatch, forgot to record before, so tested later on broken instance)

<img width="476" height="542" alt="umbraco-user-state-fix-before" src="https://github.com/user-attachments/assets/154a3f54-084d-43fc-9f62-05f8921cdf85" />


#### After fix: State correctly shows "Inactive" immediately without needing a page refresh

<img width="800" height="450" alt="umbraco-user-state-fix-after" src="https://github.com/user-attachments/assets/bffb7c65-c8d7-423f-b103-494aa1aa8e96" />

