### PR TITLE
Tests: Fix failing Management API integration tests (closes #23076)

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -400,31 +400,39 @@ stages:
           matrix:
             #            Windows:
             #              vmImage: 'windows-latest'
-            # We split the tests into 3 parts for each OS to reduce the time it takes to run them on the pipeline
-            LinuxPart1Of3:
+            # We split the tests into 4 parts for each OS to reduce the time it takes to run them on the pipeline
+            LinuxPart1Of4:
               vmImage: "ubuntu-latest"
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            LinuxPart2Of3:
+            LinuxPart2Of4:
               vmImage: "ubuntu-latest"
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            LinuxPart3Of3:
+            LinuxPart3Of4:
               vmImage: "ubuntu-latest"
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
-            macOSPart1Of3:
+            LinuxPart4Of4:
+              vmImage: "ubuntu-latest"
+              # Filter tests that are part of the ManagementApi namespace
+              testFilter: "(FullyQualifiedName~ManagementApi)"
+            macOSPart1Of4:
               vmImage: "macOS-latest"
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            macOSPart2Of3:
+            macOSPart2Of4:
               vmImage: "macOS-latest"
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            macOSPart3Of3:
+            macOSPart3Of4:
               vmImage: "macOS-latest"
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and the ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
+            macOSPart4Of4:
+              vmImage: "macOS-latest"
+              # Filter tests that are part of the ManagementApi namespace
+              testFilter: "(FullyQualifiedName~ManagementApi)"
         pool:
           vmImage: $(vmImage)
         variables:
@@ -470,46 +478,59 @@ stages:
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
-            # We split the tests into 3 parts for each OS to reduce the time it takes to run them on the pipeline
-            WindowsPart1Of3:
+            # We split the tests into 4 parts for each OS to reduce the time it takes to run them on the pipeline
+            WindowsPart1Of4:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            WindowsPart2Of3:
+            WindowsPart2Of4:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            WindowsPart3Of3:
+            WindowsPart3Of4:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
-            LinuxPart1Of3:
+            WindowsPart4Of4:
+              vmImage: "windows-latest"
+              Tests__Database__DatabaseType: LocalDb
+              Tests__Database__SQLServerMasterConnectionString: N/A
+              # Filter tests that are part of the ManagementApi namespace
+              testFilter: "(FullyQualifiedName~ManagementApi)"
+            LinuxPart1Of4:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            LinuxPart2Of3:
+            LinuxPart2Of4:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            LinuxPart3Of3:
+            LinuxPart3Of4:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
+            LinuxPart4Of4:
+              vmImage: "ubuntu-latest"
+              SA_PASSWORD: UmbracoIntegration123!
+              Tests__Database__DatabaseType: SqlServer
+              Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
+              # Filter tests that are part of the ManagementApi namespace
+              testFilter: "(FullyQualifiedName~ManagementApi)"
         pool:
           vmImage: $(vmImage)
         steps:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -400,39 +400,31 @@ stages:
           matrix:
             #            Windows:
             #              vmImage: 'windows-latest'
-            # We split the tests into 4 parts for each OS to reduce the time it takes to run them on the pipeline
-            LinuxPart1Of4:
+            # We split the tests into 3 parts for each OS to reduce the time it takes to run them on the pipeline
+            LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            LinuxPart2Of4:
+            LinuxPart2Of3:
               vmImage: "ubuntu-latest"
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            LinuxPart3Of4:
+            LinuxPart3Of3:
               vmImage: "ubuntu-latest"
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
-            LinuxPart4Of4:
-              vmImage: "ubuntu-latest"
-              # Filter tests that are part of the ManagementApi namespace
-              testFilter: "(FullyQualifiedName~ManagementApi)"
-            macOSPart1Of4:
+            macOSPart1Of3:
               vmImage: "macOS-latest"
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            macOSPart2Of4:
+            macOSPart2Of3:
               vmImage: "macOS-latest"
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            macOSPart3Of4:
+            macOSPart3Of3:
               vmImage: "macOS-latest"
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and the ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
-            macOSPart4Of4:
-              vmImage: "macOS-latest"
-              # Filter tests that are part of the ManagementApi namespace
-              testFilter: "(FullyQualifiedName~ManagementApi)"
         pool:
           vmImage: $(vmImage)
         variables:
@@ -478,59 +470,46 @@ stages:
         displayName: Integration Tests (SQL Server)
         strategy:
           matrix:
-            # We split the tests into 4 parts for each OS to reduce the time it takes to run them on the pipeline
-            WindowsPart1Of4:
+            # We split the tests into 3 parts for each OS to reduce the time it takes to run them on the pipeline
+            WindowsPart1Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            WindowsPart2Of4:
+            WindowsPart2Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            WindowsPart3Of4:
+            WindowsPart3Of3:
               vmImage: "windows-latest"
               Tests__Database__DatabaseType: LocalDb
               Tests__Database__SQLServerMasterConnectionString: N/A
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
-            WindowsPart4Of4:
-              vmImage: "windows-latest"
-              Tests__Database__DatabaseType: LocalDb
-              Tests__Database__SQLServerMasterConnectionString: N/A
-              # Filter tests that are part of the ManagementApi namespace
-              testFilter: "(FullyQualifiedName~ManagementApi)"
-            LinuxPart1Of4:
+            LinuxPart1Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
               # Filter tests that are part of the Umbraco.Infrastructure namespace but not part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure) & (FullyQualifiedName!~Umbraco.Infrastructure.Service)"
-            LinuxPart2Of4:
+            LinuxPart2Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
               # Filter tests that are part of the Umbraco.Infrastructure.Service namespace
               testFilter: "(FullyQualifiedName~Umbraco.Infrastructure.Service)"
-            LinuxPart3Of4:
+            LinuxPart3Of3:
               vmImage: "ubuntu-latest"
               SA_PASSWORD: UmbracoIntegration123!
               Tests__Database__DatabaseType: SqlServer
               Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
               # Filter tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace. So this will run all tests that are not part of the Umbraco.Infrastructure and ManagementApi namespace
               testFilter: "(FullyQualifiedName!~Umbraco.Infrastructure) & (FullyQualifiedName!~ManagementApi)"
-            LinuxPart4Of4:
-              vmImage: "ubuntu-latest"
-              SA_PASSWORD: UmbracoIntegration123!
-              Tests__Database__DatabaseType: SqlServer
-              Tests__Database__SQLServerMasterConnectionString: "Server=(local);User Id=sa;Password=$(SA_PASSWORD);TrustServerCertificate=True"
-              # Filter tests that are part of the ManagementApi namespace
-              testFilter: "(FullyQualifiedName~ManagementApi)"
         pool:
           vmImage: $(vmImage)
         steps:

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/ChildrenElementTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/ChildrenElementTreeControllerTests.cs
@@ -96,7 +96,7 @@ public class ChildrenElementTreeControllerTests : ManagementApiUserGroupTestBase
             .WithAlias(Guid.NewGuid().ToString("N"))
             .WithName("Test Group With Element Start Node")
             .WithAllowedSections(["library"])
-            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter })
+            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter, ActionElementContainerBrowse.ActionLetter })
             .WithStartElementId(startNodeFolder.Id)
             .Build();
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/RootElementTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/RootElementTreeControllerTests.cs
@@ -65,7 +65,7 @@ public class RootElementTreeControllerTests : ManagementApiUserGroupTestBase<Roo
             .WithAlias(Guid.NewGuid().ToString("N"))
             .WithName("Test Group With Element Start Node")
             .WithAllowedSections(["library"])
