### PR TITLE
Backoffice: Swap relative imports to @umbraco-cms/backoffice module imports in core packages

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
@@ -1,4 +1,4 @@
-import { UmbModalBaseElement } from '../../modal/index.js';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import type { UmbModalAppAuthConfig, UmbModalAppAuthValue } from './umb-app-auth-modal.token.js';
 import { UMB_AUTH_CONTEXT } from '../auth.context.token.js';
 import { customElement, html } from '@umbraco-cms/backoffice/external/lit';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.token.ts
@@ -1,4 +1,4 @@
-import { UmbModalToken } from '../../modal/token/index.js';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 import type { UmbUserLoginState } from '../types.js';
 
 export type UmbModalAppAuthConfig = {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-auth-timeout-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-auth-timeout-modal.token.ts
@@ -1,4 +1,4 @@
-import { UmbModalToken } from '../../modal/token/modal-token.js';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
 export type UmbModalAuthTimeoutConfig = {
 	remainingTimeInSeconds: number;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/bulk-action/collection-bulk-action.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/bulk-action/collection-bulk-action.manager.test.ts
@@ -1,5 +1,5 @@
 import { UmbCollectionBulkActionManager } from './collection-bulk-action.manager.js';
-import { umbExtensionsRegistry } from '../../extension-registry/index.js';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { expect } from '@open-wc/testing';
 import { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/manifests.ts
@@ -1,4 +1,4 @@
-import type { UmbExtensionManifestKind } from '../extension-registry/registry.js';
+import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 import { manifests as actionManifests } from './action/manifests.js';
 import { manifests as pickerModalManifests } from './collection-item-picker-modal/manifests.js';
 import { manifests as conditionManifests } from './conditions/manifests.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/repository/collection-data-source.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/repository/collection-data-source.interface.ts
@@ -1,5 +1,4 @@
-import type { UmbDataSourceResponse } from '../../repository/index.js';
-import type { UmbPagedModel } from '../../repository/types.js';
+import type { UmbDataSourceResponse, UmbPagedModel } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionFilterModel } from '../collection-filter-model.interface.js';
 
 export interface UmbCollectionDataSource<

--- a/src/Umbraco.Web.UI.Client/src/packages/core/collection/view/collection-view.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/collection/view/collection-view.manager.test.ts
@@ -1,5 +1,5 @@
 import type { ManifestCollectionView } from './collection-view.extension.js';
-import { umbExtensionsRegistry } from '../../extension-registry/index.js';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbCollectionViewManager } from './collection-view.manager.js';
 import { expect } from '@open-wc/testing';
 import { Observable } from '@umbraco-cms/backoffice/external/rxjs';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/entity-actions-bundle/entity-actions-bundle.element.ts
@@ -1,4 +1,4 @@
-import { UmbEntityContext } from '../../entity/entity.context.js';
+import { UmbEntityContext } from '@umbraco-cms/backoffice/entity';
 import { css, customElement, html, ifDefined, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbExtensionsManifestInitializer, createExtensionApi } from '@umbraco-cms/backoffice/extension-api';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/icon/icon.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/icon/icon.element.ts
@@ -1,4 +1,4 @@
-import { extractUmbColorVariable } from '../../resources/extractUmbColorVariable.function.js';
+import { extractUmbColorVariable } from '@umbraco-cms/backoffice/resources';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { html, customElement, property, state, ifDefined, css } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-slider/input-slider.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-slider/input-slider.element.ts
@@ -1,4 +1,4 @@
-import { UmbFormControlMixin } from '../../validation/mixins/index.js';
+import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 import { customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/debug/debug-modal/debug-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/debug/debug-modal/debug-modal.token.ts
@@ -1,4 +1,4 @@
-import { UmbModalToken } from '../../modal/token/modal-token.js';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 import type { TemplateResult } from '@umbraco-cms/backoffice/external/lit';
 
 export interface UmbContextDebuggerModalData {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/common/duplicate/duplicate-repository.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/common/duplicate/duplicate-repository.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbRepositoryErrorResponse } from '../../../repository/types.js';
+import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
 import type { UmbDuplicateRequestArgs } from './types.js';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/global-components/entity-actions-dropdown/entity-actions-dropdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-action/global-components/entity-actions-dropdown/entity-actions-dropdown.element.ts
@@ -1,4 +1,4 @@
-import type { UmbDropdownElement } from '../../../components/dropdown/index.js';
+import type { UmbDropdownElement } from '@umbraco-cms/backoffice/components';
 import { UmbEntityActionListElement } from '../../entity-action-list.element.js';
 import { html, customElement, property, css, query } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to-repository.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-bulk-action/common/duplicate-to/duplicate-to-repository.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbRepositoryErrorResponse } from '../../../repository/types.js';
+import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
 import type { UmbBulkDuplicateToRequestArgs } from './types.js';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-bulk-action/common/move-to/move-to-repository.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-bulk-action/common/move-to/move-to-repository.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbRepositoryErrorResponse } from '../../../repository/types.js';
