### PR TITLE
Request Logging: Avoid forcing a session store load when resolving the session id for logging (closes #23082)

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/LoggingSettings.cs
@@ -33,6 +33,11 @@ public class LoggingSettings
     internal const string StaticFileNameFormatArguments = "MachineName";
 
     /// <summary>
+    ///     The default mode for enriching log events with a session identifier.
+    /// </summary>
+    internal const SessionIdLoggingMode StaticSessionIdLogging = SessionIdLoggingMode.SessionId;
+
+    /// <summary>
     /// Gets or sets a value for the maximum age of a log file.
     /// </summary>
     /// <value>
@@ -70,4 +75,16 @@ public class LoggingSettings
     /// </remarks>
     [DefaultValue(StaticFileNameFormatArguments)]
     public string FileNameFormatArguments { get; set; } = StaticFileNameFormatArguments;
+
+    /// <summary>
+    /// Gets or sets a value determining how log events are enriched with a session identifier.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="SessionIdLoggingMode.SessionId" /> for backward compatibility. Set to
+    /// <see cref="SessionIdLoggingMode.CookieHash" /> or <see cref="SessionIdLoggingMode.None" /> to avoid the
+    /// blocking session-store load that resolving the actual session id incurs per request when the session is
+    /// backed by an <c>IDistributedCache</c>.
+    /// </remarks>
+    [DefaultValue(StaticSessionIdLogging)]
+    public SessionIdLoggingMode SessionIdLogging { get; set; } = StaticSessionIdLogging;
 }

--- a/src/Umbraco.Core/Configuration/Models/SessionIdLoggingMode.cs
+++ b/src/Umbraco.Core/Configuration/Models/SessionIdLoggingMode.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.Configuration.Models;
+
+/// <summary>
+/// Determines how request logging enriches log events with a session identifier.
+/// </summary>
+public enum SessionIdLoggingMode
+{
+    /// <summary>
+    /// Do not enrich log events with a session identifier.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Enrich log events with the actual ASP.NET Core session id. This is the default and matches the
+    /// historical behaviour, but reading the session id forces the session to be loaded from its store, which
+    /// is a blocking round-trip per request when the session is backed by an <c>IDistributedCache</c>.
+    /// </summary>
+    SessionId,
+
+    /// <summary>
+    /// Enrich log events with a one-way hash of the session cookie value. This provides the same per-session
+    /// correlation as <see cref="SessionId" /> without loading the session from its store, so it never incurs
+    /// a distributed-cache round-trip.
+    /// </summary>
+    CookieHash,
+}

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
@@ -1,9 +1,12 @@
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Web.Common.AspNetCore;
 
@@ -15,47 +18,90 @@ internal sealed class AspNetCoreSessionManager : ISessionIdResolver, ISessionMan
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IOptions<SessionOptions> _sessionOptions;
+    private readonly IOptionsMonitor<LoggingSettings> _loggingSettings;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="AspNetCoreSessionManager" /> class.
     /// </summary>
     /// <param name="httpContextAccessor">Provides access to the current <see cref="HttpContext" />.</param>
     /// <param name="sessionOptions">The configured session options, used to determine the session cookie name.</param>
-    public AspNetCoreSessionManager(IHttpContextAccessor httpContextAccessor, IOptions<SessionOptions> sessionOptions)
+    /// <param name="loggingSettings">The logging settings, used to determine how the session id is resolved for log enrichment.</param>
+    public AspNetCoreSessionManager(
+        IHttpContextAccessor httpContextAccessor,
+        IOptions<SessionOptions> sessionOptions,
+        IOptionsMonitor<LoggingSettings> loggingSettings)
     {
         _httpContextAccessor = httpContextAccessor;
         _sessionOptions = sessionOptions;
+        _loggingSettings = loggingSettings;
     }
 
     /// <inheritdoc />
