### PR TITLE
Repositories: Batch WHERE IN queries to avoid SQL Server 2100-parameter limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,14 @@ When a PR changes Management API controllers or models, the `OpenApi.json` file 
 
 The backoffice is published to npm as `@umbraco-cms/backoffice`. Runtime dependencies are provided via importmap; npm peerDependencies provide types only. For full details on dependency hoisting, version range logic, and plugin development, see `/src/Umbraco.Web.UI.Client/CLAUDE.md` → "npm Package Publishing".
 
+### SQL Server 2100-parameter limit
+
+Any `WHERE IN (@0, @1, ...)` built from a runtime-sized collection risks hitting SQL Server's 2100-parameter ceiling and throwing `SqlException` 8003 in production. This has been a recurring source of customer-reported bugs (e.g. `DocumentUrlRepository.Save`, `DocumentUrlAliasRepository.Save`, `ContentVersionService.PerformContentVersionCleanup`, the user-search index build).
+
+Batch with `IEnumerable<T>.InGroupsOf(Constants.Sql.MaxParameterCount)` or `Database.FetchByGroups(...)` whenever the collection size is driven by user data — not just when it currently fits. Watch for products of two scaling dimensions (documents × languages, properties × versions) and config-tunable batch sizes whose defaults are safe but ceilings aren't.
+
+Full guidance, safe patterns and decision rule: see `/src/Umbraco.Infrastructure/CLAUDE.md` → "Avoiding the SQL Server 2100-parameter limit".
+
 ### Known Limitations
 
 1. **Circular Dependencies**: Avoided via `Lazy<T>` or event notifications

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,7 +437,7 @@ The backoffice is published to npm as `@umbraco-cms/backoffice`. Runtime depende
 
 ### SQL Server 2100-parameter limit
 
-Any `WHERE IN (@0, @1, ...)` built from a runtime-sized collection risks hitting SQL Server's 2100-parameter ceiling and throwing `SqlException` 8003 in production. This has been a recurring source of customer-reported bugs (e.g. `DocumentUrlRepository.Save`, `DocumentUrlAliasRepository.Save`, `ContentVersionService.PerformContentVersionCleanup`, the user-search index build).
+Any `WHERE IN (@0, @1, ...)` built from a runtime-sized collection risks hitting SQL Server's 2100-parameter ceiling and throwing `SqlException` 8003 in production.
 
 Batch with `IEnumerable<T>.InGroupsOf(Constants.Sql.MaxParameterCount)` or `Database.FetchByGroups(...)` whenever the collection size is driven by user data — not just when it currently fits. Watch for products of two scaling dimensions (documents × languages, properties × versions) and config-tunable batch sizes whose defaults are safe but ceilings aren't.
 

--- a/src/Umbraco.Core/CLAUDE.md
+++ b/src/Umbraco.Core/CLAUDE.md
@@ -305,6 +305,11 @@ public class MyEntityCacheRefresher : CacheRefresherBase<MyEntityCacheRefresher>
    - `Attempt.Succeed(value)` / `Attempt.Fail<T>()`
    - `Attempt<Content, ContentEditingOperationStatus>` - typed result with status
 
