### PR TITLE
Document & Media Workspace: Limit route generation (closes #22910)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -1,4 +1,3 @@
-import type { UmbDocumentVariantOptionModel } from '../types.js';
 import { UmbDocumentWorkspaceSplitViewElement } from './document-workspace-split-view.element.js';
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from './context/document-workspace.context-token.js';
 import { customElement, state, css, html } from '@umbraco-cms/backoffice/external/lit';
@@ -6,6 +5,8 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbRoute, UmbRouterSlotInitEvent } from '@umbraco-cms/backoffice/router';
 import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
+import { createObservablePart } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbDocumentVariantOptionModel } from '../types.js';
 
 // TODO: This seem fully identical with Media Workspace Editor, so we can refactor this to a generic component. [NL]
 @customElement('umb-document-workspace-editor')
@@ -19,8 +20,7 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 
 	#workspaceRoute?: string;
 	#appCulture?: string;
-	#variants?: Array<UmbDocumentVariantOptionModel>;
-	#isForbidden = false;
+	#variants?: Array<Pick<UmbDocumentVariantOptionModel, 'culture' | 'segment' | 'unique'>>;
 
 	@state()
 	private _routes?: Array<UmbRoute>;
@@ -36,7 +36,10 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 			this.observe(this.#appLanguage?.appLanguageCulture, (appCulture) => {
 				const previousCulture = this.#appCulture;
 				this.#appCulture = appCulture;
-				this.#generateRoutes();
+				if (previousCulture === undefined) {
+					// Only relevant to call generate routes initially, a later update of appCulture has no effect on the routes.
+					this.#generateRoutes();
+				}
 				this.#syncUrlToCulture(previousCulture, appCulture);
 			});
 		});
@@ -44,21 +47,20 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 		this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (instance) => {
 			this.#workspaceContext = instance;
 			this.observe(
-				this.#workspaceContext?.variantOptions,
+				this.#workspaceContext
+					? createObservablePart(this.#workspaceContext.variantOptions, (variants) =>
+							variants.map((v) => ({
+								culture: v.culture,
+								segment: v.segment,
+								unique: v.unique,
+							})),
+						)
+					: undefined,
 				(variants) => {
 					this.#variants = variants;
 					this.#generateRoutes();
 				},
 				'_observeVariants',
-			);
-
-			this.observe(
-				this.#workspaceContext?.forbidden.isOn,
-				(isForbidden) => {
-					this.#isForbidden = isForbidden ?? false;
-					this.#generateRoutes();
-				},
-				'_observeForbidden',
 			);
 
 			this.observe(
@@ -188,7 +190,9 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 			path: '**',
 			component: async () => {
 				const router = await import('@umbraco-cms/backoffice/router');
-				return this.#isForbidden ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+				return this.#workspaceContext?.forbidden.getIsOn()
+					? router.UmbRouteForbiddenElement
+					: router.UmbRouteNotFoundElement;
 			},
 		};
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -106,8 +106,7 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 
 	#generateRoutes() {
 		if (!this.#variants || this.#variants.length === 0 || !this.#appCulture) {
-			this._routes = [];
-			this.#ensureForbiddenRoute(this._routes);
+			this._routes = [this.#createNotFoundRoute()];
 			return;
 		}
 
@@ -179,25 +178,19 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 			});
 		}
 
-		this.#ensureForbiddenRoute(routes);
+		routes.push(this.#createNotFoundRoute());
 
 		this._routes = routes;
 	}
 
-	/**
-	 * Ensure that there is a route to handle forbidden access.
-	 * This route will display a forbidden message when the user does not have permission to access certain resources.
-	 * Also handles not found routes.
-	 * @param routes
-	 */
-	#ensureForbiddenRoute(routes: Array<UmbRoute> = []) {
-		routes.push({
+	#createNotFoundRoute(): UmbRoute {
+		return {
 			path: '**',
 			component: async () => {
 				const router = await import('@umbraco-cms/backoffice/router');
 				return this.#isForbidden ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
 			},
-		});
+		};
 	}
 
 	private _gotWorkspaceRoute = (e: UmbRouterSlotInitEvent) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
@@ -67,8 +67,7 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 
 	private async _generateRoutes() {
 		if (!this.#variants || this.#variants.length === 0) {
-			this._routes = [];
-			this.#ensureForbiddenRoute(this._routes);
+			this._routes = [this.#createNotFoundRoute()];
 			return;
 		}
 
@@ -113,25 +112,19 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 			});
 		}
 
