### PR TITLE
Backoffice search: Preserve Lucene score order through content-picker lookups (closes #22862)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,14 @@ Allowed, but cheap to write and cheaper to leave behind. Keep them short and tra
 
 ---
 
+## 9. Testing Practices
+
+### Tests for a bug fix must fail before the fix
+
+Verify any test you add for a bug fix actually catches the bug: either write the failing test first (TDD), or temporarily revert the production change and confirm the test fails before re-applying. A test that passes both ways proves nothing. Watch for coincidental passes — default seed/sort orders can make a buggy path produce the right answer for the test's specific inputs; construct inputs so the broken and fixed behaviours give visibly different results.
+
+---
+
 ## Quick Reference
 
 ### Essential Commands

--- a/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
@@ -122,11 +122,29 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
             .Where(key => key != Guid.Empty)
             .ToArray();
 
+        // EntityService.GetAll returns entities in database (not Lucene score) order, which
+        // would discard the relevance ranking. Re-order to match the search result sequence.
+        IEnumerable<IEntitySlim> orderedItems;
+        if (keys.Length > 0)
+        {
+            var keyOrder = new Dictionary<Guid, int>(keys.Length);
+            for (var i = 0; i < keys.Length; i++)
+            {
+                keyOrder.TryAdd(keys[i], i);
+            }
+
+            orderedItems = _entityService
+                .GetAll(objectType, keys)
+                .OrderBy(entity => keyOrder.TryGetValue(entity.Key, out var index) ? index : int.MaxValue);
+        }
+        else
+        {
+            orderedItems = [];
+        }
+
         return Task.FromResult(new PagedModel<IEntitySlim>
         {
-            Items = keys.Any()
-                ? _entityService.GetAll(objectType, keys)
-                : Enumerable.Empty<IEntitySlim>(),
+            Items = orderedItems,
             Total = totalFound
         });
     }

--- a/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/IndexedEntitySearchService.cs
@@ -135,7 +135,8 @@ internal sealed class IndexedEntitySearchService : IIndexedEntitySearchService
 
             orderedItems = _entityService
                 .GetAll(objectType, keys)
-                .OrderBy(entity => keyOrder.TryGetValue(entity.Key, out var index) ? index : int.MaxValue);
+                .OrderBy(entity => keyOrder.TryGetValue(entity.Key, out var index) ? index : int.MaxValue)
+                .ToArray();
         }
         else
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
@@ -744,74 +744,6 @@ internal sealed class BackOfficeExamineSearcherTests : ExamineBaseTest
         });
     }
 
-    // Multi-word relevance ranking — see #22862.
-    // Long, precise multi-word queries should surface their exact node-name match at position 1,
-    // not be outranked by short noisy docs sharing only a common token.
-
-    [Test]
-    public async Task Multi_Word_Search_Ranks_Exact_Phrase_Match_First()
-    {
-        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
-
-        const string exactMatch = "Sirop de Grenade Pomegranate Syrup";
-        await PublishContents(
-            exactMatch,
-            "Quinta de la Rosa Reserva 2020",
-            "Delivery API Test Page",
-            "Test De Mocha");
-
-        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch(exactMatch);
-
-        ISearchResult[] searchResults = actual.ToArray();
-        Assert.GreaterOrEqual(searchResults.Length, 1);
-        Assert.AreEqual(exactMatch, searchResults.First().Values["nodeName"]);
-    }
-
-    [Test]
-    public async Task Multi_Word_Search_Ranks_All_Tokens_Present_Above_Partial_Match()
-    {
-        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
-
-        // Same five tokens as the query, different order — no exact phrase match.
-        const string allTokensScrambled = "Pomegranate Sirop de Syrup Grenade";
-
-        // Partial match — only the common token "de" overlaps with the query.
-        const string partialMatch = "de la Rosa";
-
-        await PublishContents(
-            allTokensScrambled,
-            partialMatch,
-            "Pomegranate Marmalade");
-
-        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch("Sirop de Grenade Pomegranate Syrup");
-
-        ISearchResult[] searchResults = actual.ToArray();
-        var scrambledIndex = Array.FindIndex(searchResults, r => (string)r.Values["nodeName"] == allTokensScrambled);
-        var partialIndex = Array.FindIndex(searchResults, r => (string)r.Values["nodeName"] == partialMatch);
-
-        Assert.GreaterOrEqual(scrambledIndex, 0, $"'{allTokensScrambled}' (all tokens present) must appear in results");
-        Assert.IsTrue(
-            partialIndex < 0 || scrambledIndex < partialIndex,
-            $"'{allTokensScrambled}' (all tokens present) must rank above '{partialMatch}' (single-token overlap)");
-    }
-
-    [Test]
-    public async Task Multi_Word_Search_Quoted_Phrase_Returns_Exact_Match_First()
-    {
-        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
-
-        const string exactMatch = "Sirop de Grenade Pomegranate Syrup";
-        await PublishContents(
-            exactMatch,
-            "de la Rosa");
-
-        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch($"\"{exactMatch}\"");
-
-        ISearchResult[] searchResults = actual.ToArray();
-        Assert.GreaterOrEqual(searchResults.Length, 1);
-        Assert.AreEqual(exactMatch, searchResults.First().Values["nodeName"]);
-    }
-
     /// <summary>
     /// Verifies that <see cref="IIndexedEntitySearchService"/> returns matches in Lucene score
     /// order. The exact-match document is published last so its nodeId is the highest of the
