### PR TITLE
Management API: Declare `multipart/form-data` on the Create Temporary File endpoint (closes #23017)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/CreateTemporaryFileController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/TemporaryFile/CreateTemporaryFileController.cs
@@ -32,6 +32,7 @@ public class CreateTemporaryFileController : TemporaryFileControllerBase
 
     [HttpPost("")]
     [MapToApiVersion("1.0")]
+    [Consumes("multipart/form-data")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [EndpointSummary("Creates a temporary file.")]

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -33430,7 +33430,7 @@
         "operationId": "PostTemporaryFile",
         "requestBody": {
           "content": {
-            "application/x-www-form-urlencoded": {
+            "multipart/form-data": {
               "schema": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
## Description

`POST /umbraco/management/api/v1/temporary-file` accepts an `IFormFile`, but the generated OpenAPI document declared its request body as `application/x-www-form-urlencoded`. A binary file upload can only be carried by `multipart/form-data`, so the endpoint could not be exercised from the OpenAPI ("Try it out") UI — it returned a 400 or a 500 depending on the uploaded file.

The fix adds `[Consumes("multipart/form-data")]` to the create action. Umbraco's existing `MimeTypesTransformer` already honours `[Consumes]`, so the request body content type is now emitted as `multipart/form-data` (the `{ Id, File }` schema is unchanged). `OpenApi.json` is regenerated accordingly.

Fixes #23017

### Why this regressed since v17

v17 generated the OpenAPI document with **Swashbuckle**, which defaults any `[FromForm]` request body to `multipart/form-data` when no `[Consumes]` attribute is present — it never defaults form bodies to `application/x-www-form-urlencoded`. This is verified by v17's own committed `OpenApi.json` (`release/17.5.0`), which declares `multipart/form-data` for this endpoint.

v18 generates the document with **`Microsoft.AspNetCore.OpenApi`**. Its `[ApiController]` multipart inference only fires when `IFormFile` is a **top-level action parameter**. Here the file is a property of `CreateTemporaryFileRequestModel`, so the inference does not trigger and the generator falls back to the `[FromForm]` default of `application/x-www-form-urlencoded`. Adding `[Consumes("multipart/form-data")]` makes the content type explicit under either generator.

### How to reproduce (before the fix)

1. Run Umbraco, open `/umbraco/openapi/`, select the Management API, and expand `POST /temporary-file` → "Try it out".
2. Provide an `Id` (any GUID) and select a file, then Execute. Swagger sends the file under a forced `application/x-www-form-urlencoded` header, so the server parses the multipart bytes as URL-encoded form keys:
   - **400** `One or more validation errors occurred. — "$.file": ["The File field is required."]`
     Occurs for a simple file whose bytes contain no `&` (e.g. a small text file containing `hello` or a simple image).
   - **500** `The key 'File[...' is invalid JQuery syntax because it is missing a closing bracket.`
     Occurs when the uploaded bytes contain a `&` followed by a `[` — i.e. the mis-parsed form data yields a key with an unbalanced bracket, which `JQueryKeyValuePairNormalizer` rejects. A minimal text file containing `hello&File[world` reproduces it deterministically.

Both errors share one root cause: the file is never transmitted as binary because the declared content type is wrong.

## Testing

1. Rebuild and run; confirm `/umbraco/openapi/management.json` now shows `multipart/form-data` for `POST /temporary-file`:
   ```
   "requestBody": { "content": { "multipart/form-data": { "schema": { ... "File": { "format": "binary" } } } } }
   ```
2. In "Try it out", upload any file (including the `hello&File[world` file that previously produced the 500) → **201 Created** with a `Location`/`Umb-Generated-Resource` header pointing at the new temporary file.

3. Verify a media upload from the backoffice still works.