### PR TITLE
Block RTE: Implement unsupported block rendering (closes #23071)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -1,12 +1,11 @@
 import type { UmbBlockRteLayoutModel } from '../../types.js';
-import { UMB_BLOCK_RTE } from '../../constants.js';
 import { UmbBlockRteEntryContext } from '../../context/block-rte-entry.context.js';
-import { css, customElement, html, nothing, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { UMB_BLOCK_RTE } from '../../constants.js';
+import { css, customElement, html, nothing, property, when, state } from '@umbraco-cms/backoffice/external/lit';
 import { stringOrStringArrayContains } from '@umbraco-cms/backoffice/utils';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbDataPathBlockElementDataQuery } from '@umbraco-cms/backoffice/block';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbObserveValidationStateController } from '@umbraco-cms/backoffice/validation';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type {
 	ManifestBlockEditorCustomView,
 	UmbBlockEditorCustomViewProperties,
@@ -254,6 +253,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 		if (this._unsupported) {
 			return false;
 		}
+
 		const elementTypeAlias = this._contentTypeAlias ?? '';
 		const isForBlockEditor =
 			!manifest.forBlockEditor || stringOrStringArrayContains(manifest.forBlockEditor, UMB_BLOCK_RTE);
@@ -271,34 +271,38 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 		if (this._exposed || this._isReadOnly) {
 			return ext.component;
 		} else {
-			return html`<div>
-				${ext.component}
-				<umb-block-overlay-expose-button
-					.contentTypeName=${this._contentTypeName}
-					@click=${this.#expose}></umb-block-overlay-expose-button>
-			</div>`;
+			return html`
+				<div>
+					${ext.component}
+					<umb-block-overlay-expose-button
+						.contentTypeName=${this._contentTypeName}
+						@click=${this.#expose}></umb-block-overlay-expose-button>
+				</div>
+			`;
 		}
 	};
 
 	#renderBlock() {
-		return this.contentKey && (this._contentTypeAlias || this._unsupported)
-			? html`
-					<div class="uui-text uui-font">
-						<umb-extension-slot
-							type="blockEditorCustomView"
-							default-element="umb-ref-rte-block"
-							.renderMethod=${this.#extensionSlotRenderMethod}
-							.fallbackRenderMethod=${this.#renderBuiltinBlockView}
-							.props=${this._blockViewProps}
-							.filter=${this.#filterBlockCustomViews}
-							single></umb-extension-slot>
-						${this.#renderActionBar()}
-						${!this._showContentEdit && this._contentInvalid
-							? html`<uui-badge attention color="invalid" label="Invalid content">!</uui-badge>`
-							: nothing}
-					</div>
-				`
-			: nothing;
+		return when(
+			this.contentKey && (this._contentTypeAlias || this._unsupported),
+			() => html`
+				<div>
+					<umb-extension-slot
+						type="blockEditorCustomView"
+						default-element="umb-ref-rte-block"
+						.renderMethod=${this.#extensionSlotRenderMethod}
+						.fallbackRenderMethod=${this.#renderBuiltinBlockView}
+						.props=${this._blockViewProps}
+						.filter=${this.#filterBlockCustomViews}
+						single></umb-extension-slot>
+					${this.#renderActionBar()}
+					${when(
+						!this._showContentEdit && this._contentInvalid,
+						() => html`<uui-badge attention color="invalid" label="Invalid content">!</uui-badge>`,
+					)}
+				</div>
+			`,
+		);
 	}
 
 	#renderActionBar() {
@@ -318,14 +322,16 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	};
 
 	#renderRefBlock() {
