### PR TITLE
Menu Structure: Guard against use-after-destroy in async structure request

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-tree-structure-workspace-context-base.ts
@@ -59,7 +59,9 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 				this.#workspaceContext?.unique,
 				(value) => {
 					if (!value) return;
-					this.#requestStructure();
+					this.#requestStructure().catch(() => {
+						// Context may have been destroyed while the async request was in flight.
+					});
 				},
 				'observeUnique',
 			);
@@ -70,7 +72,9 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 					// Workspace has changed from new to existing
 					if (value === false && this.#isNew === true) {
 						// TODO: We do not need to request here as we already know the structure and unique
-						this.#requestStructure();
+						this.#requestStructure().catch(() => {
+							// Context may have been destroyed while the async request was in flight.
+						});
 					}
 					this.#isNew = value;
 				},
@@ -130,6 +134,7 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 		const isRoot = entityType === root?.entityType;
 
 		// If the entity type is different from the root entity type, then we can request the ancestors.
+		let ancestorData: Array<UmbTreeItemModel> | undefined;
 		if (!isRoot) {
 			const { data } = await treeRepository.requestTreeItemAncestors({ treeItem: { unique, entityType } });
 
@@ -143,10 +148,17 @@ export abstract class UmbMenuTreeStructureWorkspaceContextBase extends UmbContex
 					};
 				});
 
-				this.#setAncestorData(data);
+				ancestorData = data;
 
 				structureItems.push(...ancestorItems);
 			}
+		}
+
+		// Guard: this context may have been destroyed while the async requests were in flight.
+		if (!this._host) return;
+
+		if (ancestorData) {
+			this.#setAncestorData(ancestorData);
 		}
 
 		this.#structure.setValue(structureItems);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/menu-variant-tree-structure-workspace-context-base.ts
@@ -72,7 +72,9 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 				this.#workspaceContext?.unique,
 				(value) => {
 					if (!value) return;
-					this.#requestStructure();
+					this.#requestStructure().catch(() => {
+						// Context may have been destroyed while the async request was in flight.
+					});
 				},
 				'observeUnique',
 			);
@@ -82,8 +84,9 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 				(value) => {
 					// Workspace has changed from new to existing
 					if (value === false && this.#isNew === true) {
-						// TODO: We do not need to request here as we already know the structure and unique
-						this.#requestStructure();
+						this.#requestStructure().catch(() => {
+							// Context may have been destroyed while the async request was in flight.
+						});
 					}
 					this.#isNew = value;
 				},
@@ -177,6 +180,10 @@ export abstract class UmbMenuVariantTreeStructureWorkspaceContextBase extends Um
 			});
 
 			structureItems.push(...treeItemAncestors);
+
+			// Guard: this context may have been destroyed while the async requests were in flight
+			// (e.g. a condition such as IS_NOT_TRASHED flips before the API response arrives).
+			if (!this._host) return;
 
 			this.#structure.setValue(structureItems);
 			this.#setParentData(structureItems);


### PR DESCRIPTION
## Summary

Fixes an `Uncaught (in promise) Error: _subject is undefined` thrown in the browser console when navigating to a **trashed item** in the Content or Media recycle bin.

### Root cause

The standard and recycle-bin menu structure workspace contexts target the same workspace, gated by mutually-exclusive conditions:

| Context | Condition | Default `permitted` |
|---|---|---|
| `Umb.Context.Document.Menu.Structure` | `IS_NOT_TRASHED` | **`true`** |
| `Umb.Context.DocumentRecycleBin.Menu.Structure` | `IS_TRASHED` | `false` |

`UmbEntityIsNotTrashedCondition` initialises `permitted = true`, so for a trashed item the **standard** structure context is created eagerly and kicks off the async `#requestStructure()`. Once the workspace confirms `isTrashed === true`, the `IS_NOT_TRASHED` condition flips to `false` and the standard context is destroyed (`#structure.destroy()` nulls the underlying subject). The still-in-flight `#requestStructure()` then resumes and calls `setValue()` on the destroyed state → throw.

### Fix

- Guard the state mutations in `#requestStructure()` with the framework's existing `_host`-cleared-on-destroy signal (`if (!this._host) return;`) — no new lifecycle flag needed.
- Attach `.catch()` to the previously fire-and-forget `#requestStructure()` calls so a teardown mid-request is silently abandoned rather than surfacing as an unhandled rejection.
- Applied to **both** the variant (`menu-variant-tree-structure-workspace-context-base.ts`) and non-variant (`menu-tree-structure-workspace-context-base.ts`) base contexts, since they share the identical pattern.

The existing `isNew` breadcrumb behaviour (reading the parent entity via `_internal_createUnderParent*` for new items) is unchanged.

## Test plan

- [ ] Navigate to a trashed item in the **Content** recycle bin → no console error, breadcrumb renders
  - [ ] Check the same for **Media** and **Elements** recycle bins
- [ ] Create a **new** document → breadcrumb still shows the parent structure (regression check)
- [ ] Navigate to a normal (non-trashed) document/media item → breadcrumb renders as before