### PR TITLE
QA: Stabilise rollback content versioning E2E test

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
@@ -1166,10 +1166,7 @@ export class ContentUiHelper extends UiBaseLocators {
   }
 
   async clickRollbackContainerButton(documentId?: string) {
-    // When the rollback is triggered from within an open document workspace, the workspace
-    // re-fetches the document after the rollback event is dispatched. Pass the documentId so
-    // the test waits for that GET to complete before asserting on the property values —
-    // otherwise the assertion races the async reload that follows the success notification.
+    // Workspace re-fetches the document asynchronously after rollback; wait for that GET before asserting.
     if (documentId) {
       await this.waitForResponseAfterExecutingPromise(
         `${ConstantHelper.apiEndpoints.document}/${documentId}`,

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
@@ -1165,7 +1165,19 @@ export class ContentUiHelper extends UiBaseLocators {
     await this.click(this.rollbackBtn, {force: true});
   }
 
-  async clickRollbackContainerButton() {
+  async clickRollbackContainerButton(documentId?: string) {
+    // When the rollback is triggered from within an open document workspace, the workspace
+    // re-fetches the document after the rollback event is dispatched. Pass the documentId so
+    // the test waits for that GET to complete before asserting on the property values —
+    // otherwise the assertion races the async reload that follows the success notification.
+    if (documentId) {
+      await this.waitForResponseAfterExecutingPromise(
+        `${ConstantHelper.apiEndpoints.document}/${documentId}`,
+        this.click(this.rollbackContainerBtn),
+        ConstantHelper.statusCodes.ok,
+      );
+      return;
+    }
     await this.click(this.rollbackContainerBtn);
   }
 

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
@@ -1168,11 +1168,16 @@ export class ContentUiHelper extends UiBaseLocators {
   async clickRollbackContainerButton(documentId?: string) {
     // Workspace re-fetches the document asynchronously after rollback; wait for that GET before asserting.
     if (documentId) {
-      await this.waitForResponseAfterExecutingPromise(
-        `${ConstantHelper.apiEndpoints.document}/${documentId}`,
+      const expectedPath = `${ConstantHelper.apiEndpoints.document}/${documentId}`;
+      await Promise.all([
+        this.waitForResponse(
+          (resp) =>
+            resp.request().method() === 'GET' &&
+            resp.status() === ConstantHelper.statusCodes.ok &&
+            new URL(resp.url()).pathname === expectedPath,
+        ),
         this.click(this.rollbackContainerBtn),
-        ConstantHelper.statusCodes.ok,
-      );
+      ]);
       return;
     }
     await this.click(this.rollbackContainerBtn);

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentVersioning.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ContentVersioning.spec.ts
@@ -15,7 +15,7 @@ test.afterEach(async ({umbracoApi}) => {
 
 test('can rollback content to a previous published version', {tag: '@smoke'}, async ({umbracoApi, umbracoUi}) => {
   // Arrange
-  await umbracoApi.document.createPublishedDocumentWithTwoNameVersionsAndTwoTextVersions(contentName, contentName, documentTypeName, dataTypeName, originalText, updatedText);
+  const documentId = await umbracoApi.document.createPublishedDocumentWithTwoNameVersionsAndTwoTextVersions(contentName, contentName, documentTypeName, dataTypeName, originalText, updatedText);
   await umbracoUi.goToBackOffice();
   await umbracoUi.content.goToSection(ConstantHelper.sections.content);
   await umbracoUi.content.goToContentWithName(contentName);
@@ -25,7 +25,7 @@ test('can rollback content to a previous published version', {tag: '@smoke'}, as
   await umbracoUi.content.clickRollbackButton();
   await umbracoUi.content.waitForRollbackItems();
   await umbracoUi.content.clickLatestRollBackItem();
-  await umbracoUi.content.clickRollbackContainerButton();
+  await umbracoUi.content.clickRollbackContainerButton(documentId);
 
   // Assert
   await umbracoUi.content.isSuccessNotificationVisible();
@@ -76,7 +76,7 @@ test('can rollback a variant document to a previous published version', async ({
   await umbracoUi.content.clickRollbackButton();
   await umbracoUi.content.waitForRollbackItems();
   await umbracoUi.content.clickLatestRollBackItem();
-  await umbracoUi.content.clickRollbackContainerButton();
+  await umbracoUi.content.clickRollbackContainerButton(documentId);
 
   // Assert
   await umbracoUi.content.isSuccessNotificationVisible();
@@ -97,7 +97,7 @@ test('rollback restores the document name to the previous version', async ({umbr
   await umbracoUi.content.clickRollbackButton();
   await umbracoUi.content.waitForRollbackItems();
   await umbracoUi.content.clickLatestRollBackItem();
-  await umbracoUi.content.clickRollbackContainerButton();
+  await umbracoUi.content.clickRollbackContainerButton(documentId);
 
   // Assert
   await umbracoUi.content.isSuccessNotificationVisible();


### PR DESCRIPTION
## Description

The `can rollback content to a previous published version` smoke test in `ContentVersioning.spec.ts` is flaky on v18 (main) — the first failure has been observed in CI with the property value assertion seeing `"Updated version text"` instead of `"Original version text"`. The test isn't currently observed to flake on v17, but the underlying race condition exists here too, so applying the same fix.

The race: after clicking *Rollback* in the modal, the rollback POST completes, the modal closes, and a success notification fires — but the workspace's reload of the document detail is dispatched via a fire-and-forget event listener. The Playwright assertion on the property input value then races that async GET.

## Fix

Updated `clickRollbackContainerButton` in `ContentUiHelper` to optionally accept a `documentId`. When passed, it uses the existing `waitForResponseAfterExecutingPromise` helper to wait for the document detail GET to complete before returning.

No production code is changed.

## Testing

Verify that test passes.  Once merged up it'll 🤞 resolve the flaky test on 18.