### PR TITLE
Package migrations: Surface a failed unattended package migration as a boot failure instead of getting stuck on the upgrade screen

### DIFF
--- a/src/Umbraco.Infrastructure/Install/PackageMigrationRunner.cs
+++ b/src/Umbraco.Infrastructure/Install/PackageMigrationRunner.cs
@@ -131,12 +131,15 @@ public class PackageMigrationRunner
         => RunPackagePlansAsync(plansToRun).GetAwaiter().GetResult();
 
     /// <summary>
-    ///     Runs the all specified package migration plans and publishes a <see cref="MigrationPlansExecutedNotification" />
-    ///     if all are successful.
+    ///     Runs all the specified package migration plans and publishes a <see cref="MigrationPlansExecutedNotification" />.
     /// </summary>
+    /// <remarks>
+    ///     All plans are run to completion even if one fails, so that one package's failure does not block another's.
+    ///     A failed plan is reported via <see cref="ExecutedMigrationPlan.Successful" /> on the returned result rather
+    ///     than by throwing; callers must inspect the results to detect a failure.
+    /// </remarks>
     /// <param name="plansToRun"></param>
     /// <returns></returns>
-    /// <exception cref="Exception">If any plan fails it will throw an exception.</exception>
     public async Task<IEnumerable<ExecutedMigrationPlan>> RunPackagePlansAsync(IEnumerable<string> plansToRun)
     {
         List<ExecutedMigrationPlan> results = new();

--- a/src/Umbraco.Infrastructure/Install/UnattendedUpgrader.cs
+++ b/src/Umbraco.Infrastructure/Install/UnattendedUpgrader.cs
@@ -11,6 +11,7 @@ using Umbraco.Cms.Core.Exceptions;
 using Umbraco.Cms.Core.Logging;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
 using Umbraco.Cms.Infrastructure.Migrations.Install;
 using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
 using Umbraco.Cms.Infrastructure.Runtime;
@@ -163,7 +164,23 @@ public class UnattendedUpgrader : INotificationAsyncHandler<RuntimeUnattendedUpg
 
         try
         {
-            await _packageMigrationRunner.RunPackagePlansAsync(pendingMigrations);
+            IEnumerable<ExecutedMigrationPlan> executedPlans =
+                await _packageMigrationRunner.RunPackagePlansAsync(pendingMigrations);
+
+            // Failed plans are reported via the result, not by throwing (the runner deliberately runs all plans to
+            // completion so one package's failure doesn't block another's). Surface them as a boot failure here so the
+            // failure is observable, mirroring the core upgrade path - otherwise the migration stays pending and the
+            // runtime re-derives Upgrading on every boot, leaving the site stuck on the maintenance page.
+            // All failures are reported together.
+            var failedPlans = executedPlans.Where(plan => plan.Successful is false).ToList();
+            if (failedPlans.Count > 0)
+            {
+                SetRuntimeError(CreatePackageMigrationError(failedPlans));
+                notification.UnattendedUpgradeResult =
+                    RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors;
+                return;
+            }
+
             notification.UnattendedUpgradeResult = RuntimeUnattendedUpgradeNotification.UpgradeResult.PackageMigrationComplete;
 
             // Migration plans may have changed published content, so refresh the distributed cache to ensure consistency on first request.
@@ -198,6 +215,22 @@ public class UnattendedUpgrader : INotificationAsyncHandler<RuntimeUnattendedUpg
             notification.UnattendedUpgradeResult =
                 RuntimeUnattendedUpgradeNotification.UpgradeResult.CoreUpgradeComplete;
         }
+    }
+
+    private static Exception CreatePackageMigrationError(IReadOnlyList<ExecutedMigrationPlan> failedPlans)
+    {
+        static Exception ToException(ExecutedMigrationPlan plan)
+            => plan.Exception ?? new UnattendedInstallException(
+                $"An error occurred while running the unattended package migration '{plan.Plan.Name}'.");
+
+        if (failedPlans.Count == 1)
+        {
+            return ToException(failedPlans[0]);
+        }
+
+        return new AggregateException(
+            $"{failedPlans.Count} unattended package migrations failed: {string.Join(", ", failedPlans.Select(plan => plan.Plan.Name))}.",
+            failedPlans.Select(ToException));
     }
 
     private void SetRuntimeError(Exception exception)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/UnattendedPackageMigrationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/UnattendedPackageMigrationTests.cs
