### PR TITLE
Background Jobs: Refine RecurringBackgroundJobBase API

### DIFF
--- a/src/Umbraco.Infrastructure/BackgroundJobs/IRecurringBackgroundJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/IRecurringBackgroundJob.cs
@@ -26,7 +26,7 @@ public interface IRecurringBackgroundJob
     /// The period.
     /// </value>
     /// <remarks>
-    /// Set to <see cref="Timeout.InfiniteTimeSpan" /> to (temporarily) disable automatic scheduling and turn the job into a manually triggered one (via <see cref="IRecurringBackgroundJobTrigger{TJob}" />). Raise <see cref="PeriodChanged" /> to switch back to a finite period at runtime.
+    /// Set to <see cref="Timeout.InfiniteTimeSpan" /> to (temporarily) disable automatic scheduling and turn the job into a manually triggered one (via <see cref="IRecurringBackgroundJobTrigger{TJob}" />). To change the period at runtime, subclasses of <see cref="RecurringBackgroundJobBase" /> assign the protected setter on <see cref="RecurringBackgroundJobBase.Period" /> (which auto-raises <see cref="PeriodChanged" />); direct implementors of this interface must raise <see cref="PeriodChanged" /> themselves after updating the backing value.
     /// </remarks>
     TimeSpan Period { get; }
 
@@ -49,7 +49,7 @@ public interface IRecurringBackgroundJob
     /// </value>
     /// <remarks>
     /// This back-off prevents tight looping when <see cref="Period" /> is short (or <see cref="TimeSpan.Zero" />) and an execution is skipped without invoking <see cref="RunJobAsync(CancellationToken)" />.
-    /// Set to <see cref="Timeout.InfiniteTimeSpan" /> to disable the job for the remaining application lifecycle once an ignored condition is encountered — useful when the condition is known not to change (e.g. a server role that will not be promoted on this instance).
+    /// Set to <see cref="Timeout.InfiniteTimeSpan" /> to disable the job for the remaining application lifecycle once an ignored condition is encountered — useful when the condition is known not to change (e.g. a server role that will not be promoted on this instance). To change the ignored delay at runtime, subclasses of <see cref="RecurringBackgroundJobBase" /> assign the protected setter on <see cref="RecurringBackgroundJobBase.IgnoredDelay" /> (which auto-raises <see cref="IgnoredDelayChanged" />); direct implementors of this interface must raise <see cref="IgnoredDelayChanged" /> themselves after updating the backing value.
     /// </remarks>
     TimeSpan IgnoredDelay => RecurringBackgroundJobBase.DefaultIgnoredDelay; // TODO (V19): Remove the default implementation
 

--- a/src/Umbraco.Infrastructure/BackgroundJobs/IRecurringBackgroundJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/IRecurringBackgroundJob.cs
@@ -64,7 +64,16 @@ public interface IRecurringBackgroundJob
     /// <summary>
     /// This event should be raised when the <see cref="Period" /> property changes to notify the background job manager to update the schedule for this job.
     /// </summary>
-    event EventHandler PeriodChanged;
+    event EventHandler PeriodChanged; // TODO (V19): Change to `event EventHandler? PeriodChanged;` so implementations can use field-like event syntax without manual backing-delegate accessors.
+
+    /// <summary>
+    /// This event should be raised when the <see cref="IgnoredDelay" /> property changes (e.g. from <see cref="Timeout.InfiniteTimeSpan" /> back to a finite value) to interrupt any in-progress ignored back-off and re-read the new value.
+    /// </summary>
+    event EventHandler IgnoredDelayChanged
+    {
+        add { }
+        remove { }
+    } // TODO (V19): Remove the default implementation and change to `event EventHandler? IgnoredDelayChanged;` so implementations can use field-like event syntax without manual backing-delegate accessors.
 
     /// <summary>
     /// Runs the background job.

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ReportSiteJob.cs
@@ -13,11 +13,6 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
 public class ReportSiteJob : RecurringBackgroundJobBase
 {
     /// <summary>
-    /// Gets the period at which the report site job runs.
-    /// </summary>
-    public override TimeSpan Period => TimeSpan.FromDays(1);
-
-    /// <summary>
     /// Gets the time interval to wait between executions of the <see cref="ReportSiteJob"/>.
     /// The delay is set to 5 minutes.
     /// </summary>
@@ -45,6 +40,7 @@ public class ReportSiteJob : RecurringBackgroundJobBase
         ITelemetryService telemetryService,
         IJsonSerializer jsonSerializer,
         IHttpClientFactory httpClientFactory)
