### PR TITLE
Management API: Add endpoints to sort the children of a document or media item by a system field

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenAtRootDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenAtRootDocumentController.cs
@@ -72,7 +72,7 @@ public class SortChildrenAtRootDocumentController : DocumentControllerBase
             return Forbidden();
         }
 
-        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+        var childrenAuthorized = await AllChildrenAuthorizer.IsAuthorizedForChildrenAsync(
             _authorizationService,
             _entityService,
             User,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenAtRootDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenAtRootDocumentController.cs
@@ -2,8 +2,10 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Security.Authorization;
 using Umbraco.Cms.Api.Management.ViewModels.Sorting;
 using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Security.Authorization;
 using Umbraco.Cms.Core.Services;
@@ -21,6 +23,7 @@ public class SortChildrenAtRootDocumentController : DocumentControllerBase
 {
     private readonly IAuthorizationService _authorizationService;
     private readonly IContentEditingService _contentEditingService;
+    private readonly IEntityService _entityService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     /// <summary>
@@ -28,14 +31,17 @@ public class SortChildrenAtRootDocumentController : DocumentControllerBase
     /// </summary>
     /// <param name="authorizationService">Service used to authorize user actions.</param>
     /// <param name="contentEditingService">Service for editing and managing content.</param>
+    /// <param name="entityService">Service used to resolve the children to authorize.</param>
     /// <param name="backOfficeSecurityAccessor">Accessor for back office security context.</param>
     public SortChildrenAtRootDocumentController(
         IAuthorizationService authorizationService,
         IContentEditingService contentEditingService,
+        IEntityService entityService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _authorizationService = authorizationService;
         _contentEditingService = contentEditingService;
+        _entityService = entityService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -62,6 +68,20 @@ public class SortChildrenAtRootDocumentController : DocumentControllerBase
             AuthorizationPolicies.ContentPermissionByResource);
 
         if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+            _authorizationService,
+            _entityService,
+            User,
+            parentKey: null,
+            UmbracoObjectTypes.Document,
+            childKeys => ContentPermissionResource.WithKeys(ActionSort.ActionLetter, childKeys),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!childrenAuthorized)
         {
             return Forbidden();
         }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenAtRootDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenAtRootDocumentController.cs
@@ -1,0 +1,80 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document;
+
+/// <summary>
+/// Provides an API endpoint for sorting the root-level documents by a system field.
+/// </summary>
+[ApiVersion("1.0")]
+public class SortChildrenAtRootDocumentController : DocumentControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IContentEditingService _contentEditingService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SortChildrenAtRootDocumentController"/> class.
+    /// </summary>
+    /// <param name="authorizationService">Service used to authorize user actions.</param>
+    /// <param name="contentEditingService">Service for editing and managing content.</param>
+    /// <param name="backOfficeSecurityAccessor">Accessor for back office security context.</param>
+    public SortChildrenAtRootDocumentController(
+        IAuthorizationService authorizationService,
+        IContentEditingService contentEditingService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _authorizationService = authorizationService;
+        _contentEditingService = contentEditingService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    /// <summary>
+    /// Sorts the root-level documents by a system field.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <param name="requestModel">The field to sort by and the sort direction.</param>
+    /// <returns>
+    /// An <see cref="IActionResult"/> indicating the outcome of the operation:
+    /// returns <c>200 OK</c> if sorting succeeds or <c>400 Bad Request</c> if the field is not recognised.
+    /// </returns>
+    [HttpPut("root/sort-children")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [EndpointSummary("Sorts the root-level documents by a field.")]
+    [EndpointDescription("Sorts the root-level documents by a system field in the given direction. When sorting by name, an optional culture selects the variant name; the culture is not validated, so documents that do not vary by it (or an unrecognised culture) fall back to the invariant name.")]
+    public async Task<IActionResult> SortChildren(CancellationToken cancellationToken, SortDocumentChildrenByFieldRequestModel requestModel)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            ContentPermissionResource.WithKeys(ActionSort.ActionLetter, (Guid?)null),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        ContentEditingOperationStatus result = await _contentEditingService.SortByFieldAsync(
+            null,
+            requestModel.Field,
+            requestModel.Direction,
+            requestModel.Culture,
+            CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result == ContentEditingOperationStatus.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenDocumentController.cs
@@ -1,0 +1,82 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Document;
+
+/// <summary>
+/// Provides an API endpoint for sorting the children of a document by a system field.
+/// </summary>
+[ApiVersion("1.0")]
+public class SortChildrenDocumentController : DocumentControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IContentEditingService _contentEditingService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SortChildrenDocumentController"/> class.
+    /// </summary>
+    /// <param name="authorizationService">Service used to authorize user actions.</param>
+    /// <param name="contentEditingService">Service for editing and managing content.</param>
+    /// <param name="backOfficeSecurityAccessor">Accessor for back office security context.</param>
+    public SortChildrenDocumentController(
+        IAuthorizationService authorizationService,
+        IContentEditingService contentEditingService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _authorizationService = authorizationService;
+        _contentEditingService = contentEditingService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    /// <summary>
+    /// Sorts the child documents of the specified parent document by a system field.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <param name="id">The unique identifier of the parent document whose children should be sorted.</param>
+    /// <param name="requestModel">The field to sort by and the sort direction.</param>
+    /// <returns>
+    /// An <see cref="IActionResult"/> indicating the outcome of the operation:
+    /// returns <c>200 OK</c> if sorting succeeds, <c>400 Bad Request</c> if the field is not recognised, or <c>404 Not Found</c> if the parent document does not exist.
+    /// </returns>
+    [HttpPut("{id:guid}/sort-children")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [EndpointSummary("Sorts the children of a document by a field.")]
+    [EndpointDescription("Sorts the children of the specified parent document by a system field in the given direction. When sorting by name, an optional culture selects the variant name; the culture is not validated, so children that do not vary by it (or an unrecognised culture) fall back to the invariant name.")]
+    public async Task<IActionResult> SortChildren(CancellationToken cancellationToken, Guid id, SortDocumentChildrenByFieldRequestModel requestModel)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            ContentPermissionResource.WithKeys(ActionSort.ActionLetter, id),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        ContentEditingOperationStatus result = await _contentEditingService.SortByFieldAsync(
+            id,
+            requestModel.Field,
+            requestModel.Direction,
+            requestModel.Culture,
+            CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result == ContentEditingOperationStatus.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenDocumentController.cs
@@ -74,7 +74,7 @@ public class SortChildrenDocumentController : DocumentControllerBase
             return Forbidden();
         }
 
-        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+        var childrenAuthorized = await AllChildrenAuthorizer.IsAuthorizedForChildrenAsync(
             _authorizationService,
             _entityService,
             User,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenDocumentController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/SortChildrenDocumentController.cs
@@ -2,8 +2,10 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Security.Authorization;
 using Umbraco.Cms.Api.Management.ViewModels.Sorting;
 using Umbraco.Cms.Core.Actions;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Security.Authorization;
 using Umbraco.Cms.Core.Services;
@@ -21,6 +23,7 @@ public class SortChildrenDocumentController : DocumentControllerBase
 {
     private readonly IAuthorizationService _authorizationService;
     private readonly IContentEditingService _contentEditingService;
+    private readonly IEntityService _entityService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     /// <summary>
@@ -28,14 +31,17 @@ public class SortChildrenDocumentController : DocumentControllerBase
     /// </summary>
     /// <param name="authorizationService">Service used to authorize user actions.</param>
     /// <param name="contentEditingService">Service for editing and managing content.</param>
+    /// <param name="entityService">Service used to resolve the children to authorize.</param>
     /// <param name="backOfficeSecurityAccessor">Accessor for back office security context.</param>
     public SortChildrenDocumentController(
         IAuthorizationService authorizationService,
         IContentEditingService contentEditingService,
+        IEntityService entityService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _authorizationService = authorizationService;
         _contentEditingService = contentEditingService;
+        _entityService = entityService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -64,6 +70,20 @@ public class SortChildrenDocumentController : DocumentControllerBase
             AuthorizationPolicies.ContentPermissionByResource);
 
         if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+            _authorizationService,
+            _entityService,
+            User,
+            id,
+            UmbracoObjectTypes.Document,
+            childKeys => ContentPermissionResource.WithKeys(ActionSort.ActionLetter, childKeys),
+            AuthorizationPolicies.ContentPermissionByResource);
+
+        if (!childrenAuthorized)
         {
             return Forbidden();
         }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
@@ -71,7 +71,7 @@ public class SortChildrenAtRootMediaController : MediaControllerBase
             return Forbidden();
         }
 
-        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+        var childrenAuthorized = await AllChildrenAuthorizer.IsAuthorizedForChildrenAsync(
             _authorizationService,
             _entityService,
             User,

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
@@ -52,7 +52,7 @@ public class SortChildrenAtRootMediaController : MediaControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [EndpointSummary("Sorts the root-level media items by a field.")]
-    [EndpointDescription("Sorts the root-level media items by a system field in the given direction. Media items do not vary by culture, so any supplied culture is ignored.")]
+    [EndpointDescription("Sorts the root-level media items by a system field in the given direction.")]
     public async Task<IActionResult> SortChildren(CancellationToken cancellationToken, SortMediaChildrenByFieldRequestModel requestModel)
     {
         AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
@@ -69,7 +69,6 @@ public class SortChildrenAtRootMediaController : MediaControllerBase
             null,
             requestModel.Field,
             requestModel.Direction,
-            culture: null,
             CurrentUserKey(_backOfficeSecurityAccessor));
 
         return result == ContentEditingOperationStatus.Success

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
@@ -2,7 +2,9 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Security.Authorization;
 using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Security.Authorization;
 using Umbraco.Cms.Core.Services;
@@ -20,6 +22,7 @@ public class SortChildrenAtRootMediaController : MediaControllerBase
 {
     private readonly IAuthorizationService _authorizationService;
     private readonly IMediaEditingService _mediaEditingService;
+    private readonly IEntityService _entityService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     /// <summary>
@@ -27,14 +30,17 @@ public class SortChildrenAtRootMediaController : MediaControllerBase
     /// </summary>
     /// <param name="authorizationService">Service used to authorize user actions.</param>
     /// <param name="mediaEditingService">Service responsible for editing and sorting media items.</param>
+    /// <param name="entityService">Service used to resolve the children to authorize.</param>
     /// <param name="backOfficeSecurityAccessor">Accessor for backoffice security context.</param>
     public SortChildrenAtRootMediaController(
         IAuthorizationService authorizationService,
         IMediaEditingService mediaEditingService,
+        IEntityService entityService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _authorizationService = authorizationService;
         _mediaEditingService = mediaEditingService;
+        _entityService = entityService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -61,6 +67,20 @@ public class SortChildrenAtRootMediaController : MediaControllerBase
             AuthorizationPolicies.MediaPermissionByResource);
 
         if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+            _authorizationService,
+            _entityService,
+            User,
+            parentKey: null,
+            UmbracoObjectTypes.Media,
+            childKeys => MediaPermissionResource.WithKeys(childKeys),
+            AuthorizationPolicies.MediaPermissionByResource);
+
+        if (!childrenAuthorized)
         {
             return Forbidden();
         }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenAtRootMediaController.cs
@@ -1,0 +1,79 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Media;
+
+/// <summary>
+/// Provides an API endpoint for sorting the root-level media items by a system field.
+/// </summary>
+[ApiVersion("1.0")]
+public class SortChildrenAtRootMediaController : MediaControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IMediaEditingService _mediaEditingService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SortChildrenAtRootMediaController"/> class.
+    /// </summary>
+    /// <param name="authorizationService">Service used to authorize user actions.</param>
+    /// <param name="mediaEditingService">Service responsible for editing and sorting media items.</param>
+    /// <param name="backOfficeSecurityAccessor">Accessor for backoffice security context.</param>
+    public SortChildrenAtRootMediaController(
+        IAuthorizationService authorizationService,
+        IMediaEditingService mediaEditingService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _authorizationService = authorizationService;
+        _mediaEditingService = mediaEditingService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    /// <summary>
+    /// Sorts the root-level media items by a system field.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <param name="requestModel">The field to sort by and the sort direction.</param>
+    /// <returns>
+    /// An <see cref="IActionResult"/> indicating the outcome of the operation:
+    /// returns <c>200 OK</c> if sorting succeeds or <c>400 Bad Request</c> if the field is not recognised.
+    /// </returns>
+    [HttpPut("root/sort-children")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [EndpointSummary("Sorts the root-level media items by a field.")]
+    [EndpointDescription("Sorts the root-level media items by a system field in the given direction. Media items do not vary by culture, so any supplied culture is ignored.")]
+    public async Task<IActionResult> SortChildren(CancellationToken cancellationToken, SortMediaChildrenByFieldRequestModel requestModel)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            MediaPermissionResource.Root(),
+            AuthorizationPolicies.MediaPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        ContentEditingOperationStatus result = await _mediaEditingService.SortByFieldAsync(
+            null,
+            requestModel.Field,
+            requestModel.Direction,
+            culture: null,
+            CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result == ContentEditingOperationStatus.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
@@ -54,7 +54,7 @@ public class SortChildrenMediaController : MediaControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [EndpointSummary("Sorts the children of a media item by a field.")]
-    [EndpointDescription("Sorts the children of the specified parent media item by a system field in the given direction. Media items do not vary by culture, so any supplied culture is ignored.")]
+    [EndpointDescription("Sorts the children of the specified parent media item by a system field in the given direction.")]
     public async Task<IActionResult> SortChildren(CancellationToken cancellationToken, Guid id, SortMediaChildrenByFieldRequestModel requestModel)
     {
         AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
@@ -71,7 +71,6 @@ public class SortChildrenMediaController : MediaControllerBase
             id,
             requestModel.Field,
             requestModel.Direction,
-            culture: null,
             CurrentUserKey(_backOfficeSecurityAccessor));
 
         return result == ContentEditingOperationStatus.Success

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
@@ -1,0 +1,81 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Web.Common.Authorization;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Controllers.Media;
+
+/// <summary>
+/// Provides an API endpoint for sorting the children of a media item by a system field.
+/// </summary>
+[ApiVersion("1.0")]
+public class SortChildrenMediaController : MediaControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IMediaEditingService _mediaEditingService;
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SortChildrenMediaController"/> class.
+    /// </summary>
+    /// <param name="authorizationService">Service used to authorize user actions.</param>
+    /// <param name="mediaEditingService">Service responsible for editing and sorting media items.</param>
+    /// <param name="backOfficeSecurityAccessor">Accessor for backoffice security context.</param>
+    public SortChildrenMediaController(
+        IAuthorizationService authorizationService,
+        IMediaEditingService mediaEditingService,
+        IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _authorizationService = authorizationService;
+        _mediaEditingService = mediaEditingService;
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    /// <summary>
+    /// Sorts the child media items of the specified parent media item by a system field.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <param name="id">The unique identifier of the parent media item whose children should be sorted.</param>
+    /// <param name="requestModel">The field to sort by and the sort direction.</param>
+    /// <returns>
+    /// An <see cref="IActionResult"/> indicating the outcome of the operation:
+    /// returns <c>200 OK</c> if sorting succeeds, <c>400 Bad Request</c> if the field is not recognised, or <c>404 Not Found</c> if the parent media item does not exist.
+    /// </returns>
+    [HttpPut("{id:guid}/sort-children")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [EndpointSummary("Sorts the children of a media item by a field.")]
+    [EndpointDescription("Sorts the children of the specified parent media item by a system field in the given direction. Media items do not vary by culture, so any supplied culture is ignored.")]
+    public async Task<IActionResult> SortChildren(CancellationToken cancellationToken, Guid id, SortMediaChildrenByFieldRequestModel requestModel)
+    {
+        AuthorizationResult authorizationResult = await _authorizationService.AuthorizeResourceAsync(
+            User,
+            MediaPermissionResource.WithKeys(id),
+            AuthorizationPolicies.MediaPermissionByResource);
+
+        if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        ContentEditingOperationStatus result = await _mediaEditingService.SortByFieldAsync(
+            id,
+            requestModel.Field,
+            requestModel.Direction,
+            culture: null,
+            CurrentUserKey(_backOfficeSecurityAccessor));
+
+        return result == ContentEditingOperationStatus.Success
+            ? Ok()
+            : ContentEditingOperationStatusResult(result);
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
@@ -2,7 +2,9 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Api.Management.Security.Authorization;
 using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Security.Authorization;
 using Umbraco.Cms.Core.Services;
@@ -20,6 +22,7 @@ public class SortChildrenMediaController : MediaControllerBase
 {
     private readonly IAuthorizationService _authorizationService;
     private readonly IMediaEditingService _mediaEditingService;
+    private readonly IEntityService _entityService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
     /// <summary>
@@ -27,14 +30,17 @@ public class SortChildrenMediaController : MediaControllerBase
     /// </summary>
     /// <param name="authorizationService">Service used to authorize user actions.</param>
     /// <param name="mediaEditingService">Service responsible for editing and sorting media items.</param>
+    /// <param name="entityService">Service used to resolve the children to authorize.</param>
     /// <param name="backOfficeSecurityAccessor">Accessor for backoffice security context.</param>
     public SortChildrenMediaController(
         IAuthorizationService authorizationService,
         IMediaEditingService mediaEditingService,
+        IEntityService entityService,
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _authorizationService = authorizationService;
         _mediaEditingService = mediaEditingService;
+        _entityService = entityService;
         _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
     }
 
@@ -63,6 +69,20 @@ public class SortChildrenMediaController : MediaControllerBase
             AuthorizationPolicies.MediaPermissionByResource);
 
         if (!authorizationResult.Succeeded)
+        {
+            return Forbidden();
+        }
+
+        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+            _authorizationService,
+            _entityService,
+            User,
+            id,
+            UmbracoObjectTypes.Media,
+            childKeys => MediaPermissionResource.WithKeys(childKeys),
+            AuthorizationPolicies.MediaPermissionByResource);
+
+        if (!childrenAuthorized)
         {
             return Forbidden();
         }

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/SortChildrenMediaController.cs
@@ -73,7 +73,7 @@ public class SortChildrenMediaController : MediaControllerBase
             return Forbidden();
         }
 
-        var childrenAuthorized = await SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+        var childrenAuthorized = await AllChildrenAuthorizer.IsAuthorizedForChildrenAsync(
             _authorizationService,
             _entityService,
             User,

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -10888,6 +10888,150 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/document/{id}/sort-children": {
+      "put": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Sorts the children of a document by a field.",
+        "description": "Sorts the children of the specified parent document by a system field in the given direction. When sorting by name, an optional culture selects the variant name; the culture is not validated, so children that do not vary by it (or an unrecognised culture) fall back to the invariant name.",
+        "operationId": "PutDocumentByIdSortChildren",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortDocumentChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortDocumentChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortDocumentChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice-User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/document/{id}/unpublish": {
       "put": {
         "tags": [
@@ -11273,6 +11417,113 @@
           },
           "403": {
             "description": "The authenticated user does not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice-User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/document/root/sort-children": {
+      "put": {
+        "tags": [
+          "Document"
+        ],
+        "summary": "Sorts the root-level documents by a field.",
+        "description": "Sorts the root-level documents by a system field in the given direction. When sorting by name, an optional culture selects the variant name; the culture is not validated, so documents that do not vary by it (or an unrecognised culture) fall back to the invariant name.",
+        "operationId": "PutDocumentRootSortChildren",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortDocumentChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortDocumentChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortDocumentChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
           }
         },
         "security": [
@@ -19158,6 +19409,150 @@
         ]
       }
     },
+    "/umbraco/management/api/v1/media/{id}/sort-children": {
+      "put": {
+        "tags": [
+          "Media"
+        ],
+        "summary": "Sorts the children of a media item by a field.",
+        "description": "Sorts the children of the specified parent media item by a system field in the given direction. Media items do not vary by culture, so any supplied culture is ignored.",
+        "operationId": "PutMediaByIdSortChildren",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortMediaChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortMediaChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortMediaChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Backoffice-User": [ ]
+          }
+        ]
+      }
+    },
     "/umbraco/management/api/v1/media/{id}/validate": {
       "put": {
         "tags": [
@@ -19399,6 +19794,113 @@
           },
           "403": {
             "description": "The authenticated user does not have access to this resource"
+          }
+        },
+        "security": [
+          {
+            "Backoffice-User": [ ]
+          }
+        ]
+      }
+    },
+    "/umbraco/management/api/v1/media/root/sort-children": {
+      "put": {
+        "tags": [
+          "Media"
+        ],
+        "summary": "Sorts the root-level media items by a field.",
+        "description": "Sorts the root-level media items by a system field in the given direction. Media items do not vary by culture, so any supplied culture is ignored.",
+        "operationId": "PutMediaRootSortChildren",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortMediaChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortMediaChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/SortMediaChildrenByFieldRequestModel"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ProblemDetails"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The resource is protected and requires an authentication token"
+          },
+          "403": {
+            "description": "The authenticated user does not have access to this resource",
+            "headers": {
+              "Umb-Notifications": {
+                "description": "The list of notifications produced during the request.",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationHeaderModel"
+                  },
+                  "nullable": true
+                }
+              }
+            }
           }
         },
         "security": [
@@ -39856,6 +40358,14 @@
         },
         "additionalProperties": false
       },
+      "ContentSortFieldModel": {
+        "enum": [
+          "Name",
+          "CreateDate",
+          "UpdateDate"
+        ],
+        "type": "string"
+      },
       "CopyDataTypeRequestModel": {
         "type": "object",
         "properties": {
@@ -50158,6 +50668,42 @@
         "properties": {
           "skipNegotiation": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SortDocumentChildrenByFieldRequestModel": {
+        "required": [
+          "direction",
+          "field"
+        ],
+        "type": "object",
+        "properties": {
+          "field": {
+            "$ref": "#/components/schemas/ContentSortFieldModel"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/DirectionModel"
+          },
+          "culture": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SortMediaChildrenByFieldRequestModel": {
+        "required": [
+          "direction",
+          "field"
+        ],
+        "type": "object",
+        "properties": {
+          "field": {
+            "$ref": "#/components/schemas/ContentSortFieldModel"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/DirectionModel"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/Security/Authorization/AllChildrenAuthorizer.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/Authorization/AllChildrenAuthorizer.cs
@@ -8,26 +8,21 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Api.Management.Security.Authorization;
 
 /// <summary>
-/// Authorizes the sort permission on the direct children of a node when sorting them by a field.
+/// Authorizes permissions on all direct children of a node.
 /// </summary>
-/// <remarks>
-/// The field-sort endpoints reorder a node's children without the caller supplying their keys, so - unlike the
-/// manual drag-drop sort - the children's keys must be resolved here to authorize them. They are paged so the whole
-/// set is never held in memory, and each page is authorized in a single batch that stays within the SQL parameter limit.
-/// </remarks>
-internal static class SortChildrenAuthorizer
+internal static class AllChildrenAuthorizer
 {
     /// <summary>
-    /// Determines whether the user is authorized to sort every direct child of the given parent (or the root).
+    /// Determines whether the user is authorized for every direct child of the given parent (or the root).
     /// </summary>
     /// <param name="authorizationService">The authorization service.</param>
     /// <param name="entityService">The entity service used to resolve the children.</param>
     /// <param name="user">The current user.</param>
-    /// <param name="parentKey">The parent key, or <c>null</c> to sort the root-level children.</param>
+    /// <param name="parentKey">The parent key, or <c>null</c> to authorize the root-level children.</param>
     /// <param name="objectType">The object type of the children (and parent).</param>
     /// <param name="resourceFactory">Builds the permission resource to authorize a batch of child keys against.</param>
     /// <param name="policy">The authorization policy to apply.</param>
-    /// <returns><c>true</c> if the user may sort all children; otherwise <c>false</c>.</returns>
+    /// <returns><c>true</c> if the user is authorized against all children; otherwise <c>false</c>.</returns>
     public static async Task<bool> IsAuthorizedForChildrenAsync(
         IAuthorizationService authorizationService,
         IEntityService entityService,

--- a/src/Umbraco.Cms.Api.Management/Security/Authorization/SortChildrenAuthorizer.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/Authorization/SortChildrenAuthorizer.cs
@@ -1,0 +1,69 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Api.Management.Security.Authorization;
+
+/// <summary>
+/// Authorizes the sort permission on the direct children of a node when sorting them by a field.
+/// </summary>
+/// <remarks>
+/// The field-sort endpoints reorder a node's children without the caller supplying their keys, so - unlike the
+/// manual drag-drop sort - the children's keys must be resolved here to authorize them. They are paged so the whole
+/// set is never held in memory, and each page is authorized in a single batch that stays within the SQL parameter limit.
+/// </remarks>
+internal static class SortChildrenAuthorizer
+{
+    /// <summary>
+    /// Determines whether the user is authorized to sort every direct child of the given parent (or the root).
+    /// </summary>
+    /// <param name="authorizationService">The authorization service.</param>
+    /// <param name="entityService">The entity service used to resolve the children.</param>
+    /// <param name="user">The current user.</param>
+    /// <param name="parentKey">The parent key, or <c>null</c> to sort the root-level children.</param>
+    /// <param name="objectType">The object type of the children (and parent).</param>
+    /// <param name="resourceFactory">Builds the permission resource to authorize a batch of child keys against.</param>
+    /// <param name="policy">The authorization policy to apply.</param>
+    /// <returns><c>true</c> if the user may sort all children; otherwise <c>false</c>.</returns>
+    public static async Task<bool> IsAuthorizedForChildrenAsync(
+        IAuthorizationService authorizationService,
+        IEntityService entityService,
+        ClaimsPrincipal user,
+        Guid? parentKey,
+        UmbracoObjectTypes objectType,
+        Func<IEnumerable<Guid>, IPermissionResource> resourceFactory,
+        string policy)
+    {
+        const int pageSize = 500;
+        var page = 0;
+        long total;
+        do
+        {
+            Guid[] childKeys = entityService
+                .GetPagedChildren(parentKey, [objectType], objectType, page * pageSize, pageSize, out total)
+                .Select(child => child.Key)
+                .ToArray();
+
+            if (childKeys.Length > 0)
+            {
+                AuthorizationResult authorizationResult = await authorizationService.AuthorizeResourceAsync(
+                    user,
+                    resourceFactory(childKeys),
+                    policy);
+
+                if (authorizationResult.Succeeded is false)
+                {
+                    return false;
+                }
+            }
+
+            page++;
+        }
+        while (page * pageSize < total);
+
+        return true;
+    }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortChildrenByFieldRequestModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortChildrenByFieldRequestModelBase.cs
@@ -17,5 +17,5 @@ public abstract class SortChildrenByFieldRequestModelBase
     /// <summary>
     /// Gets or sets the direction to sort in.
     /// </summary>
-    public Direction Direction { get; init; } = Direction.Ascending;
+    public required Direction Direction { get; init; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortChildrenByFieldRequestModelBase.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortChildrenByFieldRequestModelBase.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Sorting;
+
+/// <summary>
+/// Base request model for sorting the children of a node by a system field.
+/// </summary>
+public abstract class SortChildrenByFieldRequestModelBase
+{
+    /// <summary>
+    /// Gets or sets the system field to sort the children by.
+    /// The create and update dates are node-level (not culture-specific).
+    /// </summary>
+    public required ContentSortField Field { get; init; }
+
+    /// <summary>
+    /// Gets or sets the direction to sort in.
+    /// </summary>
+    public Direction Direction { get; init; } = Direction.Ascending;
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortDocumentChildrenByFieldRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortDocumentChildrenByFieldRequestModel.cs
@@ -1,0 +1,16 @@
+using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Api.Management.ViewModels.Sorting;
+
+/// <summary>
+/// Request model for sorting the children of a document by a system field.
+/// </summary>
+public class SortDocumentChildrenByFieldRequestModel : SortChildrenByFieldRequestModelBase
+{
+    /// <summary>
+    /// Gets or sets the culture whose variant name to sort by, or <c>null</c> to sort by the invariant name.
+    /// Only applies when sorting by <see cref="ContentSortField.Name"/>. The culture is not validated: a document that
+    /// does not vary by the given culture - or an unrecognised culture - falls back to the invariant name.
+    /// </summary>
+    public string? Culture { get; init; }
+}

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortMediaChildrenByFieldRequestModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Sorting/SortMediaChildrenByFieldRequestModel.cs
@@ -1,0 +1,9 @@
+namespace Umbraco.Cms.Api.Management.ViewModels.Sorting;
+
+/// <summary>
+/// Request model for sorting the children of a media item by a system field.
+/// Media items do not vary by culture, so no culture is accepted.
+/// </summary>
+public class SortMediaChildrenByFieldRequestModel : SortChildrenByFieldRequestModelBase
+{
+}

--- a/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/ContentSettings.cs
@@ -17,6 +17,11 @@ public class ContentSettings
     internal const bool StaticResolveUrlsFromTextString = false;
 
     /// <summary>
+    ///     The default value for whether sorting children by a field fires per-item notifications.
+    /// </summary>
+    internal const bool StaticSortChildrenByFieldFiresNotifications = false;
+
+    /// <summary>
     ///     The default preview badge markup template.
     /// </summary>
     internal const string StaticDefaultPreviewBadge = @"
@@ -109,6 +114,18 @@ public class ContentSettings
     /// </summary>
     [DefaultValue(StaticResolveUrlsFromTextString)]
     public bool ResolveUrlsFromTextString { get; set; } = StaticResolveUrlsFromTextString;
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether sorting the children of a node by a field fires
+    ///     per-item save/sort notifications (and therefore webhooks).
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to <c>false</c>: the children are reordered with a single set-based update and a branch
+    ///     cache refresh, without per-item notifications. Set to <c>true</c> to restore per-item notifications
+    ///     (and webhooks), accepting the additional performance cost on nodes with many children.
+    /// </remarks>
+    [DefaultValue(StaticSortChildrenByFieldFiresNotifications)]
+    public bool SortChildrenByFieldFiresNotifications { get; set; } = StaticSortChildrenByFieldFiresNotifications;
 
     /// <summary>
     ///     Gets or sets a value for the collection of error pages.

--- a/src/Umbraco.Core/Models/ContentEditing/ContentSortField.cs
+++ b/src/Umbraco.Core/Models/ContentEditing/ContentSortField.cs
@@ -1,0 +1,22 @@
+namespace Umbraco.Cms.Core.Models.ContentEditing;
+
+/// <summary>
+///     Represents a system field that a node's children can be sorted by.
+/// </summary>
+public enum ContentSortField
+{
+    /// <summary>
+    ///     Sort by the node's name.
+    /// </summary>
+    Name,
+
+    /// <summary>
+    ///     Sort by the date the node was created.
+    /// </summary>
+    CreateDate,
+
+    /// <summary>
+    ///     Sort by the date the node was last updated.
+    /// </summary>
+    UpdateDate,
+}

--- a/src/Umbraco.Core/Persistence/Repositories/IContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IContentRepository.cs
@@ -17,6 +17,19 @@ public interface IContentRepository<in TId, TEntity> : IReadWriteQueryRepository
     int RecycleBinId { get; }
 
     /// <summary>
+    ///     Updates the sort order of the specified nodes so that each node's sort order matches its
+    ///     position in the supplied (already ordered) collection, in a single set-based update.
+    /// </summary>
+    /// <param name="orderedNodeIds">The node identifiers in their desired order.</param>
+    /// <remarks>
+    ///     This persists the sort order directly and does not load the entities or fire any notifications;
+    ///     callers are responsible for any required cache refresh and auditing.
+    /// </remarks>
+    // TODO (V19): Remove the default implementation.
+    void UpdateSortOrder(IReadOnlyCollection<int> orderedNodeIds)
+        => throw new NotImplementedException();
+
+    /// <summary>
     ///     Gets versions.
     /// </summary>
     /// <remarks>Current version is first, and then versions are ordered with most recent first.</remarks>

--- a/src/Umbraco.Core/Persistence/Repositories/IContentRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IContentRepository.cs
@@ -26,7 +26,7 @@ public interface IContentRepository<in TId, TEntity> : IReadWriteQueryRepository
     ///     callers are responsible for any required cache refresh and auditing.
     /// </remarks>
     // TODO (V19): Remove the default implementation.
-    void UpdateSortOrder(IReadOnlyCollection<int> orderedNodeIds)
+    void UpdateSortOrder(IReadOnlyList<int> orderedNodeIds)
         => throw new NotImplementedException();
 
     /// <summary>

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -403,6 +403,13 @@ internal sealed class ContentEditingService
         return OperationResultToOperationStatus(result);
     }
 
+    /// <inheritdoc />
+    protected override ContentEditingOperationStatus SortChildrenInBulk(int parentId, IReadOnlyList<int> orderedChildIds, int userId)
+    {
+        OperationResult result = ContentService.SortChildren(parentId, orderedChildIds, userId);
+        return OperationResultToOperationStatus(result);
+    }
+
     private async Task<ContentEditingOperationStatus> Save(IContent content, Guid userKey)
     {
         try

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -332,6 +332,15 @@ internal sealed class ContentEditingService
         Guid userKey)
         => await HandleSortAsync(parentKey, sortingModels, userKey);
 
+    /// <inheritdoc />
+    public async Task<ContentEditingOperationStatus> SortByFieldAsync(
+        Guid? parentKey,
+        ContentSortField field,
+        Direction direction,
+        string? culture,
+        Guid userKey)
+        => await HandleSortByFieldAsync(parentKey, field, direction, culture, userKey);
+
     private async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCulturesAndPropertiesAsync(
         ContentEditingModelBase contentEditingModelBase,
         Guid contentTypeKey,
@@ -384,8 +393,8 @@ internal sealed class ContentEditingService
     protected override OperationResult? Delete(IContent content, int userId) => ContentService.Delete(content, userId);
 
     /// <inheritdoc />
-    protected override IEnumerable<IContent> GetPagedChildren(int parentId, int pageIndex, int pageSize, out long total)
-        => ContentService.GetPagedChildren(parentId, pageIndex, pageSize, out total, propertyAliases: null, filter: null, ordering: null);
+    protected override IEnumerable<IContent> GetPagedChildren(int parentId, int pageIndex, int pageSize, Ordering? ordering, out long total)
+        => ContentService.GetPagedChildren(parentId, pageIndex, pageSize, out total, propertyAliases: null, filter: null, ordering: ordering);
 
     /// <inheritdoc />
     protected override ContentEditingOperationStatus Sort(IEnumerable<IContent> items, int userId)

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -458,6 +458,10 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
         {
             // these are the only result states currently expected from the invoked IContentService operations
             OperationResultType.Success => ContentEditingOperationStatus.Success,
+
+            // a no-op (e.g. sorting children when nothing needs reordering) is a successful outcome, not an error
+            OperationResultType.NoOperation => ContentEditingOperationStatus.Success,
+
             OperationResultType.FailedCancelledByEvent => ContentEditingOperationStatus.CancelledByNotification,
             OperationResultType.FailedCannot => ContentEditingOperationStatus.CannotDeleteWhenReferenced,
 

--- a/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
@@ -86,9 +86,10 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
     /// <param name="parentId">The parent identifier.</param>
     /// <param name="pageIndex">The zero-based page index.</param>
     /// <param name="pageSize">The page size.</param>
+    /// <param name="ordering">The ordering to apply, or <c>null</c> to use the default (sort order).</param>
     /// <param name="total">The total number of children.</param>
     /// <returns>The paged children.</returns>
-    protected abstract IEnumerable<TContent> GetPagedChildren(int parentId, int pageIndex, int pageSize, out long total);
+    protected abstract IEnumerable<TContent> GetPagedChildren(int parentId, int pageIndex, int pageSize, Ordering? ordering, out long total);
 
     /// <summary>
     /// Handles the sorting operation asynchronously.
@@ -111,16 +112,7 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
             return ContentEditingOperationStatus.NotFound;
         }
 
-        const int pageSize = 500;
-        var pageNumber = 0;
-        IEnumerable<TContent> page = GetPagedChildren(contentId.Value, pageNumber++, pageSize, out var total);
-        var children = new List<TContent>((int)total);
-        children.AddRange(page);
-        while (pageNumber * pageSize < total)
-        {
-            page = GetPagedChildren(contentId.Value, pageNumber++, pageSize, out _);
-            children.AddRange(page);
-        }
+        List<TContent> children = LoadAllChildren(contentId.Value, ordering: null);
 
         try
         {
@@ -138,4 +130,76 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
             return ContentEditingOperationStatus.SortingInvalid;
         }
     }
+
+    /// <summary>
+    /// Handles sorting a parent's children by a system field asynchronously.
+    /// </summary>
+    /// <param name="parentKey">The optional parent key.</param>
+    /// <param name="field">The system field to sort the children by.</param>
+    /// <param name="direction">The direction to sort in.</param>
+    /// <param name="culture">The culture whose variant name to sort by, or <c>null</c> to sort by the invariant name. Only applies when sorting by <see cref="ContentSortField.Name"/>. The culture is not validated: a child that does not vary by the given culture - or an unrecognised culture - falls back to the invariant name.</param>
+    /// <param name="userKey">The user key performing the operation.</param>
+    /// <returns>The operation status.</returns>
+    protected async Task<ContentEditingOperationStatus> HandleSortByFieldAsync(
+        Guid? parentKey,
+        ContentSortField field,
+        Direction direction,
+        string? culture,
+        Guid userKey)
+    {
+        var contentId = parentKey.HasValue
+            ? ContentService.GetById(parentKey.Value)?.Id
+            : Constants.System.Root;
+
+        if (contentId.HasValue is false)
+        {
+            return ContentEditingOperationStatus.NotFound;
+        }
+
+        Ordering? ordering = BuildOrdering(field, direction, culture);
+        if (ordering is null)
+        {
+            return ContentEditingOperationStatus.SortingInvalid;
+        }
+
+        // The database does the ordering (matching the list view and the order shown in the sort UI),
+        // then we persist the resulting order as the children's sort order.
+        List<TContent> orderedChildren = LoadAllChildren(contentId.Value, ordering);
+        if (orderedChildren.Count == 0)
+        {
+            // Nothing to sort - the order is trivially correct.
+            return ContentEditingOperationStatus.Success;
+        }
+
+        var userId = await GetUserIdAsync(userKey);
+
+        return Sort(orderedChildren, userId);
+    }
+
+    private List<TContent> LoadAllChildren(int contentId, Ordering? ordering)
+    {
+        const int pageSize = 500;
+        var pageNumber = 0;
+        IEnumerable<TContent> page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out var total);
+        var children = new List<TContent>((int)total);
+        children.AddRange(page);
+        while (pageNumber * pageSize < total)
+        {
+            page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out _);
+            children.AddRange(page);
+        }
+
+        return children;
+    }
+
+    private static Ordering? BuildOrdering(ContentSortField field, Direction direction, string? culture)
+        => field switch
+        {
+            // Name is variant - the culture selects the variant name to order by (invariant content and media
+            // ignore it). Create and update dates are node-level, so the culture does not apply.
+            ContentSortField.Name => Ordering.By("name", direction, culture),
+            ContentSortField.CreateDate => Ordering.By("createDate", direction),
+            ContentSortField.UpdateDate => Ordering.By("updateDate", direction),
+            _ => null,
+        };
 }

--- a/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
@@ -162,18 +162,56 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
             return ContentEditingOperationStatus.SortingInvalid;
         }
 
-        // The database does the ordering (matching the list view and the order shown in the sort UI),
-        // then we persist the resulting order as the children's sort order.
-        List<TContent> orderedChildren = LoadAllChildren(contentId.Value, ordering);
-        if (orderedChildren.Count == 0)
+        // The database does the ordering (matching the list view and the order shown in the sort UI).
+        if (ContentSettings.SortChildrenByFieldFiresNotifications)
+        {
+            // Opt-in path: load the children and persist via the standard sort, firing per-item
+            // save/sort notifications (and therefore webhooks), at the cost of loading every child.
+            List<TContent> orderedChildren = LoadAllChildren(contentId.Value, ordering);
+            if (orderedChildren.Count == 0)
+            {
+                return ContentEditingOperationStatus.Success;
+            }
+
+            return Sort(orderedChildren, await GetUserIdAsync(userKey));
+        }
+
+        // Default path: persist the resulting order with a single set-based update and a branch cache
+        // refresh, without loading every child or firing per-item notifications.
+        List<int> orderedChildIds = LoadOrderedChildIds(contentId.Value, ordering);
+        if (orderedChildIds.Count == 0)
         {
             // Nothing to sort - the order is trivially correct.
             return ContentEditingOperationStatus.Success;
         }
 
-        var userId = await GetUserIdAsync(userKey);
+        return SortChildrenInBulk(contentId.Value, orderedChildIds, await GetUserIdAsync(userKey));
+    }
 
-        return Sort(orderedChildren, userId);
+    /// <summary>
+    /// Persists the supplied (already ordered) child identifiers as the new sort order, without loading
+    /// the children or firing per-item notifications.
+    /// </summary>
+    /// <param name="parentId">The parent identifier, or the root identifier for root-level sorting.</param>
+    /// <param name="orderedChildIds">The child identifiers in their desired order.</param>
+    /// <param name="userId">The user performing the operation.</param>
+    /// <returns>The operation status.</returns>
+    protected abstract ContentEditingOperationStatus SortChildrenInBulk(int parentId, IReadOnlyList<int> orderedChildIds, int userId);
+
+    private List<int> LoadOrderedChildIds(int contentId, Ordering ordering)
+    {
+        const int pageSize = 500;
+        var pageNumber = 0;
+        IEnumerable<TContent> page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out var total);
+        var ids = new List<int>((int)total);
+        ids.AddRange(page.Select(child => child.Id));
+        while (pageNumber * pageSize < total)
+        {
+            page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out _);
+            ids.AddRange(page.Select(child => child.Id));
+        }
+
+        return ids;
     }
 
     private List<TContent> LoadAllChildren(int contentId, Ordering? ordering)

--- a/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
@@ -156,11 +156,7 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
             return ContentEditingOperationStatus.NotFound;
         }
 
-        Ordering? ordering = BuildOrdering(field, direction, culture);
-        if (ordering is null)
-        {
-            return ContentEditingOperationStatus.SortingInvalid;
-        }
+        Ordering ordering = BuildOrdering(field, direction, culture);
 
         // The database does the ordering (matching the list view and the order shown in the sort UI).
         if (ContentSettings.SortChildrenByFieldFiresNotifications)
@@ -222,7 +218,7 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
         return results;
     }
 
-    private static Ordering? BuildOrdering(ContentSortField field, Direction direction, string? culture)
+    private static Ordering BuildOrdering(ContentSortField field, Direction direction, string? culture)
         => field switch
         {
             // Name is variant - the culture selects the variant name to order by (invariant content and media
@@ -230,6 +226,6 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
             ContentSortField.Name => Ordering.By("name", direction, culture),
             ContentSortField.CreateDate => Ordering.By("createDate", direction),
             ContentSortField.UpdateDate => Ordering.By("updateDate", direction),
-            _ => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Unsupported sort field."),
         };
 }

--- a/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceWithSortingBase.cs
@@ -199,35 +199,27 @@ internal abstract class ContentEditingServiceWithSortingBase<TContent, TContentT
     protected abstract ContentEditingOperationStatus SortChildrenInBulk(int parentId, IReadOnlyList<int> orderedChildIds, int userId);
 
     private List<int> LoadOrderedChildIds(int contentId, Ordering ordering)
-    {
-        const int pageSize = 500;
-        var pageNumber = 0;
-        IEnumerable<TContent> page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out var total);
-        var ids = new List<int>((int)total);
-        ids.AddRange(page.Select(child => child.Id));
-        while (pageNumber * pageSize < total)
-        {
-            page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out _);
-            ids.AddRange(page.Select(child => child.Id));
-        }
-
-        return ids;
-    }
+        => LoadAllChildren(contentId, ordering, child => child.Id);
 
     private List<TContent> LoadAllChildren(int contentId, Ordering? ordering)
+        => LoadAllChildren(contentId, ordering, child => child);
+
+    // Pages through all children, projecting each page with the selector so callers that only need a
+    // lightweight value (e.g. the id) don't retain every loaded child.
+    private List<TResult> LoadAllChildren<TResult>(int contentId, Ordering? ordering, Func<TContent, TResult> selector)
     {
         const int pageSize = 500;
         var pageNumber = 0;
         IEnumerable<TContent> page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out var total);
-        var children = new List<TContent>((int)total);
-        children.AddRange(page);
+        var results = new List<TResult>((int)total);
+        results.AddRange(page.Select(selector));
         while (pageNumber * pageSize < total)
         {
             page = GetPagedChildren(contentId, pageNumber++, pageSize, ordering, out _);
-            children.AddRange(page);
+            results.AddRange(page.Select(selector));
         }
 
-        return children;
+        return results;
     }
 
     private static Ordering? BuildOrdering(ContentSortField field, Direction direction, string? culture)

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -3189,8 +3189,9 @@ public class ContentService : RepositoryService, IContentService
 
         _documentRepository.UpdateSortOrder(orderedChildIds);
 
-        // The published and repository caches read sort order live from umbracoNode, so refreshing the
-        // affected branch is enough for them to pick up the new order without re-saving each child.
+        // Sort order lives in umbracoNode; neither the published cache nor the content repository cache keeps
+        // a separate serialized copy of it, so refreshing the affected branch (which invalidates both and has
+        // them reload from umbracoNode) is enough to pick up the new order without re-saving each child.
         if (parentId == Constants.System.Root)
         {
             IContent[] roots = GetByIds(orderedChildIds).ToArray();

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -3175,6 +3175,42 @@ public class ContentService : RepositoryService, IContentService
         }
     }
 
+    /// <inheritdoc />
+    public OperationResult SortChildren(int parentId, IReadOnlyList<int> orderedChildIds, int userId = Constants.Security.SuperUserId)
+    {
+        EventMessages evtMsgs = EventMessagesFactory.Get();
+        if (orderedChildIds.Count == 0)
+        {
+            return new OperationResult(OperationResultType.NoOperation, evtMsgs);
+        }
+
+        using ICoreScope scope = ScopeProvider.CreateCoreScope();
+        scope.WriteLock(Constants.Locks.ContentTree);
+
+        _documentRepository.UpdateSortOrder(orderedChildIds);
+
+        // The published and repository caches read sort order live from umbracoNode, so refreshing the
+        // affected branch is enough for them to pick up the new order without re-saving each child.
+        if (parentId == Constants.System.Root)
+        {
+            IContent[] roots = GetByIds(orderedChildIds).ToArray();
+            scope.Notifications.Publish(new ContentTreeChangeNotification(roots, TreeChangeTypes.RefreshNode, evtMsgs));
+        }
+        else
+        {
+            IContent? parent = GetById(parentId);
+            if (parent is not null)
+            {
+                scope.Notifications.Publish(new ContentTreeChangeNotification(parent, TreeChangeTypes.RefreshBranch, evtMsgs));
+            }
+        }
+
+        Audit(AuditType.Sort, userId, parentId);
+
+        scope.Complete();
+        return OperationResult.Succeed(evtMsgs);
+    }
+
     private OperationResult Sort(ICoreScope scope, IContent[] itemsA, int userId, EventMessages eventMessages)
     {
         var sortingNotification = new ContentSortingNotification(itemsA, eventMessages);

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -105,7 +105,7 @@ public interface IContentEditingService
     /// <param name="userKey">The unique identifier of the user performing the action.</param>
     /// <returns>The operation status indicating success or failure.</returns>
     Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, string? culture, Guid userKey)
-        => throw new NotImplementedException();
+        => throw new NotImplementedException(); // TODO (V19): Remove default implementation.
 
     /// <summary>
     ///     Deletes a content item whether it is in the recycle bin or not.

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -96,6 +96,18 @@ public interface IContentEditingService
     Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey);
 
     /// <summary>
+    ///     Sorts the children of a parent by a system field.
+    /// </summary>
+    /// <param name="parentKey">The unique identifier of the parent, or <c>null</c> for root-level sorting.</param>
+    /// <param name="field">The system field to sort the children by.</param>
+    /// <param name="direction">The direction to sort in.</param>
+    /// <param name="culture">The culture whose variant name to sort by, or <c>null</c> to sort by the invariant name. Only applies when sorting by <see cref="ContentSortField.Name"/>. The culture is not validated: a child that does not vary by the given culture - or an unrecognised culture - falls back to the invariant name.</param>
+    /// <param name="userKey">The unique identifier of the user performing the action.</param>
+    /// <returns>The operation status indicating success or failure.</returns>
+    Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, string? culture, Guid userKey)
+        => throw new NotImplementedException();
+
+    /// <summary>
     ///     Deletes a content item whether it is in the recycle bin or not.
     /// </summary>
     /// <param name="key">The unique identifier of the content item to delete.</param>

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -542,6 +542,22 @@ public interface IContentService : IContentServiceBase<IContent>
     /// <returns>The operation result.</returns>
     OperationResult Sort(IEnumerable<int>? ids, int userId = Constants.Security.SuperUserId);
 
