### PR TITLE
Background Jobs: Resolve server role so recurring jobs run when no application URL is configured

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/bs.xml
@@ -405,7 +405,8 @@
 	    0: Comma delimitted list of failed folder paths
   	-->
     <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' je postavljen na <strong>%0%</strong>.]]></key>
-    <key alias="umbracoApplicationUrlCheckResultFalse">AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' nije postavljen.</key>
+    <key alias="umbracoApplicationUrlCheckResultFalse"><![CDATA[AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' nije postavljen, pa će se URL aplikacije automatski otkriti iz dolaznih zahtjeva. Preporučuje se da ga postavite izričito.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultError"><![CDATA[AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' nije postavljen, a automatsko otkrivanje URL-a aplikacije je onemogućeno ('Umbraco:CMS:WebRouting:ApplicationUrlDetection' je 'None'). Značajke koje zahtijevaju apsolutni URL, poput e-pošte za poništavanje lozinke i pozivnica, neće raditi. Postavite URL aplikacije izričito ili omogućite automatsko otkrivanje.]]></key>
     <!-- The following key get these tokens passed in:
 	    0: Comma delimitted list of headers found
   	-->

--- a/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/cy.xml
@@ -454,7 +454,8 @@
     <key alias="httpsCheckConfigurationRectifyNotPossible">Mae gosodiad ap 'Umbraco:CMS:Global:UseHttps' wedi'i osod i 'false' yn eich ffeil appSettings.json. Unwaith y byddwch yn cyrchu'r wefan hon gan ddefnyddio'r cynllun HTTPS, dylid gosod hwnnw i 'true'.</key>
     <key alias="httpsCheckConfigurationCheckResult">Mae'r gosodiad ap 'Umbraco:CMS:Global:UseHttps' wedi'i osod i '%0%' yn eich ffeil appSettings.json, mae eich cwcis %1% wedi'u marcio'n ddiogel.</key>
     <key alias="umbracoApplicationUrlCheckResultTrue">Mae gosodiad yr ap 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' wedi'i osod i <strong>%0%</strong>.</key>
-    <key alias="umbracoApplicationUrlCheckResultFalse">Nid yw gosodiad ap 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' wedi'i osod.</key>
+    <key alias="umbracoApplicationUrlCheckResultFalse"><![CDATA[Nid yw gosodiad ap 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' wedi'i osod, felly bydd URL y rhaglen yn cael ei ganfod yn awtomatig o geisiadau sy'n dod i mewn. Argymhellir ei osod yn benodol.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultError"><![CDATA[Nid yw gosodiad ap 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' wedi'i osod ac mae canfod URL y rhaglen yn awtomatig wedi'i analluogi (mae 'Umbraco:CMS:WebRouting:ApplicationUrlDetection' yn 'None'). Ni fydd nodweddion sydd angen URL absoliwt, fel e-byst ailosod cyfrinair a gwahoddiadau, yn gweithio. Gosodwch URL y rhaglen yn benodol, neu galluogwch ganfod yn awtomatig.]]></key>
     <key alias="smtpMailSettingsNotFound">Nid oedd modd dod o hyd i'r ffurfweddiad 'Umbraco:CMS:Global:Smtp'.</key>
     <key alias="smtpMailSettingsHostNotConfigured">Nid oedd modd dod o hyd i'r ffurfweddiad 'Umbraco:CMS:Global:Smtp:Host'.</key>
     <key alias="smtpMailSettingsConnectionFail">Methwyd cyrraedd y gweinydd SMTP a ffurfweddwyd gyda gwesteiwr '%0%' a phorth '%1%'. Gwiriwch i sicrhau bod y gosodiadau SMTP yn y ffurfweddiad 'Umbraco:CMS:Global:Smtp' yn gywir.</key>

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en.xml
@@ -463,7 +463,8 @@
 	    0: Comma delimitted list of failed folder paths
   	-->
     <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is set to <strong>%0%</strong>.]]></key>