@@ -83,7 +83,7 @@ internal sealed class UnattendedPackageMigrationTests : UmbracoIntegrationTest
                 x => x.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, It.IsNotNull<Exception>()),
                 Times.Once);
             Assert.That(capturedError, Is.Not.Null);
-            Assert.That(capturedError!.ToString(), Does.Contain(ThrowingMigration.ExceptionMessage));
+            Assert.That(capturedError?.ToString(), Does.Contain(ThrowingMigration.ExceptionMessage));
         });
     }
 }
@@ -109,5 +109,5 @@ internal sealed class ThrowingMigration : AsyncMigrationBase
     {
     }
 
-    protected override async Task MigrateAsync() => throw new InvalidOperationException(ExceptionMessage);
+    protected override Task MigrateAsync() => Task.FromException(new InvalidOperationException(ExceptionMessage));
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/UnattendedPackageMigrationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/UnattendedPackageMigrationTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Packaging;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Install;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Install;
+using Umbraco.Cms.Infrastructure.Runtime;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Install;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class UnattendedPackageMigrationTests : UmbracoIntegrationTest
+{
+    // Exercises the real MigrationPlanExecutor, which catches a failing migration step and returns a
+    // result with Successful = false rather than throwing. This test locks in that this silently-failed
+    // package migration is converted into a BootFailed state (and not left stuck on Upgrading), and that
+    // the original migration exception is surfaced - the full chain the unit tests mock away.
+    [Test]
+    public async Task HandleAsync_WhenRealPackageMigrationThrows_SetsBootFailedAndSurfacesTheException()
+    {
+        var plan = new ThrowingPackageMigrationPlan();
+        var planCollection = new PackageMigrationPlanCollection(() => new PackageMigrationPlan[] { plan });
+
+        var packageMigrationRunner = new PackageMigrationRunner(
+            GetRequiredService<IProfilingLogger>(),
+            GetRequiredService<ICoreScopeProvider>(),
+            new PendingPackageMigrations(NullLogger<PendingPackageMigrations>.Instance, planCollection),
+            planCollection,
+            GetRequiredService<IMigrationPlanExecutor>(), // the real executor that swallows the failure
+            GetRequiredService<IKeyValueService>(),
+            GetRequiredService<IEventAggregator>(),
+            NullLogger<PackageMigrationRunner>.Instance);
+
+        Exception? capturedError = null;
+        var runtimeState = new Mock<IRuntimeState>();
+        runtimeState.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+        runtimeState.SetupGet(x => x.Reason).Returns(RuntimeLevelReason.UpgradePackageMigrations);
+        runtimeState.SetupGet(x => x.StartupState).Returns(new Dictionary<string, object>
+        {
+            [RuntimeState.PendingPackageMigrationsStateKey] = (IReadOnlyList<string>)new[] { ThrowingPackageMigrationPlan.PlanName },
+        });
+        runtimeState
+            .Setup(x => x.Configure(RuntimeLevel.BootFailed, It.IsAny<RuntimeLevelReason>(), It.IsAny<Exception?>()))
+            .Callback<RuntimeLevel, RuntimeLevelReason, Exception?>((_, _, exception) => capturedError = exception);
+
+        var upgrader = new UnattendedUpgrader(
+            GetRequiredService<IProfilingLogger>(),
+            GetRequiredService<IUmbracoVersion>(),
+            GetRequiredService<DatabaseBuilder>(),
+            runtimeState.Object,
+            packageMigrationRunner,
+            Options.Create(new UnattendedSettings()),
+            GetRequiredService<DistributedCache>(),
+            NullLogger<UnattendedUpgrader>.Instance);
+
+        var notification = new RuntimeUnattendedUpgradeNotification();
+
+        // The failure must not propagate as a thrown exception - it has to be reported as a boot failure.
+        await upgrader.HandleAsync(notification, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(notification.UnattendedUpgradeResult, Is.EqualTo(RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors));
+            runtimeState.Verify(
+                x => x.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, It.IsNotNull<Exception>()),
+                Times.Once);
+            Assert.That(capturedError, Is.Not.Null);
+            Assert.That(capturedError!.ToString(), Does.Contain(ThrowingMigration.ExceptionMessage));
+        });
+    }
+}
+
+internal sealed class ThrowingPackageMigrationPlan : PackageMigrationPlan
+{
+    public const string PlanName = "IntegrationThrowingPackage";
+
+    public ThrowingPackageMigrationPlan()
+        : base(PlanName)
+    {
+    }
+
+    protected override void DefinePlan() => To<ThrowingMigration>("throw");
+}
+
+internal sealed class ThrowingMigration : AsyncMigrationBase
+{
+    public const string ExceptionMessage = "Integration test package migration deliberately threw.";
+
+    public ThrowingMigration(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override async Task MigrateAsync() => throw new InvalidOperationException(ExceptionMessage);
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/UnattendedPackageMigrationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Install/UnattendedPackageMigrationTests.cs
@@ -86,28 +86,30 @@ internal sealed class UnattendedPackageMigrationTests : UmbracoIntegrationTest
             Assert.That(capturedError?.ToString(), Does.Contain(ThrowingMigration.ExceptionMessage));
         });
     }
