### PR TITLE
Block Grid: Fix inline create button width not updating on workspace resize (closes #22527)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -55,6 +55,7 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 
 	#context = new UmbBlockGridEntryContext(this);
 	#renderTimeout: number | undefined;
+	#layoutContainerResizeObserver: ResizeObserver | undefined;
 
 	@state()
 	private _contentTypeAlias?: string;
@@ -347,6 +348,16 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 		);
 
 		this.#callUpdateInlineCreateButtons();
+		if (this.parentElement) {
+			this.#layoutContainerResizeObserver = new ResizeObserver(this.#callUpdateInlineCreateButtons.bind(this));
+			this.#layoutContainerResizeObserver.observe(this.parentElement);
+		}
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		this.#layoutContainerResizeObserver?.disconnect();
+		this.#layoutContainerResizeObserver = undefined;
 	}
 
 	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -355,11 +355,11 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
-		this.#layoutContainerResizeObserver?.disconnect();
+		this.#layoutContainerResizeObserver.disconnect();
 	}
 
 	override destroy(): void {
-		this.#layoutContainerResizeObserver?.disconnect();
+		this.#layoutContainerResizeObserver.disconnect();
 		super.destroy();
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -360,6 +360,12 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 		this.#layoutContainerResizeObserver = undefined;
 	}
 
+	override destroy(): void {
+		this.#layoutContainerResizeObserver?.disconnect();
+		this.#layoutContainerResizeObserver = undefined;
+		super.destroy();
+	}
+
 	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('_blockViewProps') || _changedProperties.has('_columnSpan')) {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-entry/block-grid-entry.element.ts
@@ -55,7 +55,7 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 
 	#context = new UmbBlockGridEntryContext(this);
 	#renderTimeout: number | undefined;
-	#layoutContainerResizeObserver: ResizeObserver | undefined;
+	#layoutContainerResizeObserver = new ResizeObserver(() => this.#callUpdateInlineCreateButtons());
 
 	@state()
 	private _contentTypeAlias?: string;
@@ -349,7 +349,6 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 
 		this.#callUpdateInlineCreateButtons();
 		if (this.parentElement) {
-			this.#layoutContainerResizeObserver = new ResizeObserver(this.#callUpdateInlineCreateButtons.bind(this));
 			this.#layoutContainerResizeObserver.observe(this.parentElement);
 		}
 	}
@@ -357,12 +356,10 @@ export class UmbBlockGridEntryElement extends UmbLitElement implements UmbProper
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
 		this.#layoutContainerResizeObserver?.disconnect();
-		this.#layoutContainerResizeObserver = undefined;
 	}
 
 	override destroy(): void {
 		this.#layoutContainerResizeObserver?.disconnect();
-		this.#layoutContainerResizeObserver = undefined;
 		super.destroy();
 	}
 


### PR DESCRIPTION
  ## Summary
  - The `<uui-button-inline-create>` element had its width measured once at render time and applied as an inline style, which was never updated when the workspace was resized
  - Added a `ResizeObserver` on the layout container to re-measure and update the width whenever the container changes size
  - Added `disconnectedCallback` to disconnect the observer
  
 ## How to test:

  1. Create a Document Type with a Block Grid property configured with 4 columns
  2. Add a block type with column span options
  3. Create a content node and add 3+ blocks
  4. Hover between blocks, verify the inline create line spans the full container width
  5. Drag the content tree panel wider/narrower to resize the workspace
  6. Verify no horizontal scrollbar appears in the block grid
  7. Hover between blocks again after resize, verify the inline create line still spans the full container width

  Fixes #22527 