### PR TITLE
Property settings: preserve selected custom validation option when re-opening (closes #22916)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
@@ -145,22 +145,19 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 	// called whenever loaded data changes — otherwise the dropdown shows "No validation"
 	// for any saved regEx until the user manually edits the regex input.
 	#syncCustomValidationSelection(regEx: string | null) {
-		const noValidationIndex = 0;
-		const customIndex = this._customValidationOptions.length - 1;
-
-		let targetIndex: number;
+		let targetValue: string;
 		if (!regEx) {
-			targetIndex = noValidationIndex;
+			targetValue = '!NOVALIDATION!';
 		} else {
-			const presetIndex = this._customValidationOptions.findIndex(
-				(option, i) => i !== noValidationIndex && i !== customIndex && option.value === regEx,
+			const preset = this._customValidationOptions.find(
+				(option) => option.value !== '!NOVALIDATION!' && option.value !== '.+' && option.value === regEx,
 			);
-			targetIndex = presetIndex >= 0 ? presetIndex : customIndex;
+			targetValue = preset ? preset.value : '.+';
 		}
 
-		this._customValidationOptions = this._customValidationOptions.map((option, i) => ({
+		this._customValidationOptions = this._customValidationOptions.map((option) => ({
 			...option,
-			selected: i === targetIndex,
+			selected: option.value === targetValue,
 		}));
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/property-type/workspace/views/settings/property-workspace-view-settings.element.ts
@@ -18,7 +18,6 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 		{
 			name: this.localize.term('validation_validateNothing'),
 			value: '!NOVALIDATION!',
-			selected: true,
 		},
 		{
 			name: this.localize.term('validation_validateAsEmail'),
@@ -58,7 +57,14 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 
 		this.consumeContext(UMB_PROPERTY_TYPE_WORKSPACE_CONTEXT, (instance) => {
 			this.#context = instance;
-			this.observe(instance?.data, (data) => (this._data = data), 'observeData');
+			this.observe(
+				instance?.data,
+				(data) => {
+					this._data = data;
+					this.#syncCustomValidationSelection(data?.validation?.regEx ?? null);
+				},
+				'observeData',
+			);
 			this.observe(instance?.isNew, (isNew) => (this._isNew = isNew), '_observeIsNew');
 		});
 
@@ -133,6 +139,29 @@ export class UmbPropertyTypeWorkspaceViewSettingsElement extends UmbLitElement i
 
 	#onToggleIsSensitiveData(e: UUIBooleanInputEvent) {
 		this.updateValue({ isSensitive: e.target.checked });
+	}
+
+	// The <uui-select> binds only via each option's `selected` flag, so this must be
+	// called whenever loaded data changes — otherwise the dropdown shows "No validation"
+	// for any saved regEx until the user manually edits the regex input.
+	#syncCustomValidationSelection(regEx: string | null) {
+		const noValidationIndex = 0;
+		const customIndex = this._customValidationOptions.length - 1;
+
+		let targetIndex: number;
+		if (!regEx) {
+			targetIndex = noValidationIndex;
+		} else {
+			const presetIndex = this._customValidationOptions.findIndex(
+				(option, i) => i !== noValidationIndex && i !== customIndex && option.value === regEx,
+			);
+			targetIndex = presetIndex >= 0 ? presetIndex : customIndex;
+		}
+
+		this._customValidationOptions = this._customValidationOptions.map((option, i) => ({
+			...option,
+			selected: i === targetIndex,
+		}));
 	}
 
 	#onCustomValidationChange(event: UUISelectEvent) {

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
@@ -1354,7 +1354,7 @@ export class UiBaseLocators extends BasePage {
   }
 
   async doesSelectedValidationOptionHaveValue(value: string) {
-    await expect(this.validation).toHaveValue(value);
+    await this.hasValue(this.validation, value);
   }
 
   // Composition & Structure Methods

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/UiBaseLocators.ts
@@ -1353,6 +1353,10 @@ export class UiBaseLocators extends BasePage {
     );
   }
 
+  async doesSelectedValidationOptionHaveValue(value: string) {
+    await expect(this.validation).toHaveValue(value);
+  }
+
   // Composition & Structure Methods
   async clickCompositionsButton() {
     await this.click(this.compositionsBtn);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeDesignTab.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Settings/DocumentType/DocumentTypeDesignTab.spec.ts
@@ -323,6 +323,28 @@ test('can enable validation for a property in a document type', {tag: '@release'
   expect(documentTypeData.properties[0].validation.regExMessage).toBe(regexMessage);
 });
 
+// Tests regression issue: https://github.com/umbraco/Umbraco-CMS/issues/22916
+test('preserves the selected validation option when re-opening a property in a document type', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);
+  const numberPresetRegex = '^[0-9]*$';
+  await umbracoApi.documentType.createDocumentTypeWithPropertyEditor(documentTypeName, dataTypeName, dataTypeData.id);
+  await umbracoUi.documentType.goToSection(ConstantHelper.sections.settings);
+  await umbracoUi.documentType.goToDocumentType(documentTypeName);
+
+  // Act — set Number preset validation and save.
+  await umbracoUi.documentType.clickEditorSettingsButton();
+  await umbracoUi.documentType.selectValidationOption(numberPresetRegex);
+  await umbracoUi.documentType.clickSubmitButton();
+  await umbracoUi.documentType.clickSaveButtonAndWaitForDocumentTypeToBeUpdated();
+
+  // Re-open the property settings.
+  await umbracoUi.documentType.clickEditorSettingsButton();
+
+  // Assert — the dropdown still reflects the saved Number preset, not "No validation".
+  await umbracoUi.documentType.doesSelectedValidationOptionHaveValue(numberPresetRegex);
+});
+
 test('can allow vary by culture for a property in a document type', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const dataTypeData = await umbracoApi.dataType.getByName(dataTypeName);


### PR DESCRIPTION
## Description

Currently, on a text string property in a document type, selecting any custom validation option (Email / Number / Url / a custom regex) was persisted server-side, but the property settings dropdown reset to "No validation" when the property was re-opened.

This was happening as the options collection in `_customValidationOptions` was initialised once with `selected: true` hard-coded on "No validation" and never re-synced when the workspace context emitted loaded property data.

The fix adds a synchronisation method, that maps the saved `regEx` to the matching preset.  It'll use the "Custom" marker when the regex is a non-preset, or "No validation" when null.

Fixes #22916

## Testing

### Automated

I had a look at a unit test for this, but there was a lot of setup required and necessary to maintain, so reverted and instead added a single E2E regression guard under `DocumentTypeDesignTab.spec.ts` that picks the Number preset, saves, re-opens the property settings, and asserts the dropdown still reflects the saved value.

### Manual

- Create a Document Type with a textstring property, open property settings, pick **Number** under Custom validation, Submit + Save the document type, re-open the property settings — dropdown should now show **Number**.
- Repeat manual check with **Email**, **Url**, and a hand-typed Custom regex.
- Verify selecting "No validation" still round-trips correctly.