### PR TITLE
Tags: Fix null reference error in tags input on render (closes #23044)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
@@ -189,6 +189,9 @@ export class UmbTagsInputElement extends UUIFormControlMixin(UmbLitElement, '') 
 	}
 
 	protected override updated(): void {
+		// #main-tag is not rendered in readonly mode, and the queries can resolve to null
+		// during transient re-renders, so guard before touching the elements.
+		if (!this._mainTag || !this._widthTracker) return;
 		this._mainTag.style.width = `${this._widthTracker.offsetWidth - 4}px`;
 	}
 


### PR DESCRIPTION
## Description

Fixes a `TypeError: Cannot read properties of null (reading 'style')` thrown from `UmbTagsInputElement.updated()` when rendering the tags input.

The `updated()` lifecycle hook unconditionally dereferenced the `#main-tag` and `#input-width-tracker` query results:

```ts
this._mainTag.style.width = `${this._widthTracker.offsetWidth - 4}px`;
```

`#main-tag` (the "add tag" button) is only rendered when the control is **not** readonly — `#renderAddButton()` returns `nothing` in readonly mode — so `@query('#main-tag')` resolves to `null`. The query can also be transiently `null` while the element re-renders, e.g. when navigating between two pages that both host a tags editor (the scenario in the issue, since tags are used on a shared composition across most pages). Because `updated()` fires on every render, this surfaced as an error in the console.

## Fix

Guard the references before touching the elements:

```ts
protected override updated(): void {
    if (!this._mainTag || !this._widthTracker) return;
    this._mainTag.style.width = `${this._widthTracker.offsetWidth - 4}px`;
}
```

Fixes #23044

## Testing

I considered an automated unit test but it didn't feel like it added enough value to introduce a test class for what's just a guard.

To test manually, open up a couple of documents with a tags editor and navigate back and forth between them in the backoffice.  Before I could clearly see the error, after the fix I don't.

Make sure adding and saving tags continues to work as expected.