### PR TITLE
Document Recycle Bin: Checks user permission for Document "Read"

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/menu/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/menu/manifests.ts
@@ -1,6 +1,10 @@
 import { UMB_CONTENT_MENU_ALIAS } from '../../menu/manifests.js';
 import { UMB_DOCUMENT_RECYCLE_BIN_TREE_ALIAS } from '../constants.js';
-import { UMB_DOCUMENT_WORKSPACE_ALIAS } from '../../constants.js';
+import {
+	UMB_DOCUMENT_USER_PERMISSION_CONDITION_ALIAS,
+	UMB_DOCUMENT_WORKSPACE_ALIAS,
+	UMB_USER_PERMISSION_DOCUMENT_READ,
+} from '../../constants.js';
 import { UMB_DOCUMENT_RECYCLE_BIN_MENU_ITEM_ALIAS } from './constants.js';
 import { UMB_ENTITY_IS_TRASHED_CONDITION_ALIAS } from '@umbraco-cms/backoffice/recycle-bin';
 import { UMB_WORKSPACE_CONDITION_ALIAS } from '@umbraco-cms/backoffice/workspace';
@@ -21,6 +25,10 @@ export const manifests: Array<UmbExtensionManifest> = [
 		conditions: [
 			{
 				alias: 'Umb.Condition.CurrentUser.AllowDocumentRecycleBin',
+			},
+			{
+				alias: UMB_DOCUMENT_USER_PERMISSION_CONDITION_ALIAS,
+				allOf: [UMB_USER_PERMISSION_DOCUMENT_READ],
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/root/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/root/workspace/manifests.ts
@@ -1,3 +1,7 @@
+import {
+	UMB_DOCUMENT_USER_PERMISSION_CONDITION_ALIAS,
+	UMB_USER_PERMISSION_DOCUMENT_READ,
+} from '../../../user-permissions/constants.js';
 import { UMB_DOCUMENT_RECYCLE_BIN_TREE_ITEM_CHILDREN_COLLECTION_ALIAS } from '../../tree/constants.js';
 import { UMB_DOCUMENT_RECYCLE_BIN_ROOT_ENTITY_TYPE } from '../entity.js';
 import { UMB_DOCUMENT_RECYCLE_BIN_ROOT_WORKSPACE_ALIAS } from './constants.js';
@@ -29,6 +33,10 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: UMB_WORKSPACE_CONDITION_ALIAS,
 				match: UMB_DOCUMENT_RECYCLE_BIN_ROOT_WORKSPACE_ALIAS,
+			},
+			{
+				alias: UMB_DOCUMENT_USER_PERMISSION_CONDITION_ALIAS,
+				allOf: [UMB_USER_PERMISSION_DOCUMENT_READ],
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/manifests.ts
@@ -1,3 +1,4 @@
+import { UmbAllowMediaRecycleBinCurrentUserCondition } from './allow-media-recycle-bin.condition.js';
 import { manifests as collectionManifests } from './collection-action/manifests.js';
 import { manifests as entityActionManifests } from './entity-action/manifests.js';
 import { manifests as menuManifests } from './menu/manifests.js';
@@ -10,7 +11,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		type: 'condition',
 		name: 'Allow Media Recycle Bin Current User Condition',
 		alias: 'Umb.Condition.CurrentUser.AllowMediaRecycleBin',
-		api: () => import('./allow-media-recycle-bin.condition.js'),
+		api: UmbAllowMediaRecycleBinCurrentUserCondition,
 	},
 	...collectionManifests,
 	...entityActionManifests,


### PR DESCRIPTION
### Description

ref: https://github.com/umbraco/Umbraco-CMS/pull/22274#issuecomment-4385483790

Discovered during the development of Elements (for v18.0), if a user does not have Document "Read" permission, they can still view items in the Recycle Bin. To note, they can not access the trashed document directly, only the see the tree/collection.

This PR adds conditions to manifests of the Document Recycle Bin menu and root workspace to check the user's "Read" permission. We do not have the equivalent user permissions for Media, so it does not have the same condition.

There is an extra change in this PR, I have in-lined constructor for the "Allow Media Recycle Bin Current User Condition" manifest, as this will reduce the extra fetch request on initial app start up. This mirrors how the equivalent Document condition is loaded.

### How to test?

- Make sure you have trashed documents in the Recycle Bin
- Configure a backoffice user account with heavily restricted permissions, e.g. Document Read = false
- Log in to the backoffice with that user, **can you see the recycle bin?** (Hopefully not! 😅)