### PR TITLE
Tags: Expand `ITagService` to handle Elements

### DIFF
--- a/src/Umbraco.Core/Models/TaggableObjectTypes.cs
+++ b/src/Umbraco.Core/Models/TaggableObjectTypes.cs
@@ -24,4 +24,9 @@ public enum TaggableObjectTypes
     /// Represents member entities (user accounts).
     /// </summary>
     Member,
+
+    /// <summary>
+    /// Represents element entities.
+    /// </summary>
+    Element,
 }

--- a/src/Umbraco.Core/Services/ITagService.cs
+++ b/src/Umbraco.Core/Services/ITagService.cs
@@ -55,6 +55,18 @@ public interface ITagService : IService
     IEnumerable<TaggedEntity> GetTaggedMembersByTag(string tag, string? group = null, string? culture = null);
 
     /// <summary>
+    ///     Gets all elements tagged with any tag in the specified group.
+    /// </summary>
+    // TODO (V19): Remove the default implementation from this interface.
+    IEnumerable<TaggedEntity> GetTaggedElementsByTagGroup(string group, string? culture = null) => [];
+
+    /// <summary>
+    ///     Gets all elements tagged with the specified tag.
+    /// </summary>
+    // TODO (V19): Remove the default implementation from this interface.
+    IEnumerable<TaggedEntity> GetTaggedElementsByTag(string tag, string? group = null, string? culture = null) => [];
+
+    /// <summary>
     ///     Gets all tags.
     /// </summary>
     IEnumerable<ITag> GetAllTags(string? group = null, string? culture = null);
@@ -99,6 +111,12 @@ public interface ITagService : IService
     ///     Gets all member tags.
     /// </summary>
     IEnumerable<ITag> GetAllMemberTags(string? group = null, string? culture = null);
+
+    /// <summary>
+    ///     Gets all element tags.
+    /// </summary>
+    // TODO (V19): Remove the default implementation from this interface.
+    IEnumerable<ITag> GetAllElementTags(string? group = null, string? culture = null) => [];
 
     /// <summary>
     ///     Gets all tags attached to an entity via a property.

--- a/src/Umbraco.Core/Services/TagService.cs
+++ b/src/Umbraco.Core/Services/TagService.cs
@@ -102,6 +102,24 @@ public class TagService : RepositoryService, ITagService
     }
 
     /// <inheritdoc />
