### PR TITLE
References: Fix missing node name when content referenced by media or member (closes #22990)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TrackedReferencesRepository.cs
@@ -74,6 +74,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             string[] columns = [
                     sx.ColumnWithAlias("x", "otherId", "nodeId"),
                     sx.ColumnWithAlias("n", "uniqueId", "nodeKey"),
+                    sx.ColumnWithAlias("n", "text", "nodeName"),
                     sx.ColumnWithAlias("n", "nodeObjectType", "nodeObjectType"),
                     sx.ColumnWithAlias("d", "published", "nodePublished"),
                     sx.ColumnWithAlias("ctn", "uniqueId", "contentTypeKey"),

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackedReferencesServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackedReferencesServiceTests.cs
@@ -107,6 +107,7 @@ internal class TrackedReferencesServiceTests : UmbracoIntegrationTest
             var item = actual.Result.Items.FirstOrDefault();
             Assert.AreEqual(Root2.ContentType.Alias, item?.ContentTypeAlias);
             Assert.AreEqual(Root2.Key, item?.NodeKey);
+            Assert.AreEqual(Root2.Name, item?.NodeName);
         });
     }
 
@@ -140,6 +141,9 @@ internal class TrackedReferencesServiceTests : UmbracoIntegrationTest
             Assert.IsFalse(itemKeys.Contains(Root1.Key)); // Should not return the parent itself (see: https://github.com/umbraco/Umbraco-CMS/pull/21162)
             Assert.AreEqual(1, itemKeys.Count);
             Assert.IsTrue(itemKeys.Contains(Child1.Key));
+
+            var childItem = actual.Result.Items.FirstOrDefault(x => x.NodeKey == Child1.Key);
+            Assert.AreEqual(Child1.Name, childItem?.NodeName);
         });
     }
 
@@ -183,6 +187,7 @@ internal class TrackedReferencesServiceTests : UmbracoIntegrationTest
             var item = actual.Items.FirstOrDefault();
             Assert.AreEqual(Root2.ContentType.Alias, item?.ContentTypeAlias);
             Assert.AreEqual(Root2.Key, item?.NodeKey);
+            Assert.AreEqual(Root2.Name, item?.NodeName);
         });
     }
 }


### PR DESCRIPTION
## Description

The "Referenced By" panel on a content/media/member workspace (and on the recycle bin and delete/unpublish warning dialogs) was showing only the icon for media and member references — the name was missing.

Root cause: `TrackedReferencesRepository.GetPagedRelations` — the SQL query backing both `GetPagedRelationsForItemAsync` and `GetPagedRelationsForRecycleBinAsync` — wasn't selecting `n.text` ("nodeName") in its column list, so `RelationItemDto.ChildNodeName` (and downstream `RelationItemModel.NodeName`) was always null. `TrackedReferenceViewModelsMapDefinition.Map` then sent `Name = null` to the API for every reference type. Documents were rescued by `RelationTypePresentationFactory.MapDocumentReference` doing a second `_entityRepository.GetAll(...)` to fill `Variants`; media and member responses had no such fallback.

The sibling queries `GetPagedItemsWithRelations` and `GetPagedDescendantsInReferences` already selected `n.text` correctly — this was an inconsistency between three otherwise-parallel queries.

Fix: one-line addition of `sx.ColumnWithAlias("n", "text", "nodeName")` to the SELECT in `GetPagedRelations`, matching the alias used by the sibling queries and the `[Column(Name = "nodeName")]` attribute on the DTO.

Fixes #22990.

## Testing

### Automated

I've added `NodeName` assertions to the existing integration tests in `TrackedReferencesServiceTests.cs` that would have caught the bug, and so any future regression in the SELECT list will fail the build.

### Manual

Requires a document that is referenced by a media item or a member (via a content/document picker on the media type or member type).

1. Open the workspace of the referenced document.
2. Open the **Info > Referenced By** panel.
3. **Before this PR:** the media or member entry shows the icon but no name. **After this PR:** the entry shows both the icon and the name.
4. As per the reported issue, the same correction should be observed when unpublishing the document in the warning dialog.
