### PR TITLE
Elements: Invalidate the id/key map when an element container is deleted (closes #23072)

### DIFF
--- a/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
@@ -474,13 +474,6 @@ public static class DistributedCacheExtensions
     /// </summary>
     /// <param name="dc">The distributed cache.</param>
     /// <param name="deletedContainers">The element containers that were deleted.</param>
-    /// <remarks>
-    ///     A deleted container's node id is never reused, so its key→id mapping in
-    ///     <see cref="Umbraco.Cms.Core.Services.IIdKeyMap"/> must be evicted on every server. Otherwise a
-    ///     container recreated under the same key resolves to the stale id and the element tree's children
-    ///     query returns nothing until the next app restart. This is targeted at the id/key map only -
-    ///     container changes do not affect element data, so it avoids the broader element cache invalidation.
-    /// </remarks>
     public static void RemoveElementContainerCache(this DistributedCache dc, IEnumerable<EntityContainer> deletedContainers)
         => dc.RefreshByPayload(
             ElementContainerCacheRefresher.UniqueId,

--- a/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
@@ -465,21 +465,26 @@ public static class DistributedCacheExtensions
             UnpublishedCultures = x.UnpublishedCultures?.ToArray(),
         }));
 
+    #endregion
+
+    #region ElementContainerCacheRefresher
+
     /// <summary>
-    ///     Invalidates the element cache for the specified deleted element containers (folders).
+    ///     Invalidates the id/key map for the specified deleted element containers (folders).
     /// </summary>
     /// <param name="dc">The distributed cache.</param>
     /// <param name="deletedContainers">The element containers that were deleted.</param>
     /// <remarks>
     ///     A deleted container's node id is never reused, so its key→id mapping in
     ///     <see cref="Umbraco.Cms.Core.Services.IIdKeyMap"/> must be evicted on every server. Otherwise a
-    ///     container recreated under the same key resolves to
-    ///     the stale id and the element tree's children query returns nothing until the next app restart.
+    ///     container recreated under the same key resolves to the stale id and the element tree's children
+    ///     query returns nothing until the next app restart. This is targeted at the id/key map only -
+    ///     container changes do not affect element data, so it avoids the broader element cache invalidation.
     /// </remarks>
-    public static void RefreshElementCache(this DistributedCache dc, IEnumerable<EntityContainer> deletedContainers)
+    public static void RemoveElementContainerCache(this DistributedCache dc, IEnumerable<EntityContainer> deletedContainers)
         => dc.RefreshByPayload(
-            ElementCacheRefresher.UniqueId,
-            deletedContainers.Select(container => new ElementCacheRefresher.JsonPayload(container.Id, container.Key, TreeChangeTypes.Remove)));
+            ElementContainerCacheRefresher.UniqueId,
+            deletedContainers.Select(container => new ElementContainerCacheRefresher.JsonPayload(container.Id, container.Key)));
 
     #endregion
 

--- a/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
+++ b/src/Umbraco.Core/Cache/DistributedCacheExtensions.cs
@@ -465,6 +465,22 @@ public static class DistributedCacheExtensions
             UnpublishedCultures = x.UnpublishedCultures?.ToArray(),
         }));
 
+    /// <summary>
+    ///     Invalidates the element cache for the specified deleted element containers (folders).
+    /// </summary>
+    /// <param name="dc">The distributed cache.</param>
+    /// <param name="deletedContainers">The element containers that were deleted.</param>
+    /// <remarks>
+    ///     A deleted container's node id is never reused, so its key→id mapping in
+    ///     <see cref="Umbraco.Cms.Core.Services.IIdKeyMap"/> must be evicted on every server. Otherwise a
+    ///     container recreated under the same key resolves to
+    ///     the stale id and the element tree's children query returns nothing until the next app restart.
+    /// </remarks>
+    public static void RefreshElementCache(this DistributedCache dc, IEnumerable<EntityContainer> deletedContainers)
+        => dc.RefreshByPayload(
+            ElementCacheRefresher.UniqueId,
+            deletedContainers.Select(container => new ElementCacheRefresher.JsonPayload(container.Id, container.Key, TreeChangeTypes.Remove)));
+
     #endregion
 
     #region Published Snapshot

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ElementContainerDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ElementContainerDeletedDistributedCacheNotificationHandler.cs
@@ -11,9 +11,8 @@ namespace Umbraco.Cms.Core.Cache;
 /// <remarks>
 /// Element container deletions only publish <see cref="EntityContainerDeletedNotification"/> and an
 /// <see cref="ElementTreeChangeNotification"/> for the contained elements - never for the container node
