### PR TITLE
Performance: Coalesce concurrent tree data requests (Management API client)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/server-data-source/document-tree.server.request-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/server-data-source/document-tree.server.request-manager.ts
@@ -2,7 +2,10 @@
 
 import type { UmbDocumentTreeChildrenOfRequestArgs, UmbDocumentTreeRootItemsRequestArgs } from '../types.js';
 import { DocumentService } from '@umbraco-cms/backoffice/external/backend-api';
-import { UmbManagementApiTreeDataRequestManager } from '@umbraco-cms/backoffice/management-api';
+import {
+	UmbManagementApiInFlightRequestCache,
+	UmbManagementApiTreeDataRequestManager,
+} from '@umbraco-cms/backoffice/management-api';
 import type {
 	DocumentTreeItemResponseModel,
 	PagedDocumentTreeItemResponseModel,
@@ -41,6 +44,8 @@ export class UmbManagementApiDocumentTreeDataRequestManager extends UmbManagemen
 	UmbManagementApiDocumentTreeSiblingsFromRequestArgs,
 	SubsetDocumentTreeItemResponseModel
 > {
+	static #inflightRequestCache = new UmbManagementApiInFlightRequestCache<unknown>();
+
 	constructor(host: UmbControllerHost) {
 		super(host, {
 			getRootItems: (args) =>
@@ -78,6 +83,8 @@ export class UmbManagementApiDocumentTreeDataRequestManager extends UmbManagemen
 						after: args.paging.takeAfter,
 					},
 				}),
+
+			inflightRequestCache: UmbManagementApiDocumentTreeDataRequestManager.#inflightRequestCache,
 		});
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/tree/tree-data.request-manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/tree/tree-data.request-manager.test.ts
@@ -1,0 +1,106 @@
+import { UmbManagementApiTreeDataRequestManager } from './tree-data.request-manager.js';
+import type {
+	UmbManagementApiTreeAncestorsOfRequestArgs,
+	UmbManagementApiTreeChildrenOfRequestArgs,
+	UmbManagementApiTreeRootItemsRequestArgs,
+	UmbManagementApiTreeSiblingsFromRequestArgs,
+} from './types.js';
+import { UmbManagementApiInFlightRequestCache } from '../inflight-request/cache.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+
+interface TestTreeItemModel {
+	parent?: { id: string } | null;
+}
+
+@customElement('test-tree-request-manager-host')
+class UmbTestTreeRequestManagerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbManagementApiTreeDataRequestManager', () => {
+	let hostElement: UmbTestTreeRequestManagerHostElement;
+	let inflightRequestCache: UmbManagementApiInFlightRequestCache<unknown>;
+	let manager:
+		| UmbManagementApiTreeDataRequestManager<
+				TestTreeItemModel,
+				UmbManagementApiTreeRootItemsRequestArgs,
+				{ items: Array<TestTreeItemModel>; total: number },
+				UmbManagementApiTreeChildrenOfRequestArgs,
+				{ items: Array<TestTreeItemModel>; total: number },
+				UmbManagementApiTreeAncestorsOfRequestArgs,
+				Array<TestTreeItemModel>,
+				UmbManagementApiTreeSiblingsFromRequestArgs,
+				{ items: Array<TestTreeItemModel>; totalBefore: number; totalAfter: number }
+		  >
+		| undefined;
+
+	const createManager = (
+		getRootItems: (args: UmbManagementApiTreeRootItemsRequestArgs) => Promise<{
+			data: { items: Array<TestTreeItemModel>; total: number };
+		}>,
+		options?: { withInflightCache?: boolean },
+	) =>
+		new UmbManagementApiTreeDataRequestManager(hostElement, {
+			getRootItems,
+			getChildrenOf: async () => ({ data: { items: [], total: 0 } }),
+			getAncestorsOf: async () => ({ data: [] }),
+			getSiblingsFrom: async () => ({ data: { items: [], totalBefore: 0, totalAfter: 0 } }),
+			inflightRequestCache: options?.withInflightCache === false ? undefined : inflightRequestCache,
+		});
+
+	beforeEach(() => {
+		hostElement = new UmbTestTreeRequestManagerHostElement();
+		document.body.appendChild(hostElement);
+		inflightRequestCache = new UmbManagementApiInFlightRequestCache<unknown>();
+	});
+
+	afterEach(() => {
+		manager?.destroy();
+		manager = undefined;
+		document.body.innerHTML = '';
+	});
+
+	it('coalesces concurrent identical root requests into a single underlying call', async () => {
+		let callCount = 0;
+		manager = createManager(async () => {
+			callCount++;
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			return { data: { items: [], total: 0 } };
+		});
+
+		const [first, second] = await Promise.all([manager.getRootItems({}), manager.getRootItems({})]);
+
+		expect(callCount).to.equal(1);
+		expect(first.data).to.deep.equal(second.data);
+	});
+
+	it('removes the in-flight entry once settled so a later identical call fetches again', async () => {
+		let callCount = 0;
+		manager = createManager(async () => {
+			callCount++;
+			return { data: { items: [], total: 0 } };
+		});
+
+		await manager.getRootItems({});
+		await manager.getRootItems({});
+
+		expect(callCount).to.equal(2);
+		expect(inflightRequestCache.has(`root:${JSON.stringify({ paging: { skip: 0, take: 50 } })}`)).to.be.false;
+	});
+
+	it('does not coalesce when no in-flight cache is provided', async () => {
+		let callCount = 0;
+		manager = createManager(
+			async () => {
+				callCount++;
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				return { data: { items: [], total: 0 } };
+			},
+			{ withInflightCache: false },
+		);
+
+		await Promise.all([manager.getRootItems({}), manager.getRootItems({})]);
+
+		expect(callCount).to.equal(2);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/tree/tree-data.request-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/tree/tree-data.request-manager.ts
@@ -4,6 +4,7 @@ import type {
 	UmbManagementApiTreeRootItemsRequestArgs,
 	UmbManagementApiTreeSiblingsFromRequestArgs,
 } from './types.js';
+import type { UmbManagementApiInFlightRequestCache } from '../inflight-request/cache.js';
 import { isOffsetPaginationRequest, isTargetPaginationRequest } from '@umbraco-cms/backoffice/utils';
 import { tryExecute, UmbError, type UmbApiResponse } from '@umbraco-cms/backoffice/resources';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
@@ -33,6 +34,7 @@ export interface UmbManagementApiTreeDataRequestManagerArgs<
 	getSiblingsFrom: (
 		args: SiblingsFromRequestArgsType,
 	) => Promise<UmbApiResponse<{ data?: SiblingsFromDataResponseType }>>;
+	inflightRequestCache?: UmbManagementApiInFlightRequestCache<unknown>;
 }
 
 export class UmbManagementApiTreeDataRequestManager<
@@ -50,6 +52,7 @@ export class UmbManagementApiTreeDataRequestManager<
 	#getChildrenOf;
 	#getAncestorsOf;
 	#getSiblingsFrom;
+	#inflightRequestCache?: UmbManagementApiInFlightRequestCache<unknown>;
 	#defaultTakeSize = 50;
 
 	constructor(
@@ -71,6 +74,30 @@ export class UmbManagementApiTreeDataRequestManager<
 		this.#getChildrenOf = args.getChildrenOf;
 		this.#getAncestorsOf = args.getAncestorsOf;
 		this.#getSiblingsFrom = args.getSiblingsFrom;
+		this.#inflightRequestCache = args.inflightRequestCache;
+	}
+
+	// Coalesces concurrent identical requests so multiple consumers (tree menu,
+	// breadcrumb structure, pickers) share one in-flight call instead of each
+	// fetching the same data. In-flight only — the entry is removed once it settles.
+	async #coalesce<ResultType>(key: string, request: () => Promise<ResultType>): Promise<ResultType> {
+		const cache = this.#inflightRequestCache;
+		if (!cache) {
+			return request();
+		}
+
+		const existing = cache.get(key)?.requestPromise as Promise<ResultType> | undefined;
+		if (existing) {
+			return existing;
+		}
+
+		const promise = request();
+		cache.set(key, promise as Promise<UmbApiResponse<{ data?: unknown }>>);
+		try {
+			return await promise;
+		} finally {
+			cache.delete(key);
+		}
 	}
 
 	async getRootItems(args: UmbTreeRootItemsRequestArgs) {
@@ -96,7 +123,10 @@ export class UmbManagementApiTreeDataRequestManager<
 				},
 			} as SiblingsFromRequestArgsType;
 