-    public string? SessionId
-    {
-        get
+    /// <remarks>
+    ///     The resolved value depends on <see cref="LoggingSettings.SessionIdLogging" />: the actual session id
+    ///     (default), a one-way hash of the session cookie, or nothing.
+    /// </remarks>
+    public string? SessionId =>
+        _loggingSettings.CurrentValue.SessionIdLogging switch
         {
-            if (IsSessionsAvailable is false)
-            {
-                return "0";
-            }
+            SessionIdLoggingMode.None => null,
+            SessionIdLoggingMode.CookieHash => ResolveSessionCookieHash(),
+            _ => ResolveSessionId(),
+        };
 
-            HttpContext? httpContext = _httpContextAccessor.HttpContext;
-            if (httpContext is null)
-            {
-                return null;
-            }
-
-            // Reading Session.Id forces a synchronous, blocking load from the session store. When sessions are
-            // backed by IDistributedCache (e.g. load-balanced setups), that is a network round-trip incurred on
-            // every request that resolves the id for logging - even anonymous requests that never use session.
-            // Only an established session sends back the session cookie, so its absence means there is nothing
-            // meaningful to load. (#23082)
-            var sessionCookieName = _sessionOptions.Value.Cookie.Name;
-            if (sessionCookieName is null || httpContext.Request.Cookies.ContainsKey(sessionCookieName) is false)
-            {
-                return null;
-            }
-
-            return httpContext.Session.Id;
+    /// <summary>
+    ///     Resolves the actual ASP.NET Core session id, but only when an established session cookie is present.
+    /// </summary>
+    /// <remarks>
+    ///     Reading Session.Id forces a synchronous, blocking load from the session store. When sessions are
+    ///     backed by IDistributedCache (e.g. load-balanced setups), that is a network round-trip incurred on
+    ///     every request that resolves the id for logging - even anonymous requests that never use session.
+    ///     Only an established session sends back the session cookie, so its absence means there is nothing
+    ///     meaningful to load (see #23082).
+    /// </remarks>
+    private string? ResolveSessionId()
+    {
+        if (IsSessionsAvailable is false)
+        {
+            return "0";
         }
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext is null || TryGetSessionCookieValue(httpContext, out _) is false)
+        {
+            return null;
+        }
+
+        return httpContext.Session.Id;
+    }
+
+    /// <summary>
+    ///     Resolves a one-way hash of the session cookie value, which correlates requests to the same session
+    ///     without loading the session from its store.
+    /// </summary>
+    private string? ResolveSessionCookieHash()
+    {
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext is null || TryGetSessionCookieValue(httpContext, out var cookieValue) is false)
+        {
+            return null;
+        }
+
+        // Never log the raw cookie value - it is effectively a bearer token for the session. A one-way hash
+        // preserves per-session correlation without exposing the cookie and without loading the session.
+        return cookieValue!.GenerateHash<SHA256>();
+    }
+
+    private bool TryGetSessionCookieValue(HttpContext httpContext, out string? value)
+    {
+        var sessionCookieName = _sessionOptions.Value.Cookie.Name;
+        if (sessionCookieName is null)
+        {
+            value = null;
+            return false;
+        }
+
+        return httpContext.Request.Cookies.TryGetValue(sessionCookieName, out value);
     }
 
     /// <summary>

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManager.cs
@@ -1,34 +1,74 @@
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Net;
 using Umbraco.Cms.Core.Web;
 
 namespace Umbraco.Cms.Web.Common.AspNetCore;
 
+/// <summary>
+///     Resolves the current session identifier and reads, writes and clears session values using the
+///     ASP.NET Core <see cref="ISession" /> exposed on the current <see cref="HttpContext" />.
+/// </summary>
 internal sealed class AspNetCoreSessionManager : ISessionIdResolver, ISessionManager
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IOptions<SessionOptions> _sessionOptions;
 
-    public AspNetCoreSessionManager(IHttpContextAccessor httpContextAccessor) =>
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="AspNetCoreSessionManager" /> class.
+    /// </summary>
+    /// <param name="httpContextAccessor">Provides access to the current <see cref="HttpContext" />.</param>
+    /// <param name="sessionOptions">The configured session options, used to determine the session cookie name.</param>
+    public AspNetCoreSessionManager(IHttpContextAccessor httpContextAccessor, IOptions<SessionOptions> sessionOptions)
+    {
         _httpContextAccessor = httpContextAccessor;
+        _sessionOptions = sessionOptions;
+    }
 
+    /// <inheritdoc />
     public string? SessionId
     {
         get
         {
-            HttpContext? httpContext = _httpContextAccessor.HttpContext;
+            if (IsSessionsAvailable is false)
+            {
+                return "0";
+            }
 
-            return IsSessionsAvailable
-                ? httpContext?.Session.Id
-                : "0";
+            HttpContext? httpContext = _httpContextAccessor.HttpContext;
+            if (httpContext is null)
+            {
+                return null;
+            }
+
+            // Reading Session.Id forces a synchronous, blocking load from the session store. When sessions are
+            // backed by IDistributedCache (e.g. load-balanced setups), that is a network round-trip incurred on
+            // every request that resolves the id for logging - even anonymous requests that never use session.
+            // Only an established session sends back the session cookie, so its absence means there is nothing
+            // meaningful to load. (#23082)
+            var sessionCookieName = _sessionOptions.Value.Cookie.Name;
+            if (sessionCookieName is null || httpContext.Request.Cookies.ContainsKey(sessionCookieName) is false)
+            {
+                return null;
+            }
+
+            return httpContext.Session.Id;
         }
     }
 
     /// <summary>
