### PR TITLE
Background Jobs: Recover cache-sync and server-touch jobs when a database call hangs (closes #23106)

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/DatabaseServerMessengerSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/DatabaseServerMessengerSettings.cs
@@ -31,6 +31,11 @@ public class DatabaseServerMessengerSettings
     internal const string StaticTimeBetweenPruneOperations = "00:01:00"; // TimeSpan.FromMinutes(1);
 
     /// <summary>
+    ///     The default timeout for a single synchronization operation.
+    /// </summary>
+    internal const string StaticSyncTimeout = "00:01:00"; // TimeSpan.FromMinutes(1);
+
+    /// <summary>
     ///     Gets or sets a value for the maximum number of instructions that can be processed at startup; otherwise the server
     ///     cold-boots (rebuilds its caches).
     /// </summary>
@@ -55,4 +60,13 @@ public class DatabaseServerMessengerSettings
     /// </summary>
     [DefaultValue(StaticTimeBetweenPruneOperations)]
     public TimeSpan TimeBetweenPruneOperations { get; set; } = TimeSpan.Parse(StaticTimeBetweenPruneOperations);
+
+    /// <summary>
+    ///     Gets or sets the maximum time to wait for a single synchronization operation to complete before it is
+    ///     considered stalled (for example, blocked on a hung database connection) and abandoned, so the recurring
+    ///     job keeps running rather than stopping permanently. This bounds how long the job waits on a single sync,
+    ///     not how long a stalled connection itself takes to recover (which is governed by the database timeouts).
+    /// </summary>
+    [DefaultValue(StaticSyncTimeout)]
+    public TimeSpan SyncTimeout { get; set; } = TimeSpan.Parse(StaticSyncTimeout);
 }

--- a/src/Umbraco.Core/Configuration/Models/DatabaseServerMessengerSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/DatabaseServerMessengerSettings.cs
@@ -36,6 +36,12 @@ public class DatabaseServerMessengerSettings
     internal const string StaticSyncTimeout = "00:01:00"; // TimeSpan.FromMinutes(1);
 
     /// <summary>
+    ///     Gets the default timeout for a single synchronization operation, for use as a fallback when an invalid
+    ///     <see cref="SyncTimeout" /> is configured.
+    /// </summary>
+    public static readonly TimeSpan DefaultSyncTimeout = TimeSpan.Parse(StaticSyncTimeout);
+
+    /// <summary>
     ///     Gets or sets a value for the maximum number of instructions that can be processed at startup; otherwise the server
     ///     cold-boots (rebuilds its caches).
     /// </summary>
@@ -68,5 +74,5 @@ public class DatabaseServerMessengerSettings
     ///     not how long a stalled connection itself takes to recover (which is governed by the database timeouts).
     /// </summary>
     [DefaultValue(StaticSyncTimeout)]
-    public TimeSpan SyncTimeout { get; set; } = TimeSpan.Parse(StaticSyncTimeout);
+    public TimeSpan SyncTimeout { get; set; } = DefaultSyncTimeout;
 }

--- a/src/Umbraco.Core/Configuration/Models/DatabaseServerRegistrarSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/DatabaseServerRegistrarSettings.cs
@@ -21,6 +21,17 @@ public class DatabaseServerRegistrarSettings
     internal const string StaticStaleServerTimeout = "00:02:00";
 
     /// <summary>
+    ///     The default timeout for a single server touch operation.
+    /// </summary>
+    internal const string StaticTouchTimeout = "00:01:00"; // TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    ///     Gets the default timeout for a single server touch operation, for use as a fallback when an invalid
+    ///     <see cref="TouchTimeout" /> is configured.
+    /// </summary>
+    public static readonly TimeSpan DefaultTouchTimeout = TimeSpan.Parse(StaticTouchTimeout);
+
+    /// <summary>
     ///     Gets or sets a value for the amount of time to wait between calls to the database on the background thread.
     /// </summary>
     [DefaultValue(StaticWaitTimeBetweenCalls)]
@@ -31,4 +42,13 @@ public class DatabaseServerRegistrarSettings
     /// </summary>
     [DefaultValue(StaticStaleServerTimeout)]
     public TimeSpan StaleServerTimeout { get; set; } = TimeSpan.Parse(StaticStaleServerTimeout);
+
+    /// <summary>
+    ///     Gets or sets the maximum time to wait for a single server touch operation to complete before it is
+    ///     considered stalled (for example, blocked on a hung database connection) and abandoned, so the recurring
+    ///     job keeps running rather than stopping permanently. This bounds how long the job waits on a single touch,
+    ///     not how long a stalled connection itself takes to recover (which is governed by the database timeouts).
+    /// </summary>
+    [DefaultValue(StaticTouchTimeout)]
+    public TimeSpan TouchTimeout { get; set; } = DefaultTouchTimeout;
 }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
@@ -103,6 +103,7 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
         try
         {
             await syncTask.WaitAsync(_syncTimeout, cancellationToken);
+            _logger.LogDebug("Synchronized cache instructions.");
         }
         catch (TimeoutException)
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.ServerRegistration;
@@ -26,6 +25,7 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
 
     private readonly ILogger<InstructionProcessJob> _logger;
     private readonly IServerMessenger _messenger;
