### PR TITLE
Data Types: Tolerate invalid configuration when determining the editor value storage type (closes #23057)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
@@ -168,7 +168,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
             // Configuration editors are third-party and can throw anything when the stored configuration
             // doesn't deserialize into their configuration type. Fall back to the value editor's value type
             // rather than failing the save, but log so the misconfiguration remains observable.
-            _logger.LogWarning(
+            _logger.LogError(
                 "Could not build the configuration object for editor {EditorAlias} to determine its value storage type; falling back to the value editor's value type.",
                 editor.Alias);
         }

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
@@ -163,13 +163,12 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
                 return ValueTypes.ToStorageType(configureValueType.ValueType);
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             // Configuration editors are third-party and can throw anything when the stored configuration
             // doesn't deserialize into their configuration type. Fall back to the value editor's value type
             // rather than failing the save, but log so the misconfiguration remains observable.
             _logger.LogWarning(
-                ex,
                 "Could not build the configuration object for editor {EditorAlias} to determine its value storage type; falling back to the value editor's value type.",
                 editor.Alias);
         }

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
@@ -72,7 +72,6 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
             dataType.Key = requestModel.Id.Value;
         }
 
-
         return Attempt.SucceedWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.Success, dataType);
     }
 
@@ -82,7 +81,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
         {
             try
             {
-                var parent = await _dataTypeContainerService.GetAsync(requestModel.Parent.Id);
+                EntityContainer? parent = await _dataTypeContainerService.GetAsync(requestModel.Parent.Id);
 
                 return parent is null
                     ? Attempt.FailWithStatus(DataTypeOperationStatus.ParentNotFound, 0)
@@ -104,7 +103,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
             return Task.FromResult(Attempt.FailWithStatus<IDataType, DataTypeOperationStatus>(DataTypeOperationStatus.PropertyEditorNotFound, new DataType(new VoidEditor(_dataValueEditorFactory), _configurationEditorJsonSerializer) ));
         }
 
-        IDataType dataType = (IDataType)current.DeepClone();
+        var dataType = (IDataType)current.DeepClone();
 
         IDictionary<string, object> configurationData = MapConfigurationData(requestModel, editor);
         dataType.Name = requestModel.Name;
@@ -119,12 +118,21 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
 
     private ValueStorageType GetEditorValueStorageType(IDataEditor editor, IDictionary<string, object> configurationData)
     {
-        var configurationObject = editor.GetConfigurationEditor()
-            .ToConfigurationObject(configurationData, _configurationEditorJsonSerializer);
-
-        if (configurationObject is IConfigureValueType configureValueType)
+        // Only editors whose configuration object implements IConfigureValueType derive their storage
+        // type from the configuration. Building the typed configuration object can throw for editors
+        // whose stored configuration doesn't cleanly deserialize into their configuration type; that
+        // must not fail the save, so fall back to the value editor's value type in that case.
+        try
         {
-            return ValueTypes.ToStorageType(configureValueType.ValueType);
+            if (editor.GetConfigurationEditor().ToConfigurationObject(configurationData, _configurationEditorJsonSerializer)
+                is IConfigureValueType configureValueType)
+            {
+                return ValueTypes.ToStorageType(configureValueType.ValueType);
+            }
+        }
+        catch (Exception)
+        {
+            // Swallow and fall back to the value editor's value type below.
         }
 
         var valueType = editor.GetValueEditor().ValueType;

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
@@ -1,5 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
@@ -16,6 +19,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
     private readonly IDataValueEditorFactory _dataValueEditorFactory;
     private readonly IConfigurationEditorJsonSerializer _configurationEditorJsonSerializer;
     private readonly TimeProvider _timeProvider;
+    private readonly ILogger<DataTypePresentationFactory> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DataTypePresentationFactory"/> class, which is responsible for creating data type presentation models.
@@ -25,18 +29,46 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
     /// <param name="dataValueEditorFactory">Factory for creating data value editors.</param>
     /// <param name="configurationEditorJsonSerializer">Serializer for configuration editor JSON data.</param>
     /// <param name="timeProvider">Provides the current time for time-dependent operations.</param>
+    /// <param name="logger">The logger.</param>
     public DataTypePresentationFactory(
         IDataTypeContainerService dataTypeContainerService,
         PropertyEditorCollection propertyEditorCollection,
         IDataValueEditorFactory dataValueEditorFactory,
         IConfigurationEditorJsonSerializer configurationEditorJsonSerializer,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ILogger<DataTypePresentationFactory> logger)
     {
         _dataTypeContainerService = dataTypeContainerService;
         _propertyEditorCollection = propertyEditorCollection;
         _dataValueEditorFactory = dataValueEditorFactory;
         _configurationEditorJsonSerializer = configurationEditorJsonSerializer;
         _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataTypePresentationFactory"/> class, which is responsible for creating data type presentation models.
+    /// </summary>
+    /// <param name="dataTypeContainerService">Service used to manage data type containers.</param>
+    /// <param name="propertyEditorCollection">A collection containing all available property editors.</param>
+    /// <param name="dataValueEditorFactory">Factory for creating data value editors.</param>
+    /// <param name="configurationEditorJsonSerializer">Serializer for configuration editor JSON data.</param>
+    /// <param name="timeProvider">Provides the current time for time-dependent operations.</param>
+    [Obsolete("Please use the constructor that takes all parameters. Scheduled for removal in Umbraco 19.")]
+    public DataTypePresentationFactory(
+        IDataTypeContainerService dataTypeContainerService,
+        PropertyEditorCollection propertyEditorCollection,
+        IDataValueEditorFactory dataValueEditorFactory,
+        IConfigurationEditorJsonSerializer configurationEditorJsonSerializer,
+        TimeProvider timeProvider)
+        : this(
+            dataTypeContainerService,
+            propertyEditorCollection,
+            dataValueEditorFactory,
+            configurationEditorJsonSerializer,
+            timeProvider,
+            StaticServiceProvider.Instance.GetRequiredService<ILogger<DataTypePresentationFactory>>())
+    {
     }
 
     /// <inheritdoc />
@@ -130,9 +162,15 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
                 return ValueTypes.ToStorageType(configureValueType.ValueType);
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Swallow and fall back to the value editor's value type below.
+            // Configuration editors are third-party and can throw anything when the stored configuration
+            // doesn't deserialize into their configuration type. Fall back to the value editor's value type
+            // rather than failing the save, but log so the misconfiguration remains observable.
+            _logger.LogWarning(
+                ex,
+                "Could not build the configuration object for editor {EditorAlias} to determine its value storage type; falling back to the value editor's value type.",
+                editor.Alias);
         }
 
         var valueType = editor.GetValueEditor().ValueType;

--- a/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactory.cs
@@ -128,6 +128,7 @@ public class DataTypePresentationFactory : IDataTypePresentationFactory
         return Attempt.SucceedWithStatus(DataTypeOperationStatus.Success, Constants.System.Root);
     }
 
+    /// <inheritdoc/>
     public Task<Attempt<IDataType, DataTypeOperationStatus>> CreateAsync(UpdateDataTypeRequestModel requestModel, IDataType current)
     {
         if (!_propertyEditorCollection.TryGet(requestModel.EditorAlias, out IDataEditor? editor))

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactoryTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Factories;
@@ -186,7 +187,8 @@ public class DataTypePresentationFactoryTests
             propertyEditorCollection,
             _dataValueEditorFactory.Object,
             configurationEditorJsonSerializer,
-            TimeProvider.System);
+            TimeProvider.System,
+            NullLogger<DataTypePresentationFactory>.Instance);
     }
 
     private IDataEditor CreateMockEditorWithConfigurationEditor(string alias, IConfigurationEditor configurationEditor, string defaultValueType = ValueTypes.String)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DataTypePresentationFactoryTests.cs