+    /// <summary>
+    ///     Sorts the children of a parent by persisting the supplied (already ordered) child identifiers
+    ///     as the new sort order, in a single set-based update.
+    /// </summary>
+    /// <param name="parentId">The identifier of the parent, or <see cref="Constants.System.Root"/> for the root.</param>
+    /// <param name="orderedChildIds">The child document identifiers, in the desired order.</param>
+    /// <param name="userId">The identifier of the user performing the action.</param>
+    /// <returns>The operation result.</returns>
+    /// <remarks>
+    ///     Unlike <see cref="Sort(IEnumerable{int}?, int)" />, this does not load the children or fire per-item
+    ///     save/sort notifications; it persists the order directly and refreshes the affected cache branch.
+    /// </remarks>
+    // TODO (V19): Remove the default implementation.
+    OperationResult SortChildren(int parentId, IReadOnlyList<int> orderedChildIds, int userId = Constants.Security.SuperUserId)
+        => throw new NotImplementedException();
+
     #endregion
 
     #region Publish Document

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -128,7 +128,7 @@ public interface IMediaEditingService
     /// <param name="userKey">The unique identifier of the user performing the operation.</param>
     /// <returns>The operation status indicating the operation outcome.</returns>
     Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, string? culture, Guid userKey)
-        => throw new NotImplementedException();
+        => throw new NotImplementedException(); // TODO (V19): Remove default implementation.
 
     /// <summary>
     ///     Permanently deletes a media item from the recycle bin.

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -124,10 +124,10 @@ public interface IMediaEditingService
     /// <param name="parentKey">The unique identifier of the parent, or <c>null</c> for root-level sorting.</param>
     /// <param name="field">The system field to sort the children by.</param>
     /// <param name="direction">The direction to sort in.</param>
