### PR TITLE
EF Core: Retry transient SQLite lock errors during long-running operations (closes #22939)

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/CLAUDE.md
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/CLAUDE.md
@@ -15,8 +15,9 @@ SQLite-specific EF Core provider for Umbraco CMS. Contains SQLite migrations and
 This is a thin provider project that implements SQLite-specific functionality for the EF Core persistence layer:
 
 1. **Migration Provider** - Executes SQLite-specific migrations
-2. **Migration Provider Setup** - Configures DbContext to use SQLite
+2. **Migration Provider Setup** - Configures DbContext to use SQLite (incl. transient-error retry)
 3. **Migrations** - SQLite-specific migration files for OpenIddict tables
+4. **Retrying Execution Strategy** - Retries transient SQLite lock errors on EF Core operations
 
 ### Folder Structure
 
@@ -30,7 +31,8 @@ Umbraco.Cms.Persistence.EFCore.Sqlite/
 │   └── UmbracoDbContextModelSnapshot.cs         # Current model state
 ├── EFCoreSqliteComposer.cs                       # DI registration
 ├── SqliteMigrationProvider.cs                    # IMigrationProvider impl
-└── SqliteMigrationProviderSetup.cs               # IMigrationProviderSetup impl
+├── SqliteMigrationProviderSetup.cs               # IMigrationProviderSetup impl
+└── SqliteRetryingExecutionStrategy.cs            # IExecutionStrategy for transient lock errors
 ```
 
 ### Relationship with Parent Project
@@ -65,7 +67,19 @@ Registers `IMigrationProvider` and `IMigrationProviderSetup` for SQLite.
 
 ### SqliteMigrationProviderSetup (line 11-14)
 
-Configures `DbContextOptionsBuilder` with `UseSqlite` and migrations assembly.
+Configures `DbContextOptionsBuilder` with `UseSqlite`, the migrations assembly, and the
+`SqliteRetryingExecutionStrategy` (see below). Invoked from
+`UmbracoDbContext.ConfigureOptions` for every `UmbracoDbContext` instance, so all EF Core
+access to the Umbraco database (including OpenIddict's token store) inherits the retry.
+
+### SqliteRetryingExecutionStrategy
+
+Custom `Microsoft.EntityFrameworkCore.Storage.ExecutionStrategy` that retries on transient
+SQLite errors (`SQLITE_BUSY`, `SQLITE_LOCKED`) using `SqliteExceptionExtensions.IsBusyOrLocked`
+from the parent project. Defaults inherit `ExecutionStrategy.DefaultMaxRetryCount` (6) and
+`ExecutionStrategy.DefaultMaxDelay` (30s), giving a ~56-second retry budget — see the class's
+XML doc for the rationale and the unattended-upgrade escape hatch for very long migrations.
+Added to resolve issue #22939 (OpenIddict token reads failing during long migrations).
 
 ---
 
@@ -122,7 +136,8 @@ All tables prefixed with `umbraco`:
 | File | Purpose |
 |------|---------|
 | `SqliteMigrationProvider.cs` | Migration execution |
-| `SqliteMigrationProviderSetup.cs` | DbContext configuration |
+| `SqliteMigrationProviderSetup.cs` | DbContext configuration (UseSqlite + retry strategy) |
+| `SqliteRetryingExecutionStrategy.cs` | Retry on transient SQLite BUSY/LOCKED errors |
 | `EFCoreSqliteComposer.cs` | DI registration |
 | `Migrations/*.cs` | Migration files |
 

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProviderSetup.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProviderSetup.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Persistence.EFCore.Migrations;
 
 namespace Umbraco.Cms.Persistence.EFCore.Sqlite;
@@ -15,6 +14,15 @@ public class SqliteMigrationProviderSetup : IMigrationProviderSetup
     /// <inheritdoc />
     public void Setup(DbContextOptionsBuilder builder, string? connectionString)
     {
-        builder.UseSqlite(connectionString, x => x.MigrationsAssembly(GetType().Assembly.FullName));
+        builder.UseSqlite(connectionString, x =>
+        {
+            x.MigrationsAssembly(GetType().Assembly.FullName);
+
+            // Retry transient SQLite errors (BUSY / LOCKED). See SqliteRetryingExecutionStrategy
+            // for the rationale — long-running migrations or schema-modifying operations can
+            // briefly lock the database in a way that surfaces as a hard error to concurrent
+            // EF Core readers (notably OpenIddict token validation). See issue #22939.
+            x.ExecutionStrategy(deps => new SqliteRetryingExecutionStrategy(deps));
+        });
     }
 }

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteRetryingExecutionStrategy.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteRetryingExecutionStrategy.cs
@@ -1,0 +1,71 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Umbraco.Cms.Persistence.EFCore.Sqlite;
+
+/// <summary>
+/// EF Core execution strategy that retries on transient SQLite errors (BUSY / LOCKED).
+/// </summary>
+/// <remarks>
+/// <para>
+/// SQLite serialises writers at the database level, and schema-modifying statements briefly
+/// block readers — even in WAL mode. Without retries, concurrent EF Core reads (for example
+/// OpenIddict's token validation against <c>umbracoOpenIddictTokens</c>) surface those
+/// transient locks as <see cref="SqliteException"/> and fail the caller's request.
+/// </para>
+/// <para>
+/// Microsoft does not ship a built-in execution strategy for SQLite (only the SQL Server
+/// equivalent), so we provide this one. It piggy-backs on <see cref="ExecutionStrategy"/>'s
+/// default exponential backoff and re-uses its inherited
+/// <see cref="ExecutionStrategy.DefaultMaxRetryCount"/> (6) and
+/// <see cref="ExecutionStrategy.DefaultMaxDelay"/> (30 seconds), which produce a delay
+/// schedule of roughly 0s, 1s, 3s, 7s, 15s, 30s — a ~56-second retry window.
+/// </para>
+/// <para>
+/// On top of those EF Core delays, <c>SQLITE_BUSY</c> (error 5) is also retried internally
+/// by Microsoft.Data.Sqlite for up to the connection's <c>Default Timeout</c> (30 seconds
+/// by default) per attempt. <c>SQLITE_LOCKED</c> (error 6) is not — it returns immediately,
+/// so EF Core's retry budget is the only buffer.
+/// </para>
+/// </remarks>
+public class SqliteRetryingExecutionStrategy : ExecutionStrategy
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteRetryingExecutionStrategy"/> class
+    /// with default retry settings inherited from <see cref="ExecutionStrategy"/>.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing service dependencies.</param>
+    public SqliteRetryingExecutionStrategy(ExecutionStrategyDependencies dependencies)
+        : this(dependencies, DefaultMaxRetryCount, DefaultMaxDelay)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqliteRetryingExecutionStrategy"/> class.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing service dependencies.</param>
+    /// <param name="maxRetryCount">The maximum number of retry attempts.</param>
+    /// <param name="maxRetryDelay">The maximum delay between retries.</param>
+    public SqliteRetryingExecutionStrategy(
+        ExecutionStrategyDependencies dependencies,
+        int maxRetryCount,
+        TimeSpan maxRetryDelay)
+        : base(dependencies, maxRetryCount, maxRetryDelay)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override bool ShouldRetryOn(Exception exception)
+    {
+        // EF Core wraps provider exceptions, so walk the inner-exception chain.
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is SqliteException sqlite && sqlite.IsBusyOrLocked())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/Locking/SqliteEFCoreDistributedLockingMechanism.cs
@@ -184,17 +184,11 @@ internal sealed class SqliteEFCoreDistributedLockingMechanism<T> : IDistributedL
                         throw new ArgumentException($"LockObject with id={LockId} does not exist.");
                     }
                 }
-                catch (SqliteException ex) when (IsBusyOrLocked(ex))
+                catch (SqliteException ex) when (ex.IsBusyOrLocked())
                 {
                     throw new DistributedWriteLockTimeoutException(LockId);
                 }
             });
         }
-
-        private static bool IsBusyOrLocked(SqliteException ex) =>
-            ex.SqliteErrorCode
-                is raw.SQLITE_BUSY
-                or raw.SQLITE_LOCKED
-                or raw.SQLITE_LOCKED_SHAREDCACHE;
     }
 }

--- a/src/Umbraco.Cms.Persistence.EFCore/SqliteExceptionExtensions.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore/SqliteExceptionExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.Data.Sqlite;
+using SQLitePCL;
+
+namespace Umbraco.Cms.Persistence.EFCore;
+
+/// <summary>
+/// SQLite-specific exception helpers for code running on the EF Core persistence stack.
+/// </summary>
+/// <remarks>
+/// A parallel helper exists at <c>Umbraco.Cms.Persistence.Sqlite.Services.SqliteExceptionExtensions</c>
+/// for the NPoco stack. Both stacks are independent (neither references the other) so the small
+/// duplication is intentional — keeps the layering clean.
+/// </remarks>
+public static class SqliteExceptionExtensions
+{
+    /// <summary>
+    /// Determines if the SQLite exception is a BUSY or LOCKED error.
+    /// </summary>
+    /// <param name="ex">The SQLite exception to check.</param>
+    /// <returns><c>true</c> if the error is BUSY, LOCKED, or LOCKED_SHAREDCACHE; otherwise <c>false</c>.</returns>
+    public static bool IsBusyOrLocked(this SqliteException ex) =>
+        ex.SqliteErrorCode
+            is raw.SQLITE_BUSY
+            or raw.SQLITE_LOCKED
+            or raw.SQLITE_LOCKED_SHAREDCACHE;
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCoreSqlite/SqliteRetryingExecutionStrategyTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCoreSqlite/SqliteRetryingExecutionStrategyTests.cs
@@ -1,0 +1,239 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using SQLitePCL;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Persistence.EFCore.Sqlite;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Persistence.EFCoreSqlite;
+
+/// <summary>
+/// Verifies that <see cref="SqliteRetryingExecutionStrategy"/> turns transient SQLite lock errors
+/// (BUSY / LOCKED) into successful operations via retry.
+/// </summary>
+/// <remarks>
+/// This is surmised to be the the scenario behind issue #22939 where OpenIddict token reads via
+/// EF Core failed while a long-running migration held a write lock. We parameterise across both
+/// read and write operations because the reported customer stack trace was a read
+/// (<c>SingleOrDefaultAsync</c> on the token table); the write path is included for symmetry.
+/// </remarks>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, Logger = UmbracoTestOptions.Logger.Console)]
+public class SqliteRetryingExecutionStrategyTests : UmbracoIntegrationTest
+{
+    // Keep the per-command SQLite busy-poll short so the baseline test fails quickly
+    // and the resilient test exercises the EF Core retry loop (not SQLite's internal one).
+    private const int CommandTimeoutSeconds = 1;
+
+    // Hold the blocker write lock for longer than CommandTimeoutSeconds so a non-retrying caller
+    // sees a SqliteException, but well within the retry strategy's budget so a retrying caller wins.
+    private static readonly TimeSpan _blockerHoldDuration = TimeSpan.FromMilliseconds(2500);
+
+    public enum Operation
+    {
+        // NUnit's [TestCase] attribute reflects over public enum values, so this stays public.
+        Read,
+        Write,
+    }
+
+    private IDbContextFactory<BaselineDbContext> BaselineFactory =>
+        GetRequiredService<IDbContextFactory<BaselineDbContext>>();
+
+    private IDbContextFactory<ResilientDbContext> ResilientFactory =>
+        GetRequiredService<IDbContextFactory<ResilientDbContext>>();
+
+    private string ConnectionString =>
+        GetRequiredService<IOptionsMonitor<ConnectionStrings>>().CurrentValue.ConnectionString!;
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        // Register both DbContexts unconditionally. The lambda body only runs when a context is resolved,
+        // and the tests below Ignore on non-SQLite — so a SQL Server run never executes UseSqlite.
+        builder.Services.AddUmbracoDbContext<BaselineDbContext>(
+            (IServiceProvider sp, DbContextOptionsBuilder options, string? connectionString, string? providerName) =>
+            {
+                options.UseSqlite(ApplyShortCommandTimeout(connectionString!));
+            },
+            shareUmbracoConnection: false);
+
+        builder.Services.AddUmbracoDbContext<ResilientDbContext>(
+            (IServiceProvider sp, DbContextOptionsBuilder options, string? connectionString, string? providerName) =>
+            {
+                options.UseSqlite(
+                    ApplyShortCommandTimeout(connectionString!),
+                    sqlite => sqlite.ExecutionStrategy(deps => new SqliteRetryingExecutionStrategy(deps)));
+            },
+            shareUmbracoConnection: false);
+    }
+
+    [TestCase(Operation.Read)]
+    [TestCase(Operation.Write)]
+    public async Task Without_Retry_Strategy_Throws_When_Lock_Held_Longer_Than_Command_Timeout(Operation operation)
+    {
+        if (BaseTestDatabase.IsSqlite() is false)
+        {
+            Assert.Ignore("SQLite-only scenario.");
+        }
+
+        using var blockerRelease = HoldBlockerLock();
+
+        await using BaselineDbContext context = await BaselineFactory.CreateDbContextAsync();
+
+        // SQLite's per-command busy-poll only waits CommandTimeoutSeconds; the blocker is held longer,
+        // so without the retry strategy the operation must surface a SqliteException to the caller.
+        // Both reads and writes route through EF Core's IExecutionStrategy when expressed via DbSet
+        // (which is how OpenIddict's token store accesses umbracoOpenIddictTokens in the real failure).
+        SqliteException? ex = Assert.ThrowsAsync<SqliteException>(
+            async () => await ExecuteAsync(context.UmbracoLocks, operation));
+
+        Assert.That(
+            ex!.SqliteErrorCode,
+            Is.AnyOf(raw.SQLITE_BUSY, raw.SQLITE_LOCKED),
+            "Expected the failure to be a transient SQLite lock error — if this is something else, the test no longer reproduces issue #22939.");
+    }
+
+    [TestCase(Operation.Read)]
+    [TestCase(Operation.Write)]
+    public async Task With_Retry_Strategy_Succeeds_When_Lock_Released_Within_Retry_Budget(Operation operation)
+    {
+        if (BaseTestDatabase.IsSqlite() is false)
+        {
+            Assert.Ignore("SQLite-only scenario.");
+        }
+
+        using var blockerRelease = HoldBlockerLock();
+
+        await using ResilientDbContext context = await ResilientFactory.CreateDbContextAsync();
+
+        // With SqliteRetryingExecutionStrategy in place, the first attempt fails with BUSY/LOCKED
+        // (same as the baseline), the strategy backs off and retries, and once the blocker releases
+        // the operation succeeds — no exception bubbles out.
+        Assert.DoesNotThrowAsync(async () => await ExecuteAsync(context.UmbracoLocks, operation));
+    }
+
+    /// <summary>
+    /// Runs a single EF Core operation that routes through <see cref="IExecutionStrategy"/>:
+    /// either a <see cref="EntityFrameworkQueryableExtensions.SingleOrDefaultAsync{TSource}"/>
+    /// read (matching OpenIddict's <c>FindByReferenceIdAsync</c> shape) or an
+    /// <see cref="RelationalQueryableExtensions.ExecuteUpdateAsync"/> write.
+    /// </summary>
+    private static async Task ExecuteAsync(DbSet<LockEntity> set, Operation operation)
+    {
+        switch (operation)
+        {
+            case Operation.Read:
+                _ = await set.Where(x => x.Id == 1).SingleOrDefaultAsync();
+                break;
+            case Operation.Write:
+                await set
+                    .Where(x => x.Id == 1)
+                    .ExecuteUpdateAsync(setters => setters.SetProperty(x => x.Value, x => x.Value));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(operation), operation, null);
+        }
+    }
+
+    /// <summary>
+    /// Opens a separate SQLite connection on the same shared in-memory database,
+    /// acquires a RESERVED write lock via a transactional UPDATE, and schedules the lock's
+    /// release after <see cref="_blockerHoldDuration"/>. The returned <see cref="IDisposable"/>
+    /// joins the release task on dispose so the test method always waits for cleanup.
+    /// </summary>
+    private BlockerLockHandle HoldBlockerLock()
+    {
+        SqliteConnection blocker = new(ConnectionString);
+        blocker.Open();
+
+        SqliteTransaction blockerTx = blocker.BeginTransaction();
+
+        using (SqliteCommand cmd = blocker.CreateCommand())
+        {
+            cmd.Transaction = blockerTx;
+            cmd.CommandText = "UPDATE umbracoLock SET value = value WHERE id = 1";
+            cmd.ExecuteNonQuery();
+        }
+
+        Task release = Task.Run(async () =>
+        {
+            await Task.Delay(_blockerHoldDuration);
+            blockerTx.Commit();
+            blockerTx.Dispose();
+            blocker.Dispose();
+        });
+
+        return new BlockerLockHandle(release);
+    }
+
+    private static string ApplyShortCommandTimeout(string connectionString)
+    {
+        // Microsoft.Data.Sqlite uses Default Timeout (seconds) as the SqliteCommand.CommandTimeout
+        // default, which drives the internal busy-poll loop. Shortening it makes the baseline test
+        // surface a SqliteException quickly instead of waiting the 30-second default.
+        var builder = new SqliteConnectionStringBuilder(connectionString)
+        {
+            DefaultTimeout = CommandTimeoutSeconds,
+        };
+        return builder.ConnectionString;
+    }
+
+    private sealed class BlockerLockHandle : IDisposable
+    {
+        private readonly Task _release;
+
+        public BlockerLockHandle(Task release) => _release = release;
+
+        public void Dispose() => _release.GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Minimal entity mapped to the existing <c>umbracoLock</c> table so we can exercise EF Core's
+    /// query / ExecuteUpdate pipeline (which uses the configured execution strategy).
+    /// </summary>
+    private class LockEntity
+    {
+        public int Id { get; set; }
+
+        public int Value { get; set; }
+
+        public string Name { get; set; } = null!;
+    }
+
+    private class BaselineDbContext : DbContext
+    {
+        public BaselineDbContext(DbContextOptions<BaselineDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<LockEntity> UmbracoLocks { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => MapLockEntity(modelBuilder);
+    }
+
+    private class ResilientDbContext : DbContext
+    {
+        public ResilientDbContext(DbContextOptions<ResilientDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<LockEntity> UmbracoLocks { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => MapLockEntity(modelBuilder);
+    }
+
+    private static void MapLockEntity(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<LockEntity>(entity =>
+        {
+            entity.ToTable("umbracoLock");
+            entity.Property(e => e.Id).ValueGeneratedNever().HasColumnName("id");
+            entity.Property(e => e.Name).HasMaxLength(64).HasColumnName("name");
+            entity.Property(e => e.Value).HasColumnName("value");
+        });
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCoreSqlite/SqliteRetryingExecutionStrategyTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Persistence.EFCoreSqlite/SqliteRetryingExecutionStrategyTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using SQLitePCL;
@@ -15,7 +16,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Persistence.EFCoreSqlite;
 /// (BUSY / LOCKED) into successful operations via retry.
 /// </summary>
 /// <remarks>
-/// This is surmised to be the the scenario behind issue #22939 where OpenIddict token reads via
+/// This is potentially the scenario behind issue #22939 where OpenIddict token reads via
 /// EF Core failed while a long-running migration held a write lock. We parameterise across both
 /// read and write operations because the reported customer stack trace was a read
 /// (<c>SingleOrDefaultAsync</c> on the token table); the write path is included for symmetry.
@@ -71,7 +72,7 @@ public class SqliteRetryingExecutionStrategyTests : UmbracoIntegrationTest
 
     [TestCase(Operation.Read)]
     [TestCase(Operation.Write)]
-    public async Task Without_Retry_Strategy_Throws_When_Lock_Held_Longer_Than_Command_Timeout(Operation operation)
+    public async Task Cannot_Read_Or_Write_Via_EFCore_When_SQLite_Lock_Held_Beyond_Command_Timeout(Operation operation)
     {
         if (BaseTestDatabase.IsSqlite() is false)
         {
@@ -97,7 +98,7 @@ public class SqliteRetryingExecutionStrategyTests : UmbracoIntegrationTest
 
     [TestCase(Operation.Read)]
     [TestCase(Operation.Write)]
-    public async Task With_Retry_Strategy_Succeeds_When_Lock_Released_Within_Retry_Budget(Operation operation)
+    public async Task Can_Read_And_Write_Via_EFCore_When_SQLite_Lock_Released_Within_Retry_Budget(Operation operation)
     {
         if (BaseTestDatabase.IsSqlite() is false)
         {
@@ -115,10 +116,10 @@ public class SqliteRetryingExecutionStrategyTests : UmbracoIntegrationTest
     }
 
     /// <summary>
-    /// Runs a single EF Core operation that routes through <see cref="IExecutionStrategy"/>:
-    /// either a <see cref="EntityFrameworkQueryableExtensions.SingleOrDefaultAsync{TSource}"/>
-    /// read (matching OpenIddict's <c>FindByReferenceIdAsync</c> shape) or an
-    /// <see cref="RelationalQueryableExtensions.ExecuteUpdateAsync"/> write.
+    /// Runs a single EF Core operation that routes through the configured
+    /// <see cref="IExecutionStrategy"/>: either a <c>SingleOrDefaultAsync</c> read
+    /// (matching OpenIddict's <c>FindByReferenceIdAsync</c> shape) or an
+    /// <c>ExecuteUpdateAsync</c> write.
     /// </summary>
     private static async Task ExecuteAsync(DbSet<LockEntity> set, Operation operation)
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.EFCore/SqliteExceptionExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.EFCore/SqliteExceptionExtensionsTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+using SQLitePCL;
+using Umbraco.Cms.Persistence.EFCore;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Persistence.EFCore;
+
+[TestFixture]
+public class SqliteExceptionExtensionsTests
+{
+    [TestCase(raw.SQLITE_BUSY, ExpectedResult = true)]
+    [TestCase(raw.SQLITE_LOCKED, ExpectedResult = true)]
+    [TestCase(raw.SQLITE_LOCKED_SHAREDCACHE, ExpectedResult = true)]
+    [TestCase(raw.SQLITE_OK, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_ERROR, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_INTERNAL, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_PERM, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_ABORT, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_READONLY, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_INTERRUPT, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_CORRUPT, ExpectedResult = false)]
+    [TestCase(raw.SQLITE_FULL, ExpectedResult = false)]
+    public bool IsBusyOrLocked_returns_expected_result_for_error_code(int errorCode)
+    {
+        // Build an exception with the desired primary error code. Microsoft.Data.Sqlite exposes
+        // a constructor that takes the primary code directly — we never see the extended code
+        // surface on SqliteErrorCode in practice (the third TestCase above is defensive coverage).
+        var ex = new SqliteException("test", errorCode);
+
+        return ex.IsBusyOrLocked();
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.EFCore/SqliteExceptionExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Persistence.EFCore/SqliteExceptionExtensionsTests.cs
@@ -20,7 +20,7 @@ public class SqliteExceptionExtensionsTests
     [TestCase(raw.SQLITE_INTERRUPT, ExpectedResult = false)]
     [TestCase(raw.SQLITE_CORRUPT, ExpectedResult = false)]
     [TestCase(raw.SQLITE_FULL, ExpectedResult = false)]
-    public bool IsBusyOrLocked_returns_expected_result_for_error_code(int errorCode)
+    public bool Can_Detect_Busy_And_Locked_Codes(int errorCode)
     {
         // Build an exception with the desired primary error code. Microsoft.Data.Sqlite exposes
         // a constructor that takes the primary code directly — we never see the extended code


### PR DESCRIPTION
## Description

The initial post and a follow-up comment in #22939 reports some instability using SQLite, manifesting in locked databases.

I took a copy of the issue raiser's database, but wasn't able to replicate the problem with the migration.  Several repeats worked without error.

Nonetheless some analysis showed we weren't doing anything to handle transient errors with SQLite when it's used with EF Core - i.e. currently for OpenIddict, including token validation against `umbracoOpenIddictTokens` on every authenticated request, which aligns with the provided stack trace - and so this PR lookks to add that.

The NPoco persistence stack already retries on transient SQLite errors via `SqliteAddRetryPolicyInterceptor`. The EF Core stack [ships no built-in retrying execution strategy for SQLite — only the SQL Server family has one](https://learn.microsoft.com/en-gb/ef/core/miscellaneous/connection-resiliency).

With this up date we have a new `SqliteRetryingExecutionStrategy` (inherits EF Core's `ExecutionStrategy`) wired into every `UmbracoDbContext` via `SqliteMigrationProviderSetup`. Uses EF Core's inherited `DefaultMaxRetryCount` (6) and `DefaultMaxDelay` (30s).

The strategy is wired only to `UmbracoDbContext` via the `IMigrationProviderSetup` plumbing — that covers OpenIddict (the customer-facing path) and any future Umbraco EF Core code on the main database. 

Fixes #22939.

## Testing

### Automated

Unit tests for SQLite exception detection are added.

Integration tests are added that simulate demonstrate the issue when retries are not available and recover when they are.

### Manual

Smoke test of database read and writes using SQLite in navigating and updating via the backoffice.