### PR TITLE
OpenAPI: Disable XML documentation source generator (closes #23018)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,4 +64,14 @@
       </_ProjectReferencesWithVersions>
     </ItemGroup>
   </Target>
+
+  <!-- Workaround for https://github.com/umbraco/Umbraco-CMS/issues/23018
+       Due to the amount of XML documentation in this solution, the OpenAPI XML documentation source generator produces
+       too many lines of code causing a StackOverflowException when running on IIS. For that reason we disable the analyzer.
+       See https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/openapi-comments?view=aspnetcore-10.0#disabling-xml-documentation-support -->
+  <Target Name="DisableCompileTimeOpenApiXmlGenerator" BeforeTargets="CoreCompile" Condition="'$(IsPackable)' != 'false' or '$(IsTestProject)' == 'true'">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'Microsoft.AspNetCore.OpenApi.SourceGenerators'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Umbraco.Cms.Tests.UnitTests</RootNamespace>
-    <!-- Required for Microsoft.AspNetCore.OpenApi source generators that propagate through ProjectReferences.
-         Web SDK projects get this automatically, but test (Microsoft.NET.Sdk) projects do not. -->
-    <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23018

Description

Due to the volume of XML documentation in this solution, the Microsoft.AspNetCore.OpenApi source generator produces a GenerateCacheEntries method with too many lines of code, causing a StackOverflowException when the application runs on IIS.

Fix: The Microsoft.AspNetCore.OpenApi.SourceGenerators analyzer is removed via a BeforeTargets="CoreCompile" target in Directory.Build.props, disabling the compile-time OpenAPI XML documentation generation globally. This follows the official ASP.NET Core guidance for disabling XML documentation support (https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/openapi-comments?view=aspnetcore-10.0#disabling-xml-documentation-support).

As a cleanup, the InterceptorsNamespaces workaround that was added to Umbraco.Tests.UnitTests.csproj to support the source generator in test projects is also removed, as it is no longer needed.

How to test:
1. Build the solution — it should build without errors
2. Run the application on IIS (or IIS Express)
3. Verify OpenAPI/Swagger UI still functions correctly at `/umbraco/openapi` and `/umbraco/openapi/management.json`