### PR TITLE
Media: Restore friendly naming of uploaded media items (closes #22989)

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
@@ -730,6 +730,10 @@ public static partial class StringExtensions
     /// </summary>
     /// <param name="fileName">The file name to convert.</param>
     /// <returns>A friendly name with the extension stripped, underscores and dashes converted to spaces, and title case applied.</returns>
+    /// <remarks>
+    /// Mirrored client-side in <c>src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.ts</c>;
+    /// keep the two implementations in sync.
+    /// </remarks>
     public static string ToFriendlyName(this string fileName)
     {
         // strip the file extension

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -1,4 +1,4 @@
-import { UMB_MEDIA_ENTITY_TYPE } from '../../entity.js';
+import { ensureMediaNameFromFile } from '../../utils/ensure-media-name-from-file.function.js';
 import type { UmbImageCropperPropertyEditorValue } from './types.js';
 import type { UmbInputImageCropperFieldElement } from './image-cropper-field.element.js';
 import { css, customElement, html, ifDefined, property, state } from '@umbraco-cms/backoffice/external/lit';
@@ -6,7 +6,6 @@ import { assignToFrozenObject } from '@umbraco-cms/backoffice/observable-api';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbFileDropzoneItemStatus } from '@umbraco-cms/backoffice/dropzone';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbTemporaryFileConfigRepository } from '@umbraco-cms/backoffice/temporary-file';
 import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
@@ -100,7 +99,7 @@ export class UmbInputImageCropperElement extends UmbFormControlMixin<
 
 		const underlyingFile = file.temporaryFile?.file;
 		if (underlyingFile) {
-			void this.#ensureMediaNameFromFile(underlyingFile);
+			void ensureMediaNameFromFile(this, underlyingFile);
 		}
 
 		this.value = assignToFrozenObject(this.value ?? DefaultValue, {
@@ -108,16 +107,6 @@ export class UmbInputImageCropperElement extends UmbFormControlMixin<
 		});
 
 		this.dispatchEvent(new UmbChangeEvent());
-	}
-
-	async #ensureMediaNameFromFile(file: File) {
-		const datasetContext = await this.getContext(UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT);
-		if (!datasetContext || datasetContext.getEntityType() !== UMB_MEDIA_ENTITY_TYPE) return;
-
-		const currentName = datasetContext.getName();
-		if (currentName && currentName.trim() !== '') return;
-
-		datasetContext.setName(file.name);
 	}
 
 	#onRemove = () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-upload-field/input-upload-field.element.ts
@@ -1,5 +1,5 @@
 import type { UmbMediaValueType } from '../../property-editors/upload-field/types.js';
-import { UMB_MEDIA_ENTITY_TYPE } from '../../entity.js';
+import { ensureMediaNameFromFile } from '../../utils/ensure-media-name-from-file.function.js';
 import type { ManifestFileUploadPreview } from './file-upload-preview.extension.js';
 import { getMimeTypeFromExtension } from './utils.js';
 import { css, customElement, html, ifDefined, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
@@ -9,7 +9,6 @@ import { UmbExtensionsManifestInitializer } from '@umbraco-cms/backoffice/extens
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
 import { UmbFileDropzoneItemStatus } from '@umbraco-cms/backoffice/dropzone';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
@@ -163,19 +162,9 @@ export class UmbInputUploadFieldElement extends UmbFormControlMixin<UmbMediaValu
 		const blobUrl = URL.createObjectURL(this.temporaryFile.file);
 		this.value = { src: blobUrl };
 
-		void this.#ensureMediaNameFromFile(this.temporaryFile.file);
+		void ensureMediaNameFromFile(this, this.temporaryFile.file);
 
 		this.dispatchEvent(new UmbChangeEvent());
-	}
-
-	async #ensureMediaNameFromFile(file: File) {
-		const datasetContext = await this.getContext(UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT);
-		if (!datasetContext || datasetContext.getEntityType() !== UMB_MEDIA_ENTITY_TYPE) return;
-
-		const currentName = datasetContext.getName();
-		if (currentName && currentName.trim() !== '') return;
-
-		datasetContext.setName(file.name);
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/media-dropzone.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/dropzone/media-dropzone.manager.ts
@@ -1,6 +1,7 @@
 import { UmbMediaDetailRepository } from '../repository/detail/index.js';
 import type { UmbMediaDetailModel, UmbMediaValueModel } from '../types.js';
 import { UMB_MEDIA_PROPERTY_VALUE_ENTITY_TYPE } from '../entity.js';
