### PR TITLE
Issue template: Update version lookup instructions in bug report template (closes #22867)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -7,7 +7,7 @@ body:
   id: "version"
   attributes:
     label: "Which Umbraco version are you using?"
-    description: "Please write the *exact* version, example: `10.1.0`. Use the help icon in the Umbraco backoffice to find the version you're using"
+    description: "Please write the *exact* version, example: `10.1.0`. Click the Umbraco logo in the top left corner of the backoffice to find the version you're using."
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Closes #22867

## Description

Updated the bug report template instructions for locating the Umbraco version in the backoffice.

## Changes

- Updated the `Which Umbraco version are you using?` field description to reference the Umbraco logo in the top-left corner instead of the Help icon.
