### PR TITLE
Cache: Only write to url table on a single server in load balanced environments to remove lock contention

### DIFF
--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ContentCacheRefresher.cs
@@ -345,15 +345,15 @@ public sealed class ContentCacheRefresher : PayloadCacheRefresherBase<ContentCac
         if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshNode))
         {
             Guid key = payload.Key ?? _idKeyMap.GetKeyForId(payload.Id, UmbracoObjectTypes.Document).Result;
-            _documentUrlService.CreateOrUpdateUrlSegmentsAsync(key).GetAwaiter().GetResult();
-            _documentUrlAliasService.CreateOrUpdateAliasesAsync(key).GetAwaiter().GetResult();
+            _documentUrlService.UpdateUrlSegmentCacheAsync(key).GetAwaiter().GetResult();
+            _documentUrlAliasService.UpdateAliasCacheAsync(key).GetAwaiter().GetResult();
         }
 
         if (payload.ChangeTypes.HasType(TreeChangeTypes.RefreshBranch))
         {
             Guid key = payload.Key ?? _idKeyMap.GetKeyForId(payload.Id, UmbracoObjectTypes.Document).Result;
-            _documentUrlService.CreateOrUpdateUrlSegmentsWithDescendantsAsync(key).GetAwaiter().GetResult();
-            _documentUrlAliasService.CreateOrUpdateAliasesWithDescendantsAsync(key).GetAwaiter().GetResult();
+            _documentUrlService.UpdateUrlSegmentCacheWithDescendantsAsync(key).GetAwaiter().GetResult();
+            _documentUrlAliasService.UpdateAliasCacheWithDescendantsAsync(key).GetAwaiter().GetResult();
         }
     }
 

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -458,6 +458,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<IDocumentUrlAliasService, DocumentUrlAliasService>();
             Services.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, DocumentUrlAliasServiceInitializerNotificationHandler>();
             Services.AddNotificationAsyncHandler<ContentTypeChangedNotification, DocumentUrlServiceContentTypeChangedNotificationHandler>();
+            Services.AddNotificationAsyncHandler<ContentTreeChangeNotification, DocumentUrlServiceContentTreeChangeNotificationHandler>();
         }
     }
 }

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -305,13 +305,40 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         scope.Complete();
     }
 