-/// itself. Without this handler the container's stale mapping survives until the next app restart, and a
-/// container recreated under the same key resolves to the old id, so the element tree's children query
-/// returns nothing (see #23072).
+/// itself, so without this handler the container's stale id/key mapping survives until the next app
+/// restart (see #23072).
 /// </remarks>
 public sealed class ElementContainerDeletedDistributedCacheNotificationHandler
     : DeletedDistributedCacheNotificationHandlerBase<EntityContainer, EntityContainerDeletedNotification>
@@ -31,7 +30,7 @@ public sealed class ElementContainerDeletedDistributedCacheNotificationHandler
     protected override void Handle(IEnumerable<EntityContainer> entities, IDictionary<string, object?> state)
     {
         EntityContainer[] elementContainers = entities
-            .Where(container => container.ContainedObjectType == Constants.ObjectTypes.Element)
+            .Where(container => container.ContainerObjectType == Constants.ObjectTypes.ElementContainer)
             .ToArray();
 
         if (elementContainers.Length == 0)

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ElementContainerDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ElementContainerDeletedDistributedCacheNotificationHandler.cs
@@ -1,0 +1,44 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Core.Cache;
+
+/// <summary>
+/// Invalidates element caches when an element container (folder) is deleted, so that its key→id mapping
+/// is evicted from <see cref="Services.IIdKeyMap"/> on every server.
+/// </summary>
+/// <remarks>
+/// Element container deletions only publish <see cref="EntityContainerDeletedNotification"/> and an
+/// <see cref="ElementTreeChangeNotification"/> for the contained elements - never for the container node
+/// itself. Without this handler the container's stale mapping survives until the next app restart, and a
+/// container recreated under the same key resolves to the old id, so the element tree's children query
+/// returns nothing (see #23072).
+/// </remarks>
+public sealed class ElementContainerDeletedDistributedCacheNotificationHandler
+    : DeletedDistributedCacheNotificationHandlerBase<EntityContainer, EntityContainerDeletedNotification>
+{
+    private readonly DistributedCache _distributedCache;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ElementContainerDeletedDistributedCacheNotificationHandler"/> class.
+    /// </summary>
+    /// <param name="distributedCache">The distributed cache.</param>
+    public ElementContainerDeletedDistributedCacheNotificationHandler(DistributedCache distributedCache)
+        => _distributedCache = distributedCache;
+
+    /// <inheritdoc />
+    protected override void Handle(IEnumerable<EntityContainer> entities, IDictionary<string, object?> state)
+    {
+        EntityContainer[] elementContainers = entities
+            .Where(container => container.ContainedObjectType == Constants.ObjectTypes.Element)
+            .ToArray();
+
+        if (elementContainers.Length == 0)
+        {
+            return;
+        }
+
+        _distributedCache.RefreshElementCache(elementContainers);
+    }
+}

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ElementContainerDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/ElementContainerDeletedDistributedCacheNotificationHandler.cs
@@ -39,6 +39,6 @@ public sealed class ElementContainerDeletedDistributedCacheNotificationHandler
             return;
         }
 