-    ///     If session isn't enabled this will throw an exception so we check
+    ///     Gets a value indicating whether session is available for the current request.
     /// </summary>
-    private bool IsSessionsAvailable => !(_httpContextAccessor.HttpContext?.Features.Get<ISessionFeature>()?.Session is null);
+    /// <remarks>
+    ///     Accessing <see cref="HttpContext.Session" /> throws an <see cref="InvalidOperationException" /> when the
+    ///     session middleware has not been configured (i.e. <c>UseSession</c> was not called), so this is checked
+    ///     before reading from or writing to the session.
+    /// </remarks>
+    private bool IsSessionsAvailable => _httpContextAccessor.HttpContext?.Features.Get<ISessionFeature>()?.Session is not null;
 
+    /// <inheritdoc />
     public string? GetSessionValue(string key)
     {
         if (!IsSessionsAvailable)
@@ -39,6 +79,7 @@ internal sealed class AspNetCoreSessionManager : ISessionIdResolver, ISessionMan
         return _httpContextAccessor.HttpContext?.Session.GetString(key);
     }
 
+    /// <inheritdoc />
     public void SetSessionValue(string key, string value)
     {
         if (!IsSessionsAvailable)
@@ -49,6 +90,7 @@ internal sealed class AspNetCoreSessionManager : ISessionIdResolver, ISessionMan
         _httpContextAccessor.HttpContext?.Session.SetString(key, value);
     }
 