@@ -3,10 +3,12 @@ using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Factories;
 using Umbraco.Cms.Api.Management.ViewModels.DataType;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Serialization;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Factories;
 
@@ -103,6 +105,42 @@ public class DataTypePresentationFactoryTests
     }
 
     [Test]
+    public async Task CreateAsync_ConfigurationWithCollectionStoredAsJsonString_DoesNotThrowAndFallsBackToValueEditorType()
+    {
+        // Arrange - a real configuration editor whose typed configuration has a collection property,
+        // fed a value stored as a JSON string (as a custom multi-value config editor does). This is the
+        // shape from https://github.com/umbraco/Umbraco-CMS/issues/23057: round-tripping the configuration
+        // dictionary into the typed configuration throws because the string can't bind to List<T>.
+        IConfigurationEditorJsonSerializer serializer =
+            new SystemTextConfigurationEditorJsonSerializer(new DefaultJsonSerializerEncoderFactory());
+        var configurationEditor = new TestCollectionConfigurationEditor(Mock.Of<IIOHelper>());
+
+        IDataEditor editor = CreateMockEditorWithConfigurationEditor(
+            "Test.CollectionEditor",
+            configurationEditor,
+            defaultValueType: ValueTypes.Json);
+        DataTypePresentationFactory factory = CreateFactory(editor, serializer);
+
+        var requestModel = new CreateDataTypeRequestModel
+        {
+            Name = "Collection editor",
+            EditorAlias = "Test.CollectionEditor",
+            EditorUiAlias = "Test.CollectionEditorUi",
+            Values =
+            [
+                new DataTypePropertyPresentationModel { Alias = "buttons", Value = "[{\"value\":\"a\"}]" },
+            ],
+        };
+
+        // Act
+        var result = await factory.CreateAsync(requestModel);
+
+        // Assert - the save succeeds and falls back to the value editor's value type.
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ValueStorageType.Ntext, result.Result.DatabaseType);
+    }
+
+    [Test]
     public async Task CreateAsync_Update_LabelEditorWithTextValueType_SetsDatabaseTypeToNtext()
     {
         // Arrange
@@ -136,6 +174,9 @@ public class DataTypePresentationFactoryTests
     }
 
     private DataTypePresentationFactory CreateFactory(IDataEditor editor)
