### PR TITLE
Backoffice: Render $index in block detail overlay label (closes #21154)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
@@ -38,7 +38,11 @@ export abstract class UmbBlockEntriesContext<
 		return this._layoutEntries.getValue().length;
 	}
 
-	getLayouts() {
+	/**
+	 * Returns the current layout entries.
+	 * @returns {Array<BlockLayoutType>} The current layout entries.
+	 */
+	getLayouts(): Array<BlockLayoutType> {
 		return this._layoutEntries.getValue();
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
@@ -38,6 +38,10 @@ export abstract class UmbBlockEntriesContext<
 		return this._layoutEntries.getValue().length;
 	}
 
+	getLayouts() {
+		return this._layoutEntries.getValue();
+	}
+
 	constructor(host: UmbControllerHost, blockManagerContextToken: BlockManagerContextTokenType) {
 		super(host, UMB_BLOCK_ENTRIES_CONTEXT);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.test.ts
@@ -1,57 +1,57 @@
-import { umbResolveBlockWorkspaceLabelIndex } from './block-workspace-label-index.function.js';
+import { resolveBlockWorkspaceLabelIndex } from './block-workspace-label-index.function.js';
 import { expect } from '@open-wc/testing';
 
-describe('umbResolveBlockWorkspaceLabelIndex', () => {
+describe('resolveBlockWorkspaceLabelIndex', () => {
 	describe('Existing block (cached index)', () => {
 		it('returns the cached index when set', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(2, undefined, 5)).to.equal(2);
+			expect(resolveBlockWorkspaceLabelIndex(2, undefined, 5)).to.equal(2);
 		});
 
 		it('returns 0 (a valid cached position) rather than falling through to originData', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(0, { index: 7 }, 5)).to.equal(0);
+			expect(resolveBlockWorkspaceLabelIndex(0, { index: 7 }, 5)).to.equal(0);
 		});
 
 		it('prefers the cached index over a different originData index', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(1, { index: 7 }, 5)).to.equal(1);
+			expect(resolveBlockWorkspaceLabelIndex(1, { index: 7 }, 5)).to.equal(1);
 		});
 	});
 
 	describe('New block — explicit insertion index (originData.index >= 0)', () => {
 		it('returns originData.index when no cached index is available', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: 3 }, 5)).to.equal(3);
+			expect(resolveBlockWorkspaceLabelIndex(undefined, { index: 3 }, 5)).to.equal(3);
 		});
 
 		it('returns 0 when originData.index is 0 (insert at start)', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: 0 }, 5)).to.equal(0);
+			expect(resolveBlockWorkspaceLabelIndex(undefined, { index: 0 }, 5)).to.equal(0);
 		});
 	});
 
 	describe('New block — append sentinel (originData.index === -1)', () => {
 		it('returns layoutsLength when -1 and the layouts length is known', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, 5)).to.equal(5);
+			expect(resolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, 5)).to.equal(5);
 		});
 
 		it('returns 0 when appending to an empty list', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, 0)).to.equal(0);
+			expect(resolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, 0)).to.equal(0);
 		});
 
 		it('returns undefined when layoutsLength is not yet known', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, undefined)).to.equal(undefined);
