### PR TITLE
Unattended upgrades: Gate the front-end until post-upgrade initialization completes (fixes intermittent routing failure)

### DIFF
--- a/src/Umbraco.Core/Services/IRuntimeStartupReadiness.cs
+++ b/src/Umbraco.Core/Services/IRuntimeStartupReadiness.cs
@@ -1,0 +1,20 @@
+namespace Umbraco.Cms.Core.Services;
+
+/// <summary>
+/// Reports whether the runtime is ready to serve front-end requests.
+/// </summary>
+/// <remarks>
+/// During an unattended upgrade the HTTP server accepts requests while the upgrade runs on a background thread.
+/// The runtime level flips to <see cref="RuntimeLevel.Run"/> before component/application-starting initialization
+/// (e.g. document URL routing) has completed. This signal lets the front end stay on the maintenance page until
+/// that initialization is finished, rather than serving requests against not-yet-initialized services.
+/// On a normal boot nothing toggles this, so it always reports ready.
+/// </remarks>
+public interface IRuntimeStartupReadiness
+{
+    /// <summary>
+    /// Gets a value indicating whether the runtime is ready to serve front-end requests.
+    /// Defaults to <c>true</c> so a normal boot is never gated.
+    /// </summary>
+    bool IsReadyToServe { get; }
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -95,6 +95,9 @@ public static partial class UmbracoBuilderExtensions
         builder.AddNotificationAsyncHandler<RuntimeUnattendedUpgradeNotification, UnattendedUpgrader>();
         builder.AddNotificationAsyncHandler<RuntimePremigrationsUpgradeNotification, PremigrationUpgrader>();
         builder.Services.AddSingleton<IMigrationCoordinator, MigrationCoordinator>();
+        builder.Services.AddSingleton<RuntimeStartupReadiness>();
+        builder.Services.AddSingleton<IRuntimeStartupReadiness>(factory => factory.GetRequiredService<RuntimeStartupReadiness>());
+        builder.Services.AddSingleton<IRuntimeStartupReadinessControl>(factory => factory.GetRequiredService<RuntimeStartupReadiness>());
         builder.Services.AddHostedService<UnattendedUpgradeBackgroundService>();
 
         // Database availability check.

--- a/src/Umbraco.Infrastructure/Install/IRuntimeStartupReadinessControl.cs
+++ b/src/Umbraco.Infrastructure/Install/IRuntimeStartupReadinessControl.cs
@@ -1,0 +1,20 @@
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.Install;
+
+/// <summary>
+/// Internal control surface for toggling <see cref="IRuntimeStartupReadiness.IsReadyToServe"/>.
+/// Kept out of the public read interface so only the runtime (this assembly) can change readiness.
+/// </summary>
+internal interface IRuntimeStartupReadinessControl
+{
+    /// <summary>
+    /// Marks the runtime as not yet ready to serve front-end requests (background finalization in progress).
+    /// </summary>
+    void SetNotReady();
+
+    /// <summary>
+    /// Marks the runtime as ready to serve front-end requests.
+    /// </summary>
+    void SetReady();
+}

--- a/src/Umbraco.Infrastructure/Install/RuntimeStartupReadiness.cs
+++ b/src/Umbraco.Infrastructure/Install/RuntimeStartupReadiness.cs
@@ -1,0 +1,20 @@
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.Install;
+
+/// <inheritdoc cref="IRuntimeStartupReadiness" />
+internal sealed class RuntimeStartupReadiness : IRuntimeStartupReadiness, IRuntimeStartupReadinessControl
+{
+    // Single writer (the unattended upgrade background thread), many readers (request threads).
+    // Only visibility is required, not atomicity of a compound operation, so volatile is sufficient.
+    private volatile bool _isReady = true; // Default ready: a normal boot never touches this.
+
+    /// <inheritdoc />
+    public bool IsReadyToServe => _isReady;
+
+    /// <inheritdoc />
+    public void SetNotReady() => _isReady = false;
+
+    /// <inheritdoc />
+    public void SetReady() => _isReady = true;
+}

--- a/src/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundService.cs
+++ b/src/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundService.cs
@@ -25,6 +25,7 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
     private readonly ComponentCollection _components;
     private readonly IHostApplicationLifetime _hostApplicationLifetime;
     private readonly IMigrationCoordinator _coordinator;
+    private readonly IRuntimeStartupReadinessControl _readiness;
     private readonly ILogger<UnattendedUpgradeBackgroundService> _logger;
 
     /// <summary>
@@ -35,6 +36,7 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
     /// <param name="components">The component collection to initialize after migration completes.</param>
     /// <param name="hostApplicationLifetime">The host application lifetime for registering started/stopped callbacks.</param>
     /// <param name="coordinator">Coordinates migration leadership across servers in a load-balanced environment.</param>
+    /// <param name="readiness">Gates front-end serving until post-migration initialization has completed.</param>
     /// <param name="logger">The logger.</param>
     public UnattendedUpgradeBackgroundService(
         IRuntimeState runtimeState,
@@ -42,6 +44,7 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
         ComponentCollection components,
         IHostApplicationLifetime hostApplicationLifetime,
         IMigrationCoordinator coordinator,
+        IRuntimeStartupReadinessControl readiness,
         ILogger<UnattendedUpgradeBackgroundService> logger)
     {
         _runtimeState = runtimeState;
@@ -49,6 +52,7 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
         _components = components;
         _hostApplicationLifetime = hostApplicationLifetime;
         _coordinator = coordinator;
+        _readiness = readiness;
         _logger = logger;
     }
 
@@ -63,73 +67,88 @@ internal sealed class UnattendedUpgradeBackgroundService : BackgroundService
 
         _logger.LogInformation("Unattended upgrade background service started.");
 
+        // Keep the front end gated for the entire background finalization, re-opening only once
+        // post-migration initialization (components + application-starting handlers, e.g. document URL
+        // routing) has completed. This must be set BEFORE TryBecomeLeaderAsync: on a follower the level
+        // flips to Run while polling inside that call, so the gate has to already be closed by then.
+        _readiness.SetNotReady();
+
         bool isLeader = false;
 
         try
         {
-            isLeader = await _coordinator.TryBecomeLeaderAsync(stoppingToken);
+            try
+            {
+                isLeader = await _coordinator.TryBecomeLeaderAsync(stoppingToken);
+
+                if (_runtimeState.Level == RuntimeLevel.BootFailed)
+                {
+                    return;
+                }
+
+                if (isLeader)
+                {
+                    // Belt-and-suspenders for graceful shutdowns (e.g. Azure SIGTERM): release the claim
+                    // as soon as the host begins stopping, even if a migration step is still blocking.
+                    _hostApplicationLifetime.ApplicationStopping.Register(() => _coordinator.ReleaseLeadership());
+                    await RunMigrationsAsync(stoppingToken);
+                }
+                else
+                {
+                    // Follower: rebuild per-server in-memory navigation and publish status
+                    // from the fully-migrated database.
+                    await _eventAggregator.PublishAsync(new PostRuntimePremigrationsUpgradeNotification(), stoppingToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unattended upgrade failed.");
+                _runtimeState.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, ex);
+                return;
+            }
+            finally
+            {
+                // Always release the claim — even on leader failure — so other servers
+                // can detect completion or take over.
+                if (isLeader)
+                {
+                    _coordinator.ReleaseLeadership();
+                }
+            }
+
+            // For the leader: confirms migrations succeeded and level transitions to Run.
+            // For followers: level is already Run (set during TryBecomeLeaderAsync polling).
+            DetermineRuntimeLevel();
 
             if (_runtimeState.Level == RuntimeLevel.BootFailed)
             {
                 return;
             }
 
-            if (isLeader)
+            // Migrations complete: initialize components and fire application lifecycle events.
+            try
             {
-                // Belt-and-suspenders for graceful shutdowns (e.g. Azure SIGTERM): release the claim
-                // as soon as the host begins stopping, even if a migration step is still blocking.
-                _hostApplicationLifetime.ApplicationStopping.Register(() => _coordinator.ReleaseLeadership());
-                await RunMigrationsAsync(stoppingToken);
+                await _components.InitializeAsync(false, stoppingToken);
+                await _eventAggregator.PublishAsync(new UmbracoApplicationStartingNotification(_runtimeState.Level, false), stoppingToken);
+
+                _hostApplicationLifetime.ApplicationStarted.Register(
+                    () => _eventAggregator.Publish(new UmbracoApplicationStartedNotification(false)));
+                _hostApplicationLifetime.ApplicationStopped.Register(
+                    () => _eventAggregator.Publish(new UmbracoApplicationStoppedNotification(false)));
+
+                _logger.LogInformation("Unattended upgrade completed successfully.");
             }
-            else
+            catch (Exception ex)
             {
-                // Follower: rebuild per-server in-memory navigation and publish status
-                // from the fully-migrated database.
-                await _eventAggregator.PublishAsync(new PostRuntimePremigrationsUpgradeNotification(), stoppingToken);
+                _logger.LogError(ex, "Unattended upgrade post-migration initialization failed.");
+                _runtimeState.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, ex);
             }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unattended upgrade failed.");
-            _runtimeState.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, ex);
-            return;
         }
         finally
         {
-            // Always release the claim — even on leader failure — so other servers
-            // can detect completion or take over.
-            if (isLeader)
-            {
-                _coordinator.ReleaseLeadership();
-            }
-        }
-
-        // For the leader: confirms migrations succeeded and level transitions to Run.
-        // For followers: level is already Run (set during TryBecomeLeaderAsync polling).
-        DetermineRuntimeLevel();
-
-        if (_runtimeState.Level == RuntimeLevel.BootFailed)
-        {
-            return;
-        }
-
-        // Migrations complete: initialize components and fire application lifecycle events.
-        try
-        {
-            await _components.InitializeAsync(false, stoppingToken);
-            await _eventAggregator.PublishAsync(new UmbracoApplicationStartingNotification(_runtimeState.Level, false), stoppingToken);
-
-            _hostApplicationLifetime.ApplicationStarted.Register(
-                () => _eventAggregator.Publish(new UmbracoApplicationStartedNotification(false)));
-            _hostApplicationLifetime.ApplicationStopped.Register(
-                () => _eventAggregator.Publish(new UmbracoApplicationStoppedNotification(false)));
-
-            _logger.LogInformation("Unattended upgrade completed successfully.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Unattended upgrade post-migration initialization failed.");
-            _runtimeState.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, ex);
+            // Always re-open the gate (on every exit path) so it can never wedge closed. On BootFailed the
+            // maintenance filter no longer matters because BootFailedMiddleware intercepts the request first.
+            _readiness.SetReady();
         }
     }
 

