### PR TITLE
Migrations: Append data-anchor value to href when missing in local link migration (closes #22860)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
@@ -132,9 +132,13 @@ public class LocalLinkProcessor
             // If the anchor tag carries a data-anchor attribute and that value is not already part
             // of the href (e.g. when migrating older content that stored the anchor only in data-anchor),
             // append it to the href so the link resolves correctly in the v15+ RTE (#22860).
+            // When the href already contains a different fragment, we trust the href and skip the append
+            // rather than producing an invalid URL with two '#' separators.
             var newTrailingHrefContent = existingTrailingHrefContent;
             var anchorFromAttribute = ExtractDataAnchorValue(input, tagHrefIndex);
-            if (anchorFromAttribute is not null && existingTrailingHrefContent.Contains(anchorFromAttribute, StringComparison.Ordinal) is false)
+            if (anchorFromAttribute is not null
+                && existingTrailingHrefContent.Contains(anchorFromAttribute, StringComparison.Ordinal) is false
+                && existingTrailingHrefContent.Contains('#') is false)
             {
                 newTrailingHrefContent += anchorFromAttribute;
             }
@@ -149,12 +153,22 @@ public class LocalLinkProcessor
     }
 
     // Searches for a non-empty data-anchor attribute within the opening anchor tag that contains the
-    // local link href at tagHrefIndex. Returns the attribute value (e.g. "#section" or "?foo=bar"),
+    // local link href at tagHrefIndex. Returns the attribute value (e.g. "#" or "#section-1"),
     // or null when no usable data-anchor is present.
+    // The legacy local link pattern matches any href attribute (not just anchors), so this check
+    // is scoped to elements whose tag name is "a" — data-anchor on other elements is not relevant.
     private static string? ExtractDataAnchorValue(string input, int tagHrefIndex)
     {
         var tagStartIndex = input.LastIndexOf('<', tagHrefIndex);
-        if (tagStartIndex < 0)
+        if (tagStartIndex < 0 || tagStartIndex + 2 >= input.Length)
+        {
+            return null;
+        }
+
+        // Verify the surrounding element is an anchor tag: "<a" followed by whitespace.
+        // (An href attribute always implies at least one whitespace separator after the tag name.)
+        var nameChar = input[tagStartIndex + 1];
+        if ((nameChar != 'a' && nameChar != 'A') || char.IsWhiteSpace(input[tagStartIndex + 2]) is false)
         {
             return null;
         }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/LocalLinkProcessor.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
@@ -11,6 +12,10 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0.LocalLinks;
 [Obsolete("Scheduled for removal in Umbraco 18.")]
 public class LocalLinkProcessor
 {
+    private static readonly Regex _dataAnchorPattern = new(
+        @"data-anchor=['""](?<anchor>[^'""]*)['""]",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     private readonly HtmlLocalLinkParser _localLinkParser;
     private readonly IIdKeyMap _idKeyMap;
     private readonly IEnumerable<ITypedLocalLinkProcessor> _localLinkProcessors;
@@ -121,16 +126,54 @@ public class LocalLinkProcessor
             }
 
             // Extract any trailing href content (fragment, query string) between the localLink and closing quote.
-            var trailingHrefContent = input.Substring(afterTagHref, closingQuoteIndex - afterTagHref);
+            var existingTrailingHrefContent = input.Substring(afterTagHref, closingQuoteIndex - afterTagHref);
             var closingQuote = input[closingQuoteIndex];
 
+            // If the anchor tag carries a data-anchor attribute and that value is not already part
+            // of the href (e.g. when migrating older content that stored the anchor only in data-anchor),
+            // append it to the href so the link resolves correctly in the v15+ RTE (#22860).
+            var newTrailingHrefContent = existingTrailingHrefContent;
+            var anchorFromAttribute = ExtractDataAnchorValue(input, tagHrefIndex);
+            if (anchorFromAttribute is not null && existingTrailingHrefContent.Contains(anchorFromAttribute, StringComparison.Ordinal) is false)
+            {
+                newTrailingHrefContent += anchorFromAttribute;
+            }
+
             // Build the replacement: converted localLink + trailing content + close quote + type attribute
-            var oldSegment = tag.TagHref + trailingHrefContent + closingQuote;
-            var newSegment = convertedLocalLink + trailingHrefContent + closingQuote + $" type=\"{entityType}\"";
+            var oldSegment = tag.TagHref + existingTrailingHrefContent + closingQuote;
+            var newSegment = convertedLocalLink + newTrailingHrefContent + closingQuote + $" type=\"{entityType}\"";
             input = input.Remove(tagHrefIndex, oldSegment.Length).Insert(tagHrefIndex, newSegment);
         }
 
         return input;
+    }
+
+    // Searches for a non-empty data-anchor attribute within the opening anchor tag that contains the
+    // local link href at tagHrefIndex. Returns the attribute value (e.g. "#section" or "?foo=bar"),
+    // or null when no usable data-anchor is present.
+    private static string? ExtractDataAnchorValue(string input, int tagHrefIndex)
+    {
+        var tagStartIndex = input.LastIndexOf('<', tagHrefIndex);
+        if (tagStartIndex < 0)
+        {
+            return null;
+        }
+
+        var tagEndIndex = input.IndexOf('>', tagHrefIndex);
+        if (tagEndIndex < tagStartIndex)
+        {
+            return null;
+        }
+
+        var openingTag = input.Substring(tagStartIndex, tagEndIndex - tagStartIndex);
+        Match anchorMatch = _dataAnchorPattern.Match(openingTag);
+        if (anchorMatch.Success is false)
+        {
+            return null;
+        }
+
+        var anchorValue = anchorMatch.Groups["anchor"].Value;
+        return string.IsNullOrEmpty(anchorValue) ? null : anchorValue;
     }
 
     private (Guid Key, string EntityType)? CreateIntBasedKeyType(int id)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
