### PR TITLE
Interaction memories: Observes memories to keep updated in same view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/interaction-memory/property-editor-ui-interaction-memory.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/interaction-memory/property-editor-ui-interaction-memory.manager.test.ts
@@ -8,14 +8,16 @@ import { UmbInteractionMemoryContext } from '@umbraco-cms/backoffice/interaction
 
 @customElement('test-my-controller-host')
 class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	public interactionMemoryContext: UmbInteractionMemoryContext;
 	constructor() {
 		super();
-		new UmbInteractionMemoryContext(this);
+		this.interactionMemoryContext = new UmbInteractionMemoryContext(this);
 	}
 }
 
 describe('UmbPropertyEditorUiInteractionMemoryManager', () => {
 	let manager: UmbPropertyEditorUiInteractionMemoryManager;
+	let interactionMemoryContext: UmbInteractionMemoryContext;
 	let childMemories = [
 		{ unique: '1', value: 'Value 1' },
 		{ unique: '2', value: 'Value 2' },
@@ -24,6 +26,7 @@ describe('UmbPropertyEditorUiInteractionMemoryManager', () => {
 	beforeEach(() => {
 		const hostElement = new UmbTestControllerHostElement();
 		document.body.appendChild(hostElement);
+		interactionMemoryContext = hostElement.interactionMemoryContext;
 
 		manager = new UmbPropertyEditorUiInteractionMemoryManager(hostElement, {
 			memoryUniquePrefix: 'TestPrefix',
@@ -99,6 +102,64 @@ describe('UmbPropertyEditorUiInteractionMemoryManager', () => {
 
 				manager.saveMemoriesForPropertyEditor(childMemories);
 				manager.saveMemoriesForPropertyEditor(updatedChildMemories);
+			});
+		});
+
+		describe('observes the interactionMemoryContext', () => {
+			it('reflects memory updates made directly on the context', async () => {
+				// Seed via the manager so the context owns an entry whose unique we can discover.
+				await manager.saveMemoriesForPropertyEditor(childMemories);
+
+				const storedMemories = interactionMemoryContext.memory.getAllMemories();
+				expect(storedMemories).to.have.lengthOf(1);
+				const memoryUnique = storedMemories[0].unique;
+
+				const externalMemories = [
+					{ unique: 'external-1', value: 'External Value 1' },
+					{ unique: 'external-2', value: 'External Value 2' },
+					{ unique: 'external-3', value: 'External Value 3' },
+				];
+
+				const updatePropagated = new Promise<void>((resolve) => {
+					manager.memoriesForPropertyEditor.subscribe((memories) => {
+						if (memories.length === externalMemories.length) {
+							expect(memories).to.deep.equal(externalMemories);
+							resolve();
+						}
+					});
+				});
+
+				interactionMemoryContext.memory.setMemory({
+					unique: memoryUnique,
+					memories: externalMemories,
+				});
+
+				await updatePropagated;
+			});
+
+			it('clears its memories when the context deletes the entry', async () => {
+				await manager.saveMemoriesForPropertyEditor(childMemories);
+
+				const storedMemories = interactionMemoryContext.memory.getAllMemories();
+				expect(storedMemories).to.have.lengthOf(1);
+				const memoryUnique = storedMemories[0].unique;
+
+				const deletionPropagated = new Promise<void>((resolve) => {
+					let sawSeededValue = false;
+					manager.memoriesForPropertyEditor.subscribe((memories) => {
+						if (!sawSeededValue && memories.length === childMemories.length) {
+							sawSeededValue = true;
+							return;
+						}
+						if (sawSeededValue && memories.length === 0) {
+							resolve();
+						}
+					});
+				});
+
+				interactionMemoryContext.memory.deleteMemory(memoryUnique);
+
+				await deletionPropagated;
 			});
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/interaction-memory/property-editor-ui-interaction-memory.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor/interaction-memory/property-editor-ui-interaction-memory.manager.ts
@@ -26,6 +26,7 @@ export class UmbPropertyEditorUiInteractionMemoryManager extends UmbControllerBa
 		this.#init = Promise.all([
 			this.consumeContext(UMB_INTERACTION_MEMORY_CONTEXT, (context) => {
 				this.#interactionMemoryContext = context;
+				this.#observeInteractionMemory();
 			}).asPromise(),
 		]);
 	}
@@ -37,7 +38,7 @@ export class UmbPropertyEditorUiInteractionMemoryManager extends UmbControllerBa
 	 */
 	setPropertyEditorConfig(config: UmbPropertyEditorConfigCollection | undefined) {
 		this.#setConfigHash(config);
-		this.#getInteractionMemory();
+		this.#observeInteractionMemory();
 	}
 
 	/**
@@ -75,14 +76,17 @@ export class UmbPropertyEditorUiInteractionMemoryManager extends UmbControllerBa
 		return `${this.#memoryUniquePrefix}PropertyEditorUi${this.#configHashCode ? '-' + this.#configHashCode : ''}`;
 	}
 
-	async #getInteractionMemory() {
-		await this.#init;
+	async #observeInteractionMemory() {
+		if (!this.#interactionMemoryContext || !this.#configHashCode) return;
 		const memoryUnique = this.#getInteractionMemoryUnique();
 		if (!memoryUnique) return;
-		if (!this.#interactionMemoryContext) return;
-
-		const memory = this.#interactionMemoryContext.memory.getMemory(memoryUnique);
-		this.#memories.setValue(memory?.memories ?? []);
+		this.observe(
+			this.#interactionMemoryContext?.memory.memory(memoryUnique),
+			(memory) => {
+				this.#memories.setValue(memory?.memories ?? []);
+			},
+			'observeMemory',
+		);
 	}
 
 	#setConfigHash(config: UmbPropertyEditorConfigCollection | undefined) {


### PR DESCRIPTION
Make interaction memories be observed instead of getting. Fixes so memories have effects on other pickers in the same view.

This fixes using the same Media Picker twice on the same document; navigating the first will then have an effect on the opening folder of the second one. Before this fix, it first happened when navigating forth anc back to the document.