+    /// <inheritdoc/>
+    public async Task UpdateAliasCacheAsync(Guid documentKey)
+    {
+        using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
+        await CreateOrUpdateAliasesInternalAsync(documentKey, forceSkipDatabaseWrite: true);
+        scope.Complete();
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateAliasCacheWithDescendantsAsync(Guid documentKey)
+    {
+        using ICoreScope scope = _coreScopeProvider.CreateCoreScope();
+
+        var documentKeys = new List<Guid> { documentKey };
+        if (_documentNavigationQueryService.TryGetDescendantsKeys(documentKey, out IEnumerable<Guid> descendantKeys))
+        {
+            documentKeys.AddRange(descendantKeys);
+        }
+
+        foreach (Guid key in documentKeys)
+        {
+            await CreateOrUpdateAliasesInternalAsync(key, forceSkipDatabaseWrite: true);
+        }
+
+        scope.Complete();
+    }
+
     /// <summary>
     /// Internal implementation that processes a single document without creating its own scope.
     /// Caller must ensure a scope is active. A write lock on <see cref="Constants.Locks.DocumentUrlAliases"/>
     /// is required whenever this method may perform database writes — i.e. on all server roles except
     /// <see cref="ServerRole.Subscriber"/>, where persistence is skipped and the write lock is not taken.
     /// </summary>
-    private async Task CreateOrUpdateAliasesInternalAsync(Guid documentKey)
+    private async Task CreateOrUpdateAliasesInternalAsync(Guid documentKey, bool forceSkipDatabaseWrite = false)
     {
         IContent? document = _contentService.GetById(documentKey);
         if (document is null || document.Trashed || document.Blueprint)
@@ -329,7 +356,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         // Save to database (handles insert/update/delete via diff) and add to cache.
         // On subscribers we skip the persistence — the publisher has already written the aliases — but the
         // in-memory cache is still refreshed via the deferred enlistments so routing keeps working locally.
-        bool skipDatabaseWrites = SkipDatabaseWrites();
+        bool skipDatabaseWrites = forceSkipDatabaseWrite || SkipDatabaseWrites();
         if (aliases.Count > 0)
         {
             if (skipDatabaseWrites is false)

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -154,7 +154,7 @@ public class DocumentUrlService : IDocumentUrlService
         IPublishStatusQueryService publishStatusQueryService,
         IDomainCacheService domainCacheService)
 #pragma warning disable CS0618 // Type or member is obsolete
-        :this(
+        : this(
             logger,
             documentUrlRepository,
             documentRepository,

--- a/src/Umbraco.Core/Services/DocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlService.cs
@@ -604,7 +604,35 @@ public class DocumentUrlService : IDocumentUrlService
     }
 
     /// <inheritdoc/>
-    public async Task CreateOrUpdateUrlSegmentsAsync(IEnumerable<IContent> documentsEnumerable)
+    public async Task CreateOrUpdateUrlSegmentsAsync(IEnumerable<IContent> documents)
+        => await CreateOrUpdateUrlSegmentsInternalAsync(documents, skipDatabaseWrite: false);
+
+    /// <inheritdoc/>
+    public async Task UpdateUrlSegmentCacheAsync(Guid key)
+    {
+        IContent? content = _contentService.GetById(key);
+        if (content is not null)
+        {
+            await CreateOrUpdateUrlSegmentsInternalAsync(content.Yield(), skipDatabaseWrite: true);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task UpdateUrlSegmentCacheWithDescendantsAsync(Guid key)
+    {
+        var id = _idKeyMap.GetIdForKey(key, UmbracoObjectTypes.Document).Result;
+        IContent? item = _contentService.GetById(id);
+        if (item is null)
+        {
+            _logger.LogDebug("Skipping URL segment cache update for document with key {DocumentKey} — document not found.", key);
+            return;
+        }
+
+        IEnumerable<IContent> descendants = _contentService.GetPagedDescendants(id, 0, int.MaxValue, out _);
+        await CreateOrUpdateUrlSegmentsInternalAsync(new List<IContent>(descendants) { item }, skipDatabaseWrite: true);
+    }
+
+    private async Task CreateOrUpdateUrlSegmentsInternalAsync(IEnumerable<IContent> documentsEnumerable, bool skipDatabaseWrite)
     {
         IEnumerable<IContent> documents = documentsEnumerable as IContent[] ?? documentsEnumerable.ToArray();
         if (documents.Any() is false)
@@ -664,7 +692,7 @@ public class DocumentUrlService : IDocumentUrlService
             }
         }
 
-        if (toSave.Count > 0 && SkipDatabaseWrites() is false)
+        if (!skipDatabaseWrite && toSave.Count > 0 && SkipDatabaseWrites() is false)
         {
             scope.WriteLock(Constants.Locks.DocumentUrls);
             _documentUrlRepository.Save(toSave);

--- a/src/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandler.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandler.cs
@@ -1,0 +1,65 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Services;
+
+/// <summary>
+/// Handles <see cref="ContentTreeChangeNotification"/> to persist URL segments and aliases to the database
+/// on the originating server. This fires post-commit (during scope disposal) before the cache instruction
+/// is delivered to other servers, ensuring URL data is in the database before any server processes the instruction.
+/// </summary>
+public class DocumentUrlServiceContentTreeChangeNotificationHandler
+    : INotificationAsyncHandler<ContentTreeChangeNotification>
+{
+    private readonly IDocumentUrlService _documentUrlService;
+    private readonly IDocumentUrlAliasService _documentUrlAliasService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentUrlServiceContentTreeChangeNotificationHandler"/> class.
+    /// </summary>
+    public DocumentUrlServiceContentTreeChangeNotificationHandler(
+        IDocumentUrlService documentUrlService,
+        IDocumentUrlAliasService documentUrlAliasService)
+    {
+        _documentUrlService = documentUrlService;
+        _documentUrlAliasService = documentUrlAliasService;
+    }
+
+    /// <inheritdoc/>
+    public async Task HandleAsync(ContentTreeChangeNotification notification, CancellationToken cancellationToken)
+    {
+        if (_documentUrlService.IsInitialized is false)
+        {
+            return;
+        }
+
+        var refreshNodeItems = new List<IContent>();
+
+        foreach (TreeChange<IContent> change in notification.Changes)
+        {
+            if (change.ChangeTypes.HasType(TreeChangeTypes.RefreshNode))
+            {
+                refreshNodeItems.Add(change.Item);
+            }
+
+            if (change.ChangeTypes.HasType(TreeChangeTypes.RefreshBranch))
+            {
+                await _documentUrlService.CreateOrUpdateUrlSegmentsWithDescendantsAsync(change.Item.Key);
+                await _documentUrlAliasService.CreateOrUpdateAliasesWithDescendantsAsync(change.Item.Key);
+            }
+        }
+
+        if (refreshNodeItems.Count > 0)
+        {
+            await _documentUrlService.CreateOrUpdateUrlSegmentsAsync(refreshNodeItems);
+
+            foreach (IContent item in refreshNodeItems)
+            {
+                await _documentUrlAliasService.CreateOrUpdateAliasesAsync(item.Key);
+            }
+        }
+    }
+}

--- a/src/Umbraco.Core/Services/IDocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/IDocumentUrlAliasService.cs
@@ -60,4 +60,20 @@ public interface IDocumentUrlAliasService
     /// </summary>
     /// <returns><c>true</c> if there are any aliases in the cache; otherwise, <c>false</c>.</returns>
     bool HasAny();
+
+    /// <summary>
+    /// Updates the in-memory alias cache for a single document without writing to the database.
+    /// </summary>
+    /// <param name="documentKey">The document key.</param>
+    // TODO (V19): Remove default implementation when external implementations have had time to adopt.
+    Task UpdateAliasCacheAsync(Guid documentKey)
+        => CreateOrUpdateAliasesAsync(documentKey);
+
+    /// <summary>
+    /// Updates the in-memory alias cache for a document and its descendants without writing to the database.
+    /// </summary>
+    /// <param name="documentKey">The document key.</param>
+    // TODO (V19): Remove default implementation when external implementations have had time to adopt.
+    Task UpdateAliasCacheWithDescendantsAsync(Guid documentKey)
+        => CreateOrUpdateAliasesWithDescendantsAsync(documentKey);
 }

--- a/src/Umbraco.Core/Services/IDocumentUrlService.cs
+++ b/src/Umbraco.Core/Services/IDocumentUrlService.cs
@@ -100,4 +100,20 @@ public interface IDocumentUrlService
     /// Gets a value indicating whether any URLs have been cached.
     /// </summary>
     bool HasAny();
+
+    /// <summary>
+    /// Updates the in-memory URL segment cache for a single document without writing to the database.
+    /// </summary>
+    /// <param name="key">The document key.</param>
+    // TODO (V19): Remove default implementation when external implementations have had time to adopt.
+    Task UpdateUrlSegmentCacheAsync(Guid key)
+        => CreateOrUpdateUrlSegmentsAsync(key);
+
+    /// <summary>
+    /// Updates the in-memory URL segment cache for a document and its descendants without writing to the database.
+    /// </summary>
+    /// <param name="key">The document key.</param>
+    // TODO (V19): Remove default implementation when external implementations have had time to adopt.
+    Task UpdateUrlSegmentCacheWithDescendantsAsync(Guid key)
+        => CreateOrUpdateUrlSegmentsWithDescendantsAsync(key);
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -31,6 +31,8 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
 
     private IDocumentUrlAliasService DocumentUrlAliasService => GetRequiredService<IDocumentUrlAliasService>();
 
+    private IDocumentUrlService DocumentUrlService => GetRequiredService<IDocumentUrlService>();
+
     private IDocumentUrlAliasRepository DocumentUrlAliasRepository => GetRequiredService<IDocumentUrlAliasRepository>();
 
     private ICoreScopeProvider CoreScopeProvider => GetRequiredService<ICoreScopeProvider>();
@@ -65,6 +67,7 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
     [SetUp]
     public async Task SetupTestData()
     {
+        await DocumentUrlService.InitAsync(false, CancellationToken.None);
         await DocumentUrlAliasService.InitAsync(false, CancellationToken.None);
 
         // Create template

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeTests.cs
@@ -1,0 +1,367 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Scoping;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+
+/// <summary>
+/// Integration tests that verify the end-to-end behavior of
+/// <see cref="DocumentUrlServiceContentTreeChangeNotificationHandler"/>:
+/// the handler writes URL segments and aliases to the database on publish,
+/// while the cache-only variants (<c>UpdateUrlSegmentCacheAsync</c> /
+/// <c>UpdateAliasCacheAsync</c> etc.) leave the database unchanged.
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Mock)]
+internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrationTest
+{
+    private IDocumentUrlService DocumentUrlService => GetRequiredService<IDocumentUrlService>();
+
+    private IDocumentUrlAliasService DocumentUrlAliasService => GetRequiredService<IDocumentUrlAliasService>();
+
+    private IDocumentUrlRepository DocumentUrlRepository => GetRequiredService<IDocumentUrlRepository>();
+
+    private IDocumentUrlAliasRepository DocumentUrlAliasRepository => GetRequiredService<IDocumentUrlAliasRepository>();
+
+    private ICoreScopeProvider CoreScopeProvider => GetRequiredService<ICoreScopeProvider>();
+
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    private ITemplateService TemplateService => GetRequiredService<ITemplateService>();
+
+    private ContentType ContentType { get; set; } = null!;
+
+    private Content RootPage { get; set; } = null!;
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.Services.AddUnique<IServerMessenger, ScopedRepositoryTests.LocalServerMessenger>();
+        builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
+        builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, DocumentUrlServiceInitializerNotificationHandler>();
+        builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, DocumentUrlAliasServiceInitializerNotificationHandler>();
+        // DocumentUrlServiceContentTreeChangeNotificationHandler is globally registered via UmbracoBuilder.cs
+    }
+
+    [SetUp]
+    public async Task SetUpTestData()
+    {
+        await DocumentUrlService.InitAsync(false, CancellationToken.None);
+        await DocumentUrlAliasService.InitAsync(false, CancellationToken.None);
+
+        var template = TemplateBuilder.CreateTextPageTemplate("defaultTemplate");
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        ContentType = CreateContentTypeWithUrlAlias(template.Id);
+        await ContentTypeService.CreateAsync(ContentType, Constants.Security.SuperUserKey);
+
+        RootPage = ContentBuilder.CreateSimpleContent(ContentType, "Root Page");
+        ContentService.Save(RootPage, -1);
+        ContentService.Publish(RootPage, []);
+    }
+
+    private ContentType CreateContentTypeWithUrlAlias(int templateId)
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("testPageWithAlias")
+            .WithName("Test Page With Alias")
+            .AddPropertyGroup()
+                .WithAlias("content")
+                .WithName("Content")
+                .WithSortOrder(1)
+                .WithSupportsPublishing(true)
+                .AddPropertyType()
+                    .WithAlias("title")
+                    .WithName("Title")
+                    .WithSortOrder(1)
+                    .Done()
+                .AddPropertyType()
+                    .WithAlias("bodyText")
+                    .WithName("Body text")
+                    .WithSortOrder(2)
+                    .Done()
+                .AddPropertyType()
+                    .WithAlias("author")
+                    .WithName("Author")
+                    .WithSortOrder(3)
+                    .Done()
+                .AddPropertyType()
+                    .WithAlias(Constants.Conventions.Content.UrlAlias)
+                    .WithName("URL Alias")
+                    .WithSortOrder(4)
+                    .WithDataTypeId(Constants.DataTypes.Textbox)
+                    .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
+                    .WithValueStorageType(ValueStorageType.Nvarchar)
+                    .Done()
+                .Done()
+            .AddAllowedTemplate()
+                .WithId(templateId)
+                .WithAlias("defaultTemplate")
+                .WithName("Default Template")
+                .Done()
+            .WithDefaultTemplateId(templateId)
+            .Build();
+
+        return (ContentType)contentType;
+    }
+
+    private List<PublishedDocumentUrlSegment> GetDbSegments(Guid documentKey)
+    {
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return DocumentUrlRepository.GetAll()
+                .Where(r => r.DocumentKey == documentKey)
+                .ToList();
+        }
+    }
+
+    private List<PublishedDocumentUrlAlias> GetDbAliases(Guid documentKey)
+    {
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return DocumentUrlAliasRepository.GetAll()
+                .Where(r => r.DocumentKey == documentKey)
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// After publishing a document the notification handler must have written URL segments to
+    /// the database without any manual call to <c>CreateOrUpdateUrlSegmentsAsync</c>.
+    /// </summary>
+    [Test]
+    public void Publish_WritesUrlSegmentsToDatabase_ViaNotificationHandler()
+    {
+        var page = ContentBuilder.CreateSimpleContent(ContentType, "Test Page", RootPage.Id);
+        ContentService.Save(page, -1);
+        ContentService.Publish(page, []);
+
+        var rows = GetDbSegments(page.Key);
+
+        Assert.That(rows, Is.Not.Empty,
+            "The ContentTreeChangeNotification handler must write URL segments to the database on publish.");
+    }
+
+    /// <summary>
+    /// After publishing a document with a URL alias, the notification handler must have written
+    /// the alias to the database without any manual call to <c>CreateOrUpdateAliasesAsync</c>.
+    /// </summary>
+    [Test]
+    public void Publish_WithUrlAlias_WritesAliasesToDatabase_ViaNotificationHandler()
+    {
+        var page = ContentBuilder.CreateSimpleContent(ContentType, "Alias Page", RootPage.Id);
+        page.SetValue(Constants.Conventions.Content.UrlAlias, "my-integration-alias");
+        ContentService.Save(page, -1);
+        ContentService.Publish(page, []);
+
+        var aliases = GetDbAliases(page.Key);
+
+        Assert.That(aliases, Is.Not.Empty,
+            "The ContentTreeChangeNotification handler must write URL aliases to the database on publish.");
+        Assert.That(aliases.Any(a => a.Alias == "my-integration-alias"), Is.True,
+            "The persisted alias value must match what was set on the content.");
+    }
+
+    /// <summary>
+    /// Publishing a branch must write URL segments for every node in the subtree to the database,
+    /// covering the <c>RefreshBranch</c> path in the notification handler.
+    /// </summary>
+    [Test]
+    public void PublishBranch_WritesUrlSegmentsForAllDescendants_ViaNotificationHandler()
+    {
+        var parent = ContentBuilder.CreateSimpleContent(ContentType, "Parent", RootPage.Id);
+        ContentService.Save(parent, -1);
+
+        var child = ContentBuilder.CreateSimpleContent(ContentType, "Child", parent.Id);
+        ContentService.Save(child, -1);
+
+        var grandchild = ContentBuilder.CreateSimpleContent(ContentType, "Grandchild", child.Id);
+        ContentService.Save(grandchild, -1);
+
+        ContentService.PublishBranch(parent, PublishBranchFilter.IncludeUnpublished, ["*"]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(GetDbSegments(parent.Key), Is.Not.Empty,
+                "Parent URL segments must be in the database after PublishBranch.");
+            Assert.That(GetDbSegments(child.Key), Is.Not.Empty,
+                "Child URL segments must be in the database after PublishBranch.");
+            Assert.That(GetDbSegments(grandchild.Key), Is.Not.Empty,
+                "Grandchild URL segments must be in the database after PublishBranch.");
+        });
+    }
+
+    /// <summary>
+    /// <see cref="IDocumentUrlService.UpdateUrlSegmentCacheAsync"/> must not write additional rows
+    /// to the database. After calling it the row count for the document key must be unchanged, but
+    /// the in-memory <c>GetUrlSegment</c> lookup must still work.
+    /// </summary>
+    [Test]
+    public async Task UpdateUrlSegmentCacheAsync_DoesNotWriteAdditionalRowsToDatabase_ButUpdatesCache()
+    {
+        var page = ContentBuilder.CreateSimpleContent(ContentType, "URL Cache Test Page", RootPage.Id);
+        ContentService.Save(page, -1);
+        ContentService.Publish(page, []);
+
+        var rowsBefore = GetDbSegments(page.Key);
+        Assert.That(rowsBefore, Is.Not.Empty, "Pre-condition: publish must have written segments.");
+
+        await DocumentUrlService.UpdateUrlSegmentCacheAsync(page.Key);
+
+        var rowsAfter = GetDbSegments(page.Key);
+
+        Assert.That(rowsAfter.Count, Is.EqualTo(rowsBefore.Count),
+            "UpdateUrlSegmentCacheAsync must not write additional rows to the database.");
+
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+        var segment = DocumentUrlService.GetUrlSegment(page.Key, isoCode, isDraft: false);
+        Assert.That(segment, Is.Not.Null,
+            "UpdateUrlSegmentCacheAsync must keep the in-memory cache populated.");
+    }
+
+    /// <summary>
+    /// <see cref="IDocumentUrlAliasService.UpdateAliasCacheAsync"/> must not write additional rows
+    /// to the database. After <see cref="IDocumentUrlAliasService.DeleteAliasesFromCacheAsync"/>
+    /// evicts the alias, calling <c>UpdateAliasCacheAsync</c> must restore the cache without
+    /// touching the database.
+    /// </summary>
+    [Test]
+    public async Task UpdateAliasCacheAsync_DoesNotWriteAdditionalRowsToDatabase_ButResolvesAlias()
+    {
+        var page = ContentBuilder.CreateSimpleContent(ContentType, "Alias Cache Page", RootPage.Id);
+        page.SetValue(Constants.Conventions.Content.UrlAlias, "cache-test-alias");
+        ContentService.Save(page, -1);
+        ContentService.Publish(page, []);
+
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+
+        var aliasesBefore = GetDbAliases(page.Key);
+        Assert.That(aliasesBefore, Is.Not.Empty, "Pre-condition: publish must have written aliases.");
+
+        // Evict from cache so lookup fails.
+        await DocumentUrlAliasService.DeleteAliasesFromCacheAsync(new[] { page.Key });
+        Assert.That(
+            await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("cache-test-alias", isoCode),
+            Is.Empty,
+            "Pre-condition: alias must not be resolvable after cache eviction.");
+
+        await DocumentUrlAliasService.UpdateAliasCacheAsync(page.Key);
+
+        var aliasesAfter = GetDbAliases(page.Key);
+        Assert.That(aliasesAfter.Count, Is.EqualTo(aliasesBefore.Count),
+            "UpdateAliasCacheAsync must not write additional alias rows to the database.");
+
+        var result = await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("cache-test-alias", isoCode);
+        Assert.That(result, Does.Contain(page.Key),
+            "UpdateAliasCacheAsync must restore the in-memory alias cache.");
+    }
+
+    /// <summary>
+    /// <see cref="IDocumentUrlService.UpdateUrlSegmentCacheWithDescendantsAsync"/> must not write
+    /// additional rows to the database for any node in the subtree.
+    /// </summary>
+    [Test]
+    public async Task UpdateUrlSegmentCacheWithDescendantsAsync_DoesNotWriteAdditionalRowsToDatabase()
+    {
+        var parent = ContentBuilder.CreateSimpleContent(ContentType, "Parent Cache Test", RootPage.Id);
+        ContentService.Save(parent, -1);
+
+        var child = ContentBuilder.CreateSimpleContent(ContentType, "Child Cache Test", parent.Id);
+        ContentService.Save(child, -1);
+
+        ContentService.PublishBranch(parent, PublishBranchFilter.IncludeUnpublished, ["*"]);
+
+        var parentRowsBefore = GetDbSegments(parent.Key);
+        var childRowsBefore = GetDbSegments(child.Key);
+        Assert.That(parentRowsBefore, Is.Not.Empty, "Pre-condition: parent segments must be in DB.");
+        Assert.That(childRowsBefore, Is.Not.Empty, "Pre-condition: child segments must be in DB.");
+
+        await DocumentUrlService.UpdateUrlSegmentCacheWithDescendantsAsync(parent.Key);
+
+        var parentRowsAfter = GetDbSegments(parent.Key);
+        var childRowsAfter = GetDbSegments(child.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parentRowsAfter.Count, Is.EqualTo(parentRowsBefore.Count),
+                "UpdateUrlSegmentCacheWithDescendantsAsync must not write additional rows for the parent.");
+            Assert.That(childRowsAfter.Count, Is.EqualTo(childRowsBefore.Count),
+                "UpdateUrlSegmentCacheWithDescendantsAsync must not write additional rows for the child.");
+        });
+
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+        Assert.Multiple(() =>
+        {
+            Assert.That(DocumentUrlService.GetUrlSegment(parent.Key, isoCode, isDraft: false), Is.Not.Null,
+                "Parent URL segment must still be resolvable from in-memory cache.");
+            Assert.That(DocumentUrlService.GetUrlSegment(child.Key, isoCode, isDraft: false), Is.Not.Null,
+                "Child URL segment must still be resolvable from in-memory cache.");
+        });
+    }
+
+    /// <summary>
+    /// <see cref="IDocumentUrlAliasService.UpdateAliasCacheWithDescendantsAsync"/> must restore the
+    /// in-memory cache for both the root and all descendants without writing to the database.
+    /// </summary>
+    [Test]
+    public async Task UpdateAliasCacheWithDescendantsAsync_DoesNotWriteAdditionalRowsToDatabase_ButUpdatesCache()
+    {
+        var parent = ContentBuilder.CreateSimpleContent(ContentType, "Alias Parent", RootPage.Id);
+        parent.SetValue(Constants.Conventions.Content.UrlAlias, "parent-alias");
+        ContentService.Save(parent, -1);
+
+        var child = ContentBuilder.CreateSimpleContent(ContentType, "Alias Child", parent.Id);
+        child.SetValue(Constants.Conventions.Content.UrlAlias, "child-alias");
+        ContentService.Save(child, -1);
+
+        ContentService.PublishBranch(parent, PublishBranchFilter.IncludeUnpublished, ["*"]);
+
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+
+        var parentAliasesBefore = GetDbAliases(parent.Key);
+        var childAliasesBefore = GetDbAliases(child.Key);
+        Assert.That(parentAliasesBefore, Is.Not.Empty, "Pre-condition: parent alias must be in DB.");
+        Assert.That(childAliasesBefore, Is.Not.Empty, "Pre-condition: child alias must be in DB.");
+
+        // Evict both from cache.
+        await DocumentUrlAliasService.DeleteAliasesFromCacheAsync(new[] { parent.Key, child.Key });
+
+        await DocumentUrlAliasService.UpdateAliasCacheWithDescendantsAsync(parent.Key);
+
+        var parentAliasesAfter = GetDbAliases(parent.Key);
+        var childAliasesAfter = GetDbAliases(child.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parentAliasesAfter.Count, Is.EqualTo(parentAliasesBefore.Count),
+                "UpdateAliasCacheWithDescendantsAsync must not write additional rows for the parent.");
+            Assert.That(childAliasesAfter.Count, Is.EqualTo(childAliasesBefore.Count),
+                "UpdateAliasCacheWithDescendantsAsync must not write additional rows for the child.");
+        });
+
+        var parentResult = await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("parent-alias", isoCode);
+        var childResult = await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("child-alias", isoCode);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parentResult, Does.Contain(parent.Key),
+                "Parent alias must be resolvable after UpdateAliasCacheWithDescendantsAsync.");
+            Assert.That(childResult, Does.Contain(child.Key),
+                "Child alias must be resolvable after UpdateAliasCacheWithDescendantsAsync.");
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeTests.cs
@@ -152,7 +152,9 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         var rows = GetDbSegments(page.Key);
 