--- a/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
@@ -54,16 +54,14 @@ public sealed class MaintenanceModeActionFilterAttribute : TypeFilterAttribute
 
             // After an unattended upgrade the level flips to Run before post-migration initialization
             // (e.g. document URL routing) completes; keep the front end gated until it is ready to serve.
-            bool deferredStartupPending = _runtimeState.Level == RuntimeLevel.Run && _readiness.IsReadyToServe is false;
+            bool deferredStartupPending = IsDeferredStartupPending();
 
             // API controllers (Management/Delivery API) are only blocked during an unattended upgrade
             // (RuntimeLevel.Upgrading). During an attended upgrade (RuntimeLevel.Upgrade) the operator
             // needs API access to log in and trigger the upgrade from the backoffice.
             // MVC controllers (website, surface) are blocked during both Upgrade and Upgrading, and also
             // during the brief not-yet-ready window after the level flips to Run.
-            bool shouldBlock = isApiController
-                ? _runtimeState.Level == RuntimeLevel.Upgrading
-                : _runtimeState.Level is RuntimeLevel.Upgrade or RuntimeLevel.Upgrading || deferredStartupPending;
+            bool shouldBlock = ShouldBlockRequest(isApiController, deferredStartupPending);
 
             if (shouldBlock is false)
             {
@@ -88,6 +86,14 @@ public sealed class MaintenanceModeActionFilterAttribute : TypeFilterAttribute
                 ? new MaintenanceResult(_globalSettings.CurrentValue.UpgradingViewPath)
                 : new MaintenanceResult();
         }