@@ -552,6 +552,70 @@ public class LocalLinkProcessorTests
             result);
     }
 
+    /// <summary>
+    /// When the href already has a fragment and data-anchor specifies a different fragment, the
+    /// migration should trust the href and not append the data-anchor value — appending would produce
+    /// an invalid URL with two '#' separators.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_DataAnchorDiffersFromHrefFragment_DoesNotAppendSecondFragment()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}#a"" data-anchor=""#b"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#a"" type=""document"" data-anchor=""#b"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// The legacy local link pattern matches any href attribute (not just on anchor tags), so verify
+    /// that the data-anchor append behaviour does NOT trigger when the surrounding element is not
+    /// an anchor tag. The href format conversion itself still applies.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_NonAnchorElementWithDataAnchor_DoesNotAppendFragmentToHref()
+    {
+        var processor = CreateProcessor();
+
+        // A non-anchor element (here a custom <link-card>) carrying both a localLink-style href
+        // and a data-anchor attribute. data-anchor is not meaningful here and must not leak into href.
+        var input = @"<link-card href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"" data-anchor=""#section"">link</link-card>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<link-card href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}"" type=""document"" data-anchor=""#section"">link</link-card>",
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that the data-anchor append behaviour also applies to the integer-id code path,
+    /// which converges with the UDI path before the data-anchor lookup.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_IntegerLink_DataAnchorAttribute_FragmentNotInHref_AppendsFragmentToHref()
+    {
+        var documentKey = Guid.NewGuid();
+        var idKeyMap = new Mock<IIdKeyMap>();
+        idKeyMap
+            .Setup(x => x.GetKeyForId(1234, UmbracoObjectTypes.Document))
+            .Returns(Attempt<Guid>.Succeed(documentKey));
+
+        var processor = CreateProcessor(idKeyMap.Object);
+
+        var input = @"<a href=""{localLink:1234}"" title=""My Page"" data-anchor=""#section"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            $@"<a href=""{{localLink:{documentKey}}}#section"" type=""document"" title=""My Page"" data-anchor=""#section"">link</a>",
+            result);
+    }
+
 #pragma warning disable CS0618 // Type or member is obsolete
     private LocalLinkProcessor CreateProcessor(IIdKeyMap? idKeyMap = null)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/LocalLinkProcessorTests.cs
@@ -496,6 +496,62 @@ public class LocalLinkProcessorTests
             result);
     }
 
