### PR TITLE
Published Cache: Fix multi-site domains falling back to the first root node after restart

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Services/DomainCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DomainCacheService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
@@ -9,23 +9,35 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Changes;
 using Umbraco.Extensions;
 
-
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
+/// <summary>
+/// Implements <see cref="IDomainCacheService" />, providing an in-memory cache of the configured <see cref="Domain" />s.
+/// </summary>
+/// <remarks>
+/// The cache is lazily populated from the database on first access and kept up to date in response to domain
+/// cache refresher notifications. It is registered as a singleton, so a single instance serves all requests.
+/// </remarks>
 public class DomainCacheService : IDomainCacheService
 {
     private readonly IDomainService _domainService;
     private readonly ICoreScopeProvider _coreScopeProvider;
-    private readonly ConcurrentDictionary<int, Domain> _domains;
-    private bool _initialized = false;
+    private readonly object _initializationLock = new();
+    private ConcurrentDictionary<int, Domain> _domains = new();
+    private volatile bool _initialized;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DomainCacheService" /> class.
+    /// </summary>
+    /// <param name="domainService">The service used to load domains from the database.</param>
+    /// <param name="coreScopeProvider">The provider used to create scopes for database access.</param>
     public DomainCacheService(IDomainService domainService, ICoreScopeProvider coreScopeProvider)
     {
         _domainService = domainService;
         _coreScopeProvider = coreScopeProvider;
-        _domains = new ConcurrentDictionary<int, Domain>();
     }
 
+    /// <inheritdoc />
     public IEnumerable<Domain> GetAll(bool includeWildcards)
     {
         InitializeIfMissing();
@@ -34,22 +46,38 @@ public class DomainCacheService : IDomainCacheService
             : _domains.Select(x => x.Value).OrderBy(x => x.SortOrder);
     }
 
+    /// <summary>
+    /// Loads the domains on first access, ensuring the cache is populated before any caller reads from it.
+    /// </summary>
     private void InitializeIfMissing()
     {
+        // Lazy, on-demand initialization triggered by the first request to reach the cache.
+        // The flag must only be set to true *after* the domains have been loaded and published.
+        // Setting it beforehand creates a window where a concurrent caller observes _initialized == true,
+        // skips loading, and reads an empty domain cache. On a multi-site setup that empties domain
+        // resolution, causing every site to fall back to the first root node (see ContentFinderByUrlNew).
+        // The double-checked lock ensures a single load while concurrent readers block until it completes.
         if (_initialized)
         {
             return;
         }
-        _initialized = true;
-        LoadDomains();
+
+        lock (_initializationLock)
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            LoadDomains();
+            _initialized = true;
+        }
     }
 
     /// <inheritdoc />
     public IEnumerable<Domain> GetAssigned(int documentId, bool includeWildcards = false)
     {
         InitializeIfMissing();
-        // probably this could be optimized with an index
-        // but then we'd need a custom DomainStore of some sort
         IEnumerable<Domain> list = _domains.Values.Where(x => x.ContentId == documentId);
         if (includeWildcards == false)
         {
@@ -66,6 +94,7 @@ public class DomainCacheService : IDomainCacheService
         return documentId > 0 && GetAssigned(documentId, includeWildcards).Any();
     }
 
+    /// <inheritdoc />
     public void Refresh(DomainCacheRefresher.JsonPayload[] payloads)
     {
         foreach (DomainCacheRefresher.JsonPayload payload in payloads)
@@ -102,20 +131,23 @@ public class DomainCacheService : IDomainCacheService
                         continue; // anomaly
                     }
 
-                    var newDomain = new Domain(domain.Id, domain.DomainName, domain.RootContentId.Value, culture, domain.IsWildcard, domain.SortOrder);
-
-                    // Feels wierd to use key and oldvalue, but we're using neither when updating.
-                    _domains.AddOrUpdate(
-                        domain.Id,
-                        new Domain(domain.Id, domain.DomainName, domain.RootContentId.Value, culture, domain.IsWildcard, domain.SortOrder),
-                        (key, oldValue) => newDomain);
+                    _domains[domain.Id] = new Domain(domain.Id, domain.DomainName, domain.RootContentId.Value, culture, domain.IsWildcard, domain.SortOrder);
                     break;
             }
         }
     }
 