-            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter })
+            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter, ActionElementContainerBrowse.ActionLetter })
             .WithStartElementId(folder1.Id)
             .Build();
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/SiblingsElementTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Element/Tree/SiblingsElementTreeControllerTests.cs
@@ -64,7 +64,7 @@ public class SiblingsElementTreeControllerTests : ManagementApiUserGroupTestBase
             .WithAlias(Guid.NewGuid().ToString("N"))
             .WithName("Test Group With Element Start Node")
             .WithAllowedSections(["library"])
-            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter })
+            .WithPermissions(new HashSet<string> { ActionElementBrowse.ActionLetter, ActionElementContainerBrowse.ActionLetter })
             .WithStartElementId(_folder1Id)
             .Build();
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/CreateTemporaryFileControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/CreateTemporaryFileControllerTests.cs
@@ -1,8 +1,6 @@
 using System.Linq.Expressions;
 using System.Net;
-using System.Net.Http.Json;
 using Umbraco.Cms.Api.Management.Controllers.TemporaryFile;
-using Umbraco.Cms.Api.Management.ViewModels.TemporaryFile;
 
 namespace Umbraco.Cms.Tests.Integration.ManagementApi.TemporaryFile;
 
@@ -42,8 +40,10 @@ public class CreateTemporaryFileControllerTests : ManagementApiUserGroupTestBase
 
     protected override async Task<HttpResponseMessage> ClientRequest()
     {
-        CreateTemporaryFileRequestModel createTemporaryFileRequest = new() { Id = Guid.NewGuid(), File = null! };
+        // The endpoint only consumes multipart/form-data, so the request must be sent as such to reach the action.
+        // The required file is intentionally omitted, yielding the expected BadRequest for authenticated users.
+        var content = new MultipartFormDataContent { { new StringContent(Guid.NewGuid().ToString()), "Id" } };
 
-        return await Client.PostAsync(Url, JsonContent.Create(createTemporaryFileRequest));
+        return await Client.PostAsync(Url, content);
     }
 }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/CreateTemporaryFileControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/CreateTemporaryFileControllerTests.cs
