### PR TITLE
Tiptap: Preserve wrapping link when editing an image (closes #23013)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/figure/figure.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/figure/figure.tiptap-extension.ts
@@ -19,10 +19,9 @@ export const Figure = Node.create<UmbTiptapFigureOptions>({
 	atom: true,
 
 	addAttributes() {
+		// `null` default avoids emitting an empty `figcaption=""` on freshly built figures.
 		return {
-			figcaption: {
-				default: '',
-			},
+			figcaption: { default: null },
 		};
 	},
 
@@ -33,17 +32,7 @@ export const Figure = Node.create<UmbTiptapFigureOptions>({
 	},
 
 	parseHTML() {
-		return [
-			{
-				tag: this.name,
-				getAttrs: (dom) => {
-					const figcaption = dom.querySelector('figcaption');
-					return {
-						figcaption: figcaption?.textContent || '',
-					};
-				},
-			},
-		];
+		return [{ tag: this.name }];
 	},
 
 	renderHTML({ HTMLAttributes }) {

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar-api.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar-api.ts
@@ -1,6 +1,8 @@
 import type { Editor } from '../../externals.js';
 import { NodeSelection } from '../../externals.js';
 import { UmbTiptapToolbarElementApiBase } from '../tiptap-toolbar-element-api-base.js';
+import { extractFigureAttrs, extractFigureImageData, extractImageMarks } from './media-picker.tiptap-toolbar.utils.js';
+import type { UmbTiptapMarkInput } from './media-picker.tiptap-toolbar.utils.js';
 import { getGuidFromUdi, splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { ImageCropModeModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { UmbImagingRepository } from '@umbraco-cms/backoffice/imaging';
@@ -48,19 +50,23 @@ export default class UmbTiptapToolbarMediaPickerToolbarExtensionApi extends UmbT
 		let currentTarget = editor.getAttributes('image');
 		let currentMediaUdi = this.#extractMediaUdi(currentTarget);
 		let currentCaption: string | undefined;
+		let currentMarks: Array<UmbTiptapMarkInput> = [];
+		const currentFigureAttrs = extractFigureAttrs(editor);
 
 		// If no image found directly, check if cursor is inside a figure (e.g. in figcaption)
 		if (!currentMediaUdi) {
-			const figureData = this.#extractFigureImageData(editor);
+			const figureData = extractFigureImageData(editor);
 			if (figureData) {
 				currentTarget = figureData.imageAttrs;
 				currentMediaUdi = this.#extractMediaUdi(currentTarget);
 				currentCaption = figureData.caption;
+				currentMarks = figureData.marks;
 				// Select the figure so insertContent replaces it instead of inserting at cursor
 				editor.commands.setNodeSelection(figureData.pos);
 			}
 		} else {
 			currentCaption = this.#extractCaption(editor.state.selection);
+			currentMarks = extractImageMarks(editor.state.selection);
 		}
 
 		// If editing existing image, use its UDI; otherwise open media picker
@@ -76,7 +82,7 @@ export default class UmbTiptapToolbarMediaPickerToolbarExtensionApi extends UmbT
 		);
 		if (!media) return;
 
-		this.#insertInEditor(editor, mediaGuid, media);
+		this.#insertInEditor(editor, mediaGuid, media, currentMarks, currentFigureAttrs);
 	}
 
 	#extractMediaUdi(imageAttributes: Record<string, unknown>): string | undefined {
@@ -96,38 +102,6 @@ export default class UmbTiptapToolbarMediaPickerToolbarExtensionApi extends UmbT
 			return true;
 		});
 		return caption;
-	}
-
-	#extractFigureImageData(
-		editor: Editor,
-	): { imageAttrs: Record<string, unknown>; caption?: string; pos: number } | undefined {
-		const { $from } = editor.state.selection;
-
-		for (let depth = $from.depth; depth >= 0; depth--) {
-			const node = $from.node(depth);
-			if (node.type.name === 'figure') {
-				let imageAttrs: Record<string, unknown> = {};
-				let caption: string | undefined;
-
-				node.descendants((child) => {
-					if (child.type.name === 'image') {
-						imageAttrs = { ...child.attrs };
-						return false;
-					}
-					if (child.type.name === 'figcaption') {
-						caption = child.textContent || undefined;
-						return false;
-					}
-					return true;
-				});
-
-				if (imageAttrs['data-udi']) {
-					return { imageAttrs, caption, pos: $from.before(depth) };
-				}
-			}
-		}
-
-		return undefined;
 	}
 
 	async #openMediaPicker(currentMediaUdi?: string): Promise<string | undefined> {
@@ -162,7 +136,13 @@ export default class UmbTiptapToolbarMediaPickerToolbarExtensionApi extends UmbT
 		return modalHandler?.onSubmit().catch(() => undefined);
 	}
 
