### PR TITLE
Elements: Fix GetUdi() extension methods for Element entities

### DIFF
--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -106,6 +106,7 @@ public static class UdiGetterExtensions
         return entity switch
         {
             IContent content => content.GetUdi(),
+            IElement element => element.GetUdi(),
             IMedia media => media.GetUdi(),
             IMember member => member.GetUdi(),
             _ => throw new NotSupportedException($"Content base type {entity.GetType().FullName} is not supported."),
@@ -126,6 +127,20 @@ public static class UdiGetterExtensions
         string entityType = entity.Blueprint ? Constants.UdiEntityType.DocumentBlueprint : Constants.UdiEntityType.Document;
 
         return new GuidUdi(entityType, entity.Key).EnsureClosed();
+    }
+
+    /// <summary>
+    /// Gets the entity identifier of the entity.
+    /// </summary>
+    /// <param name="entity">The entity.</param>
+    /// <returns>
+    /// The entity identifier of the entity.
+    /// </returns>
+    public static GuidUdi GetUdi(this IElement entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new GuidUdi(Constants.UdiEntityType.Element, entity.Key).EnsureClosed();
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/UdiGetterExtensionsTests.cs
@@ -18,6 +18,7 @@ public class UdiGetterExtensionsTests
     [TestCase(Constants.ObjectTypes.Strings.DataType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://data-type-container/6ad82c70685c4e049b36d81bd779d16f")]
     [TestCase(Constants.ObjectTypes.Strings.DocumentBlueprint, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-blueprint-container/6ad82c70685c4e049b36d81bd779d16f")]
     [TestCase(Constants.ObjectTypes.Strings.DocumentType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://document-type-container/6ad82c70685c4e049b36d81bd779d16f")]
+    [TestCase(Constants.ObjectTypes.Strings.Element, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://element-container/6ad82c70685c4e049b36d81bd779d16f")]
     [TestCase(Constants.ObjectTypes.Strings.MediaType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://media-type-container/6ad82c70685c4e049b36d81bd779d16f")]
     [TestCase(Constants.ObjectTypes.Strings.MemberType, "6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://member-type-container/6ad82c70685c4e049b36d81bd779d16f")]
     public void GetUdiForEntityContainer(Guid containedObjectType, Guid key, string expected)
@@ -163,6 +164,24 @@ public class UdiGetterExtensionsTests
             .Build();
 
         Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IEntity)entity).GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+    }
+
+    [TestCase("6ad82c70-685c-4e04-9b36-d81bd779d16f", "umb://element/6ad82c70685c4e049b36d81bd779d16f")]
+    public void GetUdiForElement(Guid key, string expected)
+    {
+        Element entity = new ElementBuilder()
+            .WithKey(key)
+            .WithContentType(ContentTypeBuilder.CreateBasicContentType())
+            .Build();
+
+        Udi udi = entity.GetUdi();
+        Assert.AreEqual(expected, udi.ToString());
+
+        udi = ((IContentBase)entity).GetUdi();
         Assert.AreEqual(expected, udi.ToString());
 
         udi = ((IEntity)entity).GetUdi();


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Adds the missing `GetUdi()` overloads for `IElement`, so v18 Global Elements (Library section) can produce their `umb://element/{key}` identifier through the same extension surface used for documents, media and members.

**The gap**

`UdiGetterExtensions.GetUdi(this IContentBase)` switches on `IContent`/`IMedia`/`IMember` and throws `NotSupportedException` for anything else - including `IElement`, which inherits from `IPublishableContentBase : IContentBase`. The same path is reached via `GetUdi(this IEntity)`, which dispatches `IContentBase` instances down to the same switch.

This is part of a recurring pattern with this extension class missing new entity types - prior fixes:
- v17: #20840 - `EntityContainer.GetUdi()` for member type containers
- v15: #17490 - relation, user and user-group entity types
- v14: #16939 - `IContentBase.GetUdi()` for document blueprints
- v13: #15288 - `IWebhook.GetUdi()` and `IEntity.GetUdi()`

**Changes**

- `UdiGetterExtensions.GetUdi(this IContentBase)` - new `IElement` case (cases reordered alphabetically).
- New `UdiGetterExtensions.GetUdi(this IElement)` returning `new GuidUdi(Constants.UdiEntityType.Element, entity.Key)` (i.e. `umb://element/{key}`).
- `UdiGetterExtensionsTests` - new `GetUdiForElement` test covering direct, `IContentBase`, and `IEntity` dispatch; `GetUdiForEntityContainer` extended with an `Element` test case (already worked via `EntityContainer.GetUdi()`, now locked in).

### Testing

- [x] ``dotnet test --filter UdiGetterExtensionsTests`` - 34/34 pass.
- [x] Manual: ``((IContentBase)element).GetUdi()`` no longer throws ``NotSupportedException``.
- [x] Manual: all three dispatch paths (``IElement``, ``IContentBase``, ``IEntity``) return the same ``umb://element/{key}`` UDI.