-			const { data: responseData, error: responseError } = await tryExecute(this, this.#getSiblingsFrom(requestArgs));
+			const { data: responseData, error: responseError } = await this.#coalesce(
+				`siblings:${JSON.stringify(requestArgs)}`,
+				() => tryExecute(this, this.#getSiblingsFrom(requestArgs)),
+			);
 
 			if (responseError) {
 				return { data: undefined, error: responseError };
@@ -116,7 +146,9 @@ export class UmbManagementApiTreeDataRequestManager<
 			},
 		} as RootItemsRequestArgsType;
 
-		const { data, error } = await tryExecute(this, this.#getRootItems(requestArgs));
+		const { data, error } = await this.#coalesce(`root:${JSON.stringify(requestArgs)}`, () =>
+			tryExecute(this, this.#getRootItems(requestArgs)),
+		);
 
 		const mappedData = data
 			? {
@@ -159,7 +191,10 @@ export class UmbManagementApiTreeDataRequestManager<
 				},
 			} as unknown as SiblingsFromRequestArgsType;
 
-			const { data: responseData, error: responseError } = await tryExecute(this, this.#getSiblingsFrom(requestArgs));
+			const { data: responseData, error: responseError } = await this.#coalesce(
+				`siblings:${JSON.stringify(requestArgs)}`,
+				() => tryExecute(this, this.#getSiblingsFrom(requestArgs)),
+			);
 
 			if (responseError) {
 				return { data: undefined, error: responseError };
@@ -184,7 +219,9 @@ export class UmbManagementApiTreeDataRequestManager<
 			},
 		} as ChildrenOfRequestArgsType;
 
