### PR TITLE
Content Type Editor: Fix empty Design tab when opened in a modal workspace (closes #22855)

### DIFF
--- a/src/Umbraco.Web.UI.Client/docs/edge-cases.md
+++ b/src/Umbraco.Web.UI.Client/docs/edge-cases.md
@@ -700,9 +700,11 @@ routes.push({ path: '', pathMatch: 'full', redirectTo: 'tab/settings' });
 
 // ✅ Duplicate the landing route directly under the empty path
 const defaultRoute = routes[0]; // or whichever is the landing route
-routes.push({ ...defaultRoute, path: '', pathMatch: 'full' });
+routes.push({ ...defaultRoute, path: '' });
 ```
 
 `umb-workspace-editor` uses this pattern — see the `// Duplicate first workspace and use it for the empty path scenario.` block in `workspace-editor.element.ts`.
+
+Do **not** add `pathMatch: 'full'` to the duplicated empty-path route. The modal sub-router appends modal paths (e.g. `/add-property/-1/container-root`) to the current active local path. With `path: ''` matching prefix-wise (regex `/^/`), the main route stays matched and the modal-router can resolve the appended segment. With `pathMatch: 'full'`, the empty-path route only matches an exactly-empty URL — modal URLs fall through to the catch-all, the route component unmounts, the modal registration is torn down, and the modal never opens.
 
 

--- a/src/Umbraco.Web.UI.Client/docs/edge-cases.md
+++ b/src/Umbraco.Web.UI.Client/docs/edge-cases.md
@@ -651,3 +651,58 @@ if (state.held?.some((l) => l.name === 'umb:token-refresh')) {
 Note: there is a TOCTOU gap between `query()` and `request()`. If the lock releases between the two calls, `request()` acquires and releases immediately — this is harmless.
 
 
+### Routing (`umb-router-slot` + dynamic routes)
+
+When a view owns an `umb-router-slot` and computes its routes from observable data (e.g. workspace/design editors), three behaviours of the slot must be respected. Getting any one of them wrong leaves the view stuck on a path it cannot recover from.
+
+**Guard the slot until routes are populated**
+
+If `umb-router-slot` mounts with `routes = undefined` (or an early/empty array), it fires `init`/`change` against whatever the URL currently is, settles on that local path, and does **not** re-match the URL when the routes array is replaced later. Always wrap the slot:
+
+```typescript
+// ❌ Slot mounts with undefined routes, locks in the wrong active path
+return html`<umb-router-slot .routes=${this._routes}></umb-router-slot>`;
+
+// ✅ Slot only mounts once real routes are in hand
+return html`
+	${this._routes
+		? html`<umb-router-slot .routes=${this._routes}></umb-router-slot>`
+		: nothing}
+`;
+```
+
+`umb-workspace-editor` (`packages/core/workspace/components/workspace-editor/workspace-editor.element.ts`) uses this guard; views that build their own router-slot must do the same.
+
+**Don't compute routes against not-yet-loaded data**
+
+Helpers like `UmbContentTypeContainerStructureHelper.childContainers` ship with `[]` as their initial value, so the first observer callback fires synchronously with empty data. If `#createRoutes()` runs at that point, the slot sees a wrong route set first. Await the structure load before wiring the helper:
+
+```typescript
+this.consumeContext(UMB_CONTENT_TYPE_WORKSPACE_CONTEXT, async (workspaceContext) => {
+	this.#workspaceContext = workspaceContext;
+	if (!workspaceContext) return;
+
+	// Block route generation until real containers are loaded
+	await workspaceContext.structure.whenLoaded();
+
+	this.#tabsStructureHelper.setStructureManager(workspaceContext.structure);
+	this.#observeRootGroups();
+});
+```
+
+**`redirectTo` doesn't fire on the initial route attachment**
+
+The router-slot library only applies `redirectTo` on navigation events, not when routes are first attached. A `path: ''` route with `redirectTo: 'foo'` will leave the slot sitting on the empty local path forever. Use **route duplication** instead — copy the target route onto the empty path:
+
+```typescript
+// ❌ Redirect never fires when the slot mounts late (e.g. inside a modal workspace)
+routes.push({ path: '', pathMatch: 'full', redirectTo: 'tab/settings' });
+
+// ✅ Duplicate the landing route directly under the empty path
+const defaultRoute = routes[0]; // or whichever is the landing route
+routes.push({ ...defaultRoute, path: '', pathMatch: 'full' });
+```
+
+`umb-workspace-editor` uses this pattern (`workspace-editor.element.ts:142`). The content-type design editor was fixed to follow it in #22855.
+
+

--- a/src/Umbraco.Web.UI.Client/docs/edge-cases.md
+++ b/src/Umbraco.Web.UI.Client/docs/edge-cases.md
@@ -703,6 +703,6 @@ const defaultRoute = routes[0]; // or whichever is the landing route
 routes.push({ ...defaultRoute, path: '', pathMatch: 'full' });
 ```
 
-`umb-workspace-editor` uses this pattern (`workspace-editor.element.ts:142`). The content-type design editor was fixed to follow it in #22855.
+`umb-workspace-editor` uses this pattern — see the `// Duplicate first workspace and use it for the empty path scenario.` block in `workspace-editor.element.ts`.
 
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -246,14 +246,16 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 		// router-slot library only applies `redirectTo` on navigation events, not on the initial
 		// route attachment, so an empty-path redirect would leave the view stuck. The landing
 		// route is `root` when the content type has root properties/groups (or has no tabs),
-		// otherwise the first tab.
+		// otherwise the first tab. Note: we deliberately do NOT set `pathMatch: 'full'`, because
+		// the modal sub-router appends paths like `/add-property/...` to the active local path;
+		// with `path: ''` matching prefix-wise (regex `/^/`), the tab stays mounted and the
+		// modal-router can match the appended segment.
 		const defaultRoute =
 			this._hasRootGroups || this._hasRootProperties || this._tabs.length === 0 ? routes[routes.length - 1] : routes[0];
 		this.#landingLocalPath = defaultRoute.path;
 		routes.push({
 			...defaultRoute,
 			path: '',
-			pathMatch: 'full',
 			guards: [() => this.#processingTabId === undefined],
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -104,6 +104,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 	#tabsStructureHelper = new UmbContentTypeContainerStructureHelper<UmbContentTypeModel>(this);
 	#currentTabComponent?: UmbContentTypeDesignEditorTabElement;
 	#processingTabId?: string;
+	#landingLocalPath?: string;
 
 	set manifest(value: ManifestWorkspaceViewContentTypeDesignEditorKind) {
 		this._compositionRepositoryAlias = value.meta.compositionRepositoryAlias;
@@ -177,6 +178,13 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			// the tabs helper subscribes to populated containers and #createRoutes runs against
 			// actual tabs/groups rather than the empty initial emissions of the underlying state.
 			await workspaceContext.structure.whenLoaded();
+			if (workspaceContext !== this.#workspaceContext) return; // stale, superseded by newer context
+
+			// Ensure root-group state is correct before the first route set is generated. #createRoutes() can
+			// run synchronously when setStructureManager attaches observers, and umb-router-slot does not
+			// re-match the URL when routes are replaced.
+			this._hasRootGroups = (await workspaceContext.structure.getRootContainers('Group')).length > 0;
+			if (workspaceContext !== this.#workspaceContext) return; // stale, superseded by newer context
 
 			this.#tabsStructureHelper.setStructureManager(workspaceContext.structure);
 			this.#observeRootGroups();
@@ -241,6 +249,7 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 		// otherwise the first tab.
 		const defaultRoute =
 			this._hasRootGroups || this._hasRootProperties || this._tabs.length === 0 ? routes[routes.length - 1] : routes[0];
+		this.#landingLocalPath = defaultRoute.path;
 		routes.push({
 			...defaultRoute,
 			path: '',
@@ -481,7 +490,14 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 								this._routerPath = event.target.absoluteRouterPath;
 							}}
 							@change=${(event: UmbRouterSlotChangeEvent) => {
-								this._activePath = event.target.absoluteActiveViewPath ?? '';
+								let activePath = event.target.absoluteActiveViewPath ?? '';
+								// When the duplicated empty-path landing route is active, the router reports
+								// the absolute path as `${routerPath}/` with no local segment. Map it back to
+								// the canonical landing path so tab-navigation highlight and rename UI work.
+								if (this.#landingLocalPath && activePath === this._routerPath + '/') {
+									activePath = this._routerPath + '/' + this.#landingLocalPath;
+								}
+								this._activePath = activePath;
 							}}>
 						</umb-router-slot>`
 					: nothing}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content-type/workspace/views/design/content-type-design-editor.element.ts
@@ -168,10 +168,17 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			'observeRootProperties',
 		);
 
-		this.consumeContext(UMB_CONTENT_TYPE_WORKSPACE_CONTEXT, (workspaceContext) => {
+		this.consumeContext(UMB_CONTENT_TYPE_WORKSPACE_CONTEXT, async (workspaceContext) => {
 			this.#workspaceContext = workspaceContext;
-			this.#tabsStructureHelper.setStructureManager(workspaceContext?.structure);
+			if (!workspaceContext) return;
 
+			// The router-slot does not re-match the URL when its routes are replaced, so the
+			// initial route set must reflect real data. Awaiting the structure load here ensures
+			// the tabs helper subscribes to populated containers and #createRoutes runs against
+			// actual tabs/groups rather than the empty initial emissions of the underlying state.
+			await workspaceContext.structure.whenLoaded();
+
+			this.#tabsStructureHelper.setStructureManager(workspaceContext.structure);
 			this.#observeRootGroups();
 		});
 	}
@@ -227,21 +234,19 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 			},
 		});
 
-		if (this._hasRootGroups || this._hasRootProperties || this._tabs.length === 0) {
-			routes.push({
-				path: '',
-				pathMatch: 'full',
-				redirectTo: 'root',
-				guards: [() => this.#processingTabId === undefined],
-			});
-		} else {
-			routes.push({
-				path: '',
-				pathMatch: 'full',
-				redirectTo: routes[0]?.path,
-				guards: [() => this.#processingTabId === undefined],
-			});
-		}
+		// Duplicate the landing route onto the empty path rather than using `redirectTo`. The
+		// router-slot library only applies `redirectTo` on navigation events, not on the initial
+		// route attachment, so an empty-path redirect would leave the view stuck. The landing
+		// route is `root` when the content type has root properties/groups (or has no tabs),
+		// otherwise the first tab.
+		const defaultRoute =
+			this._hasRootGroups || this._hasRootProperties || this._tabs.length === 0 ? routes[routes.length - 1] : routes[0];
+		routes.push({
+			...defaultRoute,
+			path: '',
+			pathMatch: 'full',
+			guards: [() => this.#processingTabId === undefined],
+		});
 
 		if (routes.length !== 0) {
 			routes.push({
@@ -469,15 +474,17 @@ export class UmbContentTypeDesignEditorElement extends UmbLitElement implements 
 					<div id="container-list">${this.renderTabsNavigation()}</div>
 					${this.#renderActions()}
 				</div>
-				<umb-router-slot
-					.routes=${this._routes}
-					@init=${(event: UmbRouterSlotInitEvent) => {
-						this._routerPath = event.target.absoluteRouterPath;
-					}}
-					@change=${(event: UmbRouterSlotChangeEvent) => {
-						this._activePath = event.target.absoluteActiveViewPath ?? '';
-					}}>
-				</umb-router-slot>
+				${this._routes
+					? html`<umb-router-slot
+							.routes=${this._routes}
+							@init=${(event: UmbRouterSlotInitEvent) => {
+								this._routerPath = event.target.absoluteRouterPath;
+							}}
+							@change=${(event: UmbRouterSlotChangeEvent) => {
+								this._activePath = event.target.absoluteActiveViewPath ?? '';
+							}}>
+						</umb-router-slot>`
+					: nothing}
 			</umb-body-layout>
 		`;
 	}


### PR DESCRIPTION
## Description

The Design tab of a content type (Document Type, Media Type, Member Type) opened inside a modal workspace — e.g. by clicking a reference in the Data Type Info view — rendered empty until the user toggled to another workspace view and back. Three related interactions with `umb-router-slot` were involved:

- The tabs helper subscribed before the structure manager had loaded, so `#createRoutes` first ran against empty data. Now wait for `structure.whenLoaded()` before wiring up the helper.
- The router-slot mounted with `routes = undefined` and settled on the empty local path before real routes arrived; it does not re-match the URL when its routes array is replaced. The slot is now only rendered once `_routes` is populated.
- The empty-path route used `redirectTo`, which the router-slot only fires on navigation events, never on the initial route attachment. The landing route (root or first tab depending on content) is now duplicated onto the empty path — matching the pattern already used by `umb-workspace-editor`.

Also documented these three behaviours of `umb-router-slot` in `docs/edge-cases.md` so future routable views don't re-hit the same traps.

Fixes #22855

## Testing

### Manual

- [ ] Settings → Data Types → open a data type that is referenced by a document type → Info tab → click a Document Type reference → Design tab shows its properties on first render (no toggle to Structure required).
- [ ] Same flow for Media Types and Member Types.
- [ ] Settings → Document Types → open a doctype from the tree — Design tab still renders correctly for doctypes with only root groups, and for doctypes with tabs.
- [ ] Create a new doctype (Settings → Document Types → Create…) — Design tab renders immediately.
