### PR TITLE
Auth: Time out the session when the timeout modals "Stay logged in" refresh fails (closes #22986)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.test.ts
@@ -1,0 +1,133 @@
+import { UmbAuthContext } from '../auth.context.js';
+import type { UmbModalAuthTimeoutConfig } from '../modals/umb-auth-timeout-modal.token.js';
+import { UmbAuthSessionTimeoutController } from './auth-session-timeout.controller.js';
+import { aTimeout, expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbContextProvider } from '@umbraco-cms/backoffice/context-api';
+import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+
+@customElement('test-auth-session-timeout-host')
+class UmbTestAuthSessionTimeoutHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbAuthSessionTimeoutController', () => {
+	let hostElement: UmbTestAuthSessionTimeoutHostElement;
+	let context: UmbAuthContext;
+	let controller: UmbAuthSessionTimeoutController;
+	let channel: BroadcastChannel;
+	let openedModals: Array<UmbModalAuthTimeoutConfig>;
+	let closedModalKeys: Array<string>;
+	let timeOutCalls: number;
+	const realDateNow = Date.now;
+
+	beforeEach(() => {
+		hostElement = new UmbTestAuthSessionTimeoutHostElement();
+		document.body.appendChild(hostElement);
+
+		openedModals = [];
+		closedModalKeys = [];
+		timeOutCalls = 0;
+
+		const mockModalManager = {
+			// getHostElement is required for the context consumer to accept the instance
+			getHostElement: () => hostElement,
+			open: (_host: unknown, _token: unknown, args: { data: UmbModalAuthTimeoutConfig }) => {
+				openedModals.push(args.data);
+				return { onSubmit: () => new Promise(() => {}) };
+			},
+			close: (key: string) => {
+				closedModalKeys.push(key);
+			},
+		};
+		const provider = new UmbContextProvider(
+			hostElement,
+			UMB_MODAL_MANAGER_CONTEXT,
+			mockModalManager as unknown as typeof UMB_MODAL_MANAGER_CONTEXT.TYPE,
+		);
+		provider.hostConnected();
+
+		context = new UmbAuthContext(hostElement, 'http://localhost', '/umbraco', false);
+		context.timeOut = () => {
+			timeOutCalls++;
+		};
+
+		// The controller is not instantiated by UmbAuthContext in test environments, so create it manually.
+		controller = new UmbAuthSessionTimeoutController(context);
+
+		channel = new BroadcastChannel('umb:auth');
+	});
+
+	afterEach(() => {
+		Date.now = realDateNow;
+		channel.close();
+		controller.destroy();
+		context.destroy();
+		document.body.innerHTML = '';
+	});
+
+	/**
+	 * Injects a session into the auth context via the cross-tab BroadcastChannel,
+	 * the same way a peer tab would share a refreshed session.
+	 * @param accessTokenExpiresInSeconds Seconds until the access token expires.
+	 * @param sessionExpiresInSeconds Seconds until the full session (refresh token) expires.
+	 */
+	async function injectSession(accessTokenExpiresInSeconds: number, sessionExpiresInSeconds: number) {
+		const now = Math.floor(Date.now() / 1000);
+		channel.postMessage({
+			type: 'sessionUpdate',
+			accessTokenExpiresAt: now + accessTokenExpiresInSeconds,
+			expiresAt: now + sessionExpiresInSeconds,
+		});
+		// Wait for the BroadcastChannel message to be delivered and observed
+		await aTimeout(50);
+	}
+
+	it('opens the timeout modal when the session enters the warning zone', async () => {
+		await injectSession(5, 10);
+
+		expect(openedModals).to.have.lengthOf(1);
+		expect(openedModals[0].remainingTimeInSeconds).to.be.greaterThan(0);
+		expect(openedModals[0].remainingTimeInSeconds).to.be.at.most(10);
+		expect(timeOutCalls).to.equal(0);
+	});
+
+	it('does not time out when "Stay logged in" successfully refreshes the session', async () => {
+		context.validateToken = async () => true;
+		await injectSession(5, 10);
+
+		expect(openedModals).to.have.lengthOf(1);
+		openedModals[0].onContinue();
+		await aTimeout(10);
+
+		expect(timeOutCalls).to.equal(0);
+	});
+
+	it('times out when "Stay logged in" fails to refresh the session', async () => {
+		context.validateToken = async () => false;
+		await injectSession(5, 10);
+
+		expect(openedModals).to.have.lengthOf(1);
+		openedModals[0].onContinue();
+		await aTimeout(10);
+
+		expect(timeOutCalls).to.equal(1);
+	});
+
+	it('times out instead of opening the modal when the warning timer fires after the session expired (e.g. after system sleep)', async function () {
+		this.timeout(5000);
+
+		// Session expires in 17s, warning buffer is 15s, so the warning timer is scheduled 2s out.
+		await injectSession(5, 17);
+		expect(openedModals).to.have.lengthOf(0);
+
+		// Simulate system sleep / background-tab throttling: the wall clock jumps past the
+		// session expiry while the scheduled timer has not fired yet.
+		Date.now = () => realDateNow() + 60_000;
+
+		// Wait for the real 2s timer to fire (with slack for slow CI agents).
+		await aTimeout(2500);
+
+		expect(openedModals).to.have.lengthOf(0);
+		expect(timeOutCalls).to.equal(1);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
@@ -2,6 +2,15 @@ import type { UmbAuthContext } from '../auth.context.js';
 import { UMB_MODAL_AUTH_TIMEOUT } from '../modals/umb-auth-timeout-modal.token.js';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 
+/**
+ * Safety margin (in seconds) subtracted from the client-computed session expiry.
+ * The client stamps the session timing when the token response is received, which is
+ * slightly later than when the server issued it — so the client's expiry estimate is
+ * always a little optimistic. Treating the session as expired this much earlier ensures
+ * a "Stay logged in" click near the end of the countdown still reaches the server in time.
+ */
+const EXPIRY_SAFETY_MARGIN_IN_SECONDS = 5;
+
 export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 	#host: UmbAuthContext;
 	#timeoutId?: ReturnType<typeof setTimeout>;
@@ -58,6 +67,7 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 	/**
 	 * Schedules a check for when the session enters the warning zone (buffer before expiry).
 	 * Uses adaptive buffer: 25% of session lifetime, clamped between 5s and 60s.
+	 * @param {number} expiresAt The unix timestamp (in seconds) when the session expires.
 	 */
 	#scheduleCheck(expiresAt: number) {
 		this.#scheduledExpiresAt = expiresAt;
@@ -67,7 +77,7 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 
 		if (secondsUntilExpiry <= 0) {
 			// Already expired
-			this.#onSessionExpiring(0, expiresAt);
+			this.#onSessionExpiring(expiresAt);
 			return;
 		}
 
@@ -77,17 +87,18 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 
 		if (secondsUntilWarning <= 0) {
 			// Already in the buffer zone
-			this.#onSessionExpiring(secondsUntilExpiry, expiresAt);
+			this.#onSessionExpiring(expiresAt);
 		} else {
-			this.#timeoutId = setTimeout(() => this.#onSessionExpiring(buffer, expiresAt), secondsUntilWarning * 1000);
+			this.#timeoutId = setTimeout(() => this.#onSessionExpiring(expiresAt), secondsUntilWarning * 1000);
 		}
 	}
 
 	/**
 	 * Called when the session is expiring or has expired.
 	 * Decides whether to auto-refresh, show the timeout modal, or time out.
+	 * @param {number} originalExpiresAt The session expiry (unix timestamp in seconds) this check was scheduled for.
 	 */
-	async #onSessionExpiring(secondsRemaining: number, originalExpiresAt: number) {
+	async #onSessionExpiring(originalExpiresAt: number) {
 		// Guard: if the session was refreshed since we scheduled this check, skip.
 		// We compare expiresAt rather than using isSessionValid() because this fires
 		// during the buffer zone (before full expiry), when the session is still "valid".
@@ -95,12 +106,14 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 
 		if (this.#host.keepUserLoggedIn) {
 			console.log('[Auth] Session expiring, auto-refreshing (keepUserLoggedIn=true)');
-			const success = await this.#tryValidateToken();
-			if (!success) {
-				this.#host.timeOut();
-			}
+			await this.#tryValidateToken();
 			return;
 		}
+
+		// Recompute the remaining time from the wall clock — the scheduled timer may have
+		// fired late (system sleep, background-tab timer throttling), in which case the
+		// session can already be expired even though it was valid when the timer was set.
+		const secondsRemaining = originalExpiresAt - Math.floor(Date.now() / 1000) - EXPIRY_SAFETY_MARGIN_IN_SECONDS;
 
 		if (secondsRemaining <= 0) {
 			console.log('[Auth] Session fully expired');
@@ -120,9 +133,9 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 
 	async #openTimeoutModal(remainingTimeInSeconds: number): Promise<void> {
 		const contextToken = (await import('@umbraco-cms/backoffice/modal')).UMB_MODAL_MANAGER_CONTEXT;
-		const modalManager = await this.getContext(contextToken);
 
 		try {
+			const modalManager = await this.getContext(contextToken);
 			const modal = modalManager?.open(this, UMB_MODAL_AUTH_TIMEOUT, {
 				modal: {
 					key: 'auth-timeout',
@@ -147,9 +160,20 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 		}
 	}
 
+	/**
+	 * Forces a token refresh against the server.
+	 * Times the user out when the refresh fails (e.g. the refresh token has expired),
+	 * so the re-authentication flow starts instead of leaving the user in a session
+	 * that will be rejected on the next API call.
+	 * @returns {Promise<boolean>} True if the refresh succeeded, otherwise false.
+	 */
 	async #tryValidateToken(): Promise<boolean> {
 		try {
-			return await this.#host.validateToken();
+			const success = await this.#host.validateToken();
+			if (!success) {
+				this.#host.timeOut();
+			}
+			return success;
 		} catch (error) {
 			console.error('[Auth] Error validating token:', error);
 			this.#host.timeOut();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/manifests.ts
@@ -1,6 +1,6 @@
-import type { ManifestModal } from '@umbraco-cms/backoffice/modal';
 import UmbAppAuthModalElement from './umb-app-auth-modal.element.js';
 import UmbAuthTimeoutModalElement from './umb-auth-timeout-modal.element.js';
+import type { ManifestModal } from '@umbraco-cms/backoffice/modal';
 
 export const manifests: Array<ManifestModal> = [
 	{

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.element.ts
@@ -1,6 +1,6 @@
-import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
-import type { UmbModalAppAuthConfig, UmbModalAppAuthValue } from './umb-app-auth-modal.token.js';
 import { UMB_AUTH_CONTEXT } from '../auth.context.token.js';
+import type { UmbModalAppAuthConfig, UmbModalAppAuthValue } from './umb-app-auth-modal.token.js';
+import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
 
 import '../components/umb-auth-view.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.token.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-app-auth-modal.token.ts
@@ -1,5 +1,5 @@
-import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 import type { UmbUserLoginState } from '../types.js';
+import { UmbModalToken } from '@umbraco-cms/backoffice/modal';
 
 export type UmbModalAppAuthConfig = {
 	userLoginState: UmbUserLoginState;
@@ -8,7 +8,6 @@ export type UmbModalAppAuthConfig = {
 export type UmbModalAppAuthValue = {
 	/**
 	 * An indicator of whether the authentication was successful.
-	 * @required
 	 */
 	success?: boolean;
 };

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-auth-timeout-modal.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-auth-timeout-modal.element.test.ts
@@ -1,0 +1,49 @@
+import type { UmbAuthTimeoutModalElement } from './umb-auth-timeout-modal.element.js';
+import './umb-auth-timeout-modal.element.js';
+import { aTimeout, expect } from '@open-wc/testing';
+
+describe('UmbAuthTimeoutModalElement', () => {
+	let element: UmbAuthTimeoutModalElement;
+	let expiredCalls: number;
+	const realDateNow = Date.now;
+
+	beforeEach(() => {
+		expiredCalls = 0;
+		element = document.createElement('umb-auth-timeout-modal');
+		element.data = {
+			remainingTimeInSeconds: 30,
+			onLogout: () => {},
+			onContinue: () => {},
+			onExpired: () => {
+				expiredCalls++;
+			},
+		};
+	});
+
+	afterEach(() => {
+		Date.now = realDateNow;
+		element.remove();
+	});
+
+	it('counts down once per second', async () => {
+		document.body.appendChild(element);
+		await aTimeout(1200);
+
+		expect(expiredCalls).to.equal(0);
+		// Allow for a slow event loop having delivered an extra tick
+		expect(element.shadowRoot?.textContent).to.match(/2[89]/);
+	});
+
+	it('expires based on the wall clock, not the tick count (e.g. after system sleep)', async () => {
+		document.body.appendChild(element);
+
+		// Simulate system sleep / background-tab throttling: the wall clock jumps past the
+		// deadline while the countdown interval has not been firing.
+		Date.now = () => realDateNow() + 60_000;
+
+		// Wait for a single interval tick — it should detect the deadline has passed.
+		await aTimeout(1200);
+
+		expect(expiredCalls).to.equal(1);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-auth-timeout-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/modals/umb-auth-timeout-modal.element.ts
@@ -25,12 +25,22 @@ export class UmbAuthTimeoutModalElement extends UmbModalBaseElement<UmbModalAuth
 	}
 
 	#startCountdown() {
+		// Guard against a leaked interval if the element is reconnected
+		if (this.#interval) {
+			clearInterval(this.#interval);
+		}
 		this._remainingTimeInSeconds = this.data?.remainingTimeInSeconds ?? 60;
+		// Count down against an absolute deadline rather than the number of ticks — interval
+		// timers are paused/throttled during system sleep and in background tabs, which would
+		// otherwise leave the countdown showing time that has already passed.
+		const deadline = Date.now() + this._remainingTimeInSeconds * 1000;
 		this.#interval = setInterval(() => {
-			if (this._remainingTimeInSeconds > 0) {
-				this._remainingTimeInSeconds--;
+			const secondsLeft = Math.ceil((deadline - Date.now()) / 1000);
+			if (secondsLeft > 0) {
+				this._remainingTimeInSeconds = secondsLeft;
 			} else {
 				clearInterval(this.#interval);
+				this._remainingTimeInSeconds = 0;
 				// Timer expired — notify the controller so it can call timeOut() and
 				// open the re-auth popup. Submit (not reject) so the catch block is
 				// not triggered.


### PR DESCRIPTION
## Summary

Fixes the session timeout modal silently failing when "Stay logged in" is clicked after the refresh token has already expired server-side — the user appeared to stay logged in, then got logged out on their next action (#22986).

## Root cause

Three compounding defects in the session timeout flow:

1. **Failed refresh was swallowed** — `onContinue` ignored the `false` return of `validateToken()`; `timeOut()` only fired on a thrown exception, and the auth client never throws (it catches and returns `undefined`). A failed `/token` call closed the modal and left the stale in-memory session in place, so the user was 401'd on their next API call — and each queued 401-retry triggered yet another doomed `/token` call (18+ observed) before the forced logout.
2. **The warning timer trusted scheduling-time values** — `#onSessionExpiring` received `secondsRemaining` computed when the timer was *scheduled*. After system sleep or background-tab timer throttling the timer fires late, so the modal could open with a countdown for a session that was already dead.
3. **The countdown lied** — the modal decremented a counter per interval tick instead of deriving the remaining time from the wall clock, so sleep/throttling froze the displayed time while the real session expired underneath it.

This reproduces the reported sequence exactly: modal visible with a running countdown → click "Stay logged in" → `/token` 400 swallowed → modal closes → next interaction logs the user out.

## What changed

- `#tryValidateToken()` now calls `timeOut()` when the refresh fails, so the re-authentication flow starts immediately instead of leaving a doomed session (also consolidates the `keepUserLoggedIn` branch's existing success check).
- `#onSessionExpiring` recomputes the remaining time from `Date.now()` when the timer fires, with a 5s safety margin (the client stamps session timing at response receipt, so its expiry estimate is always slightly optimistic). A late-firing timer on a dead session now goes straight to the timed-out re-auth screen instead of opening a lying modal.
- The modal countdown is driven by an absolute deadline, so it snaps to reality after sleep/throttling, and a leaked interval on element reconnect is guarded against.
- Import order fixed in three auth modal files (separate commit) — the `import/order` rule crashes ESLint 10 whenever it needs to report a violation there, which made the package unlintable. The underlying eslint-plugin-import/ESLint 10 incompatibility remains and is worth a separate dependency bump.

## Testing

- 6 new unit tests (`auth-session-timeout.controller.test.ts`, `umb-auth-timeout-modal.element.test.ts`) — system sleep is simulated by patching `Date.now` so the wall clock jumps without timers firing; sessions are injected via the `umb:auth` BroadcastChannel. The three bug tests fail against the previous code.
- Full client suite: 2008/2008 tests pass; `tsc` clean; no new lint warnings; no circular dependencies.
- Verified end-to-end in the browser against a local instance (`Global:TimeOut` 2 min, refresh token revoked server-side while the modal was open): before — silent failure, retry storm, broken UI, delayed logout; after — exactly one `/token` call and an immediate "session timed out" sign-in screen. Happy path re-verified: a prompt click still extends the session (`/token` 200).

## Notes for reviewers

- No public API changes; `UmbModalAuthTimeoutConfig` is unchanged.
- The client still derives the session lifetime as `expires_in × 4`, mirroring the server's `timeOut.Ticks / 4` — making the token endpoint return the refresh-token expiry explicitly would decouple those, but that's backend surface and intentionally out of scope here.

Fixes #22986

🤖 Generated with [Claude Code](https://claude.com/claude-code)