-    <key alias="umbracoApplicationUrlCheckResultFalse">The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set.</key>
+    <key alias="umbracoApplicationUrlCheckResultFalse"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set, so the application URL will be auto-detected from incoming requests. Setting it explicitly is recommended.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultError"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set and application URL auto-detection is disabled ('Umbraco:CMS:WebRouting:ApplicationUrlDetection' is 'None'). Features that require an absolute URL, such as password reset and invitation emails, will not work. Set the application URL explicitly, or enable auto-detection.]]></key>
     <!-- The following key get these tokens passed in:
 	    0: Comma delimitted list of headers found
   	-->

--- a/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/en_us.xml
@@ -452,7 +452,8 @@
 	    0: Comma delimitted list of failed folder paths
   	-->
     <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is set to <strong>%0%</strong>.]]></key>
-    <key alias="umbracoApplicationUrlCheckResultFalse">The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set.</key>
+    <key alias="umbracoApplicationUrlCheckResultFalse"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set, so the application URL will be auto-detected from incoming requests. Setting it explicitly is recommended.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultError"><![CDATA[The appSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' is not set and application URL auto-detection is disabled ('Umbraco:CMS:WebRouting:ApplicationUrlDetection' is 'None'). Features that require an absolute URL, such as password reset and invitation emails, will not work. Set the application URL explicitly, or enable auto-detection.]]></key>
     <key alias="clickJackingCheckHeaderFound">
       <![CDATA[The header or meta-tag <strong>X-Frame-Options</strong> used to control whether a site can be IFRAMEd by another was found.]]></key>
     <key alias="clickJackingCheckHeaderNotFound">

--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -403,7 +403,8 @@
 	    0: Comma delimitted list of failed folder paths
   	-->
     <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' je postavljen na <strong>%0%</strong>.]]></key>
-    <key alias="umbracoApplicationUrlCheckResultFalse">AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' nije postavljen.</key>
+    <key alias="umbracoApplicationUrlCheckResultFalse"><![CDATA[AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' nije postavljen, pa će se URL aplikacije automatski otkriti iz dolaznih zahtjeva. Preporučuje se da ga postavite izričito.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultError"><![CDATA[AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' nije postavljen, a automatsko otkrivanje URL-a aplikacije je onemogućeno ('Umbraco:CMS:WebRouting:ApplicationUrlDetection' je 'None'). Značajke koje zahtijevaju apsolutni URL, poput e-pošte za poništavanje lozinke i pozivnica, neće raditi. Postavite URL aplikacije izričito ili omogućite automatsko otkrivanje.]]></key>
     <!-- The following key get these tokens passed in:
 	    0: Comma delimitted list of headers found
   	-->

