### PR TITLE
Delivery API - Open API: return inline `{}` schema for unconstrained property types (closes #23034)

### DIFF
--- a/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
@@ -343,9 +343,7 @@ public sealed class ContentTypeSchemaTransformer : IOpenApiSchemaTransformer, IO
 
         var schemaId = GetSchemaId(jsonTypeInfo);
 
-        // STJ represents unconstrained types (JsonNode, object, custom-converter types) as boolean 'true'
-        // in JSON Schema. Return an inline {} schema rather than registering a named component, since a
-        // named component adds no value and would incorrectly imply a concrete model shape.
+        // Types that produce 'true' in JSON Schema (unconstrained: JsonNode, object, custom-converter types) should be inline {} rather than named components.
         JsonNode rawSchema = JsonSchemaExporter.GetJsonSchemaAsNode(jsonTypeInfo);
         if (rawSchema.GetValueKind() == JsonValueKind.True)
         {

--- a/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
@@ -344,8 +344,7 @@ public sealed class ContentTypeSchemaTransformer : IOpenApiSchemaTransformer, IO
         var schemaId = GetSchemaId(jsonTypeInfo);
 
         // Types that produce 'true' in JSON Schema (unconstrained: JsonNode, object, custom-converter types) should be inline {} rather than named components.
-        JsonNode rawSchema = JsonSchemaExporter.GetJsonSchemaAsNode(jsonTypeInfo);
-        if (rawSchema.GetValueKind() == JsonValueKind.True)
+        if (jsonTypeInfo.Kind == JsonTypeInfoKind.None && jsonTypeInfo.GetJsonSchemaAsNode().GetValueKind() == JsonValueKind.True)
         {
             return new OpenApiSchema();
         }

--- a/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
+++ b/src/Umbraco.Cms.Api.Delivery/OpenApi/Transformers/ContentTypeSchemaTransformer.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.OpenApi;
@@ -340,6 +342,15 @@ public sealed class ContentTypeSchemaTransformer : IOpenApiSchemaTransformer, IO
         }
 
         var schemaId = GetSchemaId(jsonTypeInfo);
+
+        // STJ represents unconstrained types (JsonNode, object, custom-converter types) as boolean 'true'
+        // in JSON Schema. Return an inline {} schema rather than registering a named component, since a
+        // named component adds no value and would incorrectly imply a concrete model shape.
+        JsonNode rawSchema = JsonSchemaExporter.GetJsonSchemaAsNode(jsonTypeInfo);
+        if (rawSchema.GetValueKind() == JsonValueKind.True)
+        {
+            return new OpenApiSchema();
+        }
 
         // If this is one of the types we handle, and we already started generating it, return a placeholder
         // to avoid circular reference issues.

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/typed-schemas-with-sample-types.json
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/typed-schemas-with-sample-types.json
@@ -273,7 +273,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -413,7 +413,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -553,7 +553,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -695,7 +695,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -888,7 +888,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -974,7 +974,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -1059,7 +1059,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -1147,7 +1147,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": []
+            "ApiKeyAuth": [ ]
           }
         ]
       }
@@ -1279,7 +1279,7 @@
               }
             ]
           },
-          "plainJson": {}
+          "plainJson": { }
         }
       },
       "ArticlePageContentResponseModel": {
@@ -2734,7 +2734,7 @@
   },
   "security": [
     {
-      "ApiKeyAuth": []
+      "ApiKeyAuth": [ ]
     }
   ],
   "tags": [

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/typed-schemas-with-sample-types.json
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/ExpectedContracts/typed-schemas-with-sample-types.json
@@ -273,7 +273,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -413,7 +413,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -553,7 +553,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -695,7 +695,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -888,7 +888,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -974,7 +974,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -1059,7 +1059,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -1147,7 +1147,7 @@
         },
         "security": [
           {
-            "ApiKeyAuth": [ ]
+            "ApiKeyAuth": []
           }
         ]
       }
@@ -1278,7 +1278,8 @@
                 "type": "null"
               }
             ]
