### PR TITLE
Management API: ensure the order from the search endpoints taking a collection of keys is preserved

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemController.cs
@@ -60,7 +60,7 @@ public class SearchDataTypeItemController : DatatypeItemControllerBase
         var result = new PagedModel<DataTypeItemResponseModel>
         {
             Items = _mapper.MapEnumerable<IDataType, DataTypeItemResponseModel>(orderedDataTypes),
-            Total = searchResult.Total
+            Total = searchResult.Total,
         };
 
         return Ok(result);

--- a/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemController.cs
@@ -53,10 +53,13 @@ public class SearchDataTypeItemController : DatatypeItemControllerBase
             return Ok(new PagedModel<DataTypeItemResponseModel> { Total = searchResult.Total });
         }
 
-        IEnumerable<IDataType> dataTypes = await _dataTypeService.GetAllAsync(searchResult.Items.Select(item => item.Key).ToArray());
+        Guid[] keys = searchResult.Items.Select(x => x.Key).ToArray();
+        IEnumerable<IDataType> dataTypes = await _dataTypeService.GetAllAsync(keys);
+        IEnumerable<IDataType> orderedDataTypes = OrderByRequestedIds(dataTypes, keys);
+
         var result = new PagedModel<DataTypeItemResponseModel>
         {
-            Items = _mapper.MapEnumerable<IDataType, DataTypeItemResponseModel>(dataTypes),
+            Items = _mapper.MapEnumerable<IDataType, DataTypeItemResponseModel>(orderedDataTypes),
             Total = searchResult.Total
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
@@ -61,7 +61,7 @@ public class SearchMediaTypeItemController : MediaTypeItemControllerBase
         var result = new PagedModel<MediaTypeItemResponseModel>
         {
             Items = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(orderedMediaTypes),
-            Total = searchResult.Total
+            Total = searchResult.Total,
         };
 
         return Task.FromResult<IActionResult>(Ok(result));

--- a/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemController.cs
@@ -54,10 +54,13 @@ public class SearchMediaTypeItemController : MediaTypeItemControllerBase
             return Task.FromResult<IActionResult>(Ok(new PagedModel<MediaTypeItemResponseModel> { Total = searchResult.Total }));
         }
 
-        IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray().EmptyNull());
+        Guid[] keys = searchResult.Items.Select(item => item.Key).ToArray();
+        IEnumerable<IMediaType> mediaTypes = _mediaTypeService.GetMany(keys.EmptyNull());
+        IEnumerable<IMediaType> orderedMediaTypes = OrderByRequestedIds(mediaTypes, keys);
+
         var result = new PagedModel<MediaTypeItemResponseModel>
         {
-            Items = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(mediaTypes),
+            Items = _mapper.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(orderedMediaTypes),
             Total = searchResult.Total
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
@@ -32,6 +32,14 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
         _mapper = mapper;
     }
 
+    /// <summary>
+    /// Searches for member type items matching the specified query, with support for pagination.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <param name="query">The search query used to filter member type items.</param>
+    /// <param name="skip">The number of items to skip before starting to collect the result set (used for pagination).</param>
+    /// <param name="take">The maximum number of items to return in the result set (used for pagination).</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains an <see cref="IActionResult"/> with a <see cref="PagedModel{MemberTypeItemResponseModel}"/> containing the search results.</returns>
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<MemberTypeItemResponseModel>), StatusCodes.Status200OK)]
@@ -52,7 +60,7 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
         var result = new PagedModel<MemberTypeItemResponseModel>
         {
             Items = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(orderedMemberTypes),
-            Total = searchResult.Total
+            Total = searchResult.Total,
         };
 
         return Task.FromResult<IActionResult>(Ok(result));

--- a/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemController.cs
@@ -45,10 +45,13 @@ public class SearchMemberTypeItemController : MemberTypeItemControllerBase
             return Task.FromResult<IActionResult>(Ok(new PagedModel<MemberTypeItemResponseModel> { Total = searchResult.Total }));
         }
 
