### PR TITLE
Add error logging for NuCache database cache rebuild failures

### DIFF
--- a/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
+++ b/src/Umbraco.PublishedCache.NuCache/PublishedSnapshotService.cs
@@ -410,6 +410,11 @@ internal class PublishedSnapshotService : IPublishedSnapshotService
 
             _publishedContentService.Rebuild(contentTypeIds, mediaTypeIds, memberTypeIds);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while rebuilding the database cache.");
+            throw;
+        }
         finally
         {
             ClearIsRebuilding();


### PR DESCRIPTION
Previously, exceptions thrown during PerformRebuild would propagate without being logged, making it difficult to diagnose why a cache rebuild failed. Adds a catch block that logs the exception before re-throwing it.

Fixes #22933