+        => CreateFactory(editor, _configurationEditorJsonSerializer.Object);
+
+    private DataTypePresentationFactory CreateFactory(IDataEditor editor, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
     {
         var propertyEditorCollection = new PropertyEditorCollection(
             new DataEditorCollection(() => [editor]));
@@ -144,8 +185,21 @@ public class DataTypePresentationFactoryTests
             _dataTypeContainerService.Object,
             propertyEditorCollection,
             _dataValueEditorFactory.Object,
-            _configurationEditorJsonSerializer.Object,
+            configurationEditorJsonSerializer,
             TimeProvider.System);
+    }
+
+    private IDataEditor CreateMockEditorWithConfigurationEditor(string alias, IConfigurationEditor configurationEditor, string defaultValueType = ValueTypes.String)
+    {
+        var mockValueEditor = new Mock<IDataValueEditor>();
+        mockValueEditor.Setup(v => v.ValueType).Returns(defaultValueType);
+
+        var mockEditor = new Mock<IDataEditor>();
+        mockEditor.Setup(e => e.Alias).Returns(alias);
+        mockEditor.Setup(e => e.GetConfigurationEditor()).Returns(configurationEditor);
+        mockEditor.Setup(e => e.GetValueEditor()).Returns(mockValueEditor.Object);
+
+        return mockEditor.Object;
     }
 
     private IDataEditor CreateMockEditor(string alias, object configurationObject, string defaultValueType = ValueTypes.String)
@@ -169,5 +223,24 @@ public class DataTypePresentationFactoryTests
         mockEditor.Setup(e => e.GetValueEditor()).Returns(mockValueEditor.Object);
 
         return mockEditor.Object;
