### PR TITLE
Publishing: Add warning to scheduled publish dialog for unpublished ancestors (closes #18554)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -275,6 +275,10 @@ export default {
 		otherElements: 'Properties',
 		parentNotPublished: "This document is published but is not visible because the parent '%0%' is unpublished",
 		parentCultureNotPublished: "This culture is published but is not visible because it is unpublished on parent '%0%'",
+		ancestorNotPublishedScheduleWarning:
+			"An ancestor isn't published. The scheduled publish won't take effect until every ancestor is also published.",
+		ancestorCultureNotPublishedScheduleWarning:
+			"An ancestor isn't published in this language. The scheduled publish won't take effect until every ancestor is also published in this language.",
 		parentNotPublishedAnomaly: 'This document is published but is not in the cache',
 		getUrlException: 'Could not get the URL',
 		routeError: 'This document is published but its URL would collide with content %0%',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -244,6 +244,9 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 		if (ancestorPublishedCultures === undefined) return true;
 		// `null` entry means every ancestor is published in the invariant variant — covers all child cultures.
 		if (ancestorPublishedCultures.includes(null)) return true;
+		// An invariant child option is served wherever its ancestors are published, so any
+		// non-empty culture coverage means the schedule will take effect somewhere.
+		if (option.culture === null) return ancestorPublishedCultures.length > 0;
 		return ancestorPublishedCultures.includes(option.culture);
 	}
 
@@ -499,6 +502,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 				padding: var(--uui-size-space-2) var(--uui-size-space-3);
 				background-color: var(--uui-color-warning);
 				color: var(--uui-color-warning-contrast);
+				border: 1px solid var(--uui-color-warning-standalone);
 				border-radius: var(--uui-border-radius);
 			}
 		`,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -199,8 +199,10 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 		const pickable = this.#pickableFilter(option);
 		const fromDate = this.#fromDate(option.unique);
 		const toDate = this.#toDate(option.unique);
-		const isChanged =
-			fromDate !== option.variant?.scheduledPublishDate || toDate !== option.variant?.scheduledUnpublishDate;
+		const persistedFromDate = option.variant?.scheduledPublishDate ?? null;
+		const persistedToDate = option.variant?.scheduledUnpublishDate ?? null;
+		const isChanged = fromDate !== persistedFromDate || toDate !== persistedToDate;
+		const showAncestorWarning = pickable && !this.#ancestorsCoverVariant(option);
 
 		return html`
 			<uui-menu-item
@@ -213,6 +215,18 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 				<uui-icon slot="icon" name="icon-globe"></uui-icon>
 				${UmbDocumentVariantLanguagePickerElement.renderLabel(option)}
 			</uui-menu-item>
