### PR TITLE
runs the #onEditorUpdate, when uui-buttons are clicked on the RTE

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar-button.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/components/toolbar/tiptap-toolbar-button.element.ts
@@ -51,7 +51,10 @@ export class UmbTiptapToolbarButtonElement<
 				label=${label}
 				title=${label}
 				?disabled=${this.api?.isDisabled(this.editor)}
-				@click=${() => this.api?.execute(this.editor)}>
+				@click=${() => {
+					this.api?.execute(this.editor);
+					this.#onEditorUpdate();
+				}}>
 				${when(
 					this.manifest?.meta.icon,
 					(icon) => html`<umb-icon name=${icon}></umb-icon>`,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

#### steps to reproduce

- Make a document type with a Rich Text Editor
- Create a content node with the Rich Text Editor
- Click either the bold, italic, or underline
- See that it now applies the outline without any text being needed in the RTE

https://github.com/umbraco/Umbraco-CMS/issues/22907

### Description

Added the onEditorUpdate function to the on-click event when a uui-button is clicked on the RTE

<!-- Thanks for contributing to Umbraco CMS! -->


---
_This item has been added to our backlog AB#68804_