### PR TITLE
Umbraco.Decimal Property Editor: Add Default value (closes #21787)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DecimalConfigurationEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/DecimalConfigurationEditor.cs
@@ -19,6 +19,11 @@ public class DecimalConfigurationEditor : ConfigurationEditor
 
         Fields.Add(new ConfigurationField(new DecimalValidator())
         {
+            Key = "defaultValue",
+        });
+
+        Fields.Add(new ConfigurationField(new DecimalValidator())
+        {
             Key = "step",
         });
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/Umbraco.Decimal.ts
@@ -15,6 +15,13 @@ export const manifests: Array<UmbExtensionManifest> = [
 						config: [{ alias: 'step', value: '0.000001' }],
 					},
 					{
+						alias: 'defaultValue',
+						label: 'Default value',
+						description: 'Enter the default value to use when a new property is created',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Decimal',
+						config: [{ alias: 'step', value: '0.000001' }],
+					},
+					{
 						alias: 'max',
 						label: 'Maximum',
 						description: 'Enter the maximum amount of number to be entered',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/decimal-property-value-preset.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/decimal-property-value-preset.test.ts
@@ -1,0 +1,67 @@
+import { UmbDecimalPropertyValuePreset } from './decimal-property-value-preset.js';
+import { expect } from '@open-wc/testing';
+import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
+
+describe('UmbDecimalPropertyValuePreset', () => {
+	let preset: UmbDecimalPropertyValuePreset;
+
+	beforeEach(() => {
+		preset = new UmbDecimalPropertyValuePreset();
+	});
+
+	describe('with a configured default value', () => {
+		const config: UmbPropertyEditorConfig = [{ alias: 'defaultValue', value: '5.5' }];
+
+		it('uses the default value for a new property', async () => {
+			expect(await preset.processValue(undefined, config)).to.equal(5.5);
+		});
+
+		it('preserves an existing value over the default value', async () => {
+			expect(await preset.processValue(2.5, config)).to.equal(2.5);
+		});
+
+		it('preserves an existing value of 0 over the default value', async () => {
+			expect(await preset.processValue(0, config)).to.equal(0);
+		});
+
+		it('applies a configured default value of 0', async () => {
+			const zeroDefaultConfig: UmbPropertyEditorConfig = [{ alias: 'defaultValue', value: '0' }];
+			const minConfig: UmbPropertyEditorConfig = [
+				{ alias: 'defaultValue', value: '0' },
+				{ alias: 'min', value: '10' },
+			];
+
+			expect(await preset.processValue(undefined, zeroDefaultConfig)).to.equal(0);
+
+			// A configured default of 0 must win over min, not be treated as "no default".
+			expect(await preset.processValue(undefined, minConfig)).to.equal(0);
+		});
+	});
+
+	describe('falling back to the minimum', () => {
+		it('uses min when no default value is configured', async () => {
+			const config: UmbPropertyEditorConfig = [{ alias: 'min', value: '3' }];
+			expect(await preset.processValue(undefined, config)).to.equal(3);
+		});
+
+		it('falls back to min when the default value is an empty string', async () => {
+			const config: UmbPropertyEditorConfig = [
+				{ alias: 'defaultValue', value: '' },
+				{ alias: 'min', value: '3' },
+			];
+			expect(await preset.processValue(undefined, config)).to.equal(3);
+		});
+
+		it('falls back to min when the default value is not a finite number', async () => {
+			const config: UmbPropertyEditorConfig = [
+				{ alias: 'defaultValue', value: 'not-a-number' },
+				{ alias: 'min', value: '3' },
+			];
+			expect(await preset.processValue(undefined, config)).to.equal(3);
+		});
+
+		it('defaults to 0 when neither default value nor min is configured', async () => {
+			expect(await preset.processValue(undefined, [])).to.equal(0);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/decimal-property-value-preset.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/decimal-property-value-preset.ts
@@ -6,13 +6,26 @@ export class UmbDecimalPropertyValuePreset
 	implements UmbPropertyValuePreset<UmbDecimalPropertyEditorUiValue, UmbPropertyEditorConfig>
 {
 	async processValue(value: undefined | UmbDecimalPropertyEditorUiValue, config: UmbPropertyEditorConfig) {
-		const min = Number(config.find((x) => x.alias === 'min')?.value ?? 0);
-		const minVerified = isNaN(min) ? 0 : min;
+		const defaultValue = this.#parseConfiguredNumber(config, 'defaultValue');
+		if (defaultValue !== undefined) {
+			return value !== undefined ? value : defaultValue;
+		}
 
-		return value !== undefined ? value : minVerified;
+		const min = this.#parseConfiguredNumber(config, 'min') ?? 0;
+		return value !== undefined ? value : min;
 	}
 
 	destroy(): void {}
+
+	#parseConfiguredNumber(config: UmbPropertyEditorConfig, alias: string): number | undefined {
+		const rawValue = config.find((x) => x.alias === alias)?.value;
+		if (rawValue === undefined || rawValue === null || rawValue === '') {
+			return undefined;
+		}
+
+		const parsedValue = Number(rawValue);
+		return Number.isFinite(parsedValue) ? parsedValue : undefined;
+	}
 }
 
 export { UmbDecimalPropertyValuePreset as api };


### PR DESCRIPTION
Closes https://github.com/umbraco/Umbraco-CMS/issues/21787, with regards to Umbraco.Decimal default values.

This adds an optional default-value to the Umbraco.Decimal property editor.
If configured, the datatype using this editor will default to that value rather than 0.