+			${when(
+				showAncestorWarning,
+				() => html`
+					<p class="ancestor-not-published">
+						<uui-icon name="icon-alert"></uui-icon>
+						<umb-localize
+							key=${option.culture
+								? 'content_ancestorCultureNotPublishedScheduleWarning'
+								: 'content_ancestorNotPublishedScheduleWarning'}></umb-localize>
+					</p>
+				`,
+			)}
 			${when(this.#isSelected(option.unique), () => this.#renderPublishDateInput(option, fromDate, toDate))}
 			${when(
 				isChanged,
@@ -222,6 +236,15 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 					</p>`,
 			)}
 		`;
+	}
+
+	#ancestorsCoverVariant(option: UmbDocumentVariantOptionModel): boolean {
+		const ancestorPublishedCultures = this.data?.ancestorPublishedCultures;
+		// Undefined means root document or lookup unavailable — render no warning.
+		if (ancestorPublishedCultures === undefined) return true;
+		// `null` entry means every ancestor is published in the invariant variant — covers all child cultures.
+		if (ancestorPublishedCultures.includes(null)) return true;
+		return ancestorPublishedCultures.includes(option.culture);
 	}
 
 	#attachValidatorsToPublish(element: UmbInputDateElement | null) {
@@ -466,6 +489,17 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 
 			uui-menu-item {
 				--uui-menu-item-flat-structure: 1;
+			}
+
+			.ancestor-not-published {
+				display: flex;
+				align-items: center;
+				gap: var(--uui-size-space-2);
+				margin: 0 0 var(--uui-size-space-2);
+				padding: var(--uui-size-space-2) var(--uui-size-space-3);
+				background-color: var(--uui-color-warning);
+				color: var(--uui-color-warning-contrast);
+				border-radius: var(--uui-border-radius);
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.token.ts
@@ -12,6 +12,16 @@ export interface UmbDocumentScheduleSelectionModel {
 export interface UmbDocumentScheduleModalData extends UmbDocumentVariantPickerData {
 	activeVariants: Array<string>;
 	prevalues: Array<UmbDocumentScheduleSelectionModel>;
+	/**
+	 * Cultures published across the entire ancestor chain — i.e. the intersection of
+	 * each ancestor's published cultures. Used to warn when a scheduled publish won't
+	 * take effect because an ancestor isn't published in that culture.
+	 *
+	 * - `undefined` — root document or lookup unavailable; no warnings rendered.
+	 * - `[null]` — every ancestor is published in the invariant variant (covers all child cultures).
+	 * - `[]` — no culture is published in every ancestor; every variant is warned.
+	 */
+	ancestorPublishedCultures?: Array<string | null>;
 }
 
 export interface UmbDocumentScheduleModalValue {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/utils.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/utils.test.ts
@@ -1,0 +1,118 @@
+import { expect } from '@open-wc/testing';
+import { computeAncestorPublishedCultures, type UmbAncestorForCoverage } from './utils.js';
+import { UmbDocumentVariantState } from '../variant-state.js';
+
+const ancestor = (...variants: Array<{ culture: string | null; state: UmbDocumentVariantState }>): UmbAncestorForCoverage => ({
+	variants,
+});
+
+describe('computeAncestorPublishedCultures', () => {
+	it('returns undefined for an empty ancestor chain (root document)', () => {
+		expect(computeAncestorPublishedCultures([])).to.equal(undefined);
+	});
+
+	it('returns [null] when the single ancestor is invariant-published', () => {
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: null, state: UmbDocumentVariantState.PUBLISHED }),
+		]);
+		expect(result).to.deep.equal([null]);
+	});
+
+	it('returns [] when the single ancestor has no published variant', () => {
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: null, state: UmbDocumentVariantState.DRAFT }),
+		]);
+		expect(result).to.deep.equal([]);
+	});
+
+	it('returns the culture for a single variant ancestor published in one culture', () => {
+		const result = computeAncestorPublishedCultures([
+			ancestor(
+				{ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED },
+				{ culture: 'da-DK', state: UmbDocumentVariantState.DRAFT },
+			),
+		]);
+		expect(result).to.have.members(['en-US']);
+		expect(result).to.have.lengthOf(1);
+	});
+
+	it('returns every published culture for a single variant ancestor', () => {
+		const result = computeAncestorPublishedCultures([
+			ancestor(
+				{ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED },
+				{ culture: 'da-DK', state: UmbDocumentVariantState.PUBLISHED },
+			),
+		]);
+		expect(result).to.have.members(['en-US', 'da-DK']);
+		expect(result).to.have.lengthOf(2);
+	});
+
+	it('counts PublishedPendingChanges as published', () => {
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED_PENDING_CHANGES }),
+		]);
+		expect(result).to.have.members(['en-US']);
+	});
+
+	it('excludes Draft and NotCreated variants', () => {
+		const result = computeAncestorPublishedCultures([
+			ancestor(
+				{ culture: 'en-US', state: UmbDocumentVariantState.DRAFT },
+				{ culture: 'da-DK', state: UmbDocumentVariantState.NOT_CREATED },
+			),
+		]);
+		expect(result).to.deep.equal([]);
+	});
+
+	it('intersects published cultures across the chain', () => {
+		// Grandparent publishes en-US, parent publishes en-US AND da-DK.
+		// Only en-US is published in every ancestor.
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED }),
+			ancestor(
+				{ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED },
+				{ culture: 'da-DK', state: UmbDocumentVariantState.PUBLISHED },
+			),
+		]);
+		expect(result).to.have.members(['en-US']);
+		expect(result).to.have.lengthOf(1);
+	});
+
+	it('returns [] when the intersection is empty', () => {
+		// Grandparent only publishes en-US, parent only publishes da-DK.
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED }),
+			ancestor({ culture: 'da-DK', state: UmbDocumentVariantState.PUBLISHED }),
+		]);
+		expect(result).to.deep.equal([]);
+	});
+
+	it('ignores invariant-published ancestors when intersecting (they add no constraint)', () => {
+		// Grandparent is invariant-published; parent publishes only en-US.
+		// Only en-US should be covered (parent constrains it).
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: null, state: UmbDocumentVariantState.PUBLISHED }),
+			ancestor({ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED }),
+		]);
+		expect(result).to.have.members(['en-US']);
+		expect(result).to.have.lengthOf(1);
+	});
+
+	it('returns [null] when every ancestor is invariant-published', () => {
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: null, state: UmbDocumentVariantState.PUBLISHED }),
+			ancestor({ culture: null, state: UmbDocumentVariantState.PUBLISHED }),
+		]);
+		expect(result).to.deep.equal([null]);
+	});
+
+	it('returns [] when any ancestor in the chain has nothing published', () => {
+		// Middle ancestor has no published cultures — breaks the chain entirely.
+		const result = computeAncestorPublishedCultures([
+			ancestor({ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED }),
+			ancestor({ culture: 'en-US', state: UmbDocumentVariantState.DRAFT }),
+			ancestor({ culture: 'en-US', state: UmbDocumentVariantState.PUBLISHED }),
+		]);
+		expect(result).to.deep.equal([]);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/utils.ts
@@ -13,3 +13,63 @@ export function isNotPublishedMandatory(option: UmbDocumentVariantOptionModel): 
 		option.variant?.state !== UmbDocumentVariantState.PUBLISHED_PENDING_CHANGES
 	);
 }