-    /// <param name="culture">The culture whose variant name to sort by. Media items never vary by culture, so this is ignored; accepted for parity with content.</param>
     /// <param name="userKey">The unique identifier of the user performing the operation.</param>
     /// <returns>The operation status indicating the operation outcome.</returns>
-    Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, string? culture, Guid userKey)
+    /// <remarks>Media items never vary by culture, so children are always ordered by the invariant name.</remarks>
+    Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, Guid userKey)
         => throw new NotImplementedException(); // TODO (V19): Remove default implementation.
 
     /// <summary>

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -119,6 +119,18 @@ public interface IMediaEditingService
     Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey);
 
     /// <summary>
+    ///     Sorts the children of a parent by a system field.
+    /// </summary>
+    /// <param name="parentKey">The unique identifier of the parent, or <c>null</c> for root-level sorting.</param>
+    /// <param name="field">The system field to sort the children by.</param>
+    /// <param name="direction">The direction to sort in.</param>
+    /// <param name="culture">The culture whose variant name to sort by. Media items never vary by culture, so this is ignored; accepted for parity with content.</param>
+    /// <param name="userKey">The unique identifier of the user performing the operation.</param>
+    /// <returns>The operation status indicating the operation outcome.</returns>
+    Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, string? culture, Guid userKey)
+        => throw new NotImplementedException();
+
+    /// <summary>
     ///     Permanently deletes a media item from the recycle bin.
     /// </summary>
     /// <param name="key">The unique identifier of the media item to delete from the recycle bin.</param>

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -360,6 +360,22 @@ public interface IMediaService : IContentServiceBase<IMedia>
     bool Sort(IEnumerable<IMedia> items, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
+    ///     Sorts the children of a parent by persisting the supplied (already ordered) child identifiers
+    ///     as the new sort order, in a single set-based update.
+    /// </summary>
+    /// <param name="parentId">The identifier of the parent, or <see cref="Constants.System.Root"/> for the root.</param>
+    /// <param name="orderedChildIds">The child media identifiers, in the desired order.</param>
+    /// <param name="userId">The identifier of the user performing the action.</param>
+    /// <returns>The operation result.</returns>
+    /// <remarks>
+    ///     Unlike <see cref="Sort(IEnumerable{IMedia}, int)" />, this does not load the children or fire per-item
+    ///     save/sort notifications; it persists the order directly and refreshes the affected cache branch.
+    /// </remarks>
+    // TODO (V19): Remove the default implementation.
+    OperationResult SortChildren(int parentId, IReadOnlyList<int> orderedChildIds, int userId = Constants.Security.SuperUserId)
+        => throw new NotImplementedException();
+
+    /// <summary>
     ///     Creates an <see cref="IMedia" /> object using the alias of the <see cref="IMediaType" />
     ///     that this Media should based on.
     /// </summary>

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -166,8 +166,10 @@ internal sealed class MediaEditingService
         => await HandleSortAsync(parentKey, sortingModels, userKey);
 
     /// <inheritdoc />
-    public async Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, string? culture, Guid userKey)
-        => await HandleSortByFieldAsync(parentKey, field, direction, culture, userKey);
+    public async Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, Guid userKey)
+
+        // Media never varies by culture, so children are always ordered by the invariant name.
+        => await HandleSortByFieldAsync(parentKey, field, direction, culture: null, userKey);
 
     /// <inheritdoc />
     protected override IMedia New(string? name, int parentId, IMediaType mediaType)

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -166,6 +166,10 @@ internal sealed class MediaEditingService
         => await HandleSortAsync(parentKey, sortingModels, userKey);
 
     /// <inheritdoc />
