### PR TITLE
 Tests: Update DomainCacheServiceTests to mock GetAllAsync instead of removed GetAll

### DIFF
--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DomainCacheServiceTests.cs
@@ -21,10 +21,8 @@ internal sealed class DomainCacheServiceTests
 
         var domainService = new Mock<IDomainService>();
         domainService
-#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
-            .Setup(x => x.GetAll(true))
-#pragma warning restore CS0618 // Type or member is obsolete
-            .Returns([assigned, wildcard]);
+            .Setup(x => x.GetAllAsync(true))
+            .ReturnsAsync([assigned, wildcard]);
 
         var sut = new DomainCacheService(domainService.Object, CreateScopeProvider());
 
@@ -53,10 +51,8 @@ internal sealed class DomainCacheServiceTests
 
         var domainService = new Mock<IDomainService>();
         domainService
-#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
-            .Setup(x => x.GetAll(true))
-#pragma warning restore CS0618 // Type or member is obsolete
-            .Returns(() =>
+            .Setup(x => x.GetAllAsync(true))
+            .ReturnsAsync(() =>
             {
                 loadStarted.Set();
 
@@ -113,10 +109,8 @@ internal sealed class DomainCacheServiceTests
     {
         var domainService = new Mock<IDomainService>();
         domainService
-#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
-            .Setup(x => x.GetAll(true))
-#pragma warning restore CS0618 // Type or member is obsolete
-            .Returns([]);
+            .Setup(x => x.GetAllAsync(true))
+            .ReturnsAsync([]);
 
         var sut = new DomainCacheService(domainService.Object, CreateScopeProvider());
 
@@ -154,10 +148,8 @@ internal sealed class DomainCacheServiceTests
         var current = new List<IDomain> { first, second };
         var domainService = new Mock<IDomainService>();
         domainService
-#pragma warning disable CS0618 // Type or member is obsolete. This test is for the DomainCacheService, which still calls the obsolete GetAll(bool) method.
-            .Setup(x => x.GetAll(true))
-#pragma warning restore CS0618 // Type or member is obsolete
-            .Returns(() => current.ToArray());
+            .Setup(x => x.GetAllAsync(true))
+            .ReturnsAsync(() => current.ToArray());
 
         var sut = new DomainCacheService(domainService.Object, CreateScopeProvider());
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

### Description
<!-- 
    A description of the changes proposed in the pull-request and how to test these changes.

    The most successful pull requests usually look a like this:

    * Fill in this template with details: what did you do, why did you do it, how can we test the changes?
    * Include screenshots and animated GIFs in your pull request whenever possible.
    * Unit tests, while optional are awesome, thank you!

    While these are guidelines and not strict requirements, they really help us evaluate your PR quicker.
-->
`IDomainService.GetAll(bool)` was removed in favour of `GetAllAsync(bool)`. The unit tests were left mocking the obsolete method, causing a compile error.

<!-- Thanks for contributing to Umbraco CMS! -->
