### PR TITLE
E2E: QA Added acceptance tests for broken publish path in legacy routing

### DIFF
--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/BasePage.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/BasePage.ts
@@ -495,6 +495,15 @@ export class BasePage {
   }
 
   /**
+   * Asserts that an element does not contain specific text.
+   * @param locator - The element to check
+   * @param text - The text that should not be present
+   */
+  async doesNotContainText(locator: Locator, text: string, timeout?: number): Promise<void> {
+    await expect(locator).not.toContainText(text, {timeout: timeout ?? ConstantHelper.timeout.medium});
+  }
+
+  /**
    * Asserts that an element has specific text.
    * @param locator - The element to check
    * @param text - The exact text expected

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ConstantHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ConstantHelper.ts
@@ -407,6 +407,10 @@
     unpublish: 'Unpublish'
   }
 
+  public static readonly documentUrlInfoMessages = {
+    cannotBeRouted: 'This document is published but its URL cannot be routed'
+  }
+
   public static readonly elementTypeChangeMessages = {
     elementHasContent: 'Cannot change to document type because content has already been created with this element type.',
     documentHasContent: 'Cannot change to element type because content has already been created with this document type.',

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
@@ -750,6 +750,10 @@ export class ContentUiHelper extends UiBaseLocators {
     await this.containsText(this.linkContent, link);
   }
 
+  async doesDocumentNotHaveLink(link: string) {
+    await this.doesNotContainText(this.linkContent, link);
+  }
+
   async doesHistoryHaveText(text: string) {
     await this.hasText(this.historyItems, text);
   }

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentApiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentApiHelper.ts
@@ -161,6 +161,18 @@ export class DocumentApiHelper {
     return response.status();
   }
 
+  async unpublish(id: string, cultures: string[] | null = null) {
+    if (id == null) {
+      return;
+    }
+    const response = await this.api.put(this.api.baseUrl + '/umbraco/management/api/v1/document/' + id + '/unpublish', {cultures});
+    return response.status();
+  }
+
+  async unpublishDocumentWithCulture(id: string, culture: string) {
+    return await this.unpublish(id, [culture]);
+  }
+
   async getDocumentUrl(id: string) {
     const response = await this.api.get(this.api.baseUrl + '/umbraco/management/api/v1/document/urls?id=' + id);
     const urls = await response.json();
@@ -459,6 +471,55 @@ export class DocumentApiHelper {
       .build();
 
     return await this.create(document);
+  }
+
+  async createVariantDocumentWithParent(documentTypeId: string, parentId: string | null, cultureVariants: {culture: string, name: string}[]) {
+    const builder = new DocumentBuilder()
+      .withDocumentTypeId(documentTypeId);
+
+    if (parentId !== null) {
+      builder.withParentId(parentId);
+    }
+
+    for (const variant of cultureVariants) {
+      builder.addVariant()
+        .withName(variant.name)
+        .withCulture(variant.culture)
+        .done();
+    }
+
+    return await this.create(builder.build());
+  }
+
+  // Creates and publishes a chain of variant documents (each the parent of the next) and returns their ids in order.
+  // Each level maps culture => name; the cultures to publish are derived from those keys.
+  async createPublishedVariantChain(documentTypeId: string, levels: {[culture: string]: string}[]) {
+    const ids: string[] = [];
+    let parentId: string | null = null;
+    for (const level of levels) {
+      const cultures = Object.keys(level);
+      const variants = cultures.map(culture => ({culture, name: level[culture]}));
+      const id = await this.createVariantDocumentWithParent(documentTypeId, parentId, variants);
+      await this.publishDocumentWithCultures(id, cultures);
+      ids.push(id);
+      parentId = id;
+    }
+    return ids;
+  }
+
+  // Creates and publishes a chain of invariant documents (each the parent of the next) and returns their ids in order.
+  async createPublishedInvariantChain(documentTypeId: string, names: string[]) {
+    const ids: string[] = [];
+    let parentId: string | null = null;
+    for (const name of names) {
+      const id = parentId === null
+        ? await this.createDefaultDocument(name, documentTypeId)
+        : await this.createDefaultDocumentWithParent(name, documentTypeId, parentId);
+      await this.publish(id);
+      ids.push(id);
+      parentId = id;
+    }
+    return ids;
   }
 
   async createDocumentWithMultipleVariants(documentName: string, documentTypeId: string, dataTypeAlias: string, cultureVariants: {isoCode: string, name: string, value: string}[]) {
@@ -1504,6 +1565,14 @@ export class DocumentApiHelper {
           "culture": culture
         }
       ]
+    };
+
+    return await this.publish(id, publishScheduleData);
+  }
+
+  async publishDocumentWithCultures(id: string, cultures: string[]) {
+    const publishScheduleData = {
+      "publishSchedules": cultures.map(culture => ({culture}))
     };
 
     return await this.publish(id, publishScheduleData);

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentTypeApiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/DocumentTypeApiHelper.ts
@@ -84,6 +84,14 @@ export class DocumentTypeApiHelper {
     return response.headers().location.split("/").pop();
   }
 
+  async update(id: string, documentType) {
+    if (documentType == null) {
+      return;
+    }
+    const response = await this.api.put(this.api.baseUrl + '/umbraco/management/api/v1/document-type/' + id, documentType);
+    return response.status();
+  }
+
   async get(id: string) {
     const response = await this.api.get(this.api.baseUrl + '/umbraco/management/api/v1/document-type/' + id);
     const json = await response.json();
@@ -939,6 +947,46 @@ export class DocumentTypeApiHelper {
       .withVariesByCulture(true)
       .build();
     return await this.create(documentType);
+  }
+
+  async createDocumentTypeWithTextstringAndAllowAsRootAndAllowSelfAsChild(documentTypeName: string, variesByCulture: boolean = false) {
+    await this.ensureNameNotExists(documentTypeName);
+    const crypto = require('crypto');
+    const documentTypeId = crypto.randomUUID();
+    const containerId = crypto.randomUUID();
+    const dataType = await this.api.dataType.getByName('Textstring');
+
+    const buildDocumentType = (allowSelfAsChild: boolean) => {
+      const builder = new DocumentTypeBuilder()
+        .withId(documentTypeId)
+        .withName(documentTypeName)
+        .withAlias(AliasHelper.toAlias(documentTypeName))
+        .withAllowedAsRoot(true)
+        .withVariesByCulture(variesByCulture)
+        .addContainer()
+          .withName('Content')
+          .withId(containerId)
+          .withType('Group')
+          .done()
+        .addProperty()
+          .withContainerId(containerId)
+          .withAlias('title')
+          .withName('Title')
+          .withDataTypeId(dataType.id)
+          .done();
+      if (allowSelfAsChild) {
+        builder.addAllowedDocumentType()
+          .withId(documentTypeId)
+          .done();
+      }
+      return builder.build();
+    };
+
+    // A document type cannot reference itself as an allowed child during creation (it does not exist yet),
+    // so create it first and then update it to allow itself as a child.
+    await this.create(buildDocumentType(false));
+    await this.update(documentTypeId, buildDocumentType(true));
+    return documentTypeId;
   }
 
   async createDocumentTypeWithPropertyEditorAndAllowedTemplate(documentTypeName: string, dataTypeId: string, propertyName: string, templateId: string) {

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -23,7 +23,7 @@
     "testSqlite": "npm run build && npx playwright test DefaultConfig --grep-invert \"Users\"",
     "all": "npm run build && npx playwright test",
     "createTest": "node createTest.js",
-    "smokeTest": "npm run build && npx playwright test DocumentUrlBrokenPublishPath.spec.ts",
+    "smokeTest": "npm run build && npx playwright test DefaultConfig --grep \"@smoke\"",
     "smokeTestSqlite": "npm run build && npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\"",
     "releaseTest": "npm run build && npx playwright test DefaultConfig --grep \"@release\"",
     "testWindows": "npm run build && npx playwright test DefaultConfig --grep-invert \"RelationType\""

--- a/tests/Umbraco.Tests.AcceptanceTest/package.json
+++ b/tests/Umbraco.Tests.AcceptanceTest/package.json
@@ -23,7 +23,7 @@
     "testSqlite": "npm run build && npx playwright test DefaultConfig --grep-invert \"Users\"",
     "all": "npm run build && npx playwright test",
     "createTest": "node createTest.js",
-    "smokeTest": "npm run build && npx playwright test DefaultConfig --grep \"@smoke\"",
+    "smokeTest": "npm run build && npx playwright test DocumentUrlBrokenPublishPath.spec.ts",
     "smokeTestSqlite": "npm run build && npx playwright test DefaultConfig --grep \"@smoke\" --grep-invert \"Users\"",
     "releaseTest": "npm run build && npx playwright test DefaultConfig --grep \"@release\"",
     "testWindows": "npm run build && npx playwright test DefaultConfig --grep-invert \"RelationType\""

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/DocumentUrlBrokenPublishPath.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/DocumentUrlBrokenPublishPath.spec.ts
@@ -1,8 +1,8 @@
 import {ConstantHelper, test} from '@umbraco/acceptance-test-helpers';
 
+// Languages
 const danishIsoCode = 'da';
 const englishIsoCode = 'en-US';
-
 // Document type
 const documentTypeName = 'Broken Publish Path Document Type';
 // Content

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/DocumentUrlBrokenPublishPath.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/DocumentUrlBrokenPublishPath.spec.ts
@@ -1,0 +1,60 @@
+import {ConstantHelper, test} from '@umbraco/acceptance-test-helpers';
+
+const danishIsoCode = 'da';
+const englishIsoCode = 'en-US';
+
+// Document type
+const documentTypeName = 'Broken Publish Path Document Type';
+// Content
+const rootNames = {'en-US': 'Root en-US', 'da': 'Root da'};
+const childNames = {'en-US': 'Child en-US', 'da': 'Child da'};
+const grandchildNames = {'en-US': 'Grandchild en-US', 'da': 'Grandchild da'};
+// Content URLs
+const grandchildUrl = '/child-en-us/grandchild-en-us/';
+const collapsedGrandchildUrl = '/grandchild-en-us/';
+let documentTypeId = '';
+
+async function openGrandchildInfoTab(umbracoUi) {
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+  await umbracoUi.content.openContentCaretButtonForName(rootNames[englishIsoCode]);
+  await umbracoUi.content.openContentCaretButtonForName(childNames[englishIsoCode]);
+  await umbracoUi.content.goToContentWithName(grandchildNames[englishIsoCode]);
+  await umbracoUi.content.clickInfoTab();
+}
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.language.createDanishLanguage();
+  documentTypeId = await umbracoApi.documentType.createDocumentTypeWithTextstringAndAllowAsRootAndAllowSelfAsChild(documentTypeName, true);
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(rootNames[englishIsoCode]);
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.language.ensureIsoCodeNotExists(danishIsoCode);
+});
+
+test('can see the multi-level url for a grandchild when the ancestor chain is fully published', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames]);
+
+  // Act
+  await openGrandchildInfoTab(umbracoUi);
+
+  // Assert
+  await umbracoUi.content.doesDocumentHaveLink(grandchildUrl);
+});
+
+test('cannot see a routable url for a grandchild when an ancestor is unpublished', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames]);
+  const childId = documentIds[1];
+  await umbracoApi.document.unpublishDocumentWithCulture(childId, englishIsoCode);
+
+  // Act
+  await openGrandchildInfoTab(umbracoUi);
+
+  // Assert
+  await umbracoUi.content.doesDocumentHaveLink(ConstantHelper.documentUrlInfoMessages.cannotBeRouted);
+  await umbracoUi.content.doesDocumentNotHaveLink(collapsedGrandchildUrl);
+});

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DeliveryApi/BrokenPublishPathDeliveryApi.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DeliveryApi/BrokenPublishPathDeliveryApi.spec.ts
@@ -1,9 +1,9 @@
 import {expect} from '@playwright/test';
 import {test} from '@umbraco/acceptance-test-helpers';
 
+// Languages
 const danishIsoCode = 'da';
 const englishIsoCode = 'en-US';
-
 // Document types
 const documentTypeName = 'Broken Publish Path Document Type';
 const invariantDocumentTypeName = 'Broken Publish Path Invariant Document Type';

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DeliveryApi/BrokenPublishPathDeliveryApi.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DeliveryApi/BrokenPublishPathDeliveryApi.spec.ts
@@ -101,7 +101,7 @@ test('cannot fetch a child in a culture where the root is unpublished', async ({
   expect(contentItem.status()).toBe(404);
 });
 
-test('cannot fetch a deeply nested content when a mid-level ancestor is unpublished in the requested culture', async ({umbracoApi}) => {
+test('cannot fetch a deeply nested content node when a mid-level ancestor is unpublished in the requested culture', async ({umbracoApi}) => {
   // Arrange
   const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames, greatGrandchildNames]);
   const grandchildId = documentIds[2];
@@ -115,7 +115,7 @@ test('cannot fetch a deeply nested content when a mid-level ancestor is unpublis
   expect(contentItem.status()).toBe(404);
 });
 
-test('can fetch a deeply nested content when the whole chain is published', async ({umbracoApi}) => {
+test('can fetch a deeply nested content node when the whole chain is published', async ({umbracoApi}) => {
   // Arrange
   const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames, greatGrandchildNames]);
   const greatGrandchildId = documentIds[3];

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DeliveryApi/BrokenPublishPathDeliveryApi.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DeliveryApi/BrokenPublishPathDeliveryApi.spec.ts
@@ -1,0 +1,160 @@
+import {expect} from '@playwright/test';
+import {test} from '@umbraco/acceptance-test-helpers';
+
+const danishIsoCode = 'da';
+const englishIsoCode = 'en-US';
+
+// Document types
+const documentTypeName = 'Broken Publish Path Document Type';
+const invariantDocumentTypeName = 'Broken Publish Path Invariant Document Type';
+// Variant contents
+const rootNames = {'en-US': 'Root en-US', 'da': 'Root da'};
+const childNames = {'en-US': 'Child en-US', 'da': 'Child da'};
+const grandchildNames = {'en-US': 'Grandchild en-US', 'da': 'Grandchild da'};
+const greatGrandchildNames = {'en-US': 'Great Grandchild en-US', 'da': 'Great Grandchild da'};
+// Invariant contents
+const invariantNodeNames = ['Invariant Root', 'Invariant Child', 'Invariant Grandchild'];
+let documentTypeId = '';
+
+test.beforeEach(async ({umbracoApi}) => {
+  await umbracoApi.language.createDanishLanguage();
+  documentTypeId = await umbracoApi.documentType.createDocumentTypeWithTextstringAndAllowAsRootAndAllowSelfAsChild(documentTypeName, true);
+});
+
+test.afterEach(async ({umbracoApi}) => {
+  await umbracoApi.document.ensureNameNotExists(rootNames[englishIsoCode]);
+  await umbracoApi.document.ensureNameNotExists(invariantNodeNames[0]);
+  await umbracoApi.documentType.ensureNameNotExists(documentTypeName);
+  await umbracoApi.documentType.ensureNameNotExists(invariantDocumentTypeName);
+  await umbracoApi.language.ensureIsoCodeNotExists(danishIsoCode);
+});
+
+test('can fetch a grandchild when the full ancestor chain is published in the requested culture', async ({umbracoApi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames]);
+  const grandchildId = documentIds[2];
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(grandchildId, {'Accept-Language': englishIsoCode});
+
+  // Assert
+  expect(contentItem.status()).toBe(200);
+  const contentItemJson = await contentItem.json();
+  expect(contentItemJson.route.path).toBe('/child-en-us/grandchild-en-us/');
+});
+
+test('can fetch a grandchild in a second culture when the full ancestor chain is published', async ({umbracoApi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames]);
+  const grandchildId = documentIds[2];
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(grandchildId, {'Accept-Language': danishIsoCode});
+
+  // Assert
+  expect(contentItem.status()).toBe(200);
+  const contentItemJson = await contentItem.json();
+  expect(contentItemJson.route.path).toBe('/child-da/grandchild-da/');
+});
+
+test('cannot fetch a grandchild in a culture where an ancestor is unpublished', async ({umbracoApi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames]);
+  const childId = documentIds[1];
+  const grandchildId = documentIds[2];
+  await umbracoApi.document.unpublishDocumentWithCulture(childId, danishIsoCode);
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(grandchildId, {'Accept-Language': danishIsoCode});
+
+  // Assert
+  expect(contentItem.status()).toBe(404);
+});
+
+test('can fetch a grandchild in the culture where its ancestors are published', async ({umbracoApi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames]);
+  const childId = documentIds[1];
+  const grandchildId = documentIds[2];
+  await umbracoApi.document.unpublishDocumentWithCulture(childId, danishIsoCode);
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(grandchildId, {'Accept-Language': englishIsoCode});
+
+  // Assert
+  expect(contentItem.status()).toBe(200);
+  const contentItemJson = await contentItem.json();
+  expect(contentItemJson.route.path).toBe('/child-en-us/grandchild-en-us/');
+});
+
+test('cannot fetch a child in a culture where the root is unpublished', async ({umbracoApi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames]);
+  const rootId = documentIds[0];
+  const childId = documentIds[1];
+  await umbracoApi.document.unpublishDocumentWithCulture(rootId, danishIsoCode);
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(childId, {'Accept-Language': danishIsoCode});
+
+  // Assert
+  expect(contentItem.status()).toBe(404);
+});
+
+test('cannot fetch a deeply nested content when a mid-level ancestor is unpublished in the requested culture', async ({umbracoApi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames, greatGrandchildNames]);
+  const grandchildId = documentIds[2];
+  const greatGrandchildId = documentIds[3];
+  await umbracoApi.document.unpublishDocumentWithCulture(grandchildId, danishIsoCode);
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(greatGrandchildId, {'Accept-Language': danishIsoCode});
+
+  // Assert
+  expect(contentItem.status()).toBe(404);
+});
+
+test('can fetch a deeply nested content when the whole chain is published', async ({umbracoApi}) => {
+  // Arrange
+  const documentIds = await umbracoApi.document.createPublishedVariantChain(documentTypeId, [rootNames, childNames, grandchildNames, greatGrandchildNames]);
+  const greatGrandchildId = documentIds[3];
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(greatGrandchildId, {'Accept-Language': englishIsoCode});
+
+  // Assert
+  expect(contentItem.status()).toBe(200);
+  const contentItemJson = await contentItem.json();
+  expect(contentItemJson.route.path).toBe('/child-en-us/grandchild-en-us/great-grandchild-en-us/');
+});
+
+test('cannot fetch a grandchild when an invariant ancestor is unpublished', async ({umbracoApi}) => {
+  // Arrange
+  const invariantDocumentTypeId = await umbracoApi.documentType.createDocumentTypeWithTextstringAndAllowAsRootAndAllowSelfAsChild(invariantDocumentTypeName, false);
+  const documentIds = await umbracoApi.document.createPublishedInvariantChain(invariantDocumentTypeId, invariantNodeNames);
+  const childId = documentIds[1];
+  const grandchildId = documentIds[2];
+  await umbracoApi.document.unpublish(childId);
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(grandchildId);
+
+  // Assert
+  expect(contentItem.status()).toBe(404);
+});
+
+test('can fetch a grandchild when the invariant chain is fully published', async ({umbracoApi}) => {
+  // Arrange
+  const invariantDocumentTypeId = await umbracoApi.documentType.createDocumentTypeWithTextstringAndAllowAsRootAndAllowSelfAsChild(invariantDocumentTypeName, false);
+  const documentIds = await umbracoApi.document.createPublishedInvariantChain(invariantDocumentTypeId, invariantNodeNames);
+  const grandchildId = documentIds[2];
+
+  // Act
+  const contentItem = await umbracoApi.contentDeliveryApi.getContentItemWithId(grandchildId);
+
+  // Assert
+  expect(contentItem.status()).toBe(200);
+  const contentItemJson = await contentItem.json();
+  expect(contentItemJson.route.path).toBe('/invariant-child/invariant-grandchild/');
+});


### PR DESCRIPTION
This PR adds acceptance tests for the broken publish path scenario in legacy routing, which was introduced in this PR: https://github.com/umbraco/Umbraco-CMS/pull/22586