### PR TITLE
Date picker: Don't clear value while user edits (closes #22738)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
@@ -1,12 +1,12 @@
 import { customElement, css } from '@umbraco-cms/backoffice/external/lit';
-import { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
+import { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export type InputDateType = 'date' | 'time' | 'datetime-local';
 
 /**
  * This element passes a datetime string to a regular HTML input element.
- * Be aware that you cannot include a time demonination, i.e. "10:44:00" if you
+ * Be aware that you cannot include a time denomination, i.e. "10:44:00" if you
  * set the input type of this element to "date". If you do, the browser will not show
  * the value at all.
  * @element umb-input-date
@@ -28,6 +28,37 @@ export class UmbInputDateElement extends UUIInputElement {
 	constructor() {
 		super();
 		this.type = 'date'; // Default to 'date'
+
+		// On focusout, sync our value with whatever the native input shows now. This
+		// captures an intentional clear that #onInput skipped while focus was inside.
+		// Dispatch input and change so downstream listeners learn about the committed
+		// value — the native change event that fires at blur was emitted before this
+		// sync ran, and so carried the stale (pre-clear) value.
+		this.addEventListener('focusout', () => {
+			const native = this.shadowRoot?.querySelector('input');
+			if (native && this.value !== native.value) {
+				this.value = native.value;
+				this.dispatchEvent(new UUIInputEvent(UUIInputEvent.INPUT));
+				this.dispatchEvent(new UUIInputEvent(UUIInputEvent.CHANGE));
+			}
+		});
+	}
+
+	override onInput(e: Event) {
+		e.stopPropagation();
+		const target = e.target as HTMLInputElement;
+
+		// The browser reports `.value === ''` while a date/datetime-local/time input is
+		// in a transiently invalid state (e.g. a single "0" typed into a segment before
+		// the second digit). Reflecting that empty value back via `this.value = ''` would
+		// trigger a re-render that writes `''` to the native input, which clears all
+		// segments visually and wipes the digit just typed. Skip the reflection here;
+		// focusout commits the final value.
+		if (target.value !== '') {
+			this.value = target.value;
+		}
+
+		this.dispatchEvent(new UUIInputEvent(UUIInputEvent.INPUT));
 	}
 
 	// Adding styles override to add a darkmode version.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.element.ts
@@ -52,12 +52,13 @@ export class UmbInputDateElement extends UUIInputElement {
 		// in a transiently invalid state (e.g. a single "0" typed into a segment before
 		// the second digit). Reflecting that empty value back via `this.value = ''` would
 		// trigger a re-render that writes `''` to the native input, which clears all
-		// segments visually and wipes the digit just typed. Skip the reflection here;
-		// focusout commits the final value.
-		if (target.value !== '') {
-			this.value = target.value;
+		// segments visually and wipes the digit just typed. Skip both the reflection and
+		// the input event in this case; focusout commits the final value.
+		if (target.value === '') {
+			return;
 		}
 
+		this.value = target.value;
 		this.dispatchEvent(new UUIInputEvent(UUIInputEvent.INPUT));
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.test.ts
@@ -1,5 +1,5 @@
 import { UmbInputDateElement } from './input-date.element.js';
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
 describe('UmbInputDateElement', () => {
 	let element: UmbInputDateElement;
@@ -17,4 +17,42 @@ describe('UmbInputDateElement', () => {
 			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
 		});
 	}
+
+	describe('transient invalid input', () => {
+		it('does not reflect an empty native value back while the input is being edited', async () => {
+			element.value = '2026-05-27';
+			await element.updateComplete;
+
+			const native = element.shadowRoot!.querySelector('input')!;
+			native.value = '';
+			native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+			expect(element.value).to.equal('2026-05-27');
+		});
+
+		it('reflects a non-empty native value back via the input event', async () => {
+			element.value = '2026-05-27';
+			await element.updateComplete;
+
+			const native = element.shadowRoot!.querySelector('input')!;
+			native.value = '2026-04-27';
+			native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+			expect(element.value).to.equal('2026-04-27');
+		});
+
+		it('commits an emptied native value on focusout and dispatches a change event', async () => {
+			element.value = '2026-05-27';
+			await element.updateComplete;
+
+			const native = element.shadowRoot!.querySelector('input')!;
+			native.value = '';
+
+			const changeEvent = oneEvent(element, 'change');
+			native.dispatchEvent(new FocusEvent('focusout', { bubbles: true, composed: true }));
+			await changeEvent;
+
+			expect(element.value).to.equal('');
+		});
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/input-date/input-date.test.ts
@@ -23,11 +23,15 @@ describe('UmbInputDateElement', () => {
 			element.value = '2026-05-27';
 			await element.updateComplete;
 
+			let inputEvents = 0;
+			element.addEventListener('input', () => inputEvents++);
+
 			const native = element.shadowRoot!.querySelector('input')!;
 			native.value = '';
 			native.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
 
 			expect(element.value).to.equal('2026-05-27');
+			expect(inputEvents).to.equal(0);
 		});
 
 		it('reflects a non-empty native value back via the input event', async () => {


### PR DESCRIPTION
## Description

When typing into a date property, the browser briefly reports an empty value while the typed digit doesn't yet form a valid date — e.g. a single `0` typed into a `dd.MM.yyyy` month segment before the second digit. `uui-input.onInput` reflected that empty value back into the underlying `<input>` via Lit's reactive `.value` binding, which programmatically clears all segments of a `<input type="date">` — wiping the digit just typed and every other already-filled segment.

`UmbInputDateElement` now overrides `onInput` to skip the empty reflection while the user is editing, and a `focusout` listener syncs the value (and re-dispatches `input`/`change`) so an intentional clear still propagates.

Fixes #22738.

## Testing

### Automated

A test was added in `input-date.test.ts` covering the fix.

### Manual

1. Add a date property to a Document Type and edit content using that property.
3. Enter a value such as `27.05.2026`.
4. Click into the month segment and type `0` (intending to enter `04`).
5. Verify the field still shows the date — typing the second digit (`4`) now leaves `27.04.2026` in place. Before this change, the first `0` keystroke wiped the whole input.
6. Verify that the value is persisted correctly.