+    /// <summary>
+    /// Reads the configured domains from the database into a fresh dictionary and atomically swaps it in
+    /// as the current cache.
+    /// </summary>
     private void LoadDomains()
     {
+        // Build the replacement set in a local dictionary and swap it in atomically, rather than mutating
+        // the live one in place. This avoids a transient window (during a RefreshAll rebuild) where a
+        // concurrent reader could observe a partially populated cache, and ensures domains removed since
+        // the last load are dropped rather than lingering.
+        var newDomains = new ConcurrentDictionary<int, Domain>();
         using (ICoreScope scope = _coreScopeProvider.CreateCoreScope())
         {
             scope.ReadLock(Constants.Locks.Domains);
@@ -124,11 +156,11 @@ public class DomainCacheService : IDomainCacheService
                          .Where(x => x.RootContentId.HasValue && x.LanguageIsoCode.IsNullOrWhiteSpace() == false)
                          .Select(x => new Domain(x.Id, x.DomainName, x.RootContentId!.Value, x.LanguageIsoCode!, x.IsWildcard, x.SortOrder)))
             {
-                _domains.AddOrUpdate(domain.Id, domain, (key, oldValue) => domain);
+                newDomains[domain.Id] = domain;
             }
             scope.Complete();
         }
 
-
+        Interlocked.Exchange(ref _domains, newDomains);
     }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DomainCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DomainCacheService.cs
@@ -23,7 +23,13 @@ public class DomainCacheService : IDomainCacheService
     private readonly IDomainService _domainService;
     private readonly ICoreScopeProvider _coreScopeProvider;
     private readonly object _initializationLock = new();
-    private ConcurrentDictionary<int, Domain> _domains = new();
+
+    // Both fields are written under _initializationLock but read on the hot path (request routing) without
+    // it. Marking them volatile makes those lock-free reads acquire-reads, so a reader is guaranteed to see
+    // the fully populated dictionary and the completed-initialization flag together, never a stale or
+    // half-published value. This is required for correctness on weak memory models such as ARM; on x86/x64
+    // ordinary reads already have acquire semantics, but we cannot rely on that.
+    private volatile ConcurrentDictionary<int, Domain> _domains = new();
     private volatile bool _initialized;
 
     /// <summary>
@@ -143,10 +149,10 @@ public class DomainCacheService : IDomainCacheService
     /// </summary>
     private void LoadDomains()
     {
-        // Build the replacement set in a local dictionary and swap it in atomically, rather than mutating
-        // the live one in place. This avoids a transient window (during a RefreshAll rebuild) where a
-        // concurrent reader could observe a partially populated cache, and ensures domains removed since
-        // the last load are dropped rather than lingering.
+        // Build the replacement set in a local dictionary and publish it with a single write to the
+        // (volatile) _domains field. A reader never observes a partially populated cache during a RefreshAll
+        // rebuild, and the published set contains exactly the current domains (any removed since the last
+        // load are absent).
         var newDomains = new ConcurrentDictionary<int, Domain>();
         using (ICoreScope scope = _coreScopeProvider.CreateCoreScope())
         {
@@ -161,6 +167,6 @@ public class DomainCacheService : IDomainCacheService
             scope.Complete();
         }
 
-        Interlocked.Exchange(ref _domains, newDomains);
+        _domains = newDomains;
     }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DomainCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DomainCacheService.cs