+    public async Task<ContentEditingOperationStatus> SortByFieldAsync(Guid? parentKey, ContentSortField field, Direction direction, string? culture, Guid userKey)
+        => await HandleSortByFieldAsync(parentKey, field, direction, culture, userKey);
+
+    /// <inheritdoc />
     protected override IMedia New(string? name, int parentId, IMediaType mediaType)
         => new Models.Media(name, parentId, mediaType);
 
@@ -187,8 +191,8 @@ internal sealed class MediaEditingService
         => ContentService.Delete(media, userId).Result;
 
     /// <inheritdoc />
-    protected override IEnumerable<IMedia> GetPagedChildren(int parentId, int pageIndex, int pageSize, out long total)
-        => ContentService.GetPagedChildren(parentId, pageIndex, pageSize, out total);
+    protected override IEnumerable<IMedia> GetPagedChildren(int parentId, int pageIndex, int pageSize, Ordering? ordering, out long total)
+        => ContentService.GetPagedChildren(parentId, pageIndex, pageSize, out total, filter: null, ordering: ordering);
 
     /// <inheritdoc />
     protected override ContentEditingOperationStatus Sort(IEnumerable<IMedia> items, int userId)

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -203,6 +203,13 @@ internal sealed class MediaEditingService
             : ContentEditingOperationStatus.CancelledByNotification;
     }
 
+    /// <inheritdoc />
+    protected override ContentEditingOperationStatus SortChildrenInBulk(int parentId, IReadOnlyList<int> orderedChildIds, int userId)
+    {
+        OperationResult result = ContentService.SortChildren(parentId, orderedChildIds, userId);
+        return OperationResultToOperationStatus(result);
+    }
+
     /// <summary>
     ///     Saves a media item to the repository.
     /// </summary>

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1452,6 +1452,42 @@ namespace Umbraco.Cms.Core.Services
 
         }
 
+        /// <inheritdoc />
+        public OperationResult SortChildren(int parentId, IReadOnlyList<int> orderedChildIds, int userId = Constants.Security.SuperUserId)
+        {
+            EventMessages evtMsgs = EventMessagesFactory.Get();
+            if (orderedChildIds.Count == 0)
+            {
+                return new OperationResult(OperationResultType.NoOperation, evtMsgs);
+            }
+
+            using ICoreScope scope = ScopeProvider.CreateCoreScope();
+            scope.WriteLock(Constants.Locks.MediaTree);
+
+            _mediaRepository.UpdateSortOrder(orderedChildIds);
+
+            // The published and repository caches read sort order live from umbracoNode, so refreshing the
+            // affected branch is enough for them to pick up the new order without re-saving each child.
+            if (parentId == Constants.System.Root)
+            {
+                IMedia[] roots = GetByIds(orderedChildIds).ToArray();
+                scope.Notifications.Publish(new MediaTreeChangeNotification(roots, TreeChangeTypes.RefreshNode, evtMsgs));
+            }
+            else
+            {
+                IMedia? parent = GetById(parentId);
+                if (parent is not null)
+                {
+                    scope.Notifications.Publish(new MediaTreeChangeNotification(parent, TreeChangeTypes.RefreshBranch, evtMsgs));
+                }
+            }
+
+            Audit(AuditType.Sort, userId, parentId);
+
+            scope.Complete();
+            return OperationResult.Succeed(evtMsgs);
+        }
+
         /// <summary>
         ///     Checks the data integrity of the media tree and optionally fixes detected issues.
         /// </summary>

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1466,8 +1466,9 @@ namespace Umbraco.Cms.Core.Services
 
             _mediaRepository.UpdateSortOrder(orderedChildIds);
 
