### PR TITLE
Image Cropper: Improve contrast of append label in crop options editor (closes #22878)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/image-crops/property-editor-ui-image-crops.element.ts
@@ -259,9 +259,9 @@ export class UmbPropertyEditorUIImageCropsElement extends UmbLitElement implemen
 			}
 			.append {
 				padding-inline: var(--uui-size-space-4);
-				background: var(--uui-color-disabled);
+				background: var(--uui-color-surface-alt);
 				border-left: 1px solid var(--uui-color-border);
-				color: var(--uui-color-disabled-contrast);
+				color: var(--uui-color-text);
 				font-size: var(--uui-type-small-size);
 				display: flex;
 				align-items: center;


### PR DESCRIPTION
## Description
Suggestion fix for #22878

The `px` append label in the image crops property editor (and media picker local crops) was styled using `--uui-color-disabled` / `--uui-color-disabled-contrast`, which produced poor contrast between the text and background.

Updated to use `--uui-color-surface-alt` and `--uui-color-text` to match the styling used by the UUI library's own input component.

Before:
<img width="1171" height="250" alt="image" src="https://github.com/user-attachments/assets/25209d5c-31d9-4112-90bc-ef996c69f02b" />

After:
<img width="1164" height="244" alt="image" src="https://github.com/user-attachments/assets/d3405850-a308-4e15-9d54-b3ae3c5dc079" />

Dark mode:
<img width="1176" height="271" alt="image" src="https://github.com/user-attachments/assets/5f4678fa-3139-453a-b442-cf17235295e4" />

## Testing
1. Open the Image Cropper property editor
2. Create a crop option under Settings
3. See the contrast in the append