### PR TITLE
Task: Add `umb-ef-core-empty-migration` Claude skill

### DIFF
--- a/.claude/skills/ef-core-empty-migration/SKILL.md
+++ b/.claude/skills/ef-core-empty-migration/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: ef-core-empty-migration
+description: Generate empty (no-op) EF Core migration stubs for both SQL Server and SQLite providers in Umbraco CMS, create the Umbraco migration class that invokes it, add it to UmbracoPlan, and wire up the migration runner plumbing (enum + switch cases). Use this whenever you need to generate EF Core migrations after completing the DTO, configuration, DbSet, and customizer work — i.e., after completing Steps 1–4 of the EF Core DTO Migration Guide (Section 12 in Infrastructure CLAUDE.md). Also trigger this skill when the user mentions "dotnet ef migrations add", "adding an EF Core migration", "generating migrations for both providers", or "updating the migration runner plumbing".
+argument-hint: <MigrationName>
+---
+
+# EF Core Empty Migration Generation
+
+Automates the full workflow of adding an empty EF Core migration to Umbraco:
+
+1. Generate empty migration stubs in both SQL Server and SQLite provider projects
+2. Create the Umbraco migration class (`AsyncMigrationBase`) that runs it
+3. Add it to `UmbracoPlan`
+4. Wire up the migration runner plumbing (enum + switch cases)
+
+These migrations are intentionally no-ops — NPoco creates the actual database tables. The EF Core migrations exist only to update the model snapshot so EF Core tracks the schema state correctly.
+
+## Prerequisites Check
+
+Before running any commands, verify Steps 1–4 of the EF Core DTO Migration Guide are complete. Read the relevant files to confirm:
+
+- EF Core DTO exists in `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/` with `[EntityTypeConfiguration(...)]` attribute
+- DTO configuration exists in `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/`
+- `DbSet<FooDto>` is registered in `src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs`
+- SQL Server model customizer exists (only needed if the NPoco DTO has `[IncludeColumns]` indexes)
+
+If any are missing, tell the user which step is incomplete — do not run migration commands yet. The snapshot will silently omit the entity if the DbSet is missing.
+
+## Step 1: Determine Migration Name
+
+Use `$ARGUMENTS` as the migration name if provided. If not, ask:
+> What should the migration be named? (PascalCase, e.g. `AddRelationDtos`)
+
+Convention: names start with `Add` followed by the DTO or feature name.
+
+## Step 2: Prepare appsettings.json
+
+Read `src/Umbraco.Web.UI/appsettings.json`. This file is gitignored — it may not exist yet.
+
+Record the current value of `ConnectionStrings.umbracoDbDSN_ProviderName` as `originalProviderName` (default to `Microsoft.Data.Sqlite` if the file doesn't exist or the key is absent).
+
+The EF Core tooling reads these keys to select the correct SQL dialect — it does not need a real/reachable database for generating migrations, but `UmbracoDbContext` will reject a null or empty connection string before reading the provider.
+
+## Step 3: Generate SQL Server Migration
+
+Set both `umbracoDbDSN` (placeholder) and `umbracoDbDSN_ProviderName` in `src/Umbraco.Web.UI/appsettings.json`. If the file doesn't exist, create a minimal one:
+
+```json
+{
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Server=localhost;Database=UmbracoDev;Integrated Security=true",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
+  }
+}
+```
+
+If the file already exists, update `umbracoDbDSN_ProviderName` to `Microsoft.Data.SqlClient` and ensure `umbracoDbDSN` is non-empty (add a placeholder if missing).
+
+Run from the repository root:
+
+```bash
+dotnet ef migrations add {MigrationName} -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.SqlServer -c UmbracoDbContext
+```
+
+If the command fails, restore `originalProviderName` and stop. Show the full error. Common causes:
+- DTO not yet registered in `UmbracoDbContext`
+- Missing `[EntityTypeConfiguration]` attribute on DTO
+
+## Step 4: Generate SQLite Migration
+
+Set `umbracoDbDSN` to the SQLite placeholder and `umbracoDbDSN_ProviderName` to `Microsoft.Data.Sqlite` in `src/Umbraco.Web.UI/appsettings.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
+  }
+}
+```
+
+Run:
+
+```bash
+dotnet ef migrations add {MigrationName} -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.Sqlite -c UmbracoDbContext
+```
+
+If the command fails, restore `originalProviderName` and stop. Show the full error.
+
+## Step 5: Restore appsettings.json
+
+- If the file did not exist before Step 2, delete it: `rm src/Umbraco.Web.UI/appsettings.json`
+- If it existed, restore `umbracoDbDSN_ProviderName` to `originalProviderName` (and remove any placeholder `umbracoDbDSN` entry that wasn't there before)
+
+## Step 6: Empty Up() and Down() Methods
+
+Find the two generated migration files (they will have a timestamp prefix):
+
+```bash
+ls src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_{MigrationName}.cs
+ls src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_{MigrationName}.cs
+```
+
+In each file, replace the `Up()` and `Down()` method bodies with empty bodies:
+
+```csharp
+protected override void Up(MigrationBuilder migrationBuilder)
+{
+}
+
+protected override void Down(MigrationBuilder migrationBuilder)
+{
+}
+```
+
+Do NOT touch the `.Designer.cs` files or `UmbracoDbContextModelSnapshot.cs` — those are auto-generated and must stay as produced by the tooling.
+
+## Step 7: Create the Umbraco Migration Class
+
+The Umbraco migration class lives in the version-specific upgrade directory. These EF Core repository migrations target v19.
+
+Check whether `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/` exists. If not, create the directory.
+
+Create `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`:
+
+```csharp
+using Umbraco.Cms.Persistence.EFCore.Migrations;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+
+public class {MigrationName} : AsyncMigrationBase
+{
+    private readonly IEFCoreMigrationExecutor _migrationExecutor;
+
+    public {MigrationName}(
+        IMigrationContext context,
+        IEFCoreMigrationExecutor migrationExecutor)
+        : base(context)
+    {
+        _migrationExecutor = migrationExecutor;
+    }
+
+    protected override async Task MigrateAsync()
+    {
+        // NO-OP migration to ensure that EF Core doesn't complain about missing migrations.
+        await _migrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.{MigrationName});
+    }
+}
+```
+
+## Step 8: Add to UmbracoPlan
+
+File: `src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs`
+
+Read the file to find the last existing `To<>` call. Append a new call after it with a freshly generated GUID:
+
+```csharp
+To<V_19_0_0.{MigrationName}>("{new-unique-guid}");
+```
+
+Generate the GUID and format it in uppercase with braces:
+
+```bash
+uuidgen | tr '[:lower:]' '[:upper:]'
+```
+
+Verify the generated GUID does not already appear in `UmbracoPlan.cs` before using it.
+
+## Step 9: Update Migration Runner Plumbing
+
+Three files need updating so the Umbraco migration executor can invoke the new migration by name.
+
+### 9a. EFCoreMigration Enum
+
+File: `src/Umbraco.Infrastructure/Migrations/EFCoreMigration.cs`
+
+Read the current enum to find the highest integer value. Add the new entry at the end with the next sequential value:
+
+```csharp
+{MigrationName} = {nextValue},
+```
+
+### 9b. SqlServerMigrationProvider Switch
+
+File: `src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.cs`
+
+Add a case to `GetMigrationType()` before the `_ => throw` line:
+
+```csharp
+EFCoreMigration.{MigrationName} => typeof(Migrations.{MigrationName}),
+```
+
+Note: `GetMigrationType()` on the SQL Server provider returns `Type?` — it can return `null` for SQLite-only migrations (like `SqliteCollation`). For standard migrations, always return the migration type.
+
+### 9c. SqliteMigrationProvider Switch
+
+File: `src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs`
+
+Add the same case to `GetMigrationType()` before the `_ => throw` line:
+
+```csharp
+EFCoreMigration.{MigrationName} => typeof(Migrations.{MigrationName}),
+```
+
+Note: `GetMigrationType()` on the SQLite provider returns `Type` (non-nullable) — every enum value must have a case. Always add the case even for no-ops.
+
+## Step 10: Verify Snapshots
+
+Confirm the new entity was captured by the EF Core model snapshot. Look up the table name constant from the DTO (e.g., `Constants.DatabaseSchema.Tables.Relation` resolves to `"umbracoRelation"`), then search both snapshots:
+
+```bash
+grep -n "{tableName}" src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/UmbracoDbContextModelSnapshot.cs
+grep -n "{tableName}" src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/UmbracoDbContextModelSnapshot.cs
+```
+
+If the table name is absent from either snapshot, the DTO was not discovered. Fix by checking:
+
+1. `[EntityTypeConfiguration(typeof({Name}DtoConfiguration))]` attribute is present on the DTO
+2. `public required DbSet<{Name}Dto> {Foos} { get; set; }` is in `UmbracoDbContext`
+
+Then remove the migrations and regenerate (repeating from Step 2):
+
+```bash
+dotnet ef migrations remove -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.SqlServer
+dotnet ef migrations remove -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.Sqlite
+```
+
+## Completion Summary
+
+When all steps are done, confirm each item:
+
+- [ ] SQL Server migration generated: `src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_{MigrationName}.cs`
+- [ ] SQLite migration generated: `src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_{MigrationName}.cs`
+- [ ] Both EF Core migration files have empty `Up()` and `Down()` methods
+- [ ] Umbraco migration class created: `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`
+- [ ] `UmbracoPlan.cs` — new `To<>` call added with a unique GUID
+- [ ] `EFCoreMigration.cs` — new enum value added
+- [ ] `SqlServerMigrationProvider.cs` — new switch case added
+- [ ] `SqliteMigrationProvider.cs` — new switch case added
+- [ ] Both `UmbracoDbContextModelSnapshot.cs` files contain the expected table name
+- [ ] `appsettings.json` provider name restored to original value

--- a/.claude/skills/ef-core-empty-migration/SKILL.md
+++ b/.claude/skills/ef-core-empty-migration/SKILL.md
@@ -117,23 +117,16 @@ Do NOT touch the `.Designer.cs` files or `UmbracoDbContextModelSnapshot.cs` — 
 
 ## Step 7: Create the Umbraco Migration Class
 
-Determine the target version directory by reading `version.json` in the repository root. Parse the major version number and add one — EF Core repository migrations ship in the **next** major release, not the current one.
+The Umbraco migration class lives in the version-specific upgrade directory. These EF Core repository migrations target v19.
 
-```bash
-# Parse major version and compute target: e.g. "18.1.0-rc" → major=18 → V_19_0_0
-python3 -c "import json,re; v=json.load(open('version.json'))['version']; m=int(re.match(r'(\d+)',v).group(1)); print(f'V_{m+1}_0_0')"
-```
+Check whether `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/` exists. If not, create the directory.
 
-Store the result as `targetVersionDir` (e.g. `V_19_0_0`). All paths and namespace references below use this value.
-
-Check whether `src/Umbraco.Infrastructure/Migrations/Upgrade/{targetVersionDir}/` exists. If not, create the directory.
-
-Create `src/Umbraco.Infrastructure/Migrations/Upgrade/{targetVersionDir}/{MigrationName}.cs`:
+Create `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`:
 
 ```csharp
 using Umbraco.Cms.Persistence.EFCore.Migrations;
 
-namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.{targetVersionDir};
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
 
 public class {MigrationName} : AsyncMigrationBase
 {
@@ -162,7 +155,7 @@ File: `src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs`
 Read the file to find the last existing `To<>` call. Append a new call after it with a freshly generated GUID:
 
 ```csharp
-To<{targetVersionDir}.{MigrationName}>("{new-unique-guid}");
+To<V_19_0_0.{MigrationName}>("{new-unique-guid}");
 ```
 
 Generate the GUID and format it in uppercase with braces (works cross-platform):
@@ -239,7 +232,7 @@ When all steps are done, confirm each item:
 - [ ] SQL Server migration generated: `src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_{MigrationName}.cs`
 - [ ] SQLite migration generated: `src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_{MigrationName}.cs`
 - [ ] Both EF Core migration files have empty `Up()` and `Down()` methods
-- [ ] Umbraco migration class created: `src/Umbraco.Infrastructure/Migrations/Upgrade/{targetVersionDir}/{MigrationName}.cs`
+- [ ] Umbraco migration class created: `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`
 - [ ] `UmbracoPlan.cs` — new `To<>` call added with a unique GUID
 - [ ] `EFCoreMigration.cs` — new enum value added
 - [ ] `SqlServerMigrationProvider.cs` — new switch case added

--- a/.claude/skills/ef-core-empty-migration/SKILL.md
+++ b/.claude/skills/ef-core-empty-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ef-core-empty-migration
-description: Generate empty (no-op) EF Core migration stubs for both SQL Server and SQLite providers in Umbraco CMS, create the Umbraco migration class that invokes it, add it to UmbracoPlan, and wire up the migration runner plumbing (enum + switch cases). Use this whenever you need to generate EF Core migrations after completing the DTO, configuration, DbSet, and customizer work — i.e., after completing Steps 1–4 of the EF Core DTO Migration Guide (Section 12 in Infrastructure CLAUDE.md). Also trigger this skill when the user mentions "dotnet ef migrations add", "adding an EF Core migration", "generating migrations for both providers", or "updating the migration runner plumbing".
+description: Generate empty (no-op) EF Core migration stubs for both SQL Server and SQLite providers in Umbraco CMS, create the Umbraco migration class that invokes it, add it to UmbracoPlan, and wire up the migration runner plumbing (enum + switch cases). Use this whenever you need to generate EF Core migrations after completing the DTO, configuration, and DbSet work — i.e., after completing Steps 1–3 of the EF Core DTO Migration Guide (Section 12 in Infrastructure CLAUDE.md). Also trigger this skill when the user mentions "dotnet ef migrations add", "adding an EF Core migration", "generating migrations for both providers", or "updating the migration runner plumbing".
 argument-hint: <MigrationName>
 ---
 
@@ -17,12 +17,12 @@ These migrations are intentionally no-ops — NPoco creates the actual database 
 
 ## Prerequisites Check
 
-Before running any commands, verify Steps 1–4 of the EF Core DTO Migration Guide are complete. Read the relevant files to confirm:
+Before running any commands, verify Steps 1–3 of the EF Core DTO Migration Guide are complete (Step 4, the SQL Server model customizer, is only needed if the NPoco DTO has `[IncludeColumns]` indexes). Read the relevant files to confirm:
 
 - EF Core DTO exists in `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/` with `[EntityTypeConfiguration(...)]` attribute
 - DTO configuration exists in `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/`
 - `DbSet<FooDto>` is registered in `src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs`
-- SQL Server model customizer exists (only needed if the NPoco DTO has `[IncludeColumns]` indexes)
+- SQL Server model customizer exists in `src/Umbraco.Cms.Persistence.EFCore.SqlServer/DtoCustomization/` (only if the NPoco DTO has `[IncludeColumns]` indexes)
 
 If any are missing, tell the user which step is incomplete — do not run migration commands yet. The snapshot will silently omit the entity if the DbSet is missing.
 
@@ -117,16 +117,23 @@ Do NOT touch the `.Designer.cs` files or `UmbracoDbContextModelSnapshot.cs` — 
 
 ## Step 7: Create the Umbraco Migration Class
 
-The Umbraco migration class lives in the version-specific upgrade directory. These EF Core repository migrations target v19.
+Determine the target version directory by reading `version.json` in the repository root. Parse the major version number and add one — EF Core repository migrations ship in the **next** major release, not the current one.
 
-Check whether `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/` exists. If not, create the directory.
+```bash
+# Parse major version and compute target: e.g. "18.1.0-rc" → major=18 → V_19_0_0
+python3 -c "import json,re; v=json.load(open('version.json'))['version']; m=int(re.match(r'(\d+)',v).group(1)); print(f'V_{m+1}_0_0')"
+```
 
-Create `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`:
+Store the result as `targetVersionDir` (e.g. `V_19_0_0`). All paths and namespace references below use this value.
+
+Check whether `src/Umbraco.Infrastructure/Migrations/Upgrade/{targetVersionDir}/` exists. If not, create the directory.
+
+Create `src/Umbraco.Infrastructure/Migrations/Upgrade/{targetVersionDir}/{MigrationName}.cs`:
 
 ```csharp
 using Umbraco.Cms.Persistence.EFCore.Migrations;
 
-namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.{targetVersionDir};
 
 public class {MigrationName} : AsyncMigrationBase
 {
@@ -155,13 +162,13 @@ File: `src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs`
 Read the file to find the last existing `To<>` call. Append a new call after it with a freshly generated GUID:
 
 ```csharp
-To<V_19_0_0.{MigrationName}>("{new-unique-guid}");
+To<{targetVersionDir}.{MigrationName}>("{new-unique-guid}");
 ```
 
-Generate the GUID and format it in uppercase with braces:
+Generate the GUID and format it in uppercase with braces (works cross-platform):
 
 ```bash
-uuidgen | tr '[:lower:]' '[:upper:]'
+python3 -c "import uuid; print(str(uuid.uuid4()).upper())"
 ```
 
 Verify the generated GUID does not already appear in `UmbracoPlan.cs` before using it.
@@ -232,7 +239,7 @@ When all steps are done, confirm each item:
 - [ ] SQL Server migration generated: `src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_{MigrationName}.cs`
 - [ ] SQLite migration generated: `src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_{MigrationName}.cs`
 - [ ] Both EF Core migration files have empty `Up()` and `Down()` methods
-- [ ] Umbraco migration class created: `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`
+- [ ] Umbraco migration class created: `src/Umbraco.Infrastructure/Migrations/Upgrade/{targetVersionDir}/{MigrationName}.cs`
 - [ ] `UmbracoPlan.cs` — new `To<>` call added with a unique GUID
 - [ ] `EFCoreMigration.cs` — new enum value added
 - [ ] `SqlServerMigrationProvider.cs` — new switch case added

--- a/.claude/skills/umb-ef-core-empty-migration/SKILL.md
+++ b/.claude/skills/umb-ef-core-empty-migration/SKILL.md
@@ -86,7 +86,7 @@ If the command fails, restore `originalProviderName` and stop. Show the full err
 
 ## Step 4: Generate SQLite Migration
 
-Set `umbracoDbDSN` to the SQLite placeholder and `umbracoDbDSN_ProviderName` to `Microsoft.Data.Sqlite` in `settingsFile`:
+Update `umbracoDbDSN_ProviderName` to `Microsoft.Data.Sqlite` in `settingsFile`. If `umbracoDbDSN` is missing or empty, add the SQLite placeholder:
 
 ```json
 {

--- a/.claude/skills/umb-ef-core-empty-migration/SKILL.md
+++ b/.claude/skills/umb-ef-core-empty-migration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ef-core-empty-migration
+name: umb-ef-core-empty-migration
 description: Generate empty (no-op) EF Core migration stubs for both SQL Server and SQLite providers in Umbraco CMS, create the Umbraco migration class that invokes it, add it to UmbracoPlan, and wire up the migration runner plumbing (enum + switch cases). Use this whenever you need to generate EF Core migrations after completing the DTO, configuration, and DbSet work — i.e., after completing Steps 1–3 of the EF Core DTO Migration Guide (Section 12 in Infrastructure CLAUDE.md). Also trigger this skill when the user mentions "dotnet ef migrations add", "adding an EF Core migration", "generating migrations for both providers", or "updating the migration runner plumbing".
 argument-hint: <MigrationName>
 ---
@@ -17,14 +17,30 @@ These migrations are intentionally no-ops — NPoco creates the actual database 
 
 ## Prerequisites Check
 
-Before running any commands, verify Steps 1–3 of the EF Core DTO Migration Guide are complete (Step 4, the SQL Server model customizer, is only needed if the NPoco DTO has `[IncludeColumns]` indexes). Read the relevant files to confirm:
+Before running any commands, verify Steps 1–3 of the EF Core DTO Migration Guide are complete (Step 4, the SQL Server model customizer, is only needed if the NPoco DTO has `[IncludeColumns]` indexes). Run these concrete checks:
 
-- EF Core DTO exists in `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/` with `[EntityTypeConfiguration(...)]` attribute
-- DTO configuration exists in `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/`
-- `DbSet<FooDto>` is registered in `src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs`
-- SQL Server model customizer exists in `src/Umbraco.Cms.Persistence.EFCore.SqlServer/DtoCustomization/` (only if the NPoco DTO has `[IncludeColumns]` indexes)
+- Glob `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/**Dto.cs` — confirm the expected DTO file exists, open it, and verify it has `[EntityTypeConfiguration(...)]`
+- Glob `src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/**Configuration.cs` — confirm the expected configuration file exists
+- Grep `src/Umbraco.Infrastructure/Persistence/EFCore/UmbracoDbContext.cs` for `DbSet<` — confirm the new DTO appears
 
-If any are missing, tell the user which step is incomplete — do not run migration commands yet. The snapshot will silently omit the entity if the DbSet is missing.
+If any check fails, tell the user which step is incomplete — do not run migration commands yet. The snapshot will silently omit the entity if the DbSet is missing.
+
+## Before You Begin: Create Task List
+
+Use `TaskCreate` to create a task for each step below so no sub-step is skipped (Steps 9a–9c look nearly identical and are the most commonly missed):
+
+- Step 1: Determine migration name
+- Step 2: Prepare appsettings
+- Step 3: Generate SQL Server migration
+- Step 4: Generate SQLite migration
+- Step 5: Restore appsettings
+- Step 6: Empty Up() and Down() methods
+- Step 7: Create Umbraco migration class
+- Step 8: Add to UmbracoPlan
+- Step 9a: Update EFCoreMigration enum
+- Step 9b: Update SqlServerMigrationProvider switch
+- Step 9c: Update SqliteMigrationProvider switch
+- Step 10: Verify snapshots
 
 ## Step 1: Determine Migration Name
 
@@ -33,17 +49,19 @@ Use `$ARGUMENTS` as the migration name if provided. If not, ask:
 
 Convention: names start with `Add` followed by the DTO or feature name.
 
-## Step 2: Prepare appsettings.json
+## Step 2: Prepare appsettings
 
-Read `src/Umbraco.Web.UI/appsettings.json`. This file is gitignored — it may not exist yet.
+The EF Core tooling reads connection string settings from `src/Umbraco.Web.UI/appsettings.json` and any `appsettings.*.json` overlays (e.g., `appsettings.Development.json`). Check both files:
 
-Record the current value of `ConnectionStrings.umbracoDbDSN_ProviderName` as `originalProviderName` (default to `Microsoft.Data.Sqlite` if the file doesn't exist or the key is absent).
+1. Look for `ConnectionStrings.umbracoDbDSN_ProviderName` in `appsettings.Development.json` first (if it exists), then `appsettings.json`.
+2. Record the file path that contains the provider name as `settingsFile` (default to `appsettings.json` if neither file exists or neither has the key).
+3. Record the current `umbracoDbDSN_ProviderName` value as `originalProviderName` (default to `Microsoft.Data.Sqlite` if absent).
 
-The EF Core tooling reads these keys to select the correct SQL dialect — it does not need a real/reachable database for generating migrations, but `UmbracoDbContext` will reject a null or empty connection string before reading the provider.
+The tooling needs a non-null connection string but does not need a real/reachable database.
 
 ## Step 3: Generate SQL Server Migration
 
-Set both `umbracoDbDSN` (placeholder) and `umbracoDbDSN_ProviderName` in `src/Umbraco.Web.UI/appsettings.json`. If the file doesn't exist, create a minimal one:
+Set both `umbracoDbDSN` (placeholder) and `umbracoDbDSN_ProviderName` to `Microsoft.Data.SqlClient` in `settingsFile`. If `settingsFile` doesn't exist, create a minimal `appsettings.json`:
 
 ```json
 {
@@ -59,7 +77,7 @@ If the file already exists, update `umbracoDbDSN_ProviderName` to `Microsoft.Dat
 Run from the repository root:
 
 ```bash
-dotnet ef migrations add {MigrationName} -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.SqlServer -c UmbracoDbContext
+dotnet ef migrations add <MigrationName> -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.SqlServer -c UmbracoDbContext
 ```
 
 If the command fails, restore `originalProviderName` and stop. Show the full error. Common causes:
@@ -68,7 +86,7 @@ If the command fails, restore `originalProviderName` and stop. Show the full err
 
 ## Step 4: Generate SQLite Migration
 
-Set `umbracoDbDSN` to the SQLite placeholder and `umbracoDbDSN_ProviderName` to `Microsoft.Data.Sqlite` in `src/Umbraco.Web.UI/appsettings.json`:
+Set `umbracoDbDSN` to the SQLite placeholder and `umbracoDbDSN_ProviderName` to `Microsoft.Data.Sqlite` in `settingsFile`:
 
 ```json
 {
@@ -82,23 +100,23 @@ Set `umbracoDbDSN` to the SQLite placeholder and `umbracoDbDSN_ProviderName` to 
 Run:
 
 ```bash
-dotnet ef migrations add {MigrationName} -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.Sqlite -c UmbracoDbContext
+dotnet ef migrations add <MigrationName> -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence.EFCore.Sqlite -c UmbracoDbContext
 ```
 
 If the command fails, restore `originalProviderName` and stop. Show the full error.
 
-## Step 5: Restore appsettings.json
+## Step 5: Restore appsettings
 
-- If the file did not exist before Step 2, delete it: `rm src/Umbraco.Web.UI/appsettings.json`
-- If it existed, restore `umbracoDbDSN_ProviderName` to `originalProviderName` (and remove any placeholder `umbracoDbDSN` entry that wasn't there before)
+- If `settingsFile` did not exist before Step 2, delete it.
+- If it existed, restore `umbracoDbDSN_ProviderName` to `originalProviderName` (and remove any placeholder `umbracoDbDSN` entry that wasn't there before).
 
 ## Step 6: Empty Up() and Down() Methods
 
 Find the two generated migration files (they will have a timestamp prefix):
 
 ```bash
-ls src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_{MigrationName}.cs
-ls src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_{MigrationName}.cs
+ls src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_<MigrationName>.cs
+ls src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_<MigrationName>.cs
 ```
 
 In each file, replace the `Up()` and `Down()` method bodies with empty bodies:
@@ -117,22 +135,20 @@ Do NOT touch the `.Designer.cs` files or `UmbracoDbContextModelSnapshot.cs` — 
 
 ## Step 7: Create the Umbraco Migration Class
 
-The Umbraco migration class lives in the version-specific upgrade directory. These EF Core repository migrations target v19.
+The Umbraco migration class lives in `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/`. Check whether this directory exists. If not, create it.
 
-Check whether `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/` exists. If not, create the directory.
-
-Create `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`:
+Create `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/<MigrationName>.cs`:
 
 ```csharp
 using Umbraco.Cms.Persistence.EFCore.Migrations;
 
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_19_0_0;
 
-public class {MigrationName} : AsyncMigrationBase
+public class <MigrationName> : AsyncMigrationBase
 {
     private readonly IEFCoreMigrationExecutor _migrationExecutor;
 
-    public {MigrationName}(
+    public <MigrationName>(
         IMigrationContext context,
         IEFCoreMigrationExecutor migrationExecutor)
         : base(context)
@@ -143,7 +159,7 @@ public class {MigrationName} : AsyncMigrationBase
     protected override async Task MigrateAsync()
     {
         // NO-OP migration to ensure that EF Core doesn't complain about missing migrations.
-        await _migrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.{MigrationName});
+        await _migrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.<MigrationName>);
     }
 }
 ```
@@ -152,19 +168,25 @@ public class {MigrationName} : AsyncMigrationBase
 
 File: `src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs`
 
-Read the file to find the last existing `To<>` call. Append a new call after it with a freshly generated GUID:
+Read the file to find the last existing `To<>` call. Append a new call after it with a freshly generated GUID. The GUID must be uppercase and surrounded by curly braces (e.g., `{C8E2F7B4-5D3A-4F61-9E8C-1A2B3C4D5E6F}`).
 
-```csharp
-To<V_19_0_0.{MigrationName}>("{new-unique-guid}");
-```
-
-Generate the GUID and format it in uppercase with braces (works cross-platform):
+Generate a GUID (choose one based on what's available):
 
 ```bash
-python3 -c "import uuid; print(str(uuid.uuid4()).upper())"
+# Linux/macOS
+uuidgen | tr '[:lower:]' '[:upper:]'
 ```
 
-Verify the generated GUID does not already appear in `UmbracoPlan.cs` before using it.
+```powershell
+# PowerShell (Windows)
+[System.Guid]::NewGuid().ToString().ToUpper()
+```
+
+Verify the generated GUID does not already appear in `UmbracoPlan.cs` before using it. Then add (substituting the actual GUID for `GENERATED-GUID-HERE`, wrapped in braces):
+
+```csharp
+To<V_19_0_0.<MigrationName>>("{GENERATED-GUID-HERE}");
+```
 
 ## Step 9: Update Migration Runner Plumbing
 
@@ -177,7 +199,7 @@ File: `src/Umbraco.Infrastructure/Migrations/EFCoreMigration.cs`
 Read the current enum to find the highest integer value. Add the new entry at the end with the next sequential value:
 
 ```csharp
-{MigrationName} = {nextValue},
+<MigrationName> = <nextValue>,
 ```
 
 ### 9b. SqlServerMigrationProvider Switch
@@ -187,7 +209,7 @@ File: `src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.c
 Add a case to `GetMigrationType()` before the `_ => throw` line:
 
 ```csharp
-EFCoreMigration.{MigrationName} => typeof(Migrations.{MigrationName}),
+EFCoreMigration.<MigrationName> => typeof(Migrations.<MigrationName>),
 ```
 
 Note: `GetMigrationType()` on the SQL Server provider returns `Type?` — it can return `null` for SQLite-only migrations (like `SqliteCollation`). For standard migrations, always return the migration type.
@@ -199,7 +221,7 @@ File: `src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs`
 Add the same case to `GetMigrationType()` before the `_ => throw` line:
 
 ```csharp
-EFCoreMigration.{MigrationName} => typeof(Migrations.{MigrationName}),
+EFCoreMigration.<MigrationName> => typeof(Migrations.<MigrationName>),
 ```
 
 Note: `GetMigrationType()` on the SQLite provider returns `Type` (non-nullable) — every enum value must have a case. Always add the case even for no-ops.
@@ -209,14 +231,14 @@ Note: `GetMigrationType()` on the SQLite provider returns `Type` (non-nullable) 
 Confirm the new entity was captured by the EF Core model snapshot. Look up the table name constant from the DTO (e.g., `Constants.DatabaseSchema.Tables.Relation` resolves to `"umbracoRelation"`), then search both snapshots:
 
 ```bash
-grep -n "{tableName}" src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/UmbracoDbContextModelSnapshot.cs
-grep -n "{tableName}" src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/UmbracoDbContextModelSnapshot.cs
+grep -n "<tableName>" src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/UmbracoDbContextModelSnapshot.cs
+grep -n "<tableName>" src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/UmbracoDbContextModelSnapshot.cs
 ```
 
 If the table name is absent from either snapshot, the DTO was not discovered. Fix by checking:
 
-1. `[EntityTypeConfiguration(typeof({Name}DtoConfiguration))]` attribute is present on the DTO
-2. `public required DbSet<{Name}Dto> {Foos} { get; set; }` is in `UmbracoDbContext`
+1. `[EntityTypeConfiguration(typeof(<Name>DtoConfiguration))]` attribute is present on the DTO
+2. `public required DbSet<<Name>Dto> <Foos> { get; set; }` is in `UmbracoDbContext`
 
 Then remove the migrations and regenerate (repeating from Step 2):
 
@@ -229,13 +251,13 @@ dotnet ef migrations remove -s src/Umbraco.Web.UI -p src/Umbraco.Cms.Persistence
 
 When all steps are done, confirm each item:
 
-- [ ] SQL Server migration generated: `src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_{MigrationName}.cs`
-- [ ] SQLite migration generated: `src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_{MigrationName}.cs`
+- [ ] SQL Server migration generated: `src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/*_<MigrationName>.cs`
+- [ ] SQLite migration generated: `src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/*_<MigrationName>.cs`
 - [ ] Both EF Core migration files have empty `Up()` and `Down()` methods
-- [ ] Umbraco migration class created: `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/{MigrationName}.cs`
+- [ ] Umbraco migration class created: `src/Umbraco.Infrastructure/Migrations/Upgrade/V_19_0_0/<MigrationName>.cs`
 - [ ] `UmbracoPlan.cs` — new `To<>` call added with a unique GUID
 - [ ] `EFCoreMigration.cs` — new enum value added
 - [ ] `SqlServerMigrationProvider.cs` — new switch case added
 - [ ] `SqliteMigrationProvider.cs` — new switch case added
 - [ ] Both `UmbracoDbContextModelSnapshot.cs` files contain the expected table name
-- [ ] `appsettings.json` provider name restored to original value
+- [ ] appsettings provider name restored to original value


### PR DESCRIPTION
Since we're working in a long-running feature branch, we're hardcoding the migration version to V19 for now, but in the future want to read the version.json

## Summary

- Adds a Claude Code skill (`.claude/skills/ef-core-empty-migration/`) that automates the full workflow for generating empty EF Core migration stubs when migrating NPoco repositories to EF Core
- The skill handles: generating migrations for both SQL Server and SQLite providers, creating the Umbraco `AsyncMigrationBase` migration class, adding it to `UmbracoPlan`, and wiring up the `EFCoreMigration` enum + switch cases in both providers
- The skill automatically manages `appsettings.json` (swapping the provider name between SQL Server and SQLite and restoring it afterwards) so colleagues don't need to do it manually

## Test plan

- [ ] Invoke `/ef-core-empty-migration <MigrationName>` after completing Steps 1–4 of the EF Core DTO Migration Guide
- [ ] Verify both EF Core migration stubs are generated with empty `Up()`/`Down()` methods
- [ ] Verify the Umbraco migration class, `UmbracoPlan` entry, enum value, and provider switch cases are all created correctly
- [ ] Verify both `UmbracoDbContextModelSnapshot.cs` files contain the new table name
