### PR TITLE
Devops: Report bidirectional import detection for both Core and Packages modules

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/module-dependencies/index.js
+++ b/src/Umbraco.Web.UI.Client/devops/module-dependencies/index.js
@@ -4,7 +4,8 @@ import { createImportMap } from '../importmap/index.js';
 
 const ILLEGAL_CORE_IMPORTS_THRESHOLD = 5;
 const SELF_IMPORTS_THRESHOLD = 0;
-const BIDIRECTIONAL_IMPORTS_THRESHOLD = 15;
+const CORE_MODULES_BIDIRECTIONAL_IMPORTS_THRESHOLD = 16;
+const PACKAGES_MODULES_BIDIRECTIONAL_IMPORTS_THRESHOLD = 14;
 
 const clientProjectRoot = path.resolve(import.meta.dirname, '../../');
 const modulePrefix = '@umbraco-cms/backoffice/';
@@ -187,13 +188,13 @@ function reportSelfImportsFromModules() {
 	console.log(`\n\n`);
 }
 
-function reportBidirectionalModuleImports() {
-	console.error(`🔍 Scanning all modules for bidirectional imports...`);
+function reportBidirectionalModuleImports(modules, label, threshold) {
+	console.error(`🔍 Scanning all ${label} modules for bidirectional imports...`);
 	console.log(`\n`);
 
 	let entries = [];
 
-	packageModules.forEach(([alias, path]) => {
+	modules.forEach(([alias, path]) => {
 		const importsInModule = getUmbracoModuleImportsInModule(alias);
 
 		// Check imports for all the modules
@@ -216,16 +217,12 @@ function reportBidirectionalModuleImports() {
 		console.error(`🚨 ${moduleA} and ${moduleB} are importing each other`);
 	});
 
-	if (total > BIDIRECTIONAL_IMPORTS_THRESHOLD) {
-		throw new Error(
-			`Bidirectional imports found in ${total} modules. ${total - BIDIRECTIONAL_IMPORTS_THRESHOLD} more than the threshold.`,
-		);
+	if (total > threshold) {
+		throw new Error(`Bidirectional imports found in ${total} modules. ${total - threshold} more than the threshold.`);
 	} else if (total === 0) {
 		console.log(`✅ Success! No bidirectional imports found.`);
 	} else {
-		console.log(
-			`✅ Success! Still (${total}) under the threshold of ${BIDIRECTIONAL_IMPORTS_THRESHOLD} bidirectional imports.`,
-		);
+		console.log(`✅ Success! Still (${total}) under the threshold of ${threshold} bidirectional imports.`);
 	}
 
 	console.log(`\n\n`);
@@ -234,7 +231,8 @@ function reportBidirectionalModuleImports() {
 function report() {
 	reportIllegalImportsFromCore();
 	reportSelfImportsFromModules();
-	reportBidirectionalModuleImports();
+	reportBidirectionalModuleImports(coreModules, 'Core', CORE_MODULES_BIDIRECTIONAL_IMPORTS_THRESHOLD);
+	reportBidirectionalModuleImports(packageModules, 'Packages', PACKAGES_MODULES_BIDIRECTIONAL_IMPORTS_THRESHOLD);
 }
 
 report();


### PR DESCRIPTION
### Summary

I noticed that we haven't reported bidirectional import problems for the core modules. It turns out there are a few.

To help us maintain good separation of concerns, I have included this in the test report. I have set the threshold to the current state so we can catch new ones.

### Test plan

- Run `npm run check:module-dependencies` and confirm both Core and Packages checks run and report independently
- Verify the script exits with an error if either group exceeds its threshold