### PR TITLE
Runtime Cache: Fix `IAppPolicyCache.ClearByKey` intermittently failing to clear cached items (closes #23064)

### DIFF
--- a/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
+++ b/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
@@ -368,8 +368,17 @@ public class ObjectCacheAppCache : IAppPolicyCache, IDisposable
         }
 
         // Ensure key is removed from set when evicted from cache
-        return options.RegisterPostEvictionCallback((key, _, _, _) =>
+        return options.RegisterPostEvictionCallback((key, _, reason, _) =>
         {
+            // Removed and Replaced evictions are already handled synchronously under the write lock by
+            // Clear/ClearByPredicate/Insert (and a replaced key still has a live entry). Acting on them
+            // here runs on a background thread and races with a re-add, which can drop a key that is still
+            // cached from the tracking set. (#23064)
+            if (reason is EvictionReason.Removed or EvictionReason.Replaced)
+            {
+                return;
+            }
+
             try
             {
                 if (_locker.TryEnterWriteLock(_writeLockTimeout) is false)

--- a/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
+++ b/src/Umbraco.Core/Cache/ObjectCacheAppCache.cs
@@ -370,10 +370,10 @@ public class ObjectCacheAppCache : IAppPolicyCache, IDisposable
         // Ensure key is removed from set when evicted from cache
         return options.RegisterPostEvictionCallback((key, _, reason, _) =>
         {
-            // Removed and Replaced evictions are already handled synchronously under the write lock by
-            // Clear/ClearByPredicate/Insert (and a replaced key still has a live entry). Acting on them
-            // here runs on a background thread and races with a re-add, which can drop a key that is still
-            // cached from the tracking set. (#23064)
+            // Removed and Replaced evictions don't need pruning here: the Remove/Clear call sites already
+            // prune the tracking set synchronously under the write lock, and a Replaced key still has a
+            // live entry (the synchronous Set re-added it). Pruning here instead runs on a background
+            // thread and races with that re-add, dropping a key whose entry is still cached. (#23064)
             if (reason is EvictionReason.Removed or EvictionReason.Replaced)
             {
                 return;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/RuntimeCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/RuntimeCacheTests.cs
@@ -154,36 +154,31 @@ internal sealed class RuntimeCacheTests : UmbracoIntegrationTest
     public void ClearByKey_Clears_Entry_After_Value_Is_Replaced()
     {
         RuntimeCache.Insert("key", () => "first", _timeout);
+        RuntimeCache.Insert("key", () => "second", _timeout); // replace
 
-        // Replacing a cached value evicts the previous entry on a background thread. Once that eviction
-        // has been processed, ClearByKey must still find and clear the current entry. Regression test for
-        // #23064, where the background eviction removed the re-added key from the cache's key-tracking set.
-        RuntimeCache.Insert("key", () => "second", _timeout);
+        // Replacing evicts the previous entry on a background thread; wait for that callback to run.
+        WaitForReplacedEntryEviction("key");
 
-        WaitForKeyTrackingDesync("key");
+        // #23064: the eviction must not drop the re-added key from the tracking set, so key-based search
+        // still finds the current entry...
+        Assert.That(RuntimeCache.SearchByKey("key"), Is.EquivalentTo(new[] { "second" }));
 
+        // ...and ClearByKey can therefore still clear it.
         RuntimeCache.ClearByKey("key");
-
         Assert.That(RuntimeCache.Get("key"), Is.Null);
     }
 
     /// <summary>
-    /// Waits until the background post-eviction callback has had the chance to run. Before the fix this
-    /// leaves the cache in a desynced state (the value is still cached but key-based search no longer
-    /// finds it); after the fix the condition never becomes true and the wait simply elapses, with the
-    /// calling test's assertions validating the corrected behaviour.
+    /// Waits until the background post-eviction callback for the replaced entry has had the chance to run.
+    /// Before the fix that callback removes the re-added key from the tracking set, observable as a desync
+    /// (the value is still cached but key-based search no longer finds it) which returns early. After the
+    /// fix no desync occurs and the bounded wait simply elapses.
     /// </summary>
-    private void WaitForKeyTrackingDesync(string key)
+    private void WaitForReplacedEntryEviction(string key)
     {
         var stopwatch = Stopwatch.StartNew();
-        while (stopwatch.Elapsed < TimeSpan.FromMilliseconds(500))
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(2) && RuntimeCache.SearchByKey(key).Any())
         {
-            var desynced = RuntimeCache.Get(key) is not null && RuntimeCache.SearchByKey(key).Any() is false;
-            if (desynced)
-            {
-                return;
-            }
-
             Thread.Sleep(25);
         }
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/RuntimeCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/RuntimeCacheTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Diagnostics;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Cache;
+
+/// <summary>
+/// Integration tests for the runtime cache (<see cref="AppCaches.RuntimeCache" />) as it is wired up in the
+/// web pipeline.
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.None)]
+internal sealed class RuntimeCacheTests : UmbracoIntegrationTest
+{
+    private static readonly TimeSpan _timeout = TimeSpan.FromMinutes(10);
+
+    private IAppPolicyCache RuntimeCache => AppCaches.RuntimeCache;
+
+    // The integration harness registers AppCaches.NoCache, whose RuntimeCache caches nothing. Override it
+    // with the same runtime cache the web pipeline uses (see AppCaches.Create) so these tests exercise the
+    // production caching behaviour rather than a no-op.
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+        => builder.Services.AddUnique(_ => new AppCaches(
+            new DeepCloneAppCache(new ObjectCacheAppCache()),
+            NoAppCache.Instance,
+            new IsolatedCaches(_ => new DeepCloneAppCache(new ObjectCacheAppCache()))));
+
+    [Test]
+    public void Insert_Then_Get_Returns_Cached_Value()
+    {
+        RuntimeCache.Insert("key", () => "value", _timeout);
+
+        Assert.That(RuntimeCache.Get("key"), Is.EqualTo("value"));
+    }
+
+    [Test]
+    public void GetCacheItem_Invokes_Factory_Once_And_Caches_Result()
+    {
+        var factoryCalls = 0;
+        string Factory()
+        {
+            factoryCalls++;
+            return "value";
+        }
+
+        var first = RuntimeCache.GetCacheItem("key", Factory, _timeout);
+        var second = RuntimeCache.GetCacheItem("key", Factory, _timeout);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo("value"));
+            Assert.That(second, Is.EqualTo("value"));
+            Assert.That(factoryCalls, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Clear_Removes_All_Items()
+    {
+        RuntimeCache.Insert("a", () => "1", _timeout);
+        RuntimeCache.Insert("b", () => "2", _timeout);
+
+        RuntimeCache.Clear();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RuntimeCache.Get("a"), Is.Null);
+            Assert.That(RuntimeCache.Get("b"), Is.Null);
+        });
+    }
+
+    [Test]
+    public void Clear_With_Key_Removes_Only_The_Matching_Item()
+    {
+        RuntimeCache.Insert("a", () => "1", _timeout);
+        RuntimeCache.Insert("b", () => "2", _timeout);
+
+        RuntimeCache.Clear("a");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RuntimeCache.Get("a"), Is.Null);
+            Assert.That(RuntimeCache.Get("b"), Is.EqualTo("2"));
+        });
+    }
+
+    [Test]
+    public void ClearByKey_Removes_Items_With_Matching_Prefix()
+    {
+        RuntimeCache.Insert("prefix:a", () => "1", _timeout);
+        RuntimeCache.Insert("prefix:b", () => "2", _timeout);
+        RuntimeCache.Insert("other", () => "3", _timeout);
+
+        RuntimeCache.ClearByKey("prefix:");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RuntimeCache.Get("prefix:a"), Is.Null);
+            Assert.That(RuntimeCache.Get("prefix:b"), Is.Null);
+            Assert.That(RuntimeCache.Get("other"), Is.EqualTo("3"));
+        });
+    }
+
+    [Test]
+    public void ClearByRegex_Removes_Matching_Items()
+    {
+        RuntimeCache.Insert("item-1", () => "1", _timeout);
+        RuntimeCache.Insert("item-2", () => "2", _timeout);
+        RuntimeCache.Insert("keep", () => "3", _timeout);
+
+        RuntimeCache.ClearByRegex(@"^item-\d$");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RuntimeCache.Get("item-1"), Is.Null);
+            Assert.That(RuntimeCache.Get("item-2"), Is.Null);
+            Assert.That(RuntimeCache.Get("keep"), Is.EqualTo("3"));
+        });
+    }
+
+    [Test]
+    public void ClearOfType_Removes_Only_Items_Of_That_Type()
+    {
+        RuntimeCache.Insert("cart", () => new Cart("the-cart"), _timeout);
+        RuntimeCache.Insert("text", () => "a string", _timeout);
+
+        RuntimeCache.ClearOfType<Cart>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(RuntimeCache.Get("cart"), Is.Null);
+            Assert.That(RuntimeCache.Get("text"), Is.EqualTo("a string"));
+        });
+    }
+
+    [Test]
+    public void SearchByKey_Returns_Items_With_Matching_Prefix()
+    {
+        RuntimeCache.Insert("prefix:a", () => "1", _timeout);
+        RuntimeCache.Insert("prefix:b", () => "2", _timeout);
+        RuntimeCache.Insert("other", () => "3", _timeout);
+
+        var matches = RuntimeCache.SearchByKey("prefix:").ToArray();
+
+        Assert.That(matches, Is.EquivalentTo(new[] { "1", "2" }));
+    }
+
+    [Test]
+    public void ClearByKey_Clears_Entry_After_Value_Is_Replaced()
+    {
+        RuntimeCache.Insert("key", () => "first", _timeout);
+
+        // Replacing a cached value evicts the previous entry on a background thread. Once that eviction
+        // has been processed, ClearByKey must still find and clear the current entry. Regression test for
+        // #23064, where the background eviction removed the re-added key from the cache's key-tracking set.
+        RuntimeCache.Insert("key", () => "second", _timeout);
+
+        WaitForKeyTrackingDesync("key");
+
+        RuntimeCache.ClearByKey("key");
+
+        Assert.That(RuntimeCache.Get("key"), Is.Null);
+    }
+
+    /// <summary>
+    /// Waits until the background post-eviction callback has had the chance to run. Before the fix this
+    /// leaves the cache in a desynced state (the value is still cached but key-based search no longer
+    /// finds it); after the fix the condition never becomes true and the wait simply elapses, with the
+    /// calling test's assertions validating the corrected behaviour.
+    /// </summary>
+    private void WaitForKeyTrackingDesync(string key)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(2))
+        {
+            var desynced = RuntimeCache.Get(key) is not null && RuntimeCache.SearchByKey(key).Any() is false;
+            if (desynced)
+            {
+                return;
+            }
+
+            Thread.Sleep(25);
+        }
+    }
+
+    private sealed record Cart(string Name);
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/RuntimeCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/RuntimeCacheTests.cs
@@ -176,7 +176,7 @@ internal sealed class RuntimeCacheTests : UmbracoIntegrationTest
     private void WaitForKeyTrackingDesync(string key)
     {
         var stopwatch = Stopwatch.StartNew();
-        while (stopwatch.Elapsed < TimeSpan.FromSeconds(2))
+        while (stopwatch.Elapsed < TimeSpan.FromMilliseconds(500))
         {
             var desynced = RuntimeCache.Get(key) is not null && RuntimeCache.SearchByKey(key).Any() is false;
             if (desynced)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ObjectAppCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ObjectAppCacheTests.cs
@@ -34,11 +34,11 @@ public class ObjectAppCacheTests : RuntimeAppCacheTests
         _provider.Insert("key", () => "first", timeout);
         _provider.Insert("key", () => "second", timeout);
 
-        // Give the background eviction callback for the replaced entry time to run.
+        // The replaced entry is evicted on a background thread. On a build with the bug that eviction
+        // removes the key from the tracking set - a sticky desync we can detect. On a fixed build nothing
+        // changes and the bounded wait simply elapses.
         var stopwatch = Stopwatch.StartNew();
-        while (stopwatch.Elapsed < TimeSpan.FromMilliseconds(500)
-               && _provider.Get("key") is not null
-               && _provider.SearchByKey("key").Any())
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(2) && _provider.SearchByKey("key").Any())
         {
             Thread.Sleep(25);
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ObjectAppCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ObjectAppCacheTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Diagnostics;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
 
@@ -22,4 +23,33 @@ public class ObjectAppCacheTests : RuntimeAppCacheTests
     internal override IAppCache AppCache => _provider;
 
     internal override IAppPolicyCache AppPolicyCache => _provider;
+
+    // Replacing a cached value evicts the previous entry on a background thread. The eviction must not
+    // remove the re-added key from the key-tracking set, otherwise key-based operations stop finding the
+    // live entry. Regression test for https://github.com/umbraco/Umbraco-CMS/issues/23064.
+    [Test]
+    public void Replacing_A_Value_Keeps_The_Key_Tracked()
+    {
+        var timeout = TimeSpan.FromMinutes(10);
+        _provider.Insert("key", () => "first", timeout);
+        _provider.Insert("key", () => "second", timeout);
+
+        // Give the background eviction callback for the replaced entry time to run.
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TimeSpan.FromSeconds(2)
+               && _provider.Get("key") is not null
+               && _provider.SearchByKey("key").Any())
+        {
+            Thread.Sleep(25);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_provider.Get("key"), Is.EqualTo("second"));
+            Assert.That(_provider.SearchByKey("key"), Is.EquivalentTo(new[] { "second" }));
+        });
+
+        _provider.ClearByKey("key");
+        Assert.That(_provider.Get("key"), Is.Null);
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ObjectAppCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Cache/ObjectAppCacheTests.cs
@@ -36,7 +36,7 @@ public class ObjectAppCacheTests : RuntimeAppCacheTests
 
         // Give the background eviction callback for the replaced entry time to run.
         var stopwatch = Stopwatch.StartNew();