-	async #insertInEditor(editor: Editor, mediaUnique: string, media: UmbMediaCaptionAltTextModalValue) {
+	async #insertInEditor(
+		editor: Editor,
+		mediaUnique: string,
+		media: UmbMediaCaptionAltTextModalValue,
+		currentMarks: Array<UmbTiptapMarkInput> = [],
+		currentFigureAttrs?: Record<string, unknown>,
+	) {
 		if (!media?.url) return;
 
 		const width = media.width || this.maxImageSize;
@@ -187,16 +167,20 @@ export default class UmbTiptapToolbarMediaPickerToolbarExtensionApi extends UmbT
 			height: height.toString(),
 		};
 
+		// Forward inline marks (e.g. umbLink for a wrapping `<a>`) onto the replacement node.
+		const marks = currentMarks.length ? currentMarks : undefined;
+
 		if (media.caption) {
 			return editor.commands.insertContent({
 				type: 'figure',
+				attrs: currentFigureAttrs,
 				content: [
-					{ type: 'paragraph', content: [{ type: 'image', attrs: img }] },
+					{ type: 'paragraph', content: [{ type: 'image', attrs: img, marks }] },
 					{ type: 'figcaption', content: [{ type: 'text', text: media.caption }] },
 				],
 			});
 		}
 
