### PR TITLE
Multi-URL Picker: Fix "Remove" button overflow with long URLs (closes #23088)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -440,6 +440,19 @@ export class UmbInputMultiUrlElement extends UmbFormControlMixin<string, typeof 
 				margin-top: -20px;
 				padding-top: 20px;
 			}
+
+			uui-ref-node {
+				word-break: break-all;
+			}
+
+			uui-action-bar {
+				position: absolute;
+				right: 0;
+				top: 50%;
+				transform: translateY(-50%);
+				background-color: var(--uui-color-surface, #fff);
+				border-radius: 50px;
+			}
 		`,
 	];
 }


### PR DESCRIPTION
### Description

Fixes #23088

When a long URL (no spaces) was entered in the URL Picker field, the "Remove" button was pushed partially or fully outside the visible container bounds, making it difficult to see and interact with. Like this:

<img width="793" height="532" alt="image" src="https://github.com/user-attachments/assets/ec1464e7-3664-4eb1-9c06-722e93655a39" />


**Fix:** Two targeted CSS rules applied from `umb-input-multi-url`'s own shadow stylesheet:

1. `word-break: break-all` on `uui-ref-node` — `word-break` is an inherited property that pierces UUI's shadow DOM, reaching the internal `#name` element. This reduces the URL text's flex min-content to approximately one character width, so long URLs wrap within the available width instead of overflowing.

2. `uui-action-bar` is given `position: absolute; right: 0; top: 50%; transform: translateY(-50%)` — This matches UUI's actual design intent: `#actions-container` is `opacity: 0` by default and fades in on `:host(:hover)`, meaning it was always designed to float _over_ the content rather than sit beside it in the flex row. Taking the action bar out of the flex flow entirely means `#open-part` can safely use `width: 100%` as UUI intended, and the button is always correctly anchored to the right edge regardless of URL length or button label length (language-safe). A matching `background-color: var(--uui-color-surface, #fff)` and `border-radius: 50px` ensure the button is clearly readable when it appears over wrapped URL text.

**New hovering url text:**

<img width="768" height="473" alt="image" src="https://github.com/user-attachments/assets/111ce834-684a-460e-9d41-651c5807d298" />

**New hovering remove button:**

<img width="768" height="469" alt="image" src="https://github.com/user-attachments/assets/ab55a4f0-0279-4642-bd95-7e854e8d4df9" />

### Testing

1. Open a content item containing a URL Picker field (works inside a Block Editor modal too)
2. Add a URL Picker value with a very long URL (e.g. a deeply nested local document link or a long external URL with query parameters)
3. Observe that the URL text wraps within the container and the **Remove** button is fully visible and clickable on hover
4. Verify the button label is not broken across lines
5. Verify behaviour is correct in both normal and readonly modes