+
+        private bool IsDeferredStartupPending() =>
+            _runtimeState.Level == RuntimeLevel.Run && _readiness.IsReadyToServe is false;
+
+        private bool ShouldBlockRequest(bool isApiController, bool deferredStartupPending) =>
+            isApiController
+                ? _runtimeState.Level == RuntimeLevel.Upgrading
+                : _runtimeState.Level is RuntimeLevel.Upgrade or RuntimeLevel.Upgrading || deferredStartupPending;
 
         public void OnActionExecuted(ActionExecutedContext context)
         {

--- a/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
+++ b/src/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttribute.cs
@@ -26,11 +26,16 @@ public sealed class MaintenanceModeActionFilterAttribute : TypeFilterAttribute
     {
         private readonly IRuntimeState _runtimeState;
         private readonly IOptionsMonitor<GlobalSettings> _globalSettings;
+        private readonly IRuntimeStartupReadiness _readiness;
 
-        public MaintenanceModeActionFilter(IRuntimeState runtimeState, IOptionsMonitor<GlobalSettings> globalSettings)
+        public MaintenanceModeActionFilter(
+            IRuntimeState runtimeState,
+            IOptionsMonitor<GlobalSettings> globalSettings,
+            IRuntimeStartupReadiness readiness)
         {
             _runtimeState = runtimeState;
             _globalSettings = globalSettings;
+            _readiness = readiness;
         }
 
         public void OnActionExecuting(ActionExecutingContext context)
@@ -47,13 +52,18 @@ public sealed class MaintenanceModeActionFilterAttribute : TypeFilterAttribute
 
             bool isApiController = context.ActionDescriptor.EndpointMetadata.OfType<ApiControllerAttribute>().Any();
 
+            // After an unattended upgrade the level flips to Run before post-migration initialization
+            // (e.g. document URL routing) completes; keep the front end gated until it is ready to serve.
+            bool deferredStartupPending = _runtimeState.Level == RuntimeLevel.Run && _readiness.IsReadyToServe is false;
+
             // API controllers (Management/Delivery API) are only blocked during an unattended upgrade
             // (RuntimeLevel.Upgrading). During an attended upgrade (RuntimeLevel.Upgrade) the operator
             // needs API access to log in and trigger the upgrade from the backoffice.
-            // MVC controllers (website, surface) are blocked during both Upgrade and Upgrading.
+            // MVC controllers (website, surface) are blocked during both Upgrade and Upgrading, and also
+            // during the brief not-yet-ready window after the level flips to Run.
             bool shouldBlock = isApiController
                 ? _runtimeState.Level == RuntimeLevel.Upgrading
-                : _runtimeState.Level is RuntimeLevel.Upgrade or RuntimeLevel.Upgrading;
+                : _runtimeState.Level is RuntimeLevel.Upgrade or RuntimeLevel.Upgrading || deferredStartupPending;
 
             if (shouldBlock is false)
             {
@@ -72,7 +82,9 @@ public sealed class MaintenanceModeActionFilterAttribute : TypeFilterAttribute
                 return;
             }
 
-            context.Result = _runtimeState.Level == RuntimeLevel.Upgrading
+            // The not-yet-ready window is the tail end of an unattended upgrade, so show the same
+            // "upgrade in progress" page as during the upgrade itself.
+            context.Result = _runtimeState.Level == RuntimeLevel.Upgrading || deferredStartupPending
                 ? new MaintenanceResult(_globalSettings.CurrentValue.UpgradingViewPath)
                 : new MaintenanceResult();
         }

--- a/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
+++ b/src/Umbraco.Web.Website/Routing/EagerMatcherPolicy.cs
@@ -41,6 +41,7 @@ internal sealed class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolic
     private readonly UmbracoRequestPaths _umbracoRequestPaths;
     private readonly IUmbracoContextAccessor _umbracoContextAccessor;
     private readonly IPublishedRouter _publishedRouter;
+    private readonly IRuntimeStartupReadiness _readiness;
     private GlobalSettings _globalSettings;
     private readonly Lazy<Endpoint> _installEndpoint;
     private readonly Lazy<Endpoint> _renderEndpoint;
@@ -51,13 +52,15 @@ internal sealed class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolic
         UmbracoRequestPaths umbracoRequestPaths,
         IOptionsMonitor<GlobalSettings> globalSettings,
         IUmbracoContextAccessor umbracoContextAccessor,
-        IPublishedRouter publishedRouter)
+        IPublishedRouter publishedRouter,
+        IRuntimeStartupReadiness readiness)
     {
         _runtimeState = runtimeState;
         _endpointDataSource = endpointDataSource;
         _umbracoRequestPaths = umbracoRequestPaths;
         _umbracoContextAccessor = umbracoContextAccessor;
         _publishedRouter = publishedRouter;
+        _readiness = readiness;
         _globalSettings = globalSettings.CurrentValue;
         globalSettings.OnChange(settings => _globalSettings = settings);
         _installEndpoint = new Lazy<Endpoint>(GetInstallEndpoint);
@@ -72,7 +75,10 @@ internal sealed class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolic
 
     public async Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
     {
-        if (_runtimeState.Level != RuntimeLevel.Run)
+        // After an unattended upgrade the level flips to Run before post-migration initialization
+        // (e.g. document URL routing) completes. Treat that not-yet-ready window like an upgrade so the
+        // front end is re-routed to the maintenance page instead of routing against not-yet-initialized services.
+        if (_runtimeState.Level != RuntimeLevel.Run || _readiness.IsReadyToServe is false)
         {
             var handled = await HandleInstallUpgrade(httpContext, candidates);
             if (handled)
@@ -231,7 +237,13 @@ internal sealed class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolic
 
     private Task<bool> HandleInstallUpgrade(HttpContext httpContext, CandidateSet candidates)
     {
-        if (_runtimeState.Level is not RuntimeLevel.Upgrade and not RuntimeLevel.Upgrading)
+        // The front end is gated (re-routed to the maintenance page) during an upgrade, and also during the
+        // brief not-yet-ready window after an unattended upgrade flips the level to Run but before post-migration
+        // initialization completes. Everything else handled here is the install state.
+        var showMaintenance = _runtimeState.Level is RuntimeLevel.Upgrade or RuntimeLevel.Upgrading
+            || (_runtimeState.Level == RuntimeLevel.Run && _readiness.IsReadyToServe is false);
+
+        if (showMaintenance is false)
         {
             // We need to let the installer API requests through
             // Currently we do this with a check for the installer path
@@ -266,8 +278,7 @@ internal sealed class EagerMatcherPolicy : MatcherPolicy, IEndpointSelectorPolic
             }
         }
 
-        if (_runtimeState.Level is not RuntimeLevel.Upgrade and not RuntimeLevel.Upgrading
-            || _globalSettings.ShowMaintenancePageWhenInUpgradeState is false
+        if (_globalSettings.ShowMaintenancePageWhenInUpgradeState is false
             || hasStaticRoute)
         {
             return Task.FromResult(false);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundServiceTests.cs
@@ -229,11 +229,59 @@ public class UnattendedUpgradeBackgroundServiceTests
             Times.Once);
     }
 
+    [Test]
+    public async Task ExecuteAsync_OpensReadinessGate_OnlyAfterApplicationStartingInitialization()
+    {
+        // The front-end serving gate must close BEFORE leadership coordination (on a follower the level
+        // flips to Run while polling inside TryBecomeLeaderAsync), stay closed across the level flip, and
+        // only re-open after UmbracoApplicationStartingNotification has run post-migration initialization
+        // (e.g. document URL routing). Otherwise requests are served before routing is initialized.
+        var sequence = 0;
+        var setNotReadyOrder = 0;
+        var tryBecomeLeaderOrder = 0;
+        var applicationStartingOrder = 0;
+        var setReadyOrder = 0;
+
+        var runtimeState = CreateMockRuntimeState();
+        var eventAggregator = new Mock<IEventAggregator>();
+        SetupPublishAsync(eventAggregator, upgradeResult: RuntimeUnattendedUpgradeNotification.UpgradeResult.PackageMigrationComplete);
+        eventAggregator
+            .Setup(x => x.PublishAsync(It.IsAny<UmbracoApplicationStartingNotification>(), It.IsAny<CancellationToken>()))
+            .Callback(() => applicationStartingOrder = ++sequence)
+            .Returns(Task.CompletedTask);
+
+        var coordinator = new Mock<IMigrationCoordinator>();
+        coordinator
+            .Setup(x => x.TryBecomeLeaderAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => tryBecomeLeaderOrder = ++sequence)
+            .ReturnsAsync(true);
+
+        var readiness = new Mock<IRuntimeStartupReadinessControl>();
+        readiness.Setup(x => x.SetNotReady()).Callback(() => setNotReadyOrder = ++sequence);
+        readiness.Setup(x => x.SetReady()).Callback(() => setReadyOrder = ++sequence);
+
+        var sut = CreateSut(runtimeState.Object, eventAggregator.Object, coordinator: coordinator.Object, readiness: readiness.Object);
+
+        await sut.StartAsync(CancellationToken.None);
+        await sut.ExecuteTask!;
+
+        Assert.Multiple(() =>
+        {
+            readiness.Verify(x => x.SetNotReady(), Times.Once);
+            readiness.Verify(x => x.SetReady(), Times.Once);
+            Assert.That(setNotReadyOrder, Is.GreaterThan(0), "The gate must be closed during finalization.");
+            Assert.That(tryBecomeLeaderOrder, Is.GreaterThan(setNotReadyOrder), "The gate must close before leadership coordination (followers flip to Run inside it).");
+            Assert.That(applicationStartingOrder, Is.GreaterThan(setNotReadyOrder), "Application-starting init must run while the gate is closed.");
+            Assert.That(setReadyOrder, Is.GreaterThan(applicationStartingOrder), "The gate must re-open only after application-starting initialization completes.");
+        });
+    }
+
     private static UnattendedUpgradeBackgroundService CreateSut(
         IRuntimeState runtimeState,
         IEventAggregator eventAggregator,
         IHostApplicationLifetime? hostApplicationLifetime = null,
-        IMigrationCoordinator? coordinator = null)
+        IMigrationCoordinator? coordinator = null,
+        IRuntimeStartupReadinessControl? readiness = null)
     {
         var components = new ComponentCollection(
             () => Enumerable.Empty<IAsyncComponent>(),
@@ -249,6 +297,7 @@ public class UnattendedUpgradeBackgroundServiceTests
             components,
             hostApplicationLifetime ?? CreateMockLifetime().Object,
             coordinator,
+            readiness ?? new RuntimeStartupReadiness(),
             NullLogger<UnattendedUpgradeBackgroundService>.Instance);
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Install/UnattendedUpgradeBackgroundServiceTests.cs
@@ -276,6 +276,34 @@ public class UnattendedUpgradeBackgroundServiceTests
         });
     }
 
