### PR TITLE
EF Core: Migrating Long Running Operation Repository

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260515075837_AddLongRunningOperationDto.Designer.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260515075837_AddLongRunningOperationDto.Designer.cs
@@ -2,98 +2,91 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.Cms.Infrastructure.Persistence.EFCore;
 
 #nullable disable
 
-namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
+namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
 {
     [DbContext(typeof(UmbracoDbContext))]
-    partial class UmbracoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515075837_AddLongRunningOperationDto")]
+    partial class AddLongRunningOperationDto
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.5");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "10.0.5")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreApplication", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ApplicationType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("ClientId")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("ClientSecret")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ClientType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("ConsentType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayNames")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("JsonWebKeySet")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Permissions")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PostLogoutRedirectUris")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("RedirectUris")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Requirements")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Settings")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ClientId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[ClientId] IS NOT NULL");
 
                     b.ToTable("umbracoOpenIddictApplications", (string)null);
                 });
@@ -102,44 +95,36 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ApplicationId")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<DateTime?>("CreationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Scopes")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Subject")
                         .HasMaxLength(400)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(400)");
 
                     b.Property<string>("Type")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -152,48 +137,40 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Descriptions")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayNames")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Resources")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Name")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[Name] IS NOT NULL");
 
                     b.ToTable("umbracoOpenIddictScopes", (string)null);
                 });
@@ -202,66 +179,57 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ApplicationId")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AuthorizationId")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<DateTime?>("CreationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("ExpirationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Payload")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime?>("RedemptionDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ReferenceId")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Subject")
                         .HasMaxLength(400)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(400)");
 
                     b.Property<string>("Type")
                         .HasMaxLength(150)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(150)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AuthorizationId");
 
                     b.HasIndex("ReferenceId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[ReferenceId] IS NOT NULL");
 
                     b.HasIndex("ApplicationId", "Status", "Subject", "Type");
 