+    private readonly TimeSpan _syncTimeout;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="InstructionProcessJob" /> class.
@@ -41,27 +41,54 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
     {
         _messenger = messenger;
         _logger = logger;
+        _syncTimeout = globalSettings.Value.DatabaseServerMessenger.SyncTimeout;
     }
 
     /// <summary>
     /// Executes the instruction processing job asynchronously by synchronizing messages using the messenger service.
-    /// Logs an error if the synchronization fails, but always completes the task.
+    /// Logs an error if the synchronization fails or stalls, but always completes the task so polling continues.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token that is signaled when the host is shutting down.</param>
     /// <returns>
-    /// A completed task representing the asynchronous operation.
+    /// A task representing the asynchronous operation.
     /// </returns>
-    public override Task RunJobAsync(CancellationToken cancellationToken)
+    public override async Task RunJobAsync(CancellationToken cancellationToken)
     {
+        // IServerMessenger.Sync() is synchronous and cannot observe the cancellation token, so a hung database
+        // connection would otherwise block this job's recurring loop indefinitely and silently stop cache
+        // polling until the process is recycled. Offload it to the thread pool and bound the wait so the loop
+        // survives and keeps polling.
+        //
+        // This bounds the loop, not the stalled sync itself: the abandoned call still holds
+        // DatabaseServerMessenger's sync lock, so polls stay no-ops until that call finally faults (bounded by
+        // the database command/connection timeout, not by SyncTimeout), after which syncing resumes on its own
+        // without a recycle.
+        //
+        // The loop is already started under ExecutionContext.SuppressFlow() (see RecurringBackgroundJobHostedService.StartAsync),
+        // which is what makes offloading the scope-creating Sync() to Task.Run safe for the static ambient scope stack.
+        var syncTask = Task.Run(_messenger.Sync, cancellationToken);
+
         try
         {
-            _messenger.Sync();
+            await syncTask.WaitAsync(_syncTimeout, cancellationToken);
         }
-        catch (Exception e)
+        catch (TimeoutException)
+        {
+            _logger.LogError(
+                "Cache instruction sync did not complete within {SyncTimeout} and may be stalled on a hung database connection. Cache updates are paused on this server until the stalled connection recovers.",
+                _syncTimeout);
+
+            // The stalled sync keeps running until its database connection faults; observe its eventual failure
+            // so it does not surface as an UnobservedTaskException.
+            _ = syncTask.ContinueWith(
+                static t => _ = t.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
         {
             _logger.LogError(e, "Failed (will repeat).");
         }
-
-        return Task.CompletedTask;
     }
 }

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
@@ -26,6 +26,7 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
     private readonly ILogger<InstructionProcessJob> _logger;
     private readonly IServerMessenger _messenger;
     private readonly TimeSpan _syncTimeout;
+    private Task? _inFlightSync;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="InstructionProcessJob" /> class.
@@ -72,19 +73,32 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
     /// </returns>
     public override async Task RunJobAsync(CancellationToken cancellationToken)
     {
+        // If a previous sync is still running (e.g. blocked on a hung database connection after a timeout),
+        // skip starting another. This bounds us to a single in-flight call instead of accumulating blocked
+        // thread-pool threads, and logs the stall once rather than on every interval until it recovers.
+        if (_inFlightSync is { IsCompleted: false })
+        {
+            return;
+        }
+
         // IServerMessenger.Sync() is synchronous and cannot observe the cancellation token, so a hung database
         // connection would otherwise block this job's recurring loop indefinitely and silently stop cache
         // polling until the process is recycled. Offload it to the thread pool and bound the wait so the loop
-        // survives and keeps polling.
-        //
-        // This bounds the loop, not the stalled sync itself: the abandoned call still holds
-        // DatabaseServerMessenger's sync lock, so polls stay no-ops until that call finally faults (bounded by
-        // the database command/connection timeout, not by SyncTimeout), after which syncing resumes on its own
-        // without a recycle.
+        // survives and keeps polling; the in-flight call keeps running until its connection faults (bounded by
+        // the database command/connection timeout, not by SyncTimeout), after which syncing resumes without a recycle.
         //
         // The loop is already started under ExecutionContext.SuppressFlow() (see RecurringBackgroundJobHostedService.StartAsync),
         // which is what makes offloading the scope-creating Sync() to Task.Run safe for the static ambient scope stack.
         var syncTask = Task.Run(_messenger.Sync, cancellationToken);
+        _inFlightSync = syncTask;
+
+        // Observe the task's eventual fault on every exit path (timeout, shutdown cancellation, or a late
+        // failure once we have stopped awaiting it) so it never surfaces as an UnobservedTaskException.
+        _ = syncTask.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
         try
         {
@@ -95,14 +109,6 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
             _logger.LogError(
                 "Cache instruction sync did not complete within {SyncTimeout} and may be stalled on a hung database connection. Cache updates are paused on this server until the stalled connection recovers.",
                 _syncTimeout);
-
-            // The stalled sync keeps running until its database connection faults; observe its eventual failure
-            // so it does not surface as an UnobservedTaskException.
-            _ = syncTask.ContinueWith(
-                static t => _ = t.Exception,
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJob.cs
@@ -41,7 +41,25 @@ public class InstructionProcessJob : RecurringBackgroundJobBase
     {
         _messenger = messenger;
         _logger = logger;
-        _syncTimeout = globalSettings.Value.DatabaseServerMessenger.SyncTimeout;
+        _syncTimeout = ValidateSyncTimeout(globalSettings.Value.DatabaseServerMessenger.SyncTimeout);
+    }
+
+    // A non-positive timeout would make every sync "time out" immediately (or throw from WaitAsync for a
+    // negative value), so guard against misconfiguration and fall back to the default. Timeout.InfiniteTimeSpan
+    // is allowed as an explicit opt-out that restores the unbounded wait.
+    private TimeSpan ValidateSyncTimeout(TimeSpan configuredSyncTimeout)
+    {
+        if (configuredSyncTimeout > TimeSpan.Zero || configuredSyncTimeout == Timeout.InfiniteTimeSpan)
+        {
+            return configuredSyncTimeout;
+        }
+
+        _logger.LogWarning(
+            "Configured DatabaseServerMessenger.SyncTimeout of {ConfiguredSyncTimeout} is not valid; it must be positive (or Timeout.InfiniteTimeSpan to disable the timeout). Falling back to {DefaultSyncTimeout}.",
+            configuredSyncTimeout,
+            DatabaseServerMessengerSettings.DefaultSyncTimeout);
+
+        return DatabaseServerMessengerSettings.DefaultSyncTimeout;
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
@@ -132,6 +132,7 @@ public class TouchServerJob : RecurringBackgroundJobBase
         try
         {
             await touchTask.WaitAsync(_touchTimeout, cancellationToken);
+            _logger.LogDebug("Touched server registration for {ServerAddress}.", serverAddress);
         }
         catch (TimeoutException)
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
@@ -34,6 +34,7 @@ public class TouchServerJob : RecurringBackgroundJobBase
     private readonly IDisposable? _onChangeRegistration;
     private GlobalSettings _globalSettings;
     private TimeSpan _touchTimeout;
+    private Task? _inFlightTouch;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="TouchServerJob" /> class.
@@ -84,6 +85,15 @@ public class TouchServerJob : RecurringBackgroundJobBase
             return;
         }
 
+        // If a previous touch is still running (e.g. blocked on a hung database connection after a timeout),
+        // skip starting another. This bounds us to a single in-flight call instead of accumulating blocked
+        // thread-pool threads (each contending for the servers lock), and logs the stall once rather than on
+        // every interval until it recovers.
+        if (_inFlightTouch is { IsCompleted: false })
+        {
+            return;
+        }
+
         var serverAddress = _hostingEnvironment.ApplicationMainUrl?.ToString();
         if (string.IsNullOrWhiteSpace(serverAddress))
         {
@@ -109,6 +119,15 @@ public class TouchServerJob : RecurringBackgroundJobBase
         // (See InstructionProcessJob for the same pattern and the ExecutionContext.SuppressFlow rationale.)
         TimeSpan staleServerTimeout = _globalSettings.DatabaseServerRegistrar.StaleServerTimeout;
         var touchTask = Task.Run(() => _serverRegistrationService.TouchServer(serverAddress, staleServerTimeout), cancellationToken);
+        _inFlightTouch = touchTask;
+
+        // Observe the task's eventual fault on every exit path (timeout, shutdown cancellation, or a late
+        // failure once we have stopped awaiting it) so it never surfaces as an UnobservedTaskException.
+        _ = touchTask.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
         try
         {
@@ -119,14 +138,6 @@ public class TouchServerJob : RecurringBackgroundJobBase
             _logger.LogError(
                 "Touching the server registration did not complete within {TouchTimeout} and may be stalled on a hung database connection. Server registration is paused on this server until the stalled connection recovers.",
                 _touchTimeout);
-
-            // The stalled touch keeps running until its database connection faults; observe its eventual failure
-            // so it does not surface as an UnobservedTaskException.
-            _ = touchTask.ContinueWith(
-                static t => _ = t.Exception,
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
+++ b/src/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJob.cs
@@ -33,6 +33,7 @@ public class TouchServerJob : RecurringBackgroundJobBase
     private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly IDisposable? _onChangeRegistration;
     private GlobalSettings _globalSettings;
+    private TimeSpan _touchTimeout;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="TouchServerJob" /> class.
@@ -55,11 +56,13 @@ public class TouchServerJob : RecurringBackgroundJobBase
         _logger = logger;
         _globalSettings = globalSettings.CurrentValue;
         _serverRoleAccessor = serverRoleAccessor;
+        _touchTimeout = ValidateTouchTimeout(globalSettings.CurrentValue.DatabaseServerRegistrar.TouchTimeout);
 
         _onChangeRegistration = globalSettings.OnChange(x =>
         {
             _globalSettings = x;
             Period = x.DatabaseServerRegistrar.WaitTimeBetweenCalls;
+            _touchTimeout = ValidateTouchTimeout(x.DatabaseServerRegistrar.TouchTimeout);
         });
     }
 
@@ -71,14 +74,14 @@ public class TouchServerJob : RecurringBackgroundJobBase
     /// <returns>
     /// A completed task when the job has finished running.
     /// </returns>
-    public override Task RunJobAsync(CancellationToken cancellationToken)
+    public override async Task RunJobAsync(CancellationToken cancellationToken)
     {
         // If the IServerRoleAccessor has been changed away from ElectedServerRoleAccessor this task no longer makes sense,
         // since all it's used for is to allow the ElectedServerRoleAccessor
         // to figure out what role a given server has, so we just stop this task.
         if (_serverRoleAccessor is not ElectedServerRoleAccessor)
         {
-            return Task.CompletedTask;
+            return;
         }
 
         var serverAddress = _hostingEnvironment.ApplicationMainUrl?.ToString();
@@ -99,18 +102,54 @@ public class TouchServerJob : RecurringBackgroundJobBase
             _logger.LogDebug("Registering server with application URL {ServerAddress}.", serverAddress);
         }
 
+        // IServerRegistrationService.TouchServer() runs a synchronous database write and cannot observe the
+        // cancellation token, so a hung connection would otherwise block this job's recurring loop indefinitely
+        // and silently stop server-registration heartbeats until the process is recycled. Offload it to the
+        // thread pool and bound the wait so the loop survives and keeps touching.
+        // (See InstructionProcessJob for the same pattern and the ExecutionContext.SuppressFlow rationale.)
+        TimeSpan staleServerTimeout = _globalSettings.DatabaseServerRegistrar.StaleServerTimeout;
+        var touchTask = Task.Run(() => _serverRegistrationService.TouchServer(serverAddress, staleServerTimeout), cancellationToken);
+
         try
         {
-            _serverRegistrationService.TouchServer(
-                serverAddress,
-                _globalSettings.DatabaseServerRegistrar.StaleServerTimeout);
+            await touchTask.WaitAsync(_touchTimeout, cancellationToken);
         }
-        catch (Exception ex)
+        catch (TimeoutException)
+        {
+            _logger.LogError(
+                "Touching the server registration did not complete within {TouchTimeout} and may be stalled on a hung database connection. Server registration is paused on this server until the stalled connection recovers.",
+                _touchTimeout);
+
+            // The stalled touch keeps running until its database connection faults; observe its eventual failure
+            // so it does not surface as an UnobservedTaskException.
+            _ = touchTask.ContinueWith(
+                static t => _ = t.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, "Failed to update server record in database.");
         }
+    }
 
-        return Task.CompletedTask;
+    // A non-positive timeout would make every touch "time out" immediately (or throw from WaitAsync for a
+    // negative value), so guard against misconfiguration and fall back to the default. Timeout.InfiniteTimeSpan
+    // is allowed as an explicit opt-out that restores the unbounded wait.
+    private TimeSpan ValidateTouchTimeout(TimeSpan configuredTouchTimeout)
+    {
+        if (configuredTouchTimeout > TimeSpan.Zero || configuredTouchTimeout == Timeout.InfiniteTimeSpan)
+        {
+            return configuredTouchTimeout;
+        }
+
+        _logger.LogWarning(
+            "Configured DatabaseServerRegistrar.TouchTimeout of {ConfiguredTouchTimeout} is not valid; it must be positive (or Timeout.InfiniteTimeSpan to disable the timeout). Falling back to {DefaultTouchTimeout}.",
+            configuredTouchTimeout,
+            DatabaseServerRegistrarSettings.DefaultTouchTimeout);
+
+        return DatabaseServerRegistrarSettings.DefaultTouchTimeout;
     }
 
     /// <inheritdoc />

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
@@ -53,6 +53,20 @@ public class InstructionProcessJobTests
         }
     }
 
+    [Test]
+    public async Task Falls_Back_And_Warns_When_SyncTimeout_Invalid()
+    {
+        // A non-positive timeout is misconfiguration; the job should warn and fall back to a sane default
+        // rather than treating every sync as immediately timed out.
+        var sut = CreateInstructionProcessJob(TimeSpan.Zero);
+
+        VerifyWarningLogged();
+
+        // The fallback timeout is generous, so a normal (fast) sync still completes successfully.
+        await sut.RunJobAsync(CancellationToken.None);
+        VerifyMessengerSynced();
+    }
+
     private InstructionProcessJob CreateInstructionProcessJob(TimeSpan? syncTimeout = null, Action? onSync = null)
     {
         _mockLogger = new Mock<ILogger<InstructionProcessJob>>();
@@ -79,9 +93,13 @@ public class InstructionProcessJobTests
 
     private void VerifyMessengerSyncedTimes(Times times) => _mockDatabaseServerMessenger.Verify(x => x.Sync(), times);
 
-    private void VerifyErrorLogged() => _mockLogger.Verify(
+    private void VerifyErrorLogged() => VerifyLogged(LogLevel.Error);
+
+    private void VerifyWarningLogged() => VerifyLogged(LogLevel.Warning);
+
+    private void VerifyLogged(LogLevel level) => _mockLogger.Verify(
         l => l.Log(
-            It.Is<LogLevel>(y => y == LogLevel.Error),
+            It.Is<LogLevel>(y => y == level),
             It.IsAny<EventId>(),
             It.IsAny<It.IsAnyType>(),
             It.IsAny<Exception>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
@@ -76,6 +76,48 @@ public class InstructionProcessJobTests
     }
 
     [Test]
+    public async Task Resumes_Sync_After_In_Flight_Call_Completes()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        var syncCount = 0;
+        var sut = CreateInstructionProcessJob(
+            TimeSpan.FromMilliseconds(50),
+            () =>
+            {
+                // Only the first call blocks; later calls return immediately.
+                if (Interlocked.Increment(ref syncCount) == 1)
+                {
+                    gate.Wait();
+                }
+            });
+
+        // First run hangs and times out, leaving the sync in-flight.
+        await sut.RunJobAsync(CancellationToken.None);
+        Assert.AreEqual(1, Volatile.Read(ref syncCount));
+
+        // Release the stalled call; once its task completes the next run must start a fresh sync — i.e. the job
+        // self-heals without a recycle. Retry briefly to avoid racing the in-flight task's completion.
+        gate.Set();
+
+        var resumed = false;
+        for (var attempt = 0; attempt < 500 && resumed is false; attempt++)
+        {
+            await sut.RunJobAsync(CancellationToken.None);
+            if (Volatile.Read(ref syncCount) >= 2)
+            {
+                resumed = true;
+            }
+            else
+            {
+                await Task.Delay(10);
+            }
+        }
+
+        Assert.IsTrue(resumed, "Polling did not resume after the stalled sync completed.");
+        VerifyMessengerSyncedTimes(Times.Exactly(2));
+    }
+
+    [Test]
     public async Task Falls_Back_And_Warns_When_SyncTimeout_Invalid()
     {
         // A non-positive timeout is misconfiguration; the job should warn and fall back to a sane default

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.BackgroundJobs.Jobs.ServerRegistration;
 
@@ -18,34 +15,76 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.BackgroundJobs.Jobs
 public class InstructionProcessJobTests
 {
     private Mock<IServerMessenger> _mockDatabaseServerMessenger;
+    private Mock<ILogger<InstructionProcessJob>> _mockLogger;
 
 
     [Test]
     public async Task Executes_And_Touches_Server()
     {
         var sut = CreateInstructionProcessJob();
-        await sut.RunJobAsync();
+        await sut.RunJobAsync(CancellationToken.None);
         VerifyMessengerSynced();
     }
 
-    private InstructionProcessJob CreateInstructionProcessJob()
+    [Test]
+    public async Task Returns_And_Logs_When_Sync_Hangs()
     {
+        using var gate = new ManualResetEventSlim(false);
+        var sut = CreateInstructionProcessJob(
+            TimeSpan.FromMilliseconds(50),
+            () => gate.Wait());
 
-        var mockLogger = new Mock<ILogger<InstructionProcessJob>>();
+        try
+        {
+            // A hung Sync() must not block the recurring loop: RunJobAsync should return after the timeout
+            // rather than awaiting the (synchronous, un-cancellable) Sync() forever.
+            Task runTask = sut.RunJobAsync(CancellationToken.None);
+            Task winner = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(10)));
+
+            Assert.AreSame(runTask, winner, "RunJobAsync did not return after the sync timed out.");
+            await runTask; // Must complete without throwing so the loop continues.
+
+            VerifyErrorLogged();
+        }
+        finally
+        {
+            // Release the abandoned sync so it does not leave a blocked thread-pool thread behind.
+            gate.Set();
+        }
+    }
+
+    private InstructionProcessJob CreateInstructionProcessJob(TimeSpan? syncTimeout = null, Action? onSync = null)
+    {
+        _mockLogger = new Mock<ILogger<InstructionProcessJob>>();
 
         _mockDatabaseServerMessenger = new Mock<IServerMessenger>();
+        if (onSync is not null)
+        {
+            _mockDatabaseServerMessenger.Setup(x => x.Sync()).Callback(onSync);
+        }
 
         var settings = new GlobalSettings();
+        if (syncTimeout.HasValue)
+        {
+            settings.DatabaseServerMessenger.SyncTimeout = syncTimeout.Value;
+        }
 
         return new InstructionProcessJob(
             _mockDatabaseServerMessenger.Object,
-            mockLogger.Object,
+            _mockLogger.Object,
             Options.Create(settings));
     }
-
-    private void VerifyMessengerNotSynced() => VerifyMessengerSyncedTimes(Times.Never());
 
     private void VerifyMessengerSynced() => VerifyMessengerSyncedTimes(Times.Once());
 
     private void VerifyMessengerSyncedTimes(Times times) => _mockDatabaseServerMessenger.Verify(x => x.Sync(), times);
+
+    private void VerifyErrorLogged() => _mockLogger.Verify(
+        l => l.Log(
+            It.Is<LogLevel>(y => y == LogLevel.Error),
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+        Times.Once);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/InstructionProcessJobTests.cs
@@ -54,6 +54,28 @@ public class InstructionProcessJobTests
     }
 
     [Test]
+    public async Task Skips_Sync_While_Previous_Is_Still_Running()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        var sut = CreateInstructionProcessJob(TimeSpan.FromMilliseconds(50), () => gate.Wait());
+
+        try
+        {
+            // First run starts a sync that hangs and times out, leaving it in-flight.
+            await sut.RunJobAsync(CancellationToken.None);
+
+            // Second run must skip rather than start (and block on) another sync while the first is still running.
+            await sut.RunJobAsync(CancellationToken.None);
+
+            VerifyMessengerSyncedTimes(Times.Once());
+        }
+        finally
+        {
+            gate.Set();
+        }
+    }
+
+    [Test]
     public async Task Falls_Back_And_Warns_When_SyncTimeout_Invalid()
     {
         // A non-positive timeout is misconfiguration; the job should warn and fall back to a sane default

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
@@ -18,6 +18,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.BackgroundJobs.Jobs
 public class TouchServerJobTests
 {
     private Mock<IServerRegistrationService> _mockServerRegistrationService;
+    private Mock<ILogger<TouchServerJob>> _mockLogger;
 
     private const string ApplicationUrl = "https://mysite.com/";
     private readonly TimeSpan _staleServerTimeout = TimeSpan.FromMinutes(2);
@@ -77,11 +78,52 @@ public class TouchServerJobTests
         Assert.AreEqual(waitTimeBetweenCalls, sut.Period);
     }
 
+    [Test]
+    public async Task Returns_And_Logs_When_Touch_Hangs()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        var sut = CreateTouchServerTask(touchTimeout: TimeSpan.FromMilliseconds(50), onTouch: () => gate.Wait());
+
+        try
+        {
+            // A hung TouchServer() must not block the recurring loop: RunJobAsync should return after the timeout
+            // rather than awaiting the (synchronous, un-cancellable) call forever.
+            Task runTask = sut.RunJobAsync(CancellationToken.None);
+            Task winner = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(10)));
+
+            Assert.AreSame(runTask, winner, "RunJobAsync did not return after the touch timed out.");
+            await runTask; // Must complete without throwing so the loop continues.
+
+            VerifyErrorLogged();
+        }
+        finally
+        {
+            // Release the abandoned touch so it does not leave a blocked thread-pool thread behind.
+            gate.Set();
+        }
+    }
+
+    [Test]
+    public async Task Falls_Back_And_Warns_When_TouchTimeout_Invalid()
+    {
+        // A non-positive timeout is misconfiguration; the job should warn and fall back to a sane default
+        // rather than treating every touch as immediately timed out.
+        var sut = CreateTouchServerTask(touchTimeout: TimeSpan.Zero);
+
+        VerifyWarningLogged();
+
+        // The fallback timeout is generous, so a normal (fast) touch still completes successfully.
+        await sut.RunJobAsync(CancellationToken.None);
+        VerifyServerTouched();
+    }
+
     private TouchServerJob CreateTouchServerTask(
         RuntimeLevel runtimeLevel = RuntimeLevel.Run,
         string applicationUrl = ApplicationUrl,
         bool useElection = true,
-        TimeSpan? waitTimeBetweenCalls = null)
+        TimeSpan? waitTimeBetweenCalls = null,
+        TimeSpan? touchTimeout = null,
+        Action? onTouch = null)
     {
         var mockRequestAccessor = new Mock<IHostingEnvironment>();
         mockRequestAccessor.SetupGet(x => x.ApplicationMainUrl)
@@ -90,17 +132,29 @@ public class TouchServerJobTests
         var mockRunTimeState = new Mock<IRuntimeState>();
         mockRunTimeState.SetupGet(x => x.Level).Returns(runtimeLevel);
 
-        var mockLogger = new Mock<ILogger<TouchServerJob>>();
+        _mockLogger = new Mock<ILogger<TouchServerJob>>();
 
         _mockServerRegistrationService = new Mock<IServerRegistrationService>();
+        if (onTouch is not null)
+        {
+            _mockServerRegistrationService
+                .Setup(x => x.TouchServer(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Callback(onTouch);
+        }
+
+        var registrarSettings = new DatabaseServerRegistrarSettings
+        {
+            StaleServerTimeout = _staleServerTimeout,
+            WaitTimeBetweenCalls = waitTimeBetweenCalls ?? TimeSpan.FromMinutes(1),
+        };
+        if (touchTimeout.HasValue)
+        {
+            registrarSettings.TouchTimeout = touchTimeout.Value;
+        }
 
         var settings = new GlobalSettings
         {
-            DatabaseServerRegistrar = new DatabaseServerRegistrarSettings
-            {
-                StaleServerTimeout = _staleServerTimeout,
-                WaitTimeBetweenCalls = waitTimeBetweenCalls ?? TimeSpan.FromMinutes(1),
-            },
+            DatabaseServerRegistrar = registrarSettings,
         };
 
         IServerRoleAccessor roleAccessor = useElection
@@ -110,7 +164,7 @@ public class TouchServerJobTests
         return new TouchServerJob(
             _mockServerRegistrationService.Object,
             mockRequestAccessor.Object,
-            mockLogger.Object,
+            _mockLogger.Object,
             new TestOptionsMonitor<GlobalSettings>(settings),
             roleAccessor);
     }
@@ -132,4 +186,17 @@ public class TouchServerJobTests
                 It.Is<string>(y => y == Environment.MachineName),
                 It.Is<TimeSpan>(y => y == _staleServerTimeout)),
             Times.Once());
+
+    private void VerifyErrorLogged() => VerifyLogged(LogLevel.Error);
+
+    private void VerifyWarningLogged() => VerifyLogged(LogLevel.Warning);
+
+    private void VerifyLogged(LogLevel level) => _mockLogger.Verify(
+        l => l.Log(
+            It.Is<LogLevel>(y => y == level),
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+        Times.Once);
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
@@ -126,6 +126,48 @@ public class TouchServerJobTests
     }
 
     [Test]
+    public async Task Resumes_Touch_After_In_Flight_Call_Completes()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        var touchCount = 0;
+        var sut = CreateTouchServerTask(
+            touchTimeout: TimeSpan.FromMilliseconds(50),
+            onTouch: () =>
+            {
+                // Only the first call blocks; later calls return immediately.
+                if (Interlocked.Increment(ref touchCount) == 1)
+                {
+                    gate.Wait();
+                }
+            });
+
+        // First run hangs and times out, leaving the touch in-flight.
+        await sut.RunJobAsync(CancellationToken.None);
+        Assert.AreEqual(1, Volatile.Read(ref touchCount));
+
+        // Release the stalled call; once its task completes the next run must start a fresh touch — i.e. the job
+        // self-heals without a recycle. Retry briefly to avoid racing the in-flight task's completion.
+        gate.Set();
+
+        var resumed = false;
+        for (var attempt = 0; attempt < 500 && resumed is false; attempt++)
+        {
+            await sut.RunJobAsync(CancellationToken.None);
+            if (Volatile.Read(ref touchCount) >= 2)
+            {
+                resumed = true;
+            }
+            else
+            {
+                await Task.Delay(10);
+            }
+        }
+
+        Assert.IsTrue(resumed, "Touching did not resume after the stalled call completed.");
+        VerifyServerTouchedTimes(Times.Exactly(2));
+    }
+
+    [Test]
     public async Task Falls_Back_And_Warns_When_TouchTimeout_Invalid()
     {
         // A non-positive timeout is misconfiguration; the job should warn and fall back to a sane default

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/BackgroundJobs/Jobs/ServerRegistration/TouchServerJobTests.cs
@@ -104,6 +104,28 @@ public class TouchServerJobTests
     }
 
     [Test]
