### PR TITLE
Backoffice: Hide "Edit permissions" button in create modals from users without Settings section access (closes #22981)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/ar.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/ar.ts
@@ -373,16 +373,16 @@ export default {
 		enterFolderName: 'أدخل اسم المجلد',
 		updateData: 'اختر نوعًا وعنوانًا',
 		noDocumentTypes:
-			'لا توجد أنواع وثائق مسموح بها متاحة لإنشاء المحتوى هنا. يجب تمكينها في <strong>أنواع الوثائق</strong> ضمن قسم <strong>الإعدادات</strong>، عن طريق تعديل <strong>أنواع العقد الفرعية المسموح بها</strong> ضمن <strong>الأذونات</strong>.',
+			'لا توجد أنواع وثائق مسموح بها متاحة لإنشاء المحتوى هنا. يجب تمكينها في <strong>أنواع الوثائق</strong> ضمن قسم <strong>الإعدادات</strong>، عن طريق تعديل <strong>أنواع العقد الفرعية المسموح بها</strong> ضمن <strong>الهيكل</strong>.',
 		noDocumentTypesAtRoot:
 			'لا توجد أنواع وثائق متاحة لإنشاء المحتوى هنا. يجب عليك إنشاء هذه الأنواع في <strong>أنواع الوثائق</strong> ضمن قسم <strong>الإعدادات</strong>.',
 		noDocumentTypesWithNoSettingsAccess: 'الصفحة المحددة في شجرة المحتوى لا تسمح بإنشاء أي صفحات أسفلها.',
 		noDocumentTypesEditPermissions: 'تعديل الأذونات لهذا النوع من الوثائق',
 		noDocumentTypesCreateNew: 'إنشاء نوع وثيقة جديد',
 		noDocumentTypesAllowedAtRoot:
-			'لا توجد أنواع وثائق مسموح بها لإنشاء المحتوى هنا. يجب تمكينها في <strong>أنواع الوثائق</strong> ضمن قسم <strong>الإعدادات</strong>، عن طريق تغيير خيار <strong>السماح كجذر</strong> ضمن <strong>الأذونات</strong>.',
+			'لا توجد أنواع وثائق مسموح بها لإنشاء المحتوى هنا. يجب تمكينها في <strong>أنواع الوثائق</strong> ضمن قسم <strong>الإعدادات</strong>، عن طريق تغيير خيار <strong>السماح كجذر</strong> ضمن <strong>الهيكل</strong>.',
 		noMediaTypes:
-			'لا توجد أنواع وسائط مسموح بها لإنشاء الوسائط هنا. يجب تمكينها في <strong>أنواع الوسائط</strong> ضمن قسم <strong>الإعدادات</strong>، عن طريق تعديل <strong>أنواع العقد الفرعية المسموح بها</strong> ضمن <strong>الأذونات</strong>.',
+			'لا توجد أنواع وسائط مسموح بها لإنشاء الوسائط هنا. يجب تمكينها في <strong>أنواع الوسائط</strong> ضمن قسم <strong>الإعدادات</strong>، عن طريق تعديل <strong>أنواع العقد الفرعية المسموح بها</strong> ضمن <strong>الهيكل</strong>.',
 		noMediaTypesWithNoSettingsAccess: 'الوسائط المحددة في الشجرة لا تسمح بإنشاء أي وسائط أخرى أسفلها.',
 		noMediaTypesEditPermissions: 'تعديل الأذونات لهذا النوع من الوسائط',
 		documentTypeWithoutTemplate: 'نوع الوثيقة بدون قالب',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/bs.ts
@@ -367,7 +367,7 @@ export default {
 		enterFolderName: 'Unesite naziv foldera',
 		updateData: 'Odaberite vrstu i naslov',
 		noDocumentTypes:
-			'Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljeni tipovi podređenih čvorova</strong> unutar <strong>Dozvole</strong>.',
+			'Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljeni tipovi podređenih čvorova</strong> unutar <strong>Struktura</strong>.',
 		noDocumentTypesAtRoot:
 			'Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih kreirati u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>.',
 		noDocumentTypesWithNoSettingsAccess:
@@ -375,9 +375,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Uredi dozvole za ovaj tip dokumenta',
 		noDocumentTypesCreateNew: 'Kreiraj novi tip dokumenta',
 		noDocumentTypesAllowedAtRoot:
-			'Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>, izmjenom <strong>Dozvoli kao root</strong> opcije unutar <strong>Dozvole</strong>.',
+			'Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>, izmjenom <strong>Dozvoli kao root</strong> opcije unutar <strong>Struktura</strong>.',
 		noMediaTypes:
-			'Nema dozvoljenih tipova medija dostupnih za kreiranje medija ovdje. Morate ih omogućiti u <strong>Media Tip</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljeni tipovi podređenih čvorova</strong> unutar <strong>Dozvole</strong>.',
+			'Nema dozvoljenih tipova medija dostupnih za kreiranje medija ovdje. Morate ih omogućiti u <strong>Media Tip</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljeni tipovi podređenih čvorova</strong> unutar <strong>Struktura</strong>.',
 		noMediaTypesWithNoSettingsAccess:
 			'Odabrani medij u stablu ne dopušta bilo koji drugi medij\n       kreiran ispod njega.\n    ',
 		noMediaTypesEditPermissions: 'Uredi dozvole za ovaj tip medija',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cs.ts
@@ -343,7 +343,7 @@ export default {
 		noDocumentTypesEditPermissions: 'Oprávnění k úpravám pro tento typ dokumentu',
 		noDocumentTypesCreateNew: 'Vytvořit nový typ dokumentu',
 		noDocumentTypesAllowedAtRoot:
-			'Nejsou zde k dispozici žádné povolené typy dokumentů pro vytváření obsahu. Musíte je povolit v sekci <strong>Typy dokumentů</strong> v části <strong>Nastavení</strong> změnou možnosti <strong>Povolit jako root</strong> v části <strong>Oprávnění</strong>.',
+			'Nejsou zde k dispozici žádné povolené typy dokumentů pro vytváření obsahu. Musíte je povolit v sekci <strong>Typy dokumentů</strong> v části <strong>Nastavení</strong> změnou možnosti <strong>Povolit jako root</strong> v části <strong>Struktura</strong>.',
 		noMediaTypes:
 			'Nejsou dostupné žádné povolené typy medií. Tyto musíte povolit v sekci nastavení pod <strong>"typy medií"</strong>.',
 		noMediaTypesWithNoSettingsAccess: 'Vybraná média ve stromu neumožňuje vytváření pod nimi žádná další média.',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/cy.ts
@@ -390,7 +390,7 @@ export default {
 		enterFolderName: 'Rhoi enw ffolder i mewn',
 		updateData: 'Dewiswch fath a theitl',
 		noDocumentTypes:
-			"Nid oes unrhyw fathau o ddogfennau caniataol ar gael am greu cynnwys fan hyn. Rhaid i chi alluogi'r rhain yn <strong>Mathau o Ddogfennau</strong> o fewn y adran <strong>Gosodiadau</strong>, gan olygu y opsiwn <strong>Mathau o nod blentyn caniataol</strong> o dan <strong>Caniatadau</strong>",
+			"Nid oes unrhyw fathau o ddogfennau caniataol ar gael am greu cynnwys fan hyn. Rhaid i chi alluogi'r rhain yn <strong>Mathau o Ddogfennau</strong> o fewn y adran <strong>Gosodiadau</strong>, gan olygu y opsiwn <strong>Mathau o nod blentyn caniataol</strong> o dan <strong>Strwythyr</strong>",
 		noDocumentTypesAtRoot:
 			'Nid oes unrhyw fathau o ddogfennau ar gael. Rhaid i chi creu rhain yn <strong>Mathau o Ddogfennau</strong> tu fewn y adran <strong>Gosodiadau</strong>.',
 		noDocumentTypesWithNoSettingsAccess:
@@ -398,7 +398,7 @@ export default {
 		noDocumentTypesEditPermissions: 'Golygu caniatâd ar gyfer y math hwn o ddogfen',
 		noDocumentTypesCreateNew: 'Creu Math o Ddogfen newydd',
 		noDocumentTypesAllowedAtRoot:
-			"Nid oes unrhyw fathau o ddogfennau caniataol ar gael am greu cynnwys fan hyn. Rhaid i chi alluogi'r rhain yn <strong>Mathau o Ddogfennau</strong> o fewn y adran <strong>Gosodiadau</strong>, gan olygu y opsiwn <strong>Caniatáu fel gwraidd</strong> o dan <strong>Caniatadau</strong>",
+			"Nid oes unrhyw fathau o ddogfennau caniataol ar gael am greu cynnwys fan hyn. Rhaid i chi alluogi'r rhain yn <strong>Mathau o Ddogfennau</strong> o fewn y adran <strong>Gosodiadau</strong>, gan olygu y opsiwn <strong>Caniatáu fel gwraidd</strong> o dan <strong>Strwythyr</strong>",
 		noMediaTypes:
 			'Nid oes unrhyw fathau o gyfrwng caniataol ar gael. Rhaid i chi alluogi\'r rhain yn yr adran gosodiadau o dan <strong>"mathau o gyfrwng"</strong>.',
 		noMediaTypesWithNoSettingsAccess:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -450,7 +450,7 @@ export default {
 		noDocumentTypesEditPermissions: 'Rediger tilladelser for denne dokumenttype.',
 		noDocumentTypesCreateNew: 'Opret en ny dokumenttype',
 		noDocumentTypesAllowedAtRoot:
-			'Der er ingen tilladte Dokumenttyper tilgængelige for at lave indhold her. Du skal tillade dette i <strong>Dokumenttyper</strong> inde i <strong>Indstillinger</strong> sektionen, ved at ændre <strong>Tillad på rodniveau</strong> indestillingen under <strong>Permissions</strong>.',
+			'Der er ingen tilladte Dokumenttyper tilgængelige for at lave indhold her. Du skal tillade dette i <strong>Dokumenttyper</strong> inde i <strong>Indstillinger</strong> sektionen, ved at ændre <strong>Tillad på rodniveau</strong> indestillingen under <strong>Struktur</strong>.',
 		noMediaTypes:
 			'Der kunne ikke findes nogen tilladte media typer. Du skal tillade disse i indstillinger under <strong>"media typer"</strong>.',
 		noMediaTypesWithNoSettingsAccess: 'Det valgte medie i træet tillader ikke at medier oprettes under det.\n    ',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -464,7 +464,7 @@ export default {
 		enterFolderName: 'Enter a folder name',
 		updateData: 'Choose a type and a title',
 		noDocumentTypes:
-			'There are no allowed Document Types available for creating content here. You must enable these in <strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Permissions</strong>.',
+			'There are no allowed Document Types available for creating content here. You must enable these in <strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Structure</strong>.',
 		noDocumentTypesAtRoot:
 			'There are no Document Types available for creating content here. You must create these in <strong>Document Types</strong> within the <strong>Settings</strong> section.',
 		noDocumentTypesWithNoSettingsAccess:
@@ -472,9 +472,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Edit permissions for this Document Type',
 		noDocumentTypesCreateNew: 'Create a new Document Type',
 		noDocumentTypesAllowedAtRoot:
-			'There are no allowed Document Types available for creating content here. You must enable these in <strong>Document Types</strong> within the <strong>Settings</strong> section, by changing the <strong>Allow as root</strong> option under <strong>Permissions</strong>.',
+			'There are no allowed Document Types available for creating content here. You must enable these in <strong>Document Types</strong> within the <strong>Settings</strong> section, by changing the <strong>Allow as root</strong> option under <strong>Structure</strong>.',
 		noMediaTypes:
-			'There are no allowed Media Types available for creating media here. You must enable these in <strong>Media Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Permissions</strong>.',
+			'There are no allowed Media Types available for creating media here. You must enable these in <strong>Media Types</strong> within the <strong>Settings</strong> section, by editing the <strong>Allowed child node types</strong> under <strong>Structure</strong>.',
 		noMediaTypesWithNoSettingsAccess:
 			"The selected media in the tree doesn't allow for any other media to be created below it.",
 		noMediaTypesEditPermissions: 'Edit permissions for this Media Type',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
@@ -344,7 +344,7 @@ export default {
 		enterFolderName: 'Introduisez un nom de dossier',
 		updateData: 'Choisissez un type et un titre',
 		noDocumentTypes:
-			"Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>, en modifiant les <strong>Types de noeuds enfants autorisés</strong> sous les <strong>Permissions</strong>.",
+			"Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>, en modifiant les <strong>Types de noeuds enfants autorisés</strong> sous la <strong>Structure</strong>.",
 		noDocumentTypesAtRoot:
 			"Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>.",
 		noDocumentTypesWithNoSettingsAccess:
@@ -352,9 +352,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Modifier les permissions pour ce type de document',
 		noDocumentTypesCreateNew: 'Créer un nouveau type de document',
 		noDocumentTypesAllowedAtRoot:
-			"Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>, en modifiant l'option <strong>Autoriser comme racine</strong> sous les <strong>Permissions</strong>.",
+			"Il n'y a aucun type de document disponible pour créer du contenu ici. Vous devez d'abord les activer dans <strong>Types de documents</strong> sous la section <strong>Paramètres</strong>, en modifiant l'option <strong>Autoriser comme racine</strong> sous la <strong>Structure</strong>.",
 		noMediaTypes:
-			"Il n'y a aucun type de média disponible pour créer un media ici. Vous devez d'abord les activer dans <strong>Types de médias</strong> dans la section <strong>Paramètres</strong>, en modifiant les <strong>Types de noeuds enfants autorisés</strong> sous les <strong>Permissions</strong>.",
+			"Il n'y a aucun type de média disponible pour créer un media ici. Vous devez d'abord les activer dans <strong>Types de médias</strong> dans la section <strong>Paramètres</strong>, en modifiant les <strong>Types de noeuds enfants autorisés</strong> sous la <strong>Structure</strong>.",
 		noMediaTypesWithNoSettingsAccess:
 			"Le media sélectionné dans l'arborescence n'autorise pas la création d'un autre media sous lui.",
 		noMediaTypesEditPermissions: 'Modifier les permissions pour ce type de media',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/hr.ts
@@ -368,7 +368,7 @@ export default {
 		enterFolderName: 'Unesite naziv mape',
 		updateData: 'Odaberite vrstu i naslov',
 		noDocumentTypes:
-			'Nema dozvoljenih vrsta dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Vrste Dokumenta</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljene vrste podređenih čvorova</strong> unutar <strong>Dozvole</strong>.',
+			'Nema dozvoljenih vrsta dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Vrste Dokumenta</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljene vrste podređenih čvorova</strong> unutar <strong>Struktura</strong>.',
 		noDocumentTypesAtRoot:
 			'Nema dozvoljenih vrsta dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih kreirati u <strong>Vrste Dokumenata</strong> unutar sekcije <strong>Postavke</strong>.',
 		noDocumentTypesWithNoSettingsAccess:
@@ -376,9 +376,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Uredi dozvole za ovu vrstu dokumenta',
 		noDocumentTypesCreateNew: 'Kreiraj novu vrstu dokumenta',
 		noDocumentTypesAllowedAtRoot:
-			'Nema dozvoljenih vrsta dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Vrste Dokumenta</strong> unutar sekcije <strong>Postavke</strong>, izmjenom <strong>Dozvoli kao root</strong> opcije unutar <strong>Dozvole</strong>.',
+			'Nema dozvoljenih vrsta dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Vrste Dokumenta</strong> unutar sekcije <strong>Postavke</strong>, izmjenom <strong>Dozvoli kao root</strong> opcije unutar <strong>Struktura</strong>.',
 		noMediaTypes:
-			'Nema dozvoljenih vrsta medija dostupnih za kreiranje medija ovdje. Morate ih omogućiti u <strong>Vrste Medija</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljene vrste podređenih čvorova</strong> unutar <strong>Dozvole</strong>.',
+			'Nema dozvoljenih vrsta medija dostupnih za kreiranje medija ovdje. Morate ih omogućiti u <strong>Vrste Medija</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljene vrste podređenih čvorova</strong> unutar <strong>Struktura</strong>.',
 		noMediaTypesWithNoSettingsAccess:
 			'Odabrani medij u stablu ne dopušta bilo koji drugi medij\n       kreiran ispod njega.\n    ',
 		noMediaTypesEditPermissions: 'Uredi dozvole za ovu vrstu medija',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/it.ts
@@ -384,7 +384,7 @@ export default {
 		enterFolderName: 'Inserisci il nome della cartella',
 		updateData: 'Scegli il tipo ed il titolo',
 		noDocumentTypes:
-			'Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, modificando <strong>Tipi di nodi figlio consentiti</strong> sotto <strong>Permessi</strong>.',
+			'Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, modificando <strong>Tipi di nodi figlio consentiti</strong> sotto <strong>Struttura</strong>.',
 		noDocumentTypesAtRoot:
 			'Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi crearli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>.',
 		noDocumentTypesWithNoSettingsAccess:
@@ -392,9 +392,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Modifica permessi per questo tipo di documento',
 		noDocumentTypesCreateNew: 'Crea un nuovo tipo di documento',
 		noDocumentTypesAllowedAtRoot:
-			"Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, cambiando l'opzione <strong>Consenti come root</strong> sotto <strong>Permessi</strong>.",
+			"Non ci sono tipi di documento abilitati disponibili per creare un contenuto qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, cambiando l'opzione <strong>Consenti come root</strong> sotto <strong>Struttura</strong>.",
 		noMediaTypes:
-			'Non ci sono tipi di documento abilitati disponibili per creare un media qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, modificando <strong>Tipi di nodi figlio consentiti</strong> sotto <strong>Permessi</strong>.',
+			'Non ci sono tipi di documento abilitati disponibili per creare un media qui. Devi abilitarli in <strong>Tipi di documento</strong> dentro la sezione <strong>Impostazioni</strong>, modificando <strong>Tipi di nodi figlio consentiti</strong> sotto <strong>Struttura</strong>.',
 		noMediaTypesWithNoSettingsAccess:
 			'Il media selezionato non consente la creazione di altri media al di\n      sotto di esso.\n    ',
 		noMediaTypesEditPermissions: 'Modifica permessi per questo tipo di media',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
@@ -364,7 +364,7 @@ export default {
 		noDocumentTypesEditPermissions: 'Rechten aanpassen voor dit documenttype',
 		noDocumentTypesCreateNew: 'Nieuw documenttype aanmaken',
 		noDocumentTypesAllowedAtRoot:
-			'Er zijn geen toegestane ​​documenttypes beschikbaar om hier aan te maken. Je moet deze inschakelen bij <strong>Documenttypes</strong> in de sectie <strong>Instellingen</strong>, de optie <strong>Toestaan op root-niveau</strong> onder <strong>Rechten</strong>.',
+			'Er zijn geen toegestane ​​documenttypes beschikbaar om hier aan te maken. Je moet deze inschakelen bij <strong>Documenttypes</strong> in de sectie <strong>Instellingen</strong>, de optie <strong>Toestaan op root-niveau</strong> onder <strong>Structuur</strong>.',
 		noMediaTypes:
 			'Er zijn geen toegestande mediatypes beschikbaar. Schakel deze in in de sectie Instellingen onder <strong>"Mediatypes"</strong>.',
 		noMediaTypesWithNoSettingsAccess:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -428,7 +428,7 @@ export default {
 		enterFolderName: 'Introduza um nome de pasta',
 		updateData: 'Escolha um tipo e um título',
 		noDocumentTypes:
-			'Não existem Tipos de Documento permitidos disponíveis para criar conteúdo aqui. Deve ativá-los em <strong>Tipos de Documento</strong> na secção <strong>Definições</strong>, editando os <strong>Tipos de nó filho permitidos</strong> em <strong>Permissões</strong>.',
+			'Não existem Tipos de Documento permitidos disponíveis para criar conteúdo aqui. Deve ativá-los em <strong>Tipos de Documento</strong> na secção <strong>Definições</strong>, editando os <strong>Tipos de nó filho permitidos</strong> em <strong>Estrutura</strong>.',
 		noDocumentTypesAtRoot:
 			'Não existem Tipos de Documento disponíveis para criar conteúdo aqui. Deve criá-los em <strong>Tipos de Documento</strong> na secção <strong>Definições</strong>.',
 		noDocumentTypesWithNoSettingsAccess:
@@ -436,9 +436,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Editar permissões para este Tipo de Documento',
 		noDocumentTypesCreateNew: 'Criar um novo Tipo de Documento',
 		noDocumentTypesAllowedAtRoot:
-			'Não existem Tipos de Documento permitidos disponíveis para criar conteúdo aqui. Deve ativá-los em <strong>Tipos de Documento</strong> na secção <strong>Definições</strong>, alterando a opção <strong>Permitir como raiz</strong> em <strong>Permissões</strong>.',
+			'Não existem Tipos de Documento permitidos disponíveis para criar conteúdo aqui. Deve ativá-los em <strong>Tipos de Documento</strong> na secção <strong>Definições</strong>, alterando a opção <strong>Permitir como raiz</strong> em <strong>Estrutura</strong>.',
 		noMediaTypes:
-			'Não existem Tipos de Multimédia permitidos disponíveis para criar multimédia aqui. Deve ativá-los em <strong>Tipos de Multimédia</strong> na secção <strong>Definições</strong>, editando os <strong>Tipos de nó filho permitidos</strong> em <strong>Permissões</strong>.',
+			'Não existem Tipos de Multimédia permitidos disponíveis para criar multimédia aqui. Deve ativá-los em <strong>Tipos de Multimédia</strong> na secção <strong>Definições</strong>, editando os <strong>Tipos de nó filho permitidos</strong> em <strong>Estrutura</strong>.',
 		noMediaTypesWithNoSettingsAccess:
 			'A multimédia selecionada na árvore não permite a criação de nenhuma outra multimédia abaixo dela.',
 		noMediaTypesEditPermissions: 'Editar permissões para este Tipo de Multimédia',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/tr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/tr.ts
@@ -339,7 +339,7 @@ export default {
 		enterFolderName: 'Bir klasör adı girin',
 		updateData: 'Bir tür ve başlık seçin',
 		noDocumentTypes:
-			"Burada içerik oluşturmak için izin verilen doküman türü yok. Bunları, <strong>İzinler</strong> altında <strong>İzin verilen alt düğüm türlerini</strong> düzenleyerek <strong>Ayarlar</strong> bölümündeki <strong>Belge Türleri</strong> 'nde etkinleştirmelisiniz.",
+			"Burada içerik oluşturmak için izin verilen doküman türü yok. Bunları, <strong>Yapı</strong> altında <strong>İzin verilen alt düğüm türlerini</strong> düzenleyerek <strong>Ayarlar</strong> bölümündeki <strong>Belge Türleri</strong> 'nde etkinleştirmelisiniz.",
 		noDocumentTypesAtRoot:
 			"Burada içerik oluşturmak için uygun bir belge türü yok. Öncelikle belge türlerini <strong>Ayarlar</strong> bölümündeki <strong>Belge Türleri</strong> 'nde oluşturmanız gerekiyor.",
 		noDocumentTypesWithNoSettingsAccess:
@@ -347,9 +347,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Şu belge türü için izinleri düzenleyin',
 		noDocumentTypesCreateNew: 'Yeni bir belge türü oluşturun',
 		noDocumentTypesAllowedAtRoot:
-			"Burada içerik oluşturmak için izin verilen belge türü yok. Bunları, <strong>İzinler</strong> altında <strong>Kök olarak izin ver</strong> seçeneğini değiştirerek, <strong>Ayarlar</strong> bölümündeki <strong>Belge Türleri</strong> 'nde etkinleştirmeniz gerekir. ",
+			"Burada içerik oluşturmak için izin verilen belge türü yok. Bunları, <strong>Yapı</strong> altında <strong>Kök olarak izin ver</strong> seçeneğini değiştirerek, <strong>Ayarlar</strong> bölümündeki <strong>Belge Türleri</strong> 'nde etkinleştirmeniz gerekir. ",
 		noMediaTypes:
-			"Burada medya oluşturmak için izin verilen medya türü yok. Bunları, <strong>İzinler</strong> altında <strong>İzin verilen alt düğüm türlerini</strong> düzenleyerek <strong>Ayarlar</strong> bölümündeki <strong>Medya Türleri</strong> 'nde etkinleştirmelisiniz. .",
+			"Burada medya oluşturmak için izin verilen medya türü yok. Bunları, <strong>Yapı</strong> altında <strong>İzin verilen alt düğüm türlerini</strong> düzenleyerek <strong>Ayarlar</strong> bölümündeki <strong>Medya Türleri</strong> 'nde etkinleştirmelisiniz. .",
 		noMediaTypesWithNoSettingsAccess: 'Ağaçtaki seçili ortam, altında başka bir ortamın oluşturulmasına izin vermiyor.',
 		noMediaTypesEditPermissions: 'Şu medya türü için izinleri düzenleyin:',
 		documentTypeWithoutTemplate: 'Şablonsuz Belge Türü',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
@@ -438,7 +438,7 @@ export default {
 		enterFolderName: 'Nhập tên thư mục',
 		updateData: 'Chọn loại và tiêu đề',
 		noDocumentTypes:
-			'Không có loại tài liệu nào được phép để tạo nội dung ở đây. Bạn phải kích hoạt chúng trong <strong>Document Types</strong> trong phần <strong>Settings</strong>, bằng cách chỉnh sửa <strong>Allowed child node types</strong> dưới <strong>Permissions</strong>.',
+			'Không có loại tài liệu nào được phép để tạo nội dung ở đây. Bạn phải kích hoạt chúng trong <strong>Document Types</strong> trong phần <strong>Settings</strong>, bằng cách chỉnh sửa <strong>Allowed child node types</strong> dưới <strong>Structure</strong>.',
 		noDocumentTypesAtRoot:
 			'Không có loại tài liệu nào có sẵn để tạo nội dung ở đây. Bạn phải tạo chúng trong <strong>Document Types</strong> trong phần <strong>Settings</strong>.',
 		noDocumentTypesWithNoSettingsAccess:
@@ -446,9 +446,9 @@ export default {
 		noDocumentTypesEditPermissions: 'Chỉnh sửa quyền cho loại tài liệu này',
 		noDocumentTypesCreateNew: 'Tạo một loại tài liệu mới',
 		noDocumentTypesAllowedAtRoot:
-			'Không có loại tài liệu nào được phép có sẵn để tạo nội dung ở đây. Bạn phải kích hoạt chúng trong <strong>Document Types</strong> trong phần <strong>Settings</strong>, bằng cách thay đổi tùy chọn <strong>Allow as root</strong> dưới <strong>Permissions</strong>.',
+			'Không có loại tài liệu nào được phép có sẵn để tạo nội dung ở đây. Bạn phải kích hoạt chúng trong <strong>Document Types</strong> trong phần <strong>Settings</strong>, bằng cách thay đổi tùy chọn <strong>Allow as root</strong> dưới <strong>Structure</strong>.',
 		noMediaTypes:
-			'Không có loại phương tiện nào được phép có sẵn để tạo phương tiện ở đây. Bạn phải kích hoạt chúng trong <strong>Media Types</strong> trong phần <strong>Settings</strong>, bằng cách chỉnh sửa <strong>Allowed child node types</strong> dưới <strong>Permissions</strong>.',
+			'Không có loại phương tiện nào được phép có sẵn để tạo phương tiện ở đây. Bạn phải kích hoạt chúng trong <strong>Media Types</strong> trong phần <strong>Settings</strong>, bằng cách chỉnh sửa <strong>Allowed child node types</strong> dưới <strong>Structure</strong>.',
 		noMediaTypesWithNoSettingsAccess:
 			'Phương tiện được chọn trong cây không cho phép tạo bất kỳ phương tiện nào bên dưới nó.',
 		noMediaTypesEditPermissions: 'Chỉnh sửa quyền cho loại phương tiện này',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/create/document-create-options-modal.element.ts
@@ -20,6 +20,9 @@ import {
 	type UmbDocumentBlueprintItemBaseModel,
 } from '@umbraco-cms/backoffice/document-blueprint';
 import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
+import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_SETTINGS_SECTION_ALIAS } from '@umbraco-cms/backoffice/settings';
 
 @customElement('umb-document-create-options-modal')
 export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
@@ -45,6 +48,24 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 
 	@state()
 	private _loading = true;
+
+	@state()
+	private _hasSettingsAccess = false;
+
+	constructor() {
+		super();
+
+		createExtensionApiByAlias(this, UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS, [
+			{
+				config: {
+					match: UMB_SETTINGS_SECTION_ALIAS,
+				},
+				onChange: (permitted: boolean) => {
+					this._hasSettingsAccess = permitted;
+				},
+			},
+		]);
+	}
 
 	override async firstUpdated() {
 		const parentUnique = this.data?.parent.unique;
@@ -171,13 +192,18 @@ export class UmbDocumentCreateOptionsModalElement extends UmbModalBaseElement<
 					<strong>Document Types</strong> within the <strong>Settings</strong> section, by editing the
 					<strong>Allowed child node types</strong> under <strong>Structure</strong>.
 				</umb-localize>
-				<br />
-				<uui-button
-					id="edit-permissions"
-					look="secondary"
-					href=${`/section/settings/workspace/document-type/edit/${this.data?.documentType?.unique}/view/structure`}
-					label=${this.localize.term('create_noDocumentTypesEditPermissions')}
-					@click=${() => this._rejectModal()}></uui-button>
+				${when(
+					this._hasSettingsAccess,
+					() => html`
+						<br />
+						<uui-button
+							id="edit-permissions"
+							look="secondary"
+							href=${`/section/settings/workspace/document-type/edit/${this.data?.documentType?.unique}/view/structure`}
+							label=${this.localize.term('create_noDocumentTypesEditPermissions')}
+							@click=${() => this._rejectModal()}></uui-button>
+					`,
+				)}
 			`;
 		} else {
 			return html`

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/create/media-create-options-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/create/media-create-options-modal.element.ts
@@ -113,7 +113,7 @@ export class UmbMediaCreateOptionsModalElement extends UmbModalBaseElement<
 				<strong>Allowed child node types</strong> under <strong>Structure</strong>.
 			</umb-localize>
 			${when(
-				this._hasSettingsAccess,
+				this._hasSettingsAccess && this.data?.mediaType?.unique,
 				() => html`
 					<br />
 					<uui-button

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/create/media-create-options-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/entity-actions/create/media-create-options-modal.element.ts
@@ -7,6 +7,9 @@ import { html, nothing, customElement, state, repeat, css, when } from '@umbraco
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbMediaTypeStructureRepository, type UmbAllowedMediaTypeModel } from '@umbraco-cms/backoffice/media-type';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
+import { UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS } from '@umbraco-cms/backoffice/section';
+import { UMB_SETTINGS_SECTION_ALIAS } from '@umbraco-cms/backoffice/settings';
 
 @customElement('umb-media-create-options-modal')
 export class UmbMediaCreateOptionsModalElement extends UmbModalBaseElement<
@@ -24,6 +27,24 @@ export class UmbMediaCreateOptionsModalElement extends UmbModalBaseElement<
 
 	@state()
 	private _loading = true;
+
+	@state()
+	private _hasSettingsAccess = false;
+
+	constructor() {
+		super();
+
+		createExtensionApiByAlias(this, UMB_SECTION_USER_PERMISSION_CONDITION_ALIAS, [
+			{
+				config: {
+					match: UMB_SETTINGS_SECTION_ALIAS,
+				},
+				onChange: (permitted: boolean) => {
+					this._hasSettingsAccess = permitted;
+				},
+			},
+		]);
+	}
 
 	override async firstUpdated() {
 		const mediaUnique = this.data?.parent.unique;
@@ -89,14 +110,20 @@ export class UmbMediaCreateOptionsModalElement extends UmbModalBaseElement<
 			<umb-localize key="create_noMediaTypes">
 				There are no allowed Media Types available for creating media here. You must enable these in
 				<strong>Media Types</strong> within the <strong>Settings</strong> section, by editing the
-				<strong>Allowed child node types</strong> under <strong>Permissions</strong>. </umb-localize
-			><br />
-			<uui-button
-				id="edit-permissions"
-				look="secondary"
-				@click=${() => this._rejectModal()}
-				href=${`/section/settings/workspace/media-type/edit/${this.data?.mediaType?.unique}/view/structure`}
-				label=${this.localize.term('create_noMediaTypesEditPermissions')}></uui-button>
+				<strong>Allowed child node types</strong> under <strong>Structure</strong>.
+			</umb-localize>
+			${when(
+				this._hasSettingsAccess,
+				() => html`
+					<br />
+					<uui-button
+						id="edit-permissions"
+						look="secondary"
+						@click=${() => this._rejectModal()}
+						href=${`/section/settings/workspace/media-type/edit/${this.data?.mediaType?.unique}/view/structure`}
+						label=${this.localize.term('create_noMediaTypesEditPermissions')}></uui-button>
+				`,
+			)}
 		`;
 	}
 


### PR DESCRIPTION
## Description

This update will hide the **"Edit permissions for this Document Type"** / **"…this Media Type"** button in the create-content and create-media modals from users who don't have access to the Settings section. Previously, clicking it navigated to a `/section/settings/...` route that the routing system rejects, producing a confusing "Not Found" page.

In passing I've also fixed the localization strings (`create_noDocumentTypes`, `create_noDocumentTypesAllowedAtRoot`, `create_noMediaTypes`) where the tab name was incorrectly referred to as "Permissions" — in v17 it's called "Structure". 

Fixes #22981

## Test plan

- [ ] Log in as admin (with Settings section access). Navigate to a content node whose Document Type has no allowed child types. Click `+`. Confirm:
  - The "no allowed Document Types" message is shown, with "Structure" (not "Permissions") as the tab name.
  - The **"Edit permissions for this Document Type"** button is visible.
  - Clicking it closes the modal and navigates to the Document Type's Structure tab.
- [ ] Create (or use) a user group with only the Content section enabled, assign a test user, log in as them. Repeat the above. Confirm:
  - The message is shown.
  - The **"Edit permissions for this Document Type"** button is **not** rendered.
- [ ] Repeat both scenarios with the Media section's `+` action on a media folder whose Media Type has no allowed child types — same expectations for the media equivalent.