### PR TITLE
Members: Default Approved to true when creating a member (closes #22991)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/member-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member/repository/detail/member-detail.server.data-source.ts
@@ -41,7 +41,7 @@ export class UmbMemberServerDataSource extends UmbControllerBase implements UmbD
 				unique: memberTypeUnique,
 				icon: memberTypeIcon,
 			},
-			isApproved: false,
+			isApproved: true,
 			isLockedOut: false,
 			isTwoFactorEnabled: false,
 			kind: UmbMemberKind.DEFAULT,

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/Members.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Members/Members.spec.ts
@@ -175,6 +175,25 @@ test('can view member info', async ({umbracoApi, umbracoUi}) => {
   }));
 });
 
+test('approved is enabled by default when creating a member', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoUi.member.goToMembers();
+
+  // Act
+  await umbracoUi.member.clickCreateMembersButton();
+  await umbracoUi.member.enterMemberName(memberName);
+  await umbracoUi.member.clickInfoTab();
+  await umbracoUi.member.enterUsername(username);
+  await umbracoUi.member.enterEmail(email);
+  await umbracoUi.member.enterPassword(password);
+  await umbracoUi.member.enterConfirmPassword(password);
+  await umbracoUi.member.clickSaveButtonAndWaitForMemberToBeCreated();
+
+  // Assert
+  const memberData = await umbracoApi.member.getByName(memberName);
+  expect(memberData.isApproved).toBe(true);
+});
+
 test('can enable approved', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   memberTypeId = await umbracoApi.memberType.createDefaultMemberType(memberTypeName);


### PR DESCRIPTION
## Description

When creating a new member through the backoffice, the **Approved** toggle was unchecked by default. This looks like an unintended change of behaviour since Umbraco 13.  Per [issue #22991](https://github.com/umbraco/Umbraco-CMS/issues/22991) and the training video at https://www.youtube.com/watch?v=gdvfrqQcAGY (2:07), it should default to *checked*.

To fix I've made a one-line change to the scaffold default — `isApproved: true`. The editor can still uncheck the toggle before saving if they want an unapproved member.

The Management API contract (`CreateMemberRequestModel.IsApproved`) is intentionally **unchanged**: direct API consumers continue to be responsible for setting `isApproved` explicitly in their request body.

Fixes #22991

## Testing

### Automated

A new client-side unit test is added to verify that a scaffolded member is approved.

### Manual

1. Run the backoffice, log in as admin, go to **Members → Create Member**.
2. Confirm the **Approved** toggle is checked before any interaction.
3. Fill in the required fields and save — confirm the saved member has `isApproved: true` (reopen the editor, or query the Management API).
4. Repeat, but uncheck **Approved** before saving — confirm the member is created as unapproved (no regression on the explicit-opt-out path).