-        Assert.That(rows, Is.Not.Empty,
+        Assert.That(
+            rows,
+            Is.Not.Empty,
             "The ContentTreeChangeNotification handler must write URL segments to the database on publish.");
     }
 
@@ -170,9 +172,13 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         var aliases = GetDbAliases(page.Key);
 
-        Assert.That(aliases, Is.Not.Empty,
+        Assert.That(
+            aliases,
+            Is.Not.Empty,
             "The ContentTreeChangeNotification handler must write URL aliases to the database on publish.");
-        Assert.That(aliases.Any(a => a.Alias == "my-integration-alias"), Is.True,
+        Assert.That(
+            aliases.Any(a => a.Alias == "my-integration-alias"),
+            Is.True,
             "The persisted alias value must match what was set on the content.");
     }
 
@@ -196,11 +202,17 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         Assert.Multiple(() =>
         {
-            Assert.That(GetDbSegments(parent.Key), Is.Not.Empty,
+            Assert.That(
+                GetDbSegments(parent.Key),
+                Is.Not.Empty,
                 "Parent URL segments must be in the database after PublishBranch.");
-            Assert.That(GetDbSegments(child.Key), Is.Not.Empty,
+            Assert.That(
+                GetDbSegments(child.Key),
+                Is.Not.Empty,
                 "Child URL segments must be in the database after PublishBranch.");
-            Assert.That(GetDbSegments(grandchild.Key), Is.Not.Empty,
+            Assert.That(
+                GetDbSegments(grandchild.Key),
+                Is.Not.Empty,
                 "Grandchild URL segments must be in the database after PublishBranch.");
         });
     }
@@ -218,18 +230,25 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
         ContentService.Publish(page, []);
 
         var rowsBefore = GetDbSegments(page.Key);
-        Assert.That(rowsBefore, Is.Not.Empty, "Pre-condition: publish must have written segments.");
+        Assert.That(
+            rowsBefore,
+            Is.Not.Empty,
+            "Pre-condition: publish must have written segments.");
 
         await DocumentUrlService.UpdateUrlSegmentCacheAsync(page.Key);
 
         var rowsAfter = GetDbSegments(page.Key);
 
-        Assert.That(rowsAfter.Count, Is.EqualTo(rowsBefore.Count),
+        Assert.That(
+            rowsAfter.Count,
+            Is.EqualTo(rowsBefore.Count),
             "UpdateUrlSegmentCacheAsync must not write additional rows to the database.");
 
         var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
         var segment = DocumentUrlService.GetUrlSegment(page.Key, isoCode, isDraft: false);
-        Assert.That(segment, Is.Not.Null,
+        Assert.That(
+            segment,
+            Is.Not.Null,
             "UpdateUrlSegmentCacheAsync must keep the in-memory cache populated.");
     }
 
@@ -250,7 +269,10 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
         var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
 
         var aliasesBefore = GetDbAliases(page.Key);
-        Assert.That(aliasesBefore, Is.Not.Empty, "Pre-condition: publish must have written aliases.");
+        Assert.That(
+            aliasesBefore,
+            Is.Not.Empty,
+            "Pre-condition: publish must have written aliases.");
 
         // Evict from cache so lookup fails.
         await DocumentUrlAliasService.DeleteAliasesFromCacheAsync(new[] { page.Key });
@@ -262,11 +284,15 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
         await DocumentUrlAliasService.UpdateAliasCacheAsync(page.Key);
 
         var aliasesAfter = GetDbAliases(page.Key);
-        Assert.That(aliasesAfter.Count, Is.EqualTo(aliasesBefore.Count),
+        Assert.That(
+            aliasesAfter.Count,
+            Is.EqualTo(aliasesBefore.Count),
             "UpdateAliasCacheAsync must not write additional alias rows to the database.");
 
         var result = await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("cache-test-alias", isoCode);
-        Assert.That(result, Does.Contain(page.Key),
+        Assert.That(
+            result,
+            Does.Contain(page.Key),
             "UpdateAliasCacheAsync must restore the in-memory alias cache.");
     }
 
@@ -287,8 +313,14 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         var parentRowsBefore = GetDbSegments(parent.Key);
         var childRowsBefore = GetDbSegments(child.Key);
-        Assert.That(parentRowsBefore, Is.Not.Empty, "Pre-condition: parent segments must be in DB.");
-        Assert.That(childRowsBefore, Is.Not.Empty, "Pre-condition: child segments must be in DB.");
+        Assert.That(
+            parentRowsBefore,
+            Is.Not.Empty,
+            "Pre-condition: parent segments must be in DB.");
+        Assert.That(
+            childRowsBefore,
+            Is.Not.Empty,
+            "Pre-condition: child segments must be in DB.");
 
         await DocumentUrlService.UpdateUrlSegmentCacheWithDescendantsAsync(parent.Key);
 
@@ -297,18 +329,26 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         Assert.Multiple(() =>
         {
-            Assert.That(parentRowsAfter.Count, Is.EqualTo(parentRowsBefore.Count),
+            Assert.That(
+                parentRowsAfter.Count,
+                Is.EqualTo(parentRowsBefore.Count),
                 "UpdateUrlSegmentCacheWithDescendantsAsync must not write additional rows for the parent.");
-            Assert.That(childRowsAfter.Count, Is.EqualTo(childRowsBefore.Count),
+            Assert.That(
+                childRowsAfter.Count,
+                Is.EqualTo(childRowsBefore.Count),
                 "UpdateUrlSegmentCacheWithDescendantsAsync must not write additional rows for the child.");
         });
 
         var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
         Assert.Multiple(() =>
         {
-            Assert.That(DocumentUrlService.GetUrlSegment(parent.Key, isoCode, isDraft: false), Is.Not.Null,
+            Assert.That(
+                DocumentUrlService.GetUrlSegment(parent.Key, isoCode, isDraft: false),
+                Is.Not.Null,
                 "Parent URL segment must still be resolvable from in-memory cache.");
-            Assert.That(DocumentUrlService.GetUrlSegment(child.Key, isoCode, isDraft: false), Is.Not.Null,
+            Assert.That(
+                DocumentUrlService.GetUrlSegment(child.Key, isoCode, isDraft: false),
+                Is.Not.Null,
                 "Child URL segment must still be resolvable from in-memory cache.");
         });
     }
@@ -334,8 +374,14 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         var parentAliasesBefore = GetDbAliases(parent.Key);
         var childAliasesBefore = GetDbAliases(child.Key);
-        Assert.That(parentAliasesBefore, Is.Not.Empty, "Pre-condition: parent alias must be in DB.");
-        Assert.That(childAliasesBefore, Is.Not.Empty, "Pre-condition: child alias must be in DB.");
+        Assert.That(
+            parentAliasesBefore,
+            Is.Not.Empty,
+            "Pre-condition: parent alias must be in DB.");
+        Assert.That(
+            childAliasesBefore,
+            Is.Not.Empty,
+            "Pre-condition: child alias must be in DB.");
 
         // Evict both from cache.
         await DocumentUrlAliasService.DeleteAliasesFromCacheAsync(new[] { parent.Key, child.Key });
@@ -347,9 +393,13 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         Assert.Multiple(() =>
         {
-            Assert.That(parentAliasesAfter.Count, Is.EqualTo(parentAliasesBefore.Count),
+            Assert.That(
+                parentAliasesAfter.Count,
+                Is.EqualTo(parentAliasesBefore.Count),
                 "UpdateAliasCacheWithDescendantsAsync must not write additional rows for the parent.");
-            Assert.That(childAliasesAfter.Count, Is.EqualTo(childAliasesBefore.Count),
+            Assert.That(
+                childAliasesAfter.Count,
+                Is.EqualTo(childAliasesBefore.Count),
                 "UpdateAliasCacheWithDescendantsAsync must not write additional rows for the child.");
         });
 
@@ -358,9 +408,13 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
 
         Assert.Multiple(() =>
         {
-            Assert.That(parentResult, Does.Contain(parent.Key),
+            Assert.That(
+                parentResult,
+                Does.Contain(parent.Key),
                 "Parent alias must be resolvable after UpdateAliasCacheWithDescendantsAsync.");
-            Assert.That(childResult, Does.Contain(child.Key),
+            Assert.That(
+                childResult,
+                Does.Contain(child.Key),
                 "Child alias must be resolvable after UpdateAliasCacheWithDescendantsAsync.");
         });
     }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -681,4 +681,131 @@ public class DocumentUrlAliasServiceTests
     }
 
     #endregion
+
+    #region UpdateAliasCache Tests
+
+    /// <summary>
+    /// <see cref="DocumentUrlAliasService.UpdateAliasCacheAsync"/> must never call <c>Save</c> or
+    /// <c>DeleteByDocumentKey</c> on the repository. Its contract is to refresh the in-memory cache only.
+    /// </summary>
+    [Test]
+    public async Task UpdateAliasCacheAsync_DoesNotCallRepositorySave_OrDelete()
+    {
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks();
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, "my-alias"));
+
+        await service.UpdateAliasCacheAsync(documentKey);
+
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never,
+            "UpdateAliasCacheAsync must not write URL aliases to the database.");
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never,
+            "UpdateAliasCacheAsync must not delete URL aliases from the database.");
+    }
+
+    /// <summary>
+    /// Even when a document has no aliases, <see cref="DocumentUrlAliasService.UpdateAliasCacheAsync"/>
+    /// must not issue a database delete — it is a cache-only operation.
+    /// </summary>
+    [Test]
+    public async Task UpdateAliasCacheAsync_WhenContentHasNoAlias_DoesNotCallRepositoryDelete()
+    {
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks();
+
+        var documentKey = Guid.NewGuid();
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, aliasValue: null));
+
+        await service.UpdateAliasCacheAsync(documentKey);
+
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never,
+            "UpdateAliasCacheAsync must not delete URL aliases from the database even when no alias exists.");
+    }
+
+    /// <summary>
+    /// After <see cref="DocumentUrlAliasService.DeleteAliasesFromCacheAsync"/> evicts a cached alias,
+    /// <see cref="DocumentUrlAliasService.UpdateAliasCacheAsync"/> must restore it from the content data
+    /// without writing to the database, so subsequent lookups succeed again.
+    /// </summary>
+    [Test]
+    public async Task UpdateAliasCacheAsync_StillPopulatesInMemoryCache()
+    {
+        var documentKey = Guid.NewGuid();
+
+        var seeded = new[]
+        {
+            new PublishedDocumentUrlAlias
+            {
+                DocumentKey = documentKey,
+                NullableLanguageId = null,
+                Alias = "my-alias",
+            },
+        };
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+
+        // Create the service+mocks manually so we can configure both the repository (for InitAsync
+        // seed) and the content service (for UpdateAliasCacheAsync's GetById call).
+        var (service, aliasRepositoryMock, contentServiceMock) = CreateServiceWithMocks(
+            serverRole: ServerRole.Single,
+            languages: languages);
+        aliasRepositoryMock.Setup(x => x.GetAll()).Returns(seeded);
+        await service.InitAsync(forceEmpty: false, CancellationToken.None);
+
+        // Evict the alias from the in-memory cache so it cannot be found.
+        await service.DeleteAliasesFromCacheAsync(new[] { documentKey });
+        Assert.That(
+            await service.GetDocumentKeysByAliasAsync("my-alias", culture: null),
+            Is.Empty,
+            "Pre-condition: alias must not be resolvable after cache eviction.");
+
+        // Wire up the content service so UpdateAliasCacheAsync can repopulate the cache.
+        contentServiceMock.Setup(x => x.GetById(documentKey))
+            .Returns(CreateInvariantContentWithAlias(documentKey, "my-alias"));
+
+        await service.UpdateAliasCacheAsync(documentKey);
+
+        var result = (await service.GetDocumentKeysByAliasAsync("my-alias", culture: null)).ToList();
+        Assert.That(
+            result,
+            Does.Contain(documentKey),
+            "UpdateAliasCacheAsync must repopulate the in-memory cache without a database write.");
+
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never);
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// <see cref="DocumentUrlAliasService.UpdateAliasCacheWithDescendantsAsync"/> must not call
+    /// <c>Save</c> or <c>DeleteByDocumentKey</c> — it is a cache-only operation, even for subtrees.
+    /// </summary>
+    [Test]
+    public async Task UpdateAliasCacheWithDescendantsAsync_DoesNotCallRepositorySave()
+    {
+        var (service, aliasRepositoryMock, _) = CreateServiceWithMocks();
+
+        await service.UpdateAliasCacheWithDescendantsAsync(Guid.NewGuid());
+
+        aliasRepositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlAlias>>()),
+            Times.Never,
+            "UpdateAliasCacheWithDescendantsAsync must not write URL aliases to the database.");
+        aliasRepositoryMock.Verify(
+            x => x.DeleteByDocumentKey(It.IsAny<IEnumerable<Guid>>()),
+            Times.Never,
+            "UpdateAliasCacheWithDescendantsAsync must not delete URL aliases from the database.");
+    }
+
+    #endregion
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandlerTests.cs
@@ -42,8 +42,8 @@ public class DocumentUrlServiceContentTreeChangeNotificationHandlerTests
     }
 
     private static ContentTreeChangeNotification SingleChange(IContent content, TreeChangeTypes changeType)
