### PR TITLE
Variants: Fix per-keystroke lag in workspace editor (closes #22910)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -107,8 +107,8 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 
 	#generateRoutes() {
 		this._routes = buildDocumentWorkspaceRoutes({
-			variants: this.#variants ?? [],
-			appCulture: this.#appCulture,
+			getVariants: () => this.#variants ?? [],
+			getAppCulture: () => this.#appCulture,
 			splitViewComponent: this._splitViewElement,
 			splitView: this.#workspaceContext?.splitView,
 			getWorkspaceRoute: () => this.#workspaceRoute,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -1,6 +1,7 @@
 import type { UmbDocumentVariantOptionModel } from '../types.js';
 import { UmbDocumentWorkspaceSplitViewElement } from './document-workspace-split-view.element.js';
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from './context/document-workspace.context-token.js';
+import { buildDocumentWorkspaceRoutes } from './document-workspace-editor.routes.js';
 import { customElement, state, css, html } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
@@ -105,98 +106,13 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 	}
 
 	#generateRoutes() {
-		if (!this.#variants || this.#variants.length === 0 || !this.#appCulture) {
-			this._routes = [];
-			this.#ensureForbiddenRoute(this._routes);
-			return;
-		}
-
-		// Generate split view routes for all available routes
-		const routes: Array<UmbRoute> = [];
-
-		// Split view routes:
-		this.#variants.forEach((variantA) => {
-			this.#variants!.forEach((variantB) => {
-				routes.push({
-					// TODO: When implementing Segments, be aware if using the unique still is URL Safe, cause its most likely not... [NL]
-					path: variantA.unique + '_&_' + variantB.unique,
-					preserveQuery: true,
-					component: this._splitViewElement,
-					setup: (_component, info) => {
-						// Set split view/active info..
-						this.#workspaceContext?.splitView.setVariantParts(info.match.fragments.consumed);
-					},
-				});
-			});
-		});
-
-		// Single view:
-		this.#variants.forEach((variant) => {
-			routes.push({
-				// TODO: When implementing Segments, be aware if using the unique still is URL Safe, cause its most likely not... [NL]
-				path: variant.unique,
-				preserveQuery: true,
-				component: this._splitViewElement,
-				setup: (_component, info) => {
-					// cause we might come from a split-view, we need to reset index 1.
-					this.#workspaceContext?.splitView.removeActiveVariant(1);
-					this.#workspaceContext?.splitView.handleVariantFolderPart(0, info.match.fragments.consumed);
-				},
-			});
-		});
-
-		if (routes.length !== 0) {
-			// Using first single view as the default route for now (hence the math below):
-			routes.push({
-				path: '',
-				preserveQuery: true,
-				pathMatch: 'full',
-				resolve: async () => {
-					if (!this.#workspaceContext) {
-						throw new Error('Workspace context is not available when resolving the default route.');
-					}
-
-					// get current get variables from url, and check if openCollection is set:
-					const urlSearchParams = new URLSearchParams(window.location.search);
-					const openCollection = urlSearchParams.has('openCollection');
-
-					// Is there a path matching the current culture?
-					let path = routes.find((route) => route.path === this.#appCulture)?.path;
-
-					if (!path) {
-						// if not is there then a path matching the first variant unique.
-						path = routes.find((route) => route.path === this.#variants?.[0]?.unique)?.path;
-					}
-
-					if (!path) {
-						// If not is there then a path matching the first variant unique that is not a culture.
-						// TODO: Notice: here is a specific index used for fallback, this could be made more solid [NL]
-						path = routes[routes.length - 3].path;
-					}
-
-					history.replaceState({}, '', `${this.#workspaceRoute}/${path}${openCollection ? `/view/collection` : ''}`);
-				},
-			});
-		}
-
-		this.#ensureForbiddenRoute(routes);
-
-		this._routes = routes;
-	}
-
-	/**
-	 * Ensure that there is a route to handle forbidden access.
-	 * This route will display a forbidden message when the user does not have permission to access certain resources.
-	 * Also handles not found routes.
-	 * @param routes
-	 */
-	#ensureForbiddenRoute(routes: Array<UmbRoute> = []) {
-		routes.push({
-			path: '**',
-			component: async () => {
-				const router = await import('@umbraco-cms/backoffice/router');
-				return this.#isForbidden ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
-			},
+		this._routes = buildDocumentWorkspaceRoutes({
+			variants: this.#variants ?? [],
+			appCulture: this.#appCulture,
+			splitViewComponent: this._splitViewElement,
+			splitView: this.#workspaceContext?.splitView,
+			getWorkspaceRoute: () => this.#workspaceRoute,
+			getIsForbidden: () => this.#isForbidden,
 		});
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.test.ts
@@ -1,0 +1,325 @@
+import { expect } from '@open-wc/testing';
+import { buildDocumentWorkspaceRoutes } from './document-workspace-editor.routes.js';
+import type { UmbDocumentVariantOptionModel } from '../types.js';
+import type { UmbWorkspaceSplitViewManager } from '@umbraco-cms/backoffice/workspace';
+import type { UmbRoute } from '@umbraco-cms/backoffice/router';
+
+type SplitViewCall = { method: string; args: unknown[] };
+
+function createSplitViewStub() {
+	const calls: SplitViewCall[] = [];
+	const stub = {
+		calls,
+		setVariantParts: (...args: unknown[]) => calls.push({ method: 'setVariantParts', args }),
+		handleVariantFolderPart: (...args: unknown[]) => calls.push({ method: 'handleVariantFolderPart', args }),
+		removeActiveVariant: (...args: unknown[]) => calls.push({ method: 'removeActiveVariant', args }),
+	};
+	return stub as unknown as UmbWorkspaceSplitViewManager & { calls: SplitViewCall[] };
+}
+
+function makeVariant(unique: string, culture: string | null, segment: string | null = null): UmbDocumentVariantOptionModel {
+	return { unique, culture, segment } as UmbDocumentVariantOptionModel;
+}
+
+function findDynamicRoute(routes: Array<UmbRoute>): UmbRoute {
+	const route = routes.find((r) => r.path === ':variantPath');
+	if (!route) throw new Error('Expected a :variantPath route');
+	return route;
+}
+
+function findDefaultRoute(routes: Array<UmbRoute>): UmbRoute {
+	const route = routes.find((r) => r.path === '' && r.pathMatch === 'full');
+	if (!route) throw new Error('Expected an empty-path full-match default route');
+	return route;
+}
+
+function callSetup(route: UmbRoute, consumed: string) {
+	const info = { match: { fragments: { consumed, rest: '' }, params: {}, match: [] as unknown, route } } as any;
+	const setup = (route as unknown as { setup: (component: any, info: any) => void }).setup;
+	setup(undefined, info);
+}
+
+describe('buildDocumentWorkspaceRoutes', () => {
+	const splitViewComponent = document.createElement('div');
+
+	describe('route count', () => {
+		it('returns exactly three routes for a small variant set', () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/workspace/document/edit/x',
+				getIsForbidden: () => false,
+			});
+			expect(routes).to.have.lengthOf(3);
+		});
+
+		it('returns the same constant route count regardless of variant count (regression guard for n²)', () => {
+			const small = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			const large = buildDocumentWorkspaceRoutes({
+				variants: Array.from({ length: 200 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
+				appCulture: 'v0',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			expect(small.length).to.equal(large.length);
+			expect(large.length).to.equal(3);
+		});
+
+		it('does not generate any "_&_" route paths (regression guard for split-view pairs)', () => {
+			const variants = Array.from({ length: 50 }, (_v, i) => makeVariant(`v${i}`, `c${i}`));
+			const routes = buildDocumentWorkspaceRoutes({
+				variants,
+				appCulture: 'v0',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			for (const r of routes) {
+				expect(r.path ?? '').to.not.include('_&_');
+			}
+		});
+	});
+
+	describe('dynamic route shape', () => {
+		const routes = buildDocumentWorkspaceRoutes({
+			variants: [makeVariant('en', 'en')],
+			appCulture: 'en',
+			splitViewComponent,
+			splitView: createSplitViewStub(),
+			getWorkspaceRoute: () => '/x',
+			getIsForbidden: () => false,
+		});
+		const dynamic = findDynamicRoute(routes);
+
+		it('has path ":variantPath"', () => {
+			expect(dynamic.path).to.equal(':variantPath');
+		});
+
+		it('reuses the supplied split-view component instance', () => {
+			expect((dynamic as { component?: unknown }).component).to.equal(splitViewComponent);
+		});
+
+		it('has preserveQuery true', () => {
+			expect((dynamic as { preserveQuery?: boolean }).preserveQuery).to.equal(true);
+		});
+
+		it('has a setup callback', () => {
+			expect(typeof (dynamic as unknown as { setup?: unknown }).setup).to.equal('function');
+		});
+	});
+
+	describe('setup callback', () => {
+		it('treats a single-variant fragment as single-view (removeActiveVariant(1) then handleVariantFolderPart(0, fragment))', () => {
+			const splitView = createSplitViewStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			callSetup(findDynamicRoute(routes), 'en');
+
+			expect(splitView.calls).to.deep.equal([
+				{ method: 'removeActiveVariant', args: [1] },
+				{ method: 'handleVariantFolderPart', args: [0, 'en'] },
+			]);
+		});
+
+		it('treats a "_&_" fragment as split-view (setVariantParts with the consumed fragment)', () => {
+			const splitView = createSplitViewStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			callSetup(findDynamicRoute(routes), 'en_&_da');
+
+			expect(splitView.calls).to.deep.equal([{ method: 'setVariantParts', args: ['en_&_da'] }]);
+		});
+
+		it('handles segment-suffixed uniques on both sides of the delimiter', () => {
+			const splitView = createSplitViewStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en_segA', 'en', 'segA'), makeVariant('da_segB', 'da', 'segB')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			callSetup(findDynamicRoute(routes), 'en_segA_&_da_segB');
+
+			expect(splitView.calls).to.deep.equal([{ method: 'setVariantParts', args: ['en_segA_&_da_segB'] }]);
+		});
+	});
+
+	describe('default route resolve', () => {
+		let originalReplaceState: typeof history.replaceState;
+		let replaceStateCalls: Array<{ url: string }>;
+
+		beforeEach(() => {
+			replaceStateCalls = [];
+			originalReplaceState = history.replaceState.bind(history);
+			history.replaceState = ((_state: unknown, _title: string, url?: string) => {
+				replaceStateCalls.push({ url: String(url ?? '') });
+			}) as typeof history.replaceState;
+		});
+
+		afterEach(() => {
+			history.replaceState = originalReplaceState;
+		});
+
+		it('redirects to the variant whose unique matches the app culture', async () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/workspace/document/edit/x',
+				getIsForbidden: () => false,
+			});
+			await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
+
+			expect(replaceStateCalls).to.have.lengthOf(1);
+			expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en');
+		});
+
+		it('falls back to the first variant when the app culture has no exact-match unique', async () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				appCulture: 'fr',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/workspace/document/edit/x',
+				getIsForbidden: () => false,
+			});
+			await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
+
+			expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en');
+		});
+
+		it('falls back to the first variant when only segment-suffixed variants exist for the app culture', async () => {
+			// app culture "en" but there is no variant with unique==="en" — only "en_segA".
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en_segA', 'en', 'segA'), makeVariant('da', 'da')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/workspace/document/edit/x',
+				getIsForbidden: () => false,
+			});
+			await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
+
+			expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en_segA');
+		});
+
+		it('appends "/view/collection" when ?openCollection is set on the URL', async () => {
+			// Use the real history.pushState to put ?openCollection on the URL; history.replaceState
+			// is stubbed in beforeEach so the resolve() call won't actually navigate.
+			const originalUrl = window.location.href;
+			history.pushState({}, '', '?openCollection');
+			try {
+				const routes = buildDocumentWorkspaceRoutes({
+					variants: [makeVariant('en', 'en')],
+					appCulture: 'en',
+					splitViewComponent,
+					splitView: createSplitViewStub(),
+					getWorkspaceRoute: () => '/workspace/document/edit/x',
+					getIsForbidden: () => false,
+				});
+				await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
+				expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en/view/collection');
+			} finally {
+				history.pushState({}, '', originalUrl);
+			}
+		});
+
+		it('throws when no workspace route is available', async () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => undefined,
+				getIsForbidden: () => false,
+			});
+			let threw: unknown = null;
+			try {
+				await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
+			} catch (e) {
+				threw = e;
+			}
+			expect(threw).to.be.an.instanceOf(Error);
+		});
+	});
+
+	describe('catch-all fallback', () => {
+		it('returns only the forbidden catch-all when no variants are available', () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			expect(routes).to.have.lengthOf(1);
+			expect(routes[0].path).to.equal('**');
+		});
+
+		it('returns only the forbidden catch-all when no app culture is set yet', () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: undefined,
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			expect(routes).to.have.lengthOf(1);
+			expect(routes[0].path).to.equal('**');
+		});
+
+		it('returns only the forbidden catch-all when no split view manager is available', () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: undefined,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			expect(routes).to.have.lengthOf(1);
+			expect(routes[0].path).to.equal('**');
+		});
+
+		it('always ends with a "**" catch-all route', () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			expect(routes[routes.length - 1].path).to.equal('**');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.test.ts
@@ -6,6 +6,8 @@ import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 
 type SplitViewCall = { method: string; args: unknown[] };
 
+const DEFAULT_WORKSPACE_ROUTE = '/workspace/document/edit/x';
+
 function createSplitViewStub() {
 	const calls: SplitViewCall[] = [];
 	const stub = {
@@ -15,6 +17,14 @@ function createSplitViewStub() {
 		removeActiveVariant: (...args: unknown[]) => calls.push({ method: 'removeActiveVariant', args }),
 	};
 	return stub as unknown as UmbWorkspaceSplitViewManager & { calls: SplitViewCall[] };
+}
+
+function createSplitViewComponentStub(): HTMLElement {
+	return document.createElement('div');
+}
+
+function makeSlot(workspaceRoute: string = DEFAULT_WORKSPACE_ROUTE) {
+	return { constructAbsolutePath: () => workspaceRoute };
 }
 
 function makeVariant(unique: string, culture: string | null, segment: string | null = null): UmbDocumentVariantOptionModel {
@@ -42,17 +52,24 @@ async function callResolve(route: UmbRoute, consumed: string, slot: HTMLElement)
 	await resolve(info);
 }
 
-describe('buildDocumentWorkspaceRoutes', () => {
-	const splitViewComponent = document.createElement('div');
+async function callDefaultResolve(
+	route: UmbRoute,
+	slot: { constructAbsolutePath: () => string } = makeSlot(),
+) {
+	const info = { slot, match: { fragments: { consumed: '', rest: '' }, params: {}, match: [] as unknown, route } } as any;
+	const resolve = (route as unknown as { resolve: (info: any) => Promise<void> }).resolve;
+	await resolve(info);
+}
 
+describe('buildDocumentWorkspaceRoutes', () => {
 	describe('route count', () => {
 		it('returns exactly three routes for a small variant set', () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
-				getWorkspaceRoute: () => '/workspace/document/edit/x',
+				getWorkspaceRoute: () => DEFAULT_WORKSPACE_ROUTE,
 				getIsForbidden: () => false,
 			});
 			expect(routes).to.have.lengthOf(3);
@@ -60,17 +77,17 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('returns the same constant route count regardless of variant count (regression guard for n²)', () => {
 			const small = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
 			});
 			const large = buildDocumentWorkspaceRoutes({
-				variants: Array.from({ length: 200 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
-				appCulture: 'v0',
-				splitViewComponent,
+				getVariants: () => Array.from({ length: 200 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
+				getAppCulture: () => 'v0',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -82,9 +99,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 		it('does not generate any "_&_" route paths', () => {
 			const variants = Array.from({ length: 50 }, (_v, i) => makeVariant(`v${i}`, `c${i}`));
 			const routes = buildDocumentWorkspaceRoutes({
-				variants,
-				appCulture: 'v0',
-				splitViewComponent,
+				getVariants: () => variants,
+				getAppCulture: () => 'v0',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -96,15 +113,20 @@ describe('buildDocumentWorkspaceRoutes', () => {
 	});
 
 	describe('dynamic route shape', () => {
-		const routes = buildDocumentWorkspaceRoutes({
-			variants: [makeVariant('en', 'en')],
-			appCulture: 'en',
-			splitViewComponent,
-			splitView: createSplitViewStub(),
-			getWorkspaceRoute: () => '/x',
-			getIsForbidden: () => false,
+		let routes: Array<UmbRoute>;
+		let dynamic: UmbRoute;
+
+		beforeEach(() => {
+			routes = buildDocumentWorkspaceRoutes({
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			dynamic = findDynamicRoute(routes);
 		});
-		const dynamic = findDynamicRoute(routes);
 
 		it('has path ":variantPath"', () => {
 			expect(dynamic.path).to.equal(':variantPath');
@@ -123,9 +145,10 @@ describe('buildDocumentWorkspaceRoutes', () => {
 	describe('resolve callback — valid variants', () => {
 		it('mounts the split-view component and calls handleVariantFolderPart for a single-variant path', async () => {
 			const splitView = createSplitViewStub();
+			const splitViewComponent = createSplitViewComponentStub();
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: 'en',
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
 				splitViewComponent,
 				splitView,
 				getWorkspaceRoute: () => '/x',
@@ -143,9 +166,10 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('mounts the split-view component and calls setVariantParts for a "_&_" path', async () => {
 			const splitView = createSplitViewStub();
+			const splitViewComponent = createSplitViewComponentStub();
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				appCulture: 'en',
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => 'en',
 				splitViewComponent,
 				splitView,
 				getWorkspaceRoute: () => '/x',
@@ -160,9 +184,10 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('reuses the split-view component when it is already mounted', async () => {
 			const splitView = createSplitViewStub();
+			const splitViewComponent = createSplitViewComponentStub();
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				appCulture: 'en',
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => 'en',
 				splitViewComponent,
 				splitView,
 				getWorkspaceRoute: () => '/x',
@@ -179,9 +204,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 		it('handles segment-suffixed uniques on both sides of the delimiter', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en_segA', 'en', 'segA'), makeVariant('da_segB', 'da', 'segB')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en_segA', 'en', 'segA'), makeVariant('da_segB', 'da', 'segB')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView,
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -197,9 +222,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 		it('mounts UmbRouteNotFoundElement when the consumed fragment is unknown', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView,
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -214,9 +239,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 		it('mounts UmbRouteForbiddenElement when isForbidden is true', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView,
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => true,
@@ -230,9 +255,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 		it('mounts NotFound when only one side of a split-view path is unknown', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView,
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -246,9 +271,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('reuses an already-mounted NotFound element', async () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -259,6 +284,66 @@ describe('buildDocumentWorkspaceRoutes', () => {
 			await callResolve(findDynamicRoute(routes), 'still-nonsense', slot);
 
 			expect(slot.firstChild).to.equal(firstNotFound);
+		});
+	});
+
+	describe('resolvers read variants and appCulture at call time, not at build time', () => {
+		// Guards against the umb-router-slot dedup: when route paths are unchanged, the underlying
+		// router keeps the original route objects. If callbacks captured variants/appCulture as
+		// values, subsequent variant or language changes would be invisible to the resolvers.
+
+		it('dynamic resolver sees a newly added variant', async () => {
+			const variants: Array<UmbDocumentVariantOptionModel> = [makeVariant('en', 'en')];
+			const splitView = createSplitViewStub();
+			const splitViewComponent = createSplitViewComponentStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				getVariants: () => variants,
+				getAppCulture: () => 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+
+			// Simulate a variant added after the route table is built.
+			variants.push(makeVariant('da', 'da'));
+
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'da', slot);
+
+			expect(slot.firstChild).to.equal(splitViewComponent);
+			expect(splitView.calls).to.deep.equal([
+				{ method: 'removeActiveVariant', args: [1] },
+				{ method: 'handleVariantFolderPart', args: [0, 'da'] },
+			]);
+		});
+
+		it('default resolver picks the variant matching the current app culture', async () => {
+			let appCulture: string | undefined = 'en';
+			const routes = buildDocumentWorkspaceRoutes({
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => appCulture,
+				splitViewComponent: createSplitViewComponentStub(),
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => DEFAULT_WORKSPACE_ROUTE,
+				getIsForbidden: () => false,
+			});
+
+			const replaceStateCalls: Array<{ url: string }> = [];
+			const originalReplaceState = history.replaceState.bind(history);
+			history.replaceState = ((_s: unknown, _t: string, url?: string) => {
+				replaceStateCalls.push({ url: String(url ?? '') });
+			}) as typeof history.replaceState;
+
+			try {
+				// Simulate the user switching app language after the routes were built.
+				appCulture = 'da';
+				await callDefaultResolve(findDefaultRoute(routes));
+			} finally {
+				history.replaceState = originalReplaceState;
+			}
+
+			expect(replaceStateCalls[0].url).to.equal(`${DEFAULT_WORKSPACE_ROUTE}/da`);
 		});
 	});
 
@@ -280,31 +365,31 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('redirects to the variant whose unique matches the app culture', async () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
-				getWorkspaceRoute: () => '/workspace/document/edit/x',
+				getWorkspaceRoute: () => DEFAULT_WORKSPACE_ROUTE,
 				getIsForbidden: () => false,
 			});
-			await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
+			await callDefaultResolve(findDefaultRoute(routes));
 
 			expect(replaceStateCalls).to.have.lengthOf(1);
-			expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en');
+			expect(replaceStateCalls[0].url).to.equal(`${DEFAULT_WORKSPACE_ROUTE}/en`);
 		});
 
 		it('falls back to the first variant when the app culture has no exact-match unique', async () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				appCulture: 'fr',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getAppCulture: () => 'fr',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
-				getWorkspaceRoute: () => '/workspace/document/edit/x',
+				getWorkspaceRoute: () => DEFAULT_WORKSPACE_ROUTE,
 				getIsForbidden: () => false,
 			});
-			await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
+			await callDefaultResolve(findDefaultRoute(routes));
 
-			expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en');
+			expect(replaceStateCalls[0].url).to.equal(`${DEFAULT_WORKSPACE_ROUTE}/en`);
 		});
 
 		it('appends "/view/collection" when ?openCollection is set on the URL', async () => {
@@ -312,45 +397,41 @@ describe('buildDocumentWorkspaceRoutes', () => {
 			history.pushState({}, '', '?openCollection');
 			try {
 				const routes = buildDocumentWorkspaceRoutes({
-					variants: [makeVariant('en', 'en')],
-					appCulture: 'en',
-					splitViewComponent,
+					getVariants: () => [makeVariant('en', 'en')],
+					getAppCulture: () => 'en',
+					splitViewComponent: createSplitViewComponentStub(),
 					splitView: createSplitViewStub(),
-					getWorkspaceRoute: () => '/workspace/document/edit/x',
+					getWorkspaceRoute: () => DEFAULT_WORKSPACE_ROUTE,
 					getIsForbidden: () => false,
 				});
-				await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
-				expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en/view/collection');
+				await callDefaultResolve(findDefaultRoute(routes));
+				expect(replaceStateCalls[0].url).to.equal(`${DEFAULT_WORKSPACE_ROUTE}/en/view/collection`);
 			} finally {
 				history.pushState({}, '', originalUrl);
 			}
 		});
 
-		it('throws when no workspace route is available', async () => {
+		it('returns silently when no workspace route can be determined', async () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => undefined,
 				getIsForbidden: () => false,
 			});
-			let threw: unknown = null;
-			try {
-				await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
-			} catch (e) {
-				threw = e;
-			}
-			expect(threw).to.be.an.instanceOf(Error);
+			await callDefaultResolve(findDefaultRoute(routes), makeSlot(''));
+
+			expect(replaceStateCalls).to.have.lengthOf(0);
 		});
 	});
 
 	describe('catch-all fallback', () => {
 		it('returns only the catch-all when no variants are available', () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -361,9 +442,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('returns only the catch-all when no app culture is set yet', () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: undefined,
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => undefined,
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -374,9 +455,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('returns only the catch-all when no split view manager is available', () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: undefined,
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
@@ -387,9 +468,9 @@ describe('buildDocumentWorkspaceRoutes', () => {
 
 		it('always ends with a "**" catch-all route', () => {
 			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				appCulture: 'en',
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				getAppCulture: () => 'en',
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.test.ts
@@ -33,10 +33,13 @@ function findDefaultRoute(routes: Array<UmbRoute>): UmbRoute {
 	return route;
 }
 
-function callSetup(route: UmbRoute, consumed: string) {
-	const info = { match: { fragments: { consumed, rest: '' }, params: {}, match: [] as unknown, route } } as any;
-	const setup = (route as unknown as { setup: (component: any, info: any) => void }).setup;
-	setup(undefined, info);
+async function callResolve(route: UmbRoute, consumed: string, slot: HTMLElement) {
+	const info = {
+		slot,
+		match: { fragments: { consumed, rest: '' }, params: {}, match: [] as unknown, route },
+	} as any;
+	const resolve = (route as unknown as { resolve: (info: any) => Promise<void> }).resolve;
+	await resolve(info);
 }
 
 describe('buildDocumentWorkspaceRoutes', () => {
@@ -76,7 +79,7 @@ describe('buildDocumentWorkspaceRoutes', () => {
 			expect(large.length).to.equal(3);
 		});
 
-		it('does not generate any "_&_" route paths (regression guard for split-view pairs)', () => {
+		it('does not generate any "_&_" route paths', () => {
 			const variants = Array.from({ length: 50 }, (_v, i) => makeVariant(`v${i}`, `c${i}`));
 			const routes = buildDocumentWorkspaceRoutes({
 				variants,
@@ -107,21 +110,18 @@ describe('buildDocumentWorkspaceRoutes', () => {
 			expect(dynamic.path).to.equal(':variantPath');
 		});
 
-		it('reuses the supplied split-view component instance', () => {
-			expect((dynamic as { component?: unknown }).component).to.equal(splitViewComponent);
-		});
-
 		it('has preserveQuery true', () => {
 			expect((dynamic as { preserveQuery?: boolean }).preserveQuery).to.equal(true);
 		});
 
-		it('has a setup callback', () => {
-			expect(typeof (dynamic as unknown as { setup?: unknown }).setup).to.equal('function');
+		it('has a resolve callback (resolver route, not a component route)', () => {
+			expect(typeof (dynamic as unknown as { resolve?: unknown }).resolve).to.equal('function');
+			expect((dynamic as unknown as { component?: unknown }).component).to.be.undefined;
 		});
 	});
 
-	describe('setup callback', () => {
-		it('treats a single-variant fragment as single-view (removeActiveVariant(1) then handleVariantFolderPart(0, fragment))', () => {
+	describe('resolve callback — valid variants', () => {
+		it('mounts the split-view component and calls handleVariantFolderPart for a single-variant path', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildDocumentWorkspaceRoutes({
 				variants: [makeVariant('en', 'en')],
@@ -131,15 +131,17 @@ describe('buildDocumentWorkspaceRoutes', () => {
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
 			});
-			callSetup(findDynamicRoute(routes), 'en');
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'en', slot);
 
+			expect(slot.firstChild).to.equal(splitViewComponent);
 			expect(splitView.calls).to.deep.equal([
 				{ method: 'removeActiveVariant', args: [1] },
 				{ method: 'handleVariantFolderPart', args: [0, 'en'] },
 			]);
 		});
 
-		it('treats a "_&_" fragment as split-view (setVariantParts with the consumed fragment)', () => {
+		it('mounts the split-view component and calls setVariantParts for a "_&_" path', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildDocumentWorkspaceRoutes({
 				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
@@ -149,12 +151,32 @@ describe('buildDocumentWorkspaceRoutes', () => {
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
 			});
-			callSetup(findDynamicRoute(routes), 'en_&_da');
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'en_&_da', slot);
 
+			expect(slot.firstChild).to.equal(splitViewComponent);
 			expect(splitView.calls).to.deep.equal([{ method: 'setVariantParts', args: ['en_&_da'] }]);
 		});
 
-		it('handles segment-suffixed uniques on both sides of the delimiter', () => {
+		it('reuses the split-view component when it is already mounted', async () => {
+			const splitView = createSplitViewStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			const slot = document.createElement('div');
+			slot.appendChild(splitViewComponent);
+			await callResolve(findDynamicRoute(routes), 'da', slot);
+
+			expect(slot.firstChild).to.equal(splitViewComponent);
+			expect(slot.children).to.have.lengthOf(1);
+		});
+
+		it('handles segment-suffixed uniques on both sides of the delimiter', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildDocumentWorkspaceRoutes({
 				variants: [makeVariant('en_segA', 'en', 'segA'), makeVariant('da_segB', 'da', 'segB')],
@@ -164,9 +186,79 @@ describe('buildDocumentWorkspaceRoutes', () => {
 				getWorkspaceRoute: () => '/x',
 				getIsForbidden: () => false,
 			});
-			callSetup(findDynamicRoute(routes), 'en_segA_&_da_segB');
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'en_segA_&_da_segB', slot);
 
 			expect(splitView.calls).to.deep.equal([{ method: 'setVariantParts', args: ['en_segA_&_da_segB'] }]);
+		});
+	});
+
+	describe('resolve callback — unknown variants (URL is NOT changed)', () => {
+		it('mounts UmbRouteNotFoundElement when the consumed fragment is unknown', async () => {
+			const splitView = createSplitViewStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'nonsense', slot);
+
+			expect((slot.firstChild as Element | null)?.localName).to.equal('umb-route-not-found');
+			expect(splitView.calls).to.deep.equal([]);
+		});
+
+		it('mounts UmbRouteForbiddenElement when isForbidden is true', async () => {
+			const splitView = createSplitViewStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => true,
+			});
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'nonsense', slot);
+
+			expect((slot.firstChild as Element | null)?.localName).to.equal('umb-route-forbidden');
+		});
+
+		it('mounts NotFound when only one side of a split-view path is unknown', async () => {
+			const splitView = createSplitViewStub();
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView,
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'en_&_nonsense', slot);
+
+			expect((slot.firstChild as Element | null)?.localName).to.equal('umb-route-not-found');
+			expect(splitView.calls).to.deep.equal([]);
+		});
+
+		it('reuses an already-mounted NotFound element', async () => {
+			const routes = buildDocumentWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				appCulture: 'en',
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getWorkspaceRoute: () => '/x',
+				getIsForbidden: () => false,
+			});
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'nonsense', slot);
+			const firstNotFound = slot.firstChild;
+			await callResolve(findDynamicRoute(routes), 'still-nonsense', slot);
+
+			expect(slot.firstChild).to.equal(firstNotFound);
 		});
 	});
 
@@ -215,24 +307,7 @@ describe('buildDocumentWorkspaceRoutes', () => {
 			expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en');
 		});
 
-		it('falls back to the first variant when only segment-suffixed variants exist for the app culture', async () => {
-			// app culture "en" but there is no variant with unique==="en" — only "en_segA".
-			const routes = buildDocumentWorkspaceRoutes({
-				variants: [makeVariant('en_segA', 'en', 'segA'), makeVariant('da', 'da')],
-				appCulture: 'en',
-				splitViewComponent,
-				splitView: createSplitViewStub(),
-				getWorkspaceRoute: () => '/workspace/document/edit/x',
-				getIsForbidden: () => false,
-			});
-			await (findDefaultRoute(routes) as unknown as { resolve: () => Promise<void> }).resolve();
-
-			expect(replaceStateCalls[0].url).to.equal('/workspace/document/edit/x/en_segA');
-		});
-
 		it('appends "/view/collection" when ?openCollection is set on the URL', async () => {
-			// Use the real history.pushState to put ?openCollection on the URL; history.replaceState
-			// is stubbed in beforeEach so the resolve() call won't actually navigate.
 			const originalUrl = window.location.href;
 			history.pushState({}, '', '?openCollection');
 			try {
@@ -271,7 +346,7 @@ describe('buildDocumentWorkspaceRoutes', () => {
 	});
 
 	describe('catch-all fallback', () => {
-		it('returns only the forbidden catch-all when no variants are available', () => {
+		it('returns only the catch-all when no variants are available', () => {
 			const routes = buildDocumentWorkspaceRoutes({
 				variants: [],
 				appCulture: 'en',
@@ -284,7 +359,7 @@ describe('buildDocumentWorkspaceRoutes', () => {
 			expect(routes[0].path).to.equal('**');
 		});
 
-		it('returns only the forbidden catch-all when no app culture is set yet', () => {
+		it('returns only the catch-all when no app culture is set yet', () => {
 			const routes = buildDocumentWorkspaceRoutes({
 				variants: [makeVariant('en', 'en')],
 				appCulture: undefined,
@@ -297,7 +372,7 @@ describe('buildDocumentWorkspaceRoutes', () => {
 			expect(routes[0].path).to.equal('**');
 		});
 
-		it('returns only the forbidden catch-all when no split view manager is available', () => {
+		it('returns only the catch-all when no split view manager is available', () => {
 			const routes = buildDocumentWorkspaceRoutes({
 				variants: [makeVariant('en', 'en')],
 				appCulture: 'en',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.ts
@@ -1,0 +1,77 @@
+import type { UmbDocumentVariantOptionModel } from '../types.js';
+import type { UmbRoute } from '@umbraco-cms/backoffice/router';
+import type { UmbWorkspaceSplitViewManager } from '@umbraco-cms/backoffice/workspace';
+
+export interface UmbBuildDocumentWorkspaceRoutesArgs {
+	variants: ReadonlyArray<UmbDocumentVariantOptionModel>;
+	appCulture: string | undefined;
+	splitViewComponent: HTMLElement;
+	splitView: UmbWorkspaceSplitViewManager | undefined;
+	getWorkspaceRoute: () => string | undefined;
+	getIsForbidden: () => boolean;
+}
+
+/**
+ * Build the routes for the document workspace editor.
+ *
+ * One dynamic route handles every single-variant and split-view path. The split-view manager
+ * already parses '_&_' itself, so the route table stays at three entries regardless of how many
+ * cultures/segments the document has.
+ * @param {UmbBuildDocumentWorkspaceRoutesArgs} args - the inputs needed to construct the routes.
+ * @returns {Array<UmbRoute>} the routes to install on the workspace router slot.
+ */
+export function buildDocumentWorkspaceRoutes(args: UmbBuildDocumentWorkspaceRoutesArgs): Array<UmbRoute> {
+	const forbiddenRoute: UmbRoute = {
+		path: '**',
+		component: async () => {
+			const router = await import('@umbraco-cms/backoffice/router');
+			return args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+		},
+	};
+
+	if (args.variants.length === 0 || !args.appCulture || !args.splitView) {
+		return [forbiddenRoute];
+	}
+
+	const { splitView, variants, appCulture, splitViewComponent } = args;
+
+	return [
+		{
+			path: ':variantPath',
+			preserveQuery: true,
+			component: splitViewComponent,
+			setup: (_component, info) => {
+				const consumed = info.match.fragments.consumed;
+				if (consumed.includes('_&_')) {
+					splitView.setVariantParts(consumed);
+				} else {
+					splitView.removeActiveVariant(1);
+					splitView.handleVariantFolderPart(0, consumed);
+				}
+			},
+		},
+		{
+			path: '',
+			preserveQuery: true,
+			pathMatch: 'full',
+			resolve: async () => {
+				const workspaceRoute = args.getWorkspaceRoute();
+				if (!workspaceRoute) {
+					throw new Error('Workspace route is not available when resolving the default route.');
+				}
+
+				const urlSearchParams = new URLSearchParams(window.location.search);
+				const openCollection = urlSearchParams.has('openCollection');
+
+				// Prefer the variant whose unique matches the app culture (the default segment for that
+				// culture); otherwise fall back to the first variant.
+				const target = variants.find((v) => v.unique === appCulture)?.unique ?? variants[0]?.unique;
+
+				if (!target) return;
+
+				history.replaceState({}, '', `${workspaceRoute}/${target}${openCollection ? '/view/collection' : ''}`);
+			},
+		},
+		forbiddenRoute,
+	];
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.ts
@@ -3,8 +3,8 @@ import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 import type { UmbWorkspaceSplitViewManager } from '@umbraco-cms/backoffice/workspace';
 
 export interface UmbBuildDocumentWorkspaceRoutesArgs {
-	variants: ReadonlyArray<UmbDocumentVariantOptionModel>;
-	appCulture: string | undefined;
+	getVariants: () => ReadonlyArray<UmbDocumentVariantOptionModel>;
+	getAppCulture: () => string | undefined;
 	splitViewComponent: HTMLElement;
 	splitView: UmbWorkspaceSplitViewManager | undefined;
 	getWorkspaceRoute: () => string | undefined;
@@ -18,6 +18,10 @@ export interface UmbBuildDocumentWorkspaceRoutesArgs {
  * the split-view component for known variants and the NotFound element for unknown ones, without
  * altering the URL. Routes stay a fixed handful of entries regardless of how many variants the
  * document has.
+ *
+ * Inputs that can change at runtime (variants, appCulture) are passed as getters because
+ * umb-router-slot's routes setter skips re-applying routes when only callbacks change — the
+ * resolvers must read fresh values at call time rather than relying on captured closures.
  * @param {UmbBuildDocumentWorkspaceRoutesArgs} args - the inputs needed to construct the routes.
  * @returns {Array<UmbRoute>} the routes to install on the workspace router slot.
  */
@@ -32,11 +36,11 @@ export function buildDocumentWorkspaceRoutes(args: UmbBuildDocumentWorkspaceRout
 		component: notFoundComponent,
 	};
 
-	if (args.variants.length === 0 || !args.appCulture || !args.splitView) {
+	if (args.getVariants().length === 0 || !args.getAppCulture() || !args.splitView) {
 		return [catchAllRoute];
 	}
 
-	const { splitView, variants, appCulture, splitViewComponent } = args;
+	const { splitView, splitViewComponent } = args;
 
 	return [
 		{
@@ -44,6 +48,7 @@ export function buildDocumentWorkspaceRoutes(args: UmbBuildDocumentWorkspaceRout
 			path: ':variantPath',
 			preserveQuery: true,
 			resolve: async (info) => {
+				const variants = args.getVariants();
 				const consumed = info.match.fragments.consumed;
 
 				const parts = consumed.split('_&_');
@@ -76,18 +81,22 @@ export function buildDocumentWorkspaceRoutes(args: UmbBuildDocumentWorkspaceRout
 			path: '',
 			preserveQuery: true,
 			pathMatch: 'full',
-			resolve: async () => {
-				const workspaceRoute = args.getWorkspaceRoute();
-				if (!workspaceRoute) {
-					throw new Error('Workspace route is not available when resolving the default route.');
-				}
+			resolve: async (info) => {
+				// Workspace route may not yet be populated on the wrapper element on initial load (the
+				// init event fires after the first navigation); info.slot knows its base path at this
+				// point. Return silently rather than throwing — the next navigation will re-resolve
+				// once state is fully wired up.
+				const workspaceRoute = info.slot.constructAbsolutePath('') || args.getWorkspaceRoute();
+				if (!workspaceRoute) return;
+
+				const variants = args.getVariants();
+				if (variants.length === 0) return;
+
+				const appCulture = args.getAppCulture();
+				const target = variants.find((v) => v.unique === appCulture)?.unique ?? variants[0].unique;
 
 				const urlSearchParams = new URLSearchParams(window.location.search);
 				const openCollection = urlSearchParams.has('openCollection');
-
-				const target = variants.find((v) => v.unique === appCulture)?.unique ?? variants[0]?.unique;
-
-				if (!target) return;
 
 				history.replaceState({}, '', `${workspaceRoute}/${target}${openCollection ? '/view/collection' : ''}`);
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.routes.ts
@@ -14,34 +14,56 @@ export interface UmbBuildDocumentWorkspaceRoutesArgs {
 /**
  * Build the routes for the document workspace editor.
  *
- * One dynamic route handles every single-variant and split-view path. The split-view manager
- * already parses '_&_' itself, so the route table stays at three entries regardless of how many
- * cultures/segments the document has.
+ * One dynamic resolver route covers every single-variant and split-view path. The resolver mounts
+ * the split-view component for known variants and the NotFound element for unknown ones, without
+ * altering the URL. Routes stay a fixed handful of entries regardless of how many variants the
+ * document has.
  * @param {UmbBuildDocumentWorkspaceRoutesArgs} args - the inputs needed to construct the routes.
  * @returns {Array<UmbRoute>} the routes to install on the workspace router slot.
  */
 export function buildDocumentWorkspaceRoutes(args: UmbBuildDocumentWorkspaceRoutesArgs): Array<UmbRoute> {
-	const forbiddenRoute: UmbRoute = {
+	const notFoundComponent = async () => {
+		const router = await import('@umbraco-cms/backoffice/router');
+		return args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+	};
+
+	const catchAllRoute: UmbRoute = {
 		path: '**',
-		component: async () => {
-			const router = await import('@umbraco-cms/backoffice/router');
-			return args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
-		},
+		component: notFoundComponent,
 	};
 
 	if (args.variants.length === 0 || !args.appCulture || !args.splitView) {
-		return [forbiddenRoute];
+		return [catchAllRoute];
 	}
 
 	const { splitView, variants, appCulture, splitViewComponent } = args;
 
 	return [
 		{
+			// TODO: When implementing Segments, be aware if using the unique still is URL Safe, cause its most likely not... [NL]
 			path: ':variantPath',
 			preserveQuery: true,
-			component: splitViewComponent,
-			setup: (_component, info) => {
+			resolve: async (info) => {
 				const consumed = info.match.fragments.consumed;
+
+				const parts = consumed.split('_&_');
+				const allKnown = parts.every((part) => variants.some((v) => v.unique === part));
+
+				if (!allKnown) {
+					// Unknown variant unique in the URL. Render NotFound (or Forbidden) in place — the
+					// URL is left untouched so stale bookmarks stay visible to the user.
+					const router = await import('@umbraco-cms/backoffice/router');
+					const NotFoundCtor = args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+					if (!(info.slot.firstChild instanceof NotFoundCtor)) {
+						info.slot.replaceChildren(new NotFoundCtor());
+					}
+					return;
+				}
+
+				// Mount (or reuse) the split-view component, then push the active variants into the manager.
+				if (info.slot.firstChild !== splitViewComponent) {
+					info.slot.replaceChildren(splitViewComponent);
+				}
 				if (consumed.includes('_&_')) {
 					splitView.setVariantParts(consumed);
 				} else {
@@ -63,8 +85,6 @@ export function buildDocumentWorkspaceRoutes(args: UmbBuildDocumentWorkspaceRout
 				const urlSearchParams = new URLSearchParams(window.location.search);
 				const openCollection = urlSearchParams.has('openCollection');
 
-				// Prefer the variant whose unique matches the app culture (the default segment for that
-				// culture); otherwise fall back to the first variant.
 				const target = variants.find((v) => v.unique === appCulture)?.unique ?? variants[0]?.unique;
 
 				if (!target) return;
@@ -72,6 +92,6 @@ export function buildDocumentWorkspaceRoutes(args: UmbBuildDocumentWorkspaceRout
 				history.replaceState({}, '', `${workspaceRoute}/${target}${openCollection ? '/view/collection' : ''}`);
 			},
 		},
-		forbiddenRoute,
+		catchAllRoute,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
@@ -68,7 +68,7 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 
 	private _generateRoutes() {
 		this._routes = buildMediaWorkspaceRoutes({
-			variants: this.#variants ?? [],
+			getVariants: () => this.#variants ?? [],
 			splitViewComponent: this._splitViewElement,
 			splitView: this.#workspaceContext?.splitView,
 			getIsForbidden: () => this.#isForbidden,

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
@@ -1,6 +1,7 @@
 import type { UmbMediaVariantOptionModel } from '../types.js';
 import { UmbMediaWorkspaceSplitViewElement } from './media-workspace-split-view.element.js';
 import { UMB_MEDIA_WORKSPACE_CONTEXT } from './media-workspace.context-token.js';
+import { buildMediaWorkspaceRoutes } from './media-workspace-editor.routes.js';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { customElement, state, css, html } from '@umbraco-cms/backoffice/external/lit';
@@ -65,72 +66,12 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 		);
 	}
 
-	private async _generateRoutes() {
-		if (!this.#variants || this.#variants.length === 0) {
-			this._routes = [];
-			this.#ensureForbiddenRoute(this._routes);
-			return;
-		}
-
-		// Generate split view routes for all available routes
-		const routes: Array<UmbRoute> = [];
-
-		// Split view routes:
-		this.#variants?.forEach((variantA) => {
-			this.#variants?.forEach((variantB) => {
-				routes.push({
-					// TODO: When implementing Segments, be aware if using the unique is URL Safe... [NL]
-					path: variantA.unique + '_&_' + variantB.unique,
-					component: this._splitViewElement,
-					setup: (_component, info) => {
-						// Set split view/active info..
-						this.#workspaceContext?.splitView.setVariantParts(info.match.fragments.consumed);
-					},
-				});
-			});
-		});
-
-		// Single view:
-		this.#variants?.forEach((variant) => {
-			routes.push({
-				// TODO: When implementing Segments, be aware if using the unique is URL Safe... [NL]
-				path: variant.unique,
-				component: this._splitViewElement,
-				setup: (_component, info) => {
-					// cause we might come from a split-view, we need to reset index 1.
-					this.#workspaceContext?.splitView.removeActiveVariant(1);
-					this.#workspaceContext?.splitView.handleVariantFolderPart(0, info.match.fragments.consumed);
-				},
-			});
-		});
-
-		if (routes.length !== 0 && this.#variants?.length) {
-			// Using first single view as the default route for now (hence the math below):
-			routes.push({
-				path: '',
-				pathMatch: 'full',
-				redirectTo: routes[this.#variants.length * this.#variants.length]?.path,
-			});
-		}
-
-		this.#ensureForbiddenRoute(routes);
-
-		this._routes = routes;
-	}
-
-	/**
-	 * Ensure that there is a route to handle forbidden access.
-	 * This route will display a forbidden message when the user does not have permission to access certain resources.
-	 * Also handles not found routes.
-	 * @param {Array<UmbRoute>} routes - The array of routes to append the forbidden route to
-	 */
-	#ensureForbiddenRoute(routes: Array<UmbRoute> = []) {
-		routes.push({
-			path: '**',
-			component: async () => {
-				const router = await import('@umbraco-cms/backoffice/router');
-				return this.#isForbidden ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
-			},
+	private _generateRoutes() {
+		this._routes = buildMediaWorkspaceRoutes({
+			variants: this.#variants ?? [],
+			splitViewComponent: this._splitViewElement,
+			splitView: this.#workspaceContext?.splitView,
+			getIsForbidden: () => this.#isForbidden,
 		});
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.test.ts
@@ -1,0 +1,162 @@
+import { expect } from '@open-wc/testing';
+import { buildMediaWorkspaceRoutes } from './media-workspace-editor.routes.js';
+import type { UmbMediaVariantOptionModel } from '../types.js';
+import type { UmbWorkspaceSplitViewManager } from '@umbraco-cms/backoffice/workspace';
+import type { UmbRoute } from '@umbraco-cms/backoffice/router';
+
+type SplitViewCall = { method: string; args: unknown[] };
+
+function createSplitViewStub() {
+	const calls: SplitViewCall[] = [];
+	const stub = {
+		calls,
+		setVariantParts: (...args: unknown[]) => calls.push({ method: 'setVariantParts', args }),
+		handleVariantFolderPart: (...args: unknown[]) => calls.push({ method: 'handleVariantFolderPart', args }),
+		removeActiveVariant: (...args: unknown[]) => calls.push({ method: 'removeActiveVariant', args }),
+	};
+	return stub as unknown as UmbWorkspaceSplitViewManager & { calls: SplitViewCall[] };
+}
+
+function makeVariant(unique: string, culture: string | null, segment: string | null = null): UmbMediaVariantOptionModel {
+	return { unique, culture, segment } as UmbMediaVariantOptionModel;
+}
+
+function findDynamicRoute(routes: Array<UmbRoute>): UmbRoute {
+	const route = routes.find((r) => r.path === ':variantPath');
+	if (!route) throw new Error('Expected a :variantPath route');
+	return route;
+}
+
+function callSetup(route: UmbRoute, consumed: string) {
+	const info = { match: { fragments: { consumed, rest: '' }, params: {}, match: [] as unknown, route } } as any;
+	const setup = (route as unknown as { setup: (component: any, info: any) => void }).setup;
+	setup(undefined, info);
+}
+
+describe('buildMediaWorkspaceRoutes', () => {
+	const splitViewComponent = document.createElement('div');
+
+	describe('production behaviour today (no variants on media types)', () => {
+		it('returns only the forbidden catch-all when variants is empty', () => {
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [],
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			expect(routes).to.have.lengthOf(1);
+			expect(routes[0].path).to.equal('**');
+		});
+
+		it('returns only the forbidden catch-all when no split view manager is available', () => {
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				splitViewComponent,
+				splitView: undefined,
+				getIsForbidden: () => false,
+			});
+			expect(routes).to.have.lengthOf(1);
+			expect(routes[0].path).to.equal('**');
+		});
+	});
+
+	describe('future-proof variant routes', () => {
+		it('returns exactly three routes regardless of variant count (regression guard for n²)', () => {
+			const small = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			const large = buildMediaWorkspaceRoutes({
+				variants: Array.from({ length: 200 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			expect(small.length).to.equal(large.length);
+			expect(large.length).to.equal(3);
+		});
+
+		it('does not generate any "_&_" route paths', () => {
+			const routes = buildMediaWorkspaceRoutes({
+				variants: Array.from({ length: 50 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			for (const r of routes) {
+				expect(r.path ?? '').to.not.include('_&_');
+			}
+		});
+
+		it('dynamic route reuses the supplied split-view component instance', () => {
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			expect((findDynamicRoute(routes) as { component?: unknown }).component).to.equal(splitViewComponent);
+		});
+
+		it('dynamic route does not set preserveQuery (matches existing media behaviour)', () => {
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			expect((findDynamicRoute(routes) as { preserveQuery?: boolean }).preserveQuery).to.be.oneOf([undefined, false]);
+		});
+
+		it('setup treats a single-variant fragment as single-view', () => {
+			const splitView = createSplitViewStub();
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				splitViewComponent,
+				splitView,
+				getIsForbidden: () => false,
+			});
+			callSetup(findDynamicRoute(routes), 'en');
+			expect(splitView.calls).to.deep.equal([
+				{ method: 'removeActiveVariant', args: [1] },
+				{ method: 'handleVariantFolderPart', args: [0, 'en'] },
+			]);
+		});
+
+		it('setup treats a "_&_" fragment as split-view', () => {
+			const splitView = createSplitViewStub();
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				splitViewComponent,
+				splitView,
+				getIsForbidden: () => false,
+			});
+			callSetup(findDynamicRoute(routes), 'en_&_da');
+			expect(splitView.calls).to.deep.equal([{ method: 'setVariantParts', args: ['en_&_da'] }]);
+		});
+
+		it('default route redirects to the first variant', () => {
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			const defaultRoute = routes.find((r) => r.path === '' && r.pathMatch === 'full');
+			expect(defaultRoute).to.exist;
+			expect((defaultRoute as { redirectTo?: string }).redirectTo).to.equal('en');
+		});
+
+		it('always ends with a "**" catch-all route', () => {
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				splitViewComponent,
+				splitView: createSplitViewStub(),
+				getIsForbidden: () => false,
+			});
+			expect(routes[routes.length - 1].path).to.equal('**');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.test.ts
@@ -6,6 +6,8 @@ import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 
 type SplitViewCall = { method: string; args: unknown[] };
 
+const DEFAULT_WORKSPACE_ROUTE = '/workspace/media/edit/x';
+
 function createSplitViewStub() {
 	const calls: SplitViewCall[] = [];
 	const stub = {
@@ -15,6 +17,14 @@ function createSplitViewStub() {
 		removeActiveVariant: (...args: unknown[]) => calls.push({ method: 'removeActiveVariant', args }),
 	};
 	return stub as unknown as UmbWorkspaceSplitViewManager & { calls: SplitViewCall[] };
+}
+
+function createSplitViewComponentStub(): HTMLElement {
+	return document.createElement('div');
+}
+
+function makeSlot(workspaceRoute: string = DEFAULT_WORKSPACE_ROUTE) {
+	return { constructAbsolutePath: () => workspaceRoute };
 }
 
 function makeVariant(unique: string, culture: string | null, segment: string | null = null): UmbMediaVariantOptionModel {
@@ -27,6 +37,12 @@ function findDynamicRoute(routes: Array<UmbRoute>): UmbRoute {
 	return route;
 }
 
+function findDefaultRoute(routes: Array<UmbRoute>): UmbRoute {
+	const route = routes.find((r) => r.path === '' && r.pathMatch === 'full');
+	if (!route) throw new Error('Expected an empty-path full-match default route');
+	return route;
+}
+
 async function callResolve(route: UmbRoute, consumed: string, slot: HTMLElement) {
 	const info = {
 		slot,
@@ -36,14 +52,21 @@ async function callResolve(route: UmbRoute, consumed: string, slot: HTMLElement)
 	await resolve(info);
 }
 
-describe('buildMediaWorkspaceRoutes', () => {
-	const splitViewComponent = document.createElement('div');
+async function callDefaultResolve(
+	route: UmbRoute,
+	slot: { constructAbsolutePath: () => string } = makeSlot(),
+) {
+	const info = { slot, match: { fragments: { consumed: '', rest: '' }, params: {}, match: [] as unknown, route } } as any;
+	const resolve = (route as unknown as { resolve: (info: any) => Promise<void> }).resolve;
+	await resolve(info);
+}
 
+describe('buildMediaWorkspaceRoutes', () => {
 	describe('production behaviour today (no variants on media types)', () => {
 		it('returns only the catch-all when variants is empty', () => {
 			const routes = buildMediaWorkspaceRoutes({
-				variants: [],
-				splitViewComponent,
+				getVariants: () => [],
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getIsForbidden: () => false,
 			});
@@ -53,8 +76,8 @@ describe('buildMediaWorkspaceRoutes', () => {
 
 		it('returns only the catch-all when no split view manager is available', () => {
 			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: undefined,
 				getIsForbidden: () => false,
 			});
@@ -66,14 +89,14 @@ describe('buildMediaWorkspaceRoutes', () => {
 	describe('future-proof variant routes', () => {
 		it('returns the same constant route count regardless of variant count (regression guard for n²)', () => {
 			const small = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getIsForbidden: () => false,
 			});
 			const large = buildMediaWorkspaceRoutes({
-				variants: Array.from({ length: 200 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
-				splitViewComponent,
+				getVariants: () => Array.from({ length: 200 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getIsForbidden: () => false,
 			});
@@ -83,8 +106,8 @@ describe('buildMediaWorkspaceRoutes', () => {
 
 		it('does not generate any "_&_" route paths', () => {
 			const routes = buildMediaWorkspaceRoutes({
-				variants: Array.from({ length: 50 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
-				splitViewComponent,
+				getVariants: () => Array.from({ length: 50 }, (_v, i) => makeVariant(`v${i}`, `c${i}`)),
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getIsForbidden: () => false,
 			});
@@ -95,8 +118,8 @@ describe('buildMediaWorkspaceRoutes', () => {
 
 		it('dynamic route is a resolver (has resolve, no component)', () => {
 			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getIsForbidden: () => false,
 			});
@@ -107,8 +130,9 @@ describe('buildMediaWorkspaceRoutes', () => {
 
 		it('mounts the split-view component for a single-variant path', async () => {
 			const splitView = createSplitViewStub();
+			const splitViewComponent = createSplitViewComponentStub();
 			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
+				getVariants: () => [makeVariant('en', 'en')],
 				splitViewComponent,
 				splitView,
 				getIsForbidden: () => false,
@@ -125,8 +149,9 @@ describe('buildMediaWorkspaceRoutes', () => {
 
 		it('mounts the split-view component for a "_&_" path', async () => {
 			const splitView = createSplitViewStub();
+			const splitViewComponent = createSplitViewComponentStub();
 			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
+				getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
 				splitViewComponent,
 				splitView,
 				getIsForbidden: () => false,
@@ -141,8 +166,8 @@ describe('buildMediaWorkspaceRoutes', () => {
 		it('mounts UmbRouteNotFoundElement for an unknown variant (URL is not changed)', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView,
 				getIsForbidden: () => false,
 			});
@@ -153,26 +178,79 @@ describe('buildMediaWorkspaceRoutes', () => {
 			expect(splitView.calls).to.deep.equal([]);
 		});
 
-		it('default route redirects to the first variant', () => {
-			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
-				splitViewComponent,
-				splitView: createSplitViewStub(),
-				getIsForbidden: () => false,
-			});
-			const defaultRoute = routes.find((r) => r.path === '' && r.pathMatch === 'full');
-			expect(defaultRoute).to.exist;
-			expect((defaultRoute as { redirectTo?: string }).redirectTo).to.equal('en');
+		it('default route resolves to the first variant', async () => {
+			const replaceStateCalls: Array<{ url: string }> = [];
+			const originalReplaceState = history.replaceState.bind(history);
+			history.replaceState = ((_s: unknown, _t: string, url?: string) => {
+				replaceStateCalls.push({ url: String(url ?? '') });
+			}) as typeof history.replaceState;
+
+			try {
+				const routes = buildMediaWorkspaceRoutes({
+					getVariants: () => [makeVariant('en', 'en'), makeVariant('da', 'da')],
+					splitViewComponent: createSplitViewComponentStub(),
+					splitView: createSplitViewStub(),
+					getIsForbidden: () => false,
+				});
+				await callDefaultResolve(findDefaultRoute(routes));
+			} finally {
+				history.replaceState = originalReplaceState;
+			}
+
+			expect(replaceStateCalls[0].url).to.equal(`${DEFAULT_WORKSPACE_ROUTE}/en`);
+		});
+
+		it('default route returns silently when no workspace route can be determined', async () => {
+			const replaceStateCalls: Array<{ url: string }> = [];
+			const originalReplaceState = history.replaceState.bind(history);
+			history.replaceState = ((_s: unknown, _t: string, url?: string) => {
+				replaceStateCalls.push({ url: String(url ?? '') });
+			}) as typeof history.replaceState;
+
+			try {
+				const routes = buildMediaWorkspaceRoutes({
+					getVariants: () => [makeVariant('en', 'en')],
+					splitViewComponent: createSplitViewComponentStub(),
+					splitView: createSplitViewStub(),
+					getIsForbidden: () => false,
+				});
+				await callDefaultResolve(findDefaultRoute(routes), makeSlot(''));
+			} finally {
+				history.replaceState = originalReplaceState;
+			}
+
+			expect(replaceStateCalls).to.have.lengthOf(0);
 		});
 
 		it('always ends with a "**" catch-all route', () => {
 			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				splitViewComponent,
+				getVariants: () => [makeVariant('en', 'en')],
+				splitViewComponent: createSplitViewComponentStub(),
 				splitView: createSplitViewStub(),
 				getIsForbidden: () => false,
 			});
 			expect(routes[routes.length - 1].path).to.equal('**');
+		});
+	});
+
+	describe('resolvers read variants at call time (regression guard for stale closure)', () => {
+		it('dynamic resolver sees a newly added variant', async () => {
+			const variants: Array<UmbMediaVariantOptionModel> = [makeVariant('en', 'en')];
+			const splitView = createSplitViewStub();
+			const splitViewComponent = createSplitViewComponentStub();
+			const routes = buildMediaWorkspaceRoutes({
+				getVariants: () => variants,
+				splitViewComponent,
+				splitView,
+				getIsForbidden: () => false,
+			});
+
+			variants.push(makeVariant('da', 'da'));
+
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'da', slot);
+
+			expect(slot.firstChild).to.equal(splitViewComponent);
 		});
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.test.ts
@@ -27,17 +27,20 @@ function findDynamicRoute(routes: Array<UmbRoute>): UmbRoute {
 	return route;
 }
 
-function callSetup(route: UmbRoute, consumed: string) {
-	const info = { match: { fragments: { consumed, rest: '' }, params: {}, match: [] as unknown, route } } as any;
-	const setup = (route as unknown as { setup: (component: any, info: any) => void }).setup;
-	setup(undefined, info);
+async function callResolve(route: UmbRoute, consumed: string, slot: HTMLElement) {
+	const info = {
+		slot,
+		match: { fragments: { consumed, rest: '' }, params: {}, match: [] as unknown, route },
+	} as any;
+	const resolve = (route as unknown as { resolve: (info: any) => Promise<void> }).resolve;
+	await resolve(info);
 }
 
 describe('buildMediaWorkspaceRoutes', () => {
 	const splitViewComponent = document.createElement('div');
 
 	describe('production behaviour today (no variants on media types)', () => {
-		it('returns only the forbidden catch-all when variants is empty', () => {
+		it('returns only the catch-all when variants is empty', () => {
 			const routes = buildMediaWorkspaceRoutes({
 				variants: [],
 				splitViewComponent,
@@ -48,7 +51,7 @@ describe('buildMediaWorkspaceRoutes', () => {
 			expect(routes[0].path).to.equal('**');
 		});
 
-		it('returns only the forbidden catch-all when no split view manager is available', () => {
+		it('returns only the catch-all when no split view manager is available', () => {
 			const routes = buildMediaWorkspaceRoutes({
 				variants: [makeVariant('en', 'en')],
 				splitViewComponent,
@@ -61,7 +64,7 @@ describe('buildMediaWorkspaceRoutes', () => {
 	});
 
 	describe('future-proof variant routes', () => {
-		it('returns exactly three routes regardless of variant count (regression guard for n²)', () => {
+		it('returns the same constant route count regardless of variant count (regression guard for n²)', () => {
 			const small = buildMediaWorkspaceRoutes({
 				variants: [makeVariant('en', 'en')],
 				splitViewComponent,
@@ -90,27 +93,19 @@ describe('buildMediaWorkspaceRoutes', () => {
 			}
 		});
 
-		it('dynamic route reuses the supplied split-view component instance', () => {
+		it('dynamic route is a resolver (has resolve, no component)', () => {
 			const routes = buildMediaWorkspaceRoutes({
 				variants: [makeVariant('en', 'en')],
 				splitViewComponent,
 				splitView: createSplitViewStub(),
 				getIsForbidden: () => false,
 			});
-			expect((findDynamicRoute(routes) as { component?: unknown }).component).to.equal(splitViewComponent);
+			const dynamic = findDynamicRoute(routes);
+			expect(typeof (dynamic as unknown as { resolve?: unknown }).resolve).to.equal('function');
+			expect((dynamic as unknown as { component?: unknown }).component).to.be.undefined;
 		});
 
-		it('dynamic route does not set preserveQuery (matches existing media behaviour)', () => {
-			const routes = buildMediaWorkspaceRoutes({
-				variants: [makeVariant('en', 'en')],
-				splitViewComponent,
-				splitView: createSplitViewStub(),
-				getIsForbidden: () => false,
-			});
-			expect((findDynamicRoute(routes) as { preserveQuery?: boolean }).preserveQuery).to.be.oneOf([undefined, false]);
-		});
-
-		it('setup treats a single-variant fragment as single-view', () => {
+		it('mounts the split-view component for a single-variant path', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildMediaWorkspaceRoutes({
 				variants: [makeVariant('en', 'en')],
@@ -118,14 +113,17 @@ describe('buildMediaWorkspaceRoutes', () => {
 				splitView,
 				getIsForbidden: () => false,
 			});
-			callSetup(findDynamicRoute(routes), 'en');
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'en', slot);
+
+			expect(slot.firstChild).to.equal(splitViewComponent);
 			expect(splitView.calls).to.deep.equal([
 				{ method: 'removeActiveVariant', args: [1] },
 				{ method: 'handleVariantFolderPart', args: [0, 'en'] },
 			]);
 		});
 
-		it('setup treats a "_&_" fragment as split-view', () => {
+		it('mounts the split-view component for a "_&_" path', async () => {
 			const splitView = createSplitViewStub();
 			const routes = buildMediaWorkspaceRoutes({
 				variants: [makeVariant('en', 'en'), makeVariant('da', 'da')],
@@ -133,8 +131,26 @@ describe('buildMediaWorkspaceRoutes', () => {
 				splitView,
 				getIsForbidden: () => false,
 			});
-			callSetup(findDynamicRoute(routes), 'en_&_da');
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'en_&_da', slot);
+
+			expect(slot.firstChild).to.equal(splitViewComponent);
 			expect(splitView.calls).to.deep.equal([{ method: 'setVariantParts', args: ['en_&_da'] }]);
+		});
+
+		it('mounts UmbRouteNotFoundElement for an unknown variant (URL is not changed)', async () => {
+			const splitView = createSplitViewStub();
+			const routes = buildMediaWorkspaceRoutes({
+				variants: [makeVariant('en', 'en')],
+				splitViewComponent,
+				splitView,
+				getIsForbidden: () => false,
+			});
+			const slot = document.createElement('div');
+			await callResolve(findDynamicRoute(routes), 'nonsense', slot);
+
+			expect((slot.firstChild as Element | null)?.localName).to.equal('umb-route-not-found');
+			expect(splitView.calls).to.deep.equal([]);
 		});
 
 		it('default route redirects to the first variant', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.ts
@@ -1,0 +1,58 @@
+import type { UmbMediaVariantOptionModel } from '../types.js';
+import type { UmbRoute } from '@umbraco-cms/backoffice/router';
+import type { UmbWorkspaceSplitViewManager } from '@umbraco-cms/backoffice/workspace';
+
+export interface UmbBuildMediaWorkspaceRoutesArgs {
+	variants: ReadonlyArray<UmbMediaVariantOptionModel>;
+	splitViewComponent: HTMLElement;
+	splitView: UmbWorkspaceSplitViewManager | undefined;
+	getIsForbidden: () => boolean;
+}
+
+/**
+ * Build the routes for the media workspace editor.
+ *
+ * Media does not currently support variants (MediaType.Variations is hardcoded to Nothing), so
+ * in practice this only produces the forbidden catch-all today. The dynamic-route scaffolding is
+ * kept in sync with the document editor so the n² split-view loop cannot regress here if media
+ * gains variants later.
+ * @param {UmbBuildMediaWorkspaceRoutesArgs} args - the inputs needed to construct the routes.
+ * @returns {Array<UmbRoute>} the routes to install on the workspace router slot.
+ */
+export function buildMediaWorkspaceRoutes(args: UmbBuildMediaWorkspaceRoutesArgs): Array<UmbRoute> {
+	const forbiddenRoute: UmbRoute = {
+		path: '**',
+		component: async () => {
+			const router = await import('@umbraco-cms/backoffice/router');
+			return args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+		},
+	};
+
+	if (args.variants.length === 0 || !args.splitView) {
+		return [forbiddenRoute];
+	}
+
+	const { splitView, variants, splitViewComponent } = args;
+
+	return [
+		{
+			path: ':variantPath',
+			component: splitViewComponent,
+			setup: (_component, info) => {
+				const consumed = info.match.fragments.consumed;
+				if (consumed.includes('_&_')) {
+					splitView.setVariantParts(consumed);
+				} else {
+					splitView.removeActiveVariant(1);
+					splitView.handleVariantFolderPart(0, consumed);
+				}
+			},
+		},
+		{
+			path: '',
+			pathMatch: 'full',
+			redirectTo: variants[0]?.unique,
+		},
+		forbiddenRoute,
+	];
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.ts
@@ -3,7 +3,7 @@ import type { UmbRoute } from '@umbraco-cms/backoffice/router';
 import type { UmbWorkspaceSplitViewManager } from '@umbraco-cms/backoffice/workspace';
 
 export interface UmbBuildMediaWorkspaceRoutesArgs {
-	variants: ReadonlyArray<UmbMediaVariantOptionModel>;
+	getVariants: () => ReadonlyArray<UmbMediaVariantOptionModel>;
 	splitViewComponent: HTMLElement;
 	splitView: UmbWorkspaceSplitViewManager | undefined;
 	getIsForbidden: () => boolean;
@@ -15,6 +15,10 @@ export interface UmbBuildMediaWorkspaceRoutesArgs {
  * Media types currently hardcode `ContentVariation.Nothing`, so the variant routes are dead in
  * production today. The dynamic-route scaffolding is kept in sync with the document editor so
  * the n² split-view route table cannot reappear here if media gains variants later.
+ *
+ * Inputs that can change at runtime (variants) are passed as a getter because umb-router-slot's
+ * routes setter skips re-applying routes when only callbacks change — the resolvers must read
+ * fresh values at call time rather than relying on captured closures.
  * @param {UmbBuildMediaWorkspaceRoutesArgs} args - the inputs needed to construct the routes.
  * @returns {Array<UmbRoute>} the routes to install on the workspace router slot.
  */
@@ -29,17 +33,18 @@ export function buildMediaWorkspaceRoutes(args: UmbBuildMediaWorkspaceRoutesArgs
 		component: notFoundComponent,
 	};
 
-	if (args.variants.length === 0 || !args.splitView) {
+	if (args.getVariants().length === 0 || !args.splitView) {
 		return [catchAllRoute];
 	}
 
-	const { splitView, variants, splitViewComponent } = args;
+	const { splitView, splitViewComponent } = args;
 
 	return [
 		{
 			// TODO: When implementing Segments, be aware if using the unique is URL Safe... [NL]
 			path: ':variantPath',
 			resolve: async (info) => {
+				const variants = args.getVariants();
 				const consumed = info.match.fragments.consumed;
 
 				const parts = consumed.split('_&_');
@@ -70,7 +75,15 @@ export function buildMediaWorkspaceRoutes(args: UmbBuildMediaWorkspaceRoutesArgs
 		{
 			path: '',
 			pathMatch: 'full',
-			redirectTo: variants[0]?.unique,
+			resolve: async (info) => {
+				const workspaceRoute = info.slot.constructAbsolutePath('');
+				if (!workspaceRoute) return;
+
+				const variants = args.getVariants();
+				if (variants.length === 0) return;
+
+				history.replaceState({}, '', `${workspaceRoute}/${variants[0].unique}`);
+			},
 		},
 		catchAllRoute,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.routes.ts
@@ -12,34 +12,53 @@ export interface UmbBuildMediaWorkspaceRoutesArgs {
 /**
  * Build the routes for the media workspace editor.
  *
- * Media does not currently support variants (MediaType.Variations is hardcoded to Nothing), so
- * in practice this only produces the forbidden catch-all today. The dynamic-route scaffolding is
- * kept in sync with the document editor so the n² split-view loop cannot regress here if media
- * gains variants later.
+ * Media types currently hardcode `ContentVariation.Nothing`, so the variant routes are dead in
+ * production today. The dynamic-route scaffolding is kept in sync with the document editor so
+ * the n² split-view route table cannot reappear here if media gains variants later.
  * @param {UmbBuildMediaWorkspaceRoutesArgs} args - the inputs needed to construct the routes.
  * @returns {Array<UmbRoute>} the routes to install on the workspace router slot.
  */
 export function buildMediaWorkspaceRoutes(args: UmbBuildMediaWorkspaceRoutesArgs): Array<UmbRoute> {
-	const forbiddenRoute: UmbRoute = {
+	const notFoundComponent = async () => {
+		const router = await import('@umbraco-cms/backoffice/router');
+		return args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+	};
+
+	const catchAllRoute: UmbRoute = {
 		path: '**',
-		component: async () => {
-			const router = await import('@umbraco-cms/backoffice/router');
-			return args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
-		},
+		component: notFoundComponent,
 	};
 
 	if (args.variants.length === 0 || !args.splitView) {
-		return [forbiddenRoute];
+		return [catchAllRoute];
 	}
 
 	const { splitView, variants, splitViewComponent } = args;
 
 	return [
 		{
+			// TODO: When implementing Segments, be aware if using the unique is URL Safe... [NL]
 			path: ':variantPath',
-			component: splitViewComponent,
-			setup: (_component, info) => {
+			resolve: async (info) => {
 				const consumed = info.match.fragments.consumed;
+
+				const parts = consumed.split('_&_');
+				const allKnown = parts.every((part) => variants.some((v) => v.unique === part));
+
+				if (!allKnown) {
+					// Unknown variant unique in the URL. Render NotFound (or Forbidden) in place — the
+					// URL is left untouched so stale bookmarks stay visible to the user.
+					const router = await import('@umbraco-cms/backoffice/router');
+					const NotFoundCtor = args.getIsForbidden() ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+					if (!(info.slot.firstChild instanceof NotFoundCtor)) {
+						info.slot.replaceChildren(new NotFoundCtor());
+					}
+					return;
+				}
+
+				if (info.slot.firstChild !== splitViewComponent) {
+					info.slot.replaceChildren(splitViewComponent);
+				}
 				if (consumed.includes('_&_')) {
 					splitView.setVariantParts(consumed);
 				} else {
@@ -53,6 +72,6 @@ export function buildMediaWorkspaceRoutes(args: UmbBuildMediaWorkspaceRoutesArgs
 			pathMatch: 'full',
 			redirectTo: variants[0]?.unique,
 		},
-		forbiddenRoute,
+		catchAllRoute,
 	];
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/webhook/components/input-webhook-headers.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/webhook/components/input-webhook-headers.element.ts
@@ -119,7 +119,9 @@ export class UmbInputWebhookHeadersElement extends UmbLitElement {
 	override render() {
 		return html`
 			${this.#renderGrid()}
-			<uui-button id="add" look="placeholder" @click=${this.#addHeader}>Add</uui-button>
+			<uui-button id="add" look="placeholder" label=${this.localize.term('general_add')} @click=${this.#addHeader}>
+				<umb-localize key="general_add">Add</umb-localize>
+			</uui-button>
 		`;
 	}
 


### PR DESCRIPTION
## Description

Fixes #22910.

On a document varying by many cultures and segments, every keystroke in the name field caused a multi-second freeze. The document editor was generating `N²` split-view routes — one for every ordered pair of variant options. For the reporter's setup (4 cultures × (1 invariant + 17 A/B tests + 29 personalisations) = 188 variants) that meant **35,344 split-view routes** plus 188 single-view, default and catch-all entries — around 35,500 routes regenerated and re-evaluated on every keystroke.

The visible bottleneck was the de-duplication check in `umb-router-slot`'s routes setter at `src/Umbraco.Web.UI.Client/src/packages/core/router/route/router-slot.element.ts:30-39`. It uses `filter` + `findIndex` to detect path-set changes — `O(n²)`. With ~35k routes that's ~1.25 billion comparisons per keystroke, observed as the ~7-second freeze.

The fix replaces the static route pairs with a single dynamic `:variantPath` resolver route. The split-view manager already parses the `_&_` delimiter itself, so the resolver just forwards the consumed fragment to it. For unknown variant uniques (stale bookmarks to renamed/removed variants) the resolver mounts the NotFound element in place, leaving the URL untouched — matching the pre-refactor UX.

|  | Before | After |
|---|---|---|
| Routes generated per keystroke | ~35,534 | 3 |
| Comparisons in router-slot de-duplication | ~1.25 billion | 9 |

The same refactor is applied to the media workspace editor for consistency, even though `MediaType.Variations` is currently hardcoded to `Nothing` and the variant branch is unreachable today.

## Testing

### Automated

Unit tests have been added in `document-workspace-editor.routes.test.ts` and `media-workspace-editor.routes.test.ts` cover route count, resolver behaviour for known/unknown variants, default-route fallback, and catch-all.

### Manual

If you have enough variants to make the problem visible, open a document that varies by culture + segment with multiple variants; type rapidly in the name field. You should see no per-keystroke freeze.

Then should check the funtionality of variant editing, including split-view.

- Open a single-view variant URL (e.g. `…/edit/<id>/en-US`). Variant editor mounts.
- Open a split-view URL (`…/edit/<id>/en-US_&_da-DK`). Both panes render.
- Manually edit the URL to an unknown variant (`…/edit/<id>/en-UX`). NotFound page renders. URL stays unchanged.
- Open the workspace with no variant suffix (`…/edit/<id>`). Redirects to the app-culture variant.
- Open `…/edit/<id>?openCollection`. Redirects to `…/<variant>/view/collection`.
- Switch app language while editing — URL rewrites to the same segment under the new culture.
- Open a media item. Editor loads (variants unreachable in production today; defensive change only).

### Route Data Checks

#### Extracting `routes.json` (before/after evidence)

To capture an equivalent snapshot of the live route table from a running backoffice, open Chrome DevTools → Console while a variant document is open, paste:

```js
(() => {
    const deepQuery = (selector, root = document) => {
        const direct = root.querySelector(selector);
        if (direct) return direct;
        for (const el of root.querySelectorAll('*')) {
            if (el.shadowRoot) {
                const found = deepQuery(selector, el.shadowRoot);
                if (found) return found;
            }
        }
        return null;
    };

    const editor =
        deepQuery('umb-document-workspace-editor') ?? deepQuery('umb-media-workspace-editor');
    if (!editor) {
        console.error('No document or media workspace editor found on this page.');
        return;
    }

    const routerSlot = editor.shadowRoot?.querySelector('umb-router-slot');
    if (!routerSlot) {
        console.error('Workspace editor has no <umb-router-slot> child yet — wait for the editor to finish loading.');
        return;
    }

    const routes = routerSlot.routes ?? [];
    const seen = new WeakSet();
    const json = JSON.stringify(
        routes,
        (_key, value) => {
            if (typeof value === 'function') return `[fn ${value.name || 'anonymous'}]`;
            if (value instanceof HTMLElement) return `[element ${value.localName}]`;
            if (value && typeof value === 'object') {
                if (seen.has(value)) return '[circular]';
                seen.add(value);
            }
            return value;
        },
        2,
    );

    copy(json);
    console.log(`Copied ${routes.length} routes (${json.length} chars) to clipboard.`);
    return routes.length;
})();
```

The script walks shadow DOM, finds the workspace editor's `<umb-router-slot>`, and copies a JSON snapshot of its routes (functions and DOM elements replaced with readable placeholders) to the clipboard. Paste into a file to attach for review.

On `v17/dev` against the issue's reported setup: ~35,534 entries (but even with 3 languages, 14 entries)
On this branch: 3 entries (`:variantPath` resolver, empty default, `**` catch-all).