+
+/**
+ * Minimal shape required by {@link computeAncestorPublishedCultures}.
+ * Picks out only the fields needed for the intersection so the helper can be
+ * unit-tested without binding to the full API model.
+ */
+export interface UmbAncestorVariantForCoverage {
+	culture: string | null;
+	state?: UmbDocumentVariantState | string | null;
+}
+export interface UmbAncestorForCoverage {
+	variants: ReadonlyArray<UmbAncestorVariantForCoverage>;
+}
+
+/**
+ * Computes which cultures are published across every ancestor in the supplied chain.
+ *
+ * For a scheduled publish to take effect on a child variant, every ancestor must be
+ * published in that culture. A variant counts as "published" if its state is
+ * `Published` or `PublishedPendingChanges`. An ancestor with the invariant variant
+ * published (culture === null) covers every child culture and adds no constraint.
+ * @param ancestors The ordered list of ancestors (any order works — the result is an intersection).
+ * @returns
+ *  - `undefined` when there are no ancestors (root document) — the caller renders no warning;
+ *  - `[null]` when no ancestor adds a constraint (every ancestor is invariant-published) — covers all child cultures;
+ *  - otherwise the cultures published in every ancestor.
+ */
+export function computeAncestorPublishedCultures(
+	ancestors: ReadonlyArray<UmbAncestorForCoverage>,
+): Array<string | null> | undefined {
+	if (ancestors.length === 0) return undefined;
+
+	let covered: Set<string | null> | undefined;
+
+	for (const ancestor of ancestors) {
+		const ancestorPublished: Array<string | null> = ancestor.variants
+			.filter(
+				(variant) =>
+					variant.state === UmbDocumentVariantState.PUBLISHED ||
+					variant.state === UmbDocumentVariantState.PUBLISHED_PENDING_CHANGES,
+			)
+			.map((variant) => variant.culture);
+
+		// An invariant-published ancestor (null entry) covers every child culture — no constraint added.
+		if (ancestorPublished.includes(null)) continue;
+
+		const ancestorSet = new Set<string | null>(ancestorPublished);
+		if (covered === undefined) {
+			covered = ancestorSet;
+		} else {
+			const intersection = new Set<string | null>();
+			for (const culture of covered) {
+				if (ancestorSet.has(culture)) intersection.add(culture);
+			}
+			covered = intersection;
+		}
+	}
+
+	return covered === undefined ? [null] : Array.from(covered);
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -26,6 +26,8 @@ import {
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
+import { DocumentService } from '@umbraco-cms/backoffice/external/backend-api';
+import { tryExecute } from '@umbraco-cms/backoffice/resources';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
 import type { UmbPublishableWorkspaceContext } from '@umbraco-cms/backoffice/workspace';
@@ -128,6 +130,8 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		const { options, selected } = await this.#determineVariantOptions();
 
+		const ancestorPublishedCultures = await this.#getAncestorPublishedCultures(unique);
+
 		const result = await umbOpenModal(this, UMB_DOCUMENT_SCHEDULE_MODAL, {
 			data: {
 				options,
@@ -140,6 +144,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 						unpublishTime: option.variant?.scheduledUnpublishDate,
 					},
 				})),
+				ancestorPublishedCultures,
 			},
 		}).catch(() => undefined);
 