-		return editor.commands.setImage(img);
+		return editor.commands.insertContent({ type: 'image', attrs: img, marks });
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar.utils.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar.utils.test.ts
@@ -1,0 +1,263 @@
+import { extractFigureAttrs, extractFigureImageData, extractImageMarks } from './media-picker.tiptap-toolbar.utils.js';
+import { Document, Editor, Paragraph, Text } from '../../externals.js';
+import { UmbImage } from '../image/image.tiptap-extension.js';
+import { UmbLink } from '../link/link.tiptap-extension.js';
+import { Figure } from '../figure/figure.tiptap-extension.js';
+import { Figcaption } from '../figure/figcaption.tiptap-extension.js';
+import { expect } from '@open-wc/testing';
+
+describe('media-picker.tiptap-toolbar.utils', () => {
+	let editor: Editor;
+	let host: HTMLDivElement;
+
+	beforeEach(() => {
+		host = document.createElement('div');
+		document.body.appendChild(host);
+		editor = new Editor({
+			element: host,
+			extensions: [Document, Paragraph, Text, UmbImage.configure({ inline: true }), UmbLink, Figure, Figcaption],
+		});
+	});
+
+	afterEach(() => {
+		editor.destroy();
+		host.remove();
+	});
+
+	function findNodePos(typeName: string): number {
+		let foundPos = -1;
+		editor.state.doc.descendants((node, pos) => {
+			if (foundPos !== -1) return false;
+			if (node.type.name === typeName) {
+				foundPos = pos;
+				return false;
+			}
+			return true;
+		});
+		return foundPos;
+	}
+
+	describe('extractImageMarks', () => {
+		it('returns the umbLink mark when an image with a link is selected', () => {
+			editor.commands.setContent(
+				'<p><a href="https://example.com"><img src="foo.png" data-udi="umb://media/abc"></a></p>',
+			);
+			editor.commands.setNodeSelection(findNodePos('image'));
+
+			const marks = extractImageMarks(editor.state.selection);
+
+			expect(marks).to.have.lengthOf(1);
+			expect(marks[0].type).to.equal('umbLink');
+			expect(marks[0].attrs?.href).to.equal('https://example.com');
+		});
+
+		it('returns an empty array for an image with no marks', () => {
+			editor.commands.setContent('<p><img src="foo.png" data-udi="umb://media/abc"></p>');
+			editor.commands.setNodeSelection(findNodePos('image'));
+
+			expect(extractImageMarks(editor.state.selection)).to.deep.equal([]);
+		});
+
+		it('returns an empty array when the selection is not a NodeSelection on an image', () => {
+			editor.commands.setContent('<p>plain text</p>');
+			editor.commands.selectAll();
+
+			expect(extractImageMarks(editor.state.selection)).to.deep.equal([]);
+		});
+
+		it('drills into a NodeSelection on a figure to recover the inner image marks', () => {
+			// An atomic figure absorbs clicks meant for the inner image: the resulting
+			// selection lands on the figure node, not on the image inside it.
+			editor.commands.setContent(
+				[
+					'<figure>',
+					'  <p><a href="https://example.com"><img src="foo.png" data-udi="umb://media/abc"></a></p>',
+					'  <figcaption>Caption text</figcaption>',
+					'</figure>',
+				].join(''),
+			);
+			editor.commands.setNodeSelection(findNodePos('figure'));
+
+			const marks = extractImageMarks(editor.state.selection);
+
+			expect(marks).to.have.lengthOf(1);
+			expect(marks[0].type).to.equal('umbLink');
+			expect(marks[0].attrs?.href).to.equal('https://example.com');
+		});
+	});
+
+	describe('extractFigureAttrs', () => {
+		it('returns the figure attrs when the selection is a NodeSelection on the figure', () => {
+			editor.commands.setContent(
+				'<figure figcaption="Mirror text">' +
+					'<p><img src="foo.png" data-udi="umb://media/abc"></p>' +
+					'<figcaption>Caption text</figcaption>' +
+					'</figure>',
+			);
+			editor.commands.setNodeSelection(findNodePos('figure'));
+
+			expect(extractFigureAttrs(editor)?.figcaption).to.equal('Mirror text');
+		});
+
+		it('returns the figure attrs when the cursor is inside the figure', () => {
+			editor.commands.setContent(
+				'<figure figcaption="Mirror text">' +
+					'<p><img src="foo.png" data-udi="umb://media/abc"></p>' +
+					'<figcaption>Caption text</figcaption>' +
+					'</figure>',
+			);
+			editor.commands.setTextSelection(findNodePos('figcaption') + 1);
+
+			expect(extractFigureAttrs(editor)?.figcaption).to.equal('Mirror text');
+		});
+
+		it('returns undefined when no figure wraps the selection', () => {
+			editor.commands.setContent('<p>plain text</p>');
+			editor.commands.selectAll();
+
+			expect(extractFigureAttrs(editor)).to.be.undefined;
+		});
+	});
+
+	describe('extractFigureImageData', () => {
+		it('extracts image attrs, caption text, and the umbLink mark from a figure', () => {
+			editor.commands.setContent(
+				[
+					'<figure>',
+					'  <p><a href="https://example.com"><img src="foo.png" data-udi="umb://media/abc"></a></p>',
+					'  <figcaption>Caption text</figcaption>',
+					'</figure>',
+				].join(''),
+			);
+
+			// Place the text cursor inside the figcaption content (the `+1` skips the figcaption's opening token).
+			const figcaptionPos = findNodePos('figcaption');
+			expect(figcaptionPos, 'figcaption position').to.be.greaterThan(-1);
+			editor.commands.setTextSelection(figcaptionPos + 1);
+
+			const data = extractFigureImageData(editor);
+
+			expect(data, 'figure data').to.exist;
+			expect(data!.imageAttrs['data-udi']).to.equal('umb://media/abc');
+			expect(data!.caption).to.equal('Caption text');
+			expect(data!.marks).to.have.lengthOf(1);
+			expect(data!.marks[0].type).to.equal('umbLink');
+			expect(data!.marks[0].attrs?.href).to.equal('https://example.com');
+		});
+
+		it('also resolves when the selection is a NodeSelection on the figure itself', () => {
+			editor.commands.setContent(
+				[
+					'<figure>',
+					'  <p><a href="https://example.com"><img src="foo.png" data-udi="umb://media/abc"></a></p>',
+					'  <figcaption>Caption text</figcaption>',
+					'</figure>',
+				].join(''),
+			);
+			editor.commands.setNodeSelection(findNodePos('figure'));
+
+			const data = extractFigureImageData(editor);
+
+			expect(data, 'figure data').to.exist;
+			expect(data!.imageAttrs['data-udi']).to.equal('umb://media/abc');
+			expect(data!.caption).to.equal('Caption text');
+			expect(data!.marks[0].type).to.equal('umbLink');
+		});
+
+		it('returns undefined when the selection is not inside a figure', () => {
+			editor.commands.setContent('<p>plain text</p>');
+			editor.commands.selectAll();
+
+			expect(extractFigureImageData(editor)).to.be.undefined;
+		});
+
+		it('returns undefined when a figure contains no image (only a caption)', () => {
+			editor.commands.setContent('<figure><p>no image</p><figcaption>cap</figcaption></figure>');
+
+			const figcaptionPos = findNodePos('figcaption');
+			editor.commands.setTextSelection(figcaptionPos + 1);
+
+			expect(extractFigureImageData(editor)).to.be.undefined;
+		});
+	});
+
+	describe('round-trip via insertContent', () => {
+		it('re-inserting an image with the extracted marks keeps the surrounding link', () => {
+			editor.commands.setContent(
+				'<p><a href="https://example.com"><img src="foo.png" data-udi="umb://media/abc"></a></p>',
+			);
+			editor.commands.setNodeSelection(findNodePos('image'));
+
+			const marks = extractImageMarks(editor.state.selection);
+
+			editor.commands.insertContent({
+				type: 'image',
+				attrs: { src: 'bar.png', 'data-udi': 'umb://media/abc' },
+				marks,
+			});
+
+			expect(editor.getHTML()).to.match(/<a[^>]*href="https:\/\/example\.com"[^>]*>\s*<img[^>]+src="bar\.png"/);
+		});
+
+		it('re-inserting a figure with the extracted marks on the inner image keeps the surrounding link', () => {
+			editor.commands.setContent(
+				[
+					'<figure>',
+					'  <p><a href="https://example.com"><img src="foo.png" data-udi="umb://media/abc"></a></p>',
+					'  <figcaption>Original caption</figcaption>',
+					'</figure>',
+				].join(''),
+			);
+
+			const figcaptionPos = findNodePos('figcaption');
+			editor.commands.setTextSelection(figcaptionPos + 1);
+
+			const figureData = extractFigureImageData(editor);
+			expect(figureData, 'figure data').to.exist;
+			editor.commands.setNodeSelection(figureData!.pos);
+
+			editor.commands.insertContent({
+				type: 'figure',
+				content: [
+					{
+						type: 'paragraph',
+						content: [
+							{
+								type: 'image',
+								attrs: { src: 'bar.png', 'data-udi': 'umb://media/abc' },
+								marks: figureData!.marks,
+							},
+						],
+					},
+					{ type: 'figcaption', content: [{ type: 'text', text: 'New caption' }] },
+				],
+			});
+
+			expect(editor.getHTML(), 'figure HTML').to.match(
+				/<a[^>]*href="https:\/\/example\.com"[^>]*>\s*<img[^>]+src="bar\.png"/,
+			);
+		});
+
+		it('re-applying the captured figure attrs through insertContent preserves them', () => {
+			editor.commands.setContent(
+				'<figure figcaption="Mirror text">' +
+					'<p><img src="foo.png" data-udi="umb://media/abc"></p>' +
+					'<figcaption>Caption text</figcaption>' +
+					'</figure>',
+			);
+			editor.commands.setNodeSelection(findNodePos('figure'));
+			const attrs = extractFigureAttrs(editor);
+
+			editor.commands.insertContent({
+				type: 'figure',
+				attrs,
+				content: [
+					{ type: 'paragraph', content: [{ type: 'image', attrs: { src: 'bar.png', 'data-udi': 'umb://media/abc' } }] },
+					{ type: 'figcaption', content: [{ type: 'text', text: 'New caption' }] },
+				],
+			});
+
+			expect(editor.getHTML()).to.include('figcaption="Mirror text"');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar.utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar.utils.ts
@@ -1,8 +1,18 @@
 import type { Editor, ProseMirrorNode } from '../../externals.js';
 import { NodeSelection } from '../../externals.js';
 
+/**
+ * The plain-object shape of a Tiptap/ProseMirror mark, suitable for passing to
+ * `insertContent` JSON. Distinct from the runtime `Mark` instance, which carries
+ * a `MarkType` reference and can't be inserted directly.
+ */
 export type UmbTiptapMarkInput = { type: string; attrs?: Record<string, unknown> };
 
+/**
+ * Data extracted from a `figure` enclosing the current selection: the inner
+ * image's attributes and marks, the figcaption text (if any), and the figure's
+ * document position so callers can replace it via `setNodeSelection` / `insertContent`.
+ */
 export type UmbFigureImageData = {
 	imageAttrs: Record<string, unknown>;
 	caption?: string;

--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar.utils.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/media-picker/media-picker.tiptap-toolbar.utils.ts
@@ -1,0 +1,103 @@
+import type { Editor, ProseMirrorNode } from '../../externals.js';
+import { NodeSelection } from '../../externals.js';
+
+export type UmbTiptapMarkInput = { type: string; attrs?: Record<string, unknown> };
+
+export type UmbFigureImageData = {
+	imageAttrs: Record<string, unknown>;
+	caption?: string;
+	pos: number;
+	marks: Array<UmbTiptapMarkInput>;
+};
+
+/**
+ * Reads the marks (e.g. `umbLink`) off the selected image node. When the
+ * selection is on a container that wraps an image (e.g. a `figure`, which is
+ * atomic and can't be selected through), drills in to find the inner image's
+ * marks. Returns an empty array when no image is reachable.
+ * @param {unknown} selection The current editor selection.
+ * @returns {Array<UmbTiptapMarkInput>} The marks on the image, or an empty array.
+ */
+export function extractImageMarks(selection: unknown): Array<UmbTiptapMarkInput> {
+	if (!(selection instanceof NodeSelection)) return [];
+
+	if (selection.node.type.name === 'image') {
+		return selection.node.marks.map((mark) => ({ type: mark.type.name, attrs: { ...mark.attrs } }));
+	}
+
+	let marks: Array<UmbTiptapMarkInput> = [];
+	selection.node.descendants((child) => {
+		if (child.type.name === 'image') {
+			marks = child.marks.map((mark) => ({ type: mark.type.name, attrs: { ...mark.attrs } }));
+			return false;
+		}
+		return true;
+	});
+	return marks;
+}
+
+/**
+ * Locates the `figure` that surrounds the current selection. Handles both a
+ * `NodeSelection` directly on the figure (the common case for atomic figures)
+ * and a selection inside the figure's descendants.
+ * @param {Editor} editor The Tiptap editor instance.
+ * @returns {{ node: ProseMirrorNode; pos: number } | undefined} The figure node and its document position, or `undefined` if no figure surrounds the selection.
+ */
+function findEnclosingFigure(editor: Editor): { node: ProseMirrorNode; pos: number } | undefined {
+	const { selection } = editor.state;
+	if (selection instanceof NodeSelection && selection.node.type.name === 'figure') {
+		return { node: selection.node, pos: selection.from };
+	}
+	const { $from } = selection;
+	for (let depth = $from.depth; depth >= 0; depth--) {
+		const node = $from.node(depth);
+		if (node.type.name === 'figure') {
+			return { node, pos: $from.before(depth) };
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Reads the wrapping `figure` node's attributes from the current selection, so
+ * they can be re-applied when the figure is rebuilt.
+ * @param {Editor} editor The Tiptap editor instance.
+ * @returns {Record<string, unknown> | undefined} The figure's attrs, or `undefined` if no figure surrounds the selection.
+ */
+export function extractFigureAttrs(editor: Editor): Record<string, unknown> | undefined {
+	const figure = findEnclosingFigure(editor);
+	return figure ? { ...figure.node.attrs } : undefined;
+}
+
+/**
+ * Locates the `figure` that surrounds the current selection and pulls out the
+ * inner image's attributes and marks, the figcaption text, and the figure's
+ * document position so callers can replace it.
+ * @param {Editor} editor The Tiptap editor instance.
+ * @returns {UmbFigureImageData | undefined} The figure data, or `undefined` if no figure surrounds the selection or it contains no image with a `data-udi`.
+ */
+export function extractFigureImageData(editor: Editor): UmbFigureImageData | undefined {
+	const figure = findEnclosingFigure(editor);
+	if (!figure) return undefined;
+
+	let imageAttrs: Record<string, unknown> = {};
+	let caption: string | undefined;
+	let marks: Array<UmbTiptapMarkInput> = [];
+
+	figure.node.descendants((child) => {
+		if (child.type.name === 'image') {
+			imageAttrs = { ...child.attrs };
+			marks = child.marks.map((mark) => ({ type: mark.type.name, attrs: { ...mark.attrs } }));
+			return false;
+		}
+		if (child.type.name === 'figcaption') {
+			caption = child.textContent || undefined;
+			return false;
+		}
+		return true;
+	});
+
+	if (!imageAttrs['data-udi']) return undefined;
+
+	return { imageAttrs, caption, pos: figure.pos, marks };
+}


### PR DESCRIPTION
## Description

As reported in #23013, editing an image in the Tiptap RTE was discarding any `<a>` that wrapped the image.

Currently the rebuild inserts a fresh image node with no marks so the `umbLink` mark representing the wrapping link was dropped.

The fix captures and forwards the inline marks on the original image onto the replacement.

In testing I found an odd behaviour with an empty `figcaption` attribute being created.  This was also fixed whilst preserving any existing wrapping `<figure>`'s attributes, by removing the Figure extension's `parseHTML` mirror that copied the inner `<figcaption>` text into the figure's `figcaption` attribute and defaulting the attribute to `null` so freshly-built figures no longer emit `figcaption=""`. 

Fixes #23013.

## Testing

### Automated

For automated testing I've extracted helpers (`extractImageMarks`, `extractFigureAttrs`, `extractFigureImageData`) to a sibling utils module, and covered with 14 unit tests.

### Manual

Two starting markup shapes cover the two code paths. In each case, after editing the image, the wrapping `<a>` (with all its attributes) should still surround the `<img>` in the resulting markup.

Swap the `data-udi` and `localLink` GUID for real values from your local environment; the `src` URL doesn't matter (the editor regenerates it on submit).

#### Image wrapped directly in a link

```html
<p>
  <a data-router-slot="disabled" href="/{localLink:49ac6099-cf51-458b-b9a4-0c1f55dc7902}" title="My Page" type="document">
    <img data-udi="umb://media/209e1915528b40c594ee7bb706d5d252" src="..." alt="My Image" width="350" height="233">
  </a>
</p>
```

- [ ] Load the property in a Tiptap RTE and confirm the image renders inside the link.
- [ ] Click the image, then the image toolbar button.
- [ ] Change the dimensions and submit.
- [ ] In the resulting markup, the `<img>` is still wrapped in `<a data-router-slot="disabled" href="/{localLink:...}" title="My Page" type="document">` — all four `<a>` attributes intact.

#### Image inside a figure with a caption

```html
<figure>
  <p>
    <a data-router-slot="disabled" href="/{localLink:49ac6099-cf51-458b-b9a4-0c1f55dc7902}" title="My Page" type="document">
      <img data-udi="umb://media/209e1915528b40c594ee7bb706d5d252" src="..." alt="My Image" width="350" height="233">
    </a>
  </p>
  <figcaption>My Caption</figcaption>
</figure>
```

- [ ] Load the property and confirm the figure renders.
- [ ] Click the image, then the image toolbar button.
- [ ] Change the dimensions and submit, leaving the caption field as-is.
- [ ] In the resulting markup, the figure structure is preserved, the inner `<img>` is still wrapped in the original `<a>` with all attributes, and the `<figcaption>` text is unchanged.
- [ ] The `<figure>` element does **not** gain an empty `figcaption=""` attribute.