-        _distributedCache.RefreshElementCache(elementContainers);
+        _distributedCache.RemoveElementContainerCache(elementContainers);
     }
 }

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ElementContainerCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ElementContainerCacheRefresher.cs
@@ -38,6 +38,11 @@ public sealed class ElementContainerCacheRefresher : PayloadCacheRefresherBase<E
     /// </summary>
     public class JsonPayload
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonPayload"/> class.
+        /// </summary>
+        /// <param name="id">The unique integer identifier for the container.</param>
+        /// <param name="key">The unique GUID key associated with the container.</param>
         public JsonPayload(int id, Guid key)
         {
             Id = id;

--- a/src/Umbraco.Core/Cache/Refreshers/Implement/ElementContainerCacheRefresher.cs
+++ b/src/Umbraco.Core/Cache/Refreshers/Implement/ElementContainerCacheRefresher.cs
@@ -1,0 +1,104 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Core.Cache;
+
+/// <summary>
+/// Provides cache refresh functionality for element containers (folders).
+/// </summary>
+/// <remarks>
+/// A deleted container's node id is never reused, so its key→id mapping in <see cref="IIdKeyMap"/> must be
+/// evicted on every server. Otherwise a container recreated under the same key resolves to the stale id and
+/// the element tree's children query returns nothing until the next app restart. This refresher only evicts
+/// the id/key map - element data is unaffected by container changes, so it deliberately avoids the broader
+/// invalidation performed by <see cref="ElementCacheRefresher"/>.
+/// </remarks>
+public sealed class ElementContainerCacheRefresher : PayloadCacheRefresherBase<ElementContainerCacheRefresherNotification, ElementContainerCacheRefresher.JsonPayload>
+{
+    private readonly IIdKeyMap _idKeyMap;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ElementContainerCacheRefresher"/> class.
+    /// </summary>
+    public ElementContainerCacheRefresher(
+        AppCaches appCaches,
+        IJsonSerializer serializer,
+        IIdKeyMap idKeyMap,
+        IEventAggregator eventAggregator,
+        ICacheRefresherNotificationFactory factory)
+        : base(appCaches, serializer, eventAggregator, factory)
+        => _idKeyMap = idKeyMap;
+
+    #region Json
+
+    /// <summary>
+    /// Represents a JSON-serializable payload identifying an element container that changed.
+    /// </summary>
+    public class JsonPayload
+    {
+        public JsonPayload(int id, Guid key)
+        {
+            Id = id;
+            Key = key;
+        }
+
+        /// <summary>
+        /// Gets the unique integer identifier for the container.
+        /// </summary>
+        public int Id { get; }
+
+        /// <summary>
+        /// Gets the unique GUID key associated with the container.
+        /// </summary>
+        public Guid Key { get; }
+    }
+
+    #endregion
+
+    #region Define
+
+    /// <summary>
+    /// Represents a unique identifier for the cache refresher.
+    /// </summary>
+    public static readonly Guid UniqueId = Guid.Parse("9C9D8B0E-2F1A-4D63-9C2E-7E6B5A4F3C21");
+
+    /// <inheritdoc/>
+    public override Guid RefresherUniqueId => UniqueId;
+
+    /// <inheritdoc/>
+    public override string Name => "Element Container Cache Refresher";
+
+    #endregion
+
+    #region Refresher
+
+    /// <inheritdoc/>
+    public override void Refresh(JsonPayload[] payloads)
+    {
+        foreach (JsonPayload payload in payloads)
+        {
+            // Clearing by id also evicts the key→id direction, as the id/key map keeps both in sync.
+            _idKeyMap.ClearCache(payload.Id);
+        }
+
+        base.Refresh(payloads);
+    }
+
+    // These events should never trigger. Everything should be PAYLOAD/JSON.
+
+    /// <inheritdoc/>
+    public override void RefreshAll() => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Refresh(int id) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Refresh(Guid id) => throw new NotSupportedException();
+
+    /// <inheritdoc/>
+    public override void Remove(int id) => throw new NotSupportedException();
+
+    #endregion
+}

--- a/src/Umbraco.Core/Notifications/ElementContainerCacheRefresherNotification.cs
+++ b/src/Umbraco.Core/Notifications/ElementContainerCacheRefresherNotification.cs
@@ -1,0 +1,19 @@
+using Umbraco.Cms.Core.Sync;
+
+namespace Umbraco.Cms.Core.Notifications;
+
+/// <summary>
+/// A notification that is used to trigger the Element Container Cache Refresher.
+/// </summary>
+public class ElementContainerCacheRefresherNotification : CacheRefresherNotification
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ElementContainerCacheRefresherNotification"/> class.
+    /// </summary>
+    /// <param name="messageObject">The refresher payload.</param>
+    /// <param name="messageType">Type of the cache refresher message, <see cref="MessageType"/>.</param>
+    public ElementContainerCacheRefresherNotification(object messageObject, MessageType messageType)
+        : base(messageObject, messageType)
+    {
+    }
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -466,6 +466,7 @@ public static partial class UmbracoBuilderExtensions
             .AddNotificationHandler<MemberTypeChangedNotification, MemberTypeChangedDistributedCacheNotificationHandler>()
             .AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>()
             .AddNotificationHandler<ElementTreeChangeNotification, ElementTreeChangeDistributedCacheNotificationHandler>()
+            .AddNotificationHandler<EntityContainerDeletedNotification, ElementContainerDeletedDistributedCacheNotificationHandler>()
             ;
 
         // add notification handlers for auditing

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/ElementContainerDeletedDistributedCacheNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/ElementContainerDeletedDistributedCacheNotificationHandlerTests.cs
@@ -1,0 +1,112 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Cache;
+
+/// <summary>
+/// Tests for <see cref="ElementContainerDeletedDistributedCacheNotificationHandler"/>.
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest, WithApplication = true)]
+internal sealed class ElementContainerDeletedDistributedCacheNotificationHandlerTests : UmbracoIntegrationTest
+{
+    private IElementContainerService ElementContainerService => GetRequiredService<IElementContainerService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private IElementService ElementService => GetRequiredService<IElementService>();
+
+    private IEntityService EntityService => GetRequiredService<IEntityService>();
+
+    private static readonly UmbracoObjectTypes[] _treeObjectTypes =
+        [UmbracoObjectTypes.ElementContainer, UmbracoObjectTypes.Element];
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        // Integration tests use a no-op server messenger and do not register the distributed cache
+        // notification handlers by default, so opt in to the element handlers under test and a messenger
+        // that delivers cache refreshes locally.
+        builder.AddNotificationHandler<ElementTreeChangeNotification, ElementTreeChangeDistributedCacheNotificationHandler>();
+        builder.AddNotificationHandler<EntityContainerDeletedNotification, ElementContainerDeletedDistributedCacheNotificationHandler>();
+        builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+    }
+
+    /// <summary>
+    /// Regression test for https://github.com/umbraco/Umbraco-CMS/issues/23072: the element tree's children
+    /// query resolves the container key to an id via <see cref="IIdKeyMap"/>. When a container is deleted the
+    /// handler must evict its mapping, otherwise a container recreated under the same key resolves to the old
+    /// (now non-existent) id and nested elements stay invisible in the tree until the application is restarted.
+    /// </summary>
+    [Test]
+    public async Task Child_Element_Is_Returned_After_Container_Recreated_Under_Same_Key()
+    {
+        IContentType elementType = await CreateElementTypeAsync();
+        var containerKey = Guid.NewGuid();
+
+        // Create the container and resolve its children once, so its key->id mapping is cached in IdKeyMap.
+        EntityContainer firstContainer = await CreateContainerAsync(containerKey, "Container v1");
+        Attempt<int> warmResolve = IdKeyMap.GetIdForKey(containerKey, UmbracoObjectTypes.ElementContainer);
+        Assert.AreEqual(firstContainer.Id, warmResolve.Result);
+
+        // Delete and recreate under the same key - the recreated container gets a new id.
+        Attempt<EntityContainer?, EntityContainerOperationStatus> deleteResult =
+            await ElementContainerService.DeleteAsync(containerKey, Constants.Security.SuperUserKey);
+        Assert.IsTrue(deleteResult.Success, $"Failed to delete container: {deleteResult.Status}");
+
+        EntityContainer secondContainer = await CreateContainerAsync(containerKey, "Container v2");
+        Assert.AreNotEqual(firstContainer.Id, secondContainer.Id, "Recreated container should have a new id.");
+
+        IElement element = CreateElementUnder(secondContainer.Id, elementType);
+
+        // Without the fix, the stale containerKey->firstContainer.Id mapping survives and the children query
+        // resolves to the old (now non-existent) parent id, returning nothing.
+        Attempt<int> resolvedAfter = IdKeyMap.GetIdForKey(containerKey, UmbracoObjectTypes.ElementContainer);
+        Assert.AreEqual(secondContainer.Id, resolvedAfter.Result, "Container key should resolve to the recreated container id.");
+
+        AssertChildrenContains(containerKey, element.Key);
+    }
+
+    private void AssertChildrenContains(Guid containerKey, Guid expectedElementKey)
+    {
+        IEntitySlim[] children = EntityService
+            .GetPagedChildren(containerKey, _treeObjectTypes, _treeObjectTypes, 0, 100, false, out var total)
+            .ToArray();
+
+        Assert.AreEqual(1, total, "Expected the element tree children query to return the nested element.");
+        Assert.IsTrue(children.Any(child => child.Key == expectedElementKey), "Nested element was not returned by the children query.");
+    }
+
+    private async Task<IContentType> CreateElementTypeAsync()
+    {
+        IContentType elementType = ContentTypeBuilder.CreateSimpleElementType();
+        await ContentTypeService.CreateAsync(elementType, Constants.Security.SuperUserKey);
+        return elementType;
+    }
+
+    private async Task<EntityContainer> CreateContainerAsync(Guid key, string name)
+    {
+        Attempt<EntityContainer?, EntityContainerOperationStatus> result =
+            await ElementContainerService.CreateAsync(key, name, null, Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create container: {result.Status}");
+        return result.Result!;
+    }
+
+    private IElement CreateElementUnder(int parentId, IContentType elementType)
+    {
+        var element = new Element($"Element {Guid.NewGuid():N}", parentId, elementType);
+        OperationResult saveResult = ElementService.Save(element);
+        Assert.IsTrue(saveResult.Success, "Failed to save element.");
+        return element;
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/ElementContainerDeletedDistributedCacheNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Cache/ElementContainerDeletedDistributedCacheNotificationHandlerTests.cs
@@ -49,7 +49,7 @@ internal sealed class ElementContainerDeletedDistributedCacheNotificationHandler
     /// (now non-existent) id and nested elements stay invisible in the tree until the application is restarted.
     /// </summary>
     [Test]
-    public async Task Child_Element_Is_Returned_After_Container_Recreated_Under_Same_Key()
+    public async Task Can_Resolve_Children_After_Container_Recreated_Under_Same_Key()
     {
         IContentType elementType = await CreateElementTypeAsync();
         var containerKey = Guid.NewGuid();
@@ -57,6 +57,7 @@ internal sealed class ElementContainerDeletedDistributedCacheNotificationHandler
         // Create the container and resolve its children once, so its key->id mapping is cached in IdKeyMap.
         EntityContainer firstContainer = await CreateContainerAsync(containerKey, "Container v1");
         Attempt<int> warmResolve = IdKeyMap.GetIdForKey(containerKey, UmbracoObjectTypes.ElementContainer);
+        Assert.IsTrue(warmResolve.Success, "Expected IdKeyMap to resolve the newly created container key.");
         Assert.AreEqual(firstContainer.Id, warmResolve.Result);
 
         // Delete and recreate under the same key - the recreated container gets a new id.
@@ -72,6 +73,7 @@ internal sealed class ElementContainerDeletedDistributedCacheNotificationHandler
         // Without the fix, the stale containerKey->firstContainer.Id mapping survives and the children query
         // resolves to the old (now non-existent) parent id, returning nothing.
         Attempt<int> resolvedAfter = IdKeyMap.GetIdForKey(containerKey, UmbracoObjectTypes.ElementContainer);
+        Assert.IsTrue(resolvedAfter.Success, "Expected IdKeyMap to resolve the recreated container key.");
         Assert.AreEqual(secondContainer.Id, resolvedAfter.Result, "Container key should resolve to the recreated container id.");
 
         AssertChildrenContains(containerKey, element.Key);


### PR DESCRIPTION
## Description

https://github.com/umbraco/Umbraco-CMS/issues/23072 reports a scenario found in testing with Umbraco Deploy, where the same container and element are transferred from one environment to another, deleted and then transferred again.

This leads to the an element container being **deleted and recreated under the same fixed GUID**, but it will be allocated a **new integer Id**.

In this situation the backoffice element tree's `children` endpoint (`GET /umbraco/management/api/v1/tree/element/children?parentId=<containerGuid>`) returns no items for elements nested under an element container, even though the root endpoint reports the container with `hasChildren: true`. The tree only starts showing the children after the application is restarted.

### Root cause

The children endpoint resolves the **container** GUID to its integer id via `IIdKeyMap`, then queries `WHERE ParentId == <resolvedId>`. The failure happens because nothing has evicted the stale `GUID → old-id` entry from `IIdKeyMap` when the container was deleted.

So the children query keeps resolving the container GUID to the old (now non-existent) id and returns nothing, until an app restart rebuilds the in-memory map. 

### Fix

A new notification handler, `ElementContainerDeletedDistributedCacheNotificationHandler`, has been created and registered. It handles `EntityContainerDeletedNotification` and, for element containers, evicts the container's stale `IIdKeyMap` entry, via the distributed cache so it clears on every server in a load-balanced setup.

The eviction runs through a dedicated `ElementContainerCacheRefresher` whose only job is to clear the container's id/key mapping. A container deletion changes no element data, so this deliberately avoids the broader invalidation in
`ElementCacheRefresher` (which clears the entire elements cache on every payload).

Fixes #23072.

## Testing

### Automated

`ElementContainerDeletedDistributedCacheNotificationHandlerTests` (integration test) reproduces the
exact mechanism:

1. Create an element type and a container under a fixed GUID.
2. Resolve the container's children once, to warm the `GUID → id` mapping in `IIdKeyMap`.
3. Delete the container, then recreate it under the **same GUID** (asserting it gets a new id).
4. Create an element under the recreated container.
5. Assert the container GUID now resolves to the **new** id, and that the element-tree children query
   returns the element.

Confirmed **red before the fix** (container GUID resolves to the old id; `total = 0`) and **green after**.

### Manual

A small debug controller was used to reproduce and verify this end-to-end in a running site:

<details>
<summary>DebugElementTreeChildrenController.cs</summary>

```csharp
using System.Text;
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Models.Entities;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Services.OperationStatus;
using Umbraco.Cms.Core.Strings;

namespace Umbraco.Cms.Web.UI.Controllers;

public class DebugElementTreeChildrenController : Controller
{
    private const string ElementTypeAlias = "debugElementTreeItem";

    private readonly IContentTypeService _contentTypeService;
    private readonly IElementService _elementService;
    private readonly IElementContainerService _elementContainerService;
    private readonly IEntityService _entityService;
    private readonly IIdKeyMap _idKeyMap;
    private readonly IShortStringHelper _shortStringHelper;

    public DebugElementTreeChildrenController(
        IContentTypeService contentTypeService,
        IElementService elementService,
        IElementContainerService elementContainerService,
        IEntityService entityService,
        IIdKeyMap idKeyMap,
        IShortStringHelper shortStringHelper)
    {
        _contentTypeService = contentTypeService;
        _elementService = elementService;
        _elementContainerService = elementContainerService;
        _entityService = entityService;
        _idKeyMap = idKeyMap;
        _shortStringHelper = shortStringHelper;
    }

    [HttpGet("/debug/element-tree-children")]
    public async Task<IActionResult> Run()
    {
        IContentType elementType = await GetOrCreateElementTypeAsync();

        // Use a fixed key so the container can be deleted and re-created under the same key
        // (the node id changes because ids are never reused).
        var containerKey = Guid.Parse("d0d0d0d0-2307-2072-0000-000000000001");

        // 1. Create the container, then resolve its children once so the key->id mapping is cached.
        await CreateContainerAsync(containerKey, "Debug Element Container (v1)");
        _ = _entityService.GetPagedChildren(
            containerKey,
            [UmbracoObjectTypes.ElementContainer, UmbracoObjectTypes.Element],
            [UmbracoObjectTypes.ElementContainer, UmbracoObjectTypes.Element],
            0,
            100,
            false,
            out _);

        // 2. Delete and re-create under the same key - the new container gets a different id, but without
        //    the fix the stale key->id mapping is never evicted (no element-container cache invalidation).
        await _elementContainerService.DeleteAsync(containerKey, Constants.Security.SuperUserKey);
        EntityContainer container = await CreateContainerAsync(containerKey, "Debug Element Container (v2)");

        // Create an element under the recreated container via the low-level service.
        var element = new Element($"Debug Element {Guid.NewGuid():N}", container.Id, elementType);
        OperationResult saveResult = _elementService.Save(element);

        // Show what the tree's resolution path actually returns right now.
        Attempt<int> resolvedParentId = _idKeyMap.GetIdForKey(containerKey, UmbracoObjectTypes.ElementContainer);
        IEntitySlim[] childrenViaTreePath = _entityService.GetPagedChildren(
            containerKey,
            [UmbracoObjectTypes.ElementContainer, UmbracoObjectTypes.Element],
            [UmbracoObjectTypes.ElementContainer, UmbracoObjectTypes.Element],
            0,
            100,
            false,
            out var total).ToArray();

        var sb = new StringBuilder();
        sb.AppendLine($"Element type       : {ElementTypeAlias} (key {elementType.Key})");
        sb.AppendLine($"Container key      : {containerKey}");
        sb.AppendLine($"Container real id  : {container.Id}");
        sb.AppendLine($"Element saved      : {saveResult.Success} (key {element.Key}, parentId {element.ParentId})");
        sb.AppendLine();
        sb.AppendLine($"IdKeyMap resolves container key -> id : {(resolvedParentId.Success ? resolvedParentId.Result.ToString() : "FAILED")}");
        sb.AppendLine($"  (stale if this != container real id {container.Id})");
        sb.AppendLine($"GetPagedChildren via tree path        : total={total}, returned={childrenViaTreePath.Length}");
        sb.AppendLine();
        sb.AppendLine("Now expand the container in the backoffice Library tree, or call:");
        sb.AppendLine($"  GET /umbraco/management/api/v1/tree/element/children?parentId={containerKey}");
        sb.AppendLine();
        sb.AppendLine(total == 0
            ? "BUG REPRODUCED: the element is in the DB but the tree path returns nothing (until restart)."
            : "Tree path returns the element - bug not reproduced in this run.");

        return Content(sb.ToString(), "text/plain");
    }

    private async Task<IContentType> GetOrCreateElementTypeAsync()
    {
        IContentType? elementType = _contentTypeService.Get(ElementTypeAlias);
        if (elementType is not null)
        {
            return elementType;
        }

        elementType = new ContentType(_shortStringHelper, Constants.System.Root)
        {
            Alias = ElementTypeAlias,
            Name = "Debug Element Tree Item",
            IsElement = true,
            AllowedInLibrary = true,
        };
        await _contentTypeService.CreateAsync(elementType, Constants.Security.SuperUserKey);
        return elementType;
    }

    private async Task<EntityContainer> CreateContainerAsync(Guid key, string name)
    {
        Attempt<EntityContainer?, EntityContainerOperationStatus> result =
            await _elementContainerService.CreateAsync(key, name, null, Constants.Security.SuperUserKey);
        if (result.Success is false || result.Result is null)
        {
            throw new InvalidOperationException($"Failed to create element container: {result.Status}");
        }

        return result.Result;
    }
}
```

</details>

**Before the fix** — the container GUID resolves to the *old* id and the tree returns nothing:

```
Element type       : debugElementTreeItem (key b36df702-32bf-4eb3-975a-4c3f5e4f6102)
Container key      : d0d0d0d0-2307-2072-0000-000000000001
Container real id  : 5874
Element saved      : True (key de76e20e-6e34-49d3-92bb-a587655baac3, parentId 5874)

IdKeyMap resolves container key -> id : 5873
  (stale if this != container real id 5874)
GetPagedChildren via tree path        : total=0, returned=0

Now expand the container in the backoffice Library tree, or call:
  GET /umbraco/management/api/v1/tree/element/children?parentId=d0d0d0d0-2307-2072-0000-000000000001

BUG REPRODUCED: the element is in the DB but the tree path returns nothing (until restart).
```

The container shows no children in the Library tree until the site is restarted.

**After the fix** — the GUID resolves to the recreated container's id and the element is returned:

```
Element type       : debugElementTreeItem (key b36df702-32bf-4eb3-975a-4c3f5e4f6102)
Container key      : d0d0d0d0-2307-2072-0000-000000000001
Container real id  : 5871
Element saved      : True (key 7cf7ada7-eb4a-48fc-917b-fa7021bc50dc, parentId 5871)

IdKeyMap resolves container key -> id : 5871
  (stale if this != container real id 5871)
GetPagedChildren via tree path        : total=1, returned=1

Now expand the container in the backoffice Library tree, or call:
  GET /umbraco/management/api/v1/tree/element/children?parentId=d0d0d0d0-2307-2072-0000-000000000001

Tree path returns the element - bug not reproduced in this run.
```

The element appears in the Library tree without a restart ✅.