+    }
+
+    private sealed class TestCollectionConfigurationEditor : ConfigurationEditor<TestCollectionConfiguration>
+    {
+        public TestCollectionConfigurationEditor(IIOHelper ioHelper)
+            : base(ioHelper)
+        {
+        }
+    }
+
+    private sealed class TestCollectionConfiguration
+    {
+        [ConfigurationField("buttons")]
+        public List<TestCollectionItem> Buttons { get; set; } = [];
+    }
+
+    private sealed class TestCollectionItem
+    {
+        public string Value { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
## Description

Since 17.3, saving a Data Type whose configuration does not cleanly deserialize into its strongly-typed configuration object fails with:

```
Failed to parse configuration "System.Collections.Generic.Dictionary`2[System.String,System.Object]"
   at ConfigurationEditor`1.ToConfigurationObject(...)
   at DataTypePresentationFactory.GetEditorValueStorageType(...)
   at DataTypePresentationFactory.CreateAsync(UpdateDataTypeRequestModel, IDataType)
```

(The message is misleading — it's just `configuration.ToString()`; the real cause is the inner JSON deserialization exception.)

### Root cause

PR #21914 ("Use configured ValueType when creating Label data types") changed `DataTypePresentationFactory.GetEditorValueStorageType` to build the **typed** configuration object via `ToConfigurationObject` on **every** Data Type create/update, in order to detect editors implementing `IConfigureValueType`.

That interface is implemented in core by exactly one type, `LabelConfiguration` (though there could be others in packages) but the typed round-trip now runs for *all* editors. For any editor whose stored configuration dictionary doesn't deserialize cleanly into its `TConfiguration`, that round-trip throws and the whole save fails. Before 17.3 the typed object was never built on this path, so the mismatch was harmless here.

### The defensive change

`GetEditorValueStorageType` only needs the typed object for the `IConfigureValueType` branch. For every other editor the object is computed and immediately discarded — so a deserialization failure there is irrelevant to the task (determining the storage type). We now wrap the round-trip and fall back to the value editor's own value type if it throws.

Fixes #23057.

## Testing

### Automated

Added `CreateAsync_ConfigurationWithCollectionStoredAsJsonString_DoesNotThrowAndFallsBackToValueEditorType` to `DataTypePresentationFactoryTests`. Unlike the existing tests (which mock `ToConfigurationObject`), this uses a **real** `ConfigurationEditor<T>` with a `List<>` field and a **real** serializer, fed a value stored as a JSON string — reproducing the exact #23057 shape so the genuine `JsonException` is thrown.

Verified fails-before / passes-after.

### Manual

Reproduced the customer's setup locally (a "Button Picker" property editor with a `List<ValueListItem>` config field whose backoffice config UI stores its value as a JSON string):
1. Confirmed the error on saving a Data Type built with that editor, before the fix.
2. Confirmed the Data Type saves successfully after the fix.

---

## Note for affected package/integration authors

This fix hardens Umbraco, but it surfaced a genuine pre-existing problem worth understanding.

`ConfigurationEditor<TConfiguration>` has an implicit contract: the **stored** configuration must be deserializable into `TConfiguration`. In the reported case the `buttons` value is stored as a JSON **string**, while the property is typed `List<ValueListItem>` — those don't match. Umbraco already treats this as an invalid configuration: `DataType.ConfigurationObject` throws *"The configuration for data type … is invalid. Please fix the configuration…"* whenever the typed config is materialised (value converters, Delivery API, indexing, startup). It only appeared to "work" before 17.3 because nothing in the flow had accessed the typed config for that Data Type yet.

**Important:** the Umbraco fix unblocks *saving*, but it does **not** make such a configuration valid — it will still fail anywhere the typed config is read. Authors should correct the representation regardless of upgrading. Any one of these resolves it:

**Option A — model the property as what's actually stored (smallest change):**
```csharp
[ConfigurationField("buttons")]
public string? Buttons { get; set; }   // was List<ValueListItem>
```
The value already arrives as a JSON string, so it round-trips cleanly; parse it where you consume it. Works for existing Data Types (stored format unchanged).

**Option B — store a native array on the client instead of a JSON string** (most "correct"):
have the config UI emit a real array rather than `JSON.stringify(...)`, so it binds directly to `List<ValueListItem>`. Best paired with Option C as a transitional safety net, since existing Data Types still hold strings in the database.

**Option C — teach the configuration editor to read the string (keeps `List<ValueListItem>`):**
```csharp
public override object ToConfigurationObject(
    IDictionary<string, object> configuration,
    IConfigurationEditorJsonSerializer serializer)
{
    if (configuration.TryGetValue("buttons", out var raw)
        && raw is string s && !s.IsNullOrWhiteSpace())
    {
        configuration = new Dictionary<string, object>(configuration)
        {
            ["buttons"] = serializer.Deserialize<ButtonPickerConfiguration.ValueListItem[]>(s) ?? [],
        };
    }

    return base.ToConfigurationObject(configuration, serializer);
}
```