+    [Test]
+    public async Task ExecuteAsync_WhenInitializationFails_StillReopensReadinessGate()
+    {
+        // Even on a BootFailed exit the gate must re-open (guaranteed by the outer try/finally) so it can
+        // never wedge closed. Guards against a future refactor moving SetReady() into an inner block.
+        var runtimeState = CreateMockRuntimeState();
+        var eventAggregator = new Mock<IEventAggregator>();
+        eventAggregator
+            .Setup(x => x.PublishAsync(It.IsAny<RuntimePremigrationsUpgradeNotification>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db gone"));
+
+        var readiness = new Mock<IRuntimeStartupReadinessControl>();
+
+        var sut = CreateSut(runtimeState.Object, eventAggregator.Object, readiness: readiness.Object);
+
+        await sut.StartAsync(CancellationToken.None);
+        await sut.ExecuteTask!;
+
+        Assert.Multiple(() =>
+        {
+            runtimeState.Verify(
+                x => x.Configure(RuntimeLevel.BootFailed, RuntimeLevelReason.BootFailedOnException, It.IsNotNull<Exception>()),
+                Times.Once);
+            readiness.Verify(x => x.SetNotReady(), Times.Once);
+            readiness.Verify(x => x.SetReady(), Times.Once);
+        });
+    }
+
     private static UnattendedUpgradeBackgroundService CreateSut(
         IRuntimeState runtimeState,
         IEventAggregator eventAggregator,

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttributeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Controllers/MaintenanceModeActionFilterAttributeTests.cs
@@ -85,6 +85,42 @@ public class MaintenanceModeActionFilterAttributeTests
     }
 
     [Test]
+    public void OnActionExecuting_MvcController_WhenRunButNotReady_SetsMaintenanceResult()
+    {
+        // After an unattended upgrade the level flips to Run before post-migration initialization completes;
+        // the front end must stay gated until ready to serve.
+        var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = true };
+        var context = CreateMvcControllerContext();
+
+        InvokeFilter(RuntimeLevel.Run, settings, context, isReadyToServe: false);
+
+        Assert.That(context.Result, Is.InstanceOf<MaintenanceResult>());
+    }
+
+    [Test]
+    public void OnActionExecuting_MvcController_WhenRunButNotReadyAndMaintenanceDisabled_DoesNotSetResult()
+    {
+        var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = false };
+        var context = CreateMvcControllerContext();
+
+        InvokeFilter(RuntimeLevel.Run, settings, context, isReadyToServe: false);
+
+        Assert.That(context.Result, Is.Null);
+    }
+
+    [Test]
+    public void OnActionExecuting_ApiController_WhenRunButNotReady_DoesNotSetResult()
+    {
+        // The API/health surface comes back as soon as the level is Run; only the front end is gated by readiness.
+        var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = true };
+        var context = CreateApiControllerContext();
+
+        InvokeFilter(RuntimeLevel.Run, settings, context, isReadyToServe: false);
+
+        Assert.That(context.Result, Is.Null);
+    }
+
+    [Test]
     public void OnActionExecuting_ApiController_WhenUpgradingAndMaintenanceEnabled_SetsProblemDetailsResult()
     {
         var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = true };
