### PR TITLE
Accessibility: Added missing labels to webhook details and headers

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/components/input-webhook-headers.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/components/input-webhook-headers.element.ts
@@ -119,7 +119,9 @@ export class UmbInputWebhookHeadersElement extends UmbLitElement {
 	override render() {
 		return html`
 			${this.#renderGrid()}
-			<uui-button id="add" look="placeholder" @click=${this.#addHeader}>Add</uui-button>
+			<uui-button id="add" look="placeholder" label=${this.localize.term('general_add')} @click=${this.#addHeader}>
+				<umb-localize key="general_add">Add</umb-localize>
+			</uui-button>
 		`;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/views/webhook-details-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/views/webhook-details-workspace-view.element.ts
@@ -107,7 +107,7 @@ export class UmbWebhookDetailsWorkspaceViewElement extends UmbLitElement impleme
 					mandatory
 					label=${this.localize.term('webhooks_url')}
 					description=${this.localize.term('webhooks_urlDescription')}>
-					<uui-input @input=${this.#onUrlChange} .value=${this._webhook.url} slot="editor" required="true"></uui-input>
+					<uui-input @input=${this.#onUrlChange} label=${this.localize.term('webhooks_url')} .value=${this._webhook.url} slot="editor" required="true"></uui-input>
 				</umb-property-layout>
 				<umb-property-layout
 					mandatory
@@ -122,7 +122,7 @@ export class UmbWebhookDetailsWorkspaceViewElement extends UmbLitElement impleme
 				<umb-property-layout
 					label=${this.localize.term('webhooks_enabled')}
 					description=${this.localize.term('webhooks_enabledDescription')}>
-					<uui-toggle slot="editor" .checked=${this._webhook.enabled} @change=${this.#onEnabledChange}></uui-toggle>
+					<uui-toggle slot="editor" label=${this.localize.term('webhooks_enabled')} .checked=${this._webhook.enabled} @change=${this.#onEnabledChange}></uui-toggle>
 				</umb-property-layout>
 				<umb-property-layout
 					label=${this.localize.term('webhooks_headers')}

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/views/webhook-details-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/workspace/views/webhook-details-workspace-view.element.ts
@@ -122,7 +122,7 @@ export class UmbWebhookDetailsWorkspaceViewElement extends UmbLitElement impleme
 				<umb-property-layout
 					label=${this.localize.term('webhooks_enabled')}
 					description=${this.localize.term('webhooks_enabledDescription')}>
-					<uui-toggle slot="editor" label=${this.localize.term('webhooks_enabled')} .checked=${this._webhook.enabled} @change=${this.#onEnabledChange}></uui-toggle>
+					<uui-toggle slot="editor" aria-label=${this.localize.term('webhooks_enabled')} .checked=${this._webhook.enabled} @change=${this.#onEnabledChange}></uui-toggle>
 				</umb-property-layout>
 				<umb-property-layout
 					label=${this.localize.term('webhooks_headers')}


### PR DESCRIPTION
## Description

Found missing `label` attributes on UUI controls in the webhook workspace causing accessibility console warnings.

```
UUI-INPUT needs a `label`
UUI-TOGGLE needs a `label`
UUI-BUTTON needs a `label`
```

<img width="803" height="587" alt="image" src="https://github.com/user-attachments/assets/5fab9f66-5918-48c9-9123-4e2a18dc8bdb" />


**Changes:**

- `webhook-details-workspace-view.element.ts` added `webhooks_url` label to `uui-input`, and the `webhooks_enabled` to `uui-toggle`, so accessible names are concise and match what the controls represent.

- `input-webhook-headers.element.ts` added a localized `label` attribute to the "Add" `uui-button` (`general_add`) and replaced the hardcoded "Add" text with `<umb-localize key="general_add">`.

## Testing

1. Open the **Webhooks** section and create or edit a webhook.
2. Open browser console: verify no `needs a 'label'` accessibility warnings appear for the URL input, the enabled toggle, or the Add headers button.
3. Add a header and verify the "Add" button still functions correctly and displays the localized text.