-          }
+          },
+          "plainJson": {}
         }
       },
       "ArticlePageContentResponseModel": {
@@ -2733,7 +2734,7 @@
   },
   "security": [
     {
-      "ApiKeyAuth": [ ]
+      "ApiKeyAuth": []
     }
   ],
   "tags": [

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTestBase.cs
@@ -170,6 +170,11 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
         // discriminator mapping refs that match the registered schema names.
         var polymorphicDataType = await CreatePolymorphicTestDataTypeAsync();
 
+        // Create a Plain JSON data type. JsonValueConverter handles all JSON-type property editors
+        // and returns typeof(JsonNode) as the Delivery API model type. This verifies that the schema
+        // generator produces an inline {} schema rather than a named JsonNode component (#23034).
+        var plainJsonDataType = await CreatePlainJsonDataTypeAsync();
+
         // Create a composition type that exposes shared SEO metadata properties
         var seoMetadataComposition = new ContentTypeBuilder()
             .WithAlias("seoMetadata")
@@ -222,6 +227,11 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
                     .WithAlias("polymorphicTest")
                     .WithName("Polymorphic Test")
                     .WithDataTypeId(polymorphicDataType.Id)
+                    .Done()
+                .AddPropertyType()
+                    .WithAlias("plainJson")
+                    .WithName("Plain JSON")
+                    .WithDataTypeId(plainJsonDataType.Id)
                     .Done()
                 .Done()
             .Build();
@@ -335,6 +345,24 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
         var dataType = new DataType(editor, ConfigurationEditorJsonSerializer)
         {
             Name = "Polymorphic Test",
+            DatabaseType = ValueStorageType.Ntext,
+            ParentId = Constants.System.Root,
+            CreateDate = DateTime.UtcNow,
+        };
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        return dataType;
+    }
+
+    private async Task<IDataType> CreatePlainJsonDataTypeAsync()
+    {
+        var editor = PropertyEditorCollection[Constants.PropertyEditors.Aliases.PlainJson]
+                     ?? throw new InvalidOperationException(
+                         $"Property editor '{Constants.PropertyEditors.Aliases.PlainJson}' was not registered.");
+
+        var dataType = new DataType(editor, ConfigurationEditorJsonSerializer)
+        {
+            Name = "Plain JSON",
             DatabaseType = ValueStorageType.Ntext,
             ParentId = Constants.System.Root,
             CreateDate = DateTime.UtcNow,

--- a/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTestBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Api.Delivery/OpenApi/OpenApiContractTestBase.cs
@@ -170,9 +170,7 @@ internal abstract class OpenApiContractTestBase : OpenApiTestBase
         // discriminator mapping refs that match the registered schema names.
         var polymorphicDataType = await CreatePolymorphicTestDataTypeAsync();
 
-        // Create a Plain JSON data type. JsonValueConverter handles all JSON-type property editors
-        // and returns typeof(JsonNode) as the Delivery API model type. This verifies that the schema
-        // generator produces an inline {} schema rather than a named JsonNode component (#23034).
+        // Create a Plain JSON data type to exercise the unconstrained-type schema path (#23034).
         var plainJsonDataType = await CreatePlainJsonDataTypeAsync();
 
         // Create a composition type that exposes shared SEO metadata properties


### PR DESCRIPTION
## Summary

- `JsonValueConverter.GetDeliveryApiPropertyValueType` returns `typeof(JsonNode)`. When schema tooling (e.g. `Umbraco.Community.DeliveryApiExtensions`) passed that type to schema generation, `JsonNode`'s polymorphic subclasses triggered recursive schema generation and a stack overflow on Swashbuckle (v17). On v18's `Microsoft.AspNetCore.OpenApi`, it doesn't crash — STJ converts `JsonNode` to `{}` — but it still registers a spurious named `JsonNode` component in the document.
- `ContentTypeSchemaTransformer.CreateSchema` now checks the raw STJ schema via `JsonSchemaExporter` before calling `GetOrCreateSchemaAsync`. When STJ produces boolean `true` for a type (its representation of "any unconstrained value" — applies to `JsonNode`, `object`, and types with custom converters), the transformer returns an inline `{}` schema without registering a named component.
- A Plain JSON property is added to the existing contract test sample types to exercise this path. The expected contract is updated: the property appears as `{}` and no `JsonNode` component exists.

Relates to #23034

## Testing

Run the `OpenApiContractTestTypedSchemasWithSampleTypes` integration tests. The `OpenApiContract_MatchesExpected` test will catch any regression that produces a named `JsonNode` component or wrong property schema — the expected contract has `"plainJson": {}` in `ArticlePageContentPropertiesModel` and no `JsonNode` entry in components.

To verify manually: set the app setting `Umbraco:CMS:DeliveryApi:OpenApi:GenerateContentTypeSchemas` to `true` and add a content type with a property using the `Umbraco.Plain.Json` editor. Before this fix, the Delivery API OpenAPI document would produce a spurious `JsonNode` component. After the fix, the property appears as `{}` in the schema.