### PR TITLE
Body Layout: Replace overflow: auto with uui-scroll-container

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/rollback/modal/content-rollback-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/rollback/modal/content-rollback-modal.element.ts
@@ -465,7 +465,7 @@ export class UmbContentRollbackModalElement extends UmbModalBaseElement<
 		return html`
 			<umb-body-layout headline="Rollback">
 				<div id="main">
-					<div id="box-left">
+					<uui-scroll-container id="box-left">
 						${this._availableVariants.length
 							? html`
 									<uui-box id="language-box" headline=${this.localize.term('general_language')}>
@@ -474,7 +474,7 @@ export class UmbContentRollbackModalElement extends UmbModalBaseElement<
 								`
 							: nothing}
 						${this.#renderVersions()}
-					</div>
+					</uui-scroll-container>
 					${this.#renderSelectedVersion()}
 				</div>
 				<umb-footer-layout slot="footer">
@@ -597,7 +597,6 @@ export class UmbContentRollbackModalElement extends UmbModalBaseElement<
 			#box-left {
 				max-width: 500px;
 				flex: 1;
-				overflow: auto;
 				height: 100%;
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
@@ -120,10 +120,10 @@ export class UmbBodyLayoutElement extends LitElement {
 			</div>
 
 			<!-- This div should be changed for the uui-scroll-container when it gets updated -->
-			<div id="main">
+			<uui-scroll-container id="main">
 				${this.loading ? html`<uui-loader-bar></uui-loader-bar>` : nothing}
 				<slot></slot>
-			</div>
+			</uui-scroll-container>
 
 			<slot name="footer"></slot>
 			<umb-footer-layout style="display:${this._footerSlotHasChildren || this._actionsSlotHasChildren ? '' : 'none'}">
@@ -223,7 +223,6 @@ export class UmbBodyLayoutElement extends LitElement {
 				display: block;
 				flex: 1;
 				flex-direction: column;
-				overflow-y: auto;
 				padding: var(--uui-size-layout-1);
 			}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/body-layout/body-layout.element.ts
@@ -119,7 +119,6 @@ export class UmbBodyLayoutElement extends LitElement {
 					}}></slot>
 			</div>
 
-			<!-- This div should be changed for the uui-scroll-container when it gets updated -->
 			<uui-scroll-container id="main">
 				${this.loading ? html`<uui-loader-bar></uui-loader-bar>` : nothing}
 				<slot></slot>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/section/section-sidebar/section-sidebar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/section/section-sidebar/section-sidebar.element.ts
@@ -40,7 +40,6 @@ export class UmbSectionSidebarElement extends UmbLitElement {
 
 			#scroll-container {
 				height: 100%;
-				overflow-y: auto;
 			}
 		`,
 	];


### PR DESCRIPTION
## Summary
  - Replaces the `<div id="main">` in `umb-body-layout` with `<uui-scroll-container>
  - Removes redundant `overflow-y: auto` from `umb-section-sidebar` where `uui-scroll-container` was already in use but being overridden
  - Replaces `<div id="box-left">` in `content-rollback-modal` with `<uui-scroll-container>`

  ## Test plan
  - [ ] Open any content node and verify the workspace scrolls correctly
  - [ ] Open the content tree and verify the sidebar scrolls when there are many nodes
  - [ ] Open a content node → ⋯ menu → Rollback and verify the left panel (versions list) scrolls correctly