-        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(searchResult.Items.Select(item => item.Key).ToArray());
+        Guid[] keys = searchResult.Items.Select(item => item.Key).ToArray();
+        IEnumerable<IMemberType> memberTypes = _memberTypeService.GetMany(keys);
+        IEnumerable<IMemberType> orderedMemberTypes = OrderByRequestedIds(memberTypes, keys);
+
         var result = new PagedModel<MemberTypeItemResponseModel>
         {
-            Items = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(memberTypes),
+            Items = _mapper.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(orderedMemberTypes),
             Total = searchResult.Total
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemController.cs
@@ -45,10 +45,13 @@ public class SearchTemplateItemController : TemplateItemControllerBase
             return Ok(new PagedModel<TemplateItemResponseModel> { Total = searchResult.Total });
         }
 
-        IEnumerable<ITemplate> templates = await _templateService.GetAllAsync(searchResult.Items.Select(item => item.Key).ToArray());
+        Guid[] keys = searchResult.Items.Select(x => x.Key).ToArray();
+        IEnumerable<ITemplate> templates = await _templateService.GetAllAsync(keys);
+        IEnumerable<ITemplate> orderedTemplates = OrderByRequestedIds(templates, keys);
+
         var result = new PagedModel<TemplateItemResponseModel>
         {
-            Items = _mapper.MapEnumerable<ITemplate, TemplateItemResponseModel>(templates),
+            Items = _mapper.MapEnumerable<ITemplate, TemplateItemResponseModel>(orderedTemplates),
             Total = searchResult.Total
         };
 

--- a/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemController.cs
@@ -32,6 +32,14 @@ public class SearchTemplateItemController : TemplateItemControllerBase
         _mapper = mapper;
     }
 
+    /// <summary>
+    /// Searches for template items matching the specified query, with support for pagination.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <param name="query">The search query used to filter template items.</param>
+    /// <param name="skip">The number of items to skip before starting to collect the result set (used for pagination).</param>
+    /// <param name="take">The maximum number of items to return in the result set (used for pagination).</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains an <see cref="IActionResult"/> with a <see cref="PagedModel{TemplateItemResponseModel}"/> containing the search results.</returns>
     [HttpGet("search")]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(typeof(PagedModel<TemplateItemResponseModel>), StatusCodes.Status200OK)]
@@ -52,7 +60,7 @@ public class SearchTemplateItemController : TemplateItemControllerBase
         var result = new PagedModel<TemplateItemResponseModel>
         {
             Items = _mapper.MapEnumerable<ITemplate, TemplateItemResponseModel>(orderedTemplates),
-            Total = searchResult.Total
+            Total = searchResult.Total,
         };
 
         return Ok(result);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/DataType/Item/SearchDataTypeItemControllerTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.DataType.Item;