@@ -22,7 +22,7 @@ public class DomainCacheService : IDomainCacheService
 {
     private readonly IDomainService _domainService;
     private readonly ICoreScopeProvider _coreScopeProvider;
-    private readonly object _initializationLock = new();
+    private readonly Lock _initializationLock = new();
 
     // Both fields are written under _initializationLock but read on the hot path (request routing) without
     // it. Marking them volatile makes those lock-free reads acquire-reads, so a reader is guaranteed to see

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheServiceTests.cs
@@ -48,6 +48,7 @@ internal sealed class DomainCacheServiceTests
         IDomain configuredDomain = CreateDomain(1, "https://site-one.example/", 1001, "en-US", isWildcard: false);
 
         using var loadStarted = new ManualResetEventSlim(false);
+        using var secondCallerReady = new ManualResetEventSlim(false);
         using var releaseLoad = new ManualResetEventSlim(false);
 
         var domainService = new Mock<IDomainService>();
@@ -58,7 +59,13 @@ internal sealed class DomainCacheServiceTests
             .Returns(() =>
             {
                 loadStarted.Set();
-                releaseLoad.Wait(TimeSpan.FromSeconds(10));
+
+                // Fail loudly if the test never releases the load: returning anyway would let the test
+                // pass while the synchronization it depends on silently broke (and hide any hang).
+                Assert.IsTrue(
+                    releaseLoad.Wait(TimeSpan.FromSeconds(10)),
+                    "Timed out waiting for the gated domain load to be released.");
+
                 return [configuredDomain];
             });
 
@@ -70,14 +77,22 @@ internal sealed class DomainCacheServiceTests
 
         Assert.IsTrue(loadStarted.Wait(TimeSpan.FromSeconds(10)), "Initialization did not start.");
 
-        // A second caller arrives while initialization is still in progress. With the unfixed code it
-        // observes the initialized flag (set before the load completed), skips loading, and reads an
-        // empty cache - the failure that makes a multi-site setup fall back to the first root node.
-        Task<Domain[]> secondCaller = Task.Run(() => sut.GetAll(false).ToArray());
+        // A second caller arrives while initialization is still in progress.
+        Task<Domain[]> secondCaller = Task.Run(() =>
+        {
+            // Confirm the caller has reached the cache before we assert on its blocking behaviour.
+            secondCallerReady.Set();
+            return sut.GetAll(false).ToArray();
+        });
 
-        // Give the second caller time to reach the cache (and, on the unfixed code, return empty)
-        // before we allow the load to complete.
-        await Task.Delay(250);
+        Assert.IsTrue(secondCallerReady.Wait(TimeSpan.FromSeconds(10)), "Second caller did not start.");
+
+        // A correctly initialized cache makes the second caller block until the gated load completes, so it
+        // cannot finish while the load is still held. Observing an empty cache would instead let it return
+        // immediately. Completing here - before we release the load - therefore signals the empty-cache
+        // regression (and the result would be empty). Because this asserts a blocking invariant, it holds
+        // regardless of scheduler timing: a blocked caller never completes within any timeout.
+        var completedWhileLoadGated = secondCaller.Wait(TimeSpan.FromSeconds(1));
 
         releaseLoad.Set();
 
@@ -87,6 +102,7 @@ internal sealed class DomainCacheServiceTests
         // Assert
         Assert.Multiple(() =>
         {
+            Assert.IsFalse(completedWhileLoadGated, "Second caller returned before initialization completed - it observed an empty domain cache.");
             Assert.AreEqual(1, firstResult.Length, "The caller that initialized the cache should see the configured domain.");
             Assert.AreEqual(1, secondResult.Length, "A caller racing with initialization must not observe an empty domain cache.");
         });
@@ -126,6 +142,38 @@ internal sealed class DomainCacheServiceTests
             Assert.AreEqual(1, afterUpdate.Length, "Refreshing an existing domain must update in place, not add a duplicate.");
             Assert.AreEqual("https://renamed.example/", afterUpdate[0].Name);
             Assert.AreEqual(3003, afterUpdate[0].ContentId);
+        });
+    }
+
+    [Test]
+    public void Can_Replace_Entire_Cache_On_RefreshAll()
+    {
+        IDomain first = CreateDomain(1, "https://site-one.example/", 1001, "en-US", isWildcard: false);
+        IDomain second = CreateDomain(2, "https://site-two.example/", 1002, "da-DK", isWildcard: false);
+
+        var current = new List<IDomain> { first, second };
+        var domainService = new Mock<IDomainService>();
+        domainService
+#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
+            .Setup(x => x.GetAll(true))
+#pragma warning restore CS0618 // Type or member is obsolete
+            .Returns(() => current.ToArray());
+
+        var sut = new DomainCacheService(domainService.Object, CreateScopeProvider());
+
+        // The initial lazy load sees both domains.
+        Assert.AreEqual(2, sut.GetAll(false).Count());
+
+        // A domain is removed at the source, then a RefreshAll rebuilds the whole cache from scratch.
+        current.Remove(second);
+        sut.Refresh([new DomainCacheRefresher.JsonPayload(0, DomainChangeTypes.RefreshAll)]);
+
+        Domain[] afterRefreshAll = sut.GetAll(false).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, afterRefreshAll.Length, "RefreshAll should fully replace the cache, dropping removed domains.");
+            Assert.AreEqual(first.Id, afterRefreshAll[0].Id);
         });
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheServiceTests.cs
@@ -1,0 +1,151 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Changes;
+using Umbraco.Cms.Infrastructure.HybridCache.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.PublishedCache.HybridCache;
+
+[TestFixture]
+internal sealed class DomainCacheServiceTests
+{
+    [Test]
+    public void Can_Get_Configured_Domains_Excluding_Wildcards()
+    {
+        IDomain assigned = CreateDomain(1, "https://site-one.example/", 1001, "en-US", isWildcard: false);
+        IDomain wildcard = CreateDomain(2, "*.site-one.example", 1001, "en-US", isWildcard: true);
+
+        var domainService = new Mock<IDomainService>();
+        domainService
+#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
+            .Setup(x => x.GetAll(true))
+#pragma warning restore CS0618 // Type or member is obsolete
+            .Returns([assigned, wildcard]);
+
+        var sut = new DomainCacheService(domainService.Object, CreateScopeProvider());
+
+        Domain[] withoutWildcards = sut.GetAll(false).ToArray();
+        Domain[] withWildcards = sut.GetAll(true).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, withoutWildcards.Length);
+            Assert.AreEqual(assigned.Id, withoutWildcards[0].Id);
+            Assert.AreEqual(2, withWildcards.Length);
+        });
+    }
+
+    [Test]
+    public async Task Cannot_Observe_Empty_Domain_Cache_During_Concurrent_First_Access()
+    {
+        // Arrange - a single configured domain that every caller must be able to see once the cache
+        // has initialized. The IDomainService load is gated so we can force a second caller to race in
+        // while the very first load is still in progress.
+        IDomain configuredDomain = CreateDomain(1, "https://site-one.example/", 1001, "en-US", isWildcard: false);
+
+        using var loadStarted = new ManualResetEventSlim(false);
+        using var releaseLoad = new ManualResetEventSlim(false);
+
+        var domainService = new Mock<IDomainService>();
+        domainService
+#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
+            .Setup(x => x.GetAll(true))
+#pragma warning restore CS0618 // Type or member is obsolete
+            .Returns(() =>
+            {
+                loadStarted.Set();
+                releaseLoad.Wait(TimeSpan.FromSeconds(10));
+                return [configuredDomain];
+            });
+
+        var sut = new DomainCacheService(domainService.Object, CreateScopeProvider());
+
+        // Act
+        // The first caller triggers initialization and blocks inside the gated load.
+        Task<Domain[]> firstCaller = Task.Run(() => sut.GetAll(false).ToArray());
+
+        Assert.IsTrue(loadStarted.Wait(TimeSpan.FromSeconds(10)), "Initialization did not start.");
+
+        // A second caller arrives while initialization is still in progress. With the unfixed code it
+        // observes the initialized flag (set before the load completed), skips loading, and reads an
+        // empty cache - the failure that makes a multi-site setup fall back to the first root node.
+        Task<Domain[]> secondCaller = Task.Run(() => sut.GetAll(false).ToArray());
+
+        // Give the second caller time to reach the cache (and, on the unfixed code, return empty)
+        // before we allow the load to complete.
+        await Task.Delay(250);
+
+        releaseLoad.Set();
+
+        Domain[] firstResult = await firstCaller;
+        Domain[] secondResult = await secondCaller;
+
+        // Assert
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, firstResult.Length, "The caller that initialized the cache should see the configured domain.");
+            Assert.AreEqual(1, secondResult.Length, "A caller racing with initialization must not observe an empty domain cache.");
+        });
+    }
+
+    [Test]
+    public void Can_Refresh_To_Add_And_Update_A_Domain()
+    {
+        var domainService = new Mock<IDomainService>();
+        domainService
+#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
+            .Setup(x => x.GetAll(true))
+#pragma warning restore CS0618 // Type or member is obsolete
+            .Returns([]);
+
+        var sut = new DomainCacheService(domainService.Object, CreateScopeProvider());
+
+        // Trigger the initial (empty) load.
+        Assert.IsEmpty(sut.GetAll(true));
+
+        // A Refresh payload for a previously unknown domain adds it to the cache.
+        domainService.Setup(x => x.GetById(5)).Returns(CreateDomain(5, "https://site.example/", 2002, "en-US", isWildcard: false));
+        sut.Refresh([new DomainCacheRefresher.JsonPayload(5, DomainChangeTypes.Refresh)]);
+        Domain[] afterAdd = sut.GetAll(false).ToArray();
+
+        // A second Refresh for the same id with changed data must update in place, not duplicate the entry.
+        domainService.Setup(x => x.GetById(5)).Returns(CreateDomain(5, "https://renamed.example/", 3003, "en-US", isWildcard: false));
+        sut.Refresh([new DomainCacheRefresher.JsonPayload(5, DomainChangeTypes.Refresh)]);
+        Domain[] afterUpdate = sut.GetAll(false).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, afterAdd.Length, "Refreshing an unknown domain should add it to the cache.");
+            Assert.AreEqual("https://site.example/", afterAdd[0].Name);
+            Assert.AreEqual(2002, afterAdd[0].ContentId);
+
+            Assert.AreEqual(1, afterUpdate.Length, "Refreshing an existing domain must update in place, not add a duplicate.");
+            Assert.AreEqual("https://renamed.example/", afterUpdate[0].Name);
+            Assert.AreEqual(3003, afterUpdate[0].ContentId);
+        });
+    }
+
+    private static IDomain CreateDomain(int id, string name, int rootContentId, string culture, bool isWildcard)
+    {
+        var domain = new Mock<IDomain>();
+        domain.SetupGet(x => x.Id).Returns(id);
+        domain.SetupGet(x => x.DomainName).Returns(name);
+        domain.SetupGet(x => x.RootContentId).Returns(rootContentId);
+        domain.SetupGet(x => x.LanguageIsoCode).Returns(culture);
+        domain.SetupGet(x => x.IsWildcard).Returns(isWildcard);
+        domain.SetupGet(x => x.SortOrder).Returns(0);
+        return domain.Object;
+    }
+
+    private static ICoreScopeProvider CreateScopeProvider()
+    {
+        var scope = new Mock<ICoreScope>();
+        var scopeProvider = new Mock<ICoreScopeProvider>();
+        scopeProvider.Setup(x => x.CreateCoreScope()).Returns(scope.Object);
+        return scopeProvider.Object;
+    }
+}


