### PR TITLE
Build: Gate NuGet release stage behind nuGetDeploy parameter

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -64,7 +64,7 @@ parameters:
     default: false
 
 variables:
-  nodeVersion: 20
+  nodeVersion: 24
   solution: umbraco.sln
   buildConfiguration: Release
   UMBRACO__CMS__GLOBAL__ID: 00000000-0000-0000-0000-000000000042
@@ -939,7 +939,8 @@ stages:
     # Inspect Deploy_NuGet.result directly so a MyGet failure (which is in the transitive ancestor graph)
     # doesn't cascade-skip this stage via succeeded(). Deploy_NuGet must itself have succeeded — a NuGet
     # failure deliberately blocks the npm release.
-    condition: and(in(dependencies.Deploy_NuGet.result, 'Succeeded', 'SucceededWithIssues'), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.npmDeploy}}))
+    # Requires the npmDeploy parameter to be set explicitly at queue time — release/* pushes alone should not publish.
+    condition: and(in(dependencies.Deploy_NuGet.result, 'Succeeded', 'SucceededWithIssues'), eq('${{ parameters.npmDeploy }}', 'True'))
     dependsOn:
       - Deploy_NuGet
     jobs:
@@ -1003,7 +1004,8 @@ stages:
     # Build_Docs must have produced artifacts (we won't upload anything otherwise) and Deploy_NuGet must
     # have succeeded — a NuGet failure deliberately blocks the docs upload. Direct result checks avoid
     # transitive succeeded()/failed() which would cascade-skip on a MyGet failure.
-    condition: and(in(dependencies.Build_Docs.result, 'Succeeded', 'SucceededWithIssues'), in(dependencies.Deploy_NuGet.result, 'Succeeded', 'SucceededWithIssues'), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.uploadApiDocs}}))
+    # Requires the uploadApiDocs parameter to be set explicitly at queue time — release/* pushes alone should not upload.
+    condition: and(in(dependencies.Build_Docs.result, 'Succeeded', 'SucceededWithIssues'), in(dependencies.Deploy_NuGet.result, 'Succeeded', 'SucceededWithIssues'), eq('${{ parameters.uploadApiDocs }}', 'True'))
     jobs:
       - job:
         displayName: Upload C# Docs

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -900,7 +900,8 @@ stages:
     # Run only when Deploy_MyGet actually ran (succeeded or failed) — not when it was skipped due to an upstream test failure.
     # Inspect Deploy_MyGet's direct result rather than succeeded()/failed(), which are transitive across the full ancestor graph.
     # Approval is required every run via the WaitForApproval job below.
-    condition: and(in(dependencies.Deploy_MyGet.result, 'Succeeded', 'SucceededWithIssues', 'Failed'), or(eq(dependencies.Build.outputs['A.build.NBGV_PublicRelease'], 'True'), ${{parameters.nuGetDeploy}}))
+    # Requires the nuGetDeploy parameter to be set explicitly at queue time — release/* pushes alone should not queue NuGet approvals.
+    condition: and(in(dependencies.Deploy_MyGet.result, 'Succeeded', 'SucceededWithIssues', 'Failed'), eq('${{ parameters.nuGetDeploy }}', 'True'))
     jobs:
       - job: WaitForApproval
         displayName: Wait for manual approval


### PR DESCRIPTION
## Summary

The `Deploy_NuGet`, `Deploy_Npm`, and `Upload_API_Docs` stages all currently run on any push to `release/*` (via `NBGV_PublicRelease == 'True'`), queuing manual approvals and publish jobs per build. In practice only the one run we deliberately trigger ever gets approved — the rest accumulate stuck `WaitForApproval` jobs that block batched auto-triggers on the release branch (because ADO won't queue a new build while a previous one is still "in progress" waiting).

This change drops the `NBGV_PublicRelease` half of the condition on all three stages so they only run when their corresponding `nuGetDeploy` / `npmDeploy` / `uploadApiDocs` parameter is set explicitly at queue time.

Also bumps `nodeVersion` from 20 to 24 (Node 20 EOL April 2026).

## Discussion points

- **Coupling**: `Deploy_Npm` and `Upload_API_Docs` still depend on `Deploy_NuGet.result in (Succeeded, SucceededWithIssues)`. With both stages now parameter-gated, queuing with `npmDeploy: true` but `nuGetDeploy: false` will result in npm being skipped (because NuGet didn't run). That's the current intended coupling — npm only goes out after a NuGet push — but worth a check that nobody wants to publish npm independently.
- **MyGet result check stays**: `Deploy_NuGet` retains `in(dependencies.Deploy_MyGet.result, 'Succeeded', 'SucceededWithIssues', 'Failed')`. The `Failed` allowance is intentional and was added recently to cope with MyGet feed downtime — keeps NuGet pushes possible when the artifacts are good but the MyGet step flaked.
- **`myGetDeploy` not changed**: kept as-is. MyGet still publishes on every release-branch push, which seems desired (pre-release feed). Open to changing this too if it's contributing to agent hog.
- **Companion fix**: ([4f5985c](https://github.com/umbraco/Umbraco-CMS/commit/4f5985c4d0d)) moved `timeoutInMinutes` onto the `ManualValidation@0` task so future stuck approvals will auto-reject after 3 days. This PR is the proper fix; the timeout is the safety net.
- **Node 24**: bumped here for convenience. Happy to split out if reviewers prefer a dedicated PR.

Posted for team discussion before merge — happy to adjust scope based on feedback.

## Test plan

- [ ] Push a non-publishing commit to a release branch — verify `Deploy_NuGet`, `Deploy_Npm`, and `Upload_API_Docs` are all skipped (no approvals queued)
- [ ] Queue a build with `nuGetDeploy: true` — verify `Deploy_NuGet` runs and asks for approval; `Deploy_Npm` and `Upload_API_Docs` remain skipped
- [ ] Queue a build with all three deploy parameters `true` — verify the full release path runs
- [ ] Verify nothing else in the pipeline broke with the Node 24 bump