+import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
 import type { UmbBulkMoveToRequestArgs } from './types.js';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-sign/components/entity-sign-bundle.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-sign/components/entity-sign-bundle.element.ts
@@ -1,4 +1,4 @@
-import { UmbLitElement } from '../../lit-element/lit-element.element.js';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import type { ManifestEntitySign } from '../types.js';
 import { customElement, html, nothing, property, repeat, state, css } from '@umbraco-cms/backoffice/external/lit';
 import {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/hint/context/hint.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/hint/context/hint.controller.ts
@@ -1,4 +1,4 @@
-import type { UmbPartialSome } from '../../utils/type/index.js';
+import type { UmbPartialSome } from '@umbraco-cms/backoffice/utils';
 import type { UmbHint, UmbIncomingHintBase } from '../types.js';
 import { UMB_HINT_CONTEXT } from './hint.context-token.js';
 import { UmbControllerBase, type UmbClassInterface } from '@umbraco-cms/backoffice/class-api';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/conditions/menu-alias.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/conditions/menu-alias.condition.ts
@@ -1,4 +1,4 @@
-import { UmbConditionBase } from '../../extension-registry/conditions/condition-base.controller.js';
+import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
 import type { MenuAliasConditionConfig } from './types.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property-editor-data-source/extension/property-editor-data-source.extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property-editor-data-source/extension/property-editor-data-source.extension.ts
@@ -1,4 +1,4 @@
-import type { PropertyEditorSettings } from '../../property-editor/extensions/types.js';
+import type { PropertyEditorSettings } from '@umbraco-cms/backoffice/property-editor';
 import type { ManifestApi } from '@umbraco-cms/backoffice/extension-api';
 
 // TODO: base ManifestApiType on dataSourceType

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-dataset/property-dataset-context.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-dataset/property-dataset-context.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbVariantId } from '../../variant/variant-id.class.js';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UmbPropertyValueData } from '../types.js';
 import type { UmbContext } from '@umbraco-cms/backoffice/class-api';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-guard-manager/variant-property-guard.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-guard-manager/variant-property-guard.manager.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@open-wc/testing';
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
 import { UmbVariantPropertyGuardManager } from './variant-property-guard.manager.js';
-import { UmbVariantId } from '../../variant/variant-id.class.js';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 @customElement('test-my-controller-host')
 class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.test.ts
@@ -12,7 +12,7 @@ import type {
 } from './types.js';
 import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
 import { UmbPropertyValuePresetVariantBuilderController } from './property-value-preset-variant-builder.controller.js';
-import { UmbVariantId } from '../../variant/variant-id.class.js';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 @customElement('umb-test-controller-host')
 export class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-variant-builder.controller.ts