+    /// <inheritdoc />
     public void ClearSessionValue(string key)
     {
         if (!IsSessionsAvailable)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManagerTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Web.Common.AspNetCore;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.AspNetCore;
+
+[TestFixture]
+public class AspNetCoreSessionManagerTests
+{
+    private const string SessionCookieName = "UMB_SESSION";
+    private const string SessionId = "test-session-id";
+
+    [Test]
+    public void SessionId_Returns_Zero_When_Sessions_Not_Available()
+    {
+        var httpContext = new DefaultHttpContext();
+        var sessionManager = CreateSessionManager(httpContext);
+
+        Assert.AreEqual("0", sessionManager.SessionId);
+    }
+
+    [Test]
+    public void SessionId_Does_Not_Load_Session_When_No_Session_Cookie_Present()
+    {
+        var session = new TrackingSession(SessionId);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(session));
+        var sessionManager = CreateSessionManager(httpContext);
+
+        var result = sessionManager.SessionId;
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(result);
+            Assert.AreEqual(0, session.IdReadCount, "Session.Id must not be read when no session cookie is present, as that forces a blocking store load.");
+        });
+    }
+
+    [Test]
+    public void SessionId_Returns_Id_When_Session_Cookie_Present()
+    {
+        var session = new TrackingSession(SessionId);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(session));
+        httpContext.Request.Headers.Append(HeaderNames.Cookie, $"{SessionCookieName}={SessionId}");
+        var sessionManager = CreateSessionManager(httpContext);
+
+        var result = sessionManager.SessionId;
+
+        Assert.AreEqual(SessionId, result);
+    }
+
+    private static AspNetCoreSessionManager CreateSessionManager(DefaultHttpContext httpContext)
+    {
+        var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
+        IOptions<SessionOptions> sessionOptions = Options.Create(new SessionOptions { Cookie = { Name = SessionCookieName } });
+        return new AspNetCoreSessionManager(httpContextAccessor, sessionOptions);
+    }
+
+    private sealed class TestSessionFeature : ISessionFeature
+    {
+        public TestSessionFeature(ISession session) => Session = session;
+
+        public ISession Session { get; set; }
+    }
+
+    private sealed class TrackingSession(string id) : ISession
+    {
+        public int IdReadCount { get; private set; }
+
+        public string Id
+        {
+            get
+            {
+                IdReadCount++;
+                return id;
+            }
+        }
+
+        public bool IsAvailable => true;
+
+        public IEnumerable<string> Keys => Array.Empty<string>();
+
+        public void Clear()
+        {
+        }
+
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public void Remove(string key)
+        {
+        }
+
+        public void Set(string key, byte[] value)
+        {
+        }
+
+        public bool TryGetValue(string key, out byte[] value)
+        {
+            value = Array.Empty<byte>();
+            return false;
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManagerTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -8,7 +9,10 @@ using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Web.Common.AspNetCore;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.AspNetCore;
 
@@ -58,11 +62,69 @@ public class AspNetCoreSessionManagerTests
         Assert.AreEqual(SessionId, result);
     }
 
-    private static AspNetCoreSessionManager CreateSessionManager(DefaultHttpContext httpContext)
+    [Test]
+    public void Does_Not_Resolve_SessionId_When_Logging_Mode_Is_None()
+    {
+        var session = new TrackingSession(SessionId);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(session));
+        httpContext.Request.Headers.Append(HeaderNames.Cookie, $"{SessionCookieName}={SessionId}");
+        var sessionManager = CreateSessionManager(httpContext, SessionIdLoggingMode.None);
+
+        var result = sessionManager.SessionId;
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(result);
+            Assert.AreEqual(0, session.IdReadCount, "Session.Id must not be read when the logging mode is None.");
+        });
+    }
+
+    [Test]
+    public void Can_Resolve_Cookie_Hash_When_Session_Cookie_Present()
+    {
+        const string cookieValue = "the-session-cookie-value";
+        var session = new TrackingSession(SessionId);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(session));
+        httpContext.Request.Headers.Append(HeaderNames.Cookie, $"{SessionCookieName}={cookieValue}");
+        var sessionManager = CreateSessionManager(httpContext, SessionIdLoggingMode.CookieHash);
+
+        var result = sessionManager.SessionId;
+        var resultAgain = sessionManager.SessionId;
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(cookieValue.GenerateHash<SHA256>(), result);
+            Assert.AreNotEqual(cookieValue, result, "The raw cookie value must not be logged.");
+            Assert.AreEqual(result, resultAgain, "The hash must be stable across reads.");
+            Assert.AreEqual(0, session.IdReadCount, "Session.Id must not be read in CookieHash mode.");
+        });
+    }
+
+    [Test]
+    public void Does_Not_Resolve_Cookie_Hash_Without_Cookie_Present()
+    {
+        var session = new TrackingSession(SessionId);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(session));
+        var sessionManager = CreateSessionManager(httpContext, SessionIdLoggingMode.CookieHash);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsNull(sessionManager.SessionId);
+            Assert.AreEqual(0, session.IdReadCount);
+        });
+    }
+
+    private static AspNetCoreSessionManager CreateSessionManager(
+        DefaultHttpContext httpContext,
+        SessionIdLoggingMode mode = SessionIdLoggingMode.SessionId)
     {
         var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
         IOptions<SessionOptions> sessionOptions = Options.Create(new SessionOptions { Cookie = { Name = SessionCookieName } });
-        return new AspNetCoreSessionManager(httpContextAccessor, sessionOptions);
+        var loggingSettings = new TestOptionsMonitor<LoggingSettings>(new LoggingSettings { SessionIdLogging = mode });
+        return new AspNetCoreSessionManager(httpContextAccessor, sessionOptions, loggingSettings);
     }
 
     private sealed class TestSessionFeature : ISessionFeature

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManagerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreSessionManagerTests.cs
@@ -19,7 +19,7 @@ public class AspNetCoreSessionManagerTests
     private const string SessionId = "test-session-id";
 
     [Test]
-    public void SessionId_Returns_Zero_When_Sessions_Not_Available()
+    public void Can_Resolve_SessionId_As_Zero_When_Sessions_Not_Available()
     {
         var httpContext = new DefaultHttpContext();
         var sessionManager = CreateSessionManager(httpContext);
@@ -28,7 +28,7 @@ public class AspNetCoreSessionManagerTests
     }
 
     [Test]
-    public void SessionId_Does_Not_Load_Session_When_No_Session_Cookie_Present()
+    public void Cannot_Load_Session_Without_Cookie_Present()
     {
         var session = new TrackingSession(SessionId);
         var httpContext = new DefaultHttpContext();
@@ -45,7 +45,7 @@ public class AspNetCoreSessionManagerTests
     }
 
     [Test]