-            // The published and repository caches read sort order live from umbracoNode, so refreshing the
-            // affected branch is enough for them to pick up the new order without re-saving each child.
+            // Sort order lives in umbracoNode; neither the published cache nor the media repository cache keeps
+            // a separate serialized copy of it, so refreshing the affected branch (which invalidates both and has
+            // them reload from umbracoNode) is enough to pick up the new order without re-saving each child.
             if (parentId == Constants.System.Root)
             {
                 IMedia[] roots = GetByIds(orderedChildIds).ToArray();

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1298,7 +1298,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         public abstract int RecycleBinId { get; }
 
         /// <inheritdoc />
-        public void UpdateSortOrder(IReadOnlyCollection<int> orderedNodeIds)
+        public void UpdateSortOrder(IReadOnlyList<int> orderedNodeIds)
         {
             if (orderedNodeIds.Count == 0)
             {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1297,6 +1297,36 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         /// </summary>
         public abstract int RecycleBinId { get; }
 
+        /// <inheritdoc />
+        public void UpdateSortOrder(IReadOnlyCollection<int> orderedNodeIds)
+        {
+            if (orderedNodeIds.Count == 0)
+            {
+                return;
+            }
+
+            var nodeTable = SqlSyntax.GetQuotedTableName(NodeDto.TableName);
+            var idColumn = SqlSyntax.GetQuotedColumnName(NodeDto.IdColumnName);
+            var sortOrderColumn = SqlSyntax.GetQuotedColumnName(NodeDto.SortOrderColumnName);
+
+            // Each node's new sort order is its position in the ordered collection.
+            var ordered = orderedNodeIds
+                .Select((id, sortOrder) => new KeyValuePair<int, int>(id, sortOrder))
+                .ToList();
+
+            // Two parameters per node (id + sort order), so batch to stay within the SQL Server parameter limit.
+            foreach (IEnumerable<KeyValuePair<int, int>> group in ordered.InGroupsOf(Constants.Sql.MaxParameterCount / 2))
+            {
+                List<KeyValuePair<int, int>> groupList = group.ToList();
+                var args = groupList.SelectMany(pair => new object[] { pair.Key, pair.Value }).ToArray();
+                var whenClauses = string.Join(" ", groupList.Select((_, i) => $"WHEN @{i * 2} THEN @{(i * 2) + 1}"));
+                var inClause = string.Join(", ", groupList.Select((_, i) => $"@{i * 2}"));
+
+                var sql = $"UPDATE {nodeTable} SET {sortOrderColumn} = CASE {idColumn} {whenClauses} END WHERE {idColumn} IN ({inClause})";
+                Database.Execute(sql, args);
+            }
+        }
+
         /// <summary>
         /// Gets all entities that are currently in the recycle bin.
         /// </summary>

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenAtRootDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenAtRootDocumentControllerTests.cs
@@ -1,0 +1,57 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Document;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Document;
+
+public class SortChildrenAtRootDocumentControllerTests : ManagementApiUserGroupTestBase<SortChildrenAtRootDocumentController>
+{
+    protected override Expression<Func<SortChildrenAtRootDocumentController, object>> MethodSelector =>
+        x => x.SortChildren(CancellationToken.None, null);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        SortDocumentChildrenByFieldRequestModel requestModel = new()
+        {
+            Field = ContentSortField.Name,
+            Direction = Direction.Ascending,
+        };
+
+        return await Client.PutAsync(Url, JsonContent.Create(requestModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenDocumentControllerTests.cs
@@ -42,6 +42,19 @@ public class SortChildrenDocumentControllerTests : ManagementApiUserGroupTestBas
         };
         var response = await ContentEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
         _parentKey = response.Result.Content.Key;
+
+        // Children are needed to exercise the per-child authorization the endpoint performs.
+        for (var i = 0; i < 2; i++)
+        {
+            var childModel = new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                TemplateKey = template.Key,
+                ParentKey = _parentKey,
+                Variants = new List<VariantModel> { new() { Name = Guid.NewGuid().ToString() } },
+            };
+            await ContentEditingService.CreateAsync(childModel, Constants.Security.SuperUserKey);
+        }
     }
 
     protected override Expression<Func<SortChildrenDocumentController, object>> MethodSelector =>

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenDocumentControllerTests.cs
@@ -1,0 +1,90 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Document;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Document;
+
+public class SortChildrenDocumentControllerTests : ManagementApiUserGroupTestBase<SortChildrenDocumentController>
+{
+    private IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
+
+    private ITemplateService TemplateService => GetRequiredService<ITemplateService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private Guid _parentKey;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        var contentType = ContentTypeBuilder.CreateTextPageContentType(defaultTemplateId: template.Id, name: Guid.NewGuid().ToString(), alias: Guid.NewGuid().ToString());
+        contentType.AllowedAsRoot = true;
+        contentType.AllowedContentTypes = [new ContentTypeSort(contentType.Key, 0, contentType.Alias)];
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var createModel = new ContentCreateModel
+        {
+            ContentTypeKey = contentType.Key,
+            TemplateKey = template.Key,
+            ParentKey = Constants.System.RootKey,
+            Variants = new List<VariantModel> { new() { Name = Guid.NewGuid().ToString() } },
+        };
+        var response = await ContentEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
+        _parentKey = response.Result.Content.Key;
+    }
+
+    protected override Expression<Func<SortChildrenDocumentController, object>> MethodSelector =>
+        x => x.SortChildren(CancellationToken.None, _parentKey, null);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        SortDocumentChildrenByFieldRequestModel requestModel = new()
+        {
+            Field = ContentSortField.Name,
+            Direction = Direction.Ascending,
+        };
+
+        return await Client.PutAsync(Url, JsonContent.Create(requestModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Media/SortChildrenAtRootMediaControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Media/SortChildrenAtRootMediaControllerTests.cs
@@ -1,0 +1,57 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Media;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Media;
+
+public class SortChildrenAtRootMediaControllerTests : ManagementApiUserGroupTestBase<SortChildrenAtRootMediaController>
+{
+    protected override Expression<Func<SortChildrenAtRootMediaController, object>> MethodSelector =>
+        x => x.SortChildren(CancellationToken.None, null);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        SortMediaChildrenByFieldRequestModel requestModel = new()
+        {
+            Field = ContentSortField.Name,
+            Direction = Direction.Ascending,
+        };
+
+        return await Client.PutAsync(Url, JsonContent.Create(requestModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Media/SortChildrenMediaControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Media/SortChildrenMediaControllerTests.cs
@@ -33,6 +33,18 @@ public class SortChildrenMediaControllerTests : ManagementApiUserGroupTestBase<S
         };
         var responseParent = await MediaEditingService.CreateAsync(parentCreateModel, Constants.Security.SuperUserKey);
         _parentFolderKey = responseParent.Result.Content.Key;
+
+        // Children are needed to exercise the per-child authorization the endpoint performs.
+        for (var i = 0; i < 2; i++)
+        {
+            MediaCreateModel childCreateModel = new()
+            {
+                Variants = new List<VariantModel> { new() { Name = $"MediaChildFolder{i}" } },
+                ContentTypeKey = folderMediaType.Key,
+                ParentKey = _parentFolderKey,
+            };
+            await MediaEditingService.CreateAsync(childCreateModel, Constants.Security.SuperUserKey);
+        }
     }
 
     protected override Expression<Func<SortChildrenMediaController, object>> MethodSelector =>

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Media/SortChildrenMediaControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Media/SortChildrenMediaControllerTests.cs
@@ -1,0 +1,81 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Controllers.Media;
+using Umbraco.Cms.Api.Management.ViewModels.Sorting;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.ContentTypeEditing;
+
+namespace Umbraco.Cms.Tests.Integration.ManagementApi.Media;
+
+public class SortChildrenMediaControllerTests : ManagementApiUserGroupTestBase<SortChildrenMediaController>
+{
+    private IMediaEditingService MediaEditingService => GetRequiredService<IMediaEditingService>();
+
+    private IMediaTypeEditingService MediaTypeEditingService => GetRequiredService<IMediaTypeEditingService>();
+
+    private Guid _parentFolderKey;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        var mediaTypes = await MediaTypeEditingService.GetFolderMediaTypes(0, 100);
+        var folderMediaType = mediaTypes.Items.FirstOrDefault(x => x.Name.Contains("Folder", StringComparison.OrdinalIgnoreCase));
+
+        MediaCreateModel parentCreateModel = new()
+        {
+            Variants = new List<VariantModel> { new() { Name = "MediaParentFolder" } },
+            ContentTypeKey = folderMediaType.Key,
+            ParentKey = Constants.System.RootKey,
+        };
+        var responseParent = await MediaEditingService.CreateAsync(parentCreateModel, Constants.Security.SuperUserKey);
+        _parentFolderKey = responseParent.Result.Content.Key;
+    }
+
+    protected override Expression<Func<SortChildrenMediaController, object>> MethodSelector =>
+        x => x.SortChildren(CancellationToken.None, _parentFolderKey, null);
+
+    protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.OK
+    };
+
+    protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel TranslatorUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Forbidden
+    };
+
+    protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()
+    {
+        ExpectedStatusCode = HttpStatusCode.Unauthorized
+    };
+
+    protected override async Task<HttpResponseMessage> ClientRequest()
+    {
+        SortMediaChildrenByFieldRequestModel requestModel = new()
+        {
+            Field = ContentSortField.Name,
+            Direction = Direction.Ascending,
+        };
+
+        return await Client.PutAsync(Url, JsonContent.Create(requestModel));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -84,8 +84,9 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         .AddNotificationHandler<ContentCopiedNotification, ContentNotificationHandler>()
         .AddNotificationHandler<ContentSavingNotification, ContentNotificationHandler>();
 
-    [Test]
-    public void Sort_Preserves_Template_And_Property_Data_When_Items_Loaded_Without_Them()
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Sort_Preserves_Template_And_Property_Data_When_Items_Loaded_Without_Them(bool useSortChildren)
     {
         // The fixture's children share the content type's default template; assign it so we can verify it survives.
         var templateId = ContentType.DefaultTemplateId;
@@ -113,15 +114,30 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
 
         // Rotate the order so every item's sort order changes (and is therefore re-saved).
         Dictionary<Guid, IContent> byKey = partialChildren.ToDictionary(x => x.Key, x => x);
-        IContent[] rotated =
-        [
-            byKey[new Guid(SubPage2Key)],
-            byKey[new Guid(SubPage3Key)],
-            byKey[new Guid(SubPageKey)],
-        ];
+        if (useSortChildren)
+        {
+            int[] rotated =
+            [
+                byKey[new Guid(SubPage2Key)].Id,
+                byKey[new Guid(SubPage3Key)].Id,
+                byKey[new Guid(SubPageKey)].Id,
+            ];
 
-        OperationResult result = ContentService.Sort(rotated);
-        Assert.That(result.Success, Is.True);
+            var result = ContentService.SortChildren(Textpage.Id, rotated);
+            Assert.That(result.Success, Is.True);
+        }
+        else
+        {
+            IContent[] rotated =
+            [
+                byKey[new Guid(SubPage2Key)],
+                byKey[new Guid(SubPage3Key)],
+                byKey[new Guid(SubPageKey)],
+            ];
+
+            OperationResult result = ContentService.Sort(rotated);
+            Assert.That(result.Success, Is.True);
+        }
 
         // Every sorted child must retain its template and property data.
         foreach (var key in childKeys)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -4242,4 +4242,39 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
 
         return (langEn, langDa, contentType);
     }
+
+    [Test]
+    public void SortChildren_Persists_The_Supplied_Order()
+    {
+        var contentType = ContentTypeBuilder.CreateBasicContentType("sortChildrenPage", "Sort Children Page");
+        contentType.AllowedAsRoot = true;
+        contentType.AllowedContentTypes = [new ContentTypeSort(contentType.Key, 0, contentType.Alias)];
+        ContentTypeService.Save(contentType);
+
+        var root = new Content("Root", Constants.System.Root, contentType);
+        ContentService.Save(root);
+
+        var childIds = new List<int>();
+        for (var i = 0; i < 5; i++)
+        {
+            var child = new Content($"Child {i}", root.Id, contentType);
+            ContentService.Save(child);
+            childIds.Add(child.Id);
+        }
+
+        int[] ChildIdsInSortOrder() => ContentService
+            .GetPagedChildren(root.Id, 0, 100, out _)
+            .OrderBy(child => child.SortOrder)
+            .Select(child => child.Id)
+            .ToArray();
+
+        // Children were created in ascending sort order.
+        Assert.AreEqual(childIds.ToArray(), ChildIdsInSortOrder());
+
+        var reversed = Enumerable.Reverse(childIds).ToArray();
+        var result = ContentService.SortChildren(root.Id, reversed, Constants.Security.SuperUserId);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(reversed, ChildIdsInSortOrder());
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenNotificationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenNotificationTests.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+internal abstract class ContentEditingServiceSortChildrenNotificationTestsBase : UmbracoIntegrationTest
+{
+    protected static int SortedNotificationCount { get; set; }
+
+    protected IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    protected IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
+
+    [SetUp]
+    public void ResetNotificationCount() => SortedNotificationCount = 0;
+
+    protected async Task<IContent> CreateRootWithChildrenAsync()
+    {
+        var childContentType = ContentTypeBuilder.CreateBasicContentType("childPage", "Child Page");
+        await ContentTypeService.CreateAsync(childContentType, Constants.Security.SuperUserKey);
+
+        var rootContentType = ContentTypeBuilder.CreateBasicContentType("rootPage", "Root Page");
+        rootContentType.AllowedAsRoot = true;
+        rootContentType.AllowedContentTypes = [new ContentTypeSort(childContentType.Key, 1, childContentType.Alias)];
+        await ContentTypeService.CreateAsync(rootContentType, Constants.Security.SuperUserKey);
+
+        var root = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = rootContentType.Key, ParentKey = Constants.System.RootKey, Variants = [new() { Name = "Root" }],
+            },
+            Constants.Security.SuperUserKey)).Result.Content!;
+
+        foreach (var name in new[] { "banana", "apple", "cherry" })
+        {
+            await ContentEditingService.CreateAsync(
+                new ContentCreateModel
+                {
+                    ContentTypeKey = childContentType.Key, ParentKey = root.Key, Variants = [new() { Name = name }],
+                },
+                Constants.Security.SuperUserKey);
+        }
+
+        return root;
+    }
+
+    protected sealed class SortedNotificationRecorder : INotificationHandler<ContentSortedNotification>
+    {
+        public void Handle(ContentSortedNotification notification) => SortedNotificationCount++;
+    }
+}
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class ContentEditingServiceSortChildrenWithNotificationsTests : ContentEditingServiceSortChildrenNotificationTestsBase
+{
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.Services.Configure<ContentSettings>(config => config.SortChildrenByFieldFiresNotifications = true);
+        builder.AddNotificationHandler<ContentSortedNotification, SortedNotificationRecorder>();
+    }
+
+    [Test]
+    public async Task Sort_By_Field_Fires_Sorted_Notification_When_Opted_In()
+    {
+        var root = await CreateRootWithChildrenAsync();
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Descending, culture: null, Constants.Security.SuperUserKey);
+
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+        Assert.Greater(SortedNotificationCount, 0, "Expected a ContentSortedNotification when the opt-in setting is enabled.");
+    }
+}
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class ContentEditingServiceSortChildrenWithoutNotificationsTests : ContentEditingServiceSortChildrenNotificationTestsBase
+{
+    // Leaves ContentSettings.SortChildrenByFieldFiresNotifications at its default (false).
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+        => builder.AddNotificationHandler<ContentSortedNotification, SortedNotificationRecorder>();
+
+    [Test]
+    public async Task Sort_By_Field_Does_Not_Fire_Sorted_Notification_By_Default()
+    {
+        var root = await CreateRootWithChildrenAsync();
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Descending, culture: null, Constants.Security.SuperUserKey);
+
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+        Assert.AreEqual(0, SortedNotificationCount, "Expected no ContentSortedNotification on the default bulk path.");
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenNotificationTestsBase.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenNotificationTestsBase.cs
@@ -1,16 +1,11 @@
-using Microsoft.Extensions.DependencyInjection;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Tests.Common.Builders;
-using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
@@ -59,47 +54,5 @@ internal abstract class ContentEditingServiceSortChildrenNotificationTestsBase :
     protected sealed class SortedNotificationRecorder : INotificationHandler<ContentSortedNotification>
     {
         public void Handle(ContentSortedNotification notification) => SortedNotificationCount++;
-    }
-}
-
-[TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-internal sealed class ContentEditingServiceSortChildrenWithNotificationsTests : ContentEditingServiceSortChildrenNotificationTestsBase
-{
-    protected override void CustomTestSetup(IUmbracoBuilder builder)
-    {
-        builder.Services.Configure<ContentSettings>(config => config.SortChildrenByFieldFiresNotifications = true);
-        builder.AddNotificationHandler<ContentSortedNotification, SortedNotificationRecorder>();
-    }
-
-    [Test]
-    public async Task Sort_By_Field_Fires_Sorted_Notification_When_Opted_In()
-    {
-        var root = await CreateRootWithChildrenAsync();
-
-        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Descending, culture: null, Constants.Security.SuperUserKey);
-
-        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
-        Assert.Greater(SortedNotificationCount, 0, "Expected a ContentSortedNotification when the opt-in setting is enabled.");
-    }
-}
-
-[TestFixture]
-[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
-internal sealed class ContentEditingServiceSortChildrenWithoutNotificationsTests : ContentEditingServiceSortChildrenNotificationTestsBase
-{
-    // Leaves ContentSettings.SortChildrenByFieldFiresNotifications at its default (false).
-    protected override void CustomTestSetup(IUmbracoBuilder builder)
-        => builder.AddNotificationHandler<ContentSortedNotification, SortedNotificationRecorder>();
-
-    [Test]
-    public async Task Sort_By_Field_Does_Not_Fire_Sorted_Notification_By_Default()
-    {
-        var root = await CreateRootWithChildrenAsync();
-
-        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Descending, culture: null, Constants.Security.SuperUserKey);
-
-        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
-        Assert.AreEqual(0, SortedNotificationCount, "Expected no ContentSortedNotification on the default bulk path.");
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenWithNotificationsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenWithNotificationsTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class ContentEditingServiceSortChildrenWithNotificationsTests : ContentEditingServiceSortChildrenNotificationTestsBase
+{
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.Services.Configure<ContentSettings>(config => config.SortChildrenByFieldFiresNotifications = true);
+        builder.AddNotificationHandler<ContentSortedNotification, SortedNotificationRecorder>();
+    }
+
+    [Test]
+    public async Task Sort_By_Field_Fires_Sorted_Notification_When_Opted_In()
+    {
+        var root = await CreateRootWithChildrenAsync();
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Descending, culture: null, Constants.Security.SuperUserKey);
+
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+        Assert.Greater(SortedNotificationCount, 0, "Expected a ContentSortedNotification when the opt-in setting is enabled.");
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenWithoutNotificationsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceSortChildrenWithoutNotificationsTests.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class ContentEditingServiceSortChildrenWithoutNotificationsTests : ContentEditingServiceSortChildrenNotificationTestsBase
+{
+    // Leaves ContentSettings.SortChildrenByFieldFiresNotifications at its default (false).
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+        => builder.AddNotificationHandler<ContentSortedNotification, SortedNotificationRecorder>();
+
+    [Test]
+    public async Task Sort_By_Field_Does_Not_Fire_Sorted_Notification_By_Default()
+    {
+        var root = await CreateRootWithChildrenAsync();
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Descending, culture: null, Constants.Security.SuperUserKey);
+
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+        Assert.AreEqual(0, SortedNotificationCount, "Expected no ContentSortedNotification on the default bulk path.");
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
@@ -84,7 +84,7 @@ public partial class ContentEditingServiceTests
     {
         var contentType = await CreateVariantContentType(variantTitleAsMandatory: false);
         contentType.AllowedContentTypes = [new ContentTypeSort(contentType.Key, 0, contentType.Alias)];
-        ContentTypeService.Save(contentType);
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
 
         var root = (await ContentEditingService.CreateAsync(
             new ContentCreateModel
@@ -111,6 +111,78 @@ public partial class ContentEditingServiceTests
                 Constants.Security.SuperUserKey)).Result.Content!;
             childKeys[i] = child.Key;
         }
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Ascending, culture, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualChildKeys = ContentService
+            .GetPagedChildren(root.Id, 0, 100, out _, propertyAliases: null, filter: null, ordering: null)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedChildKeys = expectedChildIndexes.Select(i => childKeys[i]).ToArray();
+
+        Assert.AreEqual(expectedChildKeys, actualChildKeys);
+    }
+
+    // Proves the invariant-name fallback documented in ContentEditingServiceWithSortingBase.BuildOrdering():
+    // for a mix of variant and invariant children, the culture only selects the variant children's name -
+    // invariant children always sort by their single node name and ignore the culture entirely.
+    [TestCase("en-US", new[] { 0, 2, 1 })] // en names asc: banana(V0), mango(I2), yankee(V1)
+    [TestCase("da-DK", new[] { 1, 2, 0 })] // da names asc: banana(V1), mango(I2), yankee(V0)
+    public async Task Sort_Children_By_Name_With_Culture_Uses_Invariant_Name_For_Invariant_Children(string culture, int[] expectedChildIndexes)
+    {
+        var variantContentType = await CreateVariantContentType(variantTitleAsMandatory: false);
+
+        var invariantContentType = ContentTypeBuilder.CreateBasicContentType(alias: "invariantChild", name: "Invariant Child");
+        await ContentTypeService.CreateAsync(invariantContentType, Constants.Security.SuperUserKey);
+
+        // The (variant) parent allows both variant and invariant children.
+        variantContentType.AllowedContentTypes =
+        [
+            new ContentTypeSort(variantContentType.Key, 0, variantContentType.Alias),
+            new ContentTypeSort(invariantContentType.Key, 1, invariantContentType.Alias),
+        ];
+        await ContentTypeService.UpdateAsync(variantContentType, Constants.Security.SuperUserKey);
+
+        var root = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = variantContentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new() { Culture = "en-US", Name = "Root EN" }, new() { Culture = "da-DK", Name = "Root DA" }],
+            },
+            Constants.Security.SuperUserKey)).Result.Content!;
+
+        var childKeys = new Guid[3];
+
+        // index 0, 1: variant children whose en-US and da-DK names sort into opposite orders.
+        (string English, string Danish)[] variantChildNames = [("banana", "yankee"), ("yankee", "banana")];
+        for (var i = 0; i < variantChildNames.Length; i++)
+        {
+            (string english, string danish) = variantChildNames[i];
+            var child = (await ContentEditingService.CreateAsync(
+                new ContentCreateModel
+                {
+                    ContentTypeKey = variantContentType.Key,
+                    ParentKey = root.Key,
+                    Variants = [new() { Culture = "en-US", Name = english }, new() { Culture = "da-DK", Name = danish }],
+                },
+                Constants.Security.SuperUserKey)).Result.Content!;
+            childKeys[i] = child.Key;
+        }
+
+        // index 2: invariant child with a single name that sorts between the variant names in both cultures.
+        // It has no name for either culture, so a broken fallback would mis-sort it (e.g. to the start).
+        var invariantChild = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = invariantContentType.Key,
+                ParentKey = root.Key,
+                Variants = [new() { Name = "mango" }],
+            },
+            Constants.Security.SuperUserKey)).Result.Content!;
+        childKeys[2] = invariantChild.Key;
 
         var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Ascending, culture, Constants.Security.SuperUserKey);
         Assert.AreEqual(ContentEditingOperationStatus.Success, result);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