@@ -152,12 +188,13 @@ public class MaintenanceModeActionFilterAttributeTests
         Assert.That(context.Result, Is.Null);
     }
 
-    private static void InvokeFilter(RuntimeLevel level, GlobalSettings settings, ActionExecutingContext context)
+    private static void InvokeFilter(RuntimeLevel level, GlobalSettings settings, ActionExecutingContext context, bool isReadyToServe = true)
     {
         var attribute = new MaintenanceModeActionFilterAttribute();
         var services = new ServiceCollection()
             .AddSingleton(Mock.Of<IRuntimeState>(s => s.Level == level))
             .AddSingleton(Mock.Of<IOptionsMonitor<GlobalSettings>>(m => m.CurrentValue == settings))
+            .AddSingleton(Mock.Of<IRuntimeStartupReadiness>(r => r.IsReadyToServe == isReadyToServe))
             .BuildServiceProvider();
 
         var filter = (IActionFilter)attribute.CreateInstance(services);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/EagerMatcherPolicyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/EagerMatcherPolicyTests.cs
@@ -29,7 +29,7 @@ public class EagerMatcherPolicyTests
         // endpoint so the maintenance page is shown, instead of routing against not-yet-initialized services.
         Endpoint renderEndpoint = CreateRenderEndpoint();
         EagerMatcherPolicy sut = CreateSut(RuntimeLevel.Run, isReadyToServe: false, renderEndpoint);
-        CandidateSet candidates = CreateDynamicCandidateSet(out Endpoint dynamicEndpoint);
+        CandidateSet candidates = CreateDynamicCandidateSet(out _);
 
         await sut.ApplyAsync(new DefaultHttpContext(), candidates);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/EagerMatcherPolicyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/EagerMatcherPolicyTests.cs
@@ -49,9 +49,23 @@ public class EagerMatcherPolicyTests
         Assert.That(candidates[0].Endpoint, Is.SameAs(dynamicEndpoint));
     }
 