@@ -841,25 +773,6 @@ internal sealed class BackOfficeExamineSearcherTests : ExamineBaseTest
         IEntitySlim[] items = result.Items.ToArray();
         Assert.GreaterOrEqual(items.Length, 1);
         Assert.AreEqual(exactMatch, items.First().Name);
-    }
-
-    [Test]
-    public async Task Single_Token_Search_Returns_All_Prefix_Matches()
-    {
-        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
-
-        await PublishContents(
-            "Delivery API Test Page",
-            "Quinta de la Rosa",
-            "Test De Mocha",
-            "Pomegranate Marmalade"); // no "de" prefix anywhere
-
-        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch("de");
-
-        var nodeNames = actual.Select(r => (string)r.Values["nodeName"]).ToArray();
-        Assert.Contains("Delivery API Test Page", nodeNames);
-        Assert.Contains("Quinta de la Rosa", nodeNames);
-        Assert.Contains("Test De Mocha", nodeNames);
     }
 
     private async Task PublishContents(params string[] contentNames)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -741,5 +742,152 @@ internal sealed class BackOfficeExamineSearcherTests : ExamineBaseTest
             Assert.AreEqual(searchResults.First().Values["__VariesByCulture"], contentTypeCultureVariations);
             Assert.AreEqual(searchResults.First().Values["__Icon"], contentNode.ContentType.Icon);
         });