### PR DESCRIPTION
## Description

There's no public issue for this yet — it surfaced from a partner support case:

> I have a customer with a multisite setup, where hostnames will unpredictably all point to the same site.  They are currently on CMS v17.3.5 and are experiencing an issue where sometimes after a reboot, both custom domains on the site will serve content from the first root node.

### Potential cause

_I say potential, as the issue isn't easily replicable, so whilst it looks like a legitimate issue to fix, it's not possible to 100% verify that it applies in this case._

`DomainCacheService` is a lazily-initialised singleton: the domain cache is loaded from the database on the first request that needs it. The initialisation guard set its `_initialized` flag to `true` *before* `LoadDomains()` had finished populating the cache:

```csharp
if (_initialized) return;
_initialized = true;   // set before the load
LoadDomains();
```

Under concurrent first access — typical right after a restart, when several requests arrive together — a second request could observe `_initialized == true`, skip loading, and read an **empty** domain cache. With no domains, `PublishedRouter.FindDomain` finds no match and `ContentFinderByUrlNew` falls back to routing under the **first root node**. The result: on a multi-site setup, every site serves the first site's content until the cache is rebuilt or the app is restarted again.

We applied similar defensive fixes to published-content-cache race conditions in #22393 (repoted in #22254 and #22384).

### Fix