@@ -1,4 +1,4 @@
-import { UmbVariantId } from '../../variant/variant-id.class.js';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UmbPropertyValuePresetBuilderController } from './property-value-preset-builder.controller.js';
 import type {
 	UmbPropertyTypePresetModel,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/types.ts
@@ -1,4 +1,4 @@
-import type { UmbVariantId } from '../../variant/variant-id.class.js';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/collection-action/empty-recycle-bin/empty-recycle-bin.collection-action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/collection-action/empty-recycle-bin/empty-recycle-bin.collection-action.ts
@@ -1,4 +1,4 @@
-import { UmbCollectionActionBase } from '../../../collection/action/collection-action-base.js';
+import { UmbCollectionActionBase } from '@umbraco-cms/backoffice/collection';
 import type { UmbRecycleBinRepository } from '../../recycle-bin-repository.interface.js';
 import type { ManifestCollectionActionEmptyRecycleBinKind } from './types.js';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/empty-recycle-bin/empty-recycle-bin.action.kind.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/empty-recycle-bin/empty-recycle-bin.action.kind.ts
@@ -1,4 +1,4 @@
-import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../../entity-action/default/default.action.kind.js';
+import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifest: UmbExtensionManifestKind = {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/restore-from-recycle-bin.action.kind.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/restore-from-recycle-bin.action.kind.ts
@@ -1,4 +1,4 @@
-import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../../entity-action/default/default.action.kind.js';
+import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifest: UmbExtensionManifestKind = {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/trash/trash.action.kind.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/trash/trash.action.kind.ts
@@ -1,4 +1,4 @@
-import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../../entity-action/default/default.action.kind.js';
+import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 export const UMB_ENTITY_ACTION_TRASH_KIND_MANIFEST: UmbExtensionManifestKind = {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/recycle-bin-repository.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/recycle-bin-repository.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbRepositoryBase } from '../repository/repository-base.js';
+import type { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type {
 	UmbRecycleBinOriginalParentRequestArgs,
 	UmbRecycleBinRestoreRequestArgs,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/data-source-response.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/data-source-response.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbApiError, UmbCancelError, UmbError } from '../resources/umb-error.js';
+import type { UmbApiError, UmbCancelError, UmbError } from '@umbraco-cms/backoffice/resources';
 
 export interface UmbDataSourceResponse<T = unknown> extends UmbDataSourceErrorResponse {
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/path-pattern.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/path-pattern.class.ts
@@ -1,4 +1,4 @@
-import { umbUrlPatternToString } from '../utils/path/url-pattern-to-string.function.js';
+import { umbUrlPatternToString } from '@umbraco-cms/backoffice/utils';
 
 export type UmbPathPatternParamsType = { [key: string]: any };
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/paths.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/paths.ts
@@ -1,3 +1,3 @@
-import { UmbPathPattern } from '../router/path-pattern.class.js';
+import { UmbPathPattern } from '@umbraco-cms/backoffice/router';
 
 export const UMB_SECTION_PATH_PATTERN = new UmbPathPattern<{ sectionName: string }>('section/:sectionName');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-picker-modal/section-picker-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-picker-modal/section-picker-modal.token.ts
@@ -1,4 +1,4 @@
-import { UmbModalToken } from '../../modal/token/modal-token.js';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
 export interface UmbSectionPickerModalData {
 	multiple: boolean;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/rename-server-file.action.kind.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server-file-system/rename/rename-server-file.action.kind.ts
@@ -1,4 +1,4 @@
-import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '../../entity-action/default/default.action.kind.js';
+import { UMB_ENTITY_ACTION_DEFAULT_KIND_MANIFEST } from '@umbraco-cms/backoffice/entity-action';
 import type { UmbExtensionManifestKind } from '@umbraco-cms/backoffice/extension-registry';
 
 export const manifest: UmbExtensionManifestKind = {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file.server.data-source.ts
@@ -1,4 +1,4 @@
-import type { UmbDataSourceResponse } from '../repository/index.js';
+import type { UmbDataSourceResponse } from '@umbraco-cms/backoffice/repository';
 import { TemporaryFileService } from '@umbraco-cms/backoffice/external/backend-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { tryExecute, tryXhrRequest } from '@umbraco-cms/backoffice/resources';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-repository.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-repository.interface.ts
@@ -1,4 +1,4 @@
-import type { UmbRepositoryErrorResponse } from '../../../repository/types.js';
+import type { UmbRepositoryErrorResponse } from '@umbraco-cms/backoffice/repository';
 import type { UmbMoveToRequestArgs } from './types.js';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-context.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-item/tree-item-context.interface.ts
@@ -1,5 +1,5 @@
 import type { UmbTreeItemModel } from '../types.js';
-import type { UmbPaginationManager } from '../../utils/pagination-manager/pagination.manager.js';
+import type { UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbContextMinimal } from '@umbraco-cms/backoffice/context-api';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/guard-manager/readonly-variant-guard.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/guard-manager/readonly-variant-guard.manager.test.ts
@@ -3,7 +3,7 @@ import { customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
 import { UmbBasicState } from '@umbraco-cms/backoffice/observable-api';
 import { UmbReadOnlyVariantGuardManager } from './readonly-variant-guard.manager.js';
-import { UmbVariantId } from '../../variant/variant-id.class.js';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 @customElement('test-my-controller-host')
 class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/validation/controllers/validation.controller.ts
@@ -3,7 +3,7 @@ import type { UmbValidationMessageTranslator } from '../translators/index.js';
 import { UMB_VALIDATION_CONTEXT } from '../context/validation.context-token.js';
 import { type UmbValidationMessage, UmbValidationMessagesManager } from '../context/validation-messages.manager.js';
 import { ReplaceStartOfPath } from '../utils/replace-start-of-path.function.js';
-import type { UmbVariantId } from '../../variant/variant-id.class.js';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UmbContextProviderController } from '@umbraco-cms/backoffice/context-api';
 import { type UmbClassInterface, UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/view/context/view.controller.ts
@@ -1,4 +1,4 @@
-import { UmbShortcutController } from '../../shortcut/context/shortcut.controller.js';
+import { UmbShortcutController } from '@umbraco-cms/backoffice/shortcut';
 import { UMB_VIEW_CONTEXT } from './view.context-token.js';
 import { UmbClassState, UmbStringState, mergeObservables } from '@umbraco-cms/backoffice/observable-api';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/contexts/tokens/variant-dataset-workspace-context.interface.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/contexts/tokens/variant-dataset-workspace-context.interface.ts
@@ -1,5 +1,5 @@
 import type { UmbWorkspaceSplitViewManager } from '../../controllers/workspace-split-view-manager.controller.js';
-import type { UmbPropertyDatasetContext } from '../../../property/property-dataset/property-dataset-context.interface.js';
+import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
 import type { UmbSubmittableWorkspaceContext } from './submittable-workspace-context.interface.js';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import type { UmbVariantId, UmbEntityVariantModel, UmbEntityVariantOptionModel } from '@umbraco-cms/backoffice/variant';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/utils/object-to-property-value-array.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/utils/object-to-property-value-array.function.ts
@@ -1,4 +1,4 @@
-import type { UmbPropertyValueData } from '../../property/types.js';
+import type { UmbPropertyValueData } from '@umbraco-cms/backoffice/property';
 
 /**
  * @function UmbObjectToPropertyValueArray


### PR DESCRIPTION
### Summary

- Replaces relative ../../ import paths in `src/packages/core/` with their corresponding
  @umbraco-cms/backoffice/<module> package imports across 42 files.
- No new exports has been made. Everything was already exported from the modules

### Benefits
- It gives a very small decrease in network requests because Vite can chunk files a little better
- It will help us better detect bidirectional imports.

