### PR TITLE
Content/Media: Reload content on Sort to avoid data loss with partially loaded entities (closes #23120)

### DIFF
--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -3137,7 +3137,13 @@ public class ContentService : RepositoryService, IContentService
         {
             scope.WriteLock(Constants.Locks.ContentTree);
 
-            OperationResult ret = Sort(scope, itemsA, userId, evtMsgs);
+            // Reload within the lock so sorting operates on fully-loaded entities. Callers may pass
+            // partially-loaded content (e.g. loaded with loadTemplates: false or without property data),
+            // and saving those directly would wipe the template and property data (#23120).
+            // GetByIds returns items in the requested order, preserving the caller's ordering that drives the sort.
+            IContent[] reloaded = GetByIds(itemsA.Select(x => x.Id).ToArray()).ToArray();
+
+            OperationResult ret = Sort(scope, reloaded, userId, evtMsgs);
             scope.Complete();
             return ret;
         }

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1414,6 +1414,15 @@ namespace Umbraco.Cms.Core.Services
             {
                 scope.WriteLock(Constants.Locks.MediaTree);
 
+                // Reload within the lock so sorting operates on fully-loaded entities. Callers may pass
+                // partially-loaded media (e.g. without property data), and saving those directly would
+                // wipe the property data (#23120). Preserve the caller's ordering, which drives the sort.
+                var reloadedById = GetByIds(itemsA.Select(x => x.Id)).ToDictionary(x => x.Id);
+                itemsA = itemsA
+                    .Select(x => reloadedById.TryGetValue(x.Id, out IMedia? media) ? media : null)
+                    .WhereNotNull()
+                    .ToArray();
+
                 var savingNotification = new MediaSavingNotification(itemsA, messages);
                 if (scope.Notifications.PublishCancelable(savingNotification))
                 {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -85,6 +85,65 @@ internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
         .AddNotificationHandler<ContentSavingNotification, ContentNotificationHandler>();
 
     [Test]
+    public void Sort_Preserves_Template_And_Property_Data_When_Items_Loaded_Without_Them()
+    {
+        // The fixture's children share the content type's default template; assign it so we can verify it survives.
+        var templateId = ContentType.DefaultTemplateId;
+        Assert.That(templateId, Is.GreaterThan(0), "Test setup expects a default template on the content type.");
+
+        var childKeys = new[] { SubPageKey, SubPage2Key, SubPage3Key };
+        foreach (var key in childKeys)
+        {
+            IContent child = ContentService.GetById(new Guid(key));
+            child.TemplateId = templateId;
+            ContentService.Save(child);
+        }
+
+        // Load the children the way a collection view does: without templates or property data (#23120).
+        List<IContent> partialChildren = ContentService
+            .GetPagedChildren(Textpage.Id, 0, 100, out _, propertyAliases: [], filter: null, ordering: null, loadTemplates: false)
+            .ToList();
+        Assert.That(partialChildren, Has.Count.EqualTo(3));
+        Assert.Multiple(() =>
+        {
+            // Precondition for the bug: the loaded instances really are partial.
+            Assert.That(partialChildren.All(x => x.TemplateId is null), Is.True, "Expected templates not to be loaded.");
+            Assert.That(partialChildren.All(x => x.Properties.Count == 0), Is.True, "Expected properties not to be loaded.");
+        });
+
+        // Rotate the order so every item's sort order changes (and is therefore re-saved).
+        Dictionary<Guid, IContent> byKey = partialChildren.ToDictionary(x => x.Key, x => x);
+        IContent[] rotated =
+        [
+            byKey[new Guid(SubPage2Key)],
+            byKey[new Guid(SubPage3Key)],
+            byKey[new Guid(SubPageKey)],
+        ];
+
+        OperationResult result = ContentService.Sort(rotated);
+        Assert.That(result.Success, Is.True);
+
+        // Every sorted child must retain its template and property data.
+        foreach (var key in childKeys)
+        {
+            IContent reloaded = ContentService.GetById(new Guid(key));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reloaded.TemplateId, Is.EqualTo(templateId), $"Template lost for {key}.");
+                Assert.That(reloaded.GetValue<string>("title"), Is.Not.Null.And.Not.Empty, $"Property data lost for {key}.");
+            });
+        }
+
+        // And the requested order must have been applied.
+        Assert.Multiple(() =>
+        {
+            Assert.That(ContentService.GetById(new Guid(SubPage2Key)).SortOrder, Is.EqualTo(0));
+            Assert.That(ContentService.GetById(new Guid(SubPage3Key)).SortOrder, Is.EqualTo(1));
+            Assert.That(ContentService.GetById(new Guid(SubPageKey)).SortOrder, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
     public void Create_Blueprint()
     {
         var template = TemplateBuilder.CreateTextPageTemplate();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
@@ -24,6 +24,47 @@ internal sealed class MediaServiceTests : UmbracoIntegrationTest
     private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
 
     [Test]
+    public async Task Sort_Preserves_Property_Data_When_Items_Loaded_Without_It()
+    {
+        var mediaType = await CreateMediaType();
+
+        var keys = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            IMedia media = MediaBuilder.CreateSimpleMedia(mediaType, "Media " + i, -1);
+            media.SetValue("title", "Title " + i);
+            MediaService.Save(media);
+            keys.Add(media.Key);
+        }
+
+        // Mimic a partial load (e.g. a collection view): instances without property data (#23120).
+        List<IMedia> partial = keys
+            .Select(key =>
+            {
+                IMedia media = MediaService.GetById(key);
+                media.Properties = new PropertyCollection();
+                return media;
+            })
+            .ToList();
+
+        // Rotate so every item's sort order changes (and is therefore re-saved).
+        IMedia[] rotated = [partial[1], partial[2], partial[0]];
+
+        Assert.That(MediaService.Sort(rotated), Is.True);
+
+        // Every sorted item must retain its property data, and the requested order must be applied.
+        Assert.Multiple(() =>
+        {
+            Assert.That(MediaService.GetById(keys[0]).GetValue<string>("title"), Is.EqualTo("Title 0"));
+            Assert.That(MediaService.GetById(keys[1]).GetValue<string>("title"), Is.EqualTo("Title 1"));
+            Assert.That(MediaService.GetById(keys[2]).GetValue<string>("title"), Is.EqualTo("Title 2"));
+            Assert.That(MediaService.GetById(keys[1]).SortOrder, Is.EqualTo(0));
+            Assert.That(MediaService.GetById(keys[2]).SortOrder, Is.EqualTo(1));
+            Assert.That(MediaService.GetById(keys[0]).SortOrder, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
     public async Task Can_Create_Media()
     {
         var mediaType = await CreateMediaType();


### PR DESCRIPTION
## Description

Fixes a data-loss bug where calling `ContentService.Sort` (or `MediaService.Sort`) with **partially-loaded** entities removes the template assignment and deletes property data from the sorted items.

Fixes #23120

## Why it happens

`ContentService.Sort(IEnumerable<IContent> items)` saves the caller-supplied entity instances directly via `_documentRepository.Save` → `PersistUpdatedItem`. That path rebuilds the entire version row from the in-memory entity:

- `templateId` is written from `entity.TemplateId`, and
- property data is replaced by deleting all existing rows and re-inserting from `entity.Properties`.

If the caller loaded those items **without** templates/properties — `GetPagedChildren(..., loadTemplates: false)` leaves `TemplateId` null, and an empty `propertyAliases` array leaves `Properties` empty — then sorting writes those empty values back, **wiping the template (→ 0/null) and deleting all property data**. That is exactly the reporter's scenario (children retrieved with `loadTemplates: false` and `propertyAliases: []`).

Note that this doesn't occur via existing backoffice code paths.  It's only possible via custom code as shown in the linked issue, where partially loaded entities are loaded and sorted.

### Origin of the partial-load options

The ability to load content without templates/properties was introduced in **#21470 — "Performance: Optimize property retrieval and authorization checks in collection views"**, which added the `loadTemplates` parameter and the empty-`propertyAliases` convention for collection-view performance. This fix simply hardens `Sort` against the partially-populated instances that change made possible; it does **not** alter #21470's optimisation.

## The fix

In both `ContentService.Sort(items)` and `MediaService.Sort(items)`, reload the entities by id inside the existing write-lock and operate on the fully-loaded copies, preserving the caller's ordering (which drives the sort). `MemberService` has no sortable-tree `Sort(items)` overload, so it is intentionally not changed.

## Testing

This fix comes from custom code, so is verified via integration regression tests.  Each were ensured to fail before the fix and pass after.