### PR TITLE
E2E: QA Updated acceptance tests for removing the Element Picker from elements to reflect the recent changes

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/RedirectManagement.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/RedirectManagement.spec.ts
@@ -30,7 +30,9 @@ test.afterEach(async ({umbracoApi}) => {
   await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
 });
 
-test('can disable URL tracker', async ({umbracoApi, umbracoUi}) => {
+// On the latest version, the URL tracker will not be allowed through the UI, but the appsettings can be used to disable it.
+// Related PR: https://github.com/umbraco/Umbraco-CMS/pull/22830
+test.fixme('can disable URL tracker', async ({umbracoApi, umbracoUi}) => {
   // Act
   await umbracoUi.content.goToSection(ConstantHelper.sections.content);
   await umbracoUi.redirectManagement.clickRedirectManagementTab();
@@ -53,7 +55,9 @@ test('can disable URL tracker', async ({umbracoApi, umbracoUi}) => {
   expect(statusData.status).toBe(disableStatus);
 });
 
-test('can re-enable URL tracker', async ({umbracoApi, umbracoUi}) => {
+// On the latest version, the URL tracker will not be allowed through the UI, but the appsettings can be used to disable it.
+// Related PR: https://github.com/umbraco/Umbraco-CMS/pull/22830
+test.fixme('can re-enable URL tracker', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   await umbracoApi.redirectManagement.setStatus(disableStatus);
 

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementWithElementPicker.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Library/ElementWithElementPicker.spec.ts
@@ -209,7 +209,7 @@ test('can remove an element from the element picker in the element', async ({umb
   // Assert
   expect(await umbracoApi.element.doesNameExist(elementName)).toBeTruthy();
   const elementData = await umbracoApi.element.getByName(elementName);
-  expect(elementData.values[0].value).toEqual('');
+  expect(elementData.values).toEqual([]);
 });
 
 test('can remove a not-found element from the element picker in the element', async ({umbracoApi, umbracoUi}) => {
@@ -232,5 +232,5 @@ test('can remove a not-found element from the element picker in the element', as
   // Assert
   expect(await umbracoApi.element.doesNameExist(elementName)).toBeTruthy();
   const elementData = await umbracoApi.element.getByName(elementName);
-  expect(elementData.values[0].value).toEqual('');
+  expect(elementData.values).toEqual([]);
 });


### PR DESCRIPTION
This PR updates the tests for removing the Element Picker from elements to reflect the recent changes. It also adds comments to tests that are currently out of date due to the URL Tracker changes.