### PR TITLE
Sort Dialog: Show current language node names (closes #22872)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
@@ -22,8 +22,9 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 				context?.appLanguageCulture,
 				(appCulture) => {
 					this.#appCulture = appCulture;
-					if (this._children.length > 0) {
-						this._createTableItems();
+					if (this._tableItems.length > 0) {
+						// Patch names in-place so any user drag-sort or column-order is preserved.
+						this.#updateTableItemNames();
 					}
 				},
 				'umbObserveAppLanguageCulture',
@@ -66,8 +67,21 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 		});
 	}
 
+	#updateTableItemNames() {
+		this._tableItems = this._tableItems.map((tableItem) => {
+			const treeItem = this._children.find((child) => child.unique === tableItem.id);
+			if (!treeItem) return tableItem;
+			return {
+				...tableItem,
+				data: tableItem.data.map((column) =>
+					column.columnAlias === 'name' ? { ...column, value: this.#resolveName(treeItem) } : column,
+				),
+			};
+		});
+	}
+
 	#resolveName(treeItem: UmbContentTreeItemModel): string {
-		// Documents carry a variants array; media (which uses the same modal) does not, so the cast stays local here.
+		// The shared UmbContentTreeItemModel type used by this modal does not declare variants, so the cast stays local here.
 		const variants = (
 			treeItem as UmbContentTreeItemModel & { variants?: Array<{ name?: string; culture: string | null }> }
 		).variants;

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
@@ -85,15 +85,16 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 		const variants = (
 			treeItem as UmbContentTreeItemModel & { variants?: Array<{ name?: string; culture: string | null }> }
 		).variants;
-		if (!variants?.length) {
+
+		// No variants, or invariant content (culture === null) — use the tree item's own name as-is.
+		if (!variants?.length || variants[0].culture === null) {
 			return treeItem.name;
 		}
 
-		// Invariant content: the only variant has culture === null — use treeItem.name.
-		if (variants[0].culture === null) {
-			return treeItem.name;
-		}
+		return this.#pickVariantName(variants, treeItem.name);
+	}
 
+	#pickVariantName(variants: Array<{ name?: string; culture: string | null }>, defaultName: string): string {
 		const currentVariant = this.#appCulture
 			? variants.find((variant) => variant.culture === this.#appCulture)
 			: undefined;
@@ -102,8 +103,8 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 		}
 
 		// No name in the current language — fall back to any named variant, parenthesised so it's visibly a fallback.
-		const fallbackName = variants.find((variant) => variant.name)?.name ?? treeItem.name;
-		return fallbackName ? `(${fallbackName})` : treeItem.name;
+		const fallbackName = variants.find((variant) => variant.name)?.name ?? defaultName;
+		return fallbackName ? `(${fallbackName})` : defaultName;
 	}
 
 	protected override _sortCompare(columnAlias: string, valueA: unknown, valueB: unknown): number {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
@@ -1,6 +1,6 @@
 import type { UmbContentTreeItemModel } from '../../types.js';
+import type { UmbSortChildrenOfContentModalData } from './sort-children-of-content-modal.token.js';
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
-import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 import { UmbSortChildrenOfModalElement } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-sort-children-of-content-modal')
@@ -12,25 +12,6 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 		hour: 'numeric',
 		minute: '2-digit',
 	};
-
-	#appCulture?: string;
-
-	constructor() {
-		super();
-		this.consumeContext(UMB_APP_LANGUAGE_CONTEXT, (context) => {
-			this.observe(
-				context?.appLanguageCulture,
-				(appCulture) => {
-					this.#appCulture = appCulture;
-					if (this._tableItems.length > 0) {
-						// Patch names in-place so any user drag-sort or column-order is preserved.
-						this.#updateTableItemNames();
-					}
-				},
-				'umbObserveAppLanguageCulture',
-			);
-		});
-	}
 
 	protected override _setTableColumns() {
 		this._tableColumns = [
@@ -47,64 +28,38 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 		];
 	}
 
