### PR TITLE
Dependencies: Update MessagePack to 3.1.7 to address security advisories

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,7 @@
     <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="Markdig" Version="0.45.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
-    <PackageVersion Include="MessagePack" Version="3.1.4" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     <PackageVersion Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageVersion Include="ncrontab" Version="3.4.0" />


### PR DESCRIPTION
## Description

Updates the MessagePack dependency from 3.1.4 to 3.1.7.

Versions 3.1.6 and below are affected by a number of security advisories (3 high-severity, 9 moderate). 3.1.7 is the fully-patched release. Release notes: https://github.com/MessagePack-CSharp/MessagePack-CSharp/releases

### Relevance to Umbraco

The directly-relevant fix is the **LZ4 decompression out-of-bounds read** ([GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) / CVE-2026-48109), which can trigger an AccessViolationException (process termination / DoS) on a crafted payload. Umbraco's published-cache serializers (HybridCacheSerializer, MsgPackContentNestedDataSerializer) both use the Lz4BlockArray compression path.

In practice the exposure is low — Umbraco only deserializes MessagePack from trusted stores it populates itself (the cmsContentNu table and the L1/L2 hybrid cache), never from untrusted external input. Applying the patch is nonetheless the correct hardening step, particularly for distributed-cache (e.g. Redis) deployments.

### Compatibility

- **Wire format unchanged** across 3.1.4 → 3.1.7 (the only encoding change in this range was reverted within the same release), so existing serialized cache data deserializes correctly — no cache rebuild required.
- No API breakage for Umbraco's usage.
- MessagePack is referenced only by Umbraco.PublishedCache.HybridCache; no transitive version conflicts.

## Testing

Existing HybridCache integration tests cover this, including DocumentCacheServiceTests which asserts an exact MessagePack byte string — confirming the serialization format is unchanged.