### PR TITLE
Mocks: Add missing `signalR` property to mock server configuration response

### DIFF
--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/server.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/server.handlers.ts
@@ -35,6 +35,9 @@ export const serverInformationHandlers = [
 			versionCheckPeriod: 7, // days
 			allowLocalLogin: true,
 			umbracoCssPath: '/css',
+			signalR: {
+				skipNegotiation: false,
+			},
 		});
 	}),
 	http.get(umbracoPath('/server/information'), () => {


### PR DESCRIPTION
## Description

`GetServerConfigurationResponse` was updated in #22700 to require a `signalR.skipNegotiation` property, but the corresponding MSW mock handler in `server.handlers.ts` was not updated to match. This caused a `tsc` compilation error when running `npm run compile` in `src/Umbraco.Web.UI.Client`.

This PR adds the missing property to the mock response with a default value of `false` (matching the production default).

## Testing

1. Check out this branch
2. From `src/Umbraco.Web.UI.Client`, run `npm run compile`
3. Confirm `tsc` completes without errors