### PR TITLE
Output Caching: Correctly gate auto-registration of `UseOutputCache()` middleware

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Cms.Api.Delivery/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Api.Common.DependencyInjection;
 using Umbraco.Cms.Api.Delivery.Accessors;
@@ -161,6 +162,12 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IDeliveryApiOutputCacheTagProvider, DeliveryApiContentTypeOutputCacheTagProvider>();
         builder.Services.AddUnique<IDeliveryApiOutputCacheRequestFilter, DefaultDeliveryApiOutputCacheRequestFilter>();
         builder.Services.AddUnique<IDeliveryApiOutputCacheManager, DeliveryApiOutputCacheManager>();
+
+        // Signal that Umbraco has enabled output caching so the application builder registers
+        // the output cache middleware. Gated via a marker rather than IOutputCacheStore so that
+        // applications calling services.AddOutputCache(...) for their own purposes are not
+        // affected by Umbraco's automatic middleware registration.
+        builder.Services.TryAddSingleton<IUmbracoManagedOutputCacheMarker, UmbracoManagedOutputCacheMarker>();
 
         return builder;
     }

--- a/src/Umbraco.Core/DependencyInjection/IUmbracoManagedOutputCacheMarker.cs
+++ b/src/Umbraco.Core/DependencyInjection/IUmbracoManagedOutputCacheMarker.cs
@@ -1,0 +1,15 @@
+namespace Umbraco.Cms.Core.DependencyInjection;
+
+/// <summary>
+/// Marker interface indicating that Umbraco itself has enabled ASP.NET Core output caching
+/// (via Website template caching or Delivery API caching configuration).
+/// Used to gate Umbraco's automatic registration of the output cache middleware so that
+/// applications calling <c>services.AddOutputCache(...)</c> for their own purposes do not
+/// inadvertently trigger a duplicate <c>UseOutputCache()</c> registration.
+/// </summary>
+public interface IUmbracoManagedOutputCacheMarker { }
+
+/// <summary>
+/// Marker class implementation for <see cref="IUmbracoManagedOutputCacheMarker"/>.
+/// </summary>
+public sealed class UmbracoManagedOutputCacheMarker : IUmbracoManagedOutputCacheMarker { }

--- a/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
+++ b/src/Umbraco.Web.Common/ApplicationBuilder/UmbracoApplicationBuilder.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.DependencyInjection;
@@ -97,15 +96,14 @@ public class UmbracoApplicationBuilder : IUmbracoApplicationBuilder, IUmbracoEnd
         AppBuilder.UseAuthentication();
         AppBuilder.UseAuthorization();
 
-        // Register output cache middleware if any feature (website, delivery API) has configured output caching.
-        // This must be called at most once per application — individual features register policies via
-        // AddOutputCache() (which is additive) but the middleware itself must only be added here.
+        // Register output cache middleware only when Umbraco itself has enabled output caching
+        // (via Website template caching or Delivery API caching configuration). Gating on
+        // IUmbracoManagedOutputCacheMarker rather than IOutputCacheStore ensures we don't
+        // duplicate UseOutputCache() when the application has called services.AddOutputCache(...)
+        // for its own purposes (which also registers IOutputCacheStore).
         // Placed after auth (policies may check preview/access state) but before antiforgery, localization,
         // and session so that cache hits bypass those middlewares for better throughput.
-        // NOTE: If the application has already registered UseOutputCache() elsewhere (e.g. in Program.cs),
-        // this will cause an InvalidOperationException at request time. Remove the external UseOutputCache()
-        // call when using Umbraco's managed output caching.
-        if (ApplicationServices.GetService<IOutputCacheStore>() is not null)
+        if (ApplicationServices.GetService<IUmbracoManagedOutputCacheMarker>() is not null)
         {
             AppBuilder.UseOutputCache();
         }

--- a/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.Web.Website/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -124,6 +124,12 @@ public static partial class UmbracoBuilderExtensions
                 new WebsiteOutputCachePolicy(settings.ContentDuration));
         });
 
+        // Signal that Umbraco has enabled output caching so the application builder registers
+        // the output cache middleware. Gated via a marker rather than IOutputCacheStore so that
+        // applications calling services.AddOutputCache(...) for their own purposes are not
+        // affected by Umbraco's automatic middleware registration.
+        builder.Services.TryAddSingleton<IUmbracoManagedOutputCacheMarker, UmbracoManagedOutputCacheMarker>();
+
         // Register eviction handlers and providers.
         builder.AddNotificationAsyncHandler<ContentCacheRefresherNotification, WebsiteDocumentOutputCacheEvictionHandler>();
         builder.AddNotificationAsyncHandler<MediaCacheRefresherNotification, WebsiteMediaOutputCacheEvictionHandler>();


### PR DESCRIPTION
## Description

In 17.4 we centralised the registration of the ASP.NET Core output cache middleware in `UmbracoApplicationBuilder.RegisterDefaultRequiredMiddleware()`, gated on the presence of `IOutputCacheStore` in the container. That gate is too broad — `IOutputCacheStore` is registered by *any* call to `services.AddOutputCache(...)`, including calls made by the consuming application for its own (non-Umbraco) output caching needs.

The result: applications that had their own `services.AddOutputCache(...)` + `app.UseOutputCache()` in `Program.cs` (working fine pre-17.4) now get a second `UseOutputCache()` registration added by Umbraco, and requests fail with:

```
InvalidOperationException: Another instance of OutputCacheFeature already exists.
Only one instance of OutputCacheMiddleware can be configured for an application.
```

## Fix

Replace the `IOutputCacheStore` gate with a dedicated marker, `IUmbracoManagedOutputCacheMarker`, that is registered only when Umbraco itself enables output caching — via `Umbraco:CMS:Website:OutputCache:Enabled` or `Umbraco:CMS:DeliveryApi:OutputCache:Enabled`. Applications calling `services.AddOutputCache(...)` for their own purposes are no longer affected by Umbraco's automatic middleware registration.

## How to test

Reproduces with the [UmbracoNewsDashboard](https://github.com/umbraco/UmbracoNewsDashboard) sample project on 17.4.0:

1. `services.AddOutputCache(...)` + `app.UseOutputCache()` in `Program.cs`, no Umbraco output cache settings enabled → `InvalidOperationException` on every request before this fix.
2. After this fix → caching works, no exception, no behaviour change.