-        => new ContentTreeChangeNotification(
-            new[] { new TreeChange<IContent>(content, changeType) },
+        => new(
+            [new TreeChange<IContent>(content, changeType)],
             new EventMessages());
 
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandlerTests.cs
@@ -1,0 +1,191 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
+
+[TestFixture]
+public class DocumentUrlServiceContentTreeChangeNotificationHandlerTests
+{
+    private static (DocumentUrlServiceContentTreeChangeNotificationHandler Handler,
+        Mock<IDocumentUrlService> UrlService,
+        Mock<IDocumentUrlAliasService> AliasService) CreateHandler(bool isInitialized = true)
+    {
+        var urlServiceMock = new Mock<IDocumentUrlService>();
+        urlServiceMock.Setup(x => x.IsInitialized).Returns(isInitialized);
+        urlServiceMock.Setup(x => x.CreateOrUpdateUrlSegmentsAsync(It.IsAny<IEnumerable<IContent>>()))
+            .Returns(Task.CompletedTask);
+        urlServiceMock.Setup(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(It.IsAny<Guid>()))
+            .Returns(Task.CompletedTask);
+
+        var aliasServiceMock = new Mock<IDocumentUrlAliasService>();
+        aliasServiceMock.Setup(x => x.CreateOrUpdateAliasesAsync(It.IsAny<Guid>()))
+            .Returns(Task.CompletedTask);
+        aliasServiceMock.Setup(x => x.CreateOrUpdateAliasesWithDescendantsAsync(It.IsAny<Guid>()))
+            .Returns(Task.CompletedTask);
+
+        var handler = new DocumentUrlServiceContentTreeChangeNotificationHandler(
+            urlServiceMock.Object, aliasServiceMock.Object);
+
+        return (handler, urlServiceMock, aliasServiceMock);
+    }
+
+    private static Mock<IContent> MakeContent()
+    {
+        var mock = new Mock<IContent>();
+        mock.Setup(x => x.Key).Returns(Guid.NewGuid());
+        return mock;
+    }
+
+    private static ContentTreeChangeNotification SingleChange(IContent content, TreeChangeTypes changeType)
+        => new ContentTreeChangeNotification(
+            new[] { new TreeChange<IContent>(content, changeType) },
+            new EventMessages());
+
+    [Test]
+    public async Task HandleAsync_WhenNotInitialized_DoesNotCallAnyServiceMethods()
+    {
+        var (handler, urlService, aliasService) = CreateHandler(isInitialized: false);
+        var content = MakeContent();
+        var notification = SingleChange(content.Object, TreeChangeTypes.RefreshNode);
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsAsync(It.IsAny<IEnumerable<IContent>>()), Times.Never);
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_WithSingleRefreshNode_CallsUrlSegmentsWithItemAndAliasesWithKey()
+    {
+        var (handler, urlService, aliasService) = CreateHandler();
+        var content = MakeContent();
+        var key = content.Object.Key;
+        var notification = SingleChange(content.Object, TreeChangeTypes.RefreshNode);
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(
+            x => x.CreateOrUpdateUrlSegmentsAsync(It.Is<IEnumerable<IContent>>(items => items.Any(i => i.Key == key))),
+            Times.Once);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(key), Times.Once);
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_WithMultipleRefreshNodes_BatchesUrlSegmentsAndCallsAliasesPerItem()
+    {
+        var (handler, urlService, aliasService) = CreateHandler();
+        var content1 = MakeContent();
+        var content2 = MakeContent();
+        var notification = new ContentTreeChangeNotification(
+            new[]
+            {
+                new TreeChange<IContent>(content1.Object, TreeChangeTypes.RefreshNode),
+                new TreeChange<IContent>(content2.Object, TreeChangeTypes.RefreshNode),
+            },
+            new EventMessages());
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsAsync(It.IsAny<IEnumerable<IContent>>()), Times.Once);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(content1.Object.Key), Times.Once);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(content2.Object.Key), Times.Once);
+    }
+
+    [Test]
+    public async Task HandleAsync_WithRefreshBranch_CallsWithDescendantsMethods()
+    {
+        var (handler, urlService, aliasService) = CreateHandler();
+        var content = MakeContent();
+        var key = content.Object.Key;
+        var notification = SingleChange(content.Object, TreeChangeTypes.RefreshBranch);
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(key), Times.Once);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesWithDescendantsAsync(key), Times.Once);
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsAsync(It.IsAny<IEnumerable<IContent>>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_WithRemoveChange_DoesNotCallAnyCreateOrUpdateMethods()
+    {
+        var (handler, urlService, aliasService) = CreateHandler();
+        var content = MakeContent();
+        var notification = SingleChange(content.Object, TreeChangeTypes.Remove);
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsAsync(It.IsAny<IEnumerable<IContent>>()), Times.Never);
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_WithRefreshAll_DoesNotCallCreateOrUpdateMethods()
+    {
+        var (handler, urlService, aliasService) = CreateHandler();
+        var content = MakeContent();
+        var notification = SingleChange(content.Object, TreeChangeTypes.RefreshAll);
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsAsync(It.IsAny<IEnumerable<IContent>>()), Times.Never);
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_WithEmptyChanges_DoesNotCallAnyMethods()
+    {
+        var (handler, urlService, aliasService) = CreateHandler();
+        var notification = new ContentTreeChangeNotification(
+            Array.Empty<TreeChange<IContent>>(),
+            new EventMessages());
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsAsync(It.IsAny<IEnumerable<IContent>>()), Times.Never);
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(It.IsAny<Guid>()), Times.Never);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesWithDescendantsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Test]
+    public async Task HandleAsync_WithBothRefreshNodeAndBranch_CallsCorrectMethodsForEach()
+    {
+        var (handler, urlService, aliasService) = CreateHandler();
+        var nodeContent = MakeContent();
+        var branchContent = MakeContent();
+        var nodeKey = nodeContent.Object.Key;
+        var branchKey = branchContent.Object.Key;
+
+        var notification = new ContentTreeChangeNotification(
+            new[]
+            {
+                new TreeChange<IContent>(nodeContent.Object, TreeChangeTypes.RefreshNode),
+                new TreeChange<IContent>(branchContent.Object, TreeChangeTypes.RefreshBranch),
+            },
+            new EventMessages());
+
+        await handler.HandleAsync(notification, CancellationToken.None);
+
+        urlService.Verify(
+            x => x.CreateOrUpdateUrlSegmentsAsync(It.Is<IEnumerable<IContent>>(items => items.Any(i => i.Key == nodeKey))),
+            Times.Once);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesAsync(nodeKey), Times.Once);
+        urlService.Verify(x => x.CreateOrUpdateUrlSegmentsWithDescendantsAsync(branchKey), Times.Once);
+        aliasService.Verify(x => x.CreateOrUpdateAliasesWithDescendantsAsync(branchKey), Times.Once);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/DocumentUrlServiceTests.cs
@@ -818,4 +818,75 @@ public class DocumentUrlServiceTests
     }
 
     #endregion