-    private static EagerMatcherPolicy CreateSut(RuntimeLevel level, bool isReadyToServe, Endpoint renderEndpoint)
+    [Test]
+    public async Task ApplyAsync_WhenRunButNotReadyAndMaintenancePageDisabled_DoesNotReRoute()
     {
-        var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = true };
+        // With the maintenance-page opt-out disabled, the front end is not gated even while not ready:
+        // HandleInstallUpgrade returns "not handled", leaving the dynamic content route intact.
+        Endpoint renderEndpoint = CreateRenderEndpoint();
+        EagerMatcherPolicy sut = CreateSut(RuntimeLevel.Run, isReadyToServe: false, renderEndpoint, showMaintenancePage: false);
+        CandidateSet candidates = CreateDynamicCandidateSet(out Endpoint dynamicEndpoint);
+
+        await sut.ApplyAsync(new DefaultHttpContext(), candidates);
+
+        Assert.That(candidates[0].Endpoint, Is.SameAs(dynamicEndpoint));
+    }
+
+    private static EagerMatcherPolicy CreateSut(RuntimeLevel level, bool isReadyToServe, Endpoint renderEndpoint, bool showMaintenancePage = true)
+    {
+        var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = showMaintenancePage };
         return new EagerMatcherPolicy(
             Mock.Of<IRuntimeState>(s => s.Level == level),
             new DefaultEndpointDataSource(renderEndpoint),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/EagerMatcherPolicyTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Website/Routing/EagerMatcherPolicyTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Controllers;
+using Umbraco.Cms.Web.Website.Routing;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Website.Routing;
+
+[TestFixture]
+public class EagerMatcherPolicyTests
+{
+    [Test]
+    public async Task ApplyAsync_WhenRunButNotReadyToServe_ReRoutesToMaintenanceRenderEndpoint()
+    {
+        // The runtime has flipped to Run after an unattended upgrade, but post-migration initialization
+        // is not finished (not ready to serve). The front-end request must be re-routed to the render
+        // endpoint so the maintenance page is shown, instead of routing against not-yet-initialized services.
+        Endpoint renderEndpoint = CreateRenderEndpoint();
+        EagerMatcherPolicy sut = CreateSut(RuntimeLevel.Run, isReadyToServe: false, renderEndpoint);
+        CandidateSet candidates = CreateDynamicCandidateSet(out Endpoint dynamicEndpoint);
+
+        await sut.ApplyAsync(new DefaultHttpContext(), candidates);
+
+        Assert.That(candidates[0].Endpoint, Is.SameAs(renderEndpoint));
+    }
+
+    [Test]
+    public async Task ApplyAsync_WhenRunAndReadyToServe_DoesNotReRoute()
+    {
+        // Normal running state: the dynamic content route must be left intact (no false-positive gating).
+        Endpoint renderEndpoint = CreateRenderEndpoint();
+        EagerMatcherPolicy sut = CreateSut(RuntimeLevel.Run, isReadyToServe: true, renderEndpoint);
+        CandidateSet candidates = CreateDynamicCandidateSet(out Endpoint dynamicEndpoint);
+
+        await sut.ApplyAsync(new DefaultHttpContext(), candidates);
+
+        Assert.That(candidates[0].Endpoint, Is.SameAs(dynamicEndpoint));
+    }
+
+    private static EagerMatcherPolicy CreateSut(RuntimeLevel level, bool isReadyToServe, Endpoint renderEndpoint)
+    {
+        var settings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = true };
+        return new EagerMatcherPolicy(
+            Mock.Of<IRuntimeState>(s => s.Level == level),
+            new DefaultEndpointDataSource(renderEndpoint),
+            umbracoRequestPaths: null!, // only used on the install branch, which these tests don't exercise
+            Mock.Of<IOptionsMonitor<GlobalSettings>>(m => m.CurrentValue == settings),
+            umbracoContextAccessor: null!,
+            publishedRouter: null!,
+            Mock.Of<IRuntimeStartupReadiness>(r => r.IsReadyToServe == isReadyToServe));
+    }
+
+    private static Endpoint CreateRenderEndpoint()
+    {
+        var descriptor = new ControllerActionDescriptor
+        {
+            ControllerTypeInfo = typeof(RenderController).GetTypeInfo(),
+            ActionName = nameof(RenderController.Index),
+        };
+        return new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse("/"),
+            order: 0,
+            new EndpointMetadataCollection(descriptor),
+            "render");
+    }
+
+    private static CandidateSet CreateDynamicCandidateSet(out Endpoint dynamicEndpoint)
+    {
+        dynamicEndpoint = new RouteEndpoint(
+            _ => Task.CompletedTask,
+            RoutePatternFactory.Parse("{**slug}"),
+            order: 0,
+            new EndpointMetadataCollection(new FakeDynamicEndpointMetadata()),
+            "dynamic");
+
+        return new CandidateSet(
+            new[] { dynamicEndpoint },
+            new[] { new RouteValueDictionary() },
+            new[] { 0 });
+    }
+
+    private sealed class FakeDynamicEndpointMetadata : IDynamicEndpointMetadata
+    {
+        public bool IsDynamic => true;
+    }
+}