+    }
+
+    // Multi-word relevance ranking — see #22862.
+    // Long, precise multi-word queries should surface their exact node-name match at position 1,
+    // not be outranked by short noisy docs sharing only a common token.
+
+    [Test]
+    public async Task Multi_Word_Search_Ranks_Exact_Phrase_Match_First()
+    {
+        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
+
+        const string exactMatch = "Sirop de Grenade Pomegranate Syrup";
+        await PublishContents(
+            exactMatch,
+            "Quinta de la Rosa Reserva 2020",
+            "Delivery API Test Page",
+            "Test De Mocha");
+
+        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch(exactMatch);
+
+        ISearchResult[] searchResults = actual.ToArray();
+        Assert.GreaterOrEqual(searchResults.Length, 1);
+        Assert.AreEqual(exactMatch, searchResults.First().Values["nodeName"]);
+    }
+
+    [Test]
+    public async Task Multi_Word_Search_Ranks_All_Tokens_Present_Above_Partial_Match()
+    {
+        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
+
+        // Same five tokens as the query, different order — no exact phrase match.
+        const string allTokensScrambled = "Pomegranate Sirop de Syrup Grenade";
+
+        // Partial match — only the common token "de" overlaps with the query.
+        const string partialMatch = "de la Rosa";
+
+        await PublishContents(
+            allTokensScrambled,
+            partialMatch,
+            "Pomegranate Marmalade");
+
+        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch("Sirop de Grenade Pomegranate Syrup");
+
+        ISearchResult[] searchResults = actual.ToArray();
+        var scrambledIndex = Array.FindIndex(searchResults, r => (string)r.Values["nodeName"] == allTokensScrambled);
+        var partialIndex = Array.FindIndex(searchResults, r => (string)r.Values["nodeName"] == partialMatch);
+
+        Assert.GreaterOrEqual(scrambledIndex, 0, $"'{allTokensScrambled}' (all tokens present) must appear in results");
+        Assert.IsTrue(
+            partialIndex < 0 || scrambledIndex < partialIndex,
+            $"'{allTokensScrambled}' (all tokens present) must rank above '{partialMatch}' (single-token overlap)");
+    }
+
+    [Test]
+    public async Task Multi_Word_Search_Quoted_Phrase_Returns_Exact_Match_First()
+    {
+        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
+
+        const string exactMatch = "Sirop de Grenade Pomegranate Syrup";
+        await PublishContents(
+            exactMatch,
+            "de la Rosa");
+
+        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch($"\"{exactMatch}\"");
+
+        ISearchResult[] searchResults = actual.ToArray();
+        Assert.GreaterOrEqual(searchResults.Length, 1);
+        Assert.AreEqual(exactMatch, searchResults.First().Values["nodeName"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IIndexedEntitySearchService"/> returns matches in Lucene score
+    /// order. The exact-match document is published last so its nodeId is the highest of the
+    /// set, meaning a consumer that surfaces results in database order would put it last —
+    /// only a score-order-preserving consumer ranks it first.
+    /// </summary>
+    [Test]
+    public async Task IndexedEntitySearchService_Preserves_Score_Order_For_Multi_Word_Search()
+    {
+        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
+
+        const string exactMatch = "Sirop de Grenade Pomegranate Syrup";
+        await PublishContents(
+            "Quinta de la Rosa Reserva 2020",
+            "Delivery API Test Page",
+            "Test De Mocha",
+            exactMatch);
+
+        var indexedEntitySearchService = GetRequiredService<IIndexedEntitySearchService>();
+        PagedModel<IEntitySlim> result = await indexedEntitySearchService.SearchAsync(
+            UmbracoObjectTypes.Document,
+            exactMatch,
+            parentId: null,
+            contentTypeIds: null,
+            trashed: null);
+
+        IEntitySlim[] items = result.Items.ToArray();
+        Assert.GreaterOrEqual(items.Length, 1);
+        Assert.AreEqual(exactMatch, items.First().Name);
+    }
+
+    [Test]
+    public async Task Single_Token_Search_Returns_All_Prefix_Matches()
+    {
+        await SetupUserIdentity(Constants.Security.SuperUserIdAsString);
+
+        await PublishContents(
+            "Delivery API Test Page",
+            "Quinta de la Rosa",
+            "Test De Mocha",
+            "Pomegranate Marmalade"); // no "de" prefix anywhere
+
+        IEnumerable<ISearchResult> actual = BackOfficeExamineSearch("de");
+
+        var nodeNames = actual.Select(r => (string)r.Values["nodeName"]).ToArray();
+        Assert.Contains("Delivery API Test Page", nodeNames);
+        Assert.Contains("Quinta de la Rosa", nodeNames);
+        Assert.Contains("Test De Mocha", nodeNames);
+    }
+
+    private async Task PublishContents(params string[] contentNames)
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithId(0)
+            .Build();
+        await ExecuteAndWaitForIndexing(
+            () => ContentTypeService.Save(contentType),
+            Constants.UmbracoIndexes.InternalIndexName);
+
+        foreach (var name in contentNames)
+        {
+            var content = new ContentBuilder()
+                .WithId(0)
+                .WithName(name)
+                .WithContentType(contentType)
+                .Build();
+            await ExecuteAndWaitForIndexing(
+                () =>
+                {
+                    using var scope = ScopeProvider.CreateCoreScope();
+                    ContentService.Save(content);
+                    var result = ContentService.Publish(content, Array.Empty<string>());
+                    scope.Complete();
+                    return result;
+                },
+                Constants.UmbracoIndexes.InternalIndexName);
+        }
     }
 }


### PR DESCRIPTION
## Description

The content-picker tree search returned matches in database order rather than Lucene relevance order, so an exact-phrase match to a node name could rank below sibling rows that only matched a common token.

`IIndexedEntitySearchService.SearchAsync` resolved the keys from `IBackOfficeExamineSearcher.Search` (score-ordered) through `IEntityService.GetAll(Guid[] keys)`. That call generates a `WHERE UniqueId IN (...)` query whose rows come back in database order, discarding the score ranking.

This change re-orders the `GetAll` result against the input key sequence so the Lucene score order survives the database lookup.

Fixes #22862

## Testing

### Automated

A new unit integration test is added `IndexedEntitySearchService_Preserves_Score_Order_For_Multi_Word_Search` to verify the resolution.  This fails before the fix and passes afterwards.

### Manual

Repro steps from the issue:

- [ ] Create three documents (any document type, any parent):
  - `Quinta de la Rosa Reserva 2020`
  - `Sirop de Grenade Pomegranate Syrup`
  - `Maison Lorgeril O de Rose`
- [ ] *Settings → Examine Management → Rebuild* the `InternalIndex`.
- [ ] On any document type, add a Content Picker property.
- [ ] Edit a node, open the content picker, search for `Sirop de Grenade Pomegranate Syrup`. Confirm it appears at position 1.
- [ ] Search for `Quinta de la Rosa`. Confirm `Quinta de la Rosa Reserva 2020` appears at position 1.