+using Umbraco.Cms.Api.Management.ViewModels.DataType.Item;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Controllers.DataType.Item;
+
+[TestFixture]
+public class SearchDataTypeItemControllerTests
+{
+    private Mock<IEntitySearchService> _entitySearchService = null!;
+    private Mock<IDataTypeService> _dataTypeService = null!;
+    private Mock<IUmbracoMapper> _mapper = null!;
+    private SearchDataTypeItemController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _entitySearchService = new Mock<IEntitySearchService>();
+        _dataTypeService = new Mock<IDataTypeService>();
+        _mapper = new Mock<IUmbracoMapper>();
+        _controller = new SearchDataTypeItemController(
+            _entitySearchService.Object,
+            _dataTypeService.Object,
+            _mapper.Object);
+    }
+
+    [Test]
+    public async Task Search_Data_Type_Returns_Items_Ordered_By_Search_Result_Order()
+    {
+        var keyA = Guid.NewGuid();
+        var keyB = Guid.NewGuid();
+        var keyC = Guid.NewGuid();
+
+        // Search returns keys in order [A, B, C]
+        _entitySearchService
+            .Setup(x => x.Search(UmbracoObjectTypes.DataType, It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new PagedModel<IEntitySlim>
+            {
+                Items = [
+                    new EntitySlim { Key = keyA },
+                    new EntitySlim { Key = keyB },
+                    new EntitySlim { Key = keyC },
+                ],
+                Total = 3,
+            });
+
+        // Service returns data types in scrambled order [C, A, B]
+        IDataType dataTypeC = Mock.Of<IDataType>(x => x.Key == keyC);
+        IDataType dataTypeA = Mock.Of<IDataType>(x => x.Key == keyA);
+        IDataType dataTypeB = Mock.Of<IDataType>(x => x.Key == keyB);
+        _dataTypeService
+            .Setup(x => x.GetAllAsync(It.IsAny<Guid[]>()))
+            .ReturnsAsync(new[] { dataTypeC, dataTypeA, dataTypeB });
+
+        // Mapper propagates each entity's key into the response model Id so the result reflects ordering
+        _mapper
+            .Setup(x => x.MapEnumerable<IDataType, DataTypeItemResponseModel>(It.IsAny<IEnumerable<IDataType>>()))
+            .Returns<IEnumerable<IDataType>>(entities =>
+                entities.Select(e => new DataTypeItemResponseModel { Id = e.Key }).ToList());
+
+        IActionResult result = await _controller.Search(CancellationToken.None, "test");
+
+        OkObjectResult? okResult = result as OkObjectResult;
+        Assert.That(okResult, Is.Not.Null);
+        var pagedModel = okResult!.Value as PagedModel<DataTypeItemResponseModel>;
+        Assert.That(pagedModel, Is.Not.Null);
+        List<DataTypeItemResponseModel> items = pagedModel!.Items.ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(items[0].Id, Is.EqualTo(keyA));
+            Assert.That(items[1].Id, Is.EqualTo(keyB));
+            Assert.That(items[2].Id, Is.EqualTo(keyC));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/MediaType/Item/SearchMediaTypeItemControllerTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.MediaType.Item;
+using Umbraco.Cms.Api.Management.ViewModels.MediaType.Item;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Controllers.MediaType.Item;
+
+[TestFixture]
+public class SearchMediaTypeItemControllerTests
+{
+    private Mock<IEntitySearchService> _entitySearchService = null!;
+    private Mock<IMediaTypeService> _mediaTypeService = null!;
+    private Mock<IUmbracoMapper> _mapper = null!;
+    private SearchMediaTypeItemController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _entitySearchService = new Mock<IEntitySearchService>();
+        _mediaTypeService = new Mock<IMediaTypeService>();
+        _mapper = new Mock<IUmbracoMapper>();
+        _controller = new SearchMediaTypeItemController(
+            _entitySearchService.Object,
+            _mediaTypeService.Object,
+            _mapper.Object);
+    }
+
+    [Test]
+    public async Task Search_Media_Type_Returns_Items_Ordered_By_Search_Result_Order()
+    {
+        var keyA = Guid.NewGuid();
+        var keyB = Guid.NewGuid();
+        var keyC = Guid.NewGuid();
+
+        // Search returns keys in order [A, B, C]
+        _entitySearchService
+            .Setup(x => x.Search(UmbracoObjectTypes.MediaType, It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new PagedModel<IEntitySlim>
+            {
+                Items = [
+                    new EntitySlim { Key = keyA },
+                    new EntitySlim { Key = keyB },
+                    new EntitySlim { Key = keyC },
+                ],
+                Total = 3,
+            });
+
+        // Service returns media types in scrambled order [C, A, B]
+        IMediaType mediaTypeC = Mock.Of<IMediaType>(x => x.Key == keyC);
+        IMediaType mediaTypeA = Mock.Of<IMediaType>(x => x.Key == keyA);
+        IMediaType mediaTypeB = Mock.Of<IMediaType>(x => x.Key == keyB);
+        _mediaTypeService
+            .Setup(x => x.GetMany(It.IsAny<IEnumerable<Guid>>()))
+            .Returns(new[] { mediaTypeC, mediaTypeA, mediaTypeB });
+
+        _mapper
+            .Setup(x => x.MapEnumerable<IMediaType, MediaTypeItemResponseModel>(It.IsAny<IEnumerable<IMediaType>>()))
+            .Returns<IEnumerable<IMediaType>>(entities =>
+                entities.Select(e => new MediaTypeItemResponseModel { Id = e.Key }).ToList());
+
+        IActionResult result = await _controller.Search(CancellationToken.None, "test");
+
+        OkObjectResult? okResult = result as OkObjectResult;
+        Assert.That(okResult, Is.Not.Null);
+        var pagedModel = okResult!.Value as PagedModel<MediaTypeItemResponseModel>;
+        Assert.That(pagedModel, Is.Not.Null);
+        List<MediaTypeItemResponseModel> items = pagedModel!.Items.ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(items[0].Id, Is.EqualTo(keyA));
+            Assert.That(items[1].Id, Is.EqualTo(keyB));
+            Assert.That(items[2].Id, Is.EqualTo(keyC));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/MemberType/Item/SearchMemberTypeItemControllerTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.MemberType.Item;
+using Umbraco.Cms.Api.Management.ViewModels.MemberType.Item;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Controllers.MemberType.Item;
+
+[TestFixture]
+public class SearchMemberTypeItemControllerTests
+{
+    private Mock<IEntitySearchService> _entitySearchService = null!;
+    private Mock<IMemberTypeService> _memberTypeService = null!;
+    private Mock<IUmbracoMapper> _mapper = null!;
+    private SearchMemberTypeItemController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _entitySearchService = new Mock<IEntitySearchService>();
+        _memberTypeService = new Mock<IMemberTypeService>();
+        _mapper = new Mock<IUmbracoMapper>();
+        _controller = new SearchMemberTypeItemController(
+            _entitySearchService.Object,
+            _memberTypeService.Object,
+            _mapper.Object);
+    }
+
+    [Test]
+    public async Task Search_Member_Type_Returns_Items_Ordered_By_Search_Result_Order()
+    {
+        var keyA = Guid.NewGuid();
+        var keyB = Guid.NewGuid();
+        var keyC = Guid.NewGuid();
+
+        // Search returns keys in order [A, B, C]
+        _entitySearchService
+            .Setup(x => x.Search(UmbracoObjectTypes.MemberType, It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new PagedModel<IEntitySlim>
+            {
+                Items = [
+                    new EntitySlim { Key = keyA },
+                    new EntitySlim { Key = keyB },
+                    new EntitySlim { Key = keyC },
+                ],
+                Total = 3,
+            });
+
+        // Service returns member types in scrambled order [C, A, B]
+        IMemberType memberTypeC = Mock.Of<IMemberType>(x => x.Key == keyC);
+        IMemberType memberTypeA = Mock.Of<IMemberType>(x => x.Key == keyA);
+        IMemberType memberTypeB = Mock.Of<IMemberType>(x => x.Key == keyB);
+        _memberTypeService
+            .Setup(x => x.GetMany(It.IsAny<IEnumerable<Guid>>()))
+            .Returns(new[] { memberTypeC, memberTypeA, memberTypeB });
+
+        _mapper
+            .Setup(x => x.MapEnumerable<IMemberType, MemberTypeItemResponseModel>(It.IsAny<IEnumerable<IMemberType>>()))
+            .Returns<IEnumerable<IMemberType>>(entities =>
+                entities.Select(e => new MemberTypeItemResponseModel { Id = e.Key }).ToList());
+
+        IActionResult result = await _controller.Search(CancellationToken.None, "test");
+
+        OkObjectResult? okResult = result as OkObjectResult;
+        Assert.That(okResult, Is.Not.Null);
+        var pagedModel = okResult!.Value as PagedModel<MemberTypeItemResponseModel>;
+        Assert.That(pagedModel, Is.Not.Null);
+        List<MemberTypeItemResponseModel> items = pagedModel!.Items.ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(items[0].Id, Is.EqualTo(keyA));
+            Assert.That(items[1].Id, Is.EqualTo(keyB));
+            Assert.That(items[2].Id, Is.EqualTo(keyC));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemControllerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Controllers/Template/Item/SearchTemplateItemControllerTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Template.Item;
+using Umbraco.Cms.Api.Management.ViewModels.Template.Item;
+using Umbraco.Cms.Core.Mapping;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Controllers.Template.Item;
+
+[TestFixture]
+public class SearchTemplateItemControllerTests
+{
+    private Mock<IEntitySearchService> _entitySearchService = null!;
+    private Mock<ITemplateService> _templateService = null!;
+    private Mock<IUmbracoMapper> _mapper = null!;
+    private SearchTemplateItemController _controller = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _entitySearchService = new Mock<IEntitySearchService>();
+        _templateService = new Mock<ITemplateService>();
+        _mapper = new Mock<IUmbracoMapper>();
+        _controller = new SearchTemplateItemController(
+            _entitySearchService.Object,
+            _templateService.Object,
+            _mapper.Object);
+    }
+
+    [Test]
+    public async Task Search_Template_Item_Returns_Items_Ordered_By_Search_Result_Order()
+    {
+        var keyA = Guid.NewGuid();
+        var keyB = Guid.NewGuid();
+        var keyC = Guid.NewGuid();
+
+        // Search returns keys in order [A, B, C]
+        _entitySearchService
+            .Setup(x => x.Search(UmbracoObjectTypes.Template, It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new PagedModel<IEntitySlim>
+            {
+                Items = [
+                    new EntitySlim { Key = keyA },
+                    new EntitySlim { Key = keyB },
+                    new EntitySlim { Key = keyC },
+                ],
+                Total = 3,
+            });
+
+        // Service returns templates in scrambled order [C, A, B]
+        ITemplate templateC = Mock.Of<ITemplate>(x => x.Key == keyC);
+        ITemplate templateA = Mock.Of<ITemplate>(x => x.Key == keyA);
+        ITemplate templateB = Mock.Of<ITemplate>(x => x.Key == keyB);
+        _templateService
+            .Setup(x => x.GetAllAsync(It.IsAny<Guid[]>()))
+            .ReturnsAsync(new[] { templateC, templateA, templateB });
+
+        _mapper
+            .Setup(x => x.MapEnumerable<ITemplate, TemplateItemResponseModel>(It.IsAny<IEnumerable<ITemplate>>()))
+            .Returns<IEnumerable<ITemplate>>(entities =>
+                entities.Select(e => new TemplateItemResponseModel { Alias = e.Alias, Id = e.Key }).ToList());
+
+        IActionResult result = await _controller.Search(CancellationToken.None, "test");
+
+        OkObjectResult? okResult = result as OkObjectResult;
+        Assert.That(okResult, Is.Not.Null);
+        var pagedModel = okResult!.Value as PagedModel<TemplateItemResponseModel>;
+        Assert.That(pagedModel, Is.Not.Null);
+        List<TemplateItemResponseModel> items = pagedModel!.Items.ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(items[0].Id, Is.EqualTo(keyA));
+            Assert.That(items[1].Id, Is.EqualTo(keyB));
+            Assert.That(items[2].Id, Is.EqualTo(keyC));
+        });
+    }
+}


### PR DESCRIPTION
### Prerequisites
- [ ] I have added steps to test this contribution in the description below
### Description
**Problem**:
Most database-backed search endpoints currently make two calls:
`IEntitySearchService.Search()` — returns a list of entity keys in relevance/order determined by the search implementation.
`IEntityService.GetAll()` — fetches the full entity data for those keys.
According to investigation (and confirmed behavior), GetAll() does not preserve the input key order. Instead, results are returned using the entity’s default sort order from the database layer. As a result, search endpoints may return items in a different order than the original search ranking.

**Fix**:
The implementation now:
- Retrieves entity keys from Search()
- Fetches entities using GetAll()
- Reorders the final result set to match the original search key order

**Scope**:
- DataType
- MediaType
- MemberType
- Template
<!-- Thanks for contributing to Umbraco CMS! -->