-		return html`<umb-ref-rte-block
-			.label=${this._label}
-			.icon=${this._icon}
-			.index=${this._blockViewProps.index}
-			.unpublished=${!this._exposed}
-			.content=${this._blockViewProps.content}
-			.settings=${this._blockViewProps.settings}
-			.config=${this._blockViewProps.config}></umb-ref-rte-block>`;
+		return html`
+			<umb-ref-rte-block
+				.label=${this._label}
+				.icon=${this._icon}
+				.index=${this._blockViewProps.index}
+				.unpublished=${!this._exposed}
+				.content=${this._blockViewProps.content}
+				.settings=${this._blockViewProps.settings}
+				.config=${this._blockViewProps.config}></umb-ref-rte-block>
+		`;
 	}
 
 	override render() {
@@ -333,7 +339,6 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	static override readonly styles = [
-		UmbTextStyles,
 		css`
 			:host {
 				position: relative;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -63,8 +63,9 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	@state()
 	private _contentTypeAlias?: string;
 
-	@state()
-	private _unsupported?: boolean;
+	// 'unsupported' attribute is used for styling purpose.
+	@property({ type: Boolean, attribute: 'unsupported', reflect: true })
+	unsupported?: boolean;
 
 	@state()
 	private _contentTypeName?: string;
@@ -165,7 +166,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			(unsupported) => {
 				if (unsupported === undefined) return;
 				this.#updateBlockViewProps({ unsupported });
-				this._unsupported = unsupported;
+				this.unsupported = unsupported;
 			},
 			null,
 		);
@@ -250,7 +251,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	readonly #filterBlockCustomViews = (manifest: ManifestBlockEditorCustomView) => {
-		if (this._unsupported) {
+		if (this.unsupported) {
 			return false;
 		}
 
@@ -284,7 +285,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 
 	#renderBlock() {
 		return when(
-			this.contentKey && (this._contentTypeAlias || this._unsupported),
+			this.contentKey && (this._contentTypeAlias || this.unsupported),
 			() => html`
 				<div>
 					<umb-extension-slot
@@ -315,7 +316,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	#renderBuiltinBlockView = () => {
-		if (this._unsupported) {
+		if (this.unsupported) {
 			return this.#renderUnsupportedBlock();
 		}
 		return this.#renderRefBlock();

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -15,6 +15,7 @@ import type { UmbPropertyEditorUiElement } from '@umbraco-cms/backoffice/propert
 import type { UmbExtensionElementInitializer } from '@umbraco-cms/backoffice/extension-api';
 
 import '../ref-rte-block/index.js';
+import '../unsupported-rte-block/index.js';
 import '../../../block/action/block-action-list.element.js';
 
 /**
@@ -62,6 +63,9 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 
 	@state()
 	private _contentTypeAlias?: string;
+
+	@state()
+	private _unsupported?: boolean;
 
 	@state()
 	private _contentTypeName?: string;
@@ -157,6 +161,15 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			},
 			null,
 		);
+		this.observe(
+			this.#context.unsupported,
+			(unsupported) => {
+				if (unsupported === undefined) return;
+				this.#updateBlockViewProps({ unsupported });
+				this._unsupported = unsupported;
+			},
+			null,
+		);
 
 		this.observe(this.#context.actionsVisibility, (showActions) => (this._showActions = showActions), null);
 
@@ -238,6 +251,9 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	}
 
 	readonly #filterBlockCustomViews = (manifest: ManifestBlockEditorCustomView) => {
+		if (this._unsupported) {
+			return false;
+		}
 		const elementTypeAlias = this._contentTypeAlias ?? '';
 		const isForBlockEditor =
 			!manifest.forBlockEditor || stringOrStringArrayContains(manifest.forBlockEditor, UMB_BLOCK_RTE);
@@ -265,7 +281,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	};
 
 	#renderBlock() {
-		return this.contentKey && this._contentTypeAlias
+		return this.contentKey && (this._contentTypeAlias || this._unsupported)
 			? html`
 					<div class="uui-text uui-font">
 						<umb-extension-slot
@@ -290,11 +306,14 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 		return html`<umb-block-action-list id="actions" block-editor=${UMB_BLOCK_RTE}></umb-block-action-list>`;
 	}
 
+	#renderUnsupportedBlock() {
+		return html`<umb-unsupported-rte-block></umb-unsupported-rte-block>`;
+	}
+
 	#renderBuiltinBlockView = () => {
-		// TODO: Missing unsupported rendering [NL]
-		/*if (this._unsupported) {
+		if (this._unsupported) {
 			return this.#renderUnsupportedBlock();
-		}*/
+		}
 		return this.#renderRefBlock();
 	};
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -100,76 +100,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 		// We do not have index for RTE Blocks at the moment.
 		this.#context.setIndex(0);
 
-		this.observe(
-			this.#context.showContentEdit,
-			(showContentEdit) => {
-				this._showContentEdit = showContentEdit;
-				this.#updateBlockViewProps({ config: { ...this._blockViewProps.config!, showContentEdit } });
-			},
-			null,
-		);
-		this.observe(
-			this.#context.settingsElementTypeKey,
-			(key) => {
-				this.#updateBlockViewProps({ config: { ...this._blockViewProps.config!, showSettingsEdit: !!key } });
-			},
-			null,
-		);
-		this.observe(
-			this.#context.contentElementTypeAlias,
-			(alias) => {
-				this._contentTypeAlias = alias;
-			},
-			null,
-		);
-		this.observe(
-			this.#context.contentElementTypeName,
-			(contentElementTypeName) => {
-				this._contentTypeName = contentElementTypeName;
-			},
-			null,
-		);
-		this.observe(
-			this.#context.blockType,
-			(blockType) => {
-				this.#updateBlockViewProps({ blockType });
-			},
-			null,
-		);
-		this.observe(this.#context.index, (index) => this.#updateBlockViewProps({ index }), null);
-		this.observe(
-			this.#context.label,
-			(label) => {
-				this.#updateBlockViewProps({ label });
-				this._label = label;
-			},
-			null,
-		);
-		this.observe(
-			this.#context.contentElementTypeIcon,
-			(icon) => {
-				this.#updateBlockViewProps({ icon });
-				this._icon = icon;
-			},
-			null,
-		);
-		this.observe(
-			this.#context.hasExpose,
-			(exposed) => {
-				this.#updateBlockViewProps({ unpublished: !exposed });
-				this._exposed = exposed;
-			},
-			null,
-		);
-		this.observe(
-			this.#context.unsupported,
-			(unsupported) => {
-				if (unsupported === undefined) return;
-				this.#updateBlockViewProps({ unsupported });
-				this.unsupported = unsupported;
-			},
-			null,
-		);
+		this.#observeBlockViewProps();
 
 		this.observe(this.#context.actionsVisibility, (showActions) => (this._showActions = showActions), null);
 
@@ -225,6 +156,67 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 				this.#updateBlockViewProps({ readonly: isReadOnly });
 			},
 			'umbReadOnlyObserver',
+		);
+	}
+
+	#observeBlockViewProps() {
+		this.observe(
+			this.#context.showContentEdit,
+			(showContentEdit) => {
+				this._showContentEdit = showContentEdit;
+				this.#updateBlockViewProps({ config: { ...this._blockViewProps.config!, showContentEdit } });
+			},
+			null,
+		);
+		this.observe(
+			this.#context.settingsElementTypeKey,
+			(key) => {
+				this.#updateBlockViewProps({ config: { ...this._blockViewProps.config!, showSettingsEdit: !!key } });
+			},
+			null,
+		);
+		this.observe(this.#context.contentElementTypeAlias, (alias) => (this._contentTypeAlias = alias), null);
+		this.observe(this.#context.contentElementTypeName, (name) => (this._contentTypeName = name), null);
+		this.observe(
+			this.#context.blockType,
+			(blockType) => {
+				this.#updateBlockViewProps({ blockType });
+			},
+			null,
+		);
+		this.observe(this.#context.index, (index) => this.#updateBlockViewProps({ index }), null);
+		this.observe(
+			this.#context.label,
+			(label) => {
+				this.#updateBlockViewProps({ label });
+				this._label = label;
+			},
+			null,
+		);
+		this.observe(
+			this.#context.contentElementTypeIcon,
+			(icon) => {
+				this.#updateBlockViewProps({ icon });
+				this._icon = icon;
+			},
+			null,
+		);
+		this.observe(
+			this.#context.hasExpose,
+			(exposed) => {
+				this.#updateBlockViewProps({ unpublished: !exposed });
+				this._exposed = exposed;
+			},
+			null,
+		);
+		this.observe(
+			this.#context.unsupported,
+			(unsupported) => {
+				if (unsupported === undefined) return;
+				this.#updateBlockViewProps({ unsupported });
+				this.unsupported = unsupported;
+			},
+			null,
 		);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -63,7 +63,7 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 	@state()
 	private _contentTypeAlias?: string;
 
-	// 'unsupported' attribute is used for styling purpose.
+	/** Reflects whether the block's content type is no longer registered. Set internally by context — do not set externally. */
 	@property({ type: Boolean, attribute: 'unsupported', reflect: true })
 	unsupported?: boolean;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/block-rte-entry/block-rte-entry.element.ts
@@ -351,10 +351,8 @@ export class UmbBlockRteEntryElement extends UmbLitElement implements UmbPropert
 			}
 
 			:host(.ProseMirror-selectednode) {
-				umb-ref-rte-block {
-					--uui-color-default-contrast: initial;
-					outline: 3px solid var(--uui-color-focus);
-				}
+				--uui-color-default-contrast: initial;
+				outline: 3px solid var(--uui-color-focus);
 			}
 
 			umb-extension-slot::part(component) {

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/unsupported-rte-block/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/unsupported-rte-block/index.ts
@@ -1,0 +1,1 @@
+export * from './unsupported-rte-block.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/unsupported-rte-block/unsupported-rte-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/unsupported-rte-block/unsupported-rte-block.element.ts
@@ -1,0 +1,56 @@
+import { css, customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+
+/**
+ * @element umb-unsupported-rte-block
+ */
+@customElement('umb-unsupported-rte-block')
+export class UmbUnsupportedRteBlockElement extends UmbLitElement {
+	override render() {
+		return html`
+			<uui-ref-node
+				standalone
+				.readonly=${true}
+				detail=${this.localize.term('blockEditor_unsupportedBlockDescription')}>
+				<div class="selection-background" aria-hidden="true">&emsp;</div>
+				<umb-icon slot="icon" name="icon-alert"></umb-icon>
+				<span slot="name">${this.localize.term('blockEditor_unsupportedBlockName')}</span>
+			</uui-ref-node>
+		`;
+	}
+
+	static override readonly styles = [
+		css`
+			:host {
+				display: block;
+			}
+
+			uui-ref-node {
+				min-height: var(--uui-size-16);
+			}
+
+			/* HACK: Stretches a space character (&emsp;) to be full-width to make the RTE block appear text-selectable. [LK,NL] */
+			.selection-background {
+				position: absolute;
+				pointer-events: none;
+				font-size: 100vw;
+				inset: 0;
+				overflow: hidden;
+				z-index: 0;
+			}
+
+			umb-icon,
+			span {
+				z-index: 1;
+			}
+		`,
+	];
+}
+
+export default UmbUnsupportedRteBlockElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-unsupported-rte-block': UmbUnsupportedRteBlockElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/unsupported-rte-block/unsupported-rte-block.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/components/unsupported-rte-block/unsupported-rte-block.test.ts
@@ -1,0 +1,22 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+import UmbUnsupportedRteBlockElement from './unsupported-rte-block.element.js';
+
+describe('UmbUnsupportedRteBlock', () => {
+	let element: UmbUnsupportedRteBlockElement;
+
+	beforeEach(async () => {
+		element = await fixture(html`<umb-unsupported-rte-block></umb-unsupported-rte-block>`);
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbUnsupportedRteBlockElement);
+	});
+
+	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {
+		it('passes the a11y audit', async () => {
+			await expect(element).to.be.accessible(defaultA11yConfig);
+		});
+	}
+});


### PR DESCRIPTION
Implements unsupported block rendering for the Block RTE editor. When a block's content type is no longer available, the RTE entry now renders an `umb-unsupported-rte-block` placeholder instead of nothing.

Also fixes the `.ProseMirror-selectednode` focus ring so it applies to both the ref block and unsupported block variants.

Fixes #23071