-	protected override _createTableItems() {
-		this._tableItems = this._children.map((treeItem) => {
-			// TODO: implement ItemDataResolver for document and media. This will also fix the hard-coded icon.
-			return {
-				id: treeItem.unique,
-				icon: 'icon-document',
-				data: [
-					{
-						columnAlias: 'name',
-						value: this.#resolveName(treeItem),
-					},
-					{
-						columnAlias: 'createDate',
-						value: this.localize.date(treeItem.createDate, this.#localizeDateOptions),
-					},
-				],
-			};
-		});
-	}
+	protected override async _createTableItems() {
+		const itemDataResolver = (this.data as UmbSortChildrenOfContentModalData | undefined)?.itemDataResolver;
 
-	#updateTableItemNames() {
-		this._tableItems = this._tableItems.map((tableItem) => {
-			const treeItem = this._children.find((child) => child.unique === tableItem.id);
-			if (!treeItem) return tableItem;
-			return {
-				...tableItem,
-				data: tableItem.data.map((column) =>
-					column.columnAlias === 'name' ? { ...column, value: this.#resolveName(treeItem) } : column,
-				),
-			};
-		});
-	}
+		this._tableItems = await Promise.all(
+			this._children.map(async (treeItem) => {
+				let name = treeItem.name;
+				let icon = treeItem.icon ?? undefined;
 
-	#resolveName(treeItem: UmbContentTreeItemModel): string {
-		// The shared UmbContentTreeItemModel type used by this modal does not declare variants, so the cast stays local here.
-		const variants = (
-			treeItem as UmbContentTreeItemModel & { variants?: Array<{ name?: string; culture: string | null }> }
-		).variants;
+				if (itemDataResolver) {
+					const resolver = new itemDataResolver(this);
+					resolver.setData(treeItem);
+					name = (await resolver.getName()) || treeItem.name;
+					icon = (await resolver.getIcon()) ?? icon;
+					this.removeUmbController(resolver);
+				}
 
-		// No variants, or invariant content (culture === null) — use the tree item's own name as-is.
-		if (!variants?.length || variants[0].culture === null) {
-			return treeItem.name;
-		}
-
-		return this.#pickVariantName(variants, treeItem.name);
-	}
-
-	#pickVariantName(variants: Array<{ name?: string; culture: string | null }>, defaultName: string): string {
-		const currentVariant = this.#appCulture
-			? variants.find((variant) => variant.culture === this.#appCulture)
-			: undefined;
-		if (currentVariant?.name) {
-			return currentVariant.name;
-		}
-
-		// No name in the current language — fall back to any named variant, parenthesised so it's visibly a fallback.
-		const fallbackName = variants.find((variant) => variant.name)?.name ?? defaultName;
-		return fallbackName ? `(${fallbackName})` : defaultName;
+				return {
+					id: treeItem.unique,
+					icon: icon ?? 'icon-document',
+					data: [
+						{
+							columnAlias: 'name',
+							value: name,
+						},
+						{
+							columnAlias: 'createDate',
+							value: this.localize.date(treeItem.createDate, this.#localizeDateOptions),
+						},
+					],
+				};
+			}),
+		);
 	}
 
 	protected override _sortCompare(columnAlias: string, valueA: unknown, valueB: unknown): number {
@@ -128,6 +83,6 @@ export { UmbSortChildrenOfContentModalElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-sort-children-of-content-modal']: UmbSortChildrenOfContentModalElement;
+		'umb-sort-children-of-content-modal': UmbSortChildrenOfContentModalElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.element.ts
@@ -1,5 +1,6 @@
 import type { UmbContentTreeItemModel } from '../../types.js';
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 import { UmbSortChildrenOfModalElement } from '@umbraco-cms/backoffice/tree';
 
 @customElement('umb-sort-children-of-content-modal')
@@ -11,6 +12,24 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 		hour: 'numeric',
 		minute: '2-digit',
 	};
+
+	#appCulture?: string;
+
+	constructor() {
+		super();
+		this.consumeContext(UMB_APP_LANGUAGE_CONTEXT, (context) => {
+			this.observe(
+				context?.appLanguageCulture,
+				(appCulture) => {
+					this.#appCulture = appCulture;
+					if (this._children.length > 0) {
+						this._createTableItems();
+					}
+				},
+				'umbObserveAppLanguageCulture',
+			);
+		});
+	}
 
 	protected override _setTableColumns() {
 		this._tableColumns = [
@@ -29,15 +48,14 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 
 	protected override _createTableItems() {
 		this._tableItems = this._children.map((treeItem) => {
-			// TODO: implement ItemDataResolver for document and media
-			// This will fix both the icon and the variant name
+			// TODO: implement ItemDataResolver for document and media. This will also fix the hard-coded icon.
 			return {
 				id: treeItem.unique,
 				icon: 'icon-document',
 				data: [
 					{
 						columnAlias: 'name',
-						value: treeItem.name,
+						value: this.#resolveName(treeItem),
 					},
 					{
 						columnAlias: 'createDate',
@@ -46,6 +64,32 @@ export class UmbSortChildrenOfContentModalElement extends UmbSortChildrenOfModal
 				],
 			};
 		});
+	}
+
+	#resolveName(treeItem: UmbContentTreeItemModel): string {
+		// Documents carry a variants array; media (which uses the same modal) does not, so the cast stays local here.
+		const variants = (
+			treeItem as UmbContentTreeItemModel & { variants?: Array<{ name?: string; culture: string | null }> }
+		).variants;
+		if (!variants?.length) {
+			return treeItem.name;
+		}
+
+		// Invariant content: the only variant has culture === null — use treeItem.name.
+		if (variants[0].culture === null) {
+			return treeItem.name;
+		}
+
+		const currentVariant = this.#appCulture
+			? variants.find((variant) => variant.culture === this.#appCulture)
+			: undefined;
+		if (currentVariant?.name) {
+			return currentVariant.name;
+		}
+
+		// No name in the current language — fall back to any named variant, parenthesised so it's visibly a fallback.
+		const fallbackName = variants.find((variant) => variant.name)?.name ?? treeItem.name;
+		return fallbackName ? `(${fallbackName})` : treeItem.name;
 	}
 
 	protected override _sortCompare(columnAlias: string, valueA: unknown, valueB: unknown): number {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/modal/sort-children-of-content-modal.token.ts
@@ -1,10 +1,15 @@
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+import type { UmbItemDataResolverConstructor } from '@umbraco-cms/backoffice/entity-item';
 import type { UmbSortChildrenOfModalData, UmbSortChildrenOfModalValue } from '@umbraco-cms/backoffice/tree';
 
 export const UMB_SORT_CHILDREN_OF_CONTENT_MODAL_ALIAS = 'Umb.Modal.SortChildrenOfContent';
 
+export interface UmbSortChildrenOfContentModalData extends UmbSortChildrenOfModalData {
+	itemDataResolver?: UmbItemDataResolverConstructor;
+}
+
 export const UMB_SORT_CHILDREN_OF_CONTENT_MODAL = new UmbModalToken<
-	UmbSortChildrenOfModalData,
+	UmbSortChildrenOfContentModalData,
 	UmbSortChildrenOfModalValue
 >(UMB_SORT_CHILDREN_OF_CONTENT_MODAL_ALIAS, {
 	modal: {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/sort-children-of-content.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/sort-children-of-content.action.ts
@@ -1,10 +1,9 @@
 import { UMB_SORT_CHILDREN_OF_CONTENT_MODAL } from './constants.js';
+import type { MetaEntityActionSortChildrenOfContentKind } from './types.js';
+import type { UmbSortChildrenOfContentModalData } from './modal/sort-children-of-content-modal.token.js';
+import { UmbSortChildrenOfEntityAction } from '@umbraco-cms/backoffice/tree';
 import type { UmbModalToken } from '@umbraco-cms/backoffice/modal';
-import {
-	UmbSortChildrenOfEntityAction,
-	type UmbSortChildrenOfModalData,
-	type UmbSortChildrenOfModalValue,
-} from '@umbraco-cms/backoffice/tree';
+import type { UmbSortChildrenOfModalData, UmbSortChildrenOfModalValue } from '@umbraco-cms/backoffice/tree';
 
 /**
  * Entity action for sorting children of a content item
@@ -14,6 +13,14 @@ import {
 export class UmbSortChildrenOfContentEntityAction extends UmbSortChildrenOfEntityAction {
 	protected override _getModalToken(): UmbModalToken<UmbSortChildrenOfModalData, UmbSortChildrenOfModalValue> {
 		return UMB_SORT_CHILDREN_OF_CONTENT_MODAL;
+	}
+
+	protected override _getModalData(): UmbSortChildrenOfContentModalData {
+		const meta = this.args.meta as MetaEntityActionSortChildrenOfContentKind;
+		return {
+			...super._getModalData(),
+			itemDataResolver: meta.itemDataResolver,
+		};
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/tree/sort-children-of-content/types.ts
@@ -1,10 +1,14 @@
 import type { ManifestEntityAction } from '@umbraco-cms/backoffice/entity-action';
 import type { MetaEntityActionSortChildrenOfKind } from '@umbraco-cms/backoffice/tree';
+import type { UmbItemDataResolverConstructor } from '@umbraco-cms/backoffice/entity-item';
 
-export interface ManifestEntityActionSortChildrenOfContentKind
-	extends ManifestEntityAction<MetaEntityActionSortChildrenOfKind> {
+export interface ManifestEntityActionSortChildrenOfContentKind extends ManifestEntityAction<MetaEntityActionSortChildrenOfContentKind> {
 	type: 'entityAction';
 	kind: 'sortChildrenOfContent';
+}
+
+export interface MetaEntityActionSortChildrenOfContentKind extends MetaEntityActionSortChildrenOfKind {
+	itemDataResolver?: UmbItemDataResolverConstructor;
 }
 
 declare global {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -45,6 +45,9 @@ export class UmbSortChildrenOfModalElement<
 	private _sortable = false;
 
 	@state()
+	private _loading = false;
+
+	@state()
 	private _submitButtonState?: UUIButtonState;
 
 	protected _sortedUniques = new Set<string>();
@@ -87,25 +90,30 @@ export class UmbSortChildrenOfModalElement<
 		if (this.data?.unique === undefined) throw new Error('unique is required');
 		if (!this.data?.treeRepositoryAlias) throw new Error('treeRepositoryAlias is required');
 
-		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository<TreeItemModelType>>(
-			this,
-			this.data.treeRepositoryAlias,
-		);
+		this._loading = true;
+		try {
+			const treeRepository = await createExtensionApiByAlias<UmbTreeRepository<TreeItemModelType>>(
+				this,
+				this.data.treeRepositoryAlias,
+			);
 
-		const { data } = await treeRepository.requestTreeItemsOf({
-			parent: {
-				unique: this.data.unique,
-				entityType: this.data.entityType,
-			},
-			skip: this.#pagination.getSkip(),
-			take: this.#pagination.getPageSize(),
-		});
+			const { data } = await treeRepository.requestTreeItemsOf({
+				parent: {
+					unique: this.data.unique,
+					entityType: this.data.entityType,
+				},
+				skip: this.#pagination.getSkip(),
+				take: this.#pagination.getPageSize(),
+			});
 
-		if (data) {
-			this._children = [...this._children, ...data.items];
-			this.#pagination.setTotalItems(data.total);
-			this._sortable = this._children.length > 0;
-			await this._createTableItems();
+			if (data) {
+				this._children = [...this._children, ...data.items];
+				this.#pagination.setTotalItems(data.total);
+				this._sortable = this._children.length > 0;
+				await this._createTableItems();
+			}
+		} finally {
+			this._loading = false;
 		}
 	}
 
@@ -130,6 +138,7 @@ export class UmbSortChildrenOfModalElement<
 
 	protected _onLoadMore(event: PointerEvent) {
 		event.stopPropagation();
+		if (this._loading) return;
 		if (this._currentPage >= this._totalPages) return;
 		this.#pagination.setCurrentPageNumber(this._currentPage + 1);
 		this.#requestChildren();
@@ -258,7 +267,11 @@ export class UmbSortChildrenOfModalElement<
 
 			${this._hasMorePages()
 				? html`
-						<uui-button id="loadMoreButton" look="placeholder" @click=${this._onLoadMore}>
+						<uui-button
+							id="loadMoreButton"
+							look="placeholder"
+							?disabled=${this._loading}
+							@click=${this._onLoadMore}>
 							<umb-localize key="actions_loadMore">Load more</umb-localize> (${this._currentPage}/${this._totalPages})
 						</uui-button>
 					`

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/modal/sort-children-of-modal.element.ts
@@ -1,13 +1,12 @@
 import type { UmbSortChildrenOfRepository, UmbTreeItemModel } from '../../../types.js';
 import type { UmbTreeRepository } from '../../../data/index.js';
 import type { UmbSortChildrenOfModalData, UmbSortChildrenOfModalValue } from './sort-children-of-modal.token.js';
-import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
-import { html, customElement, css, state, nothing } from '@umbraco-cms/backoffice/external/lit';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { css, customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
-import { UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
 import { observeMultiple } from '@umbraco-cms/backoffice/observable-api';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
+import { UmbPaginationManager } from '@umbraco-cms/backoffice/utils';
+import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 import type { UUIButtonState } from '@umbraco-cms/backoffice/external/uui';
 import type {
 	UmbTableColumn,
@@ -18,9 +17,7 @@ import type {
 	UmbTableSortedEvent,
 } from '@umbraco-cms/backoffice/components';
 
-const elementName = 'umb-sort-children-of-modal';
-
-@customElement(elementName)
+@customElement('umb-sort-children-of-modal')
 export class UmbSortChildrenOfModalElement<
 	TreeItemModelType extends UmbTreeItemModel = UmbTreeItemModel,
 > extends UmbModalBaseElement<UmbSortChildrenOfModalData, UmbSortChildrenOfModalValue> {
@@ -108,11 +105,11 @@ export class UmbSortChildrenOfModalElement<
 			this._children = [...this._children, ...data.items];
 			this.#pagination.setTotalItems(data.total);
 			this._sortable = this._children.length > 0;
-			this._createTableItems();
+			await this._createTableItems();
 		}
 	}
 
-	protected _createTableItems() {
+	protected _createTableItems(): void | Promise<void> {
 		this._tableItems = this._children.map((treeItem) => {
 			return {
 				id: treeItem.unique,
@@ -227,7 +224,10 @@ export class UmbSortChildrenOfModalElement<
 		return html`
 			<umb-body-layout headline=${this.localize.term('actions_sort')}>
 				${this._children.length === 0 ? this.#renderEmptyState() : this.#renderTable()}
-				<uui-button slot="actions" label=${this.localize.term('general_cancel')} @click="${this._rejectModal}"></uui-button>
+				<uui-button
+					slot="actions"
+					label=${this.localize.term('general_cancel')}
+					@click="${this._rejectModal}"></uui-button>
 				<uui-button
 					slot="actions"
 					color="positive"
@@ -240,7 +240,9 @@ export class UmbSortChildrenOfModalElement<
 	}
 
 	#renderEmptyState() {
-		return html`<uui-label><umb-localize key="sort_sortEmptyState">This node has no child nodes to sort</umb-localize></uui-label>`;
+		return html`
+			<uui-label><umb-localize key="sort_sortEmptyState">This node has no child nodes to sort</umb-localize></uui-label>
+		`;
 	}
 
 	#renderTable() {
@@ -251,20 +253,20 @@ export class UmbSortChildrenOfModalElement<
 				.items=${this._tableItems}
 				.sortable=${this._sortable}
 				@sorted=${this.#onSorted}
-				@ordered=${this.#onOrdered}></umb-table>
+				@ordered=${this.#onOrdered}>
+			</umb-table>
 
 			${this._hasMorePages()
 				? html`
-						<uui-button id="loadMoreButton" look="placeholder" @click=${this._onLoadMore}
-							><umb-localize key="actions_loadMore">Load more</umb-localize> (${this._currentPage}/${this._totalPages})</uui-button
-						>
+						<uui-button id="loadMoreButton" look="placeholder" @click=${this._onLoadMore}>
+							<umb-localize key="actions_loadMore">Load more</umb-localize> (${this._currentPage}/${this._totalPages})
+						</uui-button>
 					`
 				: nothing}
 		`;
 	}
 
 	static override styles = [
-		UmbTextStyles,
 		css`
 			#loadMoreButton {
 				width: 100%;
@@ -278,6 +280,6 @@ export { UmbSortChildrenOfModalElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbSortChildrenOfModalElement;
+		'umb-sort-children-of-modal': UmbSortChildrenOfModalElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/sort-children-of.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/sort-children-of/sort-children-of.action.ts
@@ -1,4 +1,5 @@
 import { UMB_SORT_CHILDREN_OF_MODAL } from './modal/index.js';
+import type { UmbSortChildrenOfModalData } from './modal/index.js';
 import type { MetaEntityActionSortChildrenOfKind } from './types.js';
 import { UmbEntityActionBase, UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
@@ -6,14 +7,8 @@ import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 
 export class UmbSortChildrenOfEntityAction extends UmbEntityActionBase<MetaEntityActionSortChildrenOfKind> {
 	override async execute() {
-		await umbOpenModal(this, this._getModalToken(), {
-			data: {
-				unique: this.args.unique,
-				entityType: this.args.entityType,
-				sortChildrenOfRepositoryAlias: this.args.meta.sortChildrenOfRepositoryAlias,
-				treeRepositoryAlias: this.args.meta.treeRepositoryAlias,
-			},
-		}).catch(() => undefined);
+		const data = this._getModalData();
+		await umbOpenModal(this, this._getModalToken(), { data }).catch(() => undefined);
 
 		const eventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
 		if (!eventContext) throw new Error('Event context is not available');
@@ -28,6 +23,15 @@ export class UmbSortChildrenOfEntityAction extends UmbEntityActionBase<MetaEntit
 
 	protected _getModalToken() {
 		return UMB_SORT_CHILDREN_OF_MODAL;
+	}
+
+	protected _getModalData(): UmbSortChildrenOfModalData {
+		return {
+			unique: this.args.unique,
+			entityType: this.args.entityType,
+			sortChildrenOfRepositoryAlias: this.args.meta.sortChildrenOfRepositoryAlias,
+			treeRepositoryAlias: this.args.meta.treeRepositoryAlias,
+		};
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/sort-children-of/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/sort-children-of/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_ROOT_ENTITY_TYPE } from '../../entity.js';
 import { UMB_DOCUMENT_ITEM_REPOSITORY_ALIAS } from '../../item/constants.js';
+import { UmbDocumentItemDataResolver } from '../../item/index.js';
 import { UMB_DOCUMENT_TREE_REPOSITORY_ALIAS } from '../../tree/index.js';
 import { UMB_USER_PERMISSION_DOCUMENT_SORT } from '../../user-permissions/document/constants.js';
 import { UMB_SORT_CHILDREN_OF_DOCUMENT_REPOSITORY_ALIAS } from './repository/constants.js';
@@ -16,6 +17,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		forEntityTypes: [UMB_DOCUMENT_ROOT_ENTITY_TYPE, UMB_DOCUMENT_ENTITY_TYPE],
 		meta: {
 			itemRepositoryAlias: UMB_DOCUMENT_ITEM_REPOSITORY_ALIAS,
+			itemDataResolver: UmbDocumentItemDataResolver,
 			sortChildrenOfRepositoryAlias: UMB_SORT_CHILDREN_OF_DOCUMENT_REPOSITORY_ALIAS,
 			treeRepositoryAlias: UMB_DOCUMENT_TREE_REPOSITORY_ALIAS,
 			additionalOptions: true,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/document-item-data-resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/item/document-item-data-resolver.ts
@@ -1,34 +1,37 @@
 import { UmbDocumentVariantState } from '../variant-state.js';
-import type { UmbDocumentItemModel } from './types.js';
-import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import type { UmbEntityFlag } from '@umbraco-cms/backoffice/entity-flag';
+import type { UmbDocumentItemModel, UmbDocumentItemVariantModel } from './types.js';
 import {
 	UmbArrayState,
 	UmbBasicState,
 	UmbBooleanState,
 	UmbObjectState,
 	UmbStringState,
-	type Observable,
 } from '@umbraco-cms/backoffice/observable-api';
-import { type UmbVariantContext, UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbEntityFlag } from '@umbraco-cms/backoffice/entity-flag';
+import { UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
+import type { Observable } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbItemDataResolver } from '@umbraco-cms/backoffice/entity-item';
+import type { UmbVariantContext } from '@umbraco-cms/backoffice/variant';
 
 type UmbDocumentItemDataResolverModel = Omit<UmbDocumentItemModel, 'parent' | 'hasChildren'>;
 
 /**
  *
- * @param variants
+ * @param {Array<UmbDocumentItemVariantModel>} variants - An array of variants to check
+ * @returns {boolean} Returns true if the variants are invariant, false otherwise
  */
-function isVariantsInvariant(variants: Array<{ culture: string | null }>): boolean {
+function isVariantsInvariant(variants: Array<UmbDocumentItemVariantModel>): boolean {
 	return variants?.[0]?.culture === null;
 }
 /**
  *
- * @param variants
- * @param culture
+ * @param {Array<UmbDocumentItemVariantModel>} variants - An array of variants to search
+ * @param {string} culture - The culture to find
+ * @returns {T | undefined} Returns the variant with the matching culture, or undefined if not found
  */
-function findVariant<T extends { culture: string | null }>(variants: Array<T>, culture: string): T | undefined {
+function findVariant<T extends UmbDocumentItemVariantModel>(variants: Array<T>, culture: string): T | undefined {
 	return variants.find((x) => x.culture === culture);
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/sort-children-of/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/sort-children-of/manifests.ts
@@ -1,5 +1,6 @@
 import { UMB_MEDIA_ENTITY_TYPE, UMB_MEDIA_ROOT_ENTITY_TYPE } from '../../entity.js';
 import { UMB_MEDIA_ITEM_REPOSITORY_ALIAS, UMB_MEDIA_TREE_REPOSITORY_ALIAS } from '../../constants.js';
+import { UmbMediaItemDataResolver } from '../../item/index.js';
 import { UMB_SORT_CHILDREN_OF_MEDIA_REPOSITORY_ALIAS } from './repository/constants.js';
 import { manifests as repositoryManifests } from './repository/manifests.js';
 import { UMB_ENTITY_IS_NOT_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
@@ -14,6 +15,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		forEntityTypes: [UMB_MEDIA_ROOT_ENTITY_TYPE, UMB_MEDIA_ENTITY_TYPE],
 		meta: {
 			itemRepositoryAlias: UMB_MEDIA_ITEM_REPOSITORY_ALIAS,
+			itemDataResolver: UmbMediaItemDataResolver,
 			sortChildrenOfRepositoryAlias: UMB_SORT_CHILDREN_OF_MEDIA_REPOSITORY_ALIAS,
 			treeRepositoryAlias: UMB_MEDIA_TREE_REPOSITORY_ALIAS,
 		},

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
@@ -4,6 +4,7 @@ export * from './constants.js';
 export * from './user-start-node/value-type/constants.js';
 export * from './dropzone/index.js';
 export * from './global-contexts/index.js';
+export * from './item/index.js';
 export * from './modals/index.js';
 export * from './recycle-bin/index.js';
 export * from './reference/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/item/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/item/index.ts
@@ -1,0 +1,1 @@
+export * from './media-item-data-resolver.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/item/media-item-data-resolver.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/item/media-item-data-resolver.test.ts
@@ -1,0 +1,156 @@
+import { expect } from '@open-wc/testing';
+import { customElement } from 'lit/decorators.js';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbMediaItemDataResolver } from './media-item-data-resolver.js';
+import { UmbVariantContext } from '@umbraco-cms/backoffice/variant';
+
+@customElement('umb-test-media-item-data-resolver-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbMediaItemDataResolver', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let resolver: UmbMediaItemDataResolver<any>;
+	let variantContext: UmbVariantContext;
+
+	beforeEach(async () => {
+		hostElement = new UmbTestControllerHostElement();
+		document.body.appendChild(hostElement);
+
+		variantContext = new UmbVariantContext(hostElement);
+		await variantContext.setCulture('en-US');
+		await variantContext.setFallbackCulture('en-US');
+		await variantContext.setAppCulture('en-US');
+
+		resolver = new UmbMediaItemDataResolver(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('Public API', () => {
+		it('has a name observable', () => {
+			expect(resolver).to.have.property('name');
+		});
+
+		it('has setData method', () => {
+			expect(resolver).to.have.property('setData').that.is.a('function');
+		});
+
+		it('has getData method', () => {
+			expect(resolver).to.have.property('getData').that.is.a('function');
+		});
+
+		it('has getName method', () => {
+			expect(resolver).to.have.property('getName').that.is.a('function');
+		});
+
+		it('has getIcon method', () => {
+			expect(resolver).to.have.property('getIcon').that.is.a('function');
+		});
+	});
+
+	describe('name fallback behavior', () => {
+		it('should use current variant name when available', async () => {
+			const mockData = {
+				entityType: 'media',
+				unique: 'test-123',
+				mediaType: { unique: 'mt-1', icon: 'icon-picture', collection: null },
+				variants: [{ culture: 'en-US', name: 'English Title' }],
+			};
+
+			resolver.setData(mockData);
+
+			const name = await resolver.getName();
+			expect(name).to.equal('English Title');
+		});
+
+		it('should fall back to fallback culture name in parentheses', async () => {
+			await variantContext.setCulture('de-DE');
+			await variantContext.setFallbackCulture('en-US');
+
+			const mockData = {
+				entityType: 'media',
+				unique: 'test-123',
+				mediaType: { unique: 'mt-1', icon: 'icon-picture', collection: null },
+				variants: [
+					{ culture: 'en-US', name: 'English Title' },
+					{ culture: 'de-DE', name: undefined },
+				],
+			};
+
+			resolver.setData(mockData);
+
+			const name = await resolver.getName();
+			expect(name).to.equal('(English Title)');
+		});
+
+		it('should fall back to first variant with name when current and fallback have no name', async () => {
+			await variantContext.setCulture('de-DE');
+			await variantContext.setFallbackCulture('es-ES');
+
+			const mockData = {
+				entityType: 'media',
+				unique: 'test-123',
+				mediaType: { unique: 'mt-1', icon: 'icon-picture', collection: null },
+				variants: [
+					{ culture: 'de-DE', name: undefined },
+					{ culture: 'es-ES', name: undefined },
+					{ culture: 'fr-FR', name: 'Titre Français' },
+				],
+			};
+
+			resolver.setData(mockData);
+
+			const name = await resolver.getName();
+			expect(name).to.equal('(Titre Français)');
+		});
+
+		it('should return (Untitled) when no variants have names', async () => {
+			const mockData = {
+				entityType: 'media',
+				unique: 'test-123',
+				mediaType: { unique: 'mt-1', icon: 'icon-picture', collection: null },
+				variants: [
+					{ culture: 'en-US', name: undefined },
+					{ culture: 'de-DE', name: undefined },
+				],
+			};
+
+			resolver.setData(mockData);
+
+			const name = await resolver.getName();
+			expect(name).to.equal('(Untitled)');
+		});
+
+		it('should use the invariant variant name when content is invariant', async () => {
+			const mockData = {
+				entityType: 'media',
+				unique: 'test-123',
+				mediaType: { unique: 'mt-1', icon: 'icon-picture', collection: null },
+				variants: [{ culture: null, name: 'Invariant Name' }],
+			};
+
+			resolver.setData(mockData);
+
+			const name = await resolver.getName();
+			expect(name).to.equal('Invariant Name');
+		});
+	});
+
+	describe('icon', () => {
+		it('should resolve the icon from the media type', async () => {
+			const mockData = {
+				entityType: 'media',
+				unique: 'test-123',
+				mediaType: { unique: 'mt-1', icon: 'icon-picture', collection: null },
+				variants: [{ culture: 'en-US', name: 'English Title' }],
+			};
+
+			resolver.setData(mockData);
+
+			const icon = await resolver.getIcon();
+			expect(icon).to.equal('icon-picture');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/item/media-item-data-resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/item/media-item-data-resolver.ts
@@ -1,0 +1,176 @@
+import type { UmbMediaItemModel, UmbMediaItemVariantModel } from '../types.js';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { UmbObjectState, UmbStringState } from '@umbraco-cms/backoffice/observable-api';
+import { type UmbVariantContext, UMB_VARIANT_CONTEXT } from '@umbraco-cms/backoffice/variant';
+import type { UmbItemDataResolver } from '@umbraco-cms/backoffice/entity-item';
+
+type UmbMediaItemDataResolverModel = Omit<UmbMediaItemModel, 'parent' | 'hasChildren'>;
+
+/**
+ *
+ * @param {Array<UmbMediaItemVariantModel>} variants - An array of variants to check
+ * @returns {boolean} Returns true if the variants are invariant, false otherwise
+ */
+function isVariantsInvariant(variants: Array<UmbMediaItemVariantModel>): boolean {
+	return variants?.[0]?.culture === null;
+}
+
+/**
+ *
+ * @param {Array<UmbMediaItemVariantModel>} variants - An array of variants to search
+ * @param {string} culture - The culture to find
+ * @returns {T | undefined} Returns the variant that matches the culture, or undefined if not found
+ */
+function findVariant<T extends UmbMediaItemVariantModel>(variants: Array<T>, culture: string): T | undefined {
+	return variants.find((x) => x.culture === culture);
+}
+
+/**
+ * A controller for resolving data for a media item
+ * @exports
+ * @class UmbMediaItemDataResolver
+ * @augments {UmbControllerBase}
+ */
+export class UmbMediaItemDataResolver<MediaItemModel extends UmbMediaItemDataResolverModel>
+	extends UmbControllerBase
+	implements UmbItemDataResolver
+{
+	#data = new UmbObjectState<MediaItemModel | undefined>(undefined);
+
+	public readonly entityType = this.#data.asObservablePart((x) => x?.entityType);
+	public readonly unique = this.#data.asObservablePart((x) => x?.unique);
+	public readonly icon = this.#data.asObservablePart((x) => x?.mediaType.icon);
+
+	#name = new UmbStringState(undefined);
+	public readonly name = this.#name.asObservable();
+
+	#variantContext?: UmbVariantContext;
+	#fallbackCulture?: string | null;
+	#displayCulture?: string | null;
+
+	constructor(host: UmbControllerHost) {
+		super(host);
+
+		this.consumeContext(UMB_VARIANT_CONTEXT, (context) => {
+			this.#variantContext = context;
+			this.#observeVariantContext();
+		});
+	}
+
+	#observeVariantContext() {
+		this.observe(
+			this.#variantContext?.displayCulture,
+			(displayCulture) => {
+				if (displayCulture === undefined) return;
+				this.#displayCulture = displayCulture;
+				this.#setVariantAwareValues();
+			},
+			'umbObserveDisplayCulture',
+		);
+
+		this.observe(
+			this.#variantContext?.fallbackCulture,
+			(fallbackCulture) => {
+				if (fallbackCulture === undefined) return;
+				this.#fallbackCulture = fallbackCulture;
+				this.#setVariantAwareValues();
+			},
+			'umbObserveFallbackCulture',
+		);
+	}
+
+	/**
+	 * Get the current item
+	 * @returns {MediaItemModel | undefined} The current item
+	 * @memberof UmbMediaItemDataResolver
+	 */
+	getData(): MediaItemModel | undefined {
+		return this.#data.getValue();
+	}
+
+	/**
+	 * Set the current item
+	 * @param {MediaItemModel | undefined} data The current item
+	 * @memberof UmbMediaItemDataResolver
+	 */
+	setData(data: MediaItemModel | undefined) {
+		this.#data.setValue(data);
+		this.#setVariantAwareValues();
+	}
+
+	/**
+	 * Get the entity type of the item
+	 * @returns {Promise<string | undefined>} The entity type of the item
+	 * @memberof UmbMediaItemDataResolver
+	 */
+	async getEntityType(): Promise<string | undefined> {
+		return await this.observe(this.entityType).asPromise();
+	}
+
+	/**
+	 * Get the unique of the item
+	 * @returns {Promise<string | undefined>} The unique of the item
+	 * @memberof UmbMediaItemDataResolver
+	 */
+	async getUnique(): Promise<string | undefined> {
+		return await this.observe(this.unique).asPromise();
+	}
+
+	/**
+	 * Get the name of the item
+	 * @returns {Promise<string>} The name of the item
+	 * @memberof UmbMediaItemDataResolver
+	 */
+	async getName(): Promise<string> {
+		return (await this.observe(this.name).asPromise()) || '';
+	}
+
+	/**
+	 * Get the icon of the item
+	 * @returns {Promise<string | undefined>} The icon of the item
+	 * @memberof UmbMediaItemDataResolver
+	 */
+	async getIcon(): Promise<string | undefined> {
+		return await this.observe(this.icon).asPromise();
+	}
+
+	#setVariantAwareValues() {
+		if (!this.#variantContext) return;
+		if (!this.#displayCulture) return;
+		if (!this.#fallbackCulture) return;
+		if (!this.#data) return;
+		this.#setName();
+	}
+
+	#setName() {
+		const variant = this.#getCurrentVariant();
+		if (variant?.name) {
+			this.#name.setValue(variant.name);
+			return;
+		}
+
+		const variants = this.getData()?.variants;
+		if (variants) {
+			const fallbackName = findVariant(variants, this.#fallbackCulture!)?.name ?? variants.find((x) => x.name)?.name;
+
+			if (fallbackName) {
+				this.#name.setValue(`(${fallbackName})`);
+				return;
+			}
+		}
+
+		this.#name.setValue('(Untitled)');
+	}
+
+	#getCurrentVariant() {
+		const variants = this.getData()?.variants;
+		if (!variants) return undefined;
+
+		if (isVariantsInvariant(variants)) {
+			return variants[0];
+		}
+
+		return findVariant(variants, this.#displayCulture!);
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/repository/types.ts
@@ -1,1 +1,1 @@
-export type { UmbMediaItemModel } from './item/types.js';
+export type * from './item/types.js';


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #22872

### Description

The **Sort children of…** dialog showed child node names from the default language, even when the backoffice was set to a different language. The tree, content editor, and collection views all already showed the active-language name correctly.

#### What this PR changes

Name resolution in the sort dialog is now delegated to the `UmbItemDataResolver` abstraction rather than being inlined in the modal:

- **`UmbMediaItemDataResolver`** — new resolver (parallel to the existing `UmbDocumentItemDataResolver`) that resolves the display name from the media item's variant array. Media variants are not fully implemented in the backend yet, but the data structure is already in place.
- **`MetaEntityActionSortChildrenOfContentKind`** — new meta interface (extends the base sort-children meta) with an optional `itemDataResolver` field. Entity actions that implement the `sortChildrenOfContent` kind can supply a resolver constructor in their manifest.
- **Document and media sort-children manifests** now pass `UmbDocumentItemDataResolver` and `UmbMediaItemDataResolver` respectively, so each entity type's resolver is used automatically.
- **`UmbSortChildrenOfContentModalElement`** — `_createTableItems` now instantiates the supplied resolver per row, calls `getName()`, then disposes the resolver. This fixes both the variant name (showing the active backoffice language).
- **`UmbSortChildrenOfEntityAction`** — modal data is now built via an overridable `_getModalData()` hook, making it straightforward for subclasses to extend the payload.

Names fall back gracefully: if the active language has no translation, the fallback-culture name is shown in parentheses (e.g. `(English title)`); if no variant has a name, `(Untitled)` is shown.

### Testing

#### Manual

1. In **Settings → Languages**, ensure at least two languages are enabled (e.g. `en-US` default, `da-DK` secondary).
2. On a document type, enable **Allow vary by culture**.
3. Create a parent node with several children; give each child distinct names in both languages.
4. Switch the backoffice language to the non-default language.
5. Right-click the parent node and choose **Sort children of…**.
   - Names in the dialog should match the active backoffice language. 
6. For a child that has no translation in the active language, confirm the dialog shows `(default-name)` (parenthesised fallback) rather than blank. 
8. Switch the backoffice language back to the default; reopen the dialog and confirm names reflect the new active language. 
9. Open **Sort children of…** on a **media folder** (invariant). Confirm names appear correctly. 
10. Perform an actual sort and save. Confirm the new order persists. 

#### Automated

Unit tests for `UmbMediaItemDataResolver` are included in `media-item-data-resolver.test.ts`, covering current-variant name, parenthesised fallback, first-named-variant fallback, `(Untitled)`.