### PR DESCRIPTION
## Description

There's no GitHub issue for this — it was found during local testing of the unattended-upgrade path.

### Background

The unattended upgrade runs on a background service (`UnattendedUpgradeBackgroundService`) so the HTTP server can start and respond while the upgrade proceeds. That service flips `RuntimeLevel` to `Run` **before** component and application-starting initialization has completed — in particular before `DocumentUrlServiceInitializerNotificationHandler` initializes the document-URL routing cache (`UmbracoApplicationStartingNotification`).

Because requests are already being served during a background upgrade, a front-end request that lands in the window between the level flip and routing initialization routes against not-yet-initialized services. In practice this surfaces intermittently as `System.InvalidOperationException: The service needs to be initialized before it can be used` (from `DocumentUrlService`) or a 404 / "File Not Found" for content, until a restart. A normal cold boot never hits this, because `BootUmbracoAsync()` completes all initialization before `app.RunAsync()` starts serving.

### Fix

Introduce a readiness signal that keeps the front end on the maintenance page until post-migration initialization has completed, while leaving `RuntimeLevel == Run` intact (so the handlers that legitimately require `Run` — member API init, external login startup, distributed cache messenger — still run normally).

- `IRuntimeStartupReadiness` (public, **read-only** — `IsReadyToServe`) is consumed by routing and the maintenance filter.
- `IRuntimeStartupReadinessControl` (internal) is the write side, so only the runtime can toggle readiness.
- `UnattendedUpgradeBackgroundService` marks the runtime **not-ready before** `TryBecomeLeaderAsync` (covering the follower window) and **ready only after** application-starting initialization, with an outer `try/finally` guaranteeing the gate always re-opens (it can never wedge closed).
- `EagerMatcherPolicy` treats the not-ready window exactly like `Upgrading` and re-routes front-end requests to the maintenance page (this is the same mechanism that already gates `Upgrading`, and runs during endpoint routing — before the dynamic route transformer that was throwing).
- `MaintenanceModeActionFilterAttribute` renders the "Automatic upgrade in progress" page for the window. The API/health surface comes back as soon as the level is `Run`, unchanged.

