### PR TITLE
Global Elements: Workspace hotfix for `'Unique is missing'` warning

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/publishing/workspace-context/element-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/publishing/workspace-context/element-publishing.workspace-context.ts
@@ -469,7 +469,10 @@ export class UmbElementPublishingWorkspaceContext extends UmbContextBase impleme
 		// No need to check pending changes for new elements
 		if (this.#elementWorkspaceContext.getIsNew()) return;
 
-		const unique = this.#elementWorkspaceContext.getUnique();
+		// getUnique() guards against the window between unique being set and data loading
+		// starting (_getDataPromise being set). Fall back to #currentUnique, which is
+		// synchronously up-to-date from the unique observable.
+		const unique = this.#elementWorkspaceContext.getUnique() ?? this.#currentUnique;
 		if (!unique) throw new Error('Unique is missing');
 
 		// Only load the published data if the element is already published or has been published before


### PR DESCRIPTION
### Description

In the 18.0-beta, when navigating between Element workspaces in the Library section, the following error fired:

```
element-publishing.workspace-context.ts:473 Uncaught (in promise) Error: Unique is missing
    at #loadAndProcessLastPublished (element-publishing.workspace-context.ts:473:22)
    at Object.next (element-publishing.workspace-context.ts:442:11)
```

This was due to a race condition between the `unique` observable and the `getUnique()` guard in the entity-detail workspace base.

This PR resolves this by falling back to `#currentUnique`, as this is kept up-to-date from the `unique` observable.