@@ -70,12 +70,12 @@ public partial class ContentEditingServiceTests
     }
 
     [Test]
-    public async Task Sort_Children_By_Field_Returns_SortingInvalid_For_Unknown_Field()
+    public async Task Sort_Children_By_Field_Throws_For_Unrecognised_Field()
     {
         (IContent root, _) = await CreateRootWithChildrenForFieldSorting();
 
-        var result = await ContentEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
-        Assert.AreEqual(ContentEditingOperationStatus.SortingInvalid, result);
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            ContentEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, culture: null, Constants.Security.SuperUserKey));
     }
 
     [TestCase("en-US", new[] { 1, 2, 0 })] // English names ascending: A(1), B(2), C(0)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
@@ -14,10 +14,10 @@ public partial class ContentEditingServiceTests
     // a sort applied against the wrong field cannot coincidentally produce the right result.
     private static readonly (string Name, int CreateOffset, int UpdateOffset)[] _sortByFieldChildren =
     {
-        ("delta", 0, 3),   // index 0
-        ("bravo", 1, 1),   // index 1
-        ("echo", 2, 4),    // index 2
-        ("alpha", 3, 0),   // index 3
+        ("delta", 0, 0),   // index 0
+        ("bravo", 1, 3),   // index 1
+        ("echo", 2, 1),    // index 2
+        ("alpha", 3, 4),   // index 3
         ("charlie", 4, 2), // index 4
     };
 
@@ -25,8 +25,8 @@ public partial class ContentEditingServiceTests
     [TestCase(ContentSortField.Name, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
     [TestCase(ContentSortField.CreateDate, Direction.Ascending, new[] { 0, 1, 2, 3, 4 })]
     [TestCase(ContentSortField.CreateDate, Direction.Descending, new[] { 4, 3, 2, 1, 0 })]
-    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
-    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 0, 2, 4, 1, 3 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 3, 1, 4, 2, 0 })]
     public async Task Can_Sort_Children_By_Field(ContentSortField field, Direction direction, int[] expectedChildIndexes)
     {
         (IContent root, Guid[] childKeysByIndex) = await CreateRootWithChildrenForFieldSorting();
@@ -125,12 +125,17 @@ public partial class ContentEditingServiceTests
         Assert.AreEqual(expectedChildKeys, actualChildKeys);
     }
 