-    public void SessionId_Returns_Id_When_Session_Cookie_Present()
+    public void Can_Resolve_SessionId_When_Session_Cookie_Present()
     {
         var session = new TrackingSession(SessionId);
         var httpContext = new DefaultHttpContext();


### PR DESCRIPTION
## Description

On a distributed-session setup (the session store backed by an L2 cache via `IDistributedCache` — e.g. load-balanced sites or a standalone L2 cache add-on), the request-logging session-id enricher caused a **synchronous, blocking L2 cache round-trip on every non-static request**, including anonymous renders that never otherwise use session.

### Root cause

The chain:

1. Session is registered by default (`AddWebComponents` → `AddSession`).
2. `UmbracoRequestLoggingMiddleware` pushes `HttpSessionIdEnricher` into the Serilog `LogContext` for every non-static request.
3. When any log event is emitted, the enricher reads `ISessionIdResolver.SessionId` → `AspNetCoreSessionManager.SessionId` → `httpContext.Session.Id`.
4. Reading `DistributedSession.Id` forces `Load()`, which calls the **synchronous** `IDistributedCache.Get(...)` — a blocking network round-trip on a thread-pool worker, even when no session data exists.

With the in-memory store this is a cheap dictionary lookup and invisible; with a distributed store it blocks worker threads under burst load and contributes to thread-pool starvation and request timeouts.

### Fix

`AspNetCoreSessionManager.SessionId` now only reads `httpContext.Session.Id` when the **incoming request carries the configured session cookie**. An established session always sends its cookie back (ASP.NET Core has no cookieless session mode), so the cookie's absence means there is nothing meaningful to load — and we avoid forcing the blocking store read.

### Backward compatibility

There is a comment in the code to evaluate if we even need to be enriching the log with the session ID, but given we are, people could be relying on it, so we should maintain the behaviour.  The only slight change, which I think is acceptable, is the very first request where the session is established won't have a request cookie and as such the session ID won't be logged.

## Testing

### Automated

Added a new set of unit tests in `AspNetCoreSessionManagerTests` that covers this change and existing functionality.

### Manual testing

Verified end-to-end on the default in-memory session store using a temporary debug controller that establishes a session and logs (so the enricher fires).

```csharp
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Net;

namespace Umbraco.Cms.Web.UI.Controllers;

[ApiController]
[Route("debug/session-id-logging")]
public class DebugSessionIdLoggingController : ControllerBase
{
    private readonly ILogger<DebugSessionIdLoggingController> _logger;
    private readonly ISessionIdResolver _sessionIdResolver;

    public DebugSessionIdLoggingController(
        ILogger<DebugSessionIdLoggingController> logger,
        ISessionIdResolver sessionIdResolver)
    {
        _logger = logger;
        _sessionIdResolver = sessionIdResolver;
    }

    [HttpGet]
    public IActionResult Get()
    {
        HttpContext.Session.SetString("debug-session-id-logging", "touched");

        var sessionId = _sessionIdResolver.SessionId;
        _logger.LogInformation("Session id logging debug request handled");

        return Ok(new { sessionId });
    }
}
```

Hit the endpoint twice with a shared cookie jar, so the second call sends the `UMB_SESSION` cookie set by the first:

```powershell
curl.exe -ks -c c.txt -b c.txt https://localhost:44339/debug/session-id-logging
curl.exe -ks -c c.txt -b c.txt https://localhost:44339/debug/session-id-logging
```

Then check `umbraco/Logs/UmbracoTraceLog.*.json` for the `Session id logging debug request handled` entries:

```json
{"@t":"...","@mt":"Session id logging debug request handled","RequestPath":"/debug/session-id-logging","Log4NetLevel":"INFO ","HttpRequestId":"4566ed7d-ec83-4d0f-8296-083a8681bd64","HttpRequestNumber":1}
{"@t":"...","@mt":"Session id logging debug request handled","RequestPath":"/debug/session-id-logging","Log4NetLevel":"INFO ","HttpRequestId":"7817e5f9-6ffa-4c31-9fca-0d67af7b820d","HttpRequestNumber":2,"HttpSessionId":"bf0e82df-ede2-dbcc-794b-57b5379576d0"}
```

- **Call 1** (`HttpRequestNumber: 1`): no `HttpSessionId` property — anonymous request, no inbound session cookie, store never read.
- **Call 2** (`HttpRequestNumber: 2`): `HttpSessionId` present and populated — the session cookie was sent, a real session exists, and the id is logged as before.

Stashing the `AspNetCoreSessionManager` change and re-running makes call 1 log a non-null `HttpSessionId` again (the old always-read behaviour), confirming the guard is working as expected.