On a normal boot nothing toggles readiness, so it always reports ready and the front end is never gated.

## Testing

### Automated

- `EagerMatcherPolicyTests` — not-ready re-routes to the maintenance render endpoint; ready leaves the dynamic content route intact (no false-positive gating).
- `MaintenanceModeActionFilterAttributeTests` — `Run` + not-ready blocks MVC with the upgrade page; the API surface is not blocked; the maintenance opt-out is respected.
- `UnattendedUpgradeBackgroundServiceTests` — the gate closes **before** leadership coordination, stays closed across the level flip, and re-opens **only after** application-starting initialization.

Each behavioural test was verified to fail with the corresponding production change reverted, and to pass with it applied.

### Manual

1. Configure unattended upgrades (`Umbraco:CMS:Unattended:UpgradeUnattended: true`) on a site with a pending **core** migration (roll back the `Umbraco.Core` value in `umbracoKeyValue` to a prior state), and no pending package migration.
2. To make the otherwise sub-second window observable, temporarily insert `await Task.Delay(TimeSpan.FromSeconds(15));` after the level flip and before application-starting initialization in `UnattendedUpgradeBackgroundService`.
3. Start the site and request the front-end home page during the window.
   - **Before this change:** an `InvalidOperationException` (or 404) — content routed against the uninitialized URL service.
   - **After this change:** the "Automatic upgrade in progress" maintenance page, then content serves normally once initialization completes.
