### PR TITLE
Developer Experience: Improve cohost editor polyfill to work with dotnet watch (closes #22773)

### DIFF
--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <!--
-    The Razor editor in VS2026 and the C# extension for VS Code uses the Razor source generator
+    The Razor editor in modern Visual Studio and the C# extension for VS Code use the Razor source generator
     for IDE functionality. We need to add some things to make sure it works correctly, but we
     only do them for design time builds, so that we don't impact regular builds or CI.
-    We also have an escape hatch in case it does cause issues, users can set the appropriate property
+    We also have an escape hatch in case it does cause issues, users can set EnableCohostEditorCompatibility=false
     in their project file to disable this.
 
-    CompilerVisibleProperty is read by the generator at initialization (before any target runs),
-    so it stays in an evaluation-time ItemGroup. It has no duplicate-entry problem.
+    CompilerVisibleProperty is surfaced to generators via AnalyzerConfigOptionsProvider, not as a source-generator input file, 
+    so it doesn't enter the hintName-collision codepath that AdditionalFiles does. Keeping it at evaluation time is safe.
   -->
   <ItemGroup Condition="'$(DesignTimeBuild)' == 'true' and '$(EnableCohostEditorCompatibility)' != 'false'">
     <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
@@ -39,9 +39,9 @@
     item Identity (slash form / relative vs absolute) and the generator then sees two inputs that
     derive the same hintName, which crashes it with CS8785 (see issue #22773).
 
-    Run as a target right before CoreCompile so the SDK's contribution is visible, then add only
-    the .cshtml files that are not already present. Both sides are normalized to %(FullPath) so
-    items with different Identity forms still compare equal.
+    Run as a target before CoreCompile (hot-reload path) and CompileDesignTime (IDE design-time path) 
+    so the SDK's contribution is visible in both cases. Then add only the .cshtml files that are not already 
+    present. Both sides are normalized to %(FullPath) so items with different Identity forms still compare equal.
 
     Set EnableCohostEditorCompatibility=false in a project to opt out entirely.
   -->

--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
@@ -22,45 +22,10 @@
     We also have an escape hatch in case it does cause issues, users can set EnableCohostEditorCompatibility=false
     in their project file to disable this.
 
-    CompilerVisibleProperty is surfaced to generators via AnalyzerConfigOptionsProvider, not as a source-generator input file, 
+    CompilerVisibleProperty is surfaced to generators via AnalyzerConfigOptionsProvider, not as a source-generator input file,
     so it doesn't enter the hintName-collision codepath that AdditionalFiles does. Keeping it at evaluation time is safe.
   -->
   <ItemGroup Condition="'$(DesignTimeBuild)' == 'true' and '$(EnableCohostEditorCompatibility)' != 'false'">
     <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
   </ItemGroup>
-
-  <!--
-    The Razor source generator needs .cshtml files in @(AdditionalFiles). The Razor SDK adds them
-    via @(RazorGenerate), but only inside a target that runs during the build — so during cohost
-    design-time builds they may not be present yet, which is what PR #21861 worked around.
-
-    Doing the include at evaluation time (as PR #21861 did) causes duplicates with the SDK during
-    dotnet watch / hot reload design-time builds: the SDK adds the same .cshtml under a different
-    item Identity (slash form / relative vs absolute) and the generator then sees two inputs that
-    derive the same hintName, which crashes it with CS8785 (see issue #22773).
-
-    Run as a target before CoreCompile (hot-reload path) and CompileDesignTime (IDE design-time path) 
-    so the SDK's contribution is visible in both cases. Then add only the .cshtml files that are not already 
-    present. Both sides are normalized to %(FullPath) so items with different Identity forms still compare equal.
-
-    Set EnableCohostEditorCompatibility=false in a project to opt out entirely.
-  -->
-  <Target Name="_UmbracoEnsureRazorAdditionalFilesForCohostEditor"
-          BeforeTargets="CoreCompile;CompileDesignTime"
-          Condition="'$(DesignTimeBuild)' == 'true' and '$(EnableCohostEditorCompatibility)' != 'false'">
-    <ItemGroup>
-      <_UmbracoCshtmlCandidate Include="**\*.cshtml" />
-      <_UmbracoCshtmlCandidateFull Include="@(_UmbracoCshtmlCandidate->'%(FullPath)')" />
-
-      <_UmbracoExistingAdditionalCshtmlFull
-          Include="@(AdditionalFiles->'%(FullPath)')"
-          Condition="'%(Extension)' == '.cshtml'" />
-
-      <_UmbracoCshtmlMissingFromAdditional
-          Include="@(_UmbracoCshtmlCandidateFull)"
-          Exclude="@(_UmbracoExistingAdditionalCshtmlFull)" />
-
-      <AdditionalFiles Include="@(_UmbracoCshtmlMissingFromAdditional)" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.props
@@ -21,16 +21,46 @@
     only do them for design time builds, so that we don't impact regular builds or CI.
     We also have an escape hatch in case it does cause issues, users can set the appropriate property
     in their project file to disable this.
+
+    CompilerVisibleProperty is read by the generator at initialization (before any target runs),
+    so it stays in an evaluation-time ItemGroup. It has no duplicate-entry problem.
   -->
   <ItemGroup Condition="'$(DesignTimeBuild)' == 'true' and '$(EnableCohostEditorCompatibility)' != 'false'">
-    <!-- 
-      We have to make sure the source generator can see the .cshtml files, so make them AdditionalFiles.
-    -->
-    <AdditionalFiles Include="**\*.cshtml" />
-
-    <!--
-      Make sure the source generator knows where the project is, so it can compute target paths.
-    -->
     <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
   </ItemGroup>
+
+  <!--
+    The Razor source generator needs .cshtml files in @(AdditionalFiles). The Razor SDK adds them
+    via @(RazorGenerate), but only inside a target that runs during the build — so during cohost
+    design-time builds they may not be present yet, which is what PR #21861 worked around.
+
+    Doing the include at evaluation time (as PR #21861 did) causes duplicates with the SDK during
+    dotnet watch / hot reload design-time builds: the SDK adds the same .cshtml under a different
+    item Identity (slash form / relative vs absolute) and the generator then sees two inputs that
+    derive the same hintName, which crashes it with CS8785 (see issue #22773).
+
+    Run as a target right before CoreCompile so the SDK's contribution is visible, then add only
+    the .cshtml files that are not already present. Both sides are normalized to %(FullPath) so
+    items with different Identity forms still compare equal.
+
+    Set EnableCohostEditorCompatibility=false in a project to opt out entirely.
+  -->
+  <Target Name="_UmbracoEnsureRazorAdditionalFilesForCohostEditor"
+          BeforeTargets="CoreCompile;CompileDesignTime"
+          Condition="'$(DesignTimeBuild)' == 'true' and '$(EnableCohostEditorCompatibility)' != 'false'">
+    <ItemGroup>
+      <_UmbracoCshtmlCandidate Include="**\*.cshtml" />
+      <_UmbracoCshtmlCandidateFull Include="@(_UmbracoCshtmlCandidate->'%(FullPath)')" />
+
+      <_UmbracoExistingAdditionalCshtmlFull
+          Include="@(AdditionalFiles->'%(FullPath)')"
+          Condition="'%(Extension)' == '.cshtml'" />
+
+      <_UmbracoCshtmlMissingFromAdditional
+          Include="@(_UmbracoCshtmlCandidateFull)"
+          Exclude="@(_UmbracoExistingAdditionalCshtmlFull)" />
+
+      <AdditionalFiles Include="@(_UmbracoCshtmlMissingFromAdditional)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.targets
+++ b/src/Umbraco.Cms.Targets/buildTransitive/Umbraco.Cms.Targets.targets
@@ -49,4 +49,39 @@
       <ContentWithTargetPath Include="@(_UmbracoFolderFiles)" Exclude="@(ContentWithTargetPath)" TargetPath="%(Identity)" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
+
+  <!--
+    The Razor source generator needs .cshtml files in @(AdditionalFiles). The Razor SDK adds them
+    via @(RazorGenerate), but only inside a target that runs during the build — so during cohost
+    design-time builds they may not be present yet, which is what PR #21861 worked around.
+
+    Doing the include at evaluation time (as PR #21861 did) causes duplicates with the SDK during
+    dotnet watch / hot reload design-time builds: the SDK adds the same .cshtml under a different
+    item Identity (slash form / relative vs absolute) and the generator then sees two inputs that
+    derive the same hintName, which crashes it with CS8785 (see issue #22773).
+
+    Run as a target before CoreCompile (hot-reload path) and CompileDesignTime (IDE design-time path)
+    so the SDK's contribution is visible in both cases. Then add only the .cshtml files that are not already
+    present. Both sides are normalized to %(FullPath) so items with different Identity forms still compare equal.
+
+    Set EnableCohostEditorCompatibility=false in a project to opt out entirely.
+  -->
+  <Target Name="_UmbracoEnsureRazorAdditionalFilesForCohostEditor"
+          BeforeTargets="CoreCompile;CompileDesignTime"
+          Condition="'$(DesignTimeBuild)' == 'true' and '$(EnableCohostEditorCompatibility)' != 'false'">
+    <ItemGroup>
+      <_UmbracoCshtmlCandidate Include="**\*.cshtml" />
+      <_UmbracoCshtmlCandidateFull Include="@(_UmbracoCshtmlCandidate->'%(FullPath)')" />
+
+      <_UmbracoExistingAdditionalCshtmlFull
+        Include="@(AdditionalFiles->'%(FullPath)')"
+        Condition="'%(Extension)' == '.cshtml'" />
+
+      <_UmbracoCshtmlMissingFromAdditional
+        Include="@(_UmbracoCshtmlCandidateFull)"
+        Exclude="@(_UmbracoExistingAdditionalCshtmlFull)" />
+
+      <AdditionalFiles Include="@(_UmbracoCshtmlMissingFromAdditional)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #22773

### Description
This PR continues the work of https://github.com/umbraco/Umbraco-CMS/pull/21861 by improving the introduced polyfill to be compatible with the dotnet watch process. It does this by including the .cshtml in a way that does not collide with what the razor SDK does. More details can be found in the comments around the polyfill

### Things that were tested
- Initial fix allows vscode to debug cshtml files
- Initial fix makes the app crash when following reproduction steps in #22773
- Enhancement still allows vscode to debug cshtml files
- Enhacement makes it so the app does not crash when following reproduction steps in #22773

### Notes
This is far from my erea of expertise so I welcome any and all improvements to the proposed solution.
@davidwengier: if you have time, I would greatly appriciate if you could have a look at this one.