-}
 
-internal sealed class ThrowingPackageMigrationPlan : PackageMigrationPlan
-{
-    public const string PlanName = "IntegrationThrowingPackage";
-
-    public ThrowingPackageMigrationPlan()
-        : base(PlanName)
+    // Nested + private so the TypeFinder (which excludes nested-private types) does not auto-discover this
+    // PackageMigrationPlan and run it during every other integration test that boots a full server.
+    private sealed class ThrowingPackageMigrationPlan : PackageMigrationPlan
     {
+        public const string PlanName = "IntegrationThrowingPackage";
+
+        public ThrowingPackageMigrationPlan()
+            : base(PlanName)
+        {
+        }
+
+        protected override void DefinePlan() => To<ThrowingMigration>("throw");
     }
 
-    protected override void DefinePlan() => To<ThrowingMigration>("throw");
-}
-
-internal sealed class ThrowingMigration : AsyncMigrationBase
-{
-    public const string ExceptionMessage = "Integration test package migration deliberately threw.";
-
-    public ThrowingMigration(IMigrationContext context)
-        : base(context)
+    private sealed class ThrowingMigration : AsyncMigrationBase
     {
-    }
+        public const string ExceptionMessage = "Integration test package migration deliberately threw.";
 
-    protected override Task MigrateAsync() => Task.FromException(new InvalidOperationException(ExceptionMessage));
+        public ThrowingMigration(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        protected override Task MigrateAsync() => Task.FromException(new InvalidOperationException(ExceptionMessage));
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgraderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgraderTests.cs
@@ -1,0 +1,244 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Exceptions;
+using Umbraco.Cms.Core.Logging;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Packaging;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.Install;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Runtime;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Install;
+
+[TestFixture]
+public class UnattendedUpgraderTests
+{
+    [Test]
+    public async Task RunPackageMigrations_WhenSinglePlanFails_SetsBootFailedWithThePlanException()
+    {
+        var planException = new InvalidOperationException("migration step exploded");
+        (UnattendedUpgrader sut, Mock<IRuntimeState> runtimeState) =
+            CreateScenario(new PlanSpec("Failing Package", Successful: false, planException));
+        var notification = new RuntimeUnattendedUpgradeNotification();
+
+        await sut.HandleAsync(notification, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            // The failed (but not thrown) package plan must surface as a boot failure, mirroring the core upgrade path,
+            // forwarding the original migration exception rather than swallowing it.
+            runtimeState.Verify(
+                x => x.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, planException),
+                Times.Once);
+            Assert.That(notification.UnattendedUpgradeResult, Is.EqualTo(RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors));
+        });
+    }
+
+    [Test]
+    public async Task RunPackageMigrations_WhenMultiplePlansFail_SetsBootFailedWithAllFailures()
+    {
+        var firstException = new InvalidOperationException("first plan exploded");
+        var secondException = new InvalidOperationException("second plan exploded");
+
+        (UnattendedUpgrader sut, Mock<IRuntimeState> runtimeState) = CreateScenario(
+            new PlanSpec("First Failing Package", Successful: false, firstException),
+            new PlanSpec("Second Failing Package", Successful: false, secondException));
+        var notification = new RuntimeUnattendedUpgradeNotification();
+
+        Func<Exception?> capturedError = CaptureBootFailedException(runtimeState);
+
+        await sut.HandleAsync(notification, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(notification.UnattendedUpgradeResult, Is.EqualTo(RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors));
+
+            // Both failures must be reported together so the operator can address them in one pass.
+            var aggregate = capturedError() as AggregateException;
+            Assert.That(aggregate, Is.Not.Null, "Expected the boot failure to aggregate all failed plans.");
+            Assert.That(aggregate!.InnerExceptions, Does.Contain(firstException));
+            Assert.That(aggregate.InnerExceptions, Does.Contain(secondException));
+        });
+    }
+
+    [Test]
+    public async Task RunPackageMigrations_WhenPlanFailsWithoutException_SetsBootFailedWithFallbackException()
+    {
+        const string planName = "Failing Package Without Exception";
+        (UnattendedUpgrader sut, Mock<IRuntimeState> runtimeState) =
+            CreateScenario(new PlanSpec(planName, Successful: false, Exception: null));
+        var notification = new RuntimeUnattendedUpgradeNotification();
+
+        Func<Exception?> capturedError = CaptureBootFailedException(runtimeState);
+
+        await sut.HandleAsync(notification, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(notification.UnattendedUpgradeResult, Is.EqualTo(RuntimeUnattendedUpgradeNotification.UpgradeResult.HasErrors));
+
+            // A plan can fail without carrying an exception; fall back to a descriptive one naming the plan.
+            Exception? error = capturedError();
+            Assert.That(error, Is.InstanceOf<UnattendedInstallException>());
+            Assert.That(error!.Message, Does.Contain(planName));
+        });
+    }
+
+    [Test]
+    public async Task RunPackageMigrations_WhenPlanSucceeds_DoesNotSetBootFailed()
+    {
+        (UnattendedUpgrader sut, Mock<IRuntimeState> runtimeState) =
+            CreateScenario(new PlanSpec("Succeeding Package", Successful: true, Exception: null));
+        var notification = new RuntimeUnattendedUpgradeNotification();
+
+        await sut.HandleAsync(notification, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            runtimeState.Verify(
+                x => x.Configure(RuntimeLevel.BootFailed, It.IsAny<RuntimeLevelReason>(), It.IsAny<Exception?>()),
+                Times.Never);
+            Assert.That(notification.UnattendedUpgradeResult, Is.EqualTo(RuntimeUnattendedUpgradeNotification.UpgradeResult.PackageMigrationComplete));
+        });
+    }
+
+    private static (UnattendedUpgrader Sut, Mock<IRuntimeState> RuntimeState) CreateScenario(params PlanSpec[] specs)
+    {
+        var plans = specs.Select(spec => new TestPackageMigrationPlan(spec.Name)).ToArray();
+        var planCollection = new PackageMigrationPlanCollection(() => plans);
+        Dictionary<string, PlanSpec> specsByName = specs.ToDictionary(spec => spec.Name);
+
+        var migrationExecutor = new Mock<IMigrationPlanExecutor>();
+        migrationExecutor
+            .Setup(x => x.ExecutePlanAsync(It.IsAny<MigrationPlan>(), It.IsAny<string>()))
+            .ReturnsAsync((MigrationPlan executedPlan, string initialState) =>
+            {
+                PlanSpec spec = specsByName[executedPlan.Name];
+                return new ExecutedMigrationPlan
+                {
+                    Plan = executedPlan,
+                    InitialState = initialState,
+                    FinalState = spec.Successful ? "done" : initialState,
+                    Successful = spec.Successful,
+                    Exception = spec.Exception,
+                    CompletedTransitions = Array.Empty<MigrationPlan.Transition>(),
+                };
+            });
+
+        var scopeProvider = new Mock<ICoreScopeProvider>();
+        scopeProvider
+            .Setup(x => x.CreateCoreScope(
+                It.IsAny<IsolationLevel>(),
+                It.IsAny<RepositoryCacheMode>(),
+                It.IsAny<IEventDispatcher?>(),
+                It.IsAny<IScopedNotificationPublisher?>(),
+                It.IsAny<bool?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>()))
+            .Returns(Mock.Of<ICoreScope>());
+
+        var packageMigrationRunner = new PackageMigrationRunner(
+            Mock.Of<IProfilingLogger>(),
+            scopeProvider.Object,
+            new PendingPackageMigrations(NullLogger<PendingPackageMigrations>.Instance, planCollection),
+            planCollection,
+            migrationExecutor.Object,
+            Mock.Of<IKeyValueService>(),
+            Mock.Of<IEventAggregator>(),
+            NullLogger<PackageMigrationRunner>.Instance);
+
+        Mock<IRuntimeState> runtimeState = CreateRuntimeState(specs.Select(spec => spec.Name).ToArray());
+
+        var sut = new UnattendedUpgrader(
+            Mock.Of<IProfilingLogger>(),
+            Mock.Of<IUmbracoVersion>(),
+            databaseBuilder: null!, // Unused on the package-migration branch exercised by these tests.
+            runtimeState.Object,
+            packageMigrationRunner,
+            Options.Create(new UnattendedSettings()),
+            CreateDistributedCache(),
+            NullLogger<UnattendedUpgrader>.Instance);
+
+        return (sut, runtimeState);
+    }
+
+    private static Mock<IRuntimeState> CreateRuntimeState(IReadOnlyList<string> pendingPlanNames)
+    {
+        var mock = new Mock<IRuntimeState>();
+        mock.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+        mock.SetupGet(x => x.Reason).Returns(RuntimeLevelReason.UpgradePackageMigrations);
+        mock.SetupGet(x => x.StartupState).Returns(new Dictionary<string, object>
+        {
+            [RuntimeState.PendingPackageMigrationsStateKey] = pendingPlanNames,
+        });
+        return mock;
+    }
+
+    private static Func<Exception?> CaptureBootFailedException(Mock<IRuntimeState> runtimeState)
+    {
+        Exception? captured = null;
+        runtimeState
+            .Setup(x => x.Configure(RuntimeLevel.BootFailed, It.IsAny<RuntimeLevelReason>(), It.IsAny<Exception?>()))
+            .Callback<RuntimeLevel, RuntimeLevelReason, Exception?>((_, _, exception) => captured = exception);
+        return () => captured;
+    }
+
+    private static DistributedCache CreateDistributedCache()
+    {
+        static ICacheRefresher Refresher(Guid id)
+        {
+            var mock = new Mock<ICacheRefresher>();
+            mock.SetupGet(x => x.RefresherUniqueId).Returns(id);
+            return mock.Object;
+        }
+
+        var refreshers = new CacheRefresherCollection(() => new[]
+        {
+            Refresher(ContentCacheRefresher.UniqueId),
+            Refresher(MediaCacheRefresher.UniqueId),
+            Refresher(DomainCacheRefresher.UniqueId),
+        });
+
+        return new DistributedCache(Mock.Of<IServerMessenger>(), refreshers);
+    }
+
+    private sealed record PlanSpec(string Name, bool Successful, Exception? Exception);
+
+    private sealed class TestPackageMigrationPlan : PackageMigrationPlan
+    {
+        public TestPackageMigrationPlan(string planName)
+            : base(planName)
+        {
+        }
+
+        protected override void DefinePlan() => To<NoOpMigration>("done");
+    }
+
+    private sealed class NoOpMigration : AsyncMigrationBase
+    {
+        public NoOpMigration(IMigrationContext context)
+            : base(context)
+        {
+        }
+
+        protected override async Task MigrateAsync()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Description

### Background

There's no GitHub issue for this — it came in via customer support.

The Cloud team reported that, after a specific upgrade, sites would get stuck on the **"Website is Under Maintenance / Automatic upgrade in progress"** page and never recover. Restarting did not help — every restart re-stuck the site.

Tracing the reported log, the chain was:

1. The unattended upgrade background service starts and runs a **package migration** (in the reported case an UmbracoForms migration).
2. A migration step throws a `SqlException`.
3. `MigrationPlanExecutor` **catches** that exception and returns an `ExecutedMigrationPlan` with `Successful = false` rather than throwing (this is deliberate — `PackageMigrationRunner` runs *all* package plans to completion so one package's failure doesn't block another's).
4. `UnattendedUpgrader.RunPackageMigrationsAsync` only set `BootFailed` from its `catch` block — i.e. it relied on an exception being **thrown**. Because the runner returns the failure as a result instead, the catch was never hit, and the result was recorded as `PackageMigrationComplete` (a success).
5. The migration genuinely failed and rolled back, so it stays pending. On the next `DetermineRuntimeLevel()` the runtime re-derives `RuntimeLevel.Upgrading` from "package migrations still pending". The background service runs once per process and exits "successfully" while the level is still `Upgrading` → the maintenance page is served forever, and every restart repeats the same failing migration.

The **core upgrade** path does not have this hole — `RunUpgradeAsync` explicitly checks `result?.Success == false` and configures `BootFailed`. Only the **package-migration** branch swallowed the failure.

(The specific UmbracoForms migration failure that triggered this has since been [fixed separately](https://github.com/umbraco/Forms/pull/1314). This change fixes the CMS behaviour so a failed unattended package migration is surfaced consistently, regardless of which package caused it.)

### Change Details

`UnattendedUpgrader.RunPackageMigrationsAsync` now inspects the results returned by `RunPackagePlansAsync` and, if any plan did not succeed, configures `RuntimeLevel.BootFailed` (mirroring the core upgrade path) and reports `HasErrors` — instead of silently treating the run as complete.

- The "run all plans to completion even if one fails" behaviour of `PackageMigrationRunner` is **preserved** — we no longer ignore the outcome.
- **All** failed plans are reported together: a single failure surfaces that plan's own exception; multiple failures are wrapped in an `AggregateException` listing every failed plan, so an operator can address them in one pass.

A failed unattended package migration now results in `BootFailed` (HTTP 500 / the friendly `BootFailed.html` error page in production, or a rethrown exception in debug mode) instead of a permanent `Upgrading` maintenance page, consistent with how a failed core migration already behaves.

## Testing

### Automated

- `UnattendedUpgraderTests` (unit) — single failure surfaces the plan exception; multiple failures aggregate; a failed plan with no exception falls back to a descriptive `UnattendedInstallException`; a successful run does **not** set `BootFailed`.
- `UnattendedPackageMigrationTests` (integration) — drives a genuinely-throwing package migration through the **real** `MigrationPlanExecutor` and asserts the boot fails (rather than silently completing) with the original exception surfaced.

All tests were verified to fail with the fix reverted and pass with it applied.

### Manual

To manually test I created the following package migration plan:

```csharp
using Umbraco.Cms.Core.Packaging;
using Umbraco.Cms.Infrastructure.Migrations;

namespace Umbraco.Cms.Web.UI.PackageMigration;

public class FailingTestPackageMigrationPlan : PackageMigrationPlan
{
    public FailingTestPackageMigrationPlan()
        : base("FailingTestPackage")
    {
    }

    protected override void DefinePlan()
    {
        To<LogStep>("log-step");
        To<FailStep>("fail-step");
    }

    private class LogStep : MigrationBase
    {
        private readonly ILogger<LogStep> _logger;

        public LogStep(IMigrationContext context, ILogger<LogStep> logger)
            : base(context) => _logger = logger;

        protected override void Migrate()
            => _logger.LogInformation("FailingTestPackageMigrationPlan: log step ran.");
    }

    private class FailStep : MigrationBase
    {
        private readonly ILogger<FailStep> _logger;

        public FailStep(IMigrationContext context, ILogger<FailStep> logger)
            : base(context) => _logger = logger;

        protected override void Migrate()
        {
            throw new InvalidOperationException(
                "FailingTestPackageMigrationPlan: fail step deliberately threw to reproduce the stuck-upgrade bug.");
        }
    }
}
```

`Umbraco:CMS:Unattended:PackageMigrationsUnattended` should be configured to `true`.

Start the site.
   - **Before this change:** the site is stuck on "Automatic upgrade in progress" and stays there across restarts; the log shows `Plan … failed at step …` followed by `Unattended upgrade completed successfully.`
   - **After this change:** the site reports a boot failure surfacing the migration's exception, and does not get stuck on the upgrade screen.