+        : base(TimeSpan.FromDays(1))
     {
         _logger = logger;
         _telemetryService = telemetryService;

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
@@ -14,13 +14,6 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.ServerRegistration;
 /// </summary>
 public class InstructionProcessJob : RecurringBackgroundJobBase
 {
-    private readonly TimeSpan _period;
-
-    /// <summary>
-    /// Gets the interval between executions of the instruction process job.
-    /// </summary>
-    public override TimeSpan Period => _period;
-
     /// <summary>
     /// Gets the delay time before the job is executed. The delay is fixed at one minute.
     /// </summary>
@@ -44,11 +37,10 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
         IServerMessenger messenger,
         ILogger<InstructionProcessJob> logger,
         IOptions<GlobalSettings> globalSettings)
+        : base(globalSettings.Value.DatabaseServerMessenger.TimeBetweenSyncOperations)
     {
         _messenger = messenger;
         _logger = logger;
-
-        _period = globalSettings.Value.DatabaseServerMessenger.TimeBetweenSyncOperations;
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
@@ -3,12 +3,10 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.ServerRegistration;
 
@@ -17,13 +15,6 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.ServerRegistration;
 /// </summary>
 public class TouchServerJob : RecurringBackgroundJobBase
 {
-    private TimeSpan _period;
-
-    /// <summary>
-    /// Gets the period that defines how often the server should be touched.
-    /// </summary>
-    public override TimeSpan Period => _period;
-
     /// <summary>
     /// Gets the fixed delay interval of 15 seconds between executions of the touch server job.
     /// This interval determines how often the server registration is updated.
@@ -36,21 +27,11 @@ public class TouchServerJob : RecurringBackgroundJobBase
     /// <remarks>Runs on all servers</remarks>
     public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();
 
-    private event EventHandler? _periodChanged;
-
-    /// <summary>
-    /// Occurs when the period of the TouchServerJob changes.
-    /// </summary>
-    public override event EventHandler PeriodChanged
-    {
-        add { _periodChanged += value; }
-        remove { _periodChanged -= value; }
-    }
-
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly ILogger<TouchServerJob> _logger;
     private readonly IServerRegistrationService _serverRegistrationService;
     private readonly IServerRoleAccessor _serverRoleAccessor;
+    private readonly IDisposable? _onChangeRegistration;
     private GlobalSettings _globalSettings;
 
     /// <summary>
@@ -67,6 +48,7 @@ public class TouchServerJob : RecurringBackgroundJobBase
         ILogger<TouchServerJob> logger,
         IOptionsMonitor<GlobalSettings> globalSettings,
         IServerRoleAccessor serverRoleAccessor)
+        : base(globalSettings.CurrentValue.DatabaseServerRegistrar.WaitTimeBetweenCalls)
     {
         _serverRegistrationService = serverRegistrationService ?? throw new ArgumentNullException(nameof(serverRegistrationService));
         _hostingEnvironment = hostingEnvironment;
@@ -74,13 +56,10 @@ public class TouchServerJob : RecurringBackgroundJobBase
         _globalSettings = globalSettings.CurrentValue;
         _serverRoleAccessor = serverRoleAccessor;
 
-        _period = _globalSettings.DatabaseServerRegistrar.WaitTimeBetweenCalls;
-        globalSettings.OnChange(x =>
+        _onChangeRegistration = globalSettings.OnChange(x =>
         {
             _globalSettings = x;
-            _period = x.DatabaseServerRegistrar.WaitTimeBetweenCalls;
-
-            _periodChanged?.Invoke(this, EventArgs.Empty);
+            Period = x.DatabaseServerRegistrar.WaitTimeBetweenCalls;
         });
     }
 
@@ -94,7 +73,6 @@ public class TouchServerJob : RecurringBackgroundJobBase
     /// </returns>
     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
-
         // If the IServerRoleAccessor has been changed away from ElectedServerRoleAccessor this task no longer makes sense,
         // since all it's used for is to allow the ElectedServerRoleAccessor
         // to figure out what role a given server has, so we just stop this task.
@@ -104,7 +82,7 @@ public class TouchServerJob : RecurringBackgroundJobBase
         }
 
         var serverAddress = _hostingEnvironment.ApplicationMainUrl?.ToString();
-        if (serverAddress.IsNullOrWhiteSpace())
+        if (string.IsNullOrWhiteSpace(serverAddress))
         {
             _logger.LogWarning("No umbracoApplicationUrl for service (yet), skip.");
             return Task.CompletedTask;
@@ -113,7 +91,7 @@ public class TouchServerJob : RecurringBackgroundJobBase
         try
         {
             _serverRegistrationService.TouchServer(
-                serverAddress!,
+                serverAddress,
                 _globalSettings.DatabaseServerRegistrar.StaleServerTimeout);
         }
         catch (Exception ex)
@@ -122,5 +100,16 @@ public class TouchServerJob : RecurringBackgroundJobBase
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _onChangeRegistration?.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/TempFileCleanupJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/TempFileCleanupJob.cs
@@ -17,11 +17,6 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs;
 public class TempFileCleanupJob : RecurringBackgroundJobBase
 {
     /// <summary>
-    /// Gets the time interval between each execution of the temporary file cleanup job.
-    /// </summary>
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
-
-    /// <summary>
     /// Gets the server roles on which this job runs. This job is configured to run on all server roles.
     /// </summary>
     /// <remarks>Runs on all servers</remarks>
@@ -38,10 +33,10 @@ public class TempFileCleanupJob : RecurringBackgroundJobBase
     /// <param name="ioHelper">Helper service for IO operations.</param>
     /// <param name="logger">The typed logger.</param>
     public TempFileCleanupJob(IIOHelper ioHelper, ILogger<TempFileCleanupJob> logger)
+        : base(TimeSpan.FromMinutes(60))
     {
         _ioHelper = ioHelper;
         _logger = logger;
-
         _tempFolders = _ioHelper.GetTempFolders();
     }
 

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBase.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBase.cs
@@ -6,9 +6,9 @@ namespace Umbraco.Cms.Infrastructure.BackgroundJobs;
 /// Base class for recurring background jobs that provides default values for common properties.
 /// </summary>
 /// <remarks>
-/// Implementors only need to provide <see cref="Period" /> and <see cref="RunJobAsync(CancellationToken)" />.
+/// Implementors must pass an initial <see cref="Period" /> to the base constructor and implement <see cref="RunJobAsync(CancellationToken)" />.
 /// </remarks>
-public abstract class RecurringBackgroundJobBase : IRecurringBackgroundJob
+public abstract class RecurringBackgroundJobBase : IRecurringBackgroundJob, IDisposable
 {
     /// <summary>
     /// The default delay to use for recurring tasks for the first run after application start-up if no alternative is configured.
@@ -34,23 +34,113 @@ public abstract class RecurringBackgroundJobBase : IRecurringBackgroundJob
     /// </remarks>
     protected internal static readonly ServerRole[] DefaultServerRoles = [ServerRole.Single, ServerRole.SchedulingPublisher];
 
+    private TimeSpan _period;
+    private TimeSpan _ignoredDelay = DefaultIgnoredDelay;
+    private EventHandler? _periodChanged;
+    private EventHandler? _ignoredDelayChanged;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RecurringBackgroundJobBase" /> class with the specified initial <paramref name="period" />. The initial value is stored directly without raising <see cref="PeriodChanged" />.
+    /// </summary>
+    /// <param name="period">The initial period between executions. Set to <see cref="Timeout.InfiniteTimeSpan" /> for a manual-trigger-only job.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="period" /> is negative and not <see cref="Timeout.InfiniteTimeSpan" />.</exception>
+    protected RecurringBackgroundJobBase(TimeSpan period)
+    {
+        if (period != Timeout.InfiniteTimeSpan)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(period, TimeSpan.Zero);
+        }
+
+        _period = period;
+    }
+
     /// <inheritdoc />
-    public abstract TimeSpan Period { get; }
+    /// <remarks>
+    /// Setting this property to a different value raises <see cref="PeriodChanged" />.
+    /// </remarks>
+    public virtual TimeSpan Period
+    {
+        get => _period;
+        protected set
+        {
+            if (value != Timeout.InfiniteTimeSpan)
+            {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, TimeSpan.Zero);
+            }
+
+            if (_period == value)
+            {
+                return;
+            }
+
+            _period = value;
+            OnPeriodChanged(EventArgs.Empty);
+        }
+    }
 
     /// <inheritdoc />
     public virtual TimeSpan Delay => DefaultDelay;
 
     /// <inheritdoc />
-    public virtual TimeSpan IgnoredDelay => DefaultIgnoredDelay;
+    /// <remarks>
+    /// Setting this property to a different value raises <see cref="IgnoredDelayChanged" />.
+    /// </remarks>
+    public virtual TimeSpan IgnoredDelay
+    {
+        get => _ignoredDelay;
+        protected set
+        {
+            if (value != Timeout.InfiniteTimeSpan)
+            {
+                ArgumentOutOfRangeException.ThrowIfLessThan(value, TimeSpan.Zero);
+            }
+
+            if (_ignoredDelay == value)
+            {
+                return;
+            }
+
+            _ignoredDelay = value;
+            OnIgnoredDelayChanged(EventArgs.Empty);
+        }
+    }
 
     /// <inheritdoc />
     public virtual ServerRole[] ServerRoles => DefaultServerRoles;
 
     /// <inheritdoc />
-    public virtual event EventHandler PeriodChanged { add { } remove { } }
+    public virtual event EventHandler PeriodChanged
+    {
+        add { _periodChanged += value; }
+        remove { _periodChanged -= value; }
+    }
 
     /// <inheritdoc />
-    public virtual event EventHandler IgnoredDelayChanged { add { } remove { } }
+    public virtual event EventHandler IgnoredDelayChanged
+    {
+        add { _ignoredDelayChanged += value; }
+        remove { _ignoredDelayChanged -= value; }
+    }
+
+    /// <summary>
+    /// Raises the <see cref="PeriodChanged" /> event.
+    /// </summary>
+    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
+    /// <remarks>
+    /// Override this when overriding <see cref="PeriodChanged" /> to dispatch through the overridden event's backing delegate.
+    /// </remarks>
+    protected virtual void OnPeriodChanged(EventArgs e)
+        => _periodChanged?.Invoke(this, e);
+
+    /// <summary>
+    /// Raises the <see cref="IgnoredDelayChanged" /> event.
+    /// </summary>
+    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
+    /// <remarks>
+    /// Override this when overriding <see cref="IgnoredDelayChanged" /> to dispatch through the overridden event's backing delegate.
+    /// </remarks>
+    protected virtual void OnIgnoredDelayChanged(EventArgs e)
+        => _ignoredDelayChanged?.Invoke(this, e);
 
     /// <inheritdoc />
     [Obsolete("Use RunJobAsync(CancellationToken) instead. Scheduled for removal in Umbraco 19.")]
@@ -58,4 +148,25 @@ public abstract class RecurringBackgroundJobBase : IRecurringBackgroundJob
 
     /// <inheritdoc />
     public abstract Task RunJobAsync(CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases the resources used by this job. Subclasses adding disposable state should override this method, dispose their own resources, and call <c>base.Dispose(disposing)</c>.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Clear the subscriber delegates so the job does not retain references to (or invoke) listeners after disposal.
+            _periodChanged = null;
+            _ignoredDelayChanged = null;
+        }
+    }
 }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBase.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBase.cs
@@ -56,7 +56,7 @@ public abstract class RecurringBackgroundJobBase : IRecurringBackgroundJob, IDis
 
     /// <inheritdoc />
     /// <remarks>
-    /// Setting this property to a different value raises <see cref="PeriodChanged" />.
+    /// Setting this property to a different value raises <see cref="PeriodChanged" />. The initial value passed to the constructor is stored without raising the event.
     /// </remarks>
     public virtual TimeSpan Period
     {
@@ -83,7 +83,7 @@ public abstract class RecurringBackgroundJobBase : IRecurringBackgroundJob, IDis
 
     /// <inheritdoc />
     /// <remarks>
-    /// Setting this property to a different value raises <see cref="IgnoredDelayChanged" />.
+    /// Setting this property to a different value raises <see cref="IgnoredDelayChanged" />. The initial value (<see cref="DefaultIgnoredDelay" />) is set without raising the event.
     /// </remarks>
     public virtual TimeSpan IgnoredDelay
     {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBase.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBase.cs
@@ -50,6 +50,9 @@ public abstract class RecurringBackgroundJobBase : IRecurringBackgroundJob
     public virtual event EventHandler PeriodChanged { add { } remove { } }
 
     /// <inheritdoc />
+    public virtual event EventHandler IgnoredDelayChanged { add { } remove { } }
+
+    /// <inheritdoc />
     [Obsolete("Use RunJobAsync(CancellationToken) instead. Scheduled for removal in Umbraco 19.")]
     public Task RunJobAsync() => RunJobAsync(CancellationToken.None);
 

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
@@ -221,7 +221,8 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
     {
         // Rotate without disposing — the wait loop may still be registering against the old token.
         // The old CTS is small once cancelled and will be collected by the GC.
-        CancellationTokenSource oldCts = Interlocked.Exchange(ref _ignoredDelayChangeCts, new CancellationTokenSource());
+        var newCts = new CancellationTokenSource();
+        CancellationTokenSource oldCts = Interlocked.Exchange(ref _ignoredDelayChangeCts, newCts);
 
         try
         {
@@ -229,7 +230,8 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         }
         catch (ObjectDisposedException)
         {
-            // Race during shutdown: Dispose disposed the CTS between this in-flight handler reading it and calling Cancel. Safe to swallow — the wait loop is already torn down.
+            // Lost the shutdown race — newCts will not be observed.
+            newCts.Dispose();
         }
     }
 
@@ -255,7 +257,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         {
             TimeSpan ignoredDelay = _job.IgnoredDelay;
 
-            // Skip the back-off for zero and any other non-positive value (other than Timeout.InfiniteTimeSpan, which means "wait until shutdown / IgnoredDelayChanged"). Validating here defends against direct IRecurringBackgroundJob implementations or property overrides that bypass the RecurringBackgroundJobBase setter validation.
+            // Skip back-off for zero/negative; Timeout.InfiniteTimeSpan means wait until shutdown or IgnoredDelayChanged.
             if (ignoredDelay != Timeout.InfiniteTimeSpan && ignoredDelay <= TimeSpan.Zero)
             {
                 return;

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
@@ -218,22 +218,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
     /// <param name="sender">The sender.</param>
     /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
     private void OnIgnoredDelayChanged(object? sender, EventArgs e)
-    {
-        // Rotate without disposing — the wait loop may still be registering against the old token.
-        // The old CTS is small once cancelled and will be collected by the GC.
-        var newCts = new CancellationTokenSource();
-        CancellationTokenSource oldCts = Interlocked.Exchange(ref _ignoredDelayChangeCts, newCts);
-
-        try
-        {
-            oldCts.Cancel();
-        }
-        catch (ObjectDisposedException)
-        {
-            // Lost the shutdown race — newCts will not be observed.
-            newCts.Dispose();
-        }
-    }
+        => CancellationTokenSourceRotation.RotateAndCancel(ref _ignoredDelayChangeCts);
 
     /// <summary>
     /// Publishes the ignored notification and waits for <see cref="IRecurringBackgroundJob.IgnoredDelay" /> before allowing the next iteration, preventing tight looping when execution is skipped.

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
@@ -222,7 +222,15 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         // Rotate without disposing — the wait loop may still be registering against the old token.
         // The old CTS is small once cancelled and will be collected by the GC.
         CancellationTokenSource oldCts = Interlocked.Exchange(ref _ignoredDelayChangeCts, new CancellationTokenSource());
-        oldCts.Cancel();
+
+        try
+        {
+            oldCts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Race during shutdown: Dispose disposed the CTS between this in-flight handler reading it and calling Cancel. Safe to swallow — the wait loop is already torn down.
+        }
     }
 
     /// <summary>
@@ -246,7 +254,9 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         while (true)
         {
             TimeSpan ignoredDelay = _job.IgnoredDelay;
-            if (ignoredDelay == TimeSpan.Zero)
+
+            // Skip the back-off for zero and any other non-positive value (other than Timeout.InfiniteTimeSpan, which means "wait until shutdown / IgnoredDelayChanged"). Validating here defends against direct IRecurringBackgroundJob implementations or property overrides that bypass the RecurringBackgroundJobBase setter validation.
+            if (ignoredDelay != Timeout.InfiniteTimeSpan && ignoredDelay <= TimeSpan.Zero)
             {
                 return;
             }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedService.cs
@@ -49,6 +49,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
     private readonly IEventMessagesFactory _eventMessagesFactory;
     private readonly IRecurringBackgroundJob _job;
     private readonly TimeProvider _timeProvider;
+    private CancellationTokenSource _ignoredDelayChangeCts = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RecurringBackgroundJobHostedService{TJob}" /> class, which manages the execution of a recurring background job.
@@ -82,6 +83,7 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         _timeProvider = timeProvider;
 
         _job.PeriodChanged += OnPeriodChanged;
+        _job.IgnoredDelayChanged += OnIgnoredDelayChanged;
     }
 
     /// <summary>
@@ -194,6 +196,9 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         if (disposing)
         {
             _job.PeriodChanged -= OnPeriodChanged;
+            _job.IgnoredDelayChanged -= OnIgnoredDelayChanged;
+
+            _ignoredDelayChangeCts.Dispose();
         }
 
         base.Dispose(disposing);
@@ -206,6 +211,19 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
     /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
     private void OnPeriodChanged(object? sender, EventArgs e)
         => ChangePeriod(_job.Period);
+
+    /// <summary>
+    /// Handles the <see cref="IRecurringBackgroundJob.IgnoredDelayChanged" /> event by interrupting any in-progress ignored back-off so it re-reads the new <see cref="IRecurringBackgroundJob.IgnoredDelay" /> value.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+    private void OnIgnoredDelayChanged(object? sender, EventArgs e)
+    {
+        // Rotate without disposing — the wait loop may still be registering against the old token.
+        // The old CTS is small once cancelled and will be collected by the GC.
+        CancellationTokenSource oldCts = Interlocked.Exchange(ref _ignoredDelayChangeCts, new CancellationTokenSource());
+        oldCts.Cancel();
+    }
 
     /// <summary>
     /// Publishes the ignored notification and waits for <see cref="IRecurringBackgroundJob.IgnoredDelay" /> before allowing the next iteration, preventing tight looping when execution is skipped.
@@ -223,19 +241,41 @@ public class RecurringBackgroundJobHostedService<TJob> : RecurringHostedServiceB
         _logger.LogDebug(message);
         await _eventAggregator.PublishAsync(new RecurringBackgroundJobIgnoredNotification(_job, eventMessages).WithStateFrom(executingNotification), stoppingToken);
 
-        TimeSpan ignoredDelay = _job.IgnoredDelay;
-        if (ignoredDelay == TimeSpan.Zero)
-        {
-            return;
-        }
+        long waitStart = _timeProvider.GetTimestamp();
 
-        try
+        while (true)
         {
-            await Task.Delay(ignoredDelay, _timeProvider, stoppingToken);
-        }
-        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-        {
-            // Back-off interrupted by shutdown; the ignored notification has already been published, so do not also publish canceled.
+            TimeSpan ignoredDelay = _job.IgnoredDelay;
+            if (ignoredDelay == TimeSpan.Zero)
+            {
+                return;
+            }
+
+            TimeSpan remaining = ComputeNextDelay(ignoredDelay, _timeProvider.GetElapsedTime(waitStart));
+            if (remaining == TimeSpan.Zero)
+            {
+                return;
+            }
+
+            CancellationToken ignoredDelayChangeToken = _ignoredDelayChangeCts.Token;
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken, ignoredDelayChangeToken);
+
+            try
+            {
+                await Task.Delay(remaining, _timeProvider, linkedCts.Token);
+
+                // Back-off complete
+                return;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Back-off interrupted by shutdown; the ignored notification has already been published, so do not also publish canceled
+                return;
+            }
+            catch (OperationCanceledException) when (ignoredDelayChangeToken.IsCancellationRequested)
+            {
+                // IgnoredDelay changed — loop to re-read and recompute the remaining wait
+            }
         }
     }
 }

--- a/src/Umbraco.Infrastructure/HostedServices/CancellationTokenSourceRotation.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/CancellationTokenSourceRotation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Infrastructure.HostedServices;
+
+/// <summary>
+/// Helpers for rotating <see cref="CancellationTokenSource" /> instances used to interrupt cooperative waits.
+/// </summary>
+internal static class CancellationTokenSourceRotation
+{
+    /// <summary>
+    /// Atomically installs a fresh <see cref="CancellationTokenSource" /> at <paramref name="field" /> and cancels the previous one without disposing it.
+    /// If the previous CTS has already been disposed (lost the shutdown race), the newly installed CTS is also disposed since no waiter will observe it.
+    /// </summary>
+    /// <param name="field">A reference to the field holding the active CTS.</param>
+    /// <remarks>
+    /// The previous CTS is not disposed because the wait loop may still be registering against its token. Once cancelled it is small and will be collected by the GC.
+    /// </remarks>
+    public static void RotateAndCancel(ref CancellationTokenSource field)
+    {
+        var newCts = new CancellationTokenSource();
+        CancellationTokenSource oldCts = Interlocked.Exchange(ref field, newCts);
+
+        try
+        {
+            oldCts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            newCts.Dispose();
+        }
+    }
+}

--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -307,8 +307,18 @@ public abstract class RecurringHostedServiceBase : BackgroundService
 
         // Cancel but don't dispose — the wait loop may still be registering against the token.
         // The old CTS is small once cancelled and will be collected by the GC.
-        CancellationTokenSource oldCts = Interlocked.Exchange(ref _periodChangeCts, new CancellationTokenSource());
-        oldCts.Cancel();
+        var newCts = new CancellationTokenSource();
+        CancellationTokenSource oldCts = Interlocked.Exchange(ref _periodChangeCts, newCts);
+
+        try
+        {
+            oldCts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Lost the shutdown race — newCts will not be observed.
+            newCts.Dispose();
+        }
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
+++ b/src/Umbraco.Infrastructure/HostedServices/RecurringHostedServiceBase.cs
@@ -305,20 +305,7 @@ public abstract class RecurringHostedServiceBase : BackgroundService
 
         Interlocked.Exchange(ref _periodTicks, newPeriod.Ticks);
 
-        // Cancel but don't dispose — the wait loop may still be registering against the token.
-        // The old CTS is small once cancelled and will be collected by the GC.
-        var newCts = new CancellationTokenSource();
-        CancellationTokenSource oldCts = Interlocked.Exchange(ref _periodChangeCts, newCts);
-
-        try
-        {
-            oldCts.Cancel();
-        }
-        catch (ObjectDisposedException)
-        {
-            // Lost the shutdown race — newCts will not be observed.
-            newCts.Dispose();
-        }
+        CancellationTokenSourceRotation.RotateAndCancel(ref _periodChangeCts);
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobBaseTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.BackgroundJobs;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.BackgroundJobs;
+
+[TestFixture]
+public class RecurringBackgroundJobBaseTests
+{
+    [Test]
+    public void Constructor_Sets_Initial_Period()
+    {
+        var sut = new TestJob(TimeSpan.FromMinutes(7));
+
+        Assert.AreEqual(TimeSpan.FromMinutes(7), sut.Period);
+    }
+
+    [Test]
+    public void Constructor_Allows_Infinite_Period()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+
+        Assert.AreEqual(Timeout.InfiniteTimeSpan, sut.Period);
+    }
+
+    [Test]
+    public void Constructor_Throws_On_Negative_Period()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new TestJob(TimeSpan.FromSeconds(-1)));
+
+    [Test]
+    public void IgnoredDelay_Default_Is_DefaultIgnoredDelay()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+
+        Assert.AreEqual(RecurringBackgroundJobBase.DefaultIgnoredDelay, sut.IgnoredDelay);
+    }
+
+    [Test]
+    public void Setting_Period_Raises_PeriodChanged()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+        var raised = 0;
+        sut.PeriodChanged += (_, _) => raised++;
+
+        sut.SetPeriod(TimeSpan.FromMinutes(5));
+
+        Assert.AreEqual(TimeSpan.FromMinutes(5), sut.Period);
+        Assert.AreEqual(1, raised);
+    }
+
+    [Test]
+    public void Setting_Period_To_Same_Value_Does_Not_Raise()
+    {
+        var sut = new TestJob(TimeSpan.FromMinutes(5));
+        var raised = 0;
+        sut.PeriodChanged += (_, _) => raised++;
+
+        sut.SetPeriod(TimeSpan.FromMinutes(5));
+
+        Assert.AreEqual(0, raised);
+    }
+
+    [Test]
+    public void Setting_Period_To_Infinite_Is_Allowed()
+    {
+        var sut = new TestJob(TimeSpan.FromMinutes(5));
+        var raised = 0;
+        sut.PeriodChanged += (_, _) => raised++;
+
+        sut.SetPeriod(Timeout.InfiniteTimeSpan);
+
+        Assert.AreEqual(Timeout.InfiniteTimeSpan, sut.Period);
+        Assert.AreEqual(1, raised);
+    }
+
+    [Test]
+    public void Setting_Period_To_Negative_Throws()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => sut.SetPeriod(TimeSpan.FromSeconds(-1)));
+    }
+
+    [Test]
+    public void Setting_IgnoredDelay_Raises_IgnoredDelayChanged()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+        var raised = 0;
+        sut.IgnoredDelayChanged += (_, _) => raised++;
+
+        sut.SetIgnoredDelay(TimeSpan.FromSeconds(30));
+
+        Assert.AreEqual(TimeSpan.FromSeconds(30), sut.IgnoredDelay);
+        Assert.AreEqual(1, raised);
+    }
+
+    [Test]
+    public void Setting_IgnoredDelay_To_Same_Value_Does_Not_Raise()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+        sut.SetIgnoredDelay(TimeSpan.FromSeconds(30));
+        var raised = 0;
+        sut.IgnoredDelayChanged += (_, _) => raised++;
+
+        sut.SetIgnoredDelay(TimeSpan.FromSeconds(30));
+
+        Assert.AreEqual(0, raised);
+    }
+
+    [Test]
+    public void Setting_IgnoredDelay_To_Infinite_Is_Allowed()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+        var raised = 0;
+        sut.IgnoredDelayChanged += (_, _) => raised++;
+
+        sut.SetIgnoredDelay(Timeout.InfiniteTimeSpan);
+
+        Assert.AreEqual(Timeout.InfiniteTimeSpan, sut.IgnoredDelay);
+        Assert.AreEqual(1, raised);
+    }
+
+    [Test]
+    public void Setting_IgnoredDelay_To_Negative_Throws()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => sut.SetIgnoredDelay(TimeSpan.FromSeconds(-1)));
+    }
+
+    [Test]
+    public void Dispose_Clears_PeriodChanged_Subscribers()
+    {
+        var sut = new TestJob(TimeSpan.FromMinutes(5));
+        var raised = 0;
+        sut.PeriodChanged += (_, _) => raised++;
+
+        sut.Dispose();
+        sut.SetPeriod(TimeSpan.FromMinutes(6));
+
+        Assert.AreEqual(0, raised);
+    }
+
+    [Test]
+    public void Dispose_Clears_IgnoredDelayChanged_Subscribers()
+    {
+        var sut = new TestJob(Timeout.InfiniteTimeSpan);
+        var raised = 0;
+        sut.IgnoredDelayChanged += (_, _) => raised++;
+
+        sut.Dispose();
+        sut.SetIgnoredDelay(TimeSpan.FromSeconds(30));
+
+        Assert.AreEqual(0, raised);
+    }
+
+    private sealed class TestJob : RecurringBackgroundJobBase
+    {
+        public TestJob(TimeSpan period)
+            : base(period)
+        {
+        }
+
+        public override Task RunJobAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public void SetPeriod(TimeSpan value) => Period = value;
+
+        public void SetIgnoredDelay(TimeSpan value) => IgnoredDelay = value;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunnerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceRunnerTests.cs
@@ -116,9 +116,9 @@ public class RecurringBackgroundJobHostedServiceRunnerTests
     {
         private readonly Func<CancellationToken, Task>? _onExecute;
 
-        public TestJobA(Func<CancellationToken, Task>? onExecute = null) => _onExecute = onExecute;
-
-        public override TimeSpan Period => TimeSpan.FromSeconds(30);
+        public TestJobA(Func<CancellationToken, Task>? onExecute = null)
+            : base(TimeSpan.FromSeconds(30))
+            => _onExecute = onExecute;
 
         public override TimeSpan Delay => TimeSpan.Zero;
 
@@ -128,7 +128,10 @@ public class RecurringBackgroundJobHostedServiceRunnerTests
 
     private class TestJobB : RecurringBackgroundJobBase, ITriggerableRecurringBackgroundJob
     {
-        public override TimeSpan Period => TimeSpan.FromSeconds(30);
+        public TestJobB()
+            : base(TimeSpan.FromSeconds(30))
+        {
+        }
 
         public override TimeSpan Delay => TimeSpan.Zero;
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceTests.cs
@@ -237,6 +237,19 @@ public class RecurringBackgroundJobHostedServiceTests
     }
 
     [Test]
+    public async Task Skips_Wait_When_IgnoredDelay_Is_Negative()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var mockJob = new Mock<IRecurringBackgroundJob>();
+        mockJob.Setup(x => x.IgnoredDelay).Returns(TimeSpan.FromSeconds(-5));
+
+        var sut = CreateRecurringBackgroundJobHostedService(mockJob, isMainDom: false, timeProvider: timeProvider);
+
+        // Negative (and not Timeout.InfiniteTimeSpan) is treated like zero — back-off is skipped, no hang or tight loop.
+        await sut.PerformExecuteAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
     public async Task Waits_Until_Shutdown_When_IgnoredDelay_Is_Infinite()
     {
         var timeProvider = new FakeTimeProvider();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/RecurringBackgroundJobHostedServiceTests.cs
@@ -258,6 +258,77 @@ public class RecurringBackgroundJobHostedServiceTests
     }
 
     [Test]
+    public async Task IgnoredDelay_Change_From_Infinite_To_Finite_Resumes_Backoff()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var mockJob = new Mock<IRecurringBackgroundJob>();
+        mockJob.Setup(x => x.IgnoredDelay).Returns(Timeout.InfiniteTimeSpan);
+
+        var sut = CreateRecurringBackgroundJobHostedService(mockJob, isMainDom: false, timeProvider: timeProvider);
+        Task executeTask = sut.PerformExecuteAsync(CancellationToken.None);
+
+        Task completedFirst = await Task.WhenAny(executeTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        Assert.AreNotSame(executeTask, completedFirst, "Infinite back-off should be in progress");
+
+        // Switch IgnoredDelay to a finite value and signal the change — the in-progress wait must re-read it.
+        mockJob.Setup(x => x.IgnoredDelay).Returns(TimeSpan.FromMinutes(1));
+        mockJob.Raise(x => x.IgnoredDelayChanged += null, EventArgs.Empty);
+
+        completedFirst = await Task.WhenAny(executeTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        Assert.AreNotSame(executeTask, completedFirst, "New finite back-off should be pending");
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task IgnoredDelay_Change_To_Zero_Exits_Backoff_Immediately()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var mockJob = new Mock<IRecurringBackgroundJob>();
+        mockJob.Setup(x => x.IgnoredDelay).Returns(TimeSpan.FromHours(1));
+
+        var sut = CreateRecurringBackgroundJobHostedService(mockJob, isMainDom: false, timeProvider: timeProvider);
+        Task executeTask = sut.PerformExecuteAsync(CancellationToken.None);
+
+        Task completedFirst = await Task.WhenAny(executeTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        Assert.AreNotSame(executeTask, completedFirst, "Back-off should be in progress");
+
+        mockJob.Setup(x => x.IgnoredDelay).Returns(TimeSpan.Zero);
+        mockJob.Raise(x => x.IgnoredDelayChanged += null, EventArgs.Empty);
+
+        // No time advance required — the loop re-reads zero and exits.
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task IgnoredDelay_Change_Recomputes_Remaining_From_Elapsed()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var mockJob = new Mock<IRecurringBackgroundJob>();
+        mockJob.Setup(x => x.IgnoredDelay).Returns(TimeSpan.FromMinutes(10));
+
+        var sut = CreateRecurringBackgroundJobHostedService(mockJob, isMainDom: false, timeProvider: timeProvider);
+        Task executeTask = sut.PerformExecuteAsync(CancellationToken.None);
+
+        Task completedFirst = await Task.WhenAny(executeTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        Assert.AreNotSame(executeTask, completedFirst, "Back-off should be in progress");
+
+        // 4 of 10 minutes elapsed.
+        timeProvider.Advance(TimeSpan.FromMinutes(4));
+
+        // Shorten IgnoredDelay to 5 minutes — only ~1 minute should remain (5 - 4).
+        mockJob.Setup(x => x.IgnoredDelay).Returns(TimeSpan.FromMinutes(5));
+        mockJob.Raise(x => x.IgnoredDelayChanged += null, EventArgs.Empty);
+
+        completedFirst = await Task.WhenAny(executeTask, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        Assert.AreNotSame(executeTask, completedFirst, "Recomputed remaining should still be pending");
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await executeTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
     public async Task Wait_Cancellation_Does_Not_Publish_Canceled_Notification()
     {
         var timeProvider = new FakeTimeProvider();


### PR DESCRIPTION
## Summary

Refinements to `RecurringBackgroundJobBase`, which was newly introduced in #22331 and is currently in `release/17.5.0` / `release/18.0.0` but **not yet shipped to consumers** (no RC tagged). The refinements significantly improve the ergonomics of writing recurring jobs, especially jobs whose schedule changes at runtime, and they add an `IgnoredDelay` signalling capability that mirrors what already exists for `Period`.

### What changes

1. **Protected setters on `Period` and `IgnoredDelay`, with auto-raising events.** The setters validate the value, no-op on same value, and raise `PeriodChanged` / `IgnoredDelayChanged` automatically. Jobs no longer need to maintain their own `_period` field plus a custom event override just to react to config changes — `Period = newValue` is now enough.

2. **`Period` is required via the base constructor.** `RecurringBackgroundJobBase(TimeSpan period)` stores the initial value directly without raising `PeriodChanged`. This replaces the previous "abstract `Period { get; }`" contract, eliminates the implicit-default question, and enforces initialisation at compile time.

3. **`IDisposable` on the base.** Standard `Dispose()` / `protected virtual Dispose(bool disposing)` pattern. Disposal clears `_periodChanged` and `_ignoredDelayChanged` so the disposed job does not retain subscriber references and cannot invoke listeners post-teardown.

4. **Concrete jobs migrated.** `TempFileCleanupJob`, `ReportSiteJob`, `InstructionProcessJob`, and `TouchServerJob` updated to pass `Period` via `base(period)`. `TouchServerJob` in particular shrinks substantially — no more custom event override, no custom `_period` field, and it now also disposes its `IOptionsMonitor.OnChange(...)` registration via the new `Dispose(bool)` hook.

The previously-shipped `TouchServerJob` pattern (manual `_period` field + custom `PeriodChanged` event override + manual `_periodChanged?.Invoke(...)`) is exactly the pattern the [docs PR Complex example](https://github.com/umbraco/UmbracoDocs/pull/8082) currently shows. After this PR, the canonical pattern is roughly half the code (see "Required docs updates" below).

## Breaking changes

| Change | Impact |
|---|---|
| `RecurringBackgroundJobBase` constructor now requires `TimeSpan period` | Subclasses must call `: base(period)`. Source-breaking but compile-time-detected. |
| `RecurringBackgroundJobBase.Period` changed from `abstract` to `virtual` with `protected set` | Existing `public override TimeSpan Period => ...` still compiles. |
| `RecurringBackgroundJobBase` now implements `IDisposable` | DI disposes instances on container shutdown. Subclasses that previously had no `Dispose` need no changes. |

### Why these belong in 17.5 (and 18.0) rather than 17.6/18.1

- **Not yet shipped.** `RecurringBackgroundJobBase` is brand-new in #22331. `release/17.5.0` and `release/18.0.0` branches exist but no `*-rc` has been tagged. No consumer can currently depend on the old shape.
- **Small and contained.** Breaks only affect direct subclasses of `RecurringBackgroundJobBase`. The `IRecurringBackgroundJob` interface contract is unchanged (the V19 TODO comments on the events are purely informational — no runtime change).
- **Avoids back-to-back deprecations.** Shipping the awkward shape and then refactoring in 17.6/18.1 would mean two obsoletion shims on a brand-new API. Landing the clean shape in the RC means consumers learn the right pattern on day one.
- **Improves the worst case.** The mutable-period + raise-event-on-config-change pattern is the one most likely to be copy-pasted. Shipping the verbose pre-refinement shape would cement that as the canonical pattern in user code.

## Changes required to docs PR umbraco/UmbracoDocs#8082

> @AndyButland — these are the updates needed if this lands.

### 1. Minimal example: use `: base(period)`, drop the `Period` override

```diff
 public class CleanUpYourRoom : RecurringBackgroundJobBase
 {
-    public override TimeSpan Period => TimeSpan.FromMinutes(60);
+    public CleanUpYourRoom()
+        : base(TimeSpan.FromMinutes(60))
+    {
+    }

     public override Task RunJobAsync(CancellationToken cancellationToken)
     {
         // your job code goes here
         return Task.CompletedTask;
     }
 }
```

### 2. DI example: same pattern, just chain `: base(...)`

```diff
 public CleanUpYourRoom(
     IContentService contentService,
     ICoreScopeProvider scopeProvider)
+    : base(TimeSpan.FromMinutes(60))
 {
     _contentService = contentService;
     _scopeProvider = scopeProvider;
 }
-
-public override TimeSpan Period => TimeSpan.FromMinutes(60);
```

### 3. Complex example: dramatically simplified

The current Complex example has ~15 lines of `_period` + `_periodChanged` + custom event override + manual invoke. The new equivalent is:

```csharp
public class CleanUpYourRoom : RecurringBackgroundJobBase
{
    private readonly IContentService _contentService;
    private readonly IServerRoleAccessor _serverRoleAccessor;
    private readonly IProfilingLogger _profilingLogger;
    private readonly ILogger<CleanUpYourRoom> _logger;
    private readonly ICoreScopeProvider _scopeProvider;
    private readonly IDisposable? _onChangeRegistration;

    public CleanUpYourRoom(
        IContentService contentService,
        IServerRoleAccessor serverRoleAccessor,
        IProfilingLogger profilingLogger,
        ILogger<CleanUpYourRoom> logger,
        IOptionsMonitor<HealthChecksSettings> healthChecksSettings,
        ICoreScopeProvider scopeProvider)
        : base(healthChecksSettings.CurrentValue.Notification.Period)
    {
        _contentService = contentService;
        _serverRoleAccessor = serverRoleAccessor;
        _profilingLogger = profilingLogger;
        _logger = logger;
        _scopeProvider = scopeProvider;

        // When the period config changes, assign Period — the setter raises PeriodChanged.
        _onChangeRegistration = healthChecksSettings.OnChange(x => Period = x.Notification.Period);
    }

    public override ServerRole[] ServerRoles => Enum.GetValues<ServerRole>();

    public override Task RunJobAsync(CancellationToken cancellationToken)
    {
        // ... unchanged ...
    }

    protected override void Dispose(bool disposing)
    {
        if (disposing)
        {
            _onChangeRegistration?.Dispose();
        }

        base.Dispose(disposing);
    }
}
```

Worth calling out in the prose around this example:

- The manual `_periodChanged` event override is no longer required for the common "external config drives the period" case.
- The protected `Period` setter is the new mechanism — assignment raises the event automatically and no-ops if the value is unchanged.
- `IOptionsMonitor.OnChange` returns an `IDisposable` and should be disposed via the base's `Dispose(bool)` hook.

### 4. New `IgnoredDelayChanged` event

The current docs PR documents the `IgnoredDelay` property but does **not** mention `IgnoredDelayChanged`. Add a short subsection (e.g. under `IgnoredDelay` or near `PeriodChanged`):

> ### `IgnoredDelayChanged`
>
> Mirrors `PeriodChanged`. The base class raises this event automatically when `IgnoredDelay` is assigned a new value via the protected setter. The recurring background job host listens for it and interrupts any in-progress ignored back-off so the new value is picked up immediately.
>
> This makes it possible to start a job with `IgnoredDelay = Timeout.InfiniteTimeSpan` (effectively disabled after the first ignored execution until further notice), and later re-enable it by assigning a finite value — useful when an external signal indicates that the previously-ignored condition has cleared.

### 5. Manual-only jobs snippet

```diff
-public override TimeSpan Period => Timeout.InfiniteTimeSpan;
+public MyJob() : base(Timeout.InfiniteTimeSpan) { }

 public override TimeSpan Delay => Timeout.InfiniteTimeSpan;
```

### 6. (Optional) "Base Classes" section

Brief note that `RecurringBackgroundJobBase` implements `IDisposable` with a `protected virtual Dispose(bool)` hook, and that subclasses with disposable resources (e.g. an `IOptionsMonitor.OnChange` registration) should override that hook and call `base.Dispose(disposing)`.

## Test plan

- [x] New `RecurringBackgroundJobBaseTests` (12 tests) covers: constructor sets initial `Period`, infinite period allowed, negative throws, `IgnoredDelay` default, both setters raise the change event on different value, no-op on same value, infinite allowed, negative throws, `Dispose` clears `PeriodChanged` and `IgnoredDelayChanged` subscribers.
- [x] Existing `RecurringBackgroundJobHostedServiceTests` unchanged and passing.
- [x] `RecurringBackgroundJobHostedServiceRunnerTests` updated: internal `TestJobA` / `TestJobB` call `: base(TimeSpan.FromSeconds(30))`.
- [x] Build clean. No new warnings.

Fixes the `TouchServerJob` cleanup gap as a side effect — the previous code held a `globalSettings.OnChange(...)` registration with no disposal pathway.

Once this is approved, it should also be cherry-picked to `release/18.0.0`.