-		const { data, error } = await tryExecute(this, this.#getChildrenOf(requestArgs));
+		const { data, error } = await this.#coalesce(`children:${JSON.stringify(requestArgs)}`, () =>
+			tryExecute(this, this.#getChildrenOf(requestArgs)),
+		);
 
 		const mappedData = data
 			? {
@@ -204,7 +241,9 @@ export class UmbManagementApiTreeDataRequestManager<
 			treeItem: args.treeItem,
 		} as AncestorsOfRequestArgsType;
 
-		return tryExecute(this, this.#getAncestorsOf(requestArgs));
+		return this.#coalesce(`ancestors:${JSON.stringify(requestArgs)}`, () =>
+			tryExecute(this, this.#getAncestorsOf(requestArgs)),
+		);
 	}
 
 	#getSkipFromArgs(args: UmbTreeRootItemsRequestArgs | UmbTreeChildrenOfRequestArgs): number {

--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/tree/tree-data.request-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/tree/tree-data.request-manager.ts
@@ -1,10 +1,10 @@
+import type { UmbManagementApiInFlightRequestCache } from '../inflight-request/cache.js';
 import type {
 	UmbManagementApiTreeAncestorsOfRequestArgs,
 	UmbManagementApiTreeChildrenOfRequestArgs,
 	UmbManagementApiTreeRootItemsRequestArgs,
 	UmbManagementApiTreeSiblingsFromRequestArgs,
 } from './types.js';
-import type { UmbManagementApiInFlightRequestCache } from '../inflight-request/cache.js';
 import { isOffsetPaginationRequest, isTargetPaginationRequest } from '@umbraco-cms/backoffice/utils';
 import { tryExecute, UmbError, type UmbApiResponse } from '@umbraco-cms/backoffice/resources';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
@@ -34,6 +34,10 @@ export interface UmbManagementApiTreeDataRequestManagerArgs<
 	getSiblingsFrom: (
 		args: SiblingsFromRequestArgsType,
 	) => Promise<UmbApiResponse<{ data?: SiblingsFromDataResponseType }>>;
+	/**
+	 * Optional in-flight deduplication cache. When provided, concurrent identical requests
+	 * share a single in-flight call instead of each hitting the network independently.
+	 */
 	inflightRequestCache?: UmbManagementApiInFlightRequestCache<unknown>;
 }
 
@@ -77,22 +81,24 @@ export class UmbManagementApiTreeDataRequestManager<
 		this.#inflightRequestCache = args.inflightRequestCache;
 	}
 
-	// Coalesces concurrent identical requests so multiple consumers (tree menu,
-	// breadcrumb structure, pickers) share one in-flight call instead of each
-	// fetching the same data. In-flight only — the entry is removed once it settles.
-	async #coalesce<ResultType>(key: string, request: () => Promise<ResultType>): Promise<ResultType> {
+	// In-flight only — dedupes concurrent identical requests; entry removed on settle.
+	async #coalesce<ResultType extends UmbApiResponse<{ data?: unknown }>>(
+		keyFactory: () => string,
+		request: () => Promise<ResultType>,
+	): Promise<ResultType> {
 		const cache = this.#inflightRequestCache;
 		if (!cache) {
 			return request();
 		}
 
+		const key = keyFactory();
 		const existing = cache.get(key)?.requestPromise as Promise<ResultType> | undefined;
 		if (existing) {
 			return existing;
 		}
 
 		const promise = request();
-		cache.set(key, promise as Promise<UmbApiResponse<{ data?: unknown }>>);
+		cache.set(key, promise);
 		try {
 			return await promise;
 		} finally {
@@ -124,7 +130,7 @@ export class UmbManagementApiTreeDataRequestManager<
 			} as SiblingsFromRequestArgsType;
 
 			const { data: responseData, error: responseError } = await this.#coalesce(
-				`siblings:${JSON.stringify(requestArgs)}`,
+				() => `siblings:${JSON.stringify(requestArgs)}`,
 				() => tryExecute(this, this.#getSiblingsFrom(requestArgs)),
 			);
 
@@ -146,8 +152,9 @@ export class UmbManagementApiTreeDataRequestManager<
 			},
 		} as RootItemsRequestArgsType;
 