+    public async Task Skips_Touch_While_Previous_Is_Still_Running()
+    {
+        using var gate = new ManualResetEventSlim(false);
+        var sut = CreateTouchServerTask(touchTimeout: TimeSpan.FromMilliseconds(50), onTouch: () => gate.Wait());
+
+        try
+        {
+            // First run starts a touch that hangs and times out, leaving it in-flight.
+            await sut.RunJobAsync(CancellationToken.None);
+
+            // Second run must skip rather than start (and block on) another touch while the first is still running.
+            await sut.RunJobAsync(CancellationToken.None);
+
+            VerifyServerTouchedTimes(Times.Once());
+        }
+        finally
+        {
+            gate.Set();
+        }
+    }
+
+    [Test]
     public async Task Falls_Back_And_Warns_When_TouchTimeout_Invalid()
     {
         // A non-positive timeout is misconfiguration; the job should warn and fall back to a sane default


### PR DESCRIPTION
## Description

`InstructionProcessJob` and `TouchServerJob` call `IServerMessenger.Sync()` / `IServerRegistrationService.TouchServer()` **synchronously**, ignoring the `CancellationToken`. If the underlying database call *hangs* (rather than throws) the recurring loop's `await PerformExecuteAsync` blocks forever and the job stops **silently** until the app pool is recycled: stale `IPublishedContent` + intermittent 404s (cache sync), and missed server-registration heartbeats (touch).

The reporting issue raises a wider concern with 13, which is now out of support.  It's partly fixed now in 17 due to the use of `BackgroundService`; this PR closes the remaining synchronous-hang concern.

Fixes #23106.

### Fix

Offload the synchronous call to the thread pool and bound it with `Task.WaitAsync(timeout, ct)`. On timeout we log and return, so the loop survives and resumes on the next interval. New configurable, validated timeouts are introduced (default `00:01:00`): `Umbraco:CMS:Global:DatabaseServerMessenger:SyncTimeout` and `…:DatabaseServerRegistrar:TouchTimeout` (partly to give flexibility for customers, but mainly to ease testing).

This bounds the **loop**, not the stalled call itself: the abandoned call still holds the messenger's sync lock, so polls stay no-ops until it faults (bounded by the DB command/connection timeout), after which syncing resumes automatically, without the necessity of a recycle.

## Testing

### Automated

`InstructionProcessJobTests` / `TouchServerJobTests`:
- **Hang** → `RunJobAsync` returns after the timeout (loop survives) and logs an error.
- **Invalid (non-positive) timeout** → warns and falls back to the default.
- Existing success / throw / role tests still pass.

Each hang test was verified to **fail (hang) without the watchdog** by temporarily reverting to the inline call (run with `--blame-hang-timeout`), then restored — so the tests genuinely catch the regression.

## Manual test (load-balanced symptom, on default SQLite)

A decorator makes `IServerMessenger.Sync()` hang on demand, toggled via an endpoint; short timeouts in config make it observable in seconds. A healthy sync logs nothing by default, so the decorator also logs a heartbeat.

<details><summary>Scaffolding used (not committed)</summary>

`Custom/Cache/CacheSyncHangTest.cs`
```csharp
internal static class CacheSyncHangSwitch
{
    private static volatile bool _hang;
    public static bool IsHanging => _hang;
    public static void Hang() => _hang = true;
    public static void Release() => _hang = false;
}

public sealed class CacheSyncHangTestComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        ServiceDescriptor? existing = builder.Services.LastOrDefault(d => d.ServiceType == typeof(IServerMessenger));
        if (existing is null) return;

        builder.Services.Remove(existing);
        builder.Services.Add(ServiceDescriptor.Describe(
            typeof(IServerMessenger),
            sp => new HangableServerMessenger(
                (IServerMessenger)CreateInner(sp, existing),
                sp.GetRequiredService<ILogger<HangableServerMessenger>>()),
            existing.Lifetime));
    }

    private static object CreateInner(IServiceProvider sp, ServiceDescriptor d)
        => d.ImplementationInstance ?? d.ImplementationFactory?.Invoke(sp) ?? ActivatorUtilities.CreateInstance(sp, d.ImplementationType!);

    private sealed class HangableServerMessenger : IServerMessenger
    {
        private readonly IServerMessenger _inner;
        private readonly ILogger<HangableServerMessenger> _logger;
        public HangableServerMessenger(IServerMessenger inner, ILogger<HangableServerMessenger> logger) { _inner = inner; _logger = logger; }

        public void Sync()
        {
            if (CacheSyncHangSwitch.IsHanging)
            {
                _logger.LogWarning("[23106-test] Sync() entering simulated hang on thread {ThreadId}.", Environment.CurrentManagedThreadId);
                while (CacheSyncHangSwitch.IsHanging) Thread.Sleep(250);
                _logger.LogWarning("[23106-test] Sync() released from simulated hang.");
                return;
            }
            _logger.LogInformation("[23106-test] Sync() running normally on thread {ThreadId}.", Environment.CurrentManagedThreadId);
            _inner.Sync();
        }

        public void SendMessages() => _inner.SendMessages();
        public void QueueRefresh<TPayload>(ICacheRefresher r, TPayload[] p) => _inner.QueueRefresh(r, p);
        public void QueueRefresh<T>(ICacheRefresher r, Func<T, int> id, params T[] i) => _inner.QueueRefresh(r, id, i);
        public void QueueRefresh<T>(ICacheRefresher r, Func<T, Guid> id, params T[] i) => _inner.QueueRefresh(r, id, i);
        public void QueueRemove<T>(ICacheRefresher r, Func<T, int> id, params T[] i) => _inner.QueueRemove(r, id, i);
        public void QueueRemove(ICacheRefresher r, params int[] ids) => _inner.QueueRemove(r, ids);
        public void QueueRefresh(ICacheRefresher r, params int[] ids) => _inner.QueueRefresh(r, ids);
        public void QueueRefresh(ICacheRefresher r, params Guid[] ids) => _inner.QueueRefresh(r, ids);
        public void QueueRefreshAll(ICacheRefresher r) => _inner.QueueRefreshAll(r);
    }
}
```

`Controllers/CacheSyncHangTestController.cs`
```csharp
public class CacheSyncHangTestController : Controller
{
    [HttpGet("/test/cache-sync/hang")]
    public IActionResult Hang() { CacheSyncHangSwitch.Hang(); return Ok(new { hanging = true }); }

    [HttpGet("/test/cache-sync/release")]
    public IActionResult Release() { CacheSyncHangSwitch.Release(); return Ok(new { hanging = false }); }
}
```

`appsettings.Development.json`
```json
"DatabaseServerMessenger": {
  "TimeBetweenSyncOperations": "00:00:05",
  "SyncTimeout": "00:00:15"
}
```
</details>

**Steps:** run, wait ~1 min for the first sync, hit `/test/cache-sync/hang`, then `/test/cache-sync/release`.

**Expected log (with the fix):**
```
[INF] [23106-test] Sync() running normally on thread 20.            ← healthy heartbeat every 5s
[WRN] [23106-test] Sync() entering simulated hang on thread 20.
[ERR] Cache instruction sync did not complete within 00:00:15 ...   ← ~15s later; loop SURVIVES
       Cache updates are paused on this server until the stalled connection recovers.
[WRN] [23106-test] Sync() released from simulated hang.             ← after /release
[INF] [23106-test] Sync() running normally on thread 30.            ← recovered, no restart
```

**Without the fix:** after `/hang` the loop blocks and logs nothing further — the job is dead until the process restarts.