--- a/src/Umbraco.Core/HealthChecks/Checks/Security/UmbracoApplicationUrlCheck.cs
+++ b/src/Umbraco.Core/HealthChecks/Checks/Security/UmbracoApplicationUrlCheck.cs
@@ -44,28 +44,34 @@ public class UmbracoApplicationUrlCheck : HealthCheck
 
     private HealthCheckStatus CheckUmbracoApplicationUrl()
     {
-        var url = _webRoutingSettings.CurrentValue.UmbracoApplicationUrl;
+        WebRoutingSettings settings = _webRoutingSettings.CurrentValue;
+        var url = settings.UmbracoApplicationUrl;
 
         string resultMessage;
         StatusResultType resultType;
-        var success = false;
 
-        if (url.IsNullOrWhiteSpace())
+        if (url.IsNullOrWhiteSpace() is false)
         {
-            resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultFalse");
-            resultType = StatusResultType.Warning;
+            resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultTrue", [url]);
+            resultType = StatusResultType.Success;
+        }
+        else if (settings.ApplicationUrlDetection == ApplicationUrlDetection.None)
+        {
+            // No explicit URL and auto-detection is disabled, so the application URL can never be established.
+            // Features that require an absolute URL (e.g. password reset and invitation emails) will not work.
+            resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultError");
+            resultType = StatusResultType.Error;
         }
         else
         {
-            resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultTrue", new[] { url });
-            resultType = StatusResultType.Success;
-            success = true;
+            resultMessage = _textService.Localize("healthcheck", "umbracoApplicationUrlCheckResultFalse");
+            resultType = StatusResultType.Warning;
         }
 
         return new HealthCheckStatus(resultMessage)
         {
             ResultType = resultType,
-            ReadMoreLink = success
+            ReadMoreLink = resultType == StatusResultType.Success
                 ? null
                 : Constants.HealthChecks.DocumentationLinks.Security.UmbracoApplicationUrlCheck,
         };

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
@@ -84,8 +84,19 @@ public class TouchServerJob : RecurringBackgroundJobBase
         var serverAddress = _hostingEnvironment.ApplicationMainUrl?.ToString();
         if (string.IsNullOrWhiteSpace(serverAddress))
         {
-            _logger.LogWarning("No umbracoApplicationUrl for service (yet), skip.");
-            return Task.CompletedTask;
+            // No application URL is known yet: either detection is off (WebRouting:ApplicationUrlDetection is
+            // None with no UmbracoApplicationUrl set), or detection is on but no request has been served yet.
+            // Register with the machine name as a placeholder so server-role election can still proceed (uniqueness
+            // comes from the server identity, not this address). If a URL is later detected from a request, the next
+            // touch overwrites the placeholder.
+            serverAddress = Environment.MachineName;
+            _logger.LogDebug(
+                "No application URL available; registering server with placeholder address {ServerAddress}.",
+                serverAddress);
+        }
+        else
+        {
+            _logger.LogDebug("Registering server with application URL {ServerAddress}.", serverAddress);
         }
 
         try

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/BackgroundJobs/TouchServerJobTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/BackgroundJobs/TouchServerJobTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.ServerRegistration;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.BackgroundJobs;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class TouchServerJobTests : UmbracoIntegrationTest
+{
+    private const string ApplicationUrl = "https://example.com/";
+
+    private IServerRegistrationService ServerRegistrationService => GetRequiredService<IServerRegistrationService>();
+
+    [Test]
+    public async Task RunJobAsync_With_No_Application_Url_Registers_Server_And_Resolves_Role_To_Single()
+    {
+        // No application URL is available, so the job has to fall back to a placeholder address.
+        TouchServerJob job = CreateJob(ApplicationMainUrl(null));
+
+        // Before the job runs nothing has been registered, so the role cannot be determined.
+        Assert.AreEqual(ServerRole.Unknown, ServerRegistrationService.GetCurrentServerRole());
+
+        await job.RunJobAsync(CancellationToken.None);
+
+        // The server is registered despite having no application URL, so election resolves the role to Single.
+        Assert.AreEqual(ServerRole.Single, ServerRegistrationService.GetCurrentServerRole());
+
+        IServerRegistration[] activeServers = ServerRegistrationService.GetActiveServers(refresh: true).ToArray();
+        Assert.That(activeServers, Has.Length.EqualTo(1));
+        Assert.AreEqual(Environment.MachineName, activeServers[0].ServerAddress);
+    }
+
+    [Test]
+    public async Task RunJobAsync_With_Application_Url_Registers_Server_With_That_Url()
+    {
+        TouchServerJob job = CreateJob(ApplicationMainUrl(new Uri(ApplicationUrl)));
+
+        await job.RunJobAsync(CancellationToken.None);
+
+        Assert.AreEqual(ServerRole.Single, ServerRegistrationService.GetCurrentServerRole());
+
+        IServerRegistration[] activeServers = ServerRegistrationService.GetActiveServers(refresh: true).ToArray();
+        Assert.That(activeServers, Has.Length.EqualTo(1));
+        Assert.AreEqual(ApplicationUrl, activeServers[0].ServerAddress);
+    }
+
+    [Test]
+    public async Task RunJobAsync_Replaces_Placeholder_With_Real_Url_Once_It_Becomes_Available()
+    {
+        // The application URL is not known on the first touch (e.g. detection is on but no request has arrived yet),
+        // but becomes available later (e.g. detected from a request).
+        Uri? applicationMainUrl = null;
+        var hostingEnvironment = new Mock<IHostingEnvironment>();
+        hostingEnvironment.SetupGet(x => x.ApplicationMainUrl).Returns(() => applicationMainUrl);
+        TouchServerJob job = CreateJob(hostingEnvironment.Object);
+
+        await job.RunJobAsync(CancellationToken.None);
+
+        // First touch: registered with the placeholder.
+        Assert.AreEqual(
+            Environment.MachineName,
+            ServerRegistrationService.GetActiveServers(refresh: true).Single().ServerAddress);
+
+        applicationMainUrl = new Uri(ApplicationUrl);
+        await job.RunJobAsync(CancellationToken.None);
+
+        // Second touch: the same (single) registration now holds the real URL, and the role is still Single.
+        IServerRegistration[] activeServers = ServerRegistrationService.GetActiveServers(refresh: true).ToArray();
+        Assert.That(activeServers, Has.Length.EqualTo(1));
+        Assert.AreEqual(ApplicationUrl, activeServers[0].ServerAddress);
+        Assert.AreEqual(ServerRole.Single, ServerRegistrationService.GetCurrentServerRole());
+    }
+
+    private static IHostingEnvironment ApplicationMainUrl(Uri? url)
+    {
+        var hostingEnvironment = new Mock<IHostingEnvironment>();
+        hostingEnvironment.SetupGet(x => x.ApplicationMainUrl).Returns(url);
+        return hostingEnvironment.Object;
+    }
+
+    private TouchServerJob CreateJob(IHostingEnvironment hostingEnvironment) => new(
+        ServerRegistrationService,
+        hostingEnvironment,
+        GetRequiredService<ILogger<TouchServerJob>>(),
+        GetRequiredService<IOptionsMonitor<GlobalSettings>>(),
+        new ElectedServerRoleAccessor(ServerRegistrationService));
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/HealthChecks/UmbracoApplicationUrlCheckTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/HealthChecks/UmbracoApplicationUrlCheckTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Globalization;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.HealthChecks;
+using Umbraco.Cms.Core.HealthChecks.Checks.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.HealthChecks;
+
+[TestFixture]
+public class UmbracoApplicationUrlCheckTests
+{
+    // ILocalizedTextService.Localize is called via the extension Localize(area, alias) which delegates to
+    // Localize(area, alias, CultureInfo, IDictionary). We return the alias so tests can assert on which key was used.
+    private static ILocalizedTextService MockTextService()
+    {
+        var mock = new Mock<ILocalizedTextService>();
+        mock.Setup(x => x.Localize(
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CultureInfo?>(),
+                It.IsAny<IDictionary<string, string?>>()))
+            .Returns((string? _, string? alias, CultureInfo? _, IDictionary<string, string?> _) => alias ?? string.Empty);
+        return mock.Object;
+    }
+
+    private static UmbracoApplicationUrlCheck CreateCheck(string? url, ApplicationUrlDetection detection)
+    {
+        var settings = new WebRoutingSettings
+        {
+            UmbracoApplicationUrl = url!,
+            ApplicationUrlDetection = detection,
+        };
+
+        IOptionsMonitor<WebRoutingSettings> monitor = new TestOptionsMonitor<WebRoutingSettings>(settings);
+        return new UmbracoApplicationUrlCheck(MockTextService(), monitor);
+    }
+
+    [Test]
+    public async Task When_Url_Is_Configured_Returns_Success()
+    {
+        UmbracoApplicationUrlCheck check = CreateCheck("https://mysite.com/", ApplicationUrlDetection.None);
+
+        HealthCheckStatus status = (await check.GetStatusAsync()).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.ResultType, Is.EqualTo(StatusResultType.Success));
+            Assert.That(status.Message, Is.EqualTo("umbracoApplicationUrlCheckResultTrue"));
+            Assert.That(status.ReadMoreLink, Is.Null.Or.Empty);
+        });
+    }
+
+    [TestCase(ApplicationUrlDetection.FirstRequest)]
+    [TestCase(ApplicationUrlDetection.EveryRequest)]
+    public async Task When_Url_Is_Not_Configured_But_Detection_Is_Enabled_Returns_Warning(ApplicationUrlDetection detection)
+    {
+        UmbracoApplicationUrlCheck check = CreateCheck(null, detection);
+
+        HealthCheckStatus status = (await check.GetStatusAsync()).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.ResultType, Is.EqualTo(StatusResultType.Warning));
+            Assert.That(status.Message, Is.EqualTo("umbracoApplicationUrlCheckResultFalse"));
+            Assert.That(status.ReadMoreLink, Is.Not.Null.And.Not.Empty);
+        });
+    }
+
+    [Test]
+    public async Task When_Url_Is_Not_Configured_And_Detection_Is_None_Returns_Error()
+    {
+        UmbracoApplicationUrlCheck check = CreateCheck(null, ApplicationUrlDetection.None);
+
+        HealthCheckStatus status = (await check.GetStatusAsync()).Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status.ResultType, Is.EqualTo(StatusResultType.Error));
+            Assert.That(status.Message, Is.EqualTo("umbracoApplicationUrlCheckResultError"));
+            Assert.That(status.ReadMoreLink, Is.Not.Null.And.Not.Empty);
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
@@ -24,18 +24,18 @@ public class TouchServerJobTests
 
 
     [Test]