+import { toFriendlyName } from '../utils/to-friendly-name.function.js';
 import { UMB_DROPZONE_MEDIA_TYPE_PICKER_MODAL } from './modals/index.js';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import {
@@ -243,7 +244,7 @@ export class UmbMediaDropzoneManager extends UmbDropzoneManager {
 	// Scaffold
 	async #getItemScaffold(item: UmbUploadableItem, mediaTypeUnique: string): Promise<UmbMediaDetailModel> {
 		// TODO: Use a scaffolding feature to ensure consistency. [NL]
-		const name = item.temporaryFile ? item.temporaryFile.file.name : (item.folder?.name ?? '');
+		const name = item.temporaryFile ? toFriendlyName(item.temporaryFile.file.name) : (item.folder?.name ?? '');
 		const umbracoFile: UmbMediaValueModel = {
 			editorAlias: '',
 			alias: 'umbracoFile',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/index.ts
@@ -11,5 +11,6 @@ export * from './repository/index.js';
 export * from './search/index.js';
 export * from './tree/index.js';
 export * from './url/index.js';
+export * from './utils/index.js';
 
 export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.test.ts
@@ -1,0 +1,85 @@
+import { UMB_MEDIA_ENTITY_TYPE } from '../entity.js';
+import { ensureMediaNameFromFile } from './ensure-media-name-from-file.function.js';
+import { expect } from '@open-wc/testing';
+import type { UmbClassInterface } from '@umbraco-cms/backoffice/class-api';
+
+interface DatasetStub {
+	getEntityType: () => string;
+	getName: () => string | undefined;
+	setName: (value: string) => void;
+}
+
+function makeHost(datasetContext: DatasetStub | undefined): { host: UmbClassInterface; setNameCalls: string[] } {
+	const setNameCalls: string[] = [];
+	const wrappedDataset = datasetContext
+		? {
+				...datasetContext,
+				setName: (value: string) => {
+					setNameCalls.push(value);
+					datasetContext.setName(value);
+				},
+			}
+		: undefined;
+	const host = {
+		getContext: async () => wrappedDataset,
+	} as unknown as UmbClassInterface;
+	return { host, setNameCalls };
+}
+
+describe('ensureMediaNameFromFile', () => {
+	it('sets the friendly name when no name is present on a media item', async () => {
+		const { host, setNameCalls } = makeHost({
+			getEntityType: () => UMB_MEDIA_ENTITY_TYPE,
+			getName: () => '',
+			setName: () => {},
+		});
+
+		await ensureMediaNameFromFile(host, new File([''], 'my-image-file.jpg'));
+
+		expect(setNameCalls).to.deep.equal(['My Image File']);
+	});
+
+	it('sets the friendly name when the current name is whitespace only', async () => {
+		const { host, setNameCalls } = makeHost({
+			getEntityType: () => UMB_MEDIA_ENTITY_TYPE,
+			getName: () => '   ',
+			setName: () => {},
+		});
+
+		await ensureMediaNameFromFile(host, new File([''], 'photo.png'));
+
+		expect(setNameCalls).to.deep.equal(['Photo']);
+	});
+
+	it('does not overwrite a name the user has already typed', async () => {
+		const { host, setNameCalls } = makeHost({
+			getEntityType: () => UMB_MEDIA_ENTITY_TYPE,
+			getName: () => 'User typed name',
+			setName: () => {},
+		});
+
+		await ensureMediaNameFromFile(host, new File([''], 'photo.png'));
+
+		expect(setNameCalls).to.deep.equal([]);
+	});
+
+	it('does nothing when the dataset context is for a non-media entity', async () => {
+		const { host, setNameCalls } = makeHost({
+			getEntityType: () => 'document',
+			getName: () => '',
+			setName: () => {},
+		});
+
+		await ensureMediaNameFromFile(host, new File([''], 'photo.png'));
+
+		expect(setNameCalls).to.deep.equal([]);
+	});
+
+	it('does nothing when no dataset context is available', async () => {
+		const { host, setNameCalls } = makeHost(undefined);
+
+		await ensureMediaNameFromFile(host, new File([''], 'photo.png'));
+
+		expect(setNameCalls).to.deep.equal([]);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.test.ts
@@ -82,4 +82,14 @@ describe('ensureMediaNameFromFile', () => {
 
 		expect(setNameCalls).to.deep.equal([]);
 	});
+
+	it('does not reject when getContext rejects (e.g. on timeout)', async () => {
+		const host = {
+			getContext: async () => {
+				throw new Error('context not found');
+			},
+		} as unknown as UmbClassInterface;
+
+		await ensureMediaNameFromFile(host, new File([''], 'photo.png'));
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.ts
@@ -14,7 +14,7 @@ import { UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/p
  * @param {File} file - The uploaded file whose name should seed the media item name.
  */
 export async function ensureMediaNameFromFile(host: UmbClassInterface, file: File): Promise<void> {
-	const datasetContext = await host.getContext(UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT);
+	const datasetContext = await host.getContext(UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT).catch(() => undefined);
 	if (!datasetContext || datasetContext.getEntityType() !== UMB_MEDIA_ENTITY_TYPE) return;
 
 	const currentName = datasetContext.getName();

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/ensure-media-name-from-file.function.ts
@@ -1,0 +1,24 @@
+import { UMB_MEDIA_ENTITY_TYPE } from '../entity.js';
+import { toFriendlyName } from './to-friendly-name.function.js';
+import type { UmbClassInterface } from '@umbraco-cms/backoffice/class-api';
+import { UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
+
+/**
+ * Populates the media workspace name from an uploaded file when the user has not
+ * already provided one. The filename is converted to a friendly name (extension
+ * stripped, dashes/underscores replaced, title-cased) before being applied.
+ *
+ * Does nothing if the consumed dataset context is not a media item, or if a
+ * non-empty name is already set.
+ * @param {UmbClassInterface} host - The context-consuming host (typically the calling element).
+ * @param {File} file - The uploaded file whose name should seed the media item name.
+ */
+export async function ensureMediaNameFromFile(host: UmbClassInterface, file: File): Promise<void> {
+	const datasetContext = await host.getContext(UMB_NAMEABLE_PROPERTY_DATASET_CONTEXT);
+	if (!datasetContext || datasetContext.getEntityType() !== UMB_MEDIA_ENTITY_TYPE) return;
+
+	const currentName = datasetContext.getName();
+	if (currentName && currentName.trim() !== '') return;
+
+	datasetContext.setName(toFriendlyName(file.name));
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './ensure-media-name-from-file.function.js';
+export * from './to-friendly-name.function.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
@@ -50,8 +50,18 @@ describe('toFriendlyName', () => {
 		expect(toFriendlyName('   ')).to.eq('');
 	});
 
-	it('trims and collapses surrounding whitespace', () => {
-		expect(toFriendlyName('  spaced-name.jpg  ')).to.eq('Spaced Name');
+	it('collapses interior whitespace', () => {
+		expect(toFriendlyName('hello   world.jpg')).to.eq('Hello World');
+	});
+
+	it('strips a trailing dot (parity with StringExtensions.StripFileExtension)', () => {
+		expect(toFriendlyName('file.')).to.eq('File');
+	});
+
+	it('does not strip when the "extension" contains whitespace', () => {
+		// StringExtensions.StripFileExtension preserves these names rather than treating
+		// the last dot as an extension delimiter, so the dot survives into the output.
+		expect(toFriendlyName('report.final draft')).to.eq('Report.Final Draft');
 	});
 
 	it('handles Latin-extended letters as part of words', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
@@ -18,7 +18,7 @@ describe('toFriendlyName', () => {
 		expect(toFriendlyName('mixed_separator-name.docx')).to.eq('Mixed Separator Name');
 	});
 
-	it('lowercases all-lowercase words', () => {
+	it('treats each all-uppercase word as an acronym, including single-letter words', () => {
 		expect(toFriendlyName('JUST-A-FILE.jpg')).to.eq('JUST A FILE');
 	});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
@@ -1,0 +1,68 @@
+import { toFriendlyName } from './to-friendly-name.function.js';
+import { expect } from '@open-wc/testing';
+
+describe('toFriendlyName', () => {
+	it('strips the extension and title-cases dashed words', () => {
+		expect(toFriendlyName('my-image-file.jpg')).to.eq('My Image File');
+	});
+
+	it('strips the extension and title-cases underscored words', () => {
+		expect(toFriendlyName('snake_case_file.PNG')).to.eq('Snake Case File');
+	});
+
+	it('handles a filename that already contains spaces', () => {
+		expect(toFriendlyName('already nice.pdf')).to.eq('Already Nice');
+	});
+
+	it('handles a mix of separators', () => {
+		expect(toFriendlyName('mixed_separator-name.docx')).to.eq('Mixed Separator Name');
+	});
+
+	it('lowercases all-lowercase words', () => {
+		expect(toFriendlyName('JUST-A-FILE.jpg')).to.eq('JUST A FILE');
+	});
+
+	it('preserves all-uppercase words as acronyms', () => {
+		expect(toFriendlyName('NASA-photo.jpg')).to.eq('NASA Photo');
+	});
+
+	it('collapses consecutive separators', () => {
+		expect(toFriendlyName('multiple--dashes__here.jpg')).to.eq('Multiple Dashes Here');
+	});
+
+	it('returns the friendly name when there is no extension', () => {
+		expect(toFriendlyName('no-extension')).to.eq('No Extension');
+	});
+
+	it('treats dotfiles as having no extension', () => {
+		expect(toFriendlyName('.gitignore')).to.eq('.Gitignore');
+	});
+
+	it('only strips the last extension for multi-dot names', () => {
+		expect(toFriendlyName('my.file.name.jpg')).to.eq('My.File.Name');
+	});
+
+	it('returns an empty string for empty input', () => {
+		expect(toFriendlyName('')).to.eq('');
+	});
+
+	it('returns an empty string for whitespace-only input', () => {
+		expect(toFriendlyName('   ')).to.eq('');
+	});
+
+	it('trims and collapses surrounding whitespace', () => {
+		expect(toFriendlyName('  spaced-name.jpg  ')).to.eq('Spaced Name');
+	});
+
+	it('handles Latin-extended letters as part of words', () => {
+		expect(toFriendlyName('école-maternelle.jpg')).to.eq('École Maternelle');
+	});
+
+	it('handles accented letters mid-word', () => {
+		expect(toFriendlyName('café-photo.jpg')).to.eq('Café Photo');
+	});
+
+	it('handles Cyrillic letters', () => {
+		expect(toFriendlyName('файл-имя.jpg')).to.eq('Файл Имя');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.test.ts
@@ -64,6 +64,13 @@ describe('toFriendlyName', () => {
 		expect(toFriendlyName('report.final draft')).to.eq('Report.Final Draft');
 	});
 
+	it('preserves the extension when trailing whitespace is part of the extension span', () => {
+		// Same StripFileExtension rule: trailing whitespace after the dot lands inside
+		// the extension span, so the dot is not treated as a delimiter and the
+		// title-cased extension survives into the output.
+		expect(toFriendlyName('  spaced-name.jpg  ')).to.eq('Spaced Name.Jpg');
+	});
+
 	it('handles Latin-extended letters as part of words', () => {
 		expect(toFriendlyName('école-maternelle.jpg')).to.eq('École Maternelle');
 	});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.ts
@@ -1,4 +1,27 @@
-import { getFileExtension } from '@umbraco-cms/backoffice/utils';
+/**
+ * Strips the file extension following the same rules as the server-side
+ * `StringExtensions.StripFileExtension`: extensions containing whitespace are
+ * preserved (the dot is not treated as a separator), filenames with line breaks
+ * are left untouched, and a dot at the start of the name (e.g. `.gitignore`) is
+ * not treated as an extension delimiter.
+ */
+function stripFileExtension(fileName: string): string {
+	if (fileName.includes('\n') || fileName.includes('\r')) {
+		return fileName;
+	}
+
+	const lastIndex = fileName.lastIndexOf('.');
+	if (lastIndex <= 0) {
+		return fileName;
+	}
+
+	const extension = fileName.substring(lastIndex);
+	if (extension.includes(' ')) {
+		return fileName;
+	}
+
+	return fileName.substring(0, lastIndex);
+}
 
 /**
  * Converts a file name to a friendly name suitable for use as a media item name.
@@ -15,8 +38,7 @@ export function toFriendlyName(fileName: string): string {
 		return '';
 	}
 
-	const extension = getFileExtension(fileName);
-	let name = extension !== undefined ? fileName.substring(0, fileName.length - extension.length - 1) : fileName;
+	let name = stripFileExtension(fileName);
 
 	name = name.replace(/[-_]+/g, ' ');
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/utils/to-friendly-name.function.ts
@@ -1,0 +1,34 @@
+import { getFileExtension } from '@umbraco-cms/backoffice/utils';
+
+/**
+ * Converts a file name to a friendly name suitable for use as a media item name.
+ *
+ * Strips the file extension, replaces underscores and dashes with spaces, title-cases
+ * each word (preserving all-uppercase words as acronyms), and collapses consecutive
+ * whitespace. Mirrors the server-side `StringExtensions.ToFriendlyName` helper — keep
+ * the two implementations in sync.
+ * @param {string} fileName - The file name to convert.
+ * @returns {string} The friendly name.
+ */
+export function toFriendlyName(fileName: string): string {
+	if (!fileName) {
+		return '';
+	}
+
+	const extension = getFileExtension(fileName);
+	let name = extension !== undefined ? fileName.substring(0, fileName.length - extension.length - 1) : fileName;
+
+	name = name.replace(/[-_]+/g, ' ');
+
+	name = name.replace(/\p{L}+/gu, (word) => {
+		if (word.length > 1 && word === word.toUpperCase()) {
+			return word;
+		}
+		return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+	});
+
+	return name
+		.split(/\s+/)
+		.filter((part) => part.length > 0)
+		.join(' ');
+}


### PR DESCRIPTION
## Description

In Umbraco 13, uploading a file like `my-image-file.jpg` to the Media section produced a media item named `My Image File` — the extension was stripped, dashes/underscores replaced with spaces, and the result title-cased. In the current version the raw filename is used verbatim. This PR restores the "friendly renaming" behaviour for all four upload entry points.

Although we do have a `ToFriendlyName` method available on the server, I've applied this as a front-end fix. The transformation only applies when the name is auto-derived from a filename, which all happens client-side — applying it on the server would risk silently rewriting names that external API consumers POST explicitly. 

I've added a new `toFriendlyName` TypeScript helper mirrors the server-side `StringExtensions.ToFriendlyName` (with cross-references comments added in both directions to keep the implementations in sync).

Fixes #22989.

### Upload paths covered

1. **Media dashboard dropzone** — `UmbMediaDropzoneManager` scaffold path.
2. **Media picker** on a content property — uses the same dropzone manager.
3. **Media editing workspace, image upload** — `input-image-cropper.element.ts` auto-naming.
4. **Media editing workspace, non-image upload** — `input-upload-field.element.ts` auto-naming.

Paths 3 and 4 originally duplicated their `#ensureMediaNameFromFile` logic (introduced in #21775). Extracted into a single `ensureMediaNameFromFile(host, file)` helper consumed by both.

### Behaviour

- `my-image-file.jpg` → `My Image File`
- `snake_case_file.PNG` → `Snake Case File`
- `NASA-photo.jpg` → `NASA Photo` (all-uppercase words preserved as acronyms)
- `école-maternelle.jpg` → `École Maternelle` (Unicode-aware)
- `.gitignore` → `.Gitignore` (no extension to strip, treated as one word)
- Manually-typed names are not transformed; folder names are not transformed; explicit names POSTed via the management API are still stored verbatim.

## Testing

### Automated tests

Unit tests have been added for the two new shared utility functions introduced.

### Manual

- [ ] **Dashboard dropzone**: drop `my-test_file.jpg` onto the Media section listing → item created as `My Test File`.
- [ ] **Media picker**: on a document with a media picker property, upload `another-photo.PNG` → media item named `Another Photo`.
- [ ] **Workspace, image upload**: in the Media section, create a new Image media item and pick `holiday-shot.jpg` via the image cropper → workspace name pre-populates as `Holiday Shot`.
- [ ] **Workspace, file upload**: create a new File media item and pick `report-q4.pdf` via the file upload field → workspace name pre-populates as `Report Q4`.
- [ ] **Negative — user-typed name preserved**: create a new media item, type `lower-case-name` into the name field, then upload a file → typed name is **not** overwritten.
- [ ] **Negative — folder upload**: drop a folder onto the Media dashboard → folder name preserved as-is, not friendlyfied.