+    public IEnumerable<TaggedEntity> GetTaggedElementsByTagGroup(string group, string? culture = null)
+    {
+        using (ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _tagRepository.GetTaggedEntitiesByTagGroup(TaggableObjectTypes.Element, group, culture);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<TaggedEntity> GetTaggedElementsByTag(string tag, string? group = null, string? culture = null)
+    {
+        using (ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _tagRepository.GetTaggedEntitiesByTag(TaggableObjectTypes.Element, tag, group, culture);
+        }
+    }
+
+    /// <inheritdoc />
     public IEnumerable<ITag> GetAllTags(string? group = null, string? culture = null)
     {
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
@@ -159,6 +177,15 @@ public class TagService : RepositoryService, ITagService
         using (ScopeProvider.CreateCoreScope(autoComplete: true))
         {
             return _tagRepository.GetTagsForEntityType(TaggableObjectTypes.Member, group, culture);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<ITag> GetAllElementTags(string? group = null, string? culture = null)
+    {
+        using (ScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            return _tagRepository.GetTagsForEntityType(TaggableObjectTypes.Element, group, culture);
         }
     }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/TagRepository.cs
@@ -647,6 +647,8 @@ ON (tagset.tag = {cmsTags}.tag AND tagset.{group} = {cmsTags}.{group} AND COALES
                 return Constants.ObjectTypes.Media;
             case TaggableObjectTypes.Member:
                 return Constants.ObjectTypes.Member;
+            case TaggableObjectTypes.Element:
+                return Constants.ObjectTypes.Element;
             default:
                 throw new ArgumentOutOfRangeException(nameof(type));
         }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TagServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TagServiceTests.cs
@@ -44,6 +44,8 @@ internal sealed class TagServiceTests : UmbracoIntegrationTest
 
     private IContentService ContentService => GetRequiredService<IContentService>();
 
+    private IElementService ElementService => GetRequiredService<IElementService>();
+
     private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
 
     private ITagService TagService => GetRequiredService<ITagService>();
@@ -104,6 +106,103 @@ internal sealed class TagServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public async Task GetTaggedElementsByTag_Returns_Tagged_Elements()
+    {
+        IContentType elementType = await CreateElementTypeWithTags();
+
+        IElement element1 = new Element("Tagged element 1", elementType);
+        element1.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "cow", "pig", "goat" });
+        ElementService.Save(element1);
+        ElementService.Publish(element1, Array.Empty<string>());
+
+        IElement element2 = new Element("Tagged element 2", elementType);
+        element2.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "pig" });
+        ElementService.Save(element2);
+        ElementService.Publish(element2, Array.Empty<string>());
+
+        var taggedWithCow = TagService.GetTaggedElementsByTag("cow").ToArray();
+        Assert.AreEqual(1, taggedWithCow.Length);
+        Assert.AreEqual(element1.Id, taggedWithCow[0].EntityId);
+        Assert.IsTrue(taggedWithCow[0].TaggedProperties.SelectMany(x => x.Tags).Any(x => x.Text == "cow"));
+
+        var taggedWithPig = TagService.GetTaggedElementsByTag("pig").Select(x => x.EntityId).ToArray();
+        Assert.AreEqual(2, taggedWithPig.Length);
+        CollectionAssert.AreEquivalent(new[] { element1.Id, element2.Id }, taggedWithPig);
+    }
+
+    [Test]
+    public async Task GetTaggedElementsByTagGroup_Returns_Tagged_Elements()
+    {
+        IContentType elementType = await CreateElementTypeWithTags();
+
+        IElement element1 = new Element("Tagged element 1", elementType);
+        element1.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "cow", "pig" });
+        ElementService.Save(element1);
+        ElementService.Publish(element1, Array.Empty<string>());
+
+        var tagged = TagService.GetTaggedElementsByTagGroup("default").ToArray();
+        Assert.AreEqual(1, tagged.Length);
+        Assert.AreEqual(element1.Id, tagged[0].EntityId);
+    }
+
+    [Test]
+    public async Task GetAllElementTags_Returns_Element_Tags_With_NodeCount()
+    {
+        IContentType elementType = await CreateElementTypeWithTags();
+
+        IElement element1 = new Element("Tagged element 1", elementType);
+        element1.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "cow", "pig", "goat" });
+        ElementService.Save(element1);
+        ElementService.Publish(element1, Array.Empty<string>());
+
+        IElement element2 = new Element("Tagged element 2", elementType);
+        element2.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "cow", "pig" });
+        ElementService.Save(element2);
+        ElementService.Publish(element2, Array.Empty<string>());
+
+        IElement element3 = new Element("Tagged element 3", elementType);
+        element3.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "cow" });
+        ElementService.Save(element3);
+        ElementService.Publish(element3, Array.Empty<string>());
+
+        var tags = TagService.GetAllElementTags()
+            .OrderByDescending(x => x.NodeCount)
+            .ToList();
+
+        Assert.AreEqual(3, tags.Count);
+        Assert.AreEqual("cow", tags[0].Text);
+        Assert.AreEqual(3, tags[0].NodeCount);
+        Assert.AreEqual("pig", tags[1].Text);
+        Assert.AreEqual(2, tags[1].NodeCount);
+        Assert.AreEqual("goat", tags[2].Text);
+        Assert.AreEqual(1, tags[2].NodeCount);
+    }
+
+    [Test]
+    public async Task Element_And_Content_Tags_Are_Isolated_By_ObjectType()
+    {
+        IContentType elementType = await CreateElementTypeWithTags();
+
+        IContent content = ContentBuilder.CreateSimpleContent(_contentType, "Tagged content");
+        content.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "shared" });
+        ContentService.Save(content);
+        ContentService.Publish(content, Array.Empty<string>());
+
+        IElement element = new Element("Tagged element", elementType);
+        element.AssignTags(PropertyEditorCollection, DataTypeService, IdKeyMap, Serializer, "tags", new[] { "shared" });
+        ElementService.Save(element);
+        ElementService.Publish(element, Array.Empty<string>());
+
+        var taggedContent = TagService.GetTaggedContentByTag("shared").ToArray();
+        Assert.AreEqual(1, taggedContent.Length);
+        Assert.AreEqual(content.Id, taggedContent[0].EntityId);
+
+        var taggedElements = TagService.GetTaggedElementsByTag("shared").ToArray();
+        Assert.AreEqual(1, taggedElements.Length);
+        Assert.AreEqual(element.Id, taggedElements[0].EntityId);
+    }
+
+    [Test]
     public void TagList_Contains_NodeCount()
     {
         var content1 = ContentBuilder.CreateSimpleContent(_contentType, "Tagged content 1");
@@ -140,5 +239,17 @@ internal sealed class TagServiceTests : UmbracoIntegrationTest
         Assert.AreEqual(2, tags[1].NodeCount);
         Assert.AreEqual("goat", tags[2].Text);
         Assert.AreEqual(1, tags[2].NodeCount);
+    }
+
+    private async Task<IContentType> CreateElementTypeWithTags()
+    {
+        IContentType elementType = ContentTypeBuilder.CreateSimpleElementType("umbElement", "Mandatory Element Type");
+        elementType.PropertyGroups.First().PropertyTypes.Add(
+            new PropertyType(ShortStringHelper, "test", ValueStorageType.Ntext, "tags")
+            {
+                DataTypeId = Constants.DataTypes.Tags
+            });
+        await ContentTypeService.CreateAsync(elementType, Constants.Security.SuperUserKey);
+        return elementType;
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

It seems we have neglected to add Elements handling to `ITagService`. This PR fixes it.

**NOTE:** Explicitly targeting V18.0 with this one.

### Testing

Integration tests have been added to prove that `ITagService` now supports Elements, and that it can discern between Content and Elements.

You can try this out manually by adding Tags to various Elements (invariant and culture variant), and querying them with a controller like this:

```cs
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Services;

namespace Umbraco.Cms.Web.UI.Custom;

[ApiController]
public class TestElementTagsController : ControllerBase
{
    private readonly ITagService _tagService;

    public TestElementTagsController(ITagService tagService)
        => _tagService= tagService;

    [HttpGet("/test/element-tags/by-tag-group/{group}/{culture?}")]
    public ActionResult ByTagGroup(string group, string? culture = null)
        => Ok(_tagService.GetTaggedElementsByTagGroup(group, culture));

    [HttpGet("/test/element-tags/by-tag/{tag}/{group?}/{culture?}")]
    public ActionResult ByTag(string tag, string? group = null, string? culture = null)
        => Ok(_tagService.GetTaggedElementsByTag(tag, group, culture));

    [HttpGet("/test/element-tags/all-tags/{group?}/{culture?}")]
    public ActionResult AllTags(string? group = null, string? culture = null)
        => Ok(_tagService.GetAllElementTags(group, culture));
}
```