### PR TITLE
Background Jobs: Add IgnoredDelay to prevent tight looping when execution is skipped (closes #22859)

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/IRecurringBackgroundJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/IRecurringBackgroundJob.cs
@@ -9,6 +9,7 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs;
 public interface IRecurringBackgroundJob
 {
     static readonly TimeSpan DefaultDelay = System.TimeSpan.FromMinutes(3);
+    static readonly TimeSpan DefaultIgnoredDelay = System.TimeSpan.FromMinutes(1);
     static readonly ServerRole[] DefaultServerRoles = new[] { ServerRole.Single, ServerRole.SchedulingPublisher };
 
     /// <summary>
@@ -21,6 +22,14 @@ public interface IRecurringBackgroundJob
     /// occurs.
     /// </summary>
     TimeSpan Delay { get => DefaultDelay; }
+
+    /// <summary>
+    /// Timespan to wait before re-evaluating execution conditions when an execution is ignored (e.g. runtime not ready, wrong server role or not main domain).
+    /// </summary>
+    /// <remarks>
+    /// This back-off prevents tight looping when <see cref="Period" /> is short (or <see cref="TimeSpan.Zero" />) and an execution is skipped without invoking <see cref="RunJobAsync" />.
+    /// </remarks>
+    TimeSpan IgnoredDelay { get => DefaultIgnoredDelay; }
 
     /// <summary>
     /// Gets the server roles for which this recurring background job is intended.

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
@@ -86,24 +86,21 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
 
             if (_runtimeState.Level != RuntimeLevel.Run)
             {
-                _logger.LogDebug("Job not running as runlevel not yet ready");
-                await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobIgnoredNotification(_job, new EventMessages()).WithStateFrom(executingNotification));
+                await IgnoreAndWaitAsync("Job not running as runlevel not yet ready", executingNotification);
                 return;
             }
 
             // Don't run on replicas nor unknown role servers
             if (!_job.ServerRoles.Contains(_serverRoleAccessor.CurrentServerRole))
             {
-                _logger.LogDebug("Job not running on this server role");
-                await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobIgnoredNotification(_job, new EventMessages()).WithStateFrom(executingNotification));
+                await IgnoreAndWaitAsync("Job not running on this server role", executingNotification);
                 return;
             }
 
             // Ensure we do not run if not main domain, but do NOT lock it
             if (!_mainDom.IsMainDom)
             {
-                _logger.LogDebug("Job not running as not MainDom");
-                await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobIgnoredNotification(_job, new EventMessages()).WithStateFrom(executingNotification));
+                await IgnoreAndWaitAsync("Job not running as not MainDom", executingNotification);
                 return;
             }
 
@@ -119,6 +116,23 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
             _logger.LogError(ex, "Unhandled exception in recurring background job.");
         }
 
+    }
+
+    /// <summary>
+    /// Publishes the ignored notification and waits for <see cref="IRecurringBackgroundJob.IgnoredDelay" /> before returning, preventing tight looping when execution is skipped and <see cref="IRecurringBackgroundJob.Period" /> is short or <see cref="TimeSpan.Zero" />.
+    /// </summary>
+    /// <param name="message">The full debug message describing why the execution is ignored.</param>
+    /// <param name="executingNotification">The originating executing notification to carry state from.</param>
+    private async Task IgnoreAndWaitAsync(string message, Notifications.RecurringBackgroundJobExecutingNotification executingNotification)
+    {
+        _logger.LogDebug(message);
+        await _eventAggregator.PublishAsync(new Notifications.RecurringBackgroundJobIgnoredNotification(_job, new EventMessages()).WithStateFrom(executingNotification));
+
+        TimeSpan ignoredDelay = _job.IgnoredDelay;
+        if (ignoredDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(ignoredDelay);
+        }
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceTests.cs
@@ -155,6 +155,22 @@ public class RecurringBackgroundJobHostedServiceTests
     }
 
     [Test]
+    public async Task Waits_IgnoredDelay_When_Execution_Is_Ignored()
+    {
+        var ignoredDelay = TimeSpan.FromMilliseconds(200);
+        var mockJob = new Mock<IRecurringBackgroundJob>();
+        mockJob.Setup(x => x.IgnoredDelay).Returns(ignoredDelay);
+
+        var sut = CreateRecurringBackgroundJobHostedService(mockJob, isMainDom: false);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        await sut.PerformExecuteAsync(null);
+        stopwatch.Stop();
+
+        Assert.GreaterOrEqual(stopwatch.Elapsed, ignoredDelay, "Should have waited at least IgnoredDelay before returning");
+    }
+
+    [Test]
     public async Task Publishes_Start_And_Stop_Notifications()
     {
         var mockJob = new Mock<IRecurringBackgroundJob>();


### PR DESCRIPTION
> [!IMPORTANT]
> This is a focused back-port of a single fix that is also included in #22331 (which additionally rewrites the recurring hosted service loop with `SemaphoreSlim`-based signalling). **Only merge this PR if we want to ship the `IgnoredDelay` fix in a v17 patch before #22331 lands.** If #22331 merges first, close this PR without merging.

## Summary

A recurring background job with `Period = TimeSpan.Zero` — e.g. Umbraco.Engage's pattern where the job throttles itself via a semaphore inside `RunJobAsync` — spins at 100% CPU and floods logs and notifications whenever the CMS short-circuits `PerformExecuteAsync` (runtime not ready, wrong server role, or not MainDom). In those branches `RunJobAsync` is never called, so the job's own throttling never engages and the Timer loop fires again immediately.

See:
- [Umbraco.Engage.Issues#65](https://github.com/umbraco/Umbraco.Engage.Issues/issues/65)
- #22859

## Fix

Added a new `IRecurringBackgroundJob.IgnoredDelay` property (default 1 minute, overridable per job) with a default interface implementation so existing jobs don't need to change. After publishing each `RecurringBackgroundJobIgnoredNotification`, the hosted service now awaits `Task.Delay(IgnoredDelay)` before returning, which extends the elapsed time tracked by the Timer-based loop in `RecurringHostedServiceBase` and pushes the next iteration past the back-off boundary.

Regular execution paths (when the job actually runs) are unaffected — the back-off applies only when the CMS prevents the job from running. Setting `IgnoredDelay = TimeSpan.Zero` opts out of the back-off entirely.

## Test plan

- [x] Added `Waits_IgnoredDelay_When_Execution_Is_Ignored` (wall-clock test: 200 ms back-off honored)
- [x] Existing ignored-notification tests unchanged — Moq returns `TimeSpan.Zero` by default, so the back-off is skipped and the tests stay fast
- [x] Existing happy-path tests unchanged

Fixes #22859