- Flip `_initialized` only **after** `LoadDomains()` completes, guarded by a double-checked lock, so concurrent callers block until the cache is populated rather than reading it empty.
- Build the domain set into a fresh dictionary and publish it as a single write to a **`volatile`** `_domains` field. Marking the field `volatile` gives the lock-free readers on the routing hot path an acquire-read, so they consistently observe the fully populated dictionary (and the `_initialized` flag) — strictly required on weak memory models such as ARM, where #22393's `Interlocked.Exchange`-on-a-non-volatile-field approach leaves the reads unfenced. This also removes a transient partial-population window during `RefreshAll` and drops domains removed since the last load.

### Tidy-up

- Added XML docs to the class, constructor, and methods (`<inheritdoc />` for interface members).
- Removed two low-value comments.
- Replaced two redundant `AddOrUpdate` calls (one of which constructed the value twice) with the `ConcurrentDictionary` indexer.

## Testing

### Automated tests

I've added unit tests that reliably show the issue before the fix by failing and pass once the fix is in place.

- **`Cannot_Observe_Empty_Domain_Cache_During_Concurrent_First_Access`** verifies the fix. It mocks `IDomainService` so the first caller blocks inside the gated domain load (`ManualResetEventSlim`); a second caller then races in. The test asserts a **blocking invariant**: with a correctly initialised cache the second caller must block on initialisation and cannot complete until the load is released, so it never observes an empty cache. With the bug it skips initialisation and completes immediately with an empty result, which the test detects and fails on. Because it asserts blocking rather than waiting out a fixed delay, it's deterministic regardless of CI scheduling. (Verified by reintroducing the bug: fails 3/3; with the fix: passes.)
- **`Can_Get_Configured_Domains_Excluding_Wildcards`** covers the load path and wildcard filtering.
- **`Can_Refresh_To_Add_And_Update_A_Domain`** covers the single-item `Refresh` path: an unknown domain is added, and a subsequent refresh of the same id updates it in place without duplicating — guarding the `AddOrUpdate` → indexer change.
- **`Can_Replace_Entire_Cache_On_RefreshAll`** covers the `RefreshAll` path: loads two domains, removes one at the source, fires `RefreshAll`, and asserts the cache is fully rebuilt with the removed domain dropped.

[`ManualResetEventSlim`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.manualreseteventslim?view=net-10.0) was new to me - here's some explanation.

> `ManualResetEventSlim` is a lightweight thread-synchronisation primitive from `System.Threading` — essentially a gate. A thread calls `Wait()` to block until another thread calls `Set()` to open the gate.

> In the test it's used purely to make the race deterministic: it lets us freeze one caller inside the domain load while a second caller races in, instead of relying on luck to hit a microsecond-wide window. The Set()/Wait() pair also establishes a memory barrier, which is what makes the second thread reliably observe the prematurely-set _initialized flag on the unfixed code.

### Manual

This is a startup race, so it's awkward to trigger by hand, but, on a multi-site install with two root nodes, each with its own assigned domain/hostname, restart the app and issue concurrent requests to both hostnames. Before the fix, both can intermittently serve the first root node's content; after the fix they consistently resolve to their own root.