### PR TITLE
Elements: Clear user and user group start node references when deleting an element container (closes #23010)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ElementContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ElementContainerRepository.cs
@@ -38,6 +38,11 @@ internal sealed class ElementContainerRepository : EntityContainerRepository, IE
 
     protected override void PersistDeletedItem(EntityContainer entity)
     {
+        if (entity == null)
+        {
+            throw new ArgumentNullException(nameof(entity));
+        }
+
         // Element containers can be referenced as start nodes on individual users (umbracoUserStartNode)
         // and on user groups (umbracoUserGroup.startElementId). Both reference umbracoNode.id via FK,
         // so we must clear those references before deleting the underlying node.

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ElementContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ElementContainerRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Infrastructure.Scoping;
 
@@ -33,5 +34,23 @@ internal sealed class ElementContainerRepository : EntityContainerRepository, IE
             repositoryCacheVersionService,
             cacheSyncService)
     {
+    }
+
+    protected override void PersistDeletedItem(EntityContainer entity)
+    {
+        // Element containers can be referenced as start nodes on individual users (umbracoUserStartNode)
+        // and on user groups (umbracoUserGroup.startElementId). Both reference umbracoNode.id via FK,
+        // so we must clear those references before deleting the underlying node.
+        var args = new { id = entity.Id };
+        Database.Execute(
+            $"DELETE FROM {QuoteTableName(Constants.DatabaseSchema.Tables.UserStartNode)} WHERE {QuoteColumnName("startNode")} = @id",
+            args);
+        Database.Execute(
+            $@"UPDATE {QuoteTableName(Constants.DatabaseSchema.Tables.UserGroup)}
+               SET {QuoteColumnName("startElementId")} = NULL
+               WHERE {QuoteColumnName("startElementId")} = @id",
+            args);
+
+        base.PersistDeletedItem(entity);
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ElementContainerServiceTests.DeleteFromRecycleBin.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ElementContainerServiceTests.DeleteFromRecycleBin.cs
@@ -245,6 +245,11 @@ public partial class ElementContainerServiceTests
         });
 
         Assert.IsNull(await ElementContainerService.GetAsync(containerKey));
+
+        // The user's start node reference should have been cleared.
+        var updatedUser = userService.GetUserById(user.Id);
+        Assert.IsNotNull(updatedUser);
+        Assert.IsFalse(updatedUser!.StartElementIds?.Contains(container.Id) ?? false);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ElementContainerServiceTests.DeleteFromRecycleBin.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ElementContainerServiceTests.DeleteFromRecycleBin.cs
@@ -1,8 +1,10 @@
 using NUnit.Framework;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Tests.Common.Attributes;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
@@ -215,5 +217,67 @@ public partial class ElementContainerServiceTests
             ElementNotificationHandler.DeletedElement = null;
             EntityContainerNotificationHandler.DeletedContainer = null;
         }
+    }
+
+    [Test]
+    public async Task Can_Delete_Container_Set_As_User_Start_Node_From_Recycle_Bin()
+    {
+        var userService = GetRequiredService<IUserService>();
+
+        var containerKey = Guid.NewGuid();
+        var container = (await ElementContainerService.CreateAsync(containerKey, "Start Node Container", null, Constants.Security.SuperUserKey)).Result;
+        Assert.IsNotNull(container);
+
+        var user = new UserBuilder()
+            .WithName("StartNodeUser")
+            .WithStartElementId(container!.Id)
+            .Build();
+        userService.Save(user);
+
+        await ElementContainerService.MoveToRecycleBinAsync(containerKey, Constants.Security.SuperUserKey);
+        await AssertContainerIsInRecycleBin(containerKey);
+
+        var deleteResult = await ElementContainerService.DeleteFromRecycleBinAsync(containerKey, Constants.Security.SuperUserKey);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(deleteResult.Success);
+            Assert.AreEqual(EntityContainerOperationStatus.Success, deleteResult.Status);
+        });
+
+        Assert.IsNull(await ElementContainerService.GetAsync(containerKey));
+    }
+
+    [Test]
+    public async Task Can_Delete_Container_Set_As_User_Group_Start_Node_From_Recycle_Bin()
+    {
+        var userGroupService = GetRequiredService<IUserGroupService>();
+
+        var containerKey = Guid.NewGuid();
+        var container = (await ElementContainerService.CreateAsync(containerKey, "Start Node Container", null, Constants.Security.SuperUserKey)).Result;
+        Assert.IsNotNull(container);
+
+        var userGroup = new UserGroupBuilder()
+            .WithAlias(Guid.NewGuid().ToString("N"))
+            .WithStartElementId(container!.Id)
+            .Build();
+        var groupResult = await userGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
+        Assert.IsTrue(groupResult.Success);
+
+        await ElementContainerService.MoveToRecycleBinAsync(containerKey, Constants.Security.SuperUserKey);
+        await AssertContainerIsInRecycleBin(containerKey);
+
+        var deleteResult = await ElementContainerService.DeleteFromRecycleBinAsync(containerKey, Constants.Security.SuperUserKey);
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(deleteResult.Success);
+            Assert.AreEqual(EntityContainerOperationStatus.Success, deleteResult.Status);
+        });
+
+        Assert.IsNull(await ElementContainerService.GetAsync(containerKey));
+
+        // The user group's start node reference should have been cleared.
+        var updatedGroup = await userGroupService.GetAsync(userGroup.Key);
+        Assert.IsNotNull(updatedGroup);
+        Assert.IsNull(updatedGroup!.StartElementId);
     }
 }


### PR DESCRIPTION
## Description

Deleting an element folder (entity container) from the Library recycle bin failed with HTTP 500 when the folder was set as a start node for a user or user group. An FK constraint error was raised because the underlying `umbracoNode` row could not be removed while `umbracoUserStartNode.startNode` or `umbracoUserGroup.startElementId` still referenced it.

To fix we run these statements prior to deleting an element container:

- `DELETE FROM umbracoUserStartNode WHERE startNode = @id` — clears user start node references
- `UPDATE umbracoUserGroup SET startElementId = NULL WHERE startElementId = @id` — clears user group start node references

Fixes #23010.

## Testing

### Automated

Added two integration tests in `ElementContainerServiceTests.DeleteFromRecycleBin.cs` to verify deleting a container set as a start node for a user or user group.

### Manual

1. Run a clean v18 install and sign in to the backoffice.
2. In the Library section, create an element folder (e.g. `Test Folder`).
3. Edit a user and assign the new folder as an **Element Start Node**. Save.
4. Trash the folder.
5. From the element recycle bin, delete the folder (or empty the recycle bin).
6. **Expected**: the delete completes without error and the folder is removed.

Repeat steps 3–6 using a user group's start element node instead of a user's. After the delete, edit the user group and confirm the start node has been cleared.