### PR TITLE
Integration Tests: Adjusting Status Codes for Failing Tests

### DIFF
--- a/tests/Umbraco.Tests.Integration/ManagementApi/RedirectUrlManagement/DeleteByKeyRedirectUrlManagementControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/RedirectUrlManagement/DeleteByKeyRedirectUrlManagementControllerTests.cs
@@ -11,12 +11,12 @@ public class DeleteByKeyRedirectUrlManagementControllerTests : ManagementApiUser
 
     protected override UserGroupAssertionModel AdminUserGroupAssertionModel => new()
     {
-        ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.NotFound
     };
 
     protected override UserGroupAssertionModel EditorUserGroupAssertionModel => new()
     {
-        ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.NotFound
     };
 
     protected override UserGroupAssertionModel SensitiveDataUserGroupAssertionModel => new()
@@ -31,7 +31,7 @@ public class DeleteByKeyRedirectUrlManagementControllerTests : ManagementApiUser
 
     protected override UserGroupAssertionModel WriterUserGroupAssertionModel => new()
     {
-        ExpectedStatusCode = HttpStatusCode.OK
+        ExpectedStatusCode = HttpStatusCode.NotFound
     };
 
     protected override UserGroupAssertionModel UnauthorizedUserGroupAssertionModel => new()


### PR DESCRIPTION
### Description
This one kind of annoyed me when running tests on a different branch, and seeing these fail i had to fix them.

So this issue baffled me, because it seems the changes that caused this was introduced in my own PR https://github.com/umbraco/Umbraco-CMS/pull/22985, that added `RedirectUrlOperationStatus` to the deletion of redirects. This apparently messed up some of the tests. On my PR all tests passed, so that confused me a good amount, i still do not understand why or how, but regardless i see why they are failing now.

So the issue here seems to stem from the fact that the `DeleteByKeyRedirectUrlManagementControllerTests` was used as part of the auth test suite to test permissions etc. The `MethodSelector` in these tests used to call a method that would just be `void` so not return anything and therefore status code OK was fine to test against, the caller had permission to call the method, no need to worry.

Now with the `RedirectUrlOperationStatus` these tests return `NotFound`, so the caller still has permission to call it, but the tests expect OK rather than NotFound. This PR adjusts the expected outcome of the method called.


<!-- Thanks for contributing to Umbraco CMS! -->
