### PR TITLE
Block Workspace: Support variant properties and make '$settings' a key-value-object (Closes #23095)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block-inline/block-grid-block-inline.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block-inline/block-grid-block-inline.element.ts
@@ -14,7 +14,11 @@ import type { UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoff
 import type { UmbPropertyTypeModel } from '@umbraco-cms/backoffice/content-type';
 import type { UmbDataTypeDetailModel } from '@umbraco-cms/backoffice/data-type';
 import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
-import type { UMB_BLOCK_WORKSPACE_CONTEXT, UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import type {
+	UMB_BLOCK_WORKSPACE_CONTEXT,
+	UmbBlockDataType,
+	UmbBlockLabelUfmValueType,
+} from '@umbraco-cms/backoffice/block';
 
 const apiArgsCreator: UmbApiConstructorArgumentsMethodType<unknown> = (manifest: unknown) => {
 	return [{ manifest }];
@@ -204,7 +208,7 @@ export class UmbBlockGridBlockInlineElement extends UmbLitElement {
 	}
 
 	#renderBlockInfo() {
-		const blockValue = { ...this.content, $settings: this.settings, $index: this.index };
+		const blockValue: UmbBlockLabelUfmValueType = { ...this.content, $settings: this.settings, $index: this.index };
 		return html`
 			<span id="content">
 				<span id="icon">

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block/block-grid-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/components/block-grid-block/block-grid-block.element.ts
@@ -1,6 +1,6 @@
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { css, customElement, html, property, when } from '@umbraco-cms/backoffice/external/lit';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockLabelUfmValueType } from '@umbraco-cms/backoffice/block';
 import type { UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 
 import '@umbraco-cms/backoffice/ufm';
@@ -30,7 +30,7 @@ export class UmbBlockGridBlockElement extends UmbLitElement {
 	settings?: UmbBlockDataType;
 
 	override render() {
-		const blockValue = { ...this.content, $settings: this.settings, $index: this.index };
+		const blockValue: UmbBlockLabelUfmValueType = { ...this.content, $settings: this.settings, $index: this.index };
 		return html`
 			<umb-ref-grid-block
 				standalone

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/inline-list-block/inline-list-block.element.ts
@@ -12,7 +12,11 @@ import { UmbLanguageItemRepository } from '@umbraco-cms/backoffice/language';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbApiConstructorArgumentsMethodType } from '@umbraco-cms/backoffice/extension-api';
-import type { UmbBlockDataType, UMB_BLOCK_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/block';
+import type {
+	UmbBlockDataType,
+	UMB_BLOCK_WORKSPACE_CONTEXT,
+	UmbBlockLabelUfmValueType,
+} from '@umbraco-cms/backoffice/block';
 
 import '../../../block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.js';
 import { UmbContextBoundary } from '@umbraco-cms/backoffice/context-api';
@@ -186,7 +190,7 @@ export class UmbInlineListBlockElement extends UmbLitElement {
 	}
 
 	#renderBlockInfo() {
-		const blockValue = { ...this.content, $settings: this.settings, $index: this.index };
+		const blockValue: UmbBlockLabelUfmValueType = { ...this.content, $settings: this.settings, $index: this.index };
 		return html`
 			<span id="content">
 				<span id="icon">

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/ref-list-block/ref-list-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/components/ref-list-block/ref-list-block.element.ts
@@ -1,6 +1,6 @@
 import { css, customElement, html, property, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockLabelUfmValueType } from '@umbraco-cms/backoffice/block';
 
 import '@umbraco-cms/backoffice/ufm';
 import type { UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
@@ -30,7 +30,7 @@ export class UmbRefListBlockElement extends UmbLitElement {
 	config?: UmbBlockEditorCustomViewConfiguration;
 
 	override render() {
-		const blockValue = { ...this.content, $settings: this.settings, $index: this.index };
+		const blockValue: UmbBlockLabelUfmValueType = { ...this.content, $settings: this.settings, $index: this.index };
 		return html`
 			<uui-ref-node
 				standalone

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/ref-rte-block/ref-rte-block.element.ts
@@ -1,6 +1,6 @@
 import { css, customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockLabelUfmValueType } from '@umbraco-cms/backoffice/block';
 import type { UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
 
 /**
@@ -31,7 +31,7 @@ export class UmbRefRteBlockElement extends UmbLitElement {
 	config?: UmbBlockEditorCustomViewConfiguration;
 
 	override render() {
-		const blockValue = { ...this.content, $settings: this.settings, $index: this.index };
+		const blockValue: UmbBlockLabelUfmValueType = { ...this.content, $settings: this.settings, $index: this.index };
 		return html`
 			<uui-ref-node
 				standalone

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/inline-single-block/inline-single-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/inline-single-block/inline-single-block.element.ts
@@ -7,7 +7,11 @@ import { UmbLanguageItemRepository } from '@umbraco-cms/backoffice/language';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbApiConstructorArgumentsMethodType } from '@umbraco-cms/backoffice/extension-api';
-import type { UmbBlockDataType, UMB_BLOCK_WORKSPACE_CONTEXT } from '@umbraco-cms/backoffice/block';
+import type {
+	UmbBlockDataType,
+	UMB_BLOCK_WORKSPACE_CONTEXT,
+	UmbBlockLabelUfmValueType,
+} from '@umbraco-cms/backoffice/block';
 
 import '../../../block/workspace/views/edit/block-workspace-view-edit-content-no-router.element.js';
 
@@ -154,7 +158,7 @@ export class UmbInlineSingleBlockElement extends UmbLitElement {
 	}
 
 	#renderBlockInfo() {
-		const blockValue = { ...this.content, $settings: this.settings };
+		const blockValue: UmbBlockLabelUfmValueType = { ...this.content, $settings: this.settings };
 		return html`
 			<span id="content">
 				<span id="icon">

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/ref-single-block/ref-single-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/components/ref-single-block/ref-single-block.element.ts
@@ -1,6 +1,6 @@
 import { css, customElement, html, property, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbBlockDataType } from '@umbraco-cms/backoffice/block';
+import type { UmbBlockDataType, UmbBlockLabelUfmValueType } from '@umbraco-cms/backoffice/block';
 
 import '@umbraco-cms/backoffice/ufm';
 import type { UmbBlockEditorCustomViewConfiguration } from '@umbraco-cms/backoffice/block-custom-view';
@@ -27,7 +27,7 @@ export class UmbRefSingleBlockElement extends UmbLitElement {
 	config?: UmbBlockEditorCustomViewConfiguration;
 
 	override render() {
-		const blockValue = { ...this.content, $settings: this.settings };
+		const blockValue: UmbBlockLabelUfmValueType = { ...this.content, $settings: this.settings };
 		return html`
 			<uui-ref-node
 				standalone

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/types.ts
@@ -35,7 +35,13 @@ export interface UmbBlockValueDataPropertiesBaseType {
 	expose: Array<UmbBlockExposeModel>;
 }
 
-export interface UmbBlockValueType<BlockLayoutType extends UmbBlockLayoutBaseModel = UmbBlockLayoutBaseModel>
-	extends UmbBlockValueDataPropertiesBaseType {
+export interface UmbBlockValueType<
+	BlockLayoutType extends UmbBlockLayoutBaseModel = UmbBlockLayoutBaseModel,
+> extends UmbBlockValueDataPropertiesBaseType {
 	layout: { [key: string]: Array<BlockLayoutType> | undefined };
 }
+
+export type UmbBlockLabelUfmValueType = Record<string, unknown> & {
+	$settings?: Record<string, unknown>;
+	$index?: number;
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-element-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-element-manager.ts
@@ -17,6 +17,7 @@ import { UmbValidationController } from '@umbraco-cms/backoffice/validation';
 import {
 	UmbContentValidationToHintsManager,
 	UmbElementWorkspaceDataManager,
+	umbExtractVariantValues,
 	type UmbElementPropertyDataOwner,
 } from '@umbraco-cms/backoffice/content';
 import { UmbReadOnlyVariantGuardManager } from '@umbraco-cms/backoffice/utils';
@@ -60,6 +61,25 @@ export class UmbBlockElementManager<LayoutDataType extends UmbBlockLayoutBaseMod
 		this,
 		new UmbDocumentTypeDetailRepository(this),
 	);
+
+	// The values resolved to a single entry per property, matching the current variant. [NL]
+	readonly variantValues = mergeObservables(
+		[this.structure.contentTypeProperties, this.values, this.variantId],
+		([properties, values, variantId]) => {
+			if (!variantId) {
+				return [];
+			}
+			const propertyVariantIds = properties.map((property) => ({
+				alias: property.alias,
+				variantId: this.#createPropertyVariantId(property, variantId),
+			}));
+			return umbExtractVariantValues(propertyVariantIds, values);
+		},
+	);
+	#variantValuesSnapshot: Array<UmbBlockDataValueModel> = [];
+	getVariantValues() {
+		return this.#variantValuesSnapshot;
+	}
 
 	public readonly propertyViewGuard = new UmbVariantPropertyGuardManager(this);
 	public readonly propertyWriteGuard = new UmbVariantPropertyGuardManager(this);
@@ -120,6 +140,14 @@ export class UmbBlockElementManager<LayoutDataType extends UmbBlockLayoutBaseMod
 			this.structure.contentTypeDataTypeUniques,
 			(dataTypeUniques: Array<string>) => {
 				this.#dataTypeItemManager.setUniques(dataTypeUniques);
+			},
+			null,
+		);
+
+		this.observe(
+			this.variantValues,
+			(resolvedValues) => {
+				this.#variantValuesSnapshot = resolvedValues;
 			},
 			null,
 		);

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-value.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-value.function.test.ts
@@ -1,0 +1,34 @@
+import { expect } from '@open-wc/testing';
+import { buildBlockLabelValueObject } from './block-workspace-label-value.function.js';
+import type { UmbBlockDataValueModel } from '../types.js';
+
+function value(alias: string, val: unknown): UmbBlockDataValueModel {
+	return { alias, value: val, culture: null, segment: null, editorAlias: 'test' };
+}
+
+describe('buildBlockLabelValueObject', () => {
+	it('places content values at the top level keyed by alias', () => {
+		const result = buildBlockLabelValueObject([value('heading', 'Hello')], undefined);
+		expect(result.heading).to.equal('Hello');
+	});
+
+	it('places settings values under $settings as a key-value object keyed by alias', () => {
+		const result = buildBlockLabelValueObject(undefined, [value('notes', 'A note')]);
+		// $settings must be an object (not the raw value array) so labels can use `${$settings.notes}`. [NL]
+		expect(result.$settings).to.eql({ notes: 'A note' });
+	});
+
+	it('includes $index when an index is provided', () => {
+		const result = buildBlockLabelValueObject(undefined, undefined, 3);
+		expect(result.$index).to.equal(3);
+	});
+
+	it('omits $index when no index is provided', () => {
+		const result = buildBlockLabelValueObject(undefined, undefined);
+		expect('$index' in result).to.be.false;
+	});
+
+	it('returns an empty object when no values are provided', () => {
+		expect(buildBlockLabelValueObject(undefined, undefined)).to.eql({});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-value.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace-label-value.function.ts
@@ -1,0 +1,38 @@
+import type { UmbBlockDataValueModel, UmbBlockLabelUfmValueType } from '../types.js';
+
+/**
+ * Builds the value object consumed by the block label UFM render. Content values are placed at the top
+ * level and settings values under a `$settings` key — both keyed by property alias — so labels can
+ * reference them as `${alias}` and `${$settings.alias}` respectively.
+ * @param {Array<UmbBlockDataValueModel> | undefined} contentValues - The resolved block content values.
+ * @param {Array<UmbBlockDataValueModel> | undefined} settingsValues - The resolved block settings values.
+ * @param {number | undefined} index - The block index, exposed as `$index` when defined.
+ * @returns {UmbBlockLabelUfmValueType} The value object for the label render.
+ */
+export function buildBlockLabelValueObject(
+	contentValues: Array<UmbBlockDataValueModel> | undefined,
+	settingsValues: Array<UmbBlockDataValueModel> | undefined,
+	index?: number,
+): UmbBlockLabelUfmValueType {
+	const valueObject: UmbBlockLabelUfmValueType = {};
+
+	if (contentValues) {
+		for (const property of contentValues) {
+			valueObject[property.alias] = property.value;
+		}
+	}
+
+	if (settingsValues) {
+		const settingsObject: Record<string, unknown> = {};
+		for (const property of settingsValues) {
+			settingsObject[property.alias] = property.value;
+		}
+		valueObject['$settings'] = settingsObject;
+	}
+
+	if (index !== undefined) {
+		valueObject['$index'] = index;
+	}
+
+	return valueObject;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -1,9 +1,4 @@
-import type {
-	UmbBlockDataModel,
-	UmbBlockDataValueModel,
-	UmbBlockLabelUfmValueType,
-	UmbBlockLayoutBaseModel,
-} from '../types.js';
+import type { UmbBlockDataModel, UmbBlockDataValueModel, UmbBlockLayoutBaseModel } from '../types.js';
 import { UMB_BLOCK_ENTRIES_CONTEXT, UMB_BLOCK_MANAGER_CONTEXT } from '../context/index.js';
 import { UmbBlockWorkspaceEditorElement } from './block-workspace-editor.element.js';
 import { UmbBlockElementManager } from './block-element-manager.js';
@@ -11,6 +6,7 @@ import type { UmbBlockWorkspaceOriginData } from './block-workspace.modal-token.
 import { UMB_BLOCK_WORKSPACE_VIEW_CONTENT, UMB_BLOCK_WORKSPACE_VIEW_SETTINGS } from './constants.js';
 import { UmbBlockLanguageAccessWorkspaceController } from './block-workspace-language-access.controller.js';
 import { resolveBlockWorkspaceLabelIndex } from './block-workspace-label-index.function.js';
+import { buildBlockLabelValueObject } from './block-workspace-label-value.function.js';
 import {
 	UmbSubmittableWorkspaceContextBase,
 	type UmbRoutableWorkspaceContext,
@@ -291,32 +287,13 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		contentValues: Array<UmbBlockDataValueModel> | undefined,
 		settingsValues: Array<UmbBlockDataValueModel> | undefined,
 	) {
-		const valueObject: UmbBlockLabelUfmValueType = {};
-		if (contentValues) {
-			for (const property of contentValues) {
-				valueObject[property.alias] = property.value;
-			}
-		}
-
-		if (settingsValues) {
-			const settingsObject: Record<string, unknown> = {};
-			for (const property of settingsValues) {
-				settingsObject[property.alias] = property.value;
-			}
-			valueObject['$settings'] = settingsObject;
-		}
-
 		const index = resolveBlockWorkspaceLabelIndex(
 			this.#index,
 			this.#originData,
 			this.#blockEntries?.getLayouts().length,
 		);
 
-		if (index !== undefined) {
-			valueObject['$index'] = index;
-		}
-
-		this.#labelRender.value = valueObject;
+		this.#labelRender.value = buildBlockLabelValueObject(contentValues, settingsValues, index);
 
 		// Await one animation frame:
 		await new Promise((resolve) => requestAnimationFrame(() => resolve(true)));

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -285,7 +285,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		contentValues: Array<UmbBlockDataValueModel> | undefined,
 		settingsValues: Array<UmbBlockDataValueModel> | undefined,
 	) {
-		const valueObject = {} as Record<string, unknown>;
+		const valueObject = {} as Record<string, unknown> & { $settings?: Record<string, unknown>; $index?: number };
 		if (contentValues) {
 			for (const property of contentValues) {
 				valueObject[property.alias] = property.value;
@@ -293,7 +293,11 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		}
 
 		if (settingsValues) {
-			valueObject['$settings'] = settingsValues;
+			const settingsObject: Record<string, unknown> = {};
+			for (const property of settingsValues) {
+				settingsObject[property.alias] = property.value;
+			}
+			valueObject['$settings'] = settingsObject;
 		}
 
 		const index = resolveBlockWorkspaceLabelIndex(

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -1,4 +1,9 @@
-import type { UmbBlockDataModel, UmbBlockDataValueModel, UmbBlockLayoutBaseModel } from '../types.js';
+import type {
+	UmbBlockDataModel,
+	UmbBlockDataValueModel,
+	UmbBlockLabelUfmValueType,
+	UmbBlockLayoutBaseModel,
+} from '../types.js';
 import { UMB_BLOCK_ENTRIES_CONTEXT, UMB_BLOCK_MANAGER_CONTEXT } from '../context/index.js';
 import { UmbBlockWorkspaceEditorElement } from './block-workspace-editor.element.js';
 import { UmbBlockElementManager } from './block-element-manager.js';
@@ -285,7 +290,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		contentValues: Array<UmbBlockDataValueModel> | undefined,
 		settingsValues: Array<UmbBlockDataValueModel> | undefined,
 	) {
-		const valueObject = {} as Record<string, unknown> & { $settings?: Record<string, unknown>; $index?: number };
+		const valueObject: UmbBlockLabelUfmValueType = {};
 		if (contentValues) {
 			for (const property of contentValues) {
 				valueObject[property.alias] = property.value;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -128,7 +128,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 					),
 					(index) => {
 						this.#index = index;
-						this.#renderLabel(this.content.getValues(), this.settings.getValues());
+						this.#renderLabel(this.content.getVariantValues(), this.settings.getVariantValues());
 					},
 					'observeLayoutIndex',
 				);
@@ -172,7 +172,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		);
 
 		this.observe(
-			observeMultiple([this.content.values, this.settings.values]),
+			observeMultiple([this.content.variantValues, this.settings.variantValues]),
 			async ([contentValues, settingsValues]) => {
 				this.#renderLabel(contentValues, settingsValues);
 			},
@@ -283,7 +283,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 	#gotLabel(label: string | undefined) {
 		if (label) {
 			this.#labelRender.markdown = label;
-			this.#renderLabel(this.content.getValues(), this.settings.getValues());
+			this.#renderLabel(this.content.getVariantValues(), this.settings.getVariantValues());
 		}
 	}
 
@@ -291,7 +291,6 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		contentValues: Array<UmbBlockDataValueModel> | undefined,
 		settingsValues: Array<UmbBlockDataValueModel> | undefined,
 	) {
-		// TODO: content or $settings does not handle variant properties, it just uses the first value it can find for the alias. [NL]
 		const valueObject: UmbBlockLabelUfmValueType = {};
 		if (contentValues) {
 			for (const property of contentValues) {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -118,6 +118,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 			this.#blockEntries = context;
 			if (context) {
 				this.observe(
+					// TODO: Turn this into a observablePart that is retrievable from the block entries context, so we do not have to observe multiple values here. [NL]
 					observeMultiple([context.layoutEntries, this.contentKey]).pipe(
 						map(([layouts, contentKey]) => {
 							const found = contentKey ? layouts.findIndex((x) => x.contentKey === contentKey) : -1;
@@ -290,6 +291,7 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 		contentValues: Array<UmbBlockDataValueModel> | undefined,
 		settingsValues: Array<UmbBlockDataValueModel> | undefined,
 	) {
+		// TODO: content or $settings does not handle variant properties, it just uses the first value it can find for the alias. [NL]
 		const valueObject: UmbBlockLabelUfmValueType = {};
 		if (contentValues) {
 			for (const property of contentValues) {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/element-property-dataset.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/element-property-dataset.context.ts
@@ -19,13 +19,13 @@ import type { UmbEntityUnique } from '@umbraco-cms/backoffice/entity';
 type UmbPropertyVariantIdMapType = Array<{ alias: string; variantId: UmbVariantId }>;
 
 export abstract class UmbElementPropertyDatasetContext<
-		ContentModel extends UmbElementDetailModel = UmbElementDetailModel,
-		ContentTypeModel extends UmbContentTypeModel = UmbContentTypeModel,
-		DataOwnerType extends UmbElementPropertyDataOwner<ContentModel, ContentTypeModel> = UmbElementPropertyDataOwner<
-			ContentModel,
-			ContentTypeModel
-		>,
-	>
+	ContentModel extends UmbElementDetailModel = UmbElementDetailModel,
+	ContentTypeModel extends UmbContentTypeModel = UmbContentTypeModel,
+	DataOwnerType extends UmbElementPropertyDataOwner<ContentModel, ContentTypeModel> = UmbElementPropertyDataOwner<
+		ContentModel,
+		ContentTypeModel
+	>,
+>
 	extends UmbContextBase
 	implements UmbPropertyDatasetContext
 {
@@ -69,7 +69,8 @@ export abstract class UmbElementPropertyDatasetContext<
 		this.#variantContext.setVariantId(this.#variantId);
 
 		this.#propertyVariantIdPromise = new Promise((resolve) => {
-			this.#propertyVariantIdPromiseResolver = resolve as any;
+			this.#propertyVariantIdPromiseResolver = resolve as unknown as () => void;
+			// TODO: implement a rejector as well, and handle that in the places awaiting this promise. [NL]
 		});
 
 		this.observe(

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/element-property-dataset.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/element-property-dataset.context.ts
@@ -1,5 +1,6 @@
 import type { UmbElementDetailModel } from '../types.js';
 import type { UmbElementPropertyDataOwner } from './element-property-data-owner.interface.js';
+import { umbExtractVariantValues } from './merge-variant-values.function.js';
 import type { UmbPropertyDatasetContext } from '@umbraco-cms/backoffice/property';
 import { UMB_PROPERTY_DATASET_CONTEXT } from '@umbraco-cms/backoffice/property';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
@@ -119,16 +120,7 @@ export abstract class UmbElementPropertyDatasetContext<
 	}
 
 	#mergeVariantIdsAndValues([props, values]: [UmbPropertyVariantIdMapType, ContentModel['values'] | undefined]) {
-		const r: ContentModel['values'] = [];
-		if (values) {
-			for (const prop of props) {
-				const f = values.find((v) => prop.alias === v.alias && prop.variantId.compare(v));
-				if (f) {
-					r.push(f);
-				}
-			}
-		}
-		return r as ContentModel['values'];
+		return umbExtractVariantValues(props, values) as ContentModel['values'];
 	}
 
 	async getProperties(): Promise<ContentModel['values']> {

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/index.ts
@@ -2,3 +2,4 @@ export * from './content-property-dataset.context-token.js';
 export * from './content-property-dataset.context.js';
 export type * from './element-property-data-owner.interface.js';
 export * from './element-property-dataset.context.js';
+export * from './merge-variant-values.function.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/merge-variant-values.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/merge-variant-values.function.test.ts
@@ -1,0 +1,60 @@
+import { expect } from '@open-wc/testing';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { umbExtractVariantValues } from './merge-variant-values.function.js';
+
+type TestValue = { alias: string; culture: string | null; segment: string | null; value: unknown };
+
+describe('umbExtractVariantValues', () => {
+	it('picks the value matching the property variant among multiple variants of the same alias', () => {
+		// 'en' comes first and 'da' last, so a naive last-wins flatten would wrongly resolve to 'Danish'. [NL]
+		const values: Array<TestValue> = [
+			{ alias: 'title', culture: 'en', segment: null, value: 'English' },
+			{ alias: 'title', culture: 'da', segment: null, value: 'Danish' },
+		];
+
+		const result = umbExtractVariantValues(
+			[{ alias: 'title', variantId: UmbVariantId.Create({ culture: 'en', segment: null }) }],
+			values,
+		);
+
+		expect(result.length).to.equal(1);
+		expect(result[0].value).to.equal('English');
+	});
+
+	it('returns one entry per property, in property order', () => {
+		const values: Array<TestValue> = [
+			{ alias: 'body', culture: null, segment: null, value: 'B' },
+			{ alias: 'title', culture: null, segment: null, value: 'T' },
+		];
+
+		const result = umbExtractVariantValues(
+			[
+				{ alias: 'title', variantId: UmbVariantId.CreateInvariant() },
+				{ alias: 'body', variantId: UmbVariantId.CreateInvariant() },
+			],
+			values,
+		);
+
+		expect(result.map((x) => x.value)).to.eql(['T', 'B']);
+	});
+
+	it('skips properties that have no matching value', () => {
+		const values: Array<TestValue> = [{ alias: 'title', culture: null, segment: null, value: 'T' }];
+
+		const result = umbExtractVariantValues(
+			[
+				{ alias: 'title', variantId: UmbVariantId.CreateInvariant() },
+				{ alias: 'missing', variantId: UmbVariantId.CreateInvariant() },
+			],
+			values,
+		);
+
+		expect(result.length).to.equal(1);
+		expect(result[0].alias).to.equal('title');
+	});
+
+	it('returns an empty array when values are undefined', () => {
+		const result = umbExtractVariantValues([{ alias: 'title', variantId: UmbVariantId.CreateInvariant() }], undefined);
+		expect(result).to.eql([]);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/merge-variant-values.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/property-dataset-context/merge-variant-values.function.ts
@@ -1,0 +1,25 @@
+import type { UmbPropertyValueDataWithVariant } from '@umbraco-cms/backoffice/property';
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+
+/**
+ * Resolves a single value per property for a given variant.
+ * @param {Array<{ alias: string; variantId: UmbVariantId }>} propertyVariantIds - The property types paired with the
+ * variant id to extract values for.
+ * @param {Array<UmbPropertyValueDataWithVariant> | undefined} values - The full value set to pick from.
+ * @returns {Array<UmbPropertyValueDataWithVariant>} One value per property whose alias and variant matches, in property order.
+ */
+export function umbExtractVariantValues<ValueType extends UmbPropertyValueDataWithVariant>(
+	propertyVariantIds: Array<{ alias: string; variantId: UmbVariantId }>,
+	values: Array<ValueType> | undefined,
+): Array<ValueType> {
+	const result: Array<ValueType> = [];
+	if (values) {
+		for (const property of propertyVariantIds) {
+			const found = values.find((value) => property.alias === value.alias && property.variantId.compare(value));
+			if (found) {
+				result.push(found);
+			}
+		}
+	}
+	return result;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/types.ts
@@ -1,5 +1,5 @@
 import type { UmbEntityFlag } from '@umbraco-cms/backoffice/entity-flag';
-import type { UmbPropertyValueDataWithVariant } from '@umbraco-cms/backoffice/property';
+import type { UmbPropertyValueData, UmbPropertyValueDataWithVariant } from '@umbraco-cms/backoffice/property';
 import type { UmbEntityVariantModel } from '@umbraco-cms/backoffice/variant';
 
 export type * from './collection/types.js';
@@ -21,8 +21,10 @@ export interface UmbElementValueModel<ValueType = unknown> extends UmbPropertyVa
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UmbContentValueModel<ValueType = unknown> extends UmbElementValueModel<ValueType> {}
 
-export interface UmbPotentialContentValueModel<ValueType = unknown> extends UmbPropertyValueDataWithVariant<ValueType> {
+export interface UmbPotentialContentValueModel<ValueType = unknown> extends UmbPropertyValueData<ValueType> {
 	editorAlias?: string;
+	culture?: string | null;
+	segment?: string | null;
 }
 
 export interface UmbContentDetailModel<

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/types.ts
@@ -1,5 +1,5 @@
 import type { UmbEntityFlag } from '@umbraco-cms/backoffice/entity-flag';
-import type { UmbPropertyValueData } from '@umbraco-cms/backoffice/property';
+import type { UmbPropertyValueDataWithVariant } from '@umbraco-cms/backoffice/property';
 import type { UmbEntityVariantModel } from '@umbraco-cms/backoffice/variant';
 
 export type * from './collection/types.js';
@@ -10,27 +10,24 @@ export interface UmbElementDetailModel {
 	values: Array<UmbElementValueModel>;
 }
 
-export interface UmbElementValueModel<ValueType = unknown> extends UmbPropertyValueData<ValueType> {
-	culture: string | null;
+export interface UmbElementValueModel<ValueType = unknown> extends UmbPropertyValueDataWithVariant<ValueType> {
 	editorAlias: string;
 	/**
 	 * @deprecated, we do not use entityType on values anymore. To be removed in Umbraco v.18.
 	 * Just remove the property.
 	 */
 	entityType?: string;
-	segment: string | null;
 }
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface UmbContentValueModel<ValueType = unknown> extends UmbElementValueModel<ValueType> {}
 
-export interface UmbPotentialContentValueModel<ValueType = unknown> extends UmbPropertyValueData<ValueType> {
+export interface UmbPotentialContentValueModel<ValueType = unknown> extends UmbPropertyValueDataWithVariant<ValueType> {
 	editorAlias?: string;
-	culture?: string | null;
-	segment?: string | null;
 }
 
-export interface UmbContentDetailModel<VariantModelType extends UmbEntityVariantModel = UmbEntityVariantModel>
-	extends UmbElementDetailModel {
+export interface UmbContentDetailModel<
+	VariantModelType extends UmbEntityVariantModel = UmbEntityVariantModel,
+> extends UmbElementDetailModel {
 	unique: string;
 	entityType: string;
 	variants: Array<VariantModelType>;
@@ -38,5 +35,4 @@ export interface UmbContentDetailModel<VariantModelType extends UmbEntityVariant
 }
 
 export interface UmbContentLikeDetailModel
-	extends UmbElementDetailModel,
-		Partial<Pick<UmbContentDetailModel, 'variants' | 'flags'>> {}
+	extends UmbElementDetailModel, Partial<Pick<UmbContentDetailModel, 'variants' | 'flags'>> {}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/types/property-value-data.type.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/types/property-value-data.type.ts
@@ -3,7 +3,13 @@ export interface UmbPropertyValueData<ValueType = unknown> {
 	value?: ValueType;
 }
 
-export interface UmbPropertyValueDataPotentiallyWithEditorAlias<ValueType = unknown>
-	extends UmbPropertyValueData<ValueType> {
+export interface UmbPropertyValueDataPotentiallyWithEditorAlias<
+	ValueType = unknown,
+> extends UmbPropertyValueData<ValueType> {
 	editorAlias?: string;
+}
+
+export interface UmbPropertyValueDataWithVariant<ValueType = unknown> extends UmbPropertyValueData<ValueType> {
+	culture: string | null;
+	segment: string | null;
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/23095

Corrects $settings to become a key-value map as it is implemented elsewhere, and should be to enable retrieving settings values in this way: `$settings.myPropertyAlias`

As well as making sure that only the current variant version of `content` and `settings` properties are present.

Test the described case in the issue.

Additional concerns:
* Test fields that do not vary in a block that does vary.
* Also test content, i only tested settings.

**From my own test case:**
Here I have a Block in a 'shared'(invariant) field, the Block´s element varies by culture, and then the field varies by culture as well. The label utilies that field and you can see that the value present in the label is specific to the variant.
<img width="1247" height="313" alt="image" src="https://github.com/user-attachments/assets/eed596fb-cf78-45da-81bc-4b838fbaa9eb" />