### PR TITLE
Backoffice: Strip inherited class comments from TypeDoc API docs

### DIFF
--- a/src/Umbraco.Web.UI.Client/devops/typedoc-plugins/strip-inherited-class-comments.js
+++ b/src/Umbraco.Web.UI.Client/devops/typedoc-plugins/strip-inherited-class-comments.js
@@ -20,6 +20,11 @@ import { Converter, ReflectionKind } from 'typedoc';
  * and we drop it from this class. Inherited member comments (methods, properties) are
  * intentionally left alone — those are usually useful.
  *
+ * Known limitation: only `sources[0]` is checked as the "own" file. Classes that span
+ * multiple declarations (e.g. declaration merging) where the comment lives on a
+ * secondary declaration would be incorrectly stripped. We don't merge class
+ * declarations anywhere in this codebase, so the risk is theoretical.
+ *
  * Runs at EVENT_END so it sees the final state after both inheritance phases.
  * @param {import('typedoc').Application} app - the TypeDoc application instance
  */
@@ -35,8 +40,8 @@ export function load(app) {
 			const commentSource = comment.sourcePath;
 			if (!ownSource || !commentSource) continue;
 
-			// Normalise both ends (sourcePath is repo-relative, fileName is too) and
-			// strip any trailing line/column information just in case.
+			// Both paths are repo-relative; one may be the suffix of the other depending
+			// on how TypeDoc resolved them, so check both directions.
 			if (!commentSource.endsWith(ownSource) && !ownSource.endsWith(commentSource)) {
 				reflection.comment = undefined;
 				stripped++;

--- a/src/Umbraco.Web.UI.Client/devops/typedoc-plugins/strip-inherited-class-comments.js
+++ b/src/Umbraco.Web.UI.Client/devops/typedoc-plugins/strip-inherited-class-comments.js
@@ -1,0 +1,49 @@
+import { Converter, ReflectionKind } from 'typedoc';
+
+/**
+ * Strips class-level comments that TypeDoc copied from a base class.
+ *
+ * TypeDoc's default behaviour: when a subclass has no JSDoc of its own, its docs page
+ * shows the nearest ancestor's class comment. For us that means every UmbLitElement
+ * descendant displays "The base class for all Umbraco LitElement elements." until we
+ * write a real one-liner per class.
+ *
+ * The inheritance actually happens in two places:
+ *  1. comment discovery walks `extends` chains and sets `inheritedFromParentDeclaration`.
+ *  2. `ImplementsPlugin.handleInheritedComments` clones the parent comment onto the
+ *     child at EVENT_RESOLVE_END — and `Comment.clone()` carries the parent's
+ *     `sourcePath` over but resets `inheritedFromParentDeclaration` to the parent's
+ *     value (usually false, since the parent authored its own comment).
+ *
+ * So the only reliable signal is to compare `comment.sourcePath` to the reflection's
+ * own source file. If they differ, the comment was authored on a different declaration
+ * and we drop it from this class. Inherited member comments (methods, properties) are
+ * intentionally left alone — those are usually useful.
+ *
+ * Runs at EVENT_END so it sees the final state after both inheritance phases.
+ * @param {import('typedoc').Application} app - the TypeDoc application instance
+ */
+export function load(app) {
+	app.converter.on(Converter.EVENT_END, (context) => {
+		const classes = context.project.getReflectionsByKind(ReflectionKind.Class);
+		let stripped = 0;
+		for (const reflection of classes) {
+			const comment = reflection.comment;
+			if (!comment) continue;
+
+			const ownSource = reflection.sources?.[0]?.fileName;
+			const commentSource = comment.sourcePath;
+			if (!ownSource || !commentSource) continue;
+
+			// Normalise both ends (sourcePath is repo-relative, fileName is too) and
+			// strip any trailing line/column information just in case.
+			if (!commentSource.endsWith(ownSource) && !ownSource.endsWith(commentSource)) {
+				reflection.comment = undefined;
+				stripped++;
+			}
+		}
+		app.logger.info(
+			`strip-inherited-class-comments: stripped ${stripped} of ${classes.length} class comments inherited from a base class`,
+		);
+	});
+}

--- a/src/Umbraco.Web.UI.Client/typedoc.config.js
+++ b/src/Umbraco.Web.UI.Client/typedoc.config.js
@@ -20,4 +20,5 @@ export default {
 	entryPoints,
 	out: 'ui-api',
 	tsconfig: './tsconfig.typedoc.json',
+	plugin: ['./devops/typedoc-plugins/strip-inherited-class-comments.js'],
 };


### PR DESCRIPTION
## Summary

TypeDoc's default behaviour is to copy a base class's JSDoc onto any subclass that has no documentation of its own. On [apidocs.umbraco.com/v18](https://apidocs.umbraco.com/v18/ui-api/) this meant every `UmbLitElement` descendant (which is most of the public surface) displayed *"The base class for all Umbraco LitElement elements."* as its own description — misleading, and uniformly so across hundreds of pages.

This adds a small TypeDoc plugin that runs at `EVENT_END` and clears any class-level comment whose `sourcePath` doesn't match the reflection's own source file. The comment was authored on a different declaration, so it shouldn't be presented as this class's description.

Local run before/after:
- Before: `apps_app.UmbAppElement.html` rendered the parent's blurb as its own.
- After: 360 of 743 class pages no longer borrow a base class's description; classes that authored their own JSDoc (`UmbLitElement` itself etc.) are untouched.

## Notes

- Inherited member comments (methods, properties from `LitElement`, `RxJS`, etc.) are intentionally **left alone** — those are usually useful documentation.
- TypeDoc has no built-in option for this; the `Comment.inheritedFromParentDeclaration` flag is not reliable because `ImplementsPlugin.handleInheritedComments` re-clones the parent's comment (with its `false` flag) at `EVENT_RESOLVE_END`. Comparing `sourcePath` to the reflection's own source is the only signal that survives both inheritance phases. Detail is in the plugin file's docblock.
- Long-term, individual classes should still get one-liner descriptions of their own — this just stops the misleading default in the meantime.

## Test plan

- [ ] Run `npm run generate:ui-api-docs` in `src/Umbraco.Web.UI.Client/` and confirm the plugin logs `strip-inherited-class-comments: stripped N of M class comments inherited from a base class`.
- [ ] Open `ui-api/classes/apps_app.UmbAppElement.html` and confirm the class has no description rendered.
- [ ] Open `ui-api/classes/packages_core_lit-element.UmbLitElement.html` and confirm its own description ("The base class for all Umbraco LitElement elements.") is still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)