+    /// <summary>
+    /// When the v13 source has a <c>data-anchor</c> attribute but no fragment in the href
+    /// (the case reported in #22860), the anchor value should be appended to the href so
+    /// the link resolves correctly in the v15+ RTE. The user-reported case has <c>data-anchor="#"</c>.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_DataAnchorWithEmptyHash_NoFragmentInHref_AppendsHashToHref()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/99fdc05492b5458c859f91ebaaaa4775}"" title=""Page title"" data-anchor=""#"">Link text</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:99fdc054-92b5-458c-859f-91ebaaaa4775}#"" type=""document"" title=""Page title"" data-anchor=""#"">Link text</a>",
+            result);
+    }
+
+    /// <summary>
+    /// When the v13 source has a non-empty <c>data-anchor</c> value but the fragment is not
+    /// present in the href, the migration should append the data-anchor value to the href so
+    /// the link resolves correctly in the v15+ RTE.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_DataAnchorAttribute_FragmentNotInHref_AppendsFragmentToHref()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}"" title=""My Page"" data-anchor=""#section"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#section"" type=""document"" title=""My Page"" data-anchor=""#section"">link</a>",
+            result);
+    }
+
+    /// <summary>
+    /// When the v13 source already has the data-anchor value present in the href fragment,
+    /// the migration should not duplicate it.
+    /// </summary>
+    [Test]
+    public void ProcessStringValue_DataAnchorMatchesHrefFragment_DoesNotDuplicateFragment()
+    {
+        var processor = CreateProcessor();
+
+        var input = @"<a href=""/{localLink:umb://document/ac2038d9dfc24294b7787edf90d1a178}#section"" title=""My Page"" data-anchor=""#section"">link</a>";
+
+        var result = processor.ProcessStringValue(input);
+
+        Assert.AreEqual(
+            @"<a href=""/{localLink:ac2038d9-dfc2-4294-b778-7edf90d1a178}#section"" type=""document"" title=""My Page"" data-anchor=""#section"">link</a>",
+            result);
+    }
+
 #pragma warning disable CS0618 // Type or member is obsolete
     private LocalLinkProcessor CreateProcessor(IIdKeyMap? idKeyMap = null)
     {


### PR DESCRIPTION
## Description

Follow-up to #22153, addressing the remaining case described in #22860.

PR #22153 fixed the local link migration so that any fragment (`#anchor`) or query string (`?key=value`) **already present in the href** after the `{localLink:...}` closing brace is preserved. That case looks like this in the v13 source:

```html
<a href="/{localLink:umb://document/...}#section-99" data-anchor="#section-99">...</a>
```

The user-reported case in #22860 is different — the v13 source has the anchor **only** in a separate `data-anchor` attribute, with no fragment in the `href` itself:

```html
<a href="/{localLink:umb://document/99fdc054...}" title="Page title" data-anchor="#">Link text</a>
```

In v13 this rendered fine, but in v17 TipTap's link mark requires the anchor to be in the `href` for the link to be considered valid in the backoffice editor, so after migration the link shows as broken.

This PR extends `LocalLinkProcessor.ProcessStringValue` so that, after locating the trailing href content between the closing `}` and the closing quote, it also looks at the opening `<a>` tag for a `data-anchor` attribute. If that attribute carries a value that is not already part of the trailing href content, the value is appended to the href.

The idempotency case (anchor already in both `href` and `data-anchor`, as covered by #22153) is unchanged.

## Testing

### Automated

Three new unit tests added to `LocalLinkProcessorTests`:

- `ProcessStringValue_DataAnchorWithEmptyHash_NoFragmentInHref_AppendsHashToHref` — the user-reported case with `data-anchor="#"`.
- `ProcessStringValue_DataAnchorAttribute_FragmentNotInHref_AppendsFragmentToHref` — non-empty anchor not in href.
- `ProcessStringValue_DataAnchorMatchesHrefFragment_DoesNotDuplicateFragment` — guards against double-appending when anchor is already in the href.

### Manual

In a v13 site, create RTE content with a local link that has a `data-anchor` attribute but no fragment in the `href`.

**This doesn't happen by default using the latest 13** - there we get the anchor in both the attribute and the href.  So it's not obvious why the reporter's markup is in this state.  My guess is that this was a valid setup prepared by older versions that were migrated up to 13.

However you can set it up manually.  I've used this markup:

```html
<p><a href="/{localLink:umb://document/5cd38f336d004882995c7d725295a743}#test1" title="Test Content Page" data-anchor="#test1">Link 1</a></p>
<p><a href="/{localLink:umb://document/5cd38f336d004882995c7d725295a743}" title="Test Content Page" data-anchor="#test2">Link 2</a></p>
```

The second one I've manipulated in the source code to remove the anchor fragment from the `href`.

Migrate to v17 and confirm the backoffice now renders the link without the "broken" indicator.

The markup you should see is:

```html
<p><a data-router-slot="disabled" data-anchor="#test1" href="/{localLink:5cd38f33-6d00-4882-995c-7d725295a743}#test1"
        title="Test Content Page" type="document">Link 1</a></p>
<p><a data-router-slot="disabled" data-anchor="#test2" href="/{localLink:5cd38f33-6d00-4882-995c-7d725295a743}#test2"
        title="Test Content Page" type="document">Link 2</a></p>
```