-    public async Task Does_Not_Execute_When_Application_Url_Is_Not_Available()
+    public async Task Touches_Server_With_Placeholder_When_Application_Url_Is_Not_Available()
     {
         var sut = CreateTouchServerTask(applicationUrl: string.Empty);
-        await sut.RunJobAsync();
-        VerifyServerNotTouched();
+        await sut.RunJobAsync(CancellationToken.None);
+        VerifyServerTouchedWithPlaceholder();
     }
 
     [Test]
     public async Task Executes_And_Touches_Server()
     {
         var sut = CreateTouchServerTask();
-        await sut.RunJobAsync();
+        await sut.RunJobAsync(CancellationToken.None);
         VerifyServerTouched();
     }
 
@@ -43,14 +43,45 @@ public class TouchServerJobTests
     public async Task Does_Not_Execute_When_Role_Accessor_Is_Not_Elected()
     {
         var sut = CreateTouchServerTask(useElection: false);
-        await sut.RunJobAsync();
+        await sut.RunJobAsync(CancellationToken.None);
         VerifyServerNotTouched();
+    }
+
+    [Test]
+    public void Does_Not_Throw_When_Touching_The_Server_Fails()
+    {
+        var sut = CreateTouchServerTask();
+        _mockServerRegistrationService
+            .Setup(x => x.TouchServer(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+            .Throws(new InvalidOperationException("database unavailable"));
+
+        // A failure to touch the server must not bubble out and kill the recurring job loop.
+        Assert.DoesNotThrowAsync(() => sut.RunJobAsync(CancellationToken.None));
+    }
+
+    [Test]
+    public void Runs_On_All_Server_Roles()
+    {
+        var sut = CreateTouchServerTask();
+
+        // The touch job must run on every role (including Unknown/Subscriber); otherwise a server whose role
+        // has not yet been elected would never register itself and the role could never be determined.
+        CollectionAssert.AreEquivalent(Enum.GetValues<ServerRole>(), sut.ServerRoles);
+    }
+
+    [Test]
+    public void Period_Is_Configured_From_WaitTimeBetweenCalls()
+    {
+        var waitTimeBetweenCalls = TimeSpan.FromSeconds(42);
+        var sut = CreateTouchServerTask(waitTimeBetweenCalls: waitTimeBetweenCalls);
+        Assert.AreEqual(waitTimeBetweenCalls, sut.Period);
     }
 
     private TouchServerJob CreateTouchServerTask(
         RuntimeLevel runtimeLevel = RuntimeLevel.Run,
         string applicationUrl = ApplicationUrl,
-        bool useElection = true)
+        bool useElection = true,
+        TimeSpan? waitTimeBetweenCalls = null)
     {
         var mockRequestAccessor = new Mock<IHostingEnvironment>();
         mockRequestAccessor.SetupGet(x => x.ApplicationMainUrl)
@@ -65,7 +96,11 @@ public class TouchServerJobTests
 
         var settings = new GlobalSettings
         {
-            DatabaseServerRegistrar = new DatabaseServerRegistrarSettings { StaleServerTimeout = _staleServerTimeout },
+            DatabaseServerRegistrar = new DatabaseServerRegistrarSettings
+            {
+                StaleServerTimeout = _staleServerTimeout,
+                WaitTimeBetweenCalls = waitTimeBetweenCalls ?? TimeSpan.FromMinutes(1),
+            },
         };
 
         IServerRoleAccessor roleAccessor = useElection
@@ -90,4 +125,11 @@ public class TouchServerJobTests
                 It.Is<string>(y => y == ApplicationUrl),
                 It.Is<TimeSpan>(y => y == _staleServerTimeout)),
             times);