+			expect(resolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, undefined)).to.equal(undefined);
 		});
 	});
 
 	describe('No usable source — guards against NaN', () => {
 		it('returns undefined when nothing is available', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(undefined, undefined, undefined)).to.equal(undefined);
+			expect(resolveBlockWorkspaceLabelIndex(undefined, undefined, undefined)).to.equal(undefined);
 		});
 
 		it('returns undefined when originData has no index property', () => {
-			expect(umbResolveBlockWorkspaceLabelIndex(undefined, {} as never, 5)).to.equal(undefined);
+			expect(resolveBlockWorkspaceLabelIndex(undefined, {} as never, 5)).to.equal(undefined);
 		});
 
 		it('returns undefined when originData.index is non-numeric', () => {
 			expect(
-				umbResolveBlockWorkspaceLabelIndex(undefined, { index: 'oops' } as unknown as { index: number }, 5),
+				resolveBlockWorkspaceLabelIndex(undefined, { index: 'oops' } as unknown as { index: number }, 5),
 			).to.equal(undefined);
 		});
 	});

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.test.ts
@@ -1,0 +1,58 @@
+import { umbResolveBlockWorkspaceLabelIndex } from './block-workspace-label-index.function.js';
+import { expect } from '@open-wc/testing';
+
+describe('umbResolveBlockWorkspaceLabelIndex', () => {
+	describe('Existing block (cached index)', () => {
+		it('returns the cached index when set', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(2, undefined, 5)).to.equal(2);
+		});
+
+		it('returns 0 (a valid cached position) rather than falling through to originData', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(0, { index: 7 }, 5)).to.equal(0);
+		});
+
+		it('prefers the cached index over a different originData index', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(1, { index: 7 }, 5)).to.equal(1);
+		});
+	});
+
+	describe('New block — explicit insertion index (originData.index >= 0)', () => {
+		it('returns originData.index when no cached index is available', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: 3 }, 5)).to.equal(3);
+		});
+
+		it('returns 0 when originData.index is 0 (insert at start)', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: 0 }, 5)).to.equal(0);
+		});
+	});
+
+	describe('New block — append sentinel (originData.index === -1)', () => {
+		it('returns layoutsLength when -1 and the layouts length is known', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, 5)).to.equal(5);
+		});
+
+		it('returns 0 when appending to an empty list', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, 0)).to.equal(0);
+		});
+
+		it('returns undefined when layoutsLength is not yet known', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(undefined, { index: -1 }, undefined)).to.equal(undefined);
+		});
+	});
+
+	describe('No usable source — guards against NaN', () => {
+		it('returns undefined when nothing is available', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(undefined, undefined, undefined)).to.equal(undefined);
+		});
+
+		it('returns undefined when originData has no index property', () => {
+			expect(umbResolveBlockWorkspaceLabelIndex(undefined, {} as never, 5)).to.equal(undefined);
+		});
+
+		it('returns undefined when originData.index is non-numeric', () => {
+			expect(
+				umbResolveBlockWorkspaceLabelIndex(undefined, { index: 'oops' } as unknown as { index: number }, 5),
+			).to.equal(undefined);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.ts
@@ -1,0 +1,38 @@
+import type { UmbBlockWorkspaceOriginData } from './block-workspace.modal-token.js';
+
+/**
+ * Resolves the `$index` value used in block label UFM expressions.
+ *
+ * Resolution order:
+ * 1. `cachedIndex` — the block's position in the parent layout list (existing blocks).
+ * 2. `originData.index` — the insertion index carried by the catalogue modal (new blocks).
+ *    The sentinel value `-1` means "append to end" and resolves to `layoutsLength`.
+ * @param cachedIndex The position of this block in the parent layout list, or undefined if it isn't there yet.
+ * @param originData The origin data captured from the workspace modal.
+ * @param layoutsLength The current length of the parent layout list; used as the target when originData.index === -1.
+ * @returns The resolved index, or undefined if no source yields one.
+ */
+export function umbResolveBlockWorkspaceLabelIndex(
+	cachedIndex: number | undefined,
+	originData: UmbBlockWorkspaceOriginData | undefined,
+	layoutsLength: number | undefined,
+): number | undefined {
+	if (cachedIndex !== undefined) {
+		return cachedIndex;
+	}
+
+	if (!originData || !('index' in originData)) {
+		return undefined;
+	}
+
+	const originIndex = (originData as { index?: number }).index;
+	if (typeof originIndex !== 'number') {
+		return undefined;
+	}
+
+	if (originIndex === -1) {
+		return layoutsLength;
+	}
+
+	return originIndex;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.ts
@@ -7,10 +7,10 @@ import type { UmbBlockWorkspaceOriginData } from './block-workspace.modal-token.
  * 1. `cachedIndex` — the block's position in the parent layout list (existing blocks).
  * 2. `originData.index` — the insertion index carried by the catalogue modal (new blocks).
  *    The sentinel value `-1` means "append to end" and resolves to `layoutsLength`.
- * @param cachedIndex The position of this block in the parent layout list, or undefined if it isn't there yet.
- * @param originData The origin data captured from the workspace modal.
- * @param layoutsLength The current length of the parent layout list; used as the target when originData.index === -1.
- * @returns The resolved index, or undefined if no source yields one.
+ * @param {number | undefined} cachedIndex The position of this block in the parent layout list, or undefined if it isn't there yet.
+ * @param {UmbBlockWorkspaceOriginData | undefined} originData The origin data captured from the workspace modal.
+ * @param {number | undefined} layoutsLength The current length of the parent layout list; used as the target when originData.index === -1.
+ * @returns {number | undefined} The resolved index, or undefined if no source yields one.
  */
 export function resolveBlockWorkspaceLabelIndex(
 	cachedIndex: number | undefined,

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-index.function.ts
@@ -12,7 +12,7 @@ import type { UmbBlockWorkspaceOriginData } from './block-workspace.modal-token.
  * @param layoutsLength The current length of the parent layout list; used as the target when originData.index === -1.
  * @returns The resolved index, or undefined if no source yields one.
  */
-export function umbResolveBlockWorkspaceLabelIndex(
+export function resolveBlockWorkspaceLabelIndex(
 	cachedIndex: number | undefined,
 	originData: UmbBlockWorkspaceOriginData | undefined,
 	layoutsLength: number | undefined,

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -107,6 +107,8 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 
 		this.#retrieveBlockEntries = this.consumeContext(UMB_BLOCK_ENTRIES_CONTEXT, (context) => {
 			this.#blockEntries = context;
+			// Re-render the label now that we can resolve `$index` from the entries context.
+			this.#renderLabel(this.content.getValues(), this.settings.getValues());
 		}).asPromise({ preventTimeout: true });
 
 		this.consumeContext(UMB_IS_TRASHED_ENTITY_CONTEXT, (context) => {
@@ -273,8 +275,26 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			valueObject['$settings'] = settingsValues;
 		}
 
-		// TODO: Look to add support for `$index`, requires wiring up the block-entry with the workspace. [LK]
-		//valueObject['$index'] = 0;
+		const contentKey = this.#layout.value?.contentKey;
+		let index: number | undefined;
+
+		if (contentKey && this.#blockEntries) {
+			const found = this.#blockEntries.getLayouts().findIndex((x) => x.contentKey === contentKey);
+			if (found !== -1) {
+				index = found;
+			}
+		}
+
+		if (index === undefined && this.#originData && 'index' in this.#originData) {
+			const originIndex = (this.#originData as { index?: number }).index;
+			if (typeof originIndex === 'number' && originIndex !== -1) {
+				index = originIndex;
+			}
+		}
+
+		if (index !== undefined) {
+			valueObject['$index'] = index;
+		}
 
 		this.#labelRender.value = valueObject;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -28,6 +28,7 @@ import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import type { UUIModalSidebarSize } from '@umbraco-cms/backoffice/external/uui';
 import { UmbUfmVirtualRenderController } from '@umbraco-cms/backoffice/ufm';
 import { UMB_IS_TRASHED_ENTITY_CONTEXT } from '@umbraco-cms/backoffice/recycle-bin';
+import { distinctUntilChanged, map } from '@umbraco-cms/backoffice/external/rxjs';
 
 export type UmbBlockWorkspaceElementManagerNames = 'content' | 'settings';
 
@@ -112,19 +113,22 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			this.#blockEntries = context;
 			if (context) {
 				this.observe(
-					observeMultiple([context.layoutEntries, this.contentKey]),
-					([layouts, contentKey]) => {
-						const found = contentKey ? layouts.findIndex((x) => x.contentKey === contentKey) : -1;
-						const newIndex = found !== -1 ? found : undefined;
-						if (newIndex !== this.#index) {
-							this.#index = newIndex;
-							this.#renderLabel(this.content.getValues(), this.settings.getValues());
-						}
+					observeMultiple([context.layoutEntries, this.contentKey]).pipe(
+						map(([layouts, contentKey]) => {
+							const found = contentKey ? layouts.findIndex((x) => x.contentKey === contentKey) : -1;
+							return found !== -1 ? found : undefined;
+						}),
+						distinctUntilChanged(),
+					),
+					(index) => {
+						this.#index = index;
+						this.#renderLabel(this.content.getValues(), this.settings.getValues());
 					},
 					'observeLayoutIndex',
 				);
 			} else {
 				this.#index = undefined;
+				this.removeUmbControllerByAlias('observeLayoutIndex');
 			}
 		}).asPromise({ preventTimeout: true });
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -5,7 +5,7 @@ import { UmbBlockElementManager } from './block-element-manager.js';
 import type { UmbBlockWorkspaceOriginData } from './block-workspace.modal-token.js';
 import { UMB_BLOCK_WORKSPACE_VIEW_CONTENT, UMB_BLOCK_WORKSPACE_VIEW_SETTINGS } from './constants.js';
 import { UmbBlockLanguageAccessWorkspaceController } from './block-workspace-language-access.controller.js';
-import { umbResolveBlockWorkspaceLabelIndex } from './block-workspace-label-index.function.js';
+import { resolveBlockWorkspaceLabelIndex } from './block-workspace-label-index.function.js';
 import {
 	UmbSubmittableWorkspaceContextBase,
 	type UmbRoutableWorkspaceContext,
@@ -296,7 +296,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			valueObject['$settings'] = settingsValues;
 		}
 
-		const index = umbResolveBlockWorkspaceLabelIndex(
+		const index = resolveBlockWorkspaceLabelIndex(
 			this.#index,
 			this.#originData,
 			this.#blockEntries?.getLayouts().length,

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -5,6 +5,7 @@ import { UmbBlockElementManager } from './block-element-manager.js';
 import type { UmbBlockWorkspaceOriginData } from './block-workspace.modal-token.js';
 import { UMB_BLOCK_WORKSPACE_VIEW_CONTENT, UMB_BLOCK_WORKSPACE_VIEW_SETTINGS } from './constants.js';
 import { UmbBlockLanguageAccessWorkspaceController } from './block-workspace-language-access.controller.js';
+import { umbResolveBlockWorkspaceLabelIndex } from './block-workspace-label-index.function.js';
 import {
 	UmbSubmittableWorkspaceContextBase,
 	type UmbRoutableWorkspaceContext,
@@ -47,6 +48,8 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 	setOriginData(data: UmbBlockWorkspaceOriginData) {
 		this.#originData = data;
 	}
+	// Cached index of this block in its parent layout list, recomputed only when layouts or contentKey change.
+	#index: number | undefined;
 	#modalContext?: typeof UMB_MODAL_CONTEXT.TYPE;
 	#retrieveModalContext;
 
@@ -107,8 +110,22 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 
 		this.#retrieveBlockEntries = this.consumeContext(UMB_BLOCK_ENTRIES_CONTEXT, (context) => {
 			this.#blockEntries = context;
-			// Re-render the label now that we can resolve `$index` from the entries context.
-			this.#renderLabel(this.content.getValues(), this.settings.getValues());
+			if (context) {
+				this.observe(
+					observeMultiple([context.layoutEntries, this.contentKey]),
+					([layouts, contentKey]) => {
+						const found = contentKey ? layouts.findIndex((x) => x.contentKey === contentKey) : -1;
+						const newIndex = found !== -1 ? found : undefined;
+						if (newIndex !== this.#index) {
+							this.#index = newIndex;
+							this.#renderLabel(this.content.getValues(), this.settings.getValues());
+						}
+					},
+					'observeLayoutIndex',
+				);
+			} else {
+				this.#index = undefined;
+			}
 		}).asPromise({ preventTimeout: true });
 
 		this.consumeContext(UMB_IS_TRASHED_ENTITY_CONTEXT, (context) => {
@@ -275,22 +292,11 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			valueObject['$settings'] = settingsValues;
 		}
 
-		const contentKey = this.#layout.value?.contentKey;
-		let index: number | undefined;
-
-		if (contentKey && this.#blockEntries) {
-			const found = this.#blockEntries.getLayouts().findIndex((x) => x.contentKey === contentKey);
-			if (found !== -1) {
-				index = found;
-			}
-		}
-
-		if (index === undefined && this.#originData && 'index' in this.#originData) {
-			const originIndex = (this.#originData as { index?: number }).index;
-			if (typeof originIndex === 'number' && originIndex !== -1) {
-				index = originIndex;
-			}
-		}
+		const index = umbResolveBlockWorkspaceLabelIndex(
+			this.#index,
+			this.#originData,
+			this.#blockEntries?.getLayouts().length,
+		);
 
 		if (index !== undefined) {
 			valueObject['$index'] = index;


### PR DESCRIPTION
## Description

Block label expressions referencing `$index` (e.g. `${ $index + 1 }`) rendered `NaN` in the workspace detail overlay because `UmbBlockWorkspaceContext` built its UFM value object without `$index` — only the inline list/grid elements supplied it. There was a pre-existing `TODO` at the relevant spot acknowledging the gap.

`#renderLabel` in `block-workspace.context.ts` now resolves the index from the block-entries layout array (existing blocks) or `originData.index` (new blocks created via the catalogue), and exposes it as `$index` on the UFM value object.

In that way we render the index as a number for new and existing blocks.

Fixes #21154

<img width="1466" height="862" alt="image" src="https://github.com/user-attachments/assets/243d417f-96ad-4de1-abd7-0c015c5ee5c0" />

## Testing

- On a document type, configure a Block List with an element label `${ $index + 1 }. Test Block`.
- Add three blocks. Inline labels read `1. …`, `2. …`, `3. …`.
- Click the second block to open the detail overlay — header reads `Edit 2. …` (previously `Edit NaN. …`).
- Use the block catalogue to insert at position 4 — the new overlay reads `Add 4. …`.