### PR TITLE
Backoffice: Pre-expand tree to target entity when opening Duplicate and Move To modals (closes #22015)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
@@ -1,14 +1,22 @@
 import { UMB_DUPLICATE_TO_MODAL } from './modal/duplicate-to-modal.token.js';
 import type { MetaEntityActionDuplicateToKind, UmbDuplicateToRepository } from './types.js';
+import type { UmbTreeRepository } from '../../data/tree-repository.interface.js';
 import { UmbEntityActionBase, UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 
 export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityActionDuplicateToKind> {
 	override async execute() {
 		if (!this.args.unique) throw new Error('Unique is not available');
 		if (!this.args.entityType) throw new Error('Entity Type is not available');
+
+		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
+		const { data: ancestors } =
+			(await treeRepository?.requestTreeItemAncestors({
+				treeItem: { unique: this.args.unique, entityType: this.args.entityType },
+			})) ?? {};
 
 		const value = await umbOpenModal(this, UMB_DUPLICATE_TO_MODAL, {
 			data: {
@@ -16,6 +24,7 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 				entityType: this.args.entityType,
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
+				expansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
@@ -20,7 +20,7 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 				entityType: this.args.entityType,
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
-				expansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
+				treeExpansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
@@ -20,7 +20,7 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 				entityType: this.args.entityType,
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
-				treeExpansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
+				treeExpansion: linkEntityExpansionEntries(ancestors),
 			},
 		});
 
@@ -46,13 +46,18 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 	}
 
 	async #requestAncestors() {
-		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
-		const { data } =
-			(await treeRepository?.requestTreeItemAncestors({
-				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
-			})) ?? {};
-		// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
-		return data?.filter((item) => item.unique !== this.args.unique);
+		try {
+			const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
+			const { data } =
+				(await treeRepository?.requestTreeItemAncestors({
+					treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
+				})) ?? {};
+			// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
+			return data?.filter((item) => item.unique !== this.args.unique) ?? [];
+		} catch {
+			// Tree pre-expansion is a UX convenience — if it fails the modal still opens normally.
+			return [];
+		}
 	}
 
 	async #reloadMenu() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
@@ -12,11 +12,7 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 		if (!this.args.unique) throw new Error('Unique is not available');
 		if (!this.args.entityType) throw new Error('Entity Type is not available');
 
-		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
-		const { data: ancestors } =
-			(await treeRepository?.requestTreeItemAncestors({
-				treeItem: { unique: this.args.unique, entityType: this.args.entityType },
-			})) ?? {};
+		const ancestors = await this.#requestAncestors();
 
 		const value = await umbOpenModal(this, UMB_DUPLICATE_TO_MODAL, {
 			data: {
@@ -47,6 +43,15 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 		}
 
 		this.#reloadMenu();
+	}
+
+	async #requestAncestors() {
+		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
+		const { data } =
+			(await treeRepository?.requestTreeItemAncestors({
+				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
+			})) ?? {};
+		return data;
 	}
 
 	async #reloadMenu() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
@@ -51,7 +51,8 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 			(await treeRepository?.requestTreeItemAncestors({
 				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
 			})) ?? {};
-		return data;
+		// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
+		return data?.filter((item) => item.unique !== this.args.unique);
 	}
 
 	async #reloadMenu() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/duplicate-to.action.ts
@@ -20,7 +20,7 @@ export class UmbDuplicateToEntityAction extends UmbEntityActionBase<MetaEntityAc
 				entityType: this.args.entityType,
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
-				treeExpansion: linkEntityExpansionEntries(ancestors),
+				treeExpansion: ancestors.length ? linkEntityExpansionEntries(ancestors) : undefined,
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
@@ -19,7 +19,7 @@ export class UmbDuplicateToModalElement extends UmbModalBaseElement<UmbDuplicate
 	protected override updated(_changedProperties: PropertyValueMap<unknown> | Map<PropertyKey, unknown>) {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('data')) {
-			this._treeExpansion = this.data?.expansion ?? [];
+			this._treeExpansion = this.data?.treeExpansion ?? [];
 		}
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
@@ -4,8 +4,6 @@ import { html, customElement, nothing, state } from '@umbraco-cms/backoffice/ext
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import type { UmbSelectionChangeEvent } from '@umbraco-cms/backoffice/event';
-import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
-import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 
 const elementName = 'umb-duplicate-to-modal';
 @customElement(elementName)
@@ -13,14 +11,8 @@ export class UmbDuplicateToModalElement extends UmbModalBaseElement<UmbDuplicate
 	@state()
 	private _destinationUnique?: string | null;
 
-	@state()
-	private _treeExpansion: UmbEntityExpansionModel = [];
-
-	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
-		super.updated(_changedProperties);
-		if (_changedProperties.has('data')) {
-			this._treeExpansion = this.data?.treeExpansion ?? [];
-		}
+	private get _treeExpansion() {
+		return this.data?.treeExpansion ?? [];
 	}
 
 	#onTreeSelectionChange(event: UmbSelectionChangeEvent) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
@@ -16,7 +16,7 @@ export class UmbDuplicateToModalElement extends UmbModalBaseElement<UmbDuplicate
 	@state()
 	private _treeExpansion: UmbEntityExpansionModel = [];
 
-	protected override updated(_changedProperties: PropertyValueMap<unknown> | Map<PropertyKey, unknown>) {
+	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('data')) {
 			this._treeExpansion = this.data?.treeExpansion ?? [];

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
@@ -4,12 +4,24 @@ import { html, customElement, nothing, state } from '@umbraco-cms/backoffice/ext
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import type { UmbSelectionChangeEvent } from '@umbraco-cms/backoffice/event';
+import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
+import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 
 const elementName = 'umb-duplicate-to-modal';
 @customElement(elementName)
 export class UmbDuplicateToModalElement extends UmbModalBaseElement<UmbDuplicateToModalData, UmbDuplicateToModalValue> {
 	@state()
 	private _destinationUnique?: string | null;
+
+	@state()
+	private _treeExpansion: UmbEntityExpansionModel = [];
+
+	protected override updated(_changedProperties: PropertyValueMap<unknown> | Map<PropertyKey, unknown>) {
+		super.updated(_changedProperties);
+		if (_changedProperties.has('data')) {
+			this._treeExpansion = this.data?.expansion ?? [];
+		}
+	}
 
 	#onTreeSelectionChange(event: UmbSelectionChangeEvent) {
 		const target = event.target as UmbTreeElement;
@@ -32,6 +44,7 @@ export class UmbDuplicateToModalElement extends UmbModalBaseElement<UmbDuplicate
 						.props=${{
 							foldersOnly: this.data?.foldersOnly,
 							expandTreeRoot: true,
+							expansion: this._treeExpansion,
 						}}
 						@selection-change=${this.#onTreeSelectionChange}></umb-tree>
 				</uui-box>
@@ -43,7 +56,10 @@ export class UmbDuplicateToModalElement extends UmbModalBaseElement<UmbDuplicate
 
 	#renderActions() {
 		return html`
-			<uui-button slot="actions" label=${this.localize.term('general_cancel')} @click="${this._rejectModal}"></uui-button>
+			<uui-button
+				slot="actions"
+				label=${this.localize.term('general_cancel')}
+				@click="${this._rejectModal}"></uui-button>
 			<uui-button
 				slot="actions"
 				color="positive"

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.token.ts
@@ -7,7 +7,7 @@ export const UMB_DUPLICATE_TO_MODAL_ALIAS = 'Umb.Modal.DuplicateTo';
 export interface UmbDuplicateToModalData extends UmbEntityModel {
 	treeAlias: string;
 	foldersOnly?: boolean;
-	expansion?: UmbEntityExpansionModel;
+	treeExpansion?: UmbEntityExpansionModel;
 }
 
 export interface UmbDuplicateToModalValue {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.token.ts
@@ -1,11 +1,13 @@
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
+import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
 
 export const UMB_DUPLICATE_TO_MODAL_ALIAS = 'Umb.Modal.DuplicateTo';
 
 export interface UmbDuplicateToModalData extends UmbEntityModel {
 	treeAlias: string;
 	foldersOnly?: boolean;
+	expansion?: UmbEntityExpansionModel;
 }
 
 export interface UmbDuplicateToModalValue {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -1,11 +1,13 @@
 import { UMB_TREE_PICKER_MODAL } from '../../tree-picker-modal/index.js';
 import type { UmbTreeItemModel } from '../../types.js';
+import type { UmbTreeRepository } from '../../data/tree-repository.interface.js';
 import type { UmbMoveRepository } from './move-repository.interface.js';
 import type { MetaEntityActionMoveToKind } from './types.js';
 import { UmbEntityActionBase, UmbRequestReloadStructureForEntityEvent } from '@umbraco-cms/backoffice/entity-action';
 import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 
 export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionMoveToKind> {
 	protected async _getPickableFilter(unique: string): Promise<((item: UmbTreeItemModel) => boolean) | undefined> {
@@ -16,11 +18,18 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 		if (!this.args.unique) throw new Error('Unique is not available');
 		if (!this.args.entityType) throw new Error('Entity Type is not available');
 
+		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
+		const { data: ancestors } =
+			(await treeRepository?.requestTreeItemAncestors({
+				treeItem: { unique: this.args.unique, entityType: this.args.entityType },
+			})) ?? {};
+
 		const value = await umbOpenModal(this, UMB_TREE_PICKER_MODAL, {
 			data: {
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
 				expandTreeRoot: true,
+				expansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
 				pickableFilter: await this._getPickableFilter(this.args.unique),
 			},
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -18,7 +18,10 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 		if (!this.args.unique) throw new Error('Unique is not available');
 		if (!this.args.entityType) throw new Error('Entity Type is not available');
 
-		const ancestors = await this.#requestAncestors();
+		const [ancestors, pickableFilter] = await Promise.all([
+			this.#requestAncestors(),
+			this._getPickableFilter(this.args.unique),
+		]);
 
 		const value = await umbOpenModal(this, UMB_TREE_PICKER_MODAL, {
 			data: {
@@ -26,7 +29,7 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 				foldersOnly: this.args.meta.foldersOnly,
 				expandTreeRoot: true,
 				treeExpansion: ancestors.length ? linkEntityExpansionEntries(ancestors) : undefined,
-				pickableFilter: await this._getPickableFilter(this.args.unique),
+				pickableFilter,
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -25,7 +25,7 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
 				expandTreeRoot: true,
-				treeExpansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
+				treeExpansion: linkEntityExpansionEntries(ancestors),
 				pickableFilter: await this._getPickableFilter(this.args.unique),
 			},
 		});
@@ -49,13 +49,18 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 	}
 
 	async #requestAncestors() {
-		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
-		const { data } =
-			(await treeRepository?.requestTreeItemAncestors({
-				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
-			})) ?? {};
-		// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
-		return data?.filter((item) => item.unique !== this.args.unique);
+		try {
+			const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
+			const { data } =
+				(await treeRepository?.requestTreeItemAncestors({
+					treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
+				})) ?? {};
+			// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
+			return data?.filter((item) => item.unique !== this.args.unique) ?? [];
+		} catch {
+			// Tree pre-expansion is a UX convenience — if it fails the modal still opens normally.
+			return [];
+		}
 	}
 
 	async #reloadMenu() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -54,7 +54,8 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 			(await treeRepository?.requestTreeItemAncestors({
 				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
 			})) ?? {};
-		return data;
+		// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
+		return data?.filter((item) => item.unique !== this.args.unique);
 	}
 
 	async #reloadMenu() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -25,7 +25,7 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
 				expandTreeRoot: true,
-				expansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
+				treeExpansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
 				pickableFilter: await this._getPickableFilter(this.args.unique),
 			},
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -25,7 +25,7 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 				treeAlias: this.args.meta.treeAlias,
 				foldersOnly: this.args.meta.foldersOnly,
 				expandTreeRoot: true,
-				treeExpansion: linkEntityExpansionEntries(ancestors),
+				treeExpansion: ancestors.length ? linkEntityExpansionEntries(ancestors) : undefined,
 				pickableFilter: await this._getPickableFilter(this.args.unique),
 			},
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/move/move-to.action.ts
@@ -18,11 +18,7 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 		if (!this.args.unique) throw new Error('Unique is not available');
 		if (!this.args.entityType) throw new Error('Entity Type is not available');
 
-		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
-		const { data: ancestors } =
-			(await treeRepository?.requestTreeItemAncestors({
-				treeItem: { unique: this.args.unique, entityType: this.args.entityType },
-			})) ?? {};
+		const ancestors = await this.#requestAncestors();
 
 		const value = await umbOpenModal(this, UMB_TREE_PICKER_MODAL, {
 			data: {
@@ -50,6 +46,15 @@ export class UmbMoveToEntityAction extends UmbEntityActionBase<MetaEntityActionM
 		}
 
 		this.#reloadMenu();
+	}
+
+	async #requestAncestors() {
+		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, this.args.meta.treeRepositoryAlias);
+		const { data } =
+			(await treeRepository?.requestTreeItemAncestors({
+				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
+			})) ?? {};
+		return data;
 	}
 
 	async #reloadMenu() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.element.ts
@@ -75,6 +75,10 @@ export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase
 				...this._selectionConfiguration,
 				multiple,
 			};
+
+			if (this.data?.expansion !== undefined) {
+				this._pickerContext.expansion.setExpansion(this.data.expansion);
+			}
 		}
 
 		if (_changedProperties.has('value')) {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/tree-picker-modal.element.ts
@@ -76,8 +76,8 @@ export class UmbTreePickerModalElement<TreeItemType extends UmbTreeItemModelBase
 				multiple,
 			};
 
-			if (this.data?.expansion !== undefined) {
-				this._pickerContext.expansion.setExpansion(this.data.expansion);
+			if (this.data?.treeExpansion !== undefined) {
+				this._pickerContext.expansion.setExpansion(this.data.treeExpansion);
 			}
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/types.ts
@@ -18,7 +18,7 @@ export interface UmbTreePickerModalData<
 > extends UmbPickerModalData<TreeItemType> {
 	hideTreeRoot?: boolean;
 	expandTreeRoot?: boolean;
-	expansion?: UmbEntityExpansionModel;
+	treeExpansion?: UmbEntityExpansionModel;
 	treeAlias?: string;
 	// TODO: create action should be replaces by entity actions in the pickers. Then we also open up for creating folders, choosing where to place items etc. [MR]
 	createAction?: UmbTreePickerModalCreateActionData<PathPatternParamsType>;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/tree-picker-modal/types.ts
@@ -2,6 +2,7 @@ import type { UmbTreeItemModel, UmbTreeStartNode } from '../types.js';
 import type { UmbPathPattern, UmbPathPatternParamsType } from '@umbraco-cms/backoffice/router';
 import type { UmbModalToken, UmbPickerModalData, UmbPickerModalValue } from '@umbraco-cms/backoffice/modal';
 import type { UmbWorkspaceModalData } from '@umbraco-cms/backoffice/workspace';
+import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
 
 export interface UmbTreePickerModalCreateActionData<PathPatternParamsType extends UmbPathPatternParamsType> {
 	label: string;
@@ -17,6 +18,7 @@ export interface UmbTreePickerModalData<
 > extends UmbPickerModalData<TreeItemType> {
 	hideTreeRoot?: boolean;
 	expandTreeRoot?: boolean;
+	expansion?: UmbEntityExpansionModel;
 	treeAlias?: string;
 	// TODO: create action should be replaces by entity actions in the pickers. Then we also open up for creating folders, choosing where to place items etc. [MR]
 	createAction?: UmbTreePickerModalCreateActionData<PathPatternParamsType>;

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
@@ -2,6 +2,8 @@ import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_ROOT_ENTITY_TYPE } from '../../e
 import { UmbDocumentItemRepository } from '../../item/index.js';
 import { UMB_DUPLICATE_DOCUMENT_MODAL } from './modal/index.js';
 import { UmbDuplicateDocumentRepository } from './repository/index.js';
+import { UMB_DOCUMENT_TREE_REPOSITORY_ALIAS } from '../../tree/manifests.js';
+import type { UmbTreeRepository } from '@umbraco-cms/backoffice/tree';
 import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbEntityActionBase, UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
@@ -9,6 +11,8 @@ import {
 	UmbDocumentTypeDetailRepository,
 	UmbDocumentTypeStructureRepository,
 } from '@umbraco-cms/backoffice/document-type';
+import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
+import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 
 export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never> {
 	override async execute() {
@@ -18,11 +22,18 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 		const duplicateRepository = new UmbDuplicateDocumentRepository(this);
 		const selectableFilter = await this.#getSelectableFilterByDocumentUnique(this.args.unique);
 
+		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, UMB_DOCUMENT_TREE_REPOSITORY_ALIAS);
+		const { data: ancestors } =
+			(await treeRepository?.requestTreeItemAncestors({
+				treeItem: { unique: this.args.unique, entityType: this.args.entityType },
+			})) ?? {};
+
 		const value = await umbOpenModal(this, UMB_DUPLICATE_DOCUMENT_MODAL, {
 			data: {
 				unique: this.args.unique,
 				entityType: this.args.entityType,
 				selectableFilter,
+				expansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
@@ -28,7 +28,7 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 				unique: this.args.unique,
 				entityType: this.args.entityType,
 				selectableFilter,
-				expansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
+				treeExpansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
@@ -54,7 +54,8 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 		const { data } = await treeRepository.requestTreeItemAncestors({
 			treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
 		});
-		return data;
+		// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
+		return data?.filter((item) => item.unique !== this.args.unique);
 	}
 
 	async #getSelectableFilterByDocumentUnique(documentUnique: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
@@ -28,7 +28,7 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 				unique: this.args.unique,
 				entityType: this.args.entityType,
 				selectableFilter,
-				treeExpansion: linkEntityExpansionEntries(ancestors),
+				treeExpansion: ancestors.length ? linkEntityExpansionEntries(ancestors) : undefined,
 			},
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
@@ -2,8 +2,7 @@ import { UMB_DOCUMENT_ENTITY_TYPE, UMB_DOCUMENT_ROOT_ENTITY_TYPE } from '../../e
 import { UmbDocumentItemRepository } from '../../item/index.js';
 import { UMB_DUPLICATE_DOCUMENT_MODAL } from './modal/index.js';
 import { UmbDuplicateDocumentRepository } from './repository/index.js';
-import { UMB_DOCUMENT_TREE_REPOSITORY_ALIAS } from '../../tree/manifests.js';
-import type { UmbTreeRepository } from '@umbraco-cms/backoffice/tree';
+import { UmbDocumentTreeRepository } from '../../tree/index.js';
 import { umbOpenModal } from '@umbraco-cms/backoffice/modal';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbEntityActionBase, UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
@@ -11,7 +10,6 @@ import {
 	UmbDocumentTypeDetailRepository,
 	UmbDocumentTypeStructureRepository,
 } from '@umbraco-cms/backoffice/document-type';
-import { createExtensionApiByAlias } from '@umbraco-cms/backoffice/extension-registry';
 import { linkEntityExpansionEntries } from '@umbraco-cms/backoffice/utils';
 
 export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never> {
@@ -52,11 +50,10 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 	}
 
 	async #requestAncestors() {
-		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, UMB_DOCUMENT_TREE_REPOSITORY_ALIAS);
-		const { data } =
-			(await treeRepository?.requestTreeItemAncestors({
-				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
-			})) ?? {};
+		const treeRepository = new UmbDocumentTreeRepository(this);
+		const { data } = await treeRepository.requestTreeItemAncestors({
+			treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
+		});
 		return data;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
@@ -28,7 +28,7 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 				unique: this.args.unique,
 				entityType: this.args.entityType,
 				selectableFilter,
-				treeExpansion: ancestors ? linkEntityExpansionEntries(ancestors) : [],
+				treeExpansion: linkEntityExpansionEntries(ancestors),
 			},
 		});
 
@@ -50,12 +50,17 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 	}
 
 	async #requestAncestors() {
-		const treeRepository = new UmbDocumentTreeRepository(this);
-		const { data } = await treeRepository.requestTreeItemAncestors({
-			treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
-		});
-		// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
-		return data?.filter((item) => item.unique !== this.args.unique);
+		try {
+			const treeRepository = new UmbDocumentTreeRepository(this);
+			const { data } = await treeRepository.requestTreeItemAncestors({
+				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
+			});
+			// Exclude self — the API returns the descendant as part of the ancestors list, but we only want to expand its parents.
+			return data?.filter((item) => item.unique !== this.args.unique) ?? [];
+		} catch {
+			// Tree pre-expansion is a UX convenience — if it fails the modal still opens normally.
+			return [];
+		}
 	}
 
 	async #getSelectableFilterByDocumentUnique(documentUnique: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/duplicate-document.action.ts
@@ -20,13 +20,10 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 		if (!this.args.entityType) throw new Error('Entity Type is not available');
 
 		const duplicateRepository = new UmbDuplicateDocumentRepository(this);
-		const selectableFilter = await this.#getSelectableFilterByDocumentUnique(this.args.unique);
-
-		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, UMB_DOCUMENT_TREE_REPOSITORY_ALIAS);
-		const { data: ancestors } =
-			(await treeRepository?.requestTreeItemAncestors({
-				treeItem: { unique: this.args.unique, entityType: this.args.entityType },
-			})) ?? {};
+		const [selectableFilter, ancestors] = await Promise.all([
+			this.#getSelectableFilterByDocumentUnique(this.args.unique),
+			this.#requestAncestors(),
+		]);
 
 		const value = await umbOpenModal(this, UMB_DUPLICATE_DOCUMENT_MODAL, {
 			data: {
@@ -52,6 +49,15 @@ export class UmbDuplicateDocumentEntityAction extends UmbEntityActionBase<never>
 		}
 
 		this.#reloadMenu(destinationUnique);
+	}
+
+	async #requestAncestors() {
+		const treeRepository = await createExtensionApiByAlias<UmbTreeRepository>(this, UMB_DOCUMENT_TREE_REPOSITORY_ALIAS);
+		const { data } =
+			(await treeRepository?.requestTreeItemAncestors({
+				treeItem: { unique: this.args.unique!, entityType: this.args.entityType! },
+			})) ?? {};
+		return data;
 	}
 
 	async #getSelectableFilterByDocumentUnique(documentUnique: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
@@ -26,7 +26,7 @@ export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 	@state()
 	private _treeExpansion: UmbEntityExpansionModel = [];
 
-	protected override updated(_changedProperties: PropertyValueMap<unknown> | Map<PropertyKey, unknown>) {
+	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('data')) {
 			this._treeExpansion = this.data?.treeExpansion ?? [];

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
@@ -11,6 +11,8 @@ import type { UUIBooleanInputEvent } from '@umbraco-cms/backoffice/external/uui'
 import type { UmbSelectionChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbTreeElement } from '@umbraco-cms/backoffice/tree';
 import type { UmbDocumentTreeItemModel } from '../../../types.js';
+import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
+import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 
 const elementName = 'umb-document-duplicate-to-modal';
 @customElement(elementName)
@@ -20,6 +22,16 @@ export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 > {
 	@state()
 	private _destinationUnique?: string | null;
+
+	@state()
+	private _treeExpansion: UmbEntityExpansionModel = [];
+
+	protected override updated(_changedProperties: PropertyValueMap<unknown> | Map<PropertyKey, unknown>) {
+		super.updated(_changedProperties);
+		if (_changedProperties.has('data')) {
+			this._treeExpansion = this.data?.expansion ?? [];
+		}
+	}
 
 	#onTreeSelectionChange(event: UmbSelectionChangeEvent) {
 		const target = event.target as UmbTreeElement;
@@ -58,11 +70,14 @@ export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 							expandTreeRoot: true,
 							hideTreeItemActions: true,
 							selectableFilter: this.#selectableFilter,
+							expansion: this._treeExpansion,
 						}}
 						@selection-change=${this.#onTreeSelectionChange}></umb-tree>
 				</uui-box>
 				<uui-box headline=${this.localize.term('general_options')}>
-					<umb-property-layout label=${this.localize.term('defaultdialogs_relateToOriginalLabel')} orientation="vertical"
+					<umb-property-layout
+						label=${this.localize.term('defaultdialogs_relateToOriginalLabel')}
+						orientation="vertical"
 						><div slot="editor">
 							<uui-toggle
 								@change=${this.#onRelateToOriginalChange}
@@ -85,7 +100,10 @@ export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 
 	#renderActions() {
 		return html`
-			<uui-button slot="actions" label=${this.localize.term('general_cancel')} @click="${this._rejectModal}"></uui-button>
+			<uui-button
+				slot="actions"
+				label=${this.localize.term('general_cancel')}
+				@click="${this._rejectModal}"></uui-button>
 			<uui-button
 				slot="actions"
 				color="positive"

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
@@ -11,8 +11,6 @@ import type { UUIBooleanInputEvent } from '@umbraco-cms/backoffice/external/uui'
 import type { UmbSelectionChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbTreeElement } from '@umbraco-cms/backoffice/tree';
 import type { UmbDocumentTreeItemModel } from '../../../types.js';
-import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
-import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
 
 const elementName = 'umb-document-duplicate-to-modal';
 @customElement(elementName)
@@ -23,14 +21,8 @@ export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 	@state()
 	private _destinationUnique?: string | null;
 
-	@state()
-	private _treeExpansion: UmbEntityExpansionModel = [];
-
-	protected override updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
-		super.updated(_changedProperties);
-		if (_changedProperties.has('data')) {
-			this._treeExpansion = this.data?.treeExpansion ?? [];
-		}
+	private get _treeExpansion() {
+		return this.data?.treeExpansion ?? [];
 	}
 
 	#onTreeSelectionChange(event: UmbSelectionChangeEvent) {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
@@ -29,7 +29,7 @@ export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 	protected override updated(_changedProperties: PropertyValueMap<unknown> | Map<PropertyKey, unknown>) {
 		super.updated(_changedProperties);
 		if (_changedProperties.has('data')) {
-			this._treeExpansion = this.data?.expansion ?? [];
+			this._treeExpansion = this.data?.treeExpansion ?? [];
 		}
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.token.ts
@@ -2,10 +2,11 @@ import { UMB_DUPLICATE_DOCUMENT_MODAL_ALIAS } from './manifests.js';
 import type { UmbEntityModel } from '@umbraco-cms/backoffice/entity';
 import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 import type { UmbDocumentTreeItemModel } from '../../../types.js';
+import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UmbDuplicateDocumentModalData extends UmbEntityModel {
 	selectableFilter?: (item: UmbDocumentTreeItemModel) => boolean;
+	expansion?: UmbEntityExpansionModel;
 }
 
 export interface UmbDuplicateDocumentModalValue {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.token.ts
@@ -6,7 +6,7 @@ import type { UmbEntityExpansionModel } from '@umbraco-cms/backoffice/utils';
 
 export interface UmbDuplicateDocumentModalData extends UmbEntityModel {
 	selectableFilter?: (item: UmbDocumentTreeItemModel) => boolean;
-	expansion?: UmbEntityExpansionModel;
+	treeExpansion?: UmbEntityExpansionModel;
 }
 
 export interface UmbDuplicateDocumentModalValue {


### PR DESCRIPTION
### Description

Fixes https://github.com/umbraco/Umbraco-CMS/issues/22015

When opening the **Duplicate To** or **Move To** modal from a document or other tree entity, the tree is now pre-expanded to reveal the item's current location in the hierarchy. Previously, the tree always opened collapsed at the root.