-        while (stopwatch.Elapsed < TimeSpan.FromSeconds(2)
+        while (stopwatch.Elapsed < TimeSpan.FromMilliseconds(500)
                && _provider.Get("key") is not null
                && _provider.SearchByKey("key").Any())
         {


### PR DESCRIPTION
## Description

`AppCaches.RuntimeCache` (`ObjectCacheAppCache`) sits on top of `MemoryCache`, which does not expose its keys. To support prefix/regex/type-based operations, Umbraco maintains its own `_keys` set and keeps it in sync with a post-eviction callback.

That callback runs on a **background thread** and pruned the key for **every** eviction reason. When a key was removed-and-repopulated (or replaced) on the same request, the late `Removed`/`Replaced` callback for the previous entry deleted a key that had **already been re-added** — desyncing `_keys` from `MemoryCache`. The value stayed cached, but `ClearByKey` (and `ClearByRegex`, `ClearOfType`, `SearchByKey`) enumerate `_keys`, so they could no longer find it and silently cleared nothing. The next read then served a stale value.

This is the intermittent behaviour reported in #23064: *"After clearing a cache item via `_runtimeCache.ClearByKey(cacheKey);` and then accessing run time cache I see old values."* The intermittency came from the race between the background callback and the re-add.

### Fix

In the post-eviction callback, skip `EvictionReason.Removed` and `EvictionReason.Replaced`:

- `Removed` — `Clear(key)`/`ClearByPredicate` already remove the key from `_keys` synchronously under the write lock, so the background callback only risked deleting a re-added key.
- `Replaced` — a replaced key still has a live current entry, so removing it from `_keys` was incorrect.

Genuine background evictions (`Expired`, `Capacity`, `TokenExpired`) — the ones Umbraco does **not** handle itself — still prune `_keys`, so there is no key leak.

Fixes #23064

## Testing

### Automated

A regression unit test has been added ensuring that after a replace, the key stays tracked (`SearchByKey` still finds it) and `ClearByKey` clears the entry.

A new set of integration tests have been added to verify the functionality of the runtime cache as wired in the web pipeline.  A specific test for the issue fails before the fix and passes afterwards.

### Manual testing

A debug controller reproduces the report on `v17/dev` and proves the fix on this branch via a single endpoint.

> The desync check (`Get(key)` returns a value while `SearchByKey(key)` finds nothing) is the bug's internal signature — the value is still in `MemoryCache` but the key has been dropped from the tracking set. The polling loop also acts as a synchronisation barrier: it waits until the background eviction callback has had its chance to run before calling ClearByKey, so the broken build deterministically reaches the corrupted state (FAIL) rather than occasionally clearing before the callback fires. On the fixed build the desync never occurs, the loop simply elapses, and ClearByKey clears the live entry (PASS) — so the FAIL→PASS flip reflects the fix, not timing luck.


```csharp
using System.Diagnostics;
using System.Text;
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Cache;

namespace Umbraco.Cms.Web.UI.Custom.Cache;

public class DebugClearByKeyController : Controller
{
    private readonly IAppPolicyCache _runtimeCache;

    public DebugClearByKeyController(AppCaches appCaches) => _runtimeCache = appCaches.RuntimeCache;

    [HttpGet("/debug/clear-by-key-test")]
    public IActionResult Run()
    {
        const string cacheKey = "Debug23064";
        var timeout = TimeSpan.FromMinutes(10);
        var log = new StringBuilder();

        _runtimeCache.Clear(cacheKey);

        _runtimeCache.Insert(cacheKey, () => "first", timeout);
        _runtimeCache.Insert(cacheKey, () => "second", timeout);
        log.AppendLine($"Inserted '{cacheKey}' = 'first', then replaced with 'second'.");

        var stopwatch = Stopwatch.StartNew();
        var observedDesync = false;
        while (stopwatch.Elapsed < TimeSpan.FromSeconds(2))
        {
            observedDesync = _runtimeCache.Get(cacheKey) is not null && _runtimeCache.SearchByKey(cacheKey).Any() is false;
            if (observedDesync)
            {
                break;
            }

            Thread.Sleep(25);
        }

        log.AppendLine($"After background eviction: Get='{_runtimeCache.Get(cacheKey)}', SearchByKey count={_runtimeCache.SearchByKey(cacheKey).Count()}.");
        log.AppendLine($"Key-tracking set desynced from cache: {observedDesync}.");

        _runtimeCache.ClearByKey(cacheKey);
        var valueAfterClear = _runtimeCache.Get(cacheKey);
        log.AppendLine($"After ClearByKey('{cacheKey}'): Get='{valueAfterClear ?? "<null>"}'.");

        log.AppendLine();
        log.AppendLine(valueAfterClear is null
            ? "RESULT: PASS - ClearByKey cleared the item (issue #23064 is fixed on this branch)."
            : "RESULT: FAIL - ClearByKey did not clear the item; the stale value is still served (issue #23064 reproduced).");

        return Content(log.ToString(), "text/plain");
    }
}
```

Drop the file into `src/Umbraco.Web.UI/Custom/Cache/`, run the site, and `GET /debug/clear-by-key-test`.

**Before the fix (`v17/dev`):**

```
Inserted 'Debug23064' = 'first', then replaced with 'second'.
After background eviction: Get='second', SearchByKey count=0.
Key-tracking set desynced from cache: True.
After ClearByKey('Debug23064'): Get='second'.

RESULT: FAIL - ClearByKey did not clear the item; the stale value is still served (issue #23064 reproduced).
```

**After the fix (this branch):**

```
Inserted 'Debug23064' = 'first', then replaced with 'second'.
After background eviction: Get='second', SearchByKey count=1.
Key-tracking set desynced from cache: False.
After ClearByKey('Debug23064'): Get='<null>'.

RESULT: PASS - ClearByKey cleared the item (issue #23064 is fixed on this branch).
```