### PR TITLE
Backoffice Search: Batch the ancestors lookup for search results to avoid exceeding the maximum URL length (closes #23032)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.test.ts
@@ -76,9 +76,10 @@ describe('UmbDocumentSearchServerDataSource', () => {
 		expect(ancestorRequestBatches.length).to.equal(3);
 		ancestorRequestBatches.forEach((batch) => expect(batch.length).to.be.at.most(40));
 
-		// Every id is requested exactly once across the batches.
+		// Every id is requested exactly once across the batches (no duplicates, no gaps).
 		const requestedIds = ancestorRequestBatches.flat();
 		expect(requestedIds.length).to.equal(95);
+		expect(new Set(requestedIds).size).to.equal(95);
 
 		// Results are returned with their ancestors mapped from the amalgamated batches.
 		expect(data?.items.length).to.equal(95);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.test.ts
@@ -1,0 +1,98 @@
+import { UmbDocumentSearchServerDataSource } from './document-search.server.data-source.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { DocumentService } from '@umbraco-cms/backoffice/external/backend-api';
+
+@customElement('test-document-search-data-source-host')
+class UmbTestDocumentSearchDataSourceHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+const makeSearchItem = (id: string) => ({
+	id,
+	documentType: { id: `dt-${id}`, icon: 'icon-document', collection: null },
+	hasChildren: false,
+	isProtected: false,
+	isTrashed: false,
+	parent: null,
+	variants: [{ culture: null, name: `Document ${id}`, state: 'Published', flags: [] }],
+	flags: [],
+});
+
+const makeAncestorEntry = (id: string) => ({
+	id,
+	ancestors: [
+		{
+			id: `ancestor-of-${id}`,
+			documentType: { id: `dt-ancestor-${id}`, icon: 'icon-folder', collection: null },
+			hasChildren: true,
+			isProtected: false,
+			isTrashed: false,
+			parent: null,
+			variants: [{ culture: null, name: `Ancestor of ${id}`, state: 'Published', flags: [] }],
+			flags: [],
+		},
+	],
+});
+
+describe('UmbDocumentSearchServerDataSource', () => {
+	let hostElement: UmbTestDocumentSearchDataSourceHostElement;
+	let dataSource: UmbDocumentSearchServerDataSource;
+
+	const originalSearch = DocumentService.getItemDocumentSearch;
+	const originalAncestors = DocumentService.getItemDocumentAncestors;
+
+	let ancestorRequestBatches: Array<Array<string>>;
+
+	const stubSearchReturning = (count: number) => {
+		const items = Array.from({ length: count }, (_, i) => makeSearchItem(`doc-${i}`));
+		(DocumentService as any).getItemDocumentSearch = () => Promise.resolve({ data: { items, total: count } });
+	};
+
+	beforeEach(() => {
+		hostElement = new UmbTestDocumentSearchDataSourceHostElement();
+		document.body.appendChild(hostElement);
+		dataSource = new UmbDocumentSearchServerDataSource(hostElement);
+
+		ancestorRequestBatches = [];
+		(DocumentService as any).getItemDocumentAncestors = (options: { query: { id: Array<string> } }) => {
+			const ids = options.query.id;
+			ancestorRequestBatches.push([...ids]);
+			return Promise.resolve({ data: ids.map((id) => makeAncestorEntry(id)) });
+		};
+	});
+
+	afterEach(() => {
+		(DocumentService as any).getItemDocumentSearch = originalSearch;
+		(DocumentService as any).getItemDocumentAncestors = originalAncestors;
+		hostElement.remove();
+	});
+
+	it('batches the ancestors request into chunks of at most 40 ids', async () => {
+		stubSearchReturning(95);
+
+		const { data } = await dataSource.search({ query: 'pharmacy' });
+
+		// 95 ids must be split across multiple requests, none exceeding the batch size of 40.
+		expect(ancestorRequestBatches.length).to.equal(3);
+		ancestorRequestBatches.forEach((batch) => expect(batch.length).to.be.at.most(40));
+
+		// Every id is requested exactly once across the batches.
+		const requestedIds = ancestorRequestBatches.flat();
+		expect(requestedIds.length).to.equal(95);
+
+		// Results are returned with their ancestors mapped from the amalgamated batches.
+		expect(data?.items.length).to.equal(95);
+		const lastItem = data?.items.find((item) => item.unique === 'doc-94');
+		expect(lastItem?.ancestors?.[0]?.unique).to.equal('ancestor-of-doc-94');
+	});
+
+	it('sends a single ancestors request when results are within the batch size', async () => {
+		stubSearchReturning(10);
+
+		const { data } = await dataSource.search({ query: 'welcome' });
+
+		expect(ancestorRequestBatches.length).to.equal(1);
+		expect(ancestorRequestBatches[0].length).to.equal(10);
+		expect(data?.items.length).to.equal(10);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.test.ts
@@ -95,4 +95,22 @@ describe('UmbDocumentSearchServerDataSource', () => {
 		expect(ancestorRequestBatches[0].length).to.equal(10);
 		expect(data?.items.length).to.equal(10);
 	});
+
+	it('returns an error instead of throwing when one of the batches fails', async () => {
+		stubSearchReturning(95);
+
+		// Fail the second of the three batches; the controller resolves it without rejecting, which
+		// would otherwise leave an undefined hole in the amalgamated ancestors data.
+		let callCount = 0;
+		(DocumentService as any).getItemDocumentAncestors = (options: { query: { id: Array<string> } }) => {
+			callCount++;
+			if (callCount === 2) return Promise.reject(new Error('Simulated server error'));
+			return Promise.resolve({ data: options.query.id.map((id) => makeAncestorEntry(id)) });
+		};
+
+		const result = await dataSource.search({ query: 'pharmacy' });
+
+		expect(result.error).to.exist;
+		expect(result.data).to.be.undefined;
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
@@ -37,6 +37,11 @@ export class UmbDocumentSearchServerDataSource
 
 		if (error) return { error };
 
+		// A failed batch resolves without rejecting, leaving an `undefined` hole in `data` rather than
+		// surfacing an error, so guard against it before mapping below.
+		if (data?.some((entry) => entry == null))
+			return { error: new Error('Error fetching ancestors for one or more document items.') };
+
 		const ancestorsByItemId = new Map<string, Array<UmbDocumentItemModel>>();
 		if (data) {
 			for (const entry of data) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
@@ -4,6 +4,7 @@ import type { UmbSearchDataSource } from '@umbraco-cms/backoffice/search';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { DocumentService, type DocumentItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
+import { UmbItemDataApiGetRequestController } from '@umbraco-cms/backoffice/entity-item';
 import type { UmbDocumentItemModel } from '../types.js';
 
 /**
@@ -27,10 +28,12 @@ export class UmbDocumentSearchServerDataSource
 
 	async #fetchAncestors(ids: Array<string>) {
 		if (!ids.length) return { data: new Map() };
-		const { data, error } = await tryExecute(
-			this.#host,
-			DocumentService.getItemDocumentAncestors({ query: { id: ids } }),
-		);
+
+		const requestController = new UmbItemDataApiGetRequestController(this.#host, {
+			uniques: ids,
+			api: ({ uniques }) => DocumentService.getItemDocumentAncestors({ query: { id: uniques } }),
+		});
+		const { data, error } = await requestController.request();
 
 		if (error) return { error };
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
@@ -31,6 +31,7 @@ export class UmbDocumentSearchServerDataSource
 
 		const requestController = new UmbItemDataApiGetRequestController(this.#host, {
 			uniques: ids,
+			// eslint-disable-next-line local-rules/no-direct-api-import
 			api: ({ uniques }) => DocumentService.getItemDocumentAncestors({ query: { id: uniques } }),
 		});
 		const { data, error } = await requestController.request();

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/search/document-search.server.data-source.ts
@@ -46,29 +46,7 @@ export class UmbDocumentSearchServerDataSource
 		const ancestorsByItemId = new Map<string, Array<UmbDocumentItemModel>>();
 		if (data) {
 			for (const entry of data) {
-				ancestorsByItemId.set(
-					entry.id,
-					entry.ancestors.map((ancestor: DocumentItemResponseModel) => ({
-						documentType: {
-							unique: ancestor.documentType.id,
-							icon: ancestor.documentType.icon,
-							collection: ancestor.documentType.collection ? { unique: ancestor.documentType.collection.id } : null,
-						},
-						entityType: UMB_DOCUMENT_ENTITY_TYPE,
-						hasChildren: ancestor.hasChildren,
-						isProtected: ancestor.isProtected,
-						isTrashed: ancestor.isTrashed,
-						parent: ancestor.parent ? { unique: ancestor.parent.id } : null,
-						unique: ancestor.id,
-						variants: ancestor.variants.map((variant) => ({
-							name: variant.name,
-							culture: variant.culture || null,
-							state: variant.state,
-							flags: variant.flags,
-						})),
-						flags: ancestor.flags,
-					})),
-				);
+				ancestorsByItemId.set(entry.id, entry.ancestors.map(mapAncestorToItemModel));
 			}
 		}
 		return { data: ancestorsByItemId };
@@ -135,4 +113,27 @@ export class UmbDocumentSearchServerDataSource
 
 		return { error };
 	}
+}
+
+function mapAncestorToItemModel(ancestor: DocumentItemResponseModel): UmbDocumentItemModel {
+	return {
+		documentType: {
+			unique: ancestor.documentType.id,
+			icon: ancestor.documentType.icon,
+			collection: ancestor.documentType.collection ? { unique: ancestor.documentType.collection.id } : null,
+		},
+		entityType: UMB_DOCUMENT_ENTITY_TYPE,
+		hasChildren: ancestor.hasChildren,
+		isProtected: ancestor.isProtected,
+		isTrashed: ancestor.isTrashed,
+		parent: ancestor.parent ? { unique: ancestor.parent.id } : null,
+		unique: ancestor.id,
+		variants: ancestor.variants.map((variant) => ({
+			name: variant.name,
+			culture: variant.culture || null,
+			state: variant.state,
+			flags: variant.flags,
+		})),
+		flags: ancestor.flags,
+	};
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.test.ts
@@ -1,0 +1,96 @@
+import { UmbMediaSearchServerDataSource } from './media-search.server.data-source.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { MediaService } from '@umbraco-cms/backoffice/external/backend-api';
+
+@customElement('test-media-search-data-source-host')
+class UmbTestMediaSearchDataSourceHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+const makeSearchItem = (id: string) => ({
+	id,
+	mediaType: { id: `mt-${id}`, icon: 'icon-picture', collection: null },
+	hasChildren: false,
+	isTrashed: false,
+	parent: null,
+	variants: [{ culture: null, name: `Media ${id}` }],
+	flags: [],
+});
+
+const makeAncestorEntry = (id: string) => ({
+	id,
+	ancestors: [
+		{
+			id: `ancestor-of-${id}`,
+			mediaType: { id: `mt-ancestor-${id}`, icon: 'icon-folder', collection: null },
+			hasChildren: true,
+			isTrashed: false,
+			parent: null,
+			variants: [{ culture: null, name: `Ancestor of ${id}` }],
+			flags: [],
+		},
+	],
+});
+
+describe('UmbMediaSearchServerDataSource', () => {
+	let hostElement: UmbTestMediaSearchDataSourceHostElement;
+	let dataSource: UmbMediaSearchServerDataSource;
+
+	const originalSearch = MediaService.getItemMediaSearch;
+	const originalAncestors = MediaService.getItemMediaAncestors;
+
+	let ancestorRequestBatches: Array<Array<string>>;
+
+	const stubSearchReturning = (count: number) => {
+		const items = Array.from({ length: count }, (_, i) => makeSearchItem(`media-${i}`));
+		(MediaService as any).getItemMediaSearch = () => Promise.resolve({ data: { items, total: count } });
+	};
+
+	beforeEach(() => {
+		hostElement = new UmbTestMediaSearchDataSourceHostElement();
+		document.body.appendChild(hostElement);
+		dataSource = new UmbMediaSearchServerDataSource(hostElement);
+
+		ancestorRequestBatches = [];
+		(MediaService as any).getItemMediaAncestors = (options: { query: { id: Array<string> } }) => {
+			const ids = options.query.id;
+			ancestorRequestBatches.push([...ids]);
+			return Promise.resolve({ data: ids.map((id) => makeAncestorEntry(id)) });
+		};
+	});
+
+	afterEach(() => {
+		(MediaService as any).getItemMediaSearch = originalSearch;
+		(MediaService as any).getItemMediaAncestors = originalAncestors;
+		hostElement.remove();
+	});
+
+	it('batches the ancestors request into chunks of at most 40 ids', async () => {
+		stubSearchReturning(95);
+
+		const { data } = await dataSource.search({ query: 'pharmacy' });
+
+		// 95 ids must be split across multiple requests, none exceeding the batch size of 40.
+		expect(ancestorRequestBatches.length).to.equal(3);
+		ancestorRequestBatches.forEach((batch) => expect(batch.length).to.be.at.most(40));
+
+		// Every id is requested exactly once across the batches.
+		const requestedIds = ancestorRequestBatches.flat();
+		expect(requestedIds.length).to.equal(95);
+
+		// Results are returned with their ancestors mapped from the amalgamated batches.
+		expect(data?.items.length).to.equal(95);
+		const lastItem = data?.items.find((item) => item.unique === 'media-94');
+		expect(lastItem?.ancestors?.[0]?.unique).to.equal('ancestor-of-media-94');
+	});
+
+	it('sends a single ancestors request when results are within the batch size', async () => {
+		stubSearchReturning(10);
+
+		const { data } = await dataSource.search({ query: 'welcome' });
+
+		expect(ancestorRequestBatches.length).to.equal(1);
+		expect(ancestorRequestBatches[0].length).to.equal(10);
+		expect(data?.items.length).to.equal(10);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.test.ts
@@ -93,4 +93,22 @@ describe('UmbMediaSearchServerDataSource', () => {
 		expect(ancestorRequestBatches[0].length).to.equal(10);
 		expect(data?.items.length).to.equal(10);
 	});
+
+	it('returns an error instead of throwing when one of the batches fails', async () => {
+		stubSearchReturning(95);
+
+		// Fail the second of the three batches; the controller resolves it without rejecting, which
+		// would otherwise leave an undefined hole in the amalgamated ancestors data.
+		let callCount = 0;
+		(MediaService as any).getItemMediaAncestors = (options: { query: { id: Array<string> } }) => {
+			callCount++;
+			if (callCount === 2) return Promise.reject(new Error('Simulated server error'));
+			return Promise.resolve({ data: options.query.id.map((id) => makeAncestorEntry(id)) });
+		};
+
+		const result = await dataSource.search({ query: 'pharmacy' });
+
+		expect(result.error).to.exist;
+		expect(result.data).to.be.undefined;
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.test.ts
@@ -74,9 +74,10 @@ describe('UmbMediaSearchServerDataSource', () => {
 		expect(ancestorRequestBatches.length).to.equal(3);
 		ancestorRequestBatches.forEach((batch) => expect(batch.length).to.be.at.most(40));
 
-		// Every id is requested exactly once across the batches.
+		// Every id is requested exactly once across the batches (no duplicates, no gaps).
 		const requestedIds = ancestorRequestBatches.flat();
 		expect(requestedIds.length).to.equal(95);
+		expect(new Set(requestedIds).size).to.equal(95);
 
 		// Results are returned with their ancestors mapped from the amalgamated batches.
 		expect(data?.items.length).to.equal(95);

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
@@ -31,6 +31,7 @@ export class UmbMediaSearchServerDataSource
 
 		const requestController = new UmbItemDataApiGetRequestController(this.#host, {
 			uniques: ids,
+			// eslint-disable-next-line local-rules/no-direct-api-import
 			api: ({ uniques }) => MediaService.getItemMediaAncestors({ query: { id: uniques } }),
 		});
 		const { data, error } = await requestController.request();

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
@@ -46,27 +46,7 @@ export class UmbMediaSearchServerDataSource
 		const ancestorsByItemId = new Map<string, Array<UmbMediaItemModel>>();
 		if (data) {
 			for (const entry of data) {
-				ancestorsByItemId.set(
-					entry.id,
-					entry.ancestors.map((ancestor: MediaItemResponseModel) => ({
-						entityType: UMB_MEDIA_ENTITY_TYPE,
-						hasChildren: ancestor.hasChildren,
-						isTrashed: ancestor.isTrashed,
-						unique: ancestor.id,
-						mediaType: {
-							collection: ancestor.mediaType.collection ? { unique: ancestor.mediaType.collection.id } : null,
-							icon: ancestor.mediaType.icon,
-							unique: ancestor.mediaType.id,
-						},
-						name: ancestor.variants[0]?.name ?? '',
-						parent: ancestor.parent ? { unique: ancestor.parent.id } : null,
-						variants: ancestor.variants.map((variant) => ({
-							culture: variant.culture || null,
-							name: variant.name,
-						})),
-						flags: ancestor.flags,
-					})),
-				);
+				ancestorsByItemId.set(entry.id, entry.ancestors.map(mapAncestorToItemModel));
 			}
 		}
 		return { data: ancestorsByItemId };
@@ -130,4 +110,25 @@ export class UmbMediaSearchServerDataSource
 
 		return { error };
 	}
+}
+
+function mapAncestorToItemModel(ancestor: MediaItemResponseModel): UmbMediaItemModel {
+	return {
+		entityType: UMB_MEDIA_ENTITY_TYPE,
+		hasChildren: ancestor.hasChildren,
+		isTrashed: ancestor.isTrashed,
+		unique: ancestor.id,
+		mediaType: {
+			collection: ancestor.mediaType.collection ? { unique: ancestor.mediaType.collection.id } : null,
+			icon: ancestor.mediaType.icon,
+			unique: ancestor.mediaType.id,
+		},
+		name: ancestor.variants[0]?.name ?? '',
+		parent: ancestor.parent ? { unique: ancestor.parent.id } : null,
+		variants: ancestor.variants.map((variant) => ({
+			culture: variant.culture || null,
+			name: variant.name,
+		})),
+		flags: ancestor.flags,
+	};
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
@@ -4,6 +4,7 @@ import type { UmbSearchDataSource } from '@umbraco-cms/backoffice/search';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { MediaService, type MediaItemResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
 import { tryExecute } from '@umbraco-cms/backoffice/resources';
+import { UmbItemDataApiGetRequestController } from '@umbraco-cms/backoffice/entity-item';
 import type { UmbMediaItemModel } from '../types.js';
 
 /**
@@ -27,7 +28,12 @@ export class UmbMediaSearchServerDataSource
 
 	async #fetchAncestors(ids: Array<string>) {
 		if (!ids.length) return { data: new Map() };
-		const { data, error } = await tryExecute(this.#host, MediaService.getItemMediaAncestors({ query: { id: ids } }));
+
+		const requestController = new UmbItemDataApiGetRequestController(this.#host, {
+			uniques: ids,
+			api: ({ uniques }) => MediaService.getItemMediaAncestors({ query: { id: uniques } }),
+		});
+		const { data, error } = await requestController.request();
 
 		if (error) return { error };
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/search/media-search.server.data-source.ts
@@ -37,6 +37,11 @@ export class UmbMediaSearchServerDataSource
 
 		if (error) return { error };
 
+		// A failed batch resolves without rejecting, leaving an `undefined` hole in `data` rather than
+		// surfacing an error, so guard against it before mapping below.
+		if (data?.some((entry) => entry == null))
+			return { error: new Error('Error fetching ancestors for one or more media items.') };
+
 		const ancestorsByItemId = new Map<string, Array<UmbMediaItemModel>>();
 		if (data) {
 			for (const entry of data) {


### PR DESCRIPTION
## Description

As reported in https://github.com/umbraco/Umbraco-CMS/issues/23032, backoffice global search (documents and media) hangs with a never-ending spinner when a query returns many results. Searching a common term that returns 100+ hits shows the loading indicator forever, while a narrow term displays normally.

Fixes #23032,

### Root cause

After the search query returns, the backoffice fetches the **ancestors** of every result so each hit can be rendered within its tree hierarchy. That ancestor lookup was sent as a **single** GET request with one `id=<guid>` query parameter per result:

```
/umbraco/management/api/v1/item/document/ancestors?id=<guid>&id=<guid>&…(100+)
```

With ~40 characters per `id=` segment, 100+ GUIDs push the query string past default limits, which rejects the request with **HTTP 404**. The failed call halts the data source, so the results never render.

Regular multi-item ("items") lookups already avoid this: they go through `UmbItemDataApiGetRequestController`, which splits the ids into chunks of 40, runs them in parallel, and amalgamates the results. The two **search** data sources had their own bespoke `#fetchAncestors` that bypassed this controller and sent every id in one request, so they never inherited the batching protection.

### Fix

Route `#fetchAncestors` in both search data sources through the existing `UmbItemDataApiGetRequestController` so the ancestors lookup is chunked exactly like every other multi-item call.

## Testing

### Automated

I've added unit tests for both search data sources. They stub the search to return 95 results and assert the ancestors request is split into batches of at most 40 ids, that every result is mapped to its ancestors from the amalgamated batches, and that a small result set still uses a single request. Verified the tests fail against the pre-fix single-request code and pass after batching.


### Manual

To test with a smaller result set I've temporarily lowered the `#batchSize` settings in `item-data-api-get-request.controller.ts` to a small number, and verified network calls are as expected (i.e. a search result that exceeds the batch size in number of results leads to more than one request to the ancestors, and the search results are correctly rendered.