### PR TITLE
Cache: Invalidate element GUID-keyed cache on delete (closes #22911)

### DIFF
--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ElementCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ElementCacheRefresher.cs
@@ -131,8 +131,8 @@ public sealed class ElementCacheRefresher : PayloadCacheRefresherBase<ElementCac
             // By INT Id
             isolatedCache.Clear(RepositoryCacheKeys.GetKey<IElement, int>(payload.Id));
 
-            // By GUID Key
-            isolatedCache.Clear(RepositoryCacheKeys.GetKey<IElement, Guid?>(payload.Key));
+            // By GUID Key (GUID-keyed read repository uses a separate "uRepoGuid_" prefix)
+            isolatedCache.Clear(RepositoryCacheKeys.GetGuidKey<IElement>(payload.Key));
 
             HandleMemoryCache(payload);
             HandlePublishStatusAsync(payload, CancellationToken.None).GetAwaiter().GetResult();


### PR DESCRIPTION
## Description

After moving an element to the recycle bin and emptying it, `IElementService.GetById(Guid key)` still returned the element until the site was restarted.

The `EntityByGuidReadRepository` used by element/content/media repositories stores its entries with the `uRepoGuid_` prefix (via `RepositoryCacheKeys.GetGuidKey<T>`). `ContentCacheRefresher` and `MediaCacheRefresher` were updated to use that prefix when the GUID-keyed cache policy was introduced; `ElementCacheRefresher` was missed and still cleared with the old `uRepo_` prefix (via `RepositoryCacheKeys.GetKey<T, TId>`), so the GUID-keyed entry was never invalidated.

The fix changes the GUID-key clearing in `ElementCacheRefresher.Refresh` from `GetKey<IElement, Guid?>` to `GetGuidKey<IElement>`, matching the pattern already used for documents and media.

Fixes #22911

## Testing

### Automated

I wasn't successful getting an integration test running that reliably shows the error before the fix and the resolution afterward.

### Manual

Add this temporary debug controller (not committed) and run the site:

```csharp
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI.Controllers;

public class DebugElementLookupController : Controller
{
    private readonly IElementService _elementService;

    public DebugElementLookupController(IElementService elementService) => _elementService = elementService;

    [HttpGet(\"/debug/element-lookup\")]
    public IActionResult Lookup([FromQuery] Guid key)
    {
        IElement? element = _elementService.GetById(key);
        return element is null
            ? Content(\$\"No element found for key '{key}'.\", \"text/plain\")
            : Content(\$\"Found element '{element.Name}' (id={element.Id}, trashed={element.Trashed}) for key '{key}'.\", \"text/plain\");
    }
}
```

Reproduction:

1. In the backoffice, create a new element in the Library section and note its key.
2. Move the element to the recycle bin.
3. Empty the recycle bin.
4. Browse to \`/debug/element-lookup?key={key}\`.

Expected response **before** the fix:

```
Found element 'My Element' (id=1234, trashed=True) for key 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'.
```

Expected response **after** the fix:

```
No element found for key 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'.
```