### PR TITLE
Slider: fix duplicated property editor settings properties

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -256,6 +256,15 @@ export class UmbDataTypeWorkspaceContext
 
 		const mergedSettings = settings.flat();
 
+		// check if there is alias duplicates:
+		const aliasSet = new Set<string>();
+		for (const setting of mergedSettings) {
+			if (aliasSet.has(setting.alias)) {
+				throw new Error(`There is a duplicate alias "${setting.alias}" in the Property Editor configuration.`);
+			}
+			aliasSet.add(setting.alias);
+		}
+
 		if (mergedSettings) {
 			this.#properties.setValue(mergedSettings);
 
@@ -294,17 +303,17 @@ export class UmbDataTypeWorkspaceContext
 		const values: Array<UmbDataTypePropertyValueModel> = [];
 
 		// We want to keep the existing data, if it is not in the default data, and if it is in the default data, then we want to keep the default data.
-		for (const defaultDataItem of this.#properties.getValue()) {
+		for (const property of this.#properties.getValue()) {
 			// We are matching on the alias, as we assume that the alias is unique for the data type.
 			// TODO: Consider if we should also match on the editorAlias just to be on the safe side [JOV]
-			const existingData = data.values?.find((x) => x.alias === defaultDataItem.alias);
+			const existingData = data.values?.find((x) => x.alias === property.alias);
 			if (existingData) {
 				values.push(existingData);
 				continue;
 			}
 
 			// If the data is not in the existing data, then we want to add the default data if it exists.
-			const existingDefaultData = this.#settingsDefaultData.find((x) => x.alias === defaultDataItem.alias);
+			const existingDefaultData = this.#settingsDefaultData.find((x) => x.alias === property.alias);
 			if (existingDefaultData) {
 				values.push(existingDefaultData);
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -305,7 +305,6 @@ export class UmbDataTypeWorkspaceContext
 		// We want to keep the existing data, if it is not in the default data, and if it is in the default data, then we want to keep the default data.
 		for (const property of this.#properties.getValue()) {
 			// We are matching on the alias, as we assume that the alias is unique for the data type.
-			// TODO: Consider if we should also match on the editorAlias just to be on the safe side [JOV]
 			const existingData = data.values?.find((x) => x.alias === property.alias);
 			if (existingData) {
 				values.push(existingData);

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/workspace/data-type-workspace.context.ts
@@ -260,7 +260,8 @@ export class UmbDataTypeWorkspaceContext
 		const aliasSet = new Set<string>();
 		for (const setting of mergedSettings) {
 			if (aliasSet.has(setting.alias)) {
-				throw new Error(`There is a duplicate alias "${setting.alias}" in the Property Editor configuration.`);
+				console.error(`There is a duplicate alias "${setting.alias}" in the Property Editor configuration.`);
+				continue;
 			}
 			aliasSet.add(setting.alias);
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/Umbraco.Slider.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/Umbraco.Slider.ts
@@ -25,7 +25,8 @@ export const manifest: ManifestPropertyEditorSchema = {
 				{
 					alias: 'minimumRange',
 					label: 'Minimum range',
-					description: '',
+					description:
+						'Minimum difference between the low and high values when range is enabled. Set to 0 to allow equal values.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
 					config: [{ alias: 'step', value: '0.00001' }],
 				},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/slider/manifests.ts
@@ -48,14 +48,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
 						config: [{ alias: 'step', value: '0.00001' }],
 					},
-					{
-						alias: 'minimumRange',
-						label: 'Minimum range',
-						description:
-							'Minimum difference between the low and high values when range is enabled. Set to 0 to allow equal values.',
-						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
-						config: [{ alias: 'step', value: '0.00001' }],
-					},
 				],
 				defaultData: [
 					{
@@ -69,10 +61,6 @@ export const manifests: Array<UmbExtensionManifest> = [
 					{
 						alias: 'step',
 						value: 1.0,
-					},
-					{
-						alias: 'minimumRange',
-						value: 0.0,
 					},
 				],
 			},


### PR DESCRIPTION
Removes duplicate Property Editor settings and adds a client-side error when it happens.