+4. **Constants-Sql.cs** and **EnumerableExtensions.InGroupsOf**
+   - `Constants.Sql.MaxParameterCount = 2000` - the safe ceiling for parameterised IN/WHERE clauses (SQL Server's real limit is 2100; we leave headroom for joined predicates).
+   - `IEnumerable<T>.InGroupsOf(groupSize)` and NPoco's `Database.FetchByGroups(...)` are the canonical helpers for batching a query whose parameter count is driven by a runtime-sized collection.
+   - See "Avoiding the SQL Server 2100-parameter limit" in `/src/Umbraco.Infrastructure/CLAUDE.md` for when and how to apply them.
+
 ### Configuration
 
 Configuration models in `/Configuration/Models`:

--- a/src/Umbraco.Core/CLAUDE.md
+++ b/src/Umbraco.Core/CLAUDE.md
@@ -305,10 +305,7 @@ public class MyEntityCacheRefresher : CacheRefresherBase<MyEntityCacheRefresher>
    - `Attempt.Succeed(value)` / `Attempt.Fail<T>()`
    - `Attempt<Content, ContentEditingOperationStatus>` - typed result with status
 
-4. **Constants-Sql.cs** and **EnumerableExtensions.InGroupsOf**
-   - `Constants.Sql.MaxParameterCount = 2000` - the safe ceiling for parameterised IN/WHERE clauses (SQL Server's real limit is 2100; we leave headroom for joined predicates).
-   - `IEnumerable<T>.InGroupsOf(groupSize)` and NPoco's `Database.FetchByGroups(...)` are the canonical helpers for batching a query whose parameter count is driven by a runtime-sized collection.
-   - See "Avoiding the SQL Server 2100-parameter limit" in `/src/Umbraco.Infrastructure/CLAUDE.md` for when and how to apply them.
+> Writing or reviewing a query with a `WHERE IN` on a runtime-sized collection? See "Avoiding the SQL Server 2100-parameter limit" in `/src/Umbraco.Infrastructure/CLAUDE.md` — that's where the full helper list (`Constants.Sql.MaxParameterCount`, `InGroupsOf`, NPoco's `FetchByGroups`) and the decision rules live.
 
 ### Configuration
 

--- a/src/Umbraco.Infrastructure/CLAUDE.md
+++ b/src/Umbraco.Infrastructure/CLAUDE.md
@@ -390,10 +390,10 @@ using (ICoreScope scope = ScopeProvider.CreateCoreScope())
 
 SQL Server caps a single statement at 2100 parameters. When an `IN` clause is built from a collection sized by user data, that cap can be hit — and the symptom is a runtime `SqlException` (error 8003) on customer installs that nobody hit in dev.
 
-**The constant and helpers** (all in `Umbraco.Core`):
-- `Constants.Sql.MaxParameterCount = 2000` — the ceiling we target (2100 minus headroom for joined predicates already in the SQL).
-- `IEnumerable<T>.InGroupsOf(groupSize)` — extension method to batch a collection.
-- `Database.FetchByGroups<TDto, TKey>(keys, groupSize, sqlFactory)` — NPoco helper that batches a fetch.
+**The constant and helpers**:
+- `Constants.Sql.MaxParameterCount = 2000` (in `Umbraco.Core`, `Constants-Sql.cs`) — the ceiling we target (2100 minus headroom for joined predicates already in the SQL).
+- `IEnumerable<T>.InGroupsOf(groupSize)` (in `Umbraco.Core`, `Extensions/EnumerableExtensions.cs`) — extension method to batch a collection.
+- `Database.FetchByGroups<TResult, TSource>(source, groupSize, sqlFactory)` (in `Umbraco.Infrastructure`, `Persistence/NPocoDatabaseExtensions.cs`) — NPoco helper that batches a fetch.
 
 **The safe patterns** (use one of these any time the collection size is user-driven):
 
@@ -413,7 +413,7 @@ List<FooDto> dtos = Database.FetchByGroups<FooDto, int>(
 // Pattern 3: reserve headroom for other parameters in the same statement.
 foreach (IEnumerable<int> group in entityIds.InGroupsOf(Constants.Sql.MaxParameterCount - userGroupIds.Length))
 {
-    // statement uses entityIds + userGroupIds, so subtract one from the other's budget
+    // statement uses entityIds + userGroupIds, so subtract the other predicate's parameter count from the budget
 }
 ```
 

--- a/src/Umbraco.Infrastructure/CLAUDE.md
+++ b/src/Umbraco.Infrastructure/CLAUDE.md
@@ -384,6 +384,57 @@ using (ICoreScope scope = ScopeProvider.CreateCoreScope())
 3. **Lazy loading outside scope** - NPoco relationships must load within scope
 4. **Large migrations** - Split into multiple steps if > 1000 lines
 5. **Repository logic in services** - Keep repos thin, logic in services
+6. **Unbatched `WHERE IN` on user-sized collections** - See "Avoiding the SQL Server 2100-parameter limit" below
+
+### Avoiding the SQL Server 2100-parameter limit
+
+SQL Server caps a single statement at 2100 parameters. When an `IN` clause is built from a collection sized by user data, that cap can be hit — and the symptom is a runtime `SqlException` (error 8003) on customer installs that nobody hit in dev.
+
+**The constant and helpers** (all in `Umbraco.Core`):
+- `Constants.Sql.MaxParameterCount = 2000` — the ceiling we target (2100 minus headroom for joined predicates already in the SQL).
+- `IEnumerable<T>.InGroupsOf(groupSize)` — extension method to batch a collection.
+- `Database.FetchByGroups<TDto, TKey>(keys, groupSize, sqlFactory)` — NPoco helper that batches a fetch.
+
+**The safe patterns** (use one of these any time the collection size is user-driven):
+
+```csharp
+// Pattern 1: batch a DeleteMany / Execute / Fetch by looping.
+foreach (IEnumerable<int> group in ids.InGroupsOf(Constants.Sql.MaxParameterCount))
+{
+    Database.DeleteMany<FooDto>().Where(x => group.Contains(x.Id)).Execute();
+}
+
+// Pattern 2: batched fetch with NPoco helper.
+List<FooDto> dtos = Database.FetchByGroups<FooDto, int>(
+    ids,
+    Constants.Sql.MaxParameterCount,
+    batch => Sql().Select<FooDto>().From<FooDto>().WhereIn<FooDto>(x => x.Id, batch));
+
+// Pattern 3: reserve headroom for other parameters in the same statement.
+foreach (IEnumerable<int> group in entityIds.InGroupsOf(Constants.Sql.MaxParameterCount - userGroupIds.Length))
+{
+    // statement uses entityIds + userGroupIds, so subtract one from the other's budget
+}
+```
+
+**Decision rule when writing or reviewing a `WHERE IN`-style query**:
+
+Look at what drives the size of the collection feeding the `IN`. Ask: *could this realistically exceed 2000 on a large install?* Risky drivers — batch any query backed by these:
+- All content / media / member nodes (or descendants of a deep tree).
+- A product of two scaling dimensions, e.g. `documents × languages`, `properties × versions`, `relations × endpoints`.
+- Configuration-tunable batch sizes (`CacheSettings.DocumentSeedBatchSize`, `NuCacheSettings.SqlPageSize`, etc.). The default may be safe but the customer can raise it.
+- Anything that scans property data, version history, relations, or audit logs across many nodes.
+
+Safe drivers — don't bother batching:
+- Languages / content types / member groups / user groups — bounded by install configuration, typically <100.
+- "Per single content item" collections — properties on one document, versions of one document, tokens for one external login.
+- IDs supplied directly by a user action through the UI (picker selections, bulk actions on a page of results).
+
+If you're not sure, batch — the cost is one loop and an `IEnumerable<T>` allocation per batch; the cost of being wrong is a SqlException on a customer's biggest site.
+
+**For new public APIs** that take an `IEnumerable<int>`/`IEnumerable<Guid>` and feed it into a query, batch internally even if no current caller is large — package authors and future callers will not know about the 2000-limit ceiling.
+
+**Don't** rely on `if (ids.Length > MaxParameterCount) throw` as a substitute for batching. Throwing only moves the problem; the caller has no obvious way to recover and will most likely just fail in production.
 
 ---
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -257,9 +257,9 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
                 .WhereNotNull();
         }
 
-        // Batch the WhereIn fetch so we never exceed SQL Server's 2100 parameter limit
-        // (even though EntityRepositoryBase.GetMany already groups, callers that invoke this
-        // method directly should not have to know about the limit).
+        // Batch the WhereIn fetch so we never exceed SQL Server's 2100 parameter limit.
+        // EntityRepositoryBase.GetMany already groups IDs, but we keep the batching here as
+        // a defensive measure for safety and consistency at the repository boundary.
         var dtos = new List<RedirectUrlDto>(ids.Length);
         foreach (IEnumerable<Guid> group in ids.InGroupsOf(Constants.Sql.MaxParameterCount))
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -249,14 +249,24 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
 
     protected override IEnumerable<IRedirectUrl> PerformGetAll(params Guid[]? ids)
     {
-        if (ids?.Length > Constants.Sql.MaxParameterCount)
+        if (ids is null || ids.Length == 0)
         {
-            throw new NotSupportedException(
-                $"This repository does not support more than {Constants.Sql.MaxParameterCount} ids.");
+            return Database.Fetch<RedirectUrlDto>(GetBaseQuery(false))
+                .WhereNotNull()
+                .Select(Map)
+                .WhereNotNull();
         }
 
-        Sql<ISqlContext> sql = GetBaseQuery(false).WhereIn<RedirectUrlDto>(x => x.Id, ids);
-        List<RedirectUrlDto> dtos = Database.Fetch<RedirectUrlDto>(sql);
+        // Batch the WhereIn fetch so we never exceed SQL Server's 2100 parameter limit
+        // (even though EntityRepositoryBase.GetMany already groups, callers that invoke this
+        // method directly should not have to know about the limit).
+        var dtos = new List<RedirectUrlDto>(ids.Length);
+        foreach (IEnumerable<Guid> group in ids.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            Sql<ISqlContext> sql = GetBaseQuery(false).WhereIn<RedirectUrlDto>(x => x.Id, group);
+            dtos.AddRange(Database.Fetch<RedirectUrlDto>(sql));
+        }
+
         return dtos.WhereNotNull().Select(Map).WhereNotNull();
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -207,21 +207,28 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     /// <inheritdoc/>
     public async Task<IEnumerable<ContentCacheNode>> GetContentSourcesAsync(IEnumerable<Guid> keys, bool preview = false)
     {
-        Sql<ISqlContext>? sql = SqlContentSourcesSelect()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document))
-            .WhereIn<NodeDto>(x => x.UniqueId, keys)
-            .Append(SqlOrderByLevelIdSortOrder(SqlContext));
+        // Batch the WHERE IN against the configurable seed batch size so that callers configuring
+        // CacheSettings.DocumentSeedBatchSize above MaxParameterCount don't hit SQL Server's 2100 parameter limit.
+        Guid[] keysArray = keys as Guid[] ?? keys.ToArray();
+        var dtos = new List<ContentSourceDto>(keysArray.Length);
+        foreach (IEnumerable<Guid> group in keysArray.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            Sql<ISqlContext>? sql = SqlContentSourcesSelect()
+                .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Document))
+                .WhereIn<NodeDto>(x => x.UniqueId, group)
+                .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        List<ContentSourceDto> dtos = await Database.FetchAsync<ContentSourceDto>(sql);
+            dtos.AddRange(await Database.FetchAsync<ContentSourceDto>(sql));
+        }
 
-        dtos = dtos
+        var filtered = dtos
             .Where(x => x is not null)
             .Where(x => preview || ((x.PubDataRaw is not null || x.PubData is not null) && (!x.Published || x.PubName is not null)))
             .ToList();
 
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Document);
-        return dtos
+        return filtered
             .Select(x => CreateContentNodeKit(x, serializer, preview))
             .OfType<ContentCacheNode>();
     }
@@ -379,20 +386,27 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     /// <inheritdoc/>
     public async Task<IEnumerable<ContentCacheNode>> GetMediaSourcesAsync(IEnumerable<Guid> keys)
     {
-        Sql<ISqlContext>? sql = SqlMediaSourcesSelect()
-            .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media))
-            .WhereIn<NodeDto>(x => x.UniqueId, keys)
-            .Append(SqlOrderByLevelIdSortOrder(SqlContext));
+        // Batch the WHERE IN against the configurable seed batch size so that callers configuring
+        // CacheSettings.MediaSeedBatchSize above MaxParameterCount don't hit SQL Server's 2100 parameter limit.
+        Guid[] keysArray = keys as Guid[] ?? keys.ToArray();
+        var dtos = new List<ContentSourceDto>(keysArray.Length);
+        foreach (IEnumerable<Guid> group in keysArray.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            Sql<ISqlContext>? sql = SqlMediaSourcesSelect()
+                .Append(SqlObjectTypeNotTrashed(SqlContext, Constants.ObjectTypes.Media))
+                .WhereIn<NodeDto>(x => x.UniqueId, group)
+                .Append(SqlOrderByLevelIdSortOrder(SqlContext));
 
-        List<ContentSourceDto> dtos = await Database.FetchAsync<ContentSourceDto>(sql);
+            dtos.AddRange(await Database.FetchAsync<ContentSourceDto>(sql));
+        }
 
-        dtos = dtos
+        var filtered = dtos
             .Where(x => x is not null)
             .ToList();
 
         IContentCacheDataSerializer serializer =
             _contentCacheDataSerializerFactory.Create(ContentCacheDataSerializerEntityType.Media);
-        return dtos
+        return filtered
             .Select(x => CreateMediaNodeKit(x, serializer));
     }
 
@@ -578,107 +592,135 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     /// </summary>
     private List<CacheRebuildDocumentDto> GetDocumentMetadataForNodes(List<int> nodeIds)
     {
-        // Query content metadata with both edit and published version info
+        // Query content metadata with both edit and published version info.
         // Uses nested join pattern to ensure we only get the published ContentVersion
-        // (where a DocumentVersionDto with Published=true exists)
-        Sql<ISqlContext> sql = Sql()
-            .Select<NodeDto>(
-                x => x.NodeId,
-                x => x.UniqueId,
-                x => x.Text,
-                x => x.Path,
-                x => x.Level,
-                x => x.ParentId,
-                x => x.SortOrder,
-                x => x.CreateDate,
-                x => Alias(x.UserId, "CreatorId"))
-            .AndSelect<ContentDto>(x => x.ContentTypeId)
-            .AndSelect<DocumentDto>(x => x.Published)
-            .AndSelect<ContentVersionDto>(
-                x => Alias(x.Id, "EditVersionId"),
-                x => Alias(x.Text, "EditName"),
-                x => Alias(x.VersionDate, "EditVersionDate"),
-                x => Alias(x.UserId, "EditWriterId"))
-            .AndSelect<ContentVersionDto>(
-                "pcv",
-                x => Alias(x.Id, "PublishedVersionId"),
-                x => Alias(x.Text, "PublishedName"),
-                x => Alias(x.VersionDate, "PublishedVersionDate"),
-                x => Alias(x.UserId, "PublishedWriterId"))
-            .From<NodeDto>()
-            .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
-            .InnerJoin<DocumentDto>().On<NodeDto, DocumentDto>((n, d) => n.NodeId == d.NodeId)
-            .InnerJoin<ContentVersionDto>().On<NodeDto, ContentVersionDto>((n, cv) => n.NodeId == cv.NodeId && cv.Current)
+        // (where a DocumentVersionDto with Published=true exists).
+        // Batched on nodeIds so a NuCacheSettings.SqlPageSize larger than MaxParameterCount still works.
+        var results = new List<CacheRebuildDocumentDto>(nodeIds.Count);
+        foreach (IEnumerable<int> group in nodeIds.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            Sql<ISqlContext> sql = Sql()
+                .Select<NodeDto>(
+                    x => x.NodeId,
+                    x => x.UniqueId,
+                    x => x.Text,
+                    x => x.Path,
+                    x => x.Level,
+                    x => x.ParentId,
+                    x => x.SortOrder,
+                    x => x.CreateDate,
+                    x => Alias(x.UserId, "CreatorId"))
+                .AndSelect<ContentDto>(x => x.ContentTypeId)
+                .AndSelect<DocumentDto>(x => x.Published)
+                .AndSelect<ContentVersionDto>(
+                    x => Alias(x.Id, "EditVersionId"),
+                    x => Alias(x.Text, "EditName"),
+                    x => Alias(x.VersionDate, "EditVersionDate"),
+                    x => Alias(x.UserId, "EditWriterId"))
+                .AndSelect<ContentVersionDto>(
+                    "pcv",
+                    x => Alias(x.Id, "PublishedVersionId"),
+                    x => Alias(x.Text, "PublishedName"),
+                    x => Alias(x.VersionDate, "PublishedVersionDate"),
+                    x => Alias(x.UserId, "PublishedWriterId"))
+                .From<NodeDto>()
+                .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
+                .InnerJoin<DocumentDto>().On<NodeDto, DocumentDto>((n, d) => n.NodeId == d.NodeId)
+                .InnerJoin<ContentVersionDto>().On<NodeDto, ContentVersionDto>((n, cv) => n.NodeId == cv.NodeId && cv.Current)
 
-            // Nested join: ContentVersionDto "pcv" INNER JOIN DocumentVersionDto "pdv" ON published=true
-            // This ensures pcv only includes rows where there's a published DocumentVersion
-            .LeftJoin<ContentVersionDto>(
-                j => j.InnerJoin<DocumentVersionDto>("pdv")
-                      .On<ContentVersionDto, DocumentVersionDto>(
-                          (left, right) => left.Id == right.Id && right.Published == true, "pcv", "pdv"),
-                "pcv")
+                // Nested join: ContentVersionDto "pcv" INNER JOIN DocumentVersionDto "pdv" ON published=true.
+                // This ensures pcv only includes rows where there's a published DocumentVersion.
+                .LeftJoin<ContentVersionDto>(
+                    j => j.InnerJoin<DocumentVersionDto>("pdv")
+                          .On<ContentVersionDto, DocumentVersionDto>(
+                              (left, right) => left.Id == right.Id && right.Published == true, "pcv", "pdv"),
+                    "pcv")
 
-            .On<NodeDto, ContentVersionDto>((n, cv) => n.NodeId == cv.NodeId, aliasRight: "pcv")
-            .WhereIn<NodeDto>(x => x.NodeId, nodeIds);
+                .On<NodeDto, ContentVersionDto>((n, cv) => n.NodeId == cv.NodeId, aliasRight: "pcv")
+                .WhereIn<NodeDto>(x => x.NodeId, group);
 
-        return Database.Fetch<CacheRebuildDocumentDto>(sql);
+            results.AddRange(Database.Fetch<CacheRebuildDocumentDto>(sql));
+        }
+
+        return results;
     }
 
     /// <summary>
     /// Gets property data for the specified node IDs using efficient JOIN on nodeId.
     /// This avoids the expensive WHERE IN on versionId that causes index scans.
+    /// Batched on nodeIds so a NuCacheSettings.SqlPageSize larger than MaxParameterCount still works.
     /// </summary>
     private List<CacheRebuildPropertyDto> GetPropertyDataForNodes(List<int> nodeIds)
     {
-        // JOIN through nodeId → versionId path for efficient query plan
-        Sql<ISqlContext> sql = Sql()
-            .Select<PropertyDataDto>(
-                x => x.VersionId,
-                x => x.LanguageId,
-                x => x.Segment,
-                x => x.IntegerValue,
-                x => x.DecimalValue,
-                x => x.DateValue,
-                x => x.VarcharValue,
-                x => x.TextValue)
-            .AndSelect<PropertyTypeDto>(x => Alias(x.Alias, "PropertyAlias"))
-            .From<PropertyDataDto>()
-            .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((pd, pt) => pd.PropertyTypeId == pt.Id)
-            .InnerJoin<ContentVersionDto>().On<PropertyDataDto, ContentVersionDto>((pd, cv) => pd.VersionId == cv.Id)
-            .WhereIn<ContentVersionDto>(x => x.NodeId, nodeIds);
+        var results = new List<CacheRebuildPropertyDto>();
+        foreach (IEnumerable<int> group in nodeIds.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            // JOIN through nodeId → versionId path for efficient query plan.
+            Sql<ISqlContext> sql = Sql()
+                .Select<PropertyDataDto>(
+                    x => x.VersionId,
+                    x => x.LanguageId,
+                    x => x.Segment,
+                    x => x.IntegerValue,
+                    x => x.DecimalValue,
+                    x => x.DateValue,
+                    x => x.VarcharValue,
+                    x => x.TextValue)
+                .AndSelect<PropertyTypeDto>(x => Alias(x.Alias, "PropertyAlias"))
+                .From<PropertyDataDto>()
+                .InnerJoin<PropertyTypeDto>().On<PropertyDataDto, PropertyTypeDto>((pd, pt) => pd.PropertyTypeId == pt.Id)
+                .InnerJoin<ContentVersionDto>().On<PropertyDataDto, ContentVersionDto>((pd, cv) => pd.VersionId == cv.Id)
+                .WhereIn<ContentVersionDto>(x => x.NodeId, group);
 
-        return Database.Fetch<CacheRebuildPropertyDto>(sql);
+            results.AddRange(Database.Fetch<CacheRebuildPropertyDto>(sql));
+        }
+
+        return results;
     }
 
     /// <summary>
     /// Gets culture variation data for the specified node IDs.
+    /// Batched on nodeIds so a NuCacheSettings.SqlPageSize larger than MaxParameterCount still works.
     /// </summary>
     private List<CacheRebuildCultureDto> GetCultureDataForNodes(List<int> nodeIds)
     {
-        Sql<ISqlContext> sql = Sql()
-            .Select<ContentVersionCultureVariationDto>(x => x.VersionId, x => x.Name, x => x.UpdateDate)
-            .AndSelect<LanguageDto>(x => Alias(x.IsoCode, "IsoCode"))
-            .From<ContentVersionCultureVariationDto>()
-            .InnerJoin<LanguageDto>().On<ContentVersionCultureVariationDto, LanguageDto>((cv, l) => cv.LanguageId == l.Id)
-            .InnerJoin<ContentVersionDto>().On<ContentVersionCultureVariationDto, ContentVersionDto>((ccv, cv) => ccv.VersionId == cv.Id)
-            .WhereIn<ContentVersionDto>(x => x.NodeId, nodeIds);
+        var results = new List<CacheRebuildCultureDto>();
+        foreach (IEnumerable<int> group in nodeIds.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            Sql<ISqlContext> sql = Sql()
+                .Select<ContentVersionCultureVariationDto>(x => x.VersionId, x => x.Name, x => x.UpdateDate)
+                .AndSelect<LanguageDto>(x => Alias(x.IsoCode, "IsoCode"))
+                .From<ContentVersionCultureVariationDto>()
+                .InnerJoin<LanguageDto>().On<ContentVersionCultureVariationDto, LanguageDto>((cv, l) => cv.LanguageId == l.Id)
+                .InnerJoin<ContentVersionDto>().On<ContentVersionCultureVariationDto, ContentVersionDto>((ccv, cv) => ccv.VersionId == cv.Id)
+                .WhereIn<ContentVersionDto>(x => x.NodeId, group);
 
-        return Database.Fetch<CacheRebuildCultureDto>(sql);
+            results.AddRange(Database.Fetch<CacheRebuildCultureDto>(sql));
+        }
+
+        return results;
     }
 
     /// <summary>
     /// Gets document culture variation data (edited status per culture) for the specified node IDs.
+    /// Batched on nodeIds so a NuCacheSettings.SqlPageSize larger than MaxParameterCount still works.
     /// </summary>
     private List<CacheRebuildDocumentCultureDto> GetDocumentCultureDataForNodes(List<int> nodeIds)
     {
-        Sql<ISqlContext> sql = Sql()
-            .Select<DocumentCultureVariationDto>(x => x.NodeId, x => x.Edited)
-            .AndSelect<LanguageDto>(x => Alias(x.IsoCode, "IsoCode"))
-            .From<DocumentCultureVariationDto>()
-            .InnerJoin<LanguageDto>().On<DocumentCultureVariationDto, LanguageDto>((dcv, l) => dcv.LanguageId == l.Id)
-            .WhereIn<DocumentCultureVariationDto>(x => x.NodeId, nodeIds);
+        var results = new List<CacheRebuildDocumentCultureDto>();
+        foreach (IEnumerable<int> group in nodeIds.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            Sql<ISqlContext> sql = Sql()
+                .Select<DocumentCultureVariationDto>(x => x.NodeId, x => x.Edited)
+                .AndSelect<LanguageDto>(x => Alias(x.IsoCode, "IsoCode"))
+                .From<DocumentCultureVariationDto>()
+                .InnerJoin<LanguageDto>().On<DocumentCultureVariationDto, LanguageDto>((dcv, l) => dcv.LanguageId == l.Id)
+                .WhereIn<DocumentCultureVariationDto>(x => x.NodeId, group);
 
-        return Database.Fetch<CacheRebuildDocumentCultureDto>(sql);
+            results.AddRange(Database.Fetch<CacheRebuildDocumentCultureDto>(sql));
+        }
+
+        return results;
     }
 
     /// <summary>
@@ -1207,31 +1249,38 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
 
     /// <summary>
     /// Gets content metadata for the specified node IDs using efficient JOIN. Used for media and members.
+    /// Batched on nodeIds so a NuCacheSettings.SqlPageSize larger than MaxParameterCount still works.
     /// </summary>
     private List<CacheRebuildContentDto> GetContentMetadataForNodes(List<int> nodeIds)
     {
-        Sql<ISqlContext> sql = Sql()
-            .Select<NodeDto>(
-                x => x.NodeId,
-                x => x.UniqueId,
-                x => x.Text,
-                x => x.Path,
-                x => x.Level,
-                x => x.ParentId,
-                x => x.SortOrder,
-                x => x.CreateDate,
-                x => Alias(x.UserId, "CreatorId"))
-            .AndSelect<ContentDto>(x => x.ContentTypeId)
-            .AndSelect<ContentVersionDto>(
-                x => Alias(x.Id, "VersionId"),
-                x => Alias(x.VersionDate, "VersionDate"),
-                x => Alias(x.UserId, "WriterId"))
-            .From<NodeDto>()
-            .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
-            .InnerJoin<ContentVersionDto>().On<NodeDto, ContentVersionDto>((n, cv) => n.NodeId == cv.NodeId && cv.Current)
-            .WhereIn<NodeDto>(x => x.NodeId, nodeIds);
+        var results = new List<CacheRebuildContentDto>(nodeIds.Count);
+        foreach (IEnumerable<int> group in nodeIds.InGroupsOf(Constants.Sql.MaxParameterCount))
+        {
+            Sql<ISqlContext> sql = Sql()
+                .Select<NodeDto>(
+                    x => x.NodeId,
+                    x => x.UniqueId,
+                    x => x.Text,
+                    x => x.Path,
+                    x => x.Level,
+                    x => x.ParentId,
+                    x => x.SortOrder,
+                    x => x.CreateDate,
+                    x => Alias(x.UserId, "CreatorId"))
+                .AndSelect<ContentDto>(x => x.ContentTypeId)
+                .AndSelect<ContentVersionDto>(
+                    x => Alias(x.Id, "VersionId"),
+                    x => Alias(x.VersionDate, "VersionDate"),
+                    x => Alias(x.UserId, "WriterId"))
+                .From<NodeDto>()
+                .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
+                .InnerJoin<ContentVersionDto>().On<NodeDto, ContentVersionDto>((n, cv) => n.NodeId == cv.NodeId && cv.Current)
+                .WhereIn<NodeDto>(x => x.NodeId, group);
 
-        return Database.Fetch<CacheRebuildContentDto>(sql);
+            results.AddRange(Database.Fetch<CacheRebuildContentDto>(sql));
+        }
+
+        return results;
     }
 
     /// <summary>

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -207,8 +207,8 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     /// <inheritdoc/>
     public async Task<IEnumerable<ContentCacheNode>> GetContentSourcesAsync(IEnumerable<Guid> keys, bool preview = false)
     {
-        // Batch the WHERE IN against the configurable seed batch size so that callers configuring
-        // CacheSettings.DocumentSeedBatchSize above MaxParameterCount don't hit SQL Server's 2100 parameter limit.
+        // Batch the WHERE IN to stay within SQL Server's parameter limit.
+        // The configurable document seed batch size is applied upstream; this method only enforces MaxParameterCount.
         Guid[] keysArray = keys as Guid[] ?? keys.ToArray();
         var dtos = new List<ContentSourceDto>(keysArray.Length);
         foreach (IEnumerable<Guid> group in keysArray.InGroupsOf(Constants.Sql.MaxParameterCount))
@@ -386,8 +386,8 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
     /// <inheritdoc/>
     public async Task<IEnumerable<ContentCacheNode>> GetMediaSourcesAsync(IEnumerable<Guid> keys)
     {
-        // Batch the WHERE IN against the configurable seed batch size so that callers configuring
-        // CacheSettings.MediaSeedBatchSize above MaxParameterCount don't hit SQL Server's 2100 parameter limit.
+        // Batch the WHERE IN by Constants.Sql.MaxParameterCount so callers configuring
+        // CacheSettings.MediaSeedBatchSize above that limit do not hit SQL Server's 2100 parameter limit.
         Guid[] keysArray = keys as Guid[] ?? keys.ToArray();
         var dtos = new List<ContentSourceDto>(keysArray.Length);
         foreach (IEnumerable<Guid> group in keysArray.InGroupsOf(Constants.Sql.MaxParameterCount))

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RedirectUrlRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/RedirectUrlRepositoryTests.cs
@@ -288,6 +288,85 @@ internal sealed class RedirectUrlRepositoryTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public void GetMany_With_Ids_Returns_Matching_Redirects()
+    {
+        // The "happy path" — a handful of ids, well under the SQL parameter limit.
+        // Verifies that batching in PerformGetAll doesn't break the common case.
+        Guid id1, id2;
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            var repo = CreateRepository(ScopeProvider);
+
+            var rurl1 = new RedirectUrl { ContentKey = _textpage.Key, Url = "a" };
+            repo.Save(rurl1);
+            id1 = rurl1.Key;
+
+            var rurl2 = new RedirectUrl
+            {
+                ContentKey = _subpage.Key,
+                Url = "b",
+                CreateDateUtc = rurl1.CreateDateUtc.AddSeconds(1)
+            };
+            repo.Save(rurl2);
+            id2 = rurl2.Key;
+
+            // Third redirect we deliberately don't pass to GetMany — it should not be returned.
+            var rurl3 = new RedirectUrl
+            {
+                ContentKey = _otherpage.Key,
+                Url = "c",
+                CreateDateUtc = rurl1.CreateDateUtc.AddSeconds(2)
+            };
+            repo.Save(rurl3);
+
+            scope.Complete();
+        }
+
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            var repo = CreateRepository(ScopeProvider);
+            var rurls = repo.GetMany(id1, id2).ToArray();
+            scope.Complete();
+
+            Assert.That(rurls, Has.Length.EqualTo(2));
+            Assert.That(rurls.Select(r => r.Url), Is.EquivalentTo(new[] { "a", "b" }));
+        }
+    }
+
+    [Test]
+    public void GetMany_With_No_Ids_Returns_All_Redirects()
+    {
+        // When PerformGetAll is invoked with no ids (the FullDataSet cache-policy path), the repository
+        // should return every row rather than fall through to a `WHERE id IN ()` that returns nothing.
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            var repo = CreateRepository(ScopeProvider);
+
+            var rurl1 = new RedirectUrl { ContentKey = _textpage.Key, Url = "x" };
+            repo.Save(rurl1);
+
+            var rurl2 = new RedirectUrl
+            {
+                ContentKey = _subpage.Key,
+                Url = "y",
+                CreateDateUtc = rurl1.CreateDateUtc.AddSeconds(1)
+            };
+            repo.Save(rurl2);
+
+            scope.Complete();
+        }
+
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            var repo = CreateRepository(ScopeProvider);
+            var rurls = repo.GetMany().ToArray();
+            scope.Complete();
+
+            Assert.That(rurls.Select(r => r.Url), Is.SupersetOf(new[] { "x", "y" }));
+        }
+    }
+
+    [Test]
     public void Can_Search_Urls()
     {
         var provider = ScopeProvider;

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DatabaseCacheRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DatabaseCacheRepositoryTests.cs
@@ -1,0 +1,127 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
+using Umbraco.Cms.Infrastructure.HybridCache.Serialization;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class DatabaseCacheRepositoryTests : UmbracoIntegrationTestWithContent
+{
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
+        builder.AddNotificationHandler<MediaTreeChangeNotification, MediaTreeChangeDistributedCacheNotificationHandler>();
+        builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+    }
+
+    private IDatabaseCacheRepository DatabaseCacheRepository => GetRequiredService<IDatabaseCacheRepository>();
+
+    private IContentPublishingService ContentPublishingService => GetRequiredService<IContentPublishingService>();
+
+    private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
+
+    private IMediaService MediaService => GetRequiredService<IMediaService>();
+
+    private IMediaType MediaType { get; set; }
+
+    private IMedia MediaItem1 { get; set; }
+
+    private IMedia MediaItem2 { get; set; }
+
+    private IMedia MediaItem3 { get; set; }
+
+    public override void CreateTestData()
+    {
+        base.CreateTestData();
+
+        // Add a few media items so the media-side methods have something to read.
+        MediaType = MediaTypeService.Get("image")!;
+        MediaItem1 = new MediaBuilder().WithName("Image 1").WithMediaType(MediaType).Build();
+        MediaItem2 = new MediaBuilder().WithName("Image 2").WithMediaType(MediaType).Build();
+        MediaItem3 = new MediaBuilder().WithName("Image 3").WithMediaType(MediaType).Build();
+        MediaService.Save(MediaItem1);
+        MediaService.Save(MediaItem2);
+        MediaService.Save(MediaItem3);
+    }
+
+    [Test]
+    public async Task GetContentSourcesAsync_With_Keys_Returns_Matching_Sources()
+    {
+        // Arrange — publish the root so we exercise the published branch of the filter, and leave
+        // the subpages in draft. Base fixture gives us 4 non-trashed documents.
+        await ContentPublishingService.PublishAsync(Textpage.Key, [new()], Constants.Security.SuperUserKey);
+
+        var requestedKeys = new[] { Textpage.Key, Subpage.Key, Subpage2.Key };
+
+        // Act — preview = true so draft-only subpages are also returned.
+        using var scope = ScopeProvider.CreateScope(autoComplete: true);
+        var sources = (await DatabaseCacheRepository.GetContentSourcesAsync(requestedKeys, preview: true)).ToList();
+
+        // Assert — only the three requested nodes come back, ignoring Subpage3 and the trashed node.
+        var returnedKeys = sources.Select(s => s.Key).ToHashSet();
+        Assert.That(returnedKeys, Is.EquivalentTo(requestedKeys));
+    }
+
+    [Test]
+    public async Task GetContentSourcesAsync_With_Empty_Keys_Returns_Nothing()
+    {
+        // The batched loop iterates zero groups when the input is empty — no rows should be
+        // returned, and the database must not be hit with a malformed `WHERE id IN ()`.
+        using var scope = ScopeProvider.CreateScope(autoComplete: true);
+        var sources = await DatabaseCacheRepository.GetContentSourcesAsync(Array.Empty<Guid>(), preview: true);
+
+        Assert.That(sources, Is.Empty);
+    }
+
+    [Test]
+    public async Task GetMediaSourcesAsync_With_Keys_Returns_Matching_Sources()
+    {
+        var requestedKeys = new[] { MediaItem1.Key, MediaItem2.Key };
+
+        using var scope = ScopeProvider.CreateScope(autoComplete: true);
+        var sources = (await DatabaseCacheRepository.GetMediaSourcesAsync(requestedKeys)).ToList();
+
+        var returnedKeys = sources.Select(s => s.Key).ToHashSet();
+        Assert.That(returnedKeys, Is.EquivalentTo(requestedKeys));
+    }
+
+    [Test]
+    public async Task GetMediaSourcesAsync_With_Empty_Keys_Returns_Nothing()
+    {
+        using var scope = ScopeProvider.CreateScope(autoComplete: true);
+        var sources = await DatabaseCacheRepository.GetMediaSourcesAsync(Array.Empty<Guid>());
+
+        Assert.That(sources, Is.Empty);
+    }
+
+    [Test]
+    public void GetContentByContentTypeKey_With_Keys_Returns_Matching_Nodes()
+    {
+        // Exercises the batched ForNodes helpers (GetContentMetadataForNodes,
+        // GetPropertyDataForNodes, etc.) used by the rebuild/document-type lookup pipeline.
+        using var scope = ScopeProvider.CreateScope(autoComplete: true);
+        var nodes = DatabaseCacheRepository
+            .GetContentByContentTypeKey([ContentType.Key], ContentCacheDataSerializerEntityType.Document)
+            .ToList();
+
+        // The 4 non-trashed documents created by the fixture must all surface.
+        var returnedKeys = nodes.Select(n => n.Key).ToHashSet();
+        Assert.That(returnedKeys, Does.Contain(Textpage.Key));
+        Assert.That(returnedKeys, Does.Contain(Subpage.Key));
+        Assert.That(returnedKeys, Does.Contain(Subpage2.Key));
+        Assert.That(returnedKeys, Does.Contain(Subpage3.Key));
+    }
+}


### PR DESCRIPTION
## Description

We've had a few issues over the years with `WHERE IN` queries exceeding the SQL Server parameter limit.

This PR is a preventive update of a few other cases I found where we haven't had issues reported, but depending on configuration and customer data, could in theory trip up on this in future.

Also included are `CLAUDE.md` updates in an attempt that this oversight in future is caught in development or review.

The updates are:

- `DatabaseCacheRepository.GetContentSourcesAsync` / `GetMediaSourcesAsync` and the five private rebuild `ForNodes` helpers now batch their `WHERE IN` queries with `InGroupsOf(Constants.Sql.MaxParameterCount)`. These were driven by `CacheSettings.DocumentSeedBatchSize`, `CacheSettings.MediaSeedBatchSize` and `NuCacheSettings.SqlPageSize` — defaults are safe but the settings are documented as tunable, and raising any of them past 2000 would break seeding/rebuilds with this exception.
- `RedirectUrlRepository.PerformGetAll` no longer throws when given more than `MaxParameterCount` ids. It now batches the fetch, and treats null/empty ids as "fetch all" (matching the convention used by other repositories like `DomainRepository.PerformGetAll`).

## Testing

Additional integration tests have been added to ensure there's no regression of the expected and happy path of a small number of IDs for which entities are retrieved.