-    [Test]
-    public async Task Can_Sort_Root_Content_By_Field()
+    [TestCase(ContentSortField.Name, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
+    [TestCase(ContentSortField.Name, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Ascending, new[] { 0, 1, 2, 3, 4 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Descending, new[] { 4, 3, 2, 1, 0 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 0, 2, 4, 1, 3 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 3, 1, 4, 2, 0 })]
+    public async Task Can_Sort_Root_Content_By_Field(ContentSortField field, Direction direction, int[] expectedRootIndexes)
     {
         Guid[] rootKeysByIndex = await CreateRootContentForFieldSorting();
 
-        var result = await ContentEditingService.SortByFieldAsync(parentKey: null, ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        var result = await ContentEditingService.SortByFieldAsync(parentKey: null, field, direction, culture: null, Constants.Security.SuperUserKey);
         Assert.AreEqual(ContentEditingOperationStatus.Success, result);
 
         var actualRootKeys = ContentService
@@ -138,8 +143,7 @@ public partial class ContentEditingServiceTests
             .OrderBy(c => c.SortOrder)
             .Select(c => c.Key)
             .ToArray();
-        // Names ascending: alpha(3), bravo(1), charlie(4), delta(0), echo(2).
-        var expectedRootKeys = new[] { 3, 1, 4, 0, 2 }.Select(i => rootKeysByIndex[i]).ToArray();
+        var expectedRootKeys = expectedRootIndexes.Select(i => rootKeysByIndex[i]).ToArray();
 
         Assert.AreEqual(expectedRootKeys, actualRootKeys);
     }
@@ -195,10 +199,11 @@ public partial class ContentEditingServiceTests
         rootContentType.AllowedAsRoot = true;
         await ContentTypeService.CreateAsync(rootContentType, Constants.Security.SuperUserKey);
 
+        var baseDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var rootKeys = new Guid[_sortByFieldChildren.Length];
         for (var i = 0; i < _sortByFieldChildren.Length; i++)
         {
-            (string name, _, _) = _sortByFieldChildren[i];
+            (string name, int createOffset, int updateOffset) = _sortByFieldChildren[i];
 
             var root = (await ContentEditingService.CreateAsync(
                 new ContentCreateModel
@@ -207,6 +212,11 @@ public partial class ContentEditingServiceTests
                 },
                 Constants.Security.SuperUserKey)).Result.Content!;
             rootKeys[i] = root.Key;
+
+            // Setting the dates marks them dirty, so they are persisted as-is rather than being stamped with "now".
+            root.CreateDate = baseDate.AddDays(createOffset);
+            root.UpdateDate = baseDate.AddDays(100 + updateOffset);
+            ContentService.Save(root);
         }
 
         return rootKeys;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.SortByField.cs
@@ -1,0 +1,214 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Builders;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+public partial class ContentEditingServiceTests
+{
+    // Children are created in index order 0..4. Names, create dates and update dates are deliberately
+    // assigned in three different orders so that each field produces a distinct expected ordering -
+    // a sort applied against the wrong field cannot coincidentally produce the right result.
+    private static readonly (string Name, int CreateOffset, int UpdateOffset)[] _sortByFieldChildren =
+    {
+        ("delta", 0, 3),   // index 0
+        ("bravo", 1, 1),   // index 1
+        ("echo", 2, 4),    // index 2
+        ("alpha", 3, 0),   // index 3
+        ("charlie", 4, 2), // index 4
+    };
+
+    [TestCase(ContentSortField.Name, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
+    [TestCase(ContentSortField.Name, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Ascending, new[] { 0, 1, 2, 3, 4 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Descending, new[] { 4, 3, 2, 1, 0 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    public async Task Can_Sort_Children_By_Field(ContentSortField field, Direction direction, int[] expectedChildIndexes)
+    {
+        (IContent root, Guid[] childKeysByIndex) = await CreateRootWithChildrenForFieldSorting();
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, field, direction, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualChildKeys = ContentService
+            .GetPagedChildren(root.Id, 0, 100, out _, propertyAliases: null, filter: null, ordering: null)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedChildKeys = expectedChildIndexes.Select(i => childKeysByIndex[i]).ToArray();
+
+        Assert.AreEqual(expectedChildKeys, actualChildKeys);
+    }
+
+    [Test]
+    public async Task Sort_Children_By_Field_With_No_Children_Returns_Success()
+    {
+        var contentType = ContentTypeBuilder.CreateBasicContentType(alias: "rootPage", name: "Root Page");
+        contentType.AllowedAsRoot = true;
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var parent = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key, Variants = [new() { Name = "Childless" }], ParentKey = Constants.System.RootKey,
+            },
+            Constants.Security.SuperUserKey)).Result.Content!;
+
+        var result = await ContentEditingService.SortByFieldAsync(parent.Key, ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+    }
+
+    [Test]
+    public async Task Sort_Children_By_Field_Returns_NotFound_For_Unknown_Parent()
+    {
+        var result = await ContentEditingService.SortByFieldAsync(Guid.NewGuid(), ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.NotFound, result);
+    }
+
+    [Test]
+    public async Task Sort_Children_By_Field_Returns_SortingInvalid_For_Unknown_Field()
+    {
+        (IContent root, _) = await CreateRootWithChildrenForFieldSorting();
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.SortingInvalid, result);
+    }
+
+    [TestCase("en-US", new[] { 1, 2, 0 })] // English names ascending: A(1), B(2), C(0)
+    [TestCase("da-DK", new[] { 0, 2, 1 })] // Danish names ascending: 1(0), 2(2), 3(1)
+    public async Task Sort_Children_By_Name_Uses_The_Variant_Name_For_The_Given_Culture(string culture, int[] expectedChildIndexes)
+    {
+        var contentType = await CreateVariantContentType(variantTitleAsMandatory: false);
+        contentType.AllowedContentTypes = [new ContentTypeSort(contentType.Key, 0, contentType.Alias)];
+        ContentTypeService.Save(contentType);
+
+        var root = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new() { Culture = "en-US", Name = "Root EN" }, new() { Culture = "da-DK", Name = "Root DA" }],
+            },
+            Constants.Security.SuperUserKey)).Result.Content!;
+
+        // (en-US name, da-DK name) chosen so the two cultures sort into different orders.
+        (string English, string Danish)[] childNames = [("C", "1"), ("A", "3"), ("B", "2")];
+        var childKeys = new Guid[childNames.Length];
+        for (var i = 0; i < childNames.Length; i++)
+        {
+            (string english, string danish) = childNames[i];
+            var child = (await ContentEditingService.CreateAsync(
+                new ContentCreateModel
+                {
+                    ContentTypeKey = contentType.Key,
+                    ParentKey = root.Key,
+                    Variants = [new() { Culture = "en-US", Name = english }, new() { Culture = "da-DK", Name = danish }],
+                },
+                Constants.Security.SuperUserKey)).Result.Content!;
+            childKeys[i] = child.Key;
+        }
+
+        var result = await ContentEditingService.SortByFieldAsync(root.Key, ContentSortField.Name, Direction.Ascending, culture, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualChildKeys = ContentService
+            .GetPagedChildren(root.Id, 0, 100, out _, propertyAliases: null, filter: null, ordering: null)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedChildKeys = expectedChildIndexes.Select(i => childKeys[i]).ToArray();
+
+        Assert.AreEqual(expectedChildKeys, actualChildKeys);
+    }
+
+    [Test]
+    public async Task Can_Sort_Root_Content_By_Field()
+    {
+        Guid[] rootKeysByIndex = await CreateRootContentForFieldSorting();
+
+        var result = await ContentEditingService.SortByFieldAsync(parentKey: null, ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualRootKeys = ContentService
+            .GetPagedChildren(Constants.System.Root, 0, 100, out _, propertyAliases: null, filter: null, ordering: null)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        // Names ascending: alpha(3), bravo(1), charlie(4), delta(0), echo(2).
+        var expectedRootKeys = new[] { 3, 1, 4, 0, 2 }.Select(i => rootKeysByIndex[i]).ToArray();
+
+        Assert.AreEqual(expectedRootKeys, actualRootKeys);
+    }
+
+    private async Task<(IContent Root, Guid[] ChildKeysByIndex)> CreateRootWithChildrenForFieldSorting()
+    {
+        var childContentType = ContentTypeBuilder.CreateBasicContentType(alias: "childPage", name: "Child Page");
+        await ContentTypeService.CreateAsync(childContentType, Constants.Security.SuperUserKey);
+
+        var rootContentType = ContentTypeBuilder.CreateBasicContentType(alias: "rootPage", name: "Root Page");
+        rootContentType.AllowedAsRoot = true;
+        rootContentType.AllowedContentTypes = [new ContentTypeSort(childContentType.Key, 1, childContentType.Alias)];
+        await ContentTypeService.CreateAsync(rootContentType, Constants.Security.SuperUserKey);
+
+        var root = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = rootContentType.Key, Variants = [new() { Name = "Root" }], ParentKey = Constants.System.RootKey,
+            },
+            Constants.Security.SuperUserKey)).Result.Content!;
+
+        var baseDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var childKeys = new Guid[_sortByFieldChildren.Length];
+        for (var i = 0; i < _sortByFieldChildren.Length; i++)
+        {
+            (string name, int createOffset, int updateOffset) = _sortByFieldChildren[i];
+
+            var child = (await ContentEditingService.CreateAsync(
+                new ContentCreateModel
+                {
+                    ContentTypeKey = childContentType.Key, ParentKey = root.Key, Variants = [new() { Name = name }],
+                },
+                Constants.Security.SuperUserKey)).Result.Content!;
+            childKeys[i] = child.Key;
+
+            // Setting the dates marks them dirty, so they are persisted as-is rather than being stamped with "now".
+            child.CreateDate = baseDate.AddDays(createOffset);
+            child.UpdateDate = baseDate.AddDays(100 + updateOffset);
+            ContentService.Save(child);
+        }
+
+        return (root, childKeys);
+    }
+
+    private async Task<Guid[]> CreateRootContentForFieldSorting()
+    {
+        foreach (var existingRoot in ContentService.GetRootContent())
+        {
+            ContentService.Delete(existingRoot);
+        }
+
+        var rootContentType = ContentTypeBuilder.CreateBasicContentType(alias: "rootPage", name: "Root Page");
+        rootContentType.AllowedAsRoot = true;
+        await ContentTypeService.CreateAsync(rootContentType, Constants.Security.SuperUserKey);
+
+        var rootKeys = new Guid[_sortByFieldChildren.Length];
+        for (var i = 0; i < _sortByFieldChildren.Length; i++)
+        {
+            (string name, _, _) = _sortByFieldChildren[i];
+
+            var root = (await ContentEditingService.CreateAsync(
+                new ContentCreateModel
+                {
+                    ContentTypeKey = rootContentType.Key, ParentKey = Constants.System.RootKey, Variants = [new() { Name = name }],
+                },
+                Constants.Security.SuperUserKey)).Result.Content!;
+            rootKeys[i] = root.Key;
+        }
+
+        return rootKeys;
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
@@ -53,12 +53,12 @@ internal sealed partial class MediaEditingServiceTests
     }
 
     [Test]
-    public async Task Sort_Children_By_Field_Returns_SortingInvalid_For_Unknown_Field()
+    public async Task Sort_Children_By_Field_Throws_For_Unrecognised_Field()
     {
         (IMedia root, _) = await CreateRootWithChildrenForFieldSorting();
 
-        var result = await MediaEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, Constants.Security.SuperUserKey);
-        Assert.AreEqual(ContentEditingOperationStatus.SortingInvalid, result);
+        Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            MediaEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, Constants.Security.SuperUserKey));
     }
 
     [TestCase(ContentSortField.Name, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
@@ -15,10 +15,10 @@ internal sealed partial class MediaEditingServiceTests
     // produces a distinct expected ordering (see ContentEditingServiceTests.SortByField for the rationale).
     private static readonly (string Name, int CreateOffset, int UpdateOffset)[] SortByFieldFolders =
     {
-        ("delta", 0, 3),   // index 0
-        ("bravo", 1, 1),   // index 1
-        ("echo", 2, 4),    // index 2
-        ("alpha", 3, 0),   // index 3
+        ("delta", 0, 0),   // index 0
+        ("bravo", 1, 3),   // index 1
+        ("echo", 2, 1),    // index 2
+        ("alpha", 3, 4),   // index 3
         ("charlie", 4, 2), // index 4
     };
 
@@ -26,8 +26,8 @@ internal sealed partial class MediaEditingServiceTests
     [TestCase(ContentSortField.Name, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
     [TestCase(ContentSortField.CreateDate, Direction.Ascending, new[] { 0, 1, 2, 3, 4 })]
     [TestCase(ContentSortField.CreateDate, Direction.Descending, new[] { 4, 3, 2, 1, 0 })]
-    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
-    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 0, 2, 4, 1, 3 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 3, 1, 4, 2, 0 })]
     public async Task Can_Sort_Children_By_Field(ContentSortField field, Direction direction, int[] expectedChildIndexes)
     {
         (IMedia root, Guid[] childKeysByIndex) = await CreateRootWithChildrenForFieldSorting();
@@ -61,6 +61,38 @@ internal sealed partial class MediaEditingServiceTests
         Assert.AreEqual(ContentEditingOperationStatus.SortingInvalid, result);
     }
 
+    [TestCase(ContentSortField.Name, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
+    [TestCase(ContentSortField.Name, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Ascending, new[] { 0, 1, 2, 3, 4 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Descending, new[] { 4, 3, 2, 1, 0 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 0, 2, 4, 1, 3 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 3, 1, 4, 2, 0 })]
+    public async Task Can_Sort_Root_Media_By_Field(ContentSortField field, Direction direction, int[] expectedRootIndexes)
+    {
+        Guid[] rootKeysByIndex = await CreateRootMediaForFieldSorting();
+
+        var result = await MediaEditingService.SortByFieldAsync(parentKey: null, field, direction, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualRootKeys = MediaService
+            .GetPagedChildren(Constants.System.Root, 0, 100, out _)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedRootKeys = expectedRootIndexes.Select(i => rootKeysByIndex[i]).ToArray();
+
+        Assert.AreEqual(expectedRootKeys, actualRootKeys);
+    }
+
+    [Test]
+    public async Task Sort_Children_By_Field_With_No_Children_Returns_Success()
+    {
+        var folder = await CreateFolderMediaAsync("Childless");
+
+        var result = await MediaEditingService.SortByFieldAsync(folder.Key, ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+    }
+
     private async Task<(IMedia Root, Guid[] ChildKeysByIndex)> CreateRootWithChildrenForFieldSorting()
     {
         var root = await CreateFolderMediaAsync("Root");
@@ -81,5 +113,25 @@ internal sealed partial class MediaEditingServiceTests
         }
 
         return (root, childKeys);
+    }
+
+    private async Task<Guid[]> CreateRootMediaForFieldSorting()
+    {
+        var baseDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var rootKeys = new Guid[SortByFieldFolders.Length];
+        for (var i = 0; i < SortByFieldFolders.Length; i++)
+        {
+            (string name, int createOffset, int updateOffset) = SortByFieldFolders[i];
+
+            var media = await CreateFolderMediaAsync(name);
+            rootKeys[i] = media.Key;
+
+            // Setting the dates marks them dirty, so they are persisted as-is rather than being stamped with "now".
+            media.CreateDate = baseDate.AddDays(createOffset);
+            media.UpdateDate = baseDate.AddDays(100 + updateOffset);
+            MediaService.Save(media);
+        }
+
+        return rootKeys;
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
@@ -32,7 +32,7 @@ internal sealed partial class MediaEditingServiceTests
     {
         (IMedia root, Guid[] childKeysByIndex) = await CreateRootWithChildrenForFieldSorting();
 
-        var result = await MediaEditingService.SortByFieldAsync(root.Key, field, direction, culture: null, Constants.Security.SuperUserKey);
+        var result = await MediaEditingService.SortByFieldAsync(root.Key, field, direction, Constants.Security.SuperUserKey);
         Assert.AreEqual(ContentEditingOperationStatus.Success, result);
 
         var actualChildKeys = MediaService
@@ -48,7 +48,7 @@ internal sealed partial class MediaEditingServiceTests
     [Test]
     public async Task Sort_Children_By_Field_Returns_NotFound_For_Unknown_Parent()
     {
-        var result = await MediaEditingService.SortByFieldAsync(Guid.NewGuid(), ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        var result = await MediaEditingService.SortByFieldAsync(Guid.NewGuid(), ContentSortField.Name, Direction.Ascending, Constants.Security.SuperUserKey);
         Assert.AreEqual(ContentEditingOperationStatus.NotFound, result);
     }
 
@@ -57,7 +57,7 @@ internal sealed partial class MediaEditingServiceTests
     {
         (IMedia root, _) = await CreateRootWithChildrenForFieldSorting();
 
-        var result = await MediaEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        var result = await MediaEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, Constants.Security.SuperUserKey);
         Assert.AreEqual(ContentEditingOperationStatus.SortingInvalid, result);
     }
 
@@ -71,7 +71,7 @@ internal sealed partial class MediaEditingServiceTests
     {
         Guid[] rootKeysByIndex = await CreateRootMediaForFieldSorting();
 
-        var result = await MediaEditingService.SortByFieldAsync(parentKey: null, field, direction, culture: null, Constants.Security.SuperUserKey);
+        var result = await MediaEditingService.SortByFieldAsync(parentKey: null, field, direction, Constants.Security.SuperUserKey);
         Assert.AreEqual(ContentEditingOperationStatus.Success, result);
 
         var actualRootKeys = MediaService
@@ -89,7 +89,7 @@ internal sealed partial class MediaEditingServiceTests
     {
         var folder = await CreateFolderMediaAsync("Childless");
 
-        var result = await MediaEditingService.SortByFieldAsync(folder.Key, ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        var result = await MediaEditingService.SortByFieldAsync(folder.Key, ContentSortField.Name, Direction.Ascending, Constants.Security.SuperUserKey);
         Assert.AreEqual(ContentEditingOperationStatus.Success, result);
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.SortByField.cs
@@ -1,0 +1,85 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+internal sealed partial class MediaEditingServiceTests
+{
+    private IMediaService MediaService => GetRequiredService<IMediaService>();
+
+    // Names, create dates and update dates are assigned in three different orders so each field
+    // produces a distinct expected ordering (see ContentEditingServiceTests.SortByField for the rationale).
+    private static readonly (string Name, int CreateOffset, int UpdateOffset)[] SortByFieldFolders =
+    {
+        ("delta", 0, 3),   // index 0
+        ("bravo", 1, 1),   // index 1
+        ("echo", 2, 4),    // index 2
+        ("alpha", 3, 0),   // index 3
+        ("charlie", 4, 2), // index 4
+    };
+
+    [TestCase(ContentSortField.Name, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
+    [TestCase(ContentSortField.Name, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Ascending, new[] { 0, 1, 2, 3, 4 })]
+    [TestCase(ContentSortField.CreateDate, Direction.Descending, new[] { 4, 3, 2, 1, 0 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Ascending, new[] { 3, 1, 4, 0, 2 })]
+    [TestCase(ContentSortField.UpdateDate, Direction.Descending, new[] { 2, 0, 4, 1, 3 })]
+    public async Task Can_Sort_Children_By_Field(ContentSortField field, Direction direction, int[] expectedChildIndexes)
+    {
+        (IMedia root, Guid[] childKeysByIndex) = await CreateRootWithChildrenForFieldSorting();
+
+        var result = await MediaEditingService.SortByFieldAsync(root.Key, field, direction, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result);
+
+        var actualChildKeys = MediaService
+            .GetPagedChildren(root.Id, 0, 100, out _)
+            .OrderBy(c => c.SortOrder)
+            .Select(c => c.Key)
+            .ToArray();
+        var expectedChildKeys = expectedChildIndexes.Select(i => childKeysByIndex[i]).ToArray();
+
+        Assert.AreEqual(expectedChildKeys, actualChildKeys);
+    }
+
+    [Test]
+    public async Task Sort_Children_By_Field_Returns_NotFound_For_Unknown_Parent()
+    {
+        var result = await MediaEditingService.SortByFieldAsync(Guid.NewGuid(), ContentSortField.Name, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.NotFound, result);
+    }
+
+    [Test]
+    public async Task Sort_Children_By_Field_Returns_SortingInvalid_For_Unknown_Field()
+    {
+        (IMedia root, _) = await CreateRootWithChildrenForFieldSorting();
+
+        var result = await MediaEditingService.SortByFieldAsync(root.Key, (ContentSortField)999, Direction.Ascending, culture: null, Constants.Security.SuperUserKey);
+        Assert.AreEqual(ContentEditingOperationStatus.SortingInvalid, result);
+    }
+
+    private async Task<(IMedia Root, Guid[] ChildKeysByIndex)> CreateRootWithChildrenForFieldSorting()
+    {
+        var root = await CreateFolderMediaAsync("Root");
+
+        var baseDate = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var childKeys = new Guid[SortByFieldFolders.Length];
+        for (var i = 0; i < SortByFieldFolders.Length; i++)
+        {
+            (string name, int createOffset, int updateOffset) = SortByFieldFolders[i];
+
+            var child = await CreateFolderMediaAsync(name, parentKey: root.Key);
+            childKeys[i] = child.Key;
+
+            // Setting the dates marks them dirty, so they are persisted as-is rather than being stamped with "now".
+            child.CreateDate = baseDate.AddDays(createOffset);
+            child.UpdateDate = baseDate.AddDays(100 + updateOffset);
+            MediaService.Save(child);
+        }
+
+        return (root, childKeys);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
@@ -23,8 +23,9 @@ internal sealed class MediaServiceTests : UmbracoIntegrationTest
 
     private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
 
-    [Test]
-    public async Task Sort_Preserves_Property_Data_When_Items_Loaded_Without_It()
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Sort_Preserves_Property_Data_When_Items_Loaded_Without_It(bool useSortChildren)
     {
         var mediaType = await CreateMediaType();
 
@@ -48,9 +49,18 @@ internal sealed class MediaServiceTests : UmbracoIntegrationTest
             .ToList();
 
         // Rotate so every item's sort order changes (and is therefore re-saved).
-        IMedia[] rotated = [partial[1], partial[2], partial[0]];
+        if (useSortChildren)
+        {
+            int[] rotated = [partial[1].Id, partial[2].Id, partial[0].Id];
 
-        Assert.That(MediaService.Sort(rotated), Is.True);
+            var result = MediaService.SortChildren(Constants.System.Root, rotated);
+            Assert.That(result.Success, Is.True);
+        }
+        else
+        {
+            IMedia[] rotated = [partial[1], partial[2], partial[0]];
+            Assert.That(MediaService.Sort(rotated), Is.True);
+        }
 
         // Every sorted item must retain its property data, and the requested order must be applied.
         Assert.Multiple(() =>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
@@ -526,4 +526,38 @@ internal sealed class MediaServiceTests : UmbracoIntegrationTest
     }
 
     #endregion
+
+    [Test]
+    public void SortChildren_Persists_The_Supplied_Order()
+    {
+        var folderMediaType = MediaTypeService.Get(Constants.Conventions.MediaTypes.Folder)!;
+
+        var root = MediaBuilder.CreateMediaFolder(folderMediaType, Constants.System.Root);
+        root.Name = "Root";
+        MediaService.Save(root);
+
+        var childIds = new List<int>();
+        for (var i = 0; i < 5; i++)
+        {
+            var child = MediaBuilder.CreateMediaFolder(folderMediaType, root.Id);
+            child.Name = $"Folder {i}";
+            MediaService.Save(child);
+            childIds.Add(child.Id);
+        }
+
+        int[] ChildIdsInSortOrder() => MediaService
+            .GetPagedChildren(root.Id, 0, 100, out _)
+            .OrderBy(child => child.SortOrder)
+            .Select(child => child.Id)
+            .ToArray();
+
+        // Children were created in ascending sort order.
+        Assert.AreEqual(childIds.ToArray(), ChildIdsInSortOrder());
+
+        var reversed = Enumerable.Reverse(childIds).ToArray();
+        var result = MediaService.SortChildren(root.Id, reversed, Constants.Security.SuperUserId);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(reversed, ChildIdsInSortOrder());
+    }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -94,6 +94,9 @@
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Sort.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.SortByField.cs">
+      <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
+    </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Update.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -106,6 +106,9 @@
     <Compile Update="Umbraco.Infrastructure\Services\MediaEditingServiceTests.MoveToRecycleBin.cs">
       <DependentUpon>MediaEditingServiceTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\MediaEditingServiceTests.SortByField.cs">
+      <DependentUpon>MediaEditingServiceTests.cs</DependentUpon>
+    </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\ContentPublishingServiceTests.Publish.cs">
       <DependentUpon>ContentPublishingServiceTests.cs</DependentUpon>
     </Compile>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/Authorization/AllChildrenAuthorizerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/Authorization/AllChildrenAuthorizerTests.cs
@@ -12,7 +12,7 @@ using Umbraco.Cms.Core.Services;
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Security.Authorization;
 
 [TestFixture]
-public class SortChildrenAuthorizerTests
+public class AllChildrenAuthorizerTests
 {
     private const string Policy = "TestPolicy";
 
@@ -83,7 +83,7 @@ public class SortChildrenAuthorizerTests
     }
 
     private Task<bool> Authorize() =>
-        SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+        AllChildrenAuthorizer.IsAuthorizedForChildrenAsync(
             _authorizationService.Object,
             _entityService.Object,
             _user,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/Authorization/SortChildrenAuthorizerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Security/Authorization/SortChildrenAuthorizerTests.cs
@@ -1,0 +1,124 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Management.Security.Authorization;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Persistence.Querying;
+using Umbraco.Cms.Core.Security.Authorization;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Management.Security.Authorization;
+
+[TestFixture]
+public class SortChildrenAuthorizerTests
+{
+    private const string Policy = "TestPolicy";
+
+    private Mock<IAuthorizationService> _authorizationService = null!;
+    private Mock<IEntityService> _entityService = null!;
+    private ClaimsPrincipal _user = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _authorizationService = new Mock<IAuthorizationService>();
+        _entityService = new Mock<IEntityService>();
+        _user = new ClaimsPrincipal(new ClaimsIdentity());
+    }
+
+    [Test]
+    public async Task Returns_True_When_All_Children_Are_Authorized()
+    {
+        SetupChildren(skip: 0, total: 2, Guid.NewGuid(), Guid.NewGuid());
+        SetupAuthorization(AuthorizationResult.Success());
+
+        var result = await Authorize();
+
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public async Task Returns_False_When_A_Child_Is_Not_Authorized()
+    {
+        // A single denied child must fail the whole operation - the controller turns this into a 403.
+        SetupChildren(skip: 0, total: 2, Guid.NewGuid(), Guid.NewGuid());
+        SetupAuthorization(AuthorizationResult.Failed());
+
+        var result = await Authorize();
+
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public async Task Returns_True_And_Does_Not_Authorize_When_There_Are_No_Children()
+    {
+        SetupChildren(skip: 0, total: 0);
+
+        var result = await Authorize();
+
+        Assert.IsTrue(result);
+        _authorizationService.Verify(
+            x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task Authorizes_Every_Page_Of_Children()
+    {
+        // 600 children across two pages of 500; both pages must be authorized.
+        var firstPage = Enumerable.Range(0, 500).Select(_ => Guid.NewGuid()).ToArray();
+        var secondPage = Enumerable.Range(0, 100).Select(_ => Guid.NewGuid()).ToArray();
+        SetupChildren(skip: 0, total: 600, firstPage);
+        SetupChildren(skip: 500, total: 600, secondPage);
+        SetupAuthorization(AuthorizationResult.Success());
+
+        var result = await Authorize();
+
+        Assert.IsTrue(result);
+        _authorizationService.Verify(
+            x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), Policy),
+            Times.Exactly(2));
+    }
+
+    private Task<bool> Authorize() =>
+        SortChildrenAuthorizer.IsAuthorizedForChildrenAsync(
+            _authorizationService.Object,
+            _entityService.Object,
+            _user,
+            parentKey: Guid.NewGuid(),
+            UmbracoObjectTypes.Document,
+            childKeys => ContentPermissionResource.WithKeys("A", childKeys),
+            Policy);
+
+    private void SetupChildren(int skip, long total, params Guid[] childKeys)
+    {
+        IEntitySlim[] children = childKeys
+            .Select(key =>
+            {
+                var entity = new Mock<IEntitySlim>();
+                entity.SetupGet(x => x.Key).Returns(key);
+                return entity.Object;
+            })
+            .ToArray();
+
+        var totalRecords = total;
+        _entityService
+            .Setup(x => x.GetPagedChildren(
+                It.IsAny<Guid?>(),
+                It.IsAny<IEnumerable<UmbracoObjectTypes>>(),
+                It.IsAny<UmbracoObjectTypes>(),
+                skip,
+                It.IsAny<int>(),
+                out totalRecords,
+                It.IsAny<IQuery<IUmbracoEntity>>(),
+                It.IsAny<Ordering>()))
+            .Returns(children);
+    }
+
+    private void SetupAuthorization(AuthorizationResult result) =>
+        _authorizationService
+            .Setup(x => x.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+            .ReturnsAsync(result);
+}


### PR DESCRIPTION
## Description

Adds Management API endpoints to sort the children of a node by a chosen **system field** (name, create date, update date) and direction — an "auto-arrange" that persists the result as the children's sort order. Scoped to **Documents and Media**.

### New endpoints

All take a JSON body and return `200 OK` on success, `400 Bad Request` if the field is unrecognised, or `404 Not Found` if the parent doesn't exist.

| Method & route | Sorts |
|---|---|
| `PUT /umbraco/management/api/v1/document/{id}/sort-children` | children of a document |
| `PUT /umbraco/management/api/v1/document/root/sort-children` | root-level documents |
| `PUT /umbraco/management/api/v1/media/{id}/sort-children` | children of a media item |
| `PUT /umbraco/management/api/v1/media/root/sort-children` | root-level media |

**Request body:**

```jsonc
// Document
{ "field": "name" | "createDate" | "updateDate",
  "direction": "Ascending" | "Descending",   // required
  "culture": "en-US" }                       // optional

// Media (no culture)
{ "field": "createDate", "direction": "Descending" }
```

### Handling variants

For variant handling I've looked to match the existing manual drag-drop "sort children" UX, which displays the **variant name** but the **node-level create date**.

As such the provided culture only affects sorting by `name`. When provided, variant children are ordered by their name *in that culture*; invariant children, or variant children with no name for that culture, fall back to the invariant name.

Create/update dates are node-level, not culture-specific.

### Other notes

- Ordering is performed in the database, the same way the collection/list view orders its items.
- Limited to system fields that live in a database table (name / create date / update date). Property-data fields I've considered as out of scope, since children need not share a type, so may not have the same properties.
- Sorting a node with no children is a successful no-op (`200`).
- Unrecognised `field` values are rejected at model binding (the field is a typed enum), and defensively mapped to `400` at the service layer.
- Culture is not validated, and falls back to invariant if not found.
- Persistence is optimised for potentially large child sets and, by default, differs from the manual drag-drop sort — see *Sorting large numbers of children* below.

### Sorting large numbers of children

The manual drag-and-drop sort is naturally self-limiting: an editor has to load and reorder every child in the client before submitting, so it's impractical to trigger on huge sets. This endpoint is different — it can reorder a node's *entire* set of children from a single button click, regardless of how many there are, and a field sort typically moves most of them. Reusing the standard per-item sort would mean loading every child into memory and issuing (in the worst case) one `UPDATE` and one save/sort notification — and therefore one webhook — per child.

To keep this cheap and safe by default, a field sort is persisted differently from the manual sort:

- The new order is computed in the database (reusing the same ordering as the list view) and applied with a **single set-based `UPDATE`** in the repository (`IContentRepository.UpdateSortOrder`, batched only to stay within the SQL Server parameter limit). The editing service collects the ordered child ids by paging — it does not hold every child in memory.
- A **single branch cache refresh** and a **single audit entry** are emitted instead of per-item ones. The branch refresh is sufficient because the published cache reads sort order live from `umbracoNode`.
- Consequently, **no per-item save/sort notifications (and therefore no webhooks) are fired** for a field sort by default.

For the small number of cases that depend on those per-item notifications/webhooks, the previous behaviour can be restored with the `Umbraco:CMS:Content:SortChildrenByFieldFiresNotifications` setting (default `false`). When enabled, the field sort goes through the standard per-item sort path instead, accepting the additional performance cost on nodes with many children. The combined audit entry and single branch refresh are used in both cases — only the per-item notifications differ.

## Testing

### Automated

Integration tests have been added at the service level to verify the ordering functionality.

Controller authorization tests for all four endpoints are also added.

### Manual

**Prerequisites:** run the site and sign in to the backoffice — this authenticates the Swagger UI via the auth cookie. (Any other client must send the backoffice credentials, i.e. `credentials: include`.)

1. **Open Swagger UI** at `https://localhost:44339/umbraco/swagger/index.html` (adjust the port to your launch settings) and select the **Management API** definition. The new operations are under the **Document** and **Media** tags, ending in `/sort-children`.

2. **Set up content to sort.** Create a parent document with a handful of children whose **names** are deliberately out of order (e.g. "Banana", "Apple", "Cherry") and, ideally, different create/update dates. For variant testing, use a culture-varying document type with two languages and give the children different names per culture.

3. **Sort the children of a node** — `PUT /umbraco/management/api/v1/document/{id}/sort-children`, where `{id}` is the **parent's** key:
   ```json
   { "field": "name", "direction": "Ascending" }
   ```
   Expect `200 OK`, then refresh the tree / list view under the parent and confirm the new order.

4. **Sort root-level items** — `PUT /umbraco/management/api/v1/document/root/sort-children` (no id), same body.

5. **Variant check (documents only).** Repeat step 3 with a culture:
   ```json
   { "field": "name", "direction": "Ascending", "culture": "da-DK" }
   ```
   Confirm the order reflects the **Danish** names. Call again with `"culture": "en-US"` and confirm the order changes to the **English** names.

6. **Dates.** Call with `"field": "createDate"` or `"updateDate"` and confirm ordering by the node-level dates (a `culture` has no effect on these).

7. **Media.** Repeat against `/media/{id}/sort-children` and `/media/root/sort-children`. The media body has no `culture`.

8. **Error cases.**
   - Unknown parent: `PUT /document/{random-guid}/sort-children` → `404 Not Found`.
   - Unrecognised field: body `{ "field": "bogus", "direction": "Ascending" }` → `400 Bad Request`.

## Documentation

Need to document the new `SortChildrenByFieldFiresNotifications` setting.

## Related

References #19703.