@@ -418,6 +423,59 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 			const event = new UmbRequestReloadStructureForEntityEvent({ unique, entityType });
 			this.#eventContext?.dispatchEvent(event);
 		}
+	}
+
+	/**
+	 * Computes which cultures are published across the entire ancestor chain of the
+	 * current document, so the schedule dialog can warn for child variants that won't
+	 * become visible because an ancestor isn't yet published in that culture.
+	 *
+	 * For a scheduled publish to take effect, every ancestor must be published in the
+	 * scheduled culture — so the result is the intersection of each ancestor's published
+	 * cultures.
+	 * @param unique The unique of the document being scheduled.
+	 * @returns `undefined` for root documents or when the lookup is unavailable;
+	 *  `[null]` when every ancestor is published in the invariant variant (covers all child cultures);
+	 *  otherwise the list of cultures published in every ancestor.
+	 */
+	async #getAncestorPublishedCultures(unique: string): Promise<Array<string | null> | undefined> {
+		const { data, error } = await tryExecute(
+			this,
+			DocumentService.getItemDocumentAncestors({ query: { id: [unique] } }),
+		);
+		if (error || !data) return undefined;
+
+		const ancestors = data.find((entry) => entry.id === unique)?.ancestors ?? [];
+		if (ancestors.length === 0) return undefined; // root document — nothing above to block publishing
+
+		// Start as "covers all cultures" (covered = undefined) and intersect each ancestor's published cultures.
+		let covered: Set<string | null> | undefined;
+
+		for (const ancestor of ancestors) {
+			const ancestorPublished: Array<string | null> = ancestor.variants
+				.filter(
+					(variant) =>
+						variant.state === UmbDocumentVariantState.PUBLISHED ||
+						variant.state === UmbDocumentVariantState.PUBLISHED_PENDING_CHANGES,
+				)
+				.map((variant) => variant.culture ?? null);
+
+			// An invariant-published ancestor (null entry) covers every child culture — no constraint added.
+			if (ancestorPublished.includes(null)) continue;
+
+			const ancestorSet = new Set<string | null>(ancestorPublished);
+			if (covered === undefined) {
+				covered = ancestorSet;
+			} else {
+				const intersection = new Set<string | null>();
+				for (const culture of covered) {
+					if (ancestorSet.has(culture)) intersection.add(culture);
+				}
+				covered = intersection;
+			}
+		}
+
+		return covered === undefined ? [null] : Array.from(covered);
 	}
 
 	#publishableVariantsFilter = (option: UmbDocumentVariantOptionModel) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../types.js';
 import { UmbDocumentPublishingRepository } from '../repository/index.js';
 import { UmbDocumentPublishedPendingChangesManager } from '../pending-changes/index.js';
+import { computeAncestorPublishedCultures } from '../utils.js';
 import { UMB_DOCUMENT_SCHEDULE_MODAL } from '../schedule-publish/constants.js';
 import { UMB_DOCUMENT_PUBLISH_WITH_DESCENDANTS_MODAL } from '../publish-with-descendants/constants.js';
 import { UMB_DOCUMENT_PUBLISH_MODAL } from '../publish/constants.js';
@@ -128,9 +129,10 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		const entityType = this.#documentWorkspaceContext.getEntityType();
 		if (!entityType) throw new Error('Entity type is missing');
 
