### PR TITLE
Dependencies: Upgrade Examine to 3.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,8 +49,8 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageVersion Include="Examine" Version="3.7.1" />
-    <PackageVersion Include="Examine.Core" Version="3.7.1" />
+    <PackageVersion Include="Examine" Version="3.8.0" />
+    <PackageVersion Include="Examine.Core" Version="3.8.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description

I have an Umbraco 13.14.0 running on Umbraco Cloud which is configured as suggested. 

We recently started to see an issue where an Examine index is left locked after Azure performs a platform file storage recycle, which prevents search components from recovering. This results in a 500 error on any page using search until the instance is rebooted.  

More details here: [https://github.com/Shazwazza/Examine/issues/434](https://github.com/Shazwazza/Examine/issues/434)

Appreciate v13 is out of support phase, but hopefully this could be merged into a minor

<!-- Thanks for contributing to Umbraco CMS! -->