+
+    #region UpdateUrlSegmentCache Tests
+
+    /// <summary>
+    /// <see cref="DocumentUrlService.UpdateUrlSegmentCacheAsync"/> must never call <c>Save</c> on the
+    /// repository, even when content exists and would produce segments. Its sole purpose is to refresh
+    /// the in-memory cache without a DB write.
+    /// </summary>
+    [Test]
+    public async Task UpdateUrlSegmentCacheAsync_DoesNotCallRepositorySave()
+    {
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+        var urlSegmentProvider = CreateFixedSegmentProvider("test-segment");
+        var urlSegmentProviderCollection = new UrlSegmentProviderCollection(() => [urlSegmentProvider]);
+
+        var (service, repositoryMock) = CreateDocumentUrlServiceWithMocks(urlSegmentProviderCollection, languages);
+
+        // GetById returns null by default — no content, no segments, Save must never be called.
+        await service.UpdateUrlSegmentCacheAsync(Guid.NewGuid());
+
+        repositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlSegment>>()),
+            Times.Never,
+            "UpdateUrlSegmentCacheAsync must not write URL segments to the database.");
+    }
+
+    /// <summary>
+    /// Even when content exists and the service is a SchedulingPublisher (which would normally
+    /// write), <see cref="DocumentUrlService.UpdateUrlSegmentCacheAsync"/> must not call <c>Save</c>.
+    /// </summary>
+    [TestCase(ServerRole.Single)]
+    [TestCase(ServerRole.SchedulingPublisher)]
+    public async Task UpdateUrlSegmentCacheAsync_DoesNotCallRepositorySave_ForAnyPublisherRole(ServerRole role)
+    {
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+        var urlSegmentProvider = CreateFixedSegmentProvider("test-segment");
+        var urlSegmentProviderCollection = new UrlSegmentProviderCollection(() => [urlSegmentProvider]);
+
+        var (service, repositoryMock) = CreateDocumentUrlServiceWithMocks(urlSegmentProviderCollection, languages, role);
+
+        await service.UpdateUrlSegmentCacheAsync(Guid.NewGuid());
+
+        repositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlSegment>>()),
+            Times.Never,
+            $"UpdateUrlSegmentCacheAsync must not write URL segments to the database even for {role}.");
+    }
+
+    /// <summary>
+    /// <see cref="DocumentUrlService.UpdateUrlSegmentCacheWithDescendantsAsync"/> must not call
+    /// <c>Save</c> on the repository — it is strictly a cache-warming operation.
+    /// </summary>
+    [Test]
+    public async Task UpdateUrlSegmentCacheWithDescendantsAsync_DoesNotCallRepositorySave()
+    {
+        var languages = new List<ILanguage> { CreateMockLanguage(1, "en-US") };
+        var urlSegmentProvider = CreateFixedSegmentProvider("test-segment");
+        var urlSegmentProviderCollection = new UrlSegmentProviderCollection(() => [urlSegmentProvider]);
+
+        var (service, repositoryMock) = CreateDocumentUrlServiceWithMocks(urlSegmentProviderCollection, languages);
+
+        // GetById returns null by default — the method returns early without calling Save.
+        await service.UpdateUrlSegmentCacheWithDescendantsAsync(Guid.NewGuid());
+
+        repositoryMock.Verify(
+            x => x.Save(It.IsAny<IEnumerable<PublishedDocumentUrlSegment>>()),
+            Times.Never,
+            "UpdateUrlSegmentCacheWithDescendantsAsync must not write URL segments to the database.");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Fixes a lock contention issue where all servers in a load-balanced environment tried to write to the URL table at once.

## Summary

- Add `DocumentUrlServiceContentTreeChangeNotificationHandler` — fires on the originating server only (local `ContentTreeChangeNotification`, post-commit) and writes URL segments and URL aliases to the database
- Replace DB-write calls in `ContentCacheRefresher.HandleRouting()` with new cache-only methods (`UpdateUrlSegmentCacheAsync`, `UpdateAliasCacheAsync`, and their `WithDescendants` variants) that refresh the in-memory cache without acquiring write locks
- Add `IsInitialized` guard in the handler to skip execution during package migrations (before `InitAsync` fires at startup)

## Why

In v17, all load-balanced nodes run as `ScheduledPublisher`. The existing `SkipDatabaseWrites()` guard only returns `true` for `Subscriber` role, so every LB node would acquire exclusive `WriteLock(-345)` (`Constants.Locks.DocumentUrls`) and `WriteLock(-344)` (`Constants.Locks.DocumentUrlAliases`) while processing each inbound cache instruction. This serialises all nodes on every publish, causing significant lock contention in load-balanced deployments.

The fix moves DB writes to the originating server only (via the local notification), and degrades instruction processing on follower nodes to pure in-memory cache updates — no locks acquired.

## Testing

This has been tested both by Cloud and me. So a visual inspection should be enough

1. Point two Umbraco instances at the same database
2. Give each instance a distinct identity by setting a different Umbraco:Hosting:SiteName in each instance's appsettings.json
3. Create a bunch of content nodes on a slow database. I tested with 1k against a remote database
4. Let the process finish, including all the cache refreshers on both servers
5. There should be no errors, and routing should work for the newly created items