+
+    private void VerifyServerTouchedWithPlaceholder() => _mockServerRegistrationService
+        .Verify(
+            x => x.TouchServer(
+                It.Is<string>(y => y == Environment.MachineName),
+                It.Is<TimeSpan>(y => y == _staleServerTimeout)),
+            Times.Once());
 }


### PR DESCRIPTION
## Description

Since 17.4 ([#22307](https://github.com/umbraco/Umbraco-CMS/pull/22307)), `WebRouting:ApplicationUrlDetection` defaults to `None`. On a default install nothing sets `UmbracoApplicationUrl`, so `IHostingEnvironment.ApplicationMainUrl` stays `null`. `TouchServerJob` bailed out when that URL was `null`, so the server was never registered, the elected server role stayed `Unknown`, and recurring background jobs that run only on `Single`/`SchedulingPublisher` were silently skipped — including third‑party jobs such as Umbraco Automate's background processor.

This PR makes server‑role election work out of the box without an application URL, while keeping #22307's security hardening intact, and makes the misconfiguration much more visible.

> **Scope note:** Core's "scheduled" work (scheduled publishing, health‑check notifier, content‑version cleanup, etc.) is now implemented as `IDistributedBackgroundJob` and coordinated by a database lock (`DistributedBackgroundJobHostedService`) — it is **not** role‑gated, so it was not affected. The role gate only affects `RecurringBackgroundJob`s using the default `[Single, SchedulingPublisher]` roles, which today means third‑party jobs.

### Update 1 — `TouchServerJob` registers with a placeholder when no application URL is available

When `ApplicationMainUrl` is `null`/empty, the job now registers the server using a non‑URL placeholder (`Environment.MachineName`) instead of skipping, so election proceeds and the role resolves to `Single` out of the box. If a real URL is configured, or later detected from a request (`FirstRequest`/`EveryRequest`), the next touch already overwrites the placeholder with the real URL.

#### Why this appears safe — and why the old guard existed

Tracing the history the `null`‑URL guard originates from the [v7‑era commit](https://github.com/umbraco/Umbraco-CMS/commit/0f4436a465eabbdd76ad960422860b827a479c93) **U4‑5728: _"Do not run KeepAlive, ScheduledPublishing, without an url"_** (with a [sibling commit](https://github.com/umbraco/Umbraco-CMS/commit/b1d4a99510217cb3102c08473a1736798dbd53d9) noting jobs "run too soon" after boot). It was carried forward verbatim through every refactor since (#9353, #14291). So the guard doesn't seem to have been a data requirement for the address — rather it was:

1. a **boot‑readiness heuristic** ("no URL yet" ≈ "not finished booting"), which previously worked because auto‑detection was *guaranteed* to populate the URL on the first request; and
2. a genuine need for **KeepAlive**, which pinged the application's own URL.

Both reasons have since gone:

- **KeepAlive no longer exists**, so reason (2) is moot.
- The readiness concern (1) is now covered elsewhere in `RecurringBackgroundJobHostedService` (the `RuntimeLevel.Run` check, the start‑up delay, and the `MainDom` check).

The placeholder appears safe to use instead, because I can't find anything in the CMS, Management API, or backoffice reads the registration's `ServerAddress` to use it functionally — server identity, de-duplication and role election all key off `ServerIdentity` (machine name + application id), not the address.

Security is preserved: the placeholder is the machine name, never a request-derived value, and the emailed-link URL (`ApplicationMainUrl`) is untouched, so this does not reopen the forged-Host-header vector #22307 closed.

### Update 2 — `UmbracoApplicationUrlCheck` distinguishes "warning" from "error"

The health check previously returned `Success` (URL set) or `Warning` (URL not set). It now returns three states:

| Condition | Result |
| --- | --- |
| `UmbracoApplicationUrl` is set | **Success** |
| not set, but `ApplicationUrlDetection` ≠ `None` | **Warning** — relying on request‑based auto‑detection; setting it explicitly is recommended |
| not set **and** `ApplicationUrlDetection` = `None` | **Error** — no URL and nothing will ever detect one; features requiring an absolute URL (password‑reset and invitation emails) will not work |

This makes the genuinely‑broken configuration an error rather than a soft warning. Localization keys were added/reworded in `en` and `en_us`, and translated into the other languages that already had them (`bs`, `cy`, `hr`) to avoid a mixed‑language UI.

> **Reviewer note:** `HealthCheckResults` counts `Warning` as success but not `Error`, so for sites with health‑check email notifications enabled in `FailureOnly` mode, this case now triggers a notification where it previously did not. This is intended (it surfaces the misconfiguration) but is called out as a deliberate behavioural change.

## Testing

### Automated

Unit and integration tests have been added and updated to verify the functionality.

### Manual

To test I booted `Umbraco.Web.UI` six times across `{UmbracoApplicationUrl set / unset}` × `{None, FirstRequest, EveryRequest}` and confirmed the expected log lines. To verify a role‑gated recurring job actually runs once the role resolves, a temporary job using the **default** server roles was added:

```csharp
public class RoleCheckTestJob : RecurringBackgroundJobBase
{
    private readonly ILogger<RoleCheckTestJob> _logger;
    private readonly IServerRoleAccessor _serverRoleAccessor;

    public RoleCheckTestJob(ILogger<RoleCheckTestJob> logger, IServerRoleAccessor serverRoleAccessor)
        : base(TimeSpan.FromSeconds(10))
    {
        _logger = logger;
        _serverRoleAccessor = serverRoleAccessor;
    }

    public override TimeSpan Delay => TimeSpan.FromSeconds(20);

    // Intentionally does NOT override ServerRoles, so it uses the default [Single, SchedulingPublisher].

    public override Task RunJobAsync(CancellationToken cancellationToken)
    {
        _logger.LogInformation(
            "RoleCheckTestJob executed; current server role = {ServerRole}.",
            _serverRoleAccessor.CurrentServerRole);
        return Task.CompletedTask;
    }
}

public class RoleCheckTestJobComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.Services.AddRecurringBackgroundJob<RoleCheckTestJob>();
}
```

Enable debug logging for the affected namespace (the test job logs at `Information`, so it is visible by default):

```jsonc
"Serilog": {
  "MinimumLevel": {
    "Override": {
      "Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.ServerRegistration.TouchServerJob": "Debug"
    }
  }
}
```

**Expected output — no `UmbracoApplicationUrl`, `ApplicationUrlDetection: None`** (the previously‑broken case):

```
[DBG] No application URL available; registering server with placeholder address MYMACHINE.
[INF] RoleCheckTestJob executed; current server role = Single.
```

**Expected output — `UmbracoApplicationUrl` set (any detection mode):**

```
[DBG] Registering server with application URL https://localhost:44339/.
[INF] RoleCheckTestJob executed; current server role = Single.
```

**Expected output — no `UmbracoApplicationUrl`, `ApplicationUrlDetection: FirstRequest`/`EveryRequest`** (placeholder until a request arrives, then the detected URL):

```
[DBG] No application URL available; registering server with placeholder address MYMACHINE.
[INF] RoleCheckTestJob executed; current server role = Single.
... (after the first request) ...
[DBG] Registering server with application URL https://localhost:44339/.
```

For reference, before the fix the same broken case logged the old skip warning and the role‑gated job never executed:

```
[WRN] No umbracoApplicationUrl for service (yet), skip.
(no "RoleCheckTestJob executed" line — role stays Unknown)
```

## Documentation

The page linked from the health check's **Read more** button (https://umbra.co/healthchecks-umbraco-application-url) describes the old behaviour and should be updated to cover:

- The check now has **three** outcomes, not two: **Success** (URL configured), **Warning** (no URL but auto‑detection enabled — recommend setting it explicitly), and **Error** (no URL **and** `ApplicationUrlDetection: None`).
- That the **Error** state means absolute‑URL features (password‑reset and invitation emails) will not work, and how to resolve it: set `Umbraco:CMS:WebRouting:UmbracoApplicationUrl`, or set `Umbraco:CMS:WebRouting:ApplicationUrlDetection` to `FirstRequest`/`EveryRequest`.
- A cross‑reference to the [Application URL Detection](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/webroutingsettings#application-url-detection) settings docs.