-		const { data, error } = await this.#coalesce(`root:${JSON.stringify(requestArgs)}`, () =>
-			tryExecute(this, this.#getRootItems(requestArgs)),
+		const { data, error } = await this.#coalesce(
+			() => `root:${JSON.stringify(requestArgs)}`,
+			() => tryExecute(this, this.#getRootItems(requestArgs)),
 		);
 
 		const mappedData = data
@@ -192,7 +199,7 @@ export class UmbManagementApiTreeDataRequestManager<
 			} as unknown as SiblingsFromRequestArgsType;
 
 			const { data: responseData, error: responseError } = await this.#coalesce(
-				`siblings:${JSON.stringify(requestArgs)}`,
+				() => `siblings:${JSON.stringify(requestArgs)}`,
 				() => tryExecute(this, this.#getSiblingsFrom(requestArgs)),
 			);
 
@@ -219,8 +226,9 @@ export class UmbManagementApiTreeDataRequestManager<
 			},
 		} as ChildrenOfRequestArgsType;
 
-		const { data, error } = await this.#coalesce(`children:${JSON.stringify(requestArgs)}`, () =>
-			tryExecute(this, this.#getChildrenOf(requestArgs)),
+		const { data, error } = await this.#coalesce(
+			() => `children:${JSON.stringify(requestArgs)}`,
+			() => tryExecute(this, this.#getChildrenOf(requestArgs)),
 		);
 
 		const mappedData = data
@@ -241,8 +249,9 @@ export class UmbManagementApiTreeDataRequestManager<
 			treeItem: args.treeItem,
 		} as AncestorsOfRequestArgsType;
 
-		return this.#coalesce(`ancestors:${JSON.stringify(requestArgs)}`, () =>
-			tryExecute(this, this.#getAncestorsOf(requestArgs)),
+		return this.#coalesce(
+			() => `ancestors:${JSON.stringify(requestArgs)}`,
+			() => tryExecute(this, this.#getAncestorsOf(requestArgs)),
 		);
 	}
 


### PR DESCRIPTION
## What

The backoffice tree data request manager (`UmbManagementApiTreeDataRequestManager`) hit the network on **every** call, with no in-flight dedup. So multiple concurrent consumers of the same tree — the sidebar tree, the breadcrumb/menu-structure context, pickers — each fired their own request. A document-workspace load fires **`tree/document/root` three times**, plus duplicate children/ancestors fetches.

This applies the **existing** `UmbManagementApiInFlightRequestCache` — already used by the `item` and `detail` request managers (webhook, language, user, templating, data-type, …) via a `static #inflightRequestCache` — to the tree request manager. Concurrent identical `root`/`children`/`ancestors`/`siblings` requests now share a single in-flight call.

## Why

On localhost the duplicates are ~14 ms each (invisible); on high-latency hosts (e.g. Cloud) each is a full ~150 ms round-trip on the document-load critical path. This is the same dedup the item/detail managers already get — the tree manager was simply the one place the pattern was never applied.

## Design

- **In-flight only.** The cache entry is removed once the promise settles (`finally`), so it coalesces *concurrent* requests and never serves stale data. No cache invalidation concerns.
- **Behind the existing seam.** No public/extension API change — consumers still call `requestTreeRootItems` etc.
- **Opt-in per tree.** The base accepts an optional `inflightRequestCache`; only the **document** tree wires the shared `static` cache in this PR. Other trees (media, members, data-types…) are unchanged until they pass one — a natural, low-risk follow-up.

## How to test

1. Open a document workspace; observe the network panel — `tree/document/root` should fire **once** instead of three times.
2. Expand/collapse tree nodes and confirm tree behaviour is unchanged (data still loads, pagination/siblings still work).

## Notes / follow-ups

- No unit tests added yet — the coalescing helper is a good candidate for a focused concurrency test (two simultaneous `getRootItems` → one underlying call). Happy to add if wanted.
- Wiring the same shared cache into the other trees (media/members/etc.) is a trivial follow-up that removes their duplicates too.
- Part of the backoffice boot/load perf work; independent of the boot-parallelization PR.

Related to #21152 

🤖 Generated with [Claude Code](https://claude.com/claude-code)