-		const { options, selected } = await this.#determineVariantOptions();
-
-		const ancestorPublishedCultures = await this.#getAncestorPublishedCultures(unique);
+		const [{ options, selected }, ancestorPublishedCultures] = await Promise.all([
+			this.#determineVariantOptions(),
+			this.#getAncestorPublishedCultures(unique),
+		]);
 
 		const result = await umbOpenModal(this, UMB_DOCUMENT_SCHEDULE_MODAL, {
 			data: {
@@ -426,17 +428,10 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 	}
 
 	/**
-	 * Computes which cultures are published across the entire ancestor chain of the
-	 * current document, so the schedule dialog can warn for child variants that won't
-	 * become visible because an ancestor isn't yet published in that culture.
-	 *
-	 * For a scheduled publish to take effect, every ancestor must be published in the
-	 * scheduled culture — so the result is the intersection of each ancestor's published
-	 * cultures.
+	 * Fetches the ancestor chain of the current document and delegates to
+	 * {@link computeAncestorPublishedCultures} to derive which cultures are
+	 * published across every ancestor.
 	 * @param unique The unique of the document being scheduled.
-	 * @returns `undefined` for root documents or when the lookup is unavailable;
-	 *  `[null]` when every ancestor is published in the invariant variant (covers all child cultures);
-	 *  otherwise the list of cultures published in every ancestor.
 	 */
 	async #getAncestorPublishedCultures(unique: string): Promise<Array<string | null> | undefined> {
 		const { data, error } = await tryExecute(
@@ -446,36 +441,14 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 		if (error || !data) return undefined;
 
 		const ancestors = data.find((entry) => entry.id === unique)?.ancestors ?? [];
-		if (ancestors.length === 0) return undefined; // root document — nothing above to block publishing
-
-		// Start as "covers all cultures" (covered = undefined) and intersect each ancestor's published cultures.
-		let covered: Set<string | null> | undefined;
-
-		for (const ancestor of ancestors) {
-			const ancestorPublished: Array<string | null> = ancestor.variants
-				.filter(
-					(variant) =>
-						variant.state === UmbDocumentVariantState.PUBLISHED ||
-						variant.state === UmbDocumentVariantState.PUBLISHED_PENDING_CHANGES,
-				)
-				.map((variant) => variant.culture ?? null);
-
-			// An invariant-published ancestor (null entry) covers every child culture — no constraint added.
-			if (ancestorPublished.includes(null)) continue;
-
-			const ancestorSet = new Set<string | null>(ancestorPublished);
-			if (covered === undefined) {
-				covered = ancestorSet;
-			} else {
-				const intersection = new Set<string | null>();
-				for (const culture of covered) {
-					if (ancestorSet.has(culture)) intersection.add(culture);
-				}
-				covered = intersection;
-			}
-		}
-
-		return covered === undefined ? [null] : Array.from(covered);
+		return computeAncestorPublishedCultures(
+			ancestors.map((ancestor) => ({
+				variants: ancestor.variants.map((variant) => ({
+					culture: variant.culture ?? null,
+					state: variant.state,
+				})),
+			})),
+		);
 	}
 
 	#publishableVariantsFilter = (option: UmbDocumentVariantOptionModel) => {


### PR DESCRIPTION
## Description

Currently if you schedule publishing for a node there is no warning if it is under an unpublished parent node, and as such won't actually be published when the scheduled time arrives.

Being able to schedule seems fine - could be you'll continue that task and then go and publish the necessary ancestor.  But the issue raised is around being able to let the editor now.

This PR adds that features, so a warning will be displayed if the document, or document language variant, is not published in all the ancestor documents.

Fixes #18554.

## Testing

Schedule publishing on a in invariant node that has an unpublished parent or higher ancestor, and verify that the following warning is shown:

<img width="865" height="431" alt="image" src="https://github.com/user-attachments/assets/31243f81-9534-4271-90f4-5e0e027a60f6" />

Similarly do the same for variant content, noting that the warning is shown for any language that isn't published in all ancestors:

<img width="1003" height="613" alt="image" src="https://github.com/user-attachments/assets/15f078bf-7666-465b-8af9-e6755a7c9c5e" />