@@ -272,57 +240,54 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AffectedDetails")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("affectedDetails")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1024)")
+                        .HasColumnName("affectedDetails");
 
                     b.Property<int>("AffectedUserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("affectedUserId");
 
                     b.Property<Guid?>("AffectedUserKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("affectedUserKey");
 
                     b.Property<DateTime>("EventDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("eventDateUtc");
 
                     b.Property<string>("EventDetails")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("eventDetails")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1024)")
+                        .HasColumnName("eventDetails");
 
                     b.Property<string>("EventType")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("eventType")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("eventType");
 
                     b.Property<string>("PerformingDetails")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("performingDetails")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1024)")
+                        .HasColumnName("performingDetails");
 
                     b.Property<string>("PerformingIp")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("performingIp")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(64)")
+                        .HasColumnName("performingIp");
 
                     b.Property<int>("PerformingUserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("performingUserId");
 
                     b.Property<Guid?>("PerformingUserKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("performingUserKey");
 
                     b.HasKey("Id");
@@ -334,30 +299,30 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("InstructionCount")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasDefaultValue(1)
                         .HasColumnName("instructionCount");
 
                     b.Property<string>("Instructions")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("jsonInstruction")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("jsonInstruction");
 
                     b.Property<string>("OriginIdentity")
                         .IsRequired()
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("originated")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("originated");
 
                     b.Property<DateTime>("UtcStamp")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("utcStamp");
 
                     b.HasKey("Id");
@@ -369,29 +334,30 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<int?>("DefaultLanguage")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("domainDefaultLanguage");
 
                     b.Property<string>("DomainName")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("domainName")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("domainName");
 
                     b.Property<Guid>("Key")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("key");
 
                     b.Property<int?>("RootStructureId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("domainRootStructureID");
 
                     b.Property<int>("SortOrder")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("sortOrder");
 
                     b.HasKey("Id");
@@ -406,18 +372,16 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("key")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("key");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updated");
 
                     b.Property<string>("Value")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("value")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("value");
 
                     b.HasKey("Key");
 
@@ -428,39 +392,39 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CultureName")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("languageCultureName")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(100)")
+                        .HasColumnName("languageCultureName");
 
                     b.Property<int?>("FallbackLanguageId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("fallbackLanguageId");
 
                     b.Property<bool>("IsDefault")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("isDefaultVariantLang");
 
                     b.Property<bool>("IsMandatory")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("mandatory");
 
                     b.Property<string>("IsoCode")
                         .HasMaxLength(14)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("languageISOCode")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(14)")
+                        .HasColumnName("languageISOCode");
 
                     b.Property<Guid>("LanguageKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("languageKey");
 
                     b.HasKey("Id");
@@ -468,7 +432,8 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                     b.HasIndex("FallbackLanguageId");
 
                     b.HasIndex("IsoCode")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[languageISOCode] IS NOT NULL");
 
                     b.HasIndex("LanguageKey")
                         .IsUnique();
@@ -479,19 +444,18 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.LastSyncedDto", b =>
                 {
                     b.Property<string>("MachineId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("machineId")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("machineId");
 
                     b.Property<DateTime>("LastSyncedDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastSyncedDate");
 
                     b.Property<int?>("LastSyncedExternalId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("LastSyncedInternalId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("lastSyncedInternalId");
 
                     b.HasKey("MachineId");
@@ -503,44 +467,42 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Comment")
                         .HasMaxLength(4000)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("logComment")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(4000)")
+                        .HasColumnName("logComment");
 
                     b.Property<DateTime>("Datestamp")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("Datestamp");
 
                     b.Property<string>("EntityType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("entityType")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("entityType");
 
                     b.Property<string>("Header")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("logHeader")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("logHeader");
 
                     b.Property<int>("NodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("NodeId");
 
                     b.Property<string>("Parameters")
                         .HasMaxLength(4000)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("parameters")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(4000)")
+                        .HasColumnName("parameters");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("userId");
 
                     b.HasKey("Id");
@@ -562,38 +524,35 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.LongRunningOperationDto", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("id");
 
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<DateTime>("ExpirationDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("expirationDate");
 
                     b.Property<string>("Result")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("result")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("result");
 
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("status")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("status");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("type")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(200)")
+                        .HasColumnName("type");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updateDate");
 
                     b.HasKey("Id")
@@ -606,53 +565,53 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("NodeId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("NodeId"));
+
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<short>("Level")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("smallint")
                         .HasColumnName("level");
 
                     b.Property<Guid?>("NodeObjectType")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("nodeObjectType");
 
                     b.Property<int>("ParentId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("parentId");
 
                     b.Property<string>("Path")
                         .IsRequired()
                         .HasMaxLength(150)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("path")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(150)")
+                        .HasColumnName("path");
 
                     b.Property<int>("SortOrder")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("sortOrder");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("text")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("text");
 
                     b.Property<bool>("Trashed")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("trashed");
 
                     b.Property<Guid>("UniqueId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("uniqueId");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("nodeUser");
 
                     b.HasKey("NodeId");
@@ -686,110 +645,104 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Avatar")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("avatar")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("avatar");
 
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<bool>("Disabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("userDisabled");
 
                     b.Property<string>("Email")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userEmail")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("userEmail");
 
                     b.Property<DateTime?>("EmailConfirmedDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("emailConfirmedDate");
 
                     b.Property<int?>("FailedLoginAttempts")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("failedLoginAttempts");
 
                     b.Property<DateTime?>("InvitedDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("invitedDate");
 
                     b.Property<Guid>("Key")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("key");
 
                     b.Property<short>("Kind")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("smallint")
                         .HasDefaultValue((short)0)
                         .HasColumnName("kind");
 
                     b.Property<DateTime?>("LastLockoutDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastLockoutDate");
 
                     b.Property<DateTime?>("LastLoginDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastLoginDate");
 
                     b.Property<DateTime?>("LastPasswordChangeDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastPasswordChangeDate");
 
                     b.Property<string>("Login")
                         .HasMaxLength(125)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userLogin")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(125)")
+                        .HasColumnName("userLogin");
 
                     b.Property<bool>("NoConsole")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("userNoConsole");
 
                     b.Property<string>("Password")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userPassword")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("userPassword");
 
                     b.Property<string>("PasswordConfig")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("passwordConfig")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("passwordConfig");
 
                     b.Property<string>("SecurityStampToken")
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("securityStampToken")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(255)")
+                        .HasColumnName("securityStampToken");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updateDate");
 
                     b.Property<string>("UserLanguage")
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userLanguage")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(10)")
+                        .HasColumnName("userLanguage");
 
                     b.Property<string>("UserName")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userName")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("userName");
 
                     b.HasKey("Id")
                         .HasName("PK_user");
@@ -806,11 +759,11 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Webhook2ContentTypeKeysDto", b =>
                 {
                     b.Property<int>("WebhookId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("webhookId");
 
                     b.Property<Guid>("ContentTypeKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("entityKey");
 
                     b.HasKey("WebhookId", "ContentTypeKey")
@@ -822,14 +775,13 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Webhook2EventsDto", b =>
                 {
                     b.Property<int>("WebhookId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("webhookId");
 
                     b.Property<string>("Event")
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("event")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(255)")
+                        .HasColumnName("event");
 
                     b.HasKey("WebhookId", "Event")
                         .HasName("PK_webhookEvent2WebhookDto");
@@ -840,18 +792,16 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Webhook2HeadersDto", b =>
                 {
                     b.Property<int>("WebhookId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("webhookId");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Key")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("Key");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("WebhookId", "Key")
                         .HasName("PK_headers2WebhookDto");
@@ -863,32 +813,31 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("description")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("description");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("enabled");
 
                     b.Property<Guid>("Key")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("key");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("name")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("name");
 
                     b.Property<string>("Url")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("url")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("url");
 
                     b.HasKey("Id");
 

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260515075837_AddLongRunningOperationDto.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260515075837_AddLongRunningOperationDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLongRunningOperationDto : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/UmbracoDbContextModelSnapshot.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/UmbracoDbContextModelSnapshot.cs
@@ -518,6 +518,46 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
                     b.ToTable("umbracoLog", (string)null);
                 });
 
+            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.LongRunningOperationDto", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnName("id");
+
+                    b.Property<DateTime>("CreateDate")
+                        .HasColumnType("datetime2")
+                        .HasColumnName("createDate");
+
+                    b.Property<DateTime>("ExpirationDate")
+                        .HasColumnType("datetime2")
+                        .HasColumnName("expirationDate");
+
+                    b.Property<string>("Result")
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("result");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("status");
+
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)")
+                        .HasColumnName("type");
+
+                    b.Property<DateTime>("UpdateDate")
+                        .HasColumnType("datetime2")
+                        .HasColumnName("updateDate");
+
+                    b.HasKey("Id")
+                        .HasName("PK_umbracoLongRunningOperation");
+
+                    b.ToTable("umbracoLongRunningOperation", (string)null);
+                });
+
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.NodeDto", b =>
                 {
                     b.Property<int>("NodeId")

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.cs
@@ -57,6 +57,7 @@ public class SqlServerMigrationProvider : IMigrationProvider
             EFCoreMigration.AddLanguageDto => typeof(Migrations.AddLanguageDto),
             EFCoreMigration.AddDomainDto => typeof(Migrations.AddDomainDto),
             EFCoreMigration.AddAuditDtos => typeof(Migrations.AddAuditDtos),
+            EFCoreMigration.AddLongRunningOperationDto => typeof(Migrations.AddLongRunningOperationDto),
             _ => throw new ArgumentOutOfRangeException(nameof(migration), $@"Not expected migration value: {migration}")
         };
 }

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260515075914_AddLongRunningOperationDto.Designer.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260515075914_AddLongRunningOperationDto.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.Cms.Infrastructure.Persistence.EFCore;
 
@@ -10,9 +11,11 @@ using Umbraco.Cms.Infrastructure.Persistence.EFCore;
 namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
 {
     [DbContext(typeof(UmbracoDbContext))]
-    partial class UmbracoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515075914_AddLongRunningOperationDto")]
+    partial class AddLongRunningOperationDto
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260515075914_AddLongRunningOperationDto.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260515075914_AddLongRunningOperationDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLongRunningOperationDto : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs
@@ -57,6 +57,7 @@ public class SqliteMigrationProvider : IMigrationProvider
             EFCoreMigration.SqliteCollation => typeof(Migrations.SqliteCollation),
             EFCoreMigration.AddLanguageDto => typeof(Migrations.AddLanguageDto),
             EFCoreMigration.AddAuditDtos => typeof(Migrations.AddAuditDtos),
+            EFCoreMigration.AddLongRunningOperationDto => typeof(Migrations.AddLongRunningOperationDto),
             _ => throw new ArgumentOutOfRangeException(nameof(migration), $@"Not expected migration value: {migration}")
         };
 }

--- a/src/Umbraco.Core/Services/LongRunningOperationService.cs
+++ b/src/Umbraco.Core/Services/LongRunningOperationService.cs
@@ -4,6 +4,7 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Scoping.EFCore;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
 namespace Umbraco.Cms.Core.Services;
@@ -13,7 +14,7 @@ internal class LongRunningOperationService : ILongRunningOperationService
 {
     private readonly IOptions<LongRunningOperationsSettings> _options;
     private readonly ILongRunningOperationRepository _repository;
-    private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IScopeProvider _scopeProvider;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<LongRunningOperationService> _logger;
 
@@ -28,7 +29,7 @@ internal class LongRunningOperationService : ILongRunningOperationService
     public LongRunningOperationService(
         IOptions<LongRunningOperationsSettings> options,
         ILongRunningOperationRepository repository,
-        ICoreScopeProvider scopeProvider,
+        IScopeProvider scopeProvider,
         TimeProvider timeProvider,
         ILogger<LongRunningOperationService> logger)
     {
@@ -70,8 +71,11 @@ internal class LongRunningOperationService : ILongRunningOperationService
     /// <inheritdoc/>
     public async Task<LongRunningOperationStatus?> GetStatusAsync(Guid operationId)
     {
-        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
-        return await _repository.GetStatusAsync(operationId);
+        using ICoreScope scope = _scopeProvider.CreateScope();
+        LongRunningOperationStatus? status = await _repository.GetStatusAsync(operationId);
+        scope.Complete();
+
+        return status;
     }
 
     /// <inheritdoc/>
@@ -81,19 +85,24 @@ internal class LongRunningOperationService : ILongRunningOperationService
         int take,
         LongRunningOperationStatus[]? statuses = null)
     {
-        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
-        return await _repository.GetByTypeAsync(
+        using ICoreScope scope = _scopeProvider.CreateScope();
+        PagedModel<LongRunningOperation> operation = await _repository.GetByTypeAsync(
                 type,
                 statuses ?? [LongRunningOperationStatus.Enqueued, LongRunningOperationStatus.Running],
                 skip,
                 take);
+
+        scope.Complete();
+        return operation;
     }
 
     /// <inheritdoc />
     public async Task<Attempt<TResult?, LongRunningOperationResultStatus>> GetResultAsync<TResult>(Guid operationId)
     {
-        using ICoreScope scope = _scopeProvider.CreateCoreScope(autoComplete: true);
+        using ICoreScope scope = _scopeProvider.CreateScope();
         LongRunningOperation<TResult>? operation = await _repository.GetAsync<TResult>(operationId);
+
+        scope.Complete();
         if (operation?.Status is not LongRunningOperationStatus.Success)
         {
             return Attempt.FailWithStatus<TResult?, LongRunningOperationResultStatus>(
@@ -117,13 +126,13 @@ internal class LongRunningOperationService : ILongRunningOperationService
         bool runInBackground = true,
         CancellationToken cancellationToken = default)
     {
-        if (!runInBackground && _scopeProvider.Context is not null)
+        if (!runInBackground && _scopeProvider.AmbientScopeContext is not null)
         {
             throw new InvalidOperationException("Long running operations cannot be executed in the foreground within an existing scope.");
         }
 
         Guid operationId;
-        using (ICoreScope scope = _scopeProvider.CreateCoreScope())
+        using (ICoreScope scope = _scopeProvider.CreateScope())
         {
             if (allowConcurrentExecution is false)
             {
@@ -210,7 +219,7 @@ internal class LongRunningOperationService : ILongRunningOperationService
             {
                 // Update the status in the database and increase the expiration time.
                 // That way, even if the status has not changed, we know that the operation is still being processed.
-                using (ICoreScope scope = _scopeProvider.CreateCoreScope())
+                using (ICoreScope scope = _scopeProvider.CreateScope())
                 {
                     await _repository.UpdateStatusAsync(operationId, LongRunningOperationStatus.Running, _timeProvider.GetUtcNow() + _options.Value.ExpirationTime);
                     scope.Complete();
@@ -223,7 +232,7 @@ internal class LongRunningOperationService : ILongRunningOperationService
         {
             // If an exception occurs, we update the status to Failed and rethrow the exception.
             _logger.LogDebug("Finished long-running operation {Type} with id {OperationId} and status {Status}.", type, operationId, LongRunningOperationStatus.Failed);
-            using (ICoreScope scope = _scopeProvider.CreateCoreScope())
+            using (ICoreScope scope = _scopeProvider.CreateScope())
             {
                 await _repository.UpdateStatusAsync(operationId, LongRunningOperationStatus.Failed, _timeProvider.GetUtcNow() + _options.Value.ExpirationTime);
                 scope.Complete();
@@ -234,7 +243,7 @@ internal class LongRunningOperationService : ILongRunningOperationService
 
         _logger.LogDebug("Finished long-running operation {Type} with id {OperationId} and status {Status}.", type, operationId, LongRunningOperationStatus.Success);
 
-        using (ICoreScope scope = _scopeProvider.CreateCoreScope())
+        using (ICoreScope scope = _scopeProvider.CreateScope())
         {
             await _repository.UpdateStatusAsync(operationId, LongRunningOperationStatus.Success, _timeProvider.GetUtcNow() + _options.Value.ExpirationTime);
             if (operationTask.Result != null)

--- a/src/Umbraco.Infrastructure/Migrations/EFCoreMigration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/EFCoreMigration.cs
@@ -16,4 +16,5 @@ public enum EFCoreMigration
     AddLanguageDto = 8,
     AddDomainDto = 9,
     AddAuditDtos = 10,
+    AddLongRunningOperationDto = 11,
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -184,5 +184,6 @@ public class UmbracoPlan : MigrationPlan
         To<V_18_0_0.AddLanguageDto>("{9880258E-834C-452D-A915-400D03BF9C41}");
         To<V_18_0_0.AddDomainKeyColumn>("{B7E4F2A1-3C5D-4E6F-8A9B-0C1D2E3F4A5B}");
         To<V_18_0_0.AddAuditDtos>("{2A1B0EAD-105F-4AB7-A033-17EE8E8E7357}");
+        To<V_18_0_0.AddLongRunningOperationDto>("{DED2564D-59CD-4C75-8639-6A24D69E63DC}");
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/AddLongRunningOperationDto.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/AddLongRunningOperationDto.cs
@@ -1,0 +1,22 @@
+﻿using Umbraco.Cms.Persistence.EFCore.Migrations;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_18_0_0;
+
+public class AddLongRunningOperationDto : AsyncMigrationBase
+{
+    private readonly IEFCoreMigrationExecutor _migrationExecutor;
+
+    public AddLongRunningOperationDto(
+        IMigrationContext context,
+        IEFCoreMigrationExecutor migrationExecutor)
+        : base(context)
+    {
+        _migrationExecutor = migrationExecutor;
+    }
+
+    protected override async Task MigrateAsync()
+    {
+        // NO-OP migration to ensure that EF Core doesn't complain about missing migrations.
+        await _migrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.AddLongRunningOperationDto);
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/LongRunningOperationDtoConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/LongRunningOperationDtoConfiguration.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Configurations;
+
+public class LongRunningOperationDtoConfiguration : IEntityTypeConfiguration<LongRunningOperationDto>
+{
+    public void Configure(EntityTypeBuilder<LongRunningOperationDto> builder)
+    {
+        builder.ToTable(LongRunningOperationDto.TableName);
+
+        builder.HasKey(x => x.Id)
+            .HasName($"PK_{LongRunningOperationDto.TableName}");
+
+        builder.Property(x => x.Id)
+            .HasColumnName(LongRunningOperationDto.IdColumnName)
+            .ValueGeneratedNever();
+
+        builder.Property(x => x.Type)
+            .HasColumnName(LongRunningOperationDto.TypeColumnName)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(x => x.Status)
+            .HasColumnName(LongRunningOperationDto.StatusColumnName)
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(x => x.Result)
+            .HasColumnName(LongRunningOperationDto.ResultColumnName);
+
+        builder.Property(x => x.CreateDate)
+            .HasColumnName(LongRunningOperationDto.CreateDateColumnName);
+
+        builder.Property(x => x.UpdateDate)
+            .HasColumnName(LongRunningOperationDto.UpdateDateColumnName);
+
+        builder.Property(x => x.ExpirationDate)
+            .HasColumnName(LongRunningOperationDto.ExpirationDateColumnName);
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/LongRunningOperationDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/LongRunningOperationDto.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Configurations;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore;
+
+[EntityTypeConfiguration(typeof(LongRunningOperationDtoConfiguration))]
+public class LongRunningOperationDto
+{
+    public const string TableName = Constants.DatabaseSchema.Tables.LongRunningOperation;
+    public const string PrimaryKeyColumnName = Constants.DatabaseSchema.Columns.PrimaryKeyNameId;
+
+    // Public constants to bind properties between configurations and customizers.
+    public const string IdColumnName = PrimaryKeyColumnName;
+    public const string TypeColumnName = "type";
+    public const string StatusColumnName = "status";
+    public const string ResultColumnName = "result";
+    public const string CreateDateColumnName = "createDate";
+    public const string UpdateDateColumnName = "updateDate";
+    public const string ExpirationDateColumnName = "expirationDate";
+
+    public Guid Id { get; set; }
+
+    public string Type { get; set; } = null!;
+
+    public string Status { get; set; } = null!;
+
+    public string? Result { get; set; }
+
+    public DateTime CreateDate { get; set; } = DateTime.UtcNow;
+
+    public DateTime UpdateDate { get; set; } = DateTime.UtcNow;
+
+    public DateTime ExpirationDate { get; set; }
+}

--- a/src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs
+++ b/src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs
@@ -66,6 +66,8 @@ public class UmbracoDbContext : DbContext
 
     public required DbSet<AuditEntryDto> AuditEntries { get; set; }
 
+    public required DbSet<LongRunningOperationDto> LongRunningOperations { get; set; }
+
     private static DbContextOptions<UmbracoDbContext> ConfigureOptions(DbContextOptions<UmbracoDbContext> options)
     {
         var coreExtensions = options.FindExtension<Microsoft.EntityFrameworkCore.Infrastructure.CoreOptionsExtension>();

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LongRunningOperationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LongRunningOperationRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
@@ -40,8 +41,13 @@ internal class LongRunningOperationRepository : AsyncRepositoryBase, ILongRunnin
 
         await AmbientScope.ExecuteWithContextAsync<LongRunningOperationDto>(async db =>
         {
-            db.LongRunningOperations.Add(dto);
+            EntityEntry<LongRunningOperationDto> entry = db.LongRunningOperations.Add(dto);
             await db.SaveChangesAsync();
+
+            // Detaching the entity from the change tracker here to get consistent exceptions in case of duplicates.
+            // If not detached, the same scope that created it will throw a InvalidOperationException and a different
+            // scope will throw DbUpdateException.
+            entry.State = EntityState.Detached;
         });
     }
 
@@ -147,7 +153,7 @@ internal class LongRunningOperationRepository : AsyncRepositoryBase, ILongRunnin
         await AmbientScope.ExecuteWithContextAsync<LongRunningOperationDto>(async db =>
         {
             await db.LongRunningOperations
-                .Where(x => x.UpdateDate < olderThan)
+                .Where(x => x.UpdateDate < olderThan.UtcDateTime)
                 .ExecuteDeleteAsync();
         });
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LongRunningOperationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LongRunningOperationRepository.cs
@@ -1,11 +1,12 @@
-using Microsoft.Extensions.Logging;
-using NPoco;
+using Microsoft.EntityFrameworkCore;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Serialization;
-using Umbraco.Cms.Infrastructure.Persistence.Dtos;
-using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.EFCore;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
@@ -13,7 +14,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 /// <summary>
 /// Repository for managing long-running operations.
 /// </summary>
-internal class LongRunningOperationRepository : RepositoryBase, ILongRunningOperationRepository
+internal class LongRunningOperationRepository : AsyncRepositoryBase, ILongRunningOperationRepository
 {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly TimeProvider _timeProvider;
@@ -23,7 +24,7 @@ internal class LongRunningOperationRepository : RepositoryBase, ILongRunningOper
     /// </summary>
     public LongRunningOperationRepository(
         IJsonSerializer jsonSerializer,
-        IScopeAccessor scopeAccessor,
+        IEFCoreScopeAccessor<UmbracoDbContext> scopeAccessor,
         AppCaches appCaches,
         TimeProvider timeProvider)
         : base(scopeAccessor, appCaches)
@@ -36,32 +37,35 @@ internal class LongRunningOperationRepository : RepositoryBase, ILongRunningOper
     public async Task CreateAsync(LongRunningOperation operation, DateTimeOffset expirationDate)
     {
         LongRunningOperationDto dto = MapEntityToDto(operation, expirationDate);
-        await Database.InsertAsync(dto);
+
+        await AmbientScope.ExecuteWithContextAsync<LongRunningOperationDto>(async db =>
+        {
+            db.LongRunningOperations.Add(dto);
+            await db.SaveChangesAsync();
+        });
     }
 
     /// <inheritdoc />
-    public async Task<LongRunningOperation?> GetAsync(Guid id)
-    {
-        Sql<ISqlContext> sql = Sql()
-            .Select<LongRunningOperationDto>()
-            .From<LongRunningOperationDto>()
-            .Where<LongRunningOperationDto>(x => x.Id == id);
+    public async Task<LongRunningOperation?> GetAsync(Guid id) =>
+        await AmbientScope.ExecuteWithContextAsync(async db =>
+        {
+            LongRunningOperationDto? dto = await db.LongRunningOperations
+                .Where(x => x.Id == id)
+                .FirstOrDefaultAsync();
 
-        LongRunningOperationDto? dto = await Database.FirstOrDefaultAsync<LongRunningOperationDto>(sql);
-        return dto == null ? null : MapDtoToEntity(dto);
-    }
+            return dto == null ? null : MapDtoToEntity(dto);
+        });
 
     /// <inheritdoc />
-    public async Task<LongRunningOperation<T>?> GetAsync<T>(Guid id)
-    {
-        Sql<ISqlContext> sql = Sql()
-            .Select<LongRunningOperationDto>()
-            .From<LongRunningOperationDto>()
-            .Where<LongRunningOperationDto>(x => x.Id == id);
+    public async Task<LongRunningOperation<T>?> GetAsync<T>(Guid id) =>
+        await AmbientScope.ExecuteWithContextAsync(async db =>
+        {
+            LongRunningOperationDto? dto = await db.LongRunningOperations
+                .Where(x => x.Id == id)
+                .FirstOrDefaultAsync();
 
-        LongRunningOperationDto? dto = await Database.FirstOrDefaultAsync<LongRunningOperationDto>(sql);
-        return dto == null ? null : MapDtoToEntity<T>(dto);
-    }
+            return dto == null ? null : MapDtoToEntity<T>(dto);
+        });
 
     /// <inheritdoc/>
     public async Task<PagedModel<LongRunningOperation>> GetByTypeAsync(
@@ -70,80 +74,82 @@ internal class LongRunningOperationRepository : RepositoryBase, ILongRunningOper
         int skip,
         int take)
     {
-        Sql<ISqlContext> sql = Sql()
-            .Select<LongRunningOperationDto>()
-            .From<LongRunningOperationDto>()
-            .Where<LongRunningOperationDto>(x => x.Type == type);
-
-        if (statuses.Length > 0)
+        return await AmbientScope.ExecuteWithContextAsync(async db =>
         {
-            var includeStale = statuses.Contains(LongRunningOperationStatus.Stale);
-            var possibleStaleStatuses = new List<string>
+            IQueryable<LongRunningOperationDto> query = db.LongRunningOperations
+                .Where(x => x.Type == type);
+
+            if (statuses.Length > 0)
             {
-                nameof(LongRunningOperationStatus.Enqueued),
-                nameof(LongRunningOperationStatus.Running)
-            };
-            var statusList = statuses.Except([LongRunningOperationStatus.Stale]).Select(s => s.ToString()).ToList();
+                var includeStale = statuses.Contains(LongRunningOperationStatus.Stale);
+                var possibleStaleStatuses = new List<string>
+                {
+                    nameof(LongRunningOperationStatus.Enqueued),
+                    nameof(LongRunningOperationStatus.Running)
+                };
+                var statusList = statuses.Except([LongRunningOperationStatus.Stale]).Select(s => s.ToString()).ToList();
 
-            DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
-            sql = sql.Where<LongRunningOperationDto>(x =>
-                (statusList.Contains(x.Status) && (!possibleStaleStatuses.Contains(x.Status) || x.ExpirationDate >= now))
-                || (includeStale && possibleStaleStatuses.Contains(x.Status) && x.ExpirationDate < now));
-        }
+                DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
+                query = query.Where(x =>
+                    (statusList.Contains(x.Status) && (!possibleStaleStatuses.Contains(x.Status) || x.ExpirationDate >= now))
+                    || (includeStale && possibleStaleStatuses.Contains(x.Status) && x.ExpirationDate < now));
+            }
 
-        return await Database.PagedAsync<LongRunningOperationDto, LongRunningOperation>(
-            sql,
-            skip,
-            take,
-            sortingAction: sql2 => sql2.OrderBy<LongRunningOperationDto>(x => x.CreateDate),
-            mapper: MapDtoToEntity);
+            int total = await query.CountAsync();
+
+            List<LongRunningOperationDto> dtos = await query
+                .OrderBy(x => x.CreateDate)
+                .Skip(skip)
+                .Take(take)
+                .ToListAsync();
+
+            return new PagedModel<LongRunningOperation>(total, dtos.Select(MapDtoToEntity));
+        });
     }
 
     /// <inheritdoc/>
-    public async Task<LongRunningOperationStatus?> GetStatusAsync(Guid id)
-    {
-        Sql<ISqlContext> sql = Sql()
-            .Select<LongRunningOperationDto>(x => x.Status)
-            .From<LongRunningOperationDto>()
-            .Where<LongRunningOperationDto>(x => x.Id == id);
+    public async Task<LongRunningOperationStatus?> GetStatusAsync(Guid id) =>
+        await AmbientScope.ExecuteWithContextAsync(async db =>
+        {
+            var status = await db.LongRunningOperations
+                .Where(x => x.Id == id)
+                .Select(x => x.Status)
+                .FirstOrDefaultAsync();
 
-        return (await Database.ExecuteScalarAsync<string>(sql))?.EnumParse<LongRunningOperationStatus>(false);
-    }
-
-    /// <inheritdoc/>
-    public async Task UpdateStatusAsync(Guid id, LongRunningOperationStatus status, DateTimeOffset expirationTime)
-    {
-        Sql<ISqlContext> sql = Sql()
-            .Update<LongRunningOperationDto>(x => x
-                .Set(y => y.Status, status.ToString())
-                .Set(y => y.UpdateDate, DateTime.UtcNow)
-                .Set(y => y.ExpirationDate, expirationTime.DateTime))
-            .Where<LongRunningOperationDto>(x => x.Id == id);
-
-        await Database.ExecuteAsync(sql);
-    }
+            return status?.EnumParse<LongRunningOperationStatus>(false);
+        });
 
     /// <inheritdoc/>
-    public async Task SetResultAsync<T>(Guid id, T result)
-    {
-        Sql<ISqlContext> sql = Sql()
-            .Update<LongRunningOperationDto>(x => x
-                .Set(y => y.Result, _jsonSerializer.Serialize(result))
-                .Set(y => y.UpdateDate, DateTime.UtcNow))
-            .Where<LongRunningOperationDto>(x => x.Id == id);
-
-        await Database.ExecuteAsync(sql);
-    }
+    public async Task UpdateStatusAsync(Guid id, LongRunningOperationStatus status, DateTimeOffset expirationTime) =>
+        await AmbientScope.ExecuteWithContextAsync<LongRunningOperationDto>(async db =>
+        {
+            await db.LongRunningOperations
+                .Where(x => x.Id == id)
+                .ExecuteUpdateAsync(setter => setter
+                        .SetProperty(y => y.Status, status.ToString())
+                        .SetProperty(y => y.UpdateDate, DateTime.UtcNow)
+                        .SetProperty(y => y.ExpirationDate, expirationTime.DateTime));
+        });
 
     /// <inheritdoc/>
-    public async Task CleanOperationsAsync(DateTimeOffset olderThan)
-    {
-        Sql<ISqlContext> sql = Sql()
-            .Delete<LongRunningOperationDto>()
-            .Where<LongRunningOperationDto>(x => x.UpdateDate < olderThan);
+    public async Task SetResultAsync<T>(Guid id, T result) =>
+        await AmbientScope.ExecuteWithContextAsync<LongRunningOperationDto>(async db =>
+        {
+            await db.LongRunningOperations
+                .Where(x => x.Id == id)
+                .ExecuteUpdateAsync(setter => setter
+                    .SetProperty(y => y.Result, _jsonSerializer.Serialize(result))
+                    .SetProperty(y => y.UpdateDate, DateTime.UtcNow));
+        });
 
-        await Database.ExecuteAsync(sql);
-    }
+    /// <inheritdoc/>
+    public async Task CleanOperationsAsync(DateTimeOffset olderThan) =>
+        await AmbientScope.ExecuteWithContextAsync<LongRunningOperationDto>(async db =>
+        {
+            await db.LongRunningOperations
+                .Where(x => x.UpdateDate < olderThan)
+                .ExecuteDeleteAsync();
+        });
 
     private LongRunningOperation MapDtoToEntity(LongRunningOperationDto dto) =>
         new()

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LongRunningOperationRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LongRunningOperationRepository.cs
@@ -56,10 +56,9 @@ internal class LongRunningOperationRepository : AsyncRepositoryBase, ILongRunnin
         await AmbientScope.ExecuteWithContextAsync(async db =>
         {
             LongRunningOperationDto? dto = await db.LongRunningOperations
-                .Where(x => x.Id == id)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(x => x.Id == id);
 
-            return dto == null ? null : MapDtoToEntity(dto);
+            return dto is null ? null : MapDtoToEntity(dto);
         });
 
     /// <inheritdoc />
@@ -67,10 +66,9 @@ internal class LongRunningOperationRepository : AsyncRepositoryBase, ILongRunnin
         await AmbientScope.ExecuteWithContextAsync(async db =>
         {
             LongRunningOperationDto? dto = await db.LongRunningOperations
-                .Where(x => x.Id == id)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(x => x.Id == id);
 
-            return dto == null ? null : MapDtoToEntity<T>(dto);
+            return dto is null ? null : MapDtoToEntity<T>(dto);
         });
 
     /// <inheritdoc/>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LongRunningOperationRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LongRunningOperationRepositoryTests.cs
@@ -1,10 +1,12 @@
 using System.Data.Common;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore.Scoping;
 using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
-using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
@@ -17,9 +19,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task Get_ReturnsNull_WhenOperationDoesNotExist()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var result = await repository.GetAsync(Guid.NewGuid());
@@ -29,9 +31,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task Get_ReturnsExpectedOperation_WhenOperationExists()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var testOperation = _operations[1];
@@ -57,9 +59,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [TestCase("Test", new LongRunningOperationStatus[] { }, 5, 1, 0, 5)]
     public async Task GetByType_ReturnsExpectedOperations(string type, LongRunningOperationStatus[] statuses, int skip, int take, int expectedCount, int expectedTotal)
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var result = await repository.GetByTypeAsync(type, statuses, skip, take);
@@ -72,9 +74,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task GetStatus_ReturnsNull_WhenOperationDoesNotExist()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var result = await repository.GetStatusAsync(Guid.NewGuid());
@@ -84,9 +86,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task GetStatus_ReturnsExpectedStatus_WhenOperationExists()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var result = await repository.GetStatusAsync(_operations[0].Operation.Id);
@@ -96,9 +98,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task Create_InsertsOperationIntoDatabase()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var newOperation = new LongRunningOperation
@@ -119,9 +121,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task Create_ThrowsException_WhenOperationWithTheSameIdExists()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var newOperation = new LongRunningOperation
@@ -136,9 +138,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task UpdateStatus_UpdatesOperationStatusInDatabase()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var testOperation = _operations[1];
@@ -152,9 +154,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task SetResult_UpdatesOperationResultInDatabase()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var testOperation = _operations[1];
@@ -170,9 +172,9 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
     [Test]
     public async Task CleanOperations_RemovesOldOperationsFromTheDatabase()
     {
-        var provider = ScopeProvider;
+        var provider = NewScopeProvider;
         using var scope = provider.CreateScope();
-        var repository = CreateRepository(provider);
+        var repository = CreateRepository();
         await CreateTestData(repository);
 
         var oldOperation = _operations[0];
@@ -188,8 +190,12 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
         Assert.IsNull(result);
     }
 
-    private LongRunningOperationRepository CreateRepository(IScopeProvider provider)
-        => new(GetRequiredService<IJsonSerializer>(), (IScopeAccessor)provider, AppCaches.Disabled, TimeProvider.System);
+    private LongRunningOperationRepository CreateRepository() =>
+        new(
+            GetRequiredService<IJsonSerializer>(),
+            GetRequiredService<IEFCoreScopeAccessor<UmbracoDbContext>>(),
+            AppCaches.Disabled,
+            TimeProvider.System);
 
     private async Task CreateTestData(LongRunningOperationRepository repository)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LongRunningOperationRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/LongRunningOperationRepositoryTests.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
@@ -132,7 +133,7 @@ public class LongRunningOperationRepositoryTests : UmbracoIntegrationTest
             Type = "NewTest",
             Status = LongRunningOperationStatus.Enqueued,
         };
-        Assert.ThrowsAsync(Is.InstanceOf<DbException>(), () => repository.CreateAsync(newOperation, DateTimeOffset.UtcNow.AddMinutes(5)));
+        Assert.ThrowsAsync(Is.InstanceOf<DbUpdateException>(), () => repository.CreateAsync(newOperation, DateTimeOffset.UtcNow.AddMinutes(5)));
     }
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/LongRunningOperationServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/LongRunningOperationServiceTests.cs
@@ -1,15 +1,14 @@
-using System.Data;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
+using IScopeProvider = Umbraco.Cms.Core.Scoping.EFCore.IScopeProvider;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
 
@@ -17,7 +16,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
 public class LongRunningOperationServiceTests
 {
     private ILongRunningOperationService _longRunningOperationService;
-    private Mock<ICoreScopeProvider> _scopeProviderMock;
+    private Mock<IScopeProvider> _scopeProviderMock;
     private Mock<ILongRunningOperationRepository> _longRunningOperationRepositoryMock;
     private Mock<TimeProvider> _timeProviderMock;
     private Mock<ICoreScope> _scopeMock;
@@ -25,7 +24,7 @@ public class LongRunningOperationServiceTests
     [SetUp]
     public void Setup()
     {
-        _scopeProviderMock = new Mock<ICoreScopeProvider>(MockBehavior.Strict);
+        _scopeProviderMock = new Mock<IScopeProvider>(MockBehavior.Strict);
         _longRunningOperationRepositoryMock = new Mock<ILongRunningOperationRepository>(MockBehavior.Strict);
         _timeProviderMock = new Mock<TimeProvider>(MockBehavior.Strict);
         _scopeMock = new Mock<ICoreScope>();
@@ -90,7 +89,7 @@ public class LongRunningOperationServiceTests
             .Returns(Task.CompletedTask)
             .Verifiable(Times.Once);
 
-        _scopeProviderMock.Setup(scopeProvider => scopeProvider.Context)
+        _scopeProviderMock.Setup(scopeProvider => scopeProvider.AmbientScopeContext)
             .Returns(default(IScopeContext?))
             .Verifiable(Times.Exactly(1));
 
@@ -131,7 +130,7 @@ public class LongRunningOperationServiceTests
     {
         SetupScopeProviderMock();
 
-        _scopeProviderMock.Setup(scopeProvider => scopeProvider.Context)
+        _scopeProviderMock.Setup(scopeProvider => scopeProvider.AmbientScopeContext)
             .Returns(new ScopeContext())
             .Verifiable(Times.Exactly(1));
 
@@ -403,14 +402,9 @@ public class LongRunningOperationServiceTests
 
     private void SetupScopeProviderMock() =>
         _scopeProviderMock
-            .Setup(x => x.CreateCoreScope(
-                It.IsAny<IsolationLevel>(),
+            .Setup(x => x.CreateScope(
                 It.IsAny<RepositoryCacheMode>(),
-                It.IsAny<IEventDispatcher>(),
-                It.IsAny<IScopedNotificationPublisher>(),
-                It.IsAny<bool?>(),
-                It.IsAny<bool>(),
-                It.IsAny<bool>()))
+                It.IsAny<bool?>()))
             .Returns(_scopeMock.Object);
 }
 


### PR DESCRIPTION
### Description
This PR migrates the Long Running Opreations DTO

For this migration a few things have been done, however it's a relateively small migration compared to others:
* Migrated the `LongRunningOperationsRepository` and its service.
* Created an EFCore DTO for LongRunningOperations
* Adjusted tests.

### Exception Consistency
One thing to note is the `CreateAsync` method in the repository, here i had to get the `EntityEntry` from the database operation to detach it from the change tracker. One of the integration tests caught a slight mishap in this method due to the EF Core change tracker attaching the entity when calling the `.Add()` and still keeping the entity as "Unchanged" in the change tracker after the save call. This behavior caused the method to throw a wrong exception when attempting to save a `LongRunningOperation` with an existing ID. The change tracker would throw an `InvalidOperationException `rather than having the DB throw a `DbUpdateException`.

So to consistently throw the same exception this detachment has to happen.

<!-- Thanks for contributing to Umbraco CMS! -->
