### PR TITLE
Elements: Hide element actions from the document notifications dialog (closes #23053)

### DIFF
--- a/src/Umbraco.Core/Actions/ActionElementContainerDelete.cs
+++ b/src/Umbraco.Core/Actions/ActionElementContainerDelete.cs
@@ -21,7 +21,7 @@ public class ActionElementContainerDelete : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementContainerMove.cs
+++ b/src/Umbraco.Core/Actions/ActionElementContainerMove.cs
@@ -21,7 +21,7 @@ public class ActionElementContainerMove : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementContainerNew.cs
+++ b/src/Umbraco.Core/Actions/ActionElementContainerNew.cs
@@ -21,7 +21,7 @@ public class ActionElementContainerNew : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementContainerUpdate.cs
+++ b/src/Umbraco.Core/Actions/ActionElementContainerUpdate.cs
@@ -21,7 +21,7 @@ public class ActionElementContainerUpdate : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementCopy.cs
+++ b/src/Umbraco.Core/Actions/ActionElementCopy.cs
@@ -21,7 +21,7 @@ public class ActionElementCopy : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementDelete.cs
+++ b/src/Umbraco.Core/Actions/ActionElementDelete.cs
@@ -21,7 +21,7 @@ public class ActionElementDelete : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementMove.cs
+++ b/src/Umbraco.Core/Actions/ActionElementMove.cs
@@ -21,7 +21,7 @@ public class ActionElementMove : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementNew.cs
+++ b/src/Umbraco.Core/Actions/ActionElementNew.cs
@@ -21,7 +21,7 @@ public class ActionElementNew : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementPublish.cs
+++ b/src/Umbraco.Core/Actions/ActionElementPublish.cs
@@ -21,7 +21,7 @@ public class ActionElementPublish : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementRollback.cs
+++ b/src/Umbraco.Core/Actions/ActionElementRollback.cs
@@ -21,7 +21,7 @@ public class ActionElementRollback : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/src/Umbraco.Core/Actions/ActionElementUpdate.cs
+++ b/src/Umbraco.Core/Actions/ActionElementUpdate.cs
@@ -21,7 +21,7 @@ public class ActionElementUpdate : IAction
     public string Alias => ActionAlias;
 
     /// <inheritdoc />
-    public bool ShowInNotifier => true;
+    public bool ShowInNotifier => false;
 
     /// <inheritdoc />
     public bool CanBePermissionAssigned => true;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DocumentNotificationPresentationFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DocumentNotificationPresentationFactoryTests.cs
@@ -1,0 +1,83 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Factories;
+
+[TestFixture]
+public class DocumentNotificationPresentationFactoryTests
+{
+    private DocumentNotificationPresentationFactory _factory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var actionCollection = new ActionCollection(() =>
+        [
+            new TestNotifiableAction(),
+            new TestNonNotifiableAction(),
+        ]);
+
+        var notificationService = new Mock<INotificationService>();
+        notificationService
+            .Setup(x => x.GetUserNotifications(It.IsAny<IUser>(), It.IsAny<string>()))
+            .Returns((IEnumerable<Notification>?)null);
+
+        _factory = new DocumentNotificationPresentationFactory(
+            actionCollection,
+            notificationService.Object,
+            Mock.Of<IBackOfficeSecurityAccessor>());
+    }
+
+    [Test]
+    public async Task CreateNotificationModelsAsync_Includes_Only_Actions_That_Show_In_Notifier()
+    {
+        IEnumerable<DocumentNotificationResponseModel> models = await _factory.CreateNotificationModelsAsync(CreateContent());
+
+        var aliases = models.Select(x => x.Alias).ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(aliases, Does.Contain(TestNotifiableAction.ActionAlias));
+            Assert.That(aliases, Does.Not.Contain(TestNonNotifiableAction.ActionAlias));
+        });
+    }
+
+    private static IContent CreateContent()
+    {
+        var content = new Mock<IContent>();
+        content.SetupGet(x => x.Path).Returns("-1,1000");
+        return content.Object;
+    }
+
+    private sealed class TestNotifiableAction : IAction
+    {
+        public const string ActionAlias = "testnotifiable";
+
+        public string Letter => "Umb.TestNotifiable";
+
+        public string Alias => ActionAlias;
+
+        public bool ShowInNotifier => true;
+
+        public bool CanBePermissionAssigned => false;
+    }
+
+    private sealed class TestNonNotifiableAction : IAction
+    {
+        public const string ActionAlias = "testnonnotifiable";
+
+        public string Letter => "Umb.TestNonNotifiable";
+
+        public string Alias => ActionAlias;
+
+        public bool ShowInNotifier => false;
+
+        public bool CanBePermissionAssigned => true;
+    }
+}


### PR DESCRIPTION
## Description

The new element actions (`ActionElement*`/`ActionElementContainer*`) were registered with `ShowInNotifier => true`, and `DocumentNotificationPresentationFactory` returns every action with that flag set. As a result the document Notifications dialog listed element options that:

- Don't belong on documents,
- Displayed as raw, untranslated aliases (`elementpublish`, `elementcontainercreate`, …), and
- Could never do anything — `UserNotificationsHandler` only handles `Content*` notifications, so element subscriptions would never produce an email.

This PR sets `ShowInNotifier => false` on the 11 affected element actions. All of them keep `CanBePermissionAssigned => true`, so the `ActionCollectionBuilder` invariant holds and Library-section element permissions are unaffected.

Also adds `DocumentNotificationPresentationFactoryTests`, a contract test using custom `IAction` implementations verifying the factory includes only actions with `ShowInNotifier` set (so it won't false-fail if element actions legitimately opt back in later).

Fixes #23053

### Out of scope

A real element notifications feature (Notifications dialog in the Library section, element notification endpoints, and `Element*` notification email handling). Maybe we want that in the future? If so, when that's built, the flags can be flipped back and `actions_element*` localization keys added.

## Testing

Open up the Notifications dialog and verify that the elements related actions are no longer shown.