### PR TITLE
Collections: Replace direct filter pass-through in collection server data sources

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/language/collection/repository/language-collection.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/collection/repository/language-collection.server.data-source.ts
@@ -30,7 +30,10 @@ export class UmbLanguageCollectionServerDataSource implements UmbCollectionDataS
 	 * @memberof UmbLanguageCollectionServerDataSource
 	 */
 	async getCollection(filter: UmbLanguageCollectionFilterModel) {
-		const { data, error } = await tryExecute(this.#host, LanguageService.getLanguage({ query: filter }));
+		const { data, error } = await tryExecute(
+			this.#host,
+			LanguageService.getLanguage({ query: { skip: filter.skip, take: filter.take } }),
+		);
 
 		if (data) {
 			const items = data.items.map((item) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/repository/member-group-collection.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-group/collection/repository/member-group-collection.server.data-source.ts
@@ -31,7 +31,10 @@ export class UmbMemberGroupCollectionServerDataSource implements UmbCollectionDa
 	 * @memberof UmbMemberGroupCollectionServerDataSource
 	 */
 	async getCollection(query: UmbMemberGroupCollectionFilterModel) {
-		const { data, error } = await tryExecute(this.#host, MemberGroupService.getMemberGroup({ query }));
+		const { data, error } = await tryExecute(
+			this.#host,
+			MemberGroupService.getMemberGroup({ query: { skip: query.skip, take: query.take } }),
+		);
 
 		if (error) {
 			return { error };

--- a/src/Umbraco.Web.UI.Client/src/packages/segment/collection/repository/segment-collection.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/segment/collection/repository/segment-collection.server.data-source.ts
@@ -22,7 +22,10 @@ export class UmbSegmentCollectionServerDataSource
 	 * @memberof UmbLanguageCollectionServerDataSource
 	 */
 	async getCollection(filter: UmbSegmentCollectionFilterModel) {
-		const { data, error } = await tryExecute(this, SegmentService.getSegment({ query: filter }));
+		const { data, error } = await tryExecute(
+			this,
+			SegmentService.getSegment({ query: { skip: filter.skip, take: filter.take } }),
+		);
 
 		if (data) {
 			const items = data.items.map((item) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/collection/repository/webhook-collection.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/webhook/collection/repository/webhook-collection.server.data-source.ts
@@ -29,8 +29,11 @@ export class UmbWebhookCollectionServerDataSource implements UmbWebhookCollectio
 	 * @returns {*}
 	 * @memberof UmbWebhookCollectionServerDataSource
 	 */
-	async getCollection(_filter: UmbWebhookCollectionFilterModel) {
-		const { data, error } = await tryExecute(this.#host, WebhookService.getWebhook({ query: _filter }));
+	async getCollection(filter: UmbWebhookCollectionFilterModel) {
+		const { data, error } = await tryExecute(
+			this.#host,
+			WebhookService.getWebhook({ query: { skip: filter.skip, take: filter.take } }),
+		);
 
 		if (error || !data) {
 			return { error };


### PR DESCRIPTION
### Summary

Collection server data sources were passing their entire filter object directly as query parameters to Management API services (e.g. `LanguageService.getLanguage({ query: filter })`). Because TypeScript uses structural subtyping, extra properties on a filter variable are not caught at compile time — they silently end up in the HTTP query string, which causes the API to respond with errors when it encounters unsupported parameters.

This PR fixes the issue in four data sources by cherry-picking only the parameters each endpoint explicitly supports:

- `language-collection.server.data-source.ts` — passes `{ skip, take }` to `LanguageService.getLanguage`
- `segment-collection.server.data-source.ts` — passes `{ skip, take }` to `SegmentService.getSegment`
- `webhook-collection.server.data-source.ts` — passes `{ skip, take }` to `WebhookService.getWebhook`
- `member-group-collection.server.data-source.ts` — passes `{ skip, take }` to `MemberGroupService.getMemberGroup`

 The existing data sources that already cherry-pick (documents, media, user, member, user-group, relation, relation-type, webhook-delivery) were not changed.