### PR TITLE
Build: app-local ICU is now configurable at runtime

### DIFF
--- a/src/Umbraco.Web.UI/CLAUDE.md
+++ b/src/Umbraco.Web.UI/CLAUDE.md
@@ -192,7 +192,7 @@ Development-specific overrides:
 | Console logging | `Async` sink | Serilog console output |
 | Examine log levels | `Debug` | Detailed Examine logging |
 
-### Auto-Copy Build Target (csproj lines 65-73)
+### Auto-Copy Build Target
 
 MSBuild targets automatically copy template files if missing (appsettings.json and appsettings.Development.json).
 
@@ -215,7 +215,7 @@ umbraco/models/*.generated.cs    # Source files (for reference)
 umbraco/Data/TEMP/InMemoryAuto/  # Runtime compilation
 ```
 
-### Razor Compilation Settings (csproj lines 50-51)
+### Razor Compilation Settings
 
 Razor compilation is disabled for InMemoryAuto mode (`RazorCompileOnBuild=false`, `RazorCompileOnPublish=false`).
 
@@ -223,11 +223,22 @@ Razor compilation is disabled for InMemoryAuto mode (`RazorCompileOnBuild=false`
 
 ## 6. ICU Globalization
 
-### App-Local ICU (csproj lines 39-40)
+### App-Local ICU
 
-Uses app-local ICU (`Microsoft.ICU.ICU4C.Runtime` v72.1.0.3) for consistent globalization across platforms.
+Opts in to app-local ICU (`Microsoft.ICU.ICU4C.Runtime` v72.1.0.3) so globalization behaves consistently across Windows / Linux hosts (notably Windows Server 2016 and Windows 10 1703–1809, which otherwise fall back to NLS). Gated by the `UmbracoUseAppLocalIcu` MSBuild property, which defaults to `true` for non-macOS Linux/Windows builds and `false` otherwise — mirroring the prior `RuntimeIdentifier`-aware condition.
 
-**Note**: Ensure ICU version matches between package reference and runtime option. Changes must also be made to `Umbraco.Templates`.
+**Override paths**:
+
+| Scope | How |
+| --- | --- |
+| Build/publish | `dotnet publish -p:UmbracoUseAppLocalIcu=false` (or set the property in `.csproj` / `Directory.Build.props`) |
+| Post-publish, no rebuild | Edit the published `*.runtimeconfig.json` and remove (or change) `System.Globalization.AppLocalIcu` under `runtimeOptions.configProperties` |
+
+**Note on `DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU`**: this env var **cannot** override a value that's already in `runtimeconfig.json` — verified empirically on .NET 10. AppLocalIcu is read by the native host before the CLR boots, so the general .NET 9 env-var-precedence rule does not apply here. The env var is only honored when the runtimeconfig has no AppLocalIcu entry (i.e. either build with `-p:UmbracoUseAppLocalIcu=false` or strip the key from `runtimeconfig.json` first). Use one of the two paths above instead.
+
+**Other notes**:
+- Keep `UmbracoAppLocalIcuVersion` in sync with the `Microsoft.ICU.ICU4C.Runtime` package version.
+- Mirror any change here in `templates/UmbracoProject/UmbracoProject.csproj` (both the CPM and non-CPM branches).
 
 ---
 
@@ -249,19 +260,20 @@ This project is for **development only**:
 Does NOT use central package management. Versions specified directly:
 - `Microsoft.EntityFrameworkCore.Design` - For EF Core migrations tooling
 - `Microsoft.Build.Tasks.Core` - Security fix for EFCore.Design dependency
-- `Microsoft.ICU.ICU4C.Runtime` - Globalization
+- `Microsoft.CodeAnalysis.CSharp.Workspaces` / `Microsoft.CodeAnalysis.Workspaces.MSBuild` - Aligns transitive Microsoft.CodeAnalysis versions pulled in by EFCore.Design (fixes NU1107/NU1608)
+- `Microsoft.ICU.ICU4C.Runtime` - Globalization (gated by `UmbracoUseAppLocalIcu`, see §6)
 
-### Umbraco Targets Import (csproj lines 19-20)
+### Umbraco Targets Import
 
 Imports shared build configuration from `Umbraco.Cms.Targets` project (props and targets).
 
-### Excluded Views (csproj lines 55-57)
+### Excluded Views
 
 Three Umbraco views excluded from content (UmbracoInstall, UmbracoLogin, UmbracoBackOffice) as they come from `Umbraco.Cms.StaticAssets` RCL.
 
 ### Known Technical Debt
 
-1. **Warning Suppression** (csproj lines 12-16): `SA1119` - Unnecessary parenthesis to fix
+1. **Warning Suppression**: `SA1119` - Unnecessary parenthesis to fix
 
 ### Runtime Data (umbraco/ directory)
 

--- a/src/Umbraco.Web.UI/CLAUDE.md
+++ b/src/Umbraco.Web.UI/CLAUDE.md
@@ -260,7 +260,6 @@ This project is for **development only**:
 Does NOT use central package management. Versions specified directly:
 - `Microsoft.EntityFrameworkCore.Design` - For EF Core migrations tooling
 - `Microsoft.Build.Tasks.Core` - Security fix for EFCore.Design dependency
-- `Microsoft.CodeAnalysis.CSharp.Workspaces` / `Microsoft.CodeAnalysis.Workspaces.MSBuild` - Aligns transitive Microsoft.CodeAnalysis versions pulled in by EFCore.Design (fixes NU1107/NU1608)
 - `Microsoft.ICU.ICU4C.Runtime` - Globalization (gated by `UmbracoUseAppLocalIcu`, see §6)
 
 ### Umbraco Targets Import

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -34,11 +34,25 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="17.14.28" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Ensure the AppLocalIcu setting is the same as the referenced ICU package version and changes are also done to the template project! -->
-    <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
+  <PropertyGroup>
+    <!--
+      Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms.
+      Defaults mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
+      To override:
+        * Build/publish:   dotnet publish -p:UmbracoUseAppLocalIcu=false
+        * Post-publish:    edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
+        * Runtime (.NET 9+): set env var DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU="" (or to a version)
+      Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version
+      and with the equivalent property in templates/UmbracoProject/UmbracoProject.csproj.
+    -->
+    <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == '' and ($(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx'))))">true</UmbracoUseAppLocalIcu>
+    <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == ''">false</UmbracoUseAppLocalIcu>
+    <UmbracoAppLocalIcuVersion Condition="'$(UmbracoAppLocalIcuVersion)' == ''">72.1.0.3</UmbracoAppLocalIcuVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UmbracoUseAppLocalIcu)' == 'true'">
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="$(UmbracoAppLocalIcuVersion)" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="$(UmbracoAppLocalIcuVersion)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -37,11 +37,13 @@
   <PropertyGroup>
     <!--
       Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms.
-      Defaults mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
+      Default mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
       To override:
-        * Build/publish:   dotnet publish -p:UmbracoUseAppLocalIcu=false
-        * Post-publish:    edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
-        * Runtime (.NET 9+): set env var DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU="" (or to a version)
+        * Build/publish:  dotnet publish -p:UmbracoUseAppLocalIcu=false
+        * Post-publish:   edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
+      Note: DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU is only honored when AppLocalIcu is absent from runtimeconfig.json
+      (verified on .NET 10) — the general .NET 9 env-var-precedence rule does not apply to this knob, since it is
+      resolved by the native host before the CLR boots. Use one of the two override paths above instead.
       Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version
       and with the equivalent property in templates/UmbracoProject/UmbracoProject.csproj.
     -->

--- a/templates/UmbracoProject/Directory.Packages.props
+++ b/templates/UmbracoProject/Directory.Packages.props
@@ -2,11 +2,17 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <!--
+      Default must match UmbracoAppLocalIcuVersion in UmbracoProject.csproj. Defined here too because this file
+      is imported before the main project's own PropertyGroup runs, so under CPM the PackageVersion below needs
+      its own fallback to stay in sync with the RuntimeHostConfigurationOption value set from the same property.
+    -->
+    <UmbracoAppLocalIcuVersion Condition="'$(UmbracoAppLocalIcuVersion)' == ''">72.1.0.3</UmbracoAppLocalIcuVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Umbraco.Cms" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+    <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="$(UmbracoAppLocalIcuVersion)" />
     <!--#if (StarterKit != "None") -->
     <PackageVersion Include="STARTER_KIT_NAME" Version="STARTER_KIT_VERSION" />
     <!--#endif -->

--- a/templates/UmbracoProject/UmbracoProject.csproj
+++ b/templates/UmbracoProject/UmbracoProject.csproj
@@ -18,10 +18,25 @@
     <!--#endif -->
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
+  <PropertyGroup>
+    <!--
+      Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms.
+      Defaults mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
+      To override:
+        * Build/publish:   dotnet publish -p:UmbracoUseAppLocalIcu=false
+        * Post-publish:    edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
+        * Runtime (.NET 9+): set env var DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU="" (or to a version)
+      Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version
+      and with the equivalent property in templates/UmbracoProject/UmbracoProject.csproj.
+    -->
+    <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == '' and ($(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx'))))">true</UmbracoUseAppLocalIcu>
+    <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == ''">false</UmbracoUseAppLocalIcu>
+    <UmbracoAppLocalIcuVersion Condition="'$(UmbracoAppLocalIcuVersion)' == ''">72.1.0.3</UmbracoAppLocalIcuVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UmbracoUseAppLocalIcu)' == 'true'">
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime"/>
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="$(UmbracoAppLocalIcuVersion)" />
   </ItemGroup>
   <!--#endif -->
 
@@ -36,10 +51,25 @@
     <!--#endif -->
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3"/>
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
+  <PropertyGroup>
+    <!--
+      Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms.
+      Defaults mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
+      To override:
+        * Build/publish:   dotnet publish -p:UmbracoUseAppLocalIcu=false
+        * Post-publish:    edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
+        * Runtime (.NET 9+): set env var DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU="" (or to a version)
+      Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version
+      and with the equivalent property in templates/UmbracoProject/UmbracoProject.csproj.
+    -->
+    <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == '' and ($(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx'))))">true</UmbracoUseAppLocalIcu>
+    <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == ''">false</UmbracoUseAppLocalIcu>
+    <UmbracoAppLocalIcuVersion Condition="'$(UmbracoAppLocalIcuVersion)' == ''">72.1.0.3</UmbracoAppLocalIcuVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(UmbracoUseAppLocalIcu)' == 'true'">
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="$(UmbracoAppLocalIcuVersion)"/>
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="$(UmbracoAppLocalIcuVersion)" />
   </ItemGroup>
   <!--#endif -->
 

--- a/templates/UmbracoProject/UmbracoProject.csproj
+++ b/templates/UmbracoProject/UmbracoProject.csproj
@@ -21,13 +21,14 @@
   <PropertyGroup>
     <!--
       Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms.
-      Defaults mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
+      Default mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
       To override:
-        * Build/publish:   dotnet publish -p:UmbracoUseAppLocalIcu=false
-        * Post-publish:    edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
-        * Runtime (.NET 9+): set env var DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU="" (or to a version)
-      Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version
-      and with the equivalent property in templates/UmbracoProject/UmbracoProject.csproj.
+        * Build/publish:  dotnet publish -p:UmbracoUseAppLocalIcu=false
+        * Post-publish:   edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
+      Note: DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU is only honored when AppLocalIcu is absent from runtimeconfig.json
+      (verified on .NET 10) — the general .NET 9 env-var-precedence rule does not apply to this knob, since it is
+      resolved by the native host before the CLR boots. Use one of the two override paths above instead.
+      Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version.
     -->
     <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == '' and ($(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx'))))">true</UmbracoUseAppLocalIcu>
     <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == ''">false</UmbracoUseAppLocalIcu>
@@ -54,13 +55,14 @@
   <PropertyGroup>
     <!--
       Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms.
-      Defaults mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
+      Default mirrors prior behaviour introduced in https://github.com/umbraco/Umbraco-CMS/pull/11276: enabled unless building on macOS without an explicit RuntimeIdentifier.
       To override:
-        * Build/publish:   dotnet publish -p:UmbracoUseAppLocalIcu=false
-        * Post-publish:    edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
-        * Runtime (.NET 9+): set env var DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU="" (or to a version)
-      Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version
-      and with the equivalent property in templates/UmbracoProject/UmbracoProject.csproj.
+        * Build/publish:  dotnet publish -p:UmbracoUseAppLocalIcu=false
+        * Post-publish:   edit System.Globalization.AppLocalIcu in the published *.runtimeconfig.json
+      Note: DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU is only honored when AppLocalIcu is absent from runtimeconfig.json
+      (verified on .NET 10) — the general .NET 9 env-var-precedence rule does not apply to this knob, since it is
+      resolved by the native host before the CLR boots. Use one of the two override paths above instead.
+      Keep UmbracoAppLocalIcuVersion in sync with the referenced Microsoft.ICU.ICU4C.Runtime package version.
     -->
     <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == '' and ($(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx'))))">true</UmbracoUseAppLocalIcu>
     <UmbracoUseAppLocalIcu Condition="'$(UmbracoUseAppLocalIcu)' == ''">false</UmbracoUseAppLocalIcu>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #22758. Non funtional breaking approach to #22771.

### Description

#22758 reports that an Umbraco app built on Linux or Windows crashes on macOS with `Failed to load app-local ICU: libicuuc.68.2.0.9.dylib`. Root cause: `RuntimeIdentifier` is build-time, so the `RuntimeHostConfigurationOption` for `System.Globalization.AppLocalIcu` gets baked into `runtimeconfig.json` whenever the build host is not macOS — even for cross-platform deployment artifacts.

PR #22771 fixes this by **removing** app-local ICU entirely. That works, but it also throws out the original cross-platform consistency guarantee added in #11276 and silently changes globalization behavior on Windows Server 2016 / Windows 10 1703–1809 (which fall back to NLS without app-local ICU — see [Microsoft Learn](https://learn.microsoft.com/dotnet/core/extensions/globalization-icu#globalization-setup-in-net-apps)).

This PR instead **keeps the default outcome** but introduces an MSBuild property knob (`UmbracoUseAppLocalIcu`) plus a documented post-publish escape hatch. The default still enables app-local ICU 72.1.0.3 for Linux/Windows builds; deployers who need different behavior on a particular target (macOS, or anywhere else) can override without rebuilding.

### Override paths

| Scope | How |
| --- | --- |
| Build / publish | `dotnet publish -p:UmbracoUseAppLocalIcu=false` (or set the property in `.csproj` / `Directory.Build.props`) |
| Post-publish, no rebuild | Remove or edit `System.Globalization.AppLocalIcu` under `runtimeOptions.configProperties` in the published `*.runtimeconfig.json` |
| Env var fallback | `DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU` is honored **only when the runtimeconfig has no AppLocalIcu key** — i.e. as a fallback, not as a runtime override of a JSON value already present. The general [.NET 9 env-var-precedence](https://learn.microsoft.com/dotnet/core/compatibility/deployment/9.0/envvar-precedence) rule does **not** apply here (verified on .NET 10); This is probably because AppLocalIcu is resolved by the native host before the CLR boots. Use the build-time or post-publish path for an actual override. |

### How to test

1. **Default outcome is unchanged**:
dotnet publish src/Umbraco.Web.UI/Umbraco.Web.UI.csproj -c Release -o ./out

Expected: `out/Umbraco.Web.UI.runtimeconfig.json` contains `"System.Globalization.AppLocalIcu": "72.1.0.3"` and `out/runtimes/linux-x64/native/libicuuc.so.72.1.0.3` + `out/runtimes/win-x64/native/icuuc72.dll` are present.

2. **Build-time opt-out**:
dotnet publish src/Umbraco.Web.UI/Umbraco.Web.UI.csproj -c Release -p:UmbracoUseAppLocalIcu=false -o ./out

Expected: `AppLocalIcu` key absent from `runtimeconfig.json`; no `runtimes/<rid>/native/*icu*` files; publish output ~3 MB smaller (ICU natives gone).

3. **Post-publish override** (reproduces and resolves #22758 without rebuilding):
- Publish on Linux/Windows with defaults.
- Open `*.runtimeconfig.json` and delete the `System.Globalization.AppLocalIcu` line (or change its value).
- Run on the target host — no `Failed to load app-local ICU` crash; falls back to system ICU.

4. **Regression check**: app-local ICU still loads on Linux/Windows builds. The `runtimeconfig.json` contains the entry; the runtime loads `icuuc72.dll` / `libicuuc.so.72.1.0.3` from the publish output as before.