-		this.#ensureForbiddenRoute(routes);
+		routes.push(this.#createNotFoundRoute());
 
 		this._routes = routes;
 	}
 
-	/**
-	 * Ensure that there is a route to handle forbidden access.
-	 * This route will display a forbidden message when the user does not have permission to access certain resources.
-	 * Also handles not found routes.
-	 * @param {Array<UmbRoute>} routes - The array of routes to append the forbidden route to
-	 */
-	#ensureForbiddenRoute(routes: Array<UmbRoute> = []) {
-		routes.push({
+	#createNotFoundRoute(): UmbRoute {
+		return {
 			path: '**',
 			component: async () => {
 				const router = await import('@umbraco-cms/backoffice/router');
 				return this.#isForbidden ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
 			},
-		});
+		};
 	}
 
 	private _gotWorkspaceRoute = (e: UmbRouterSlotInitEvent) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/workspace/media-workspace-editor.element.ts
@@ -5,6 +5,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { customElement, state, css, html } from '@umbraco-cms/backoffice/external/lit';
 import type { UmbRoute, UmbRouterSlotInitEvent } from '@umbraco-cms/backoffice/router';
+import { createObservablePart } from '@umbraco-cms/backoffice/observable-api';
 
 @customElement('umb-media-workspace-editor')
 export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
@@ -13,8 +14,7 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 	private _splitViewElement = new UmbMediaWorkspaceSplitViewElement();
 
 	#workspaceContext?: typeof UMB_MEDIA_WORKSPACE_CONTEXT.TYPE;
-	#variants?: Array<UmbMediaVariantOptionModel>;
-	#isForbidden = false;
+	#variants?: Array<Pick<UmbMediaVariantOptionModel, 'culture' | 'segment' | 'unique'>>;
 
 	@state()
 	private _routes?: Array<UmbRoute>;
@@ -28,30 +28,26 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 		this.consumeContext(UMB_MEDIA_WORKSPACE_CONTEXT, (instance) => {
 			this.#workspaceContext = instance;
 			this.#observeVariants();
-			this.#observeForbidden();
 			this.#observeLoading();
 		});
 	}
 
 	#observeVariants() {
 		this.observe(
-			this.#workspaceContext?.variantOptions,
+			this.#workspaceContext
+				? createObservablePart(this.#workspaceContext.variantOptions, (variants) =>
+						variants.map((v) => ({
+							culture: v.culture,
+							segment: v.segment,
+							unique: v.unique,
+						})),
+					)
+				: undefined,
 			(options) => {
 				this.#variants = options;
 				this._generateRoutes();
 			},
 			'_observeVariants',
-		);
-	}
-
-	#observeForbidden() {
-		this.observe(
-			this.#workspaceContext?.forbidden.isOn,
-			(forbidden) => {
-				this.#isForbidden = forbidden ?? false;
-				this._generateRoutes();
-			},
-			'_observeForbidden',
 		);
 	}
 
@@ -122,7 +118,9 @@ export class UmbMediaWorkspaceEditorElement extends UmbLitElement {
 			path: '**',
 			component: async () => {
 				const router = await import('@umbraco-cms/backoffice/router');
-				return this.#isForbidden ? router.UmbRouteForbiddenElement : router.UmbRouteNotFoundElement;
+				return this.#workspaceContext?.forbidden.getIsOn()
+					? router.UmbRouteForbiddenElement
+					: router.UmbRouteNotFoundElement;
 			},
 		};
 	}


### PR DESCRIPTION
Only generate routes when the dependent data for the routes change.

Done by creating a createObservablePart of the variantOptions, in this way routes are only generated when the 'data of the variants that is relevant for the routes' change.

As well cleaned up an observation of isForbidden as it was only used once.

Fixes https://github.com/umbraco/Umbraco-CMS/issues/22910

Replaces PR: https://github.com/umbraco/Umbraco-CMS/pull/22958

**No Unit Tests:**

This PR has no unit tests, testing this scenario would require quite a bit of mocking, which is hard to maintain and could case tests that parse despite they in real life would not.

As Claude put it:
_the test is probably not worth it, and it's likely to cause friction later_

**Test Notes:**

See issue for aspects to test.