@@ -42,7 +42,8 @@ public class CreateTemporaryFileControllerTests : ManagementApiUserGroupTestBase
     {
         // The endpoint only consumes multipart/form-data, so the request must be sent as such to reach the action.
         // The required file is intentionally omitted, yielding the expected BadRequest for authenticated users.
-        var content = new MultipartFormDataContent { { new StringContent(Guid.NewGuid().ToString()), "Id" } };
+        using var content = new MultipartFormDataContent();
+        content.Add(new StringContent(Guid.NewGuid().ToString()), "Id");
 
         return await Client.PostAsync(Url, content);
     }


### PR DESCRIPTION
## Description

#23076 reported several integration tests failing locally on `release/18.0`. Investigation showed two separate problems, plus the reason CI never caught them.

Fixes #23076

### Why CI didn't catch this

The integration test stage shards the suite into matrix partitions by namespace. The "catch-all" partition explicitly excluded both `Umbraco.Infrastructure` **and** `ManagementApi`, while the other partitions only included `Umbraco.Infrastructure*`. As a result, **the entire `ManagementApi` integration-test namespace was never executed on CI** (on `release/18.0`, `v17/dev`, and earlier). The failures could therefore only surface when running locally.

This may have historically been deliberate?  I'm not sure, but we can discuss if we want to include these.  They do take a while to spin up, so in the interest of not slowing the builds down further I've not adjusted the pipeline to include them.

### Test failures fixed

1. **`CreateTemporaryFileControllerTests` (6 tests) — returned `404` for every request.**
   A v18 change (#23025) added `[Consumes("multipart/form-data")]` to the Create Temporary File endpoint — correct, intended behaviour for an `IFormFile` upload. The test still posted `application/json`, which no longer matches the action's content-type constraint, so the request was rejected at routing before auth/model-binding (hence `404` even for the unauthenticated case). Updated the test to send `multipart/form-data`.

2. **Element tree start-node tests (3 tests) — returned `0` items where `1` was expected.**
   The element tree separates `ActionElementBrowse` (`Umb.Element.Read`) for elements from `ActionElementContainerBrowse` (`Umb.ElementContainer.Read`) for containers/folders, and the built-in user groups are seeded with both. These tests created element *containers* (folders) but granted the custom user group only `ActionElementBrowse`, so the (fail-closed) permission filter correctly stripped the folders. Granted `ActionElementContainerBrowse` alongside `ActionElementBrowse` in the three tests.

All changes test-only and specific to v18 (the `[Consumes]` attribute and the Elements feature do not exist on v17).

### How to test

Run the previously-failing tests on SQLite:

```
dotnet test tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj \
  --filter "FullyQualifiedName~ManagementApi.Element.Tree|FullyQualifiedName~ManagementApi.TemporaryFile.CreateTemporaryFileControllerTests"
```