### PR TITLE
User Groups: Clear the user group cache when a language is deleted (closes #23121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,6 +545,8 @@ Allowed, but cheap to write and cheaper to leave behind. Keep them short and tra
 
 Verify any test you add for a bug fix actually catches the bug: either write the failing test first (TDD), or temporarily revert the production change and confirm the test fails before re-applying. A test that passes both ways proves nothing. Watch for coincidental passes — default seed/sort orders can make a buggy path produce the right answer for the test's specific inputs; construct inputs so the broken and fixed behaviours give visibly different results.
 
+For integration tests that exercise caching or cache refreshers, see `tests/Umbraco.Tests.Integration/CLAUDE.md` — the harness disables caching by default, which can produce false greens.
+
 ---
 
 ## Quick Reference

--- a/src/Umbraco.Core/Cache/NotificationHandlers/Implement/LanguageDeletedDistributedCacheNotificationHandler.cs
+++ b/src/Umbraco.Core/Cache/NotificationHandlers/Implement/LanguageDeletedDistributedCacheNotificationHandler.cs
@@ -23,5 +23,14 @@ public sealed class LanguageDeletedDistributedCacheNotificationHandler : Deleted
 
     /// <inheritdoc />
     protected override void Handle(IEnumerable<ILanguage> entities, IDictionary<string, object?> state)
-        => _distributedCache.RemoveLanguageCache(entities);
+    {
+        _distributedCache.RemoveLanguageCache(entities);
+
+        // User groups cache their allowed language ids, so a deleted language must be evicted from
+        // them too - otherwise a stale, now-missing id lingers on the cached user group and breaks
+        // reads that resolve those ids. This is a deliberately coarse refresh of the entire user group
+        // and user caches (RefreshAll also clears IUser): we can't know which groups reference the
+        // language without a query, and language deletion is rare enough that a full refresh is fine.
+        _distributedCache.RefreshAllUserGroupCache();
+    }
 }

--- a/tests/Umbraco.Tests.Integration/CLAUDE.md
+++ b/tests/Umbraco.Tests.Integration/CLAUDE.md
@@ -1,0 +1,45 @@
+# Umbraco.Tests.Integration
+
+Integration tests that boot a real Umbraco container (`UmbracoBuilder`) against a real database
+(SQLite in-memory by default, LocalDb/SQL Server optionally — see the root `CLAUDE.md` →
+"Integration Test Database Configuration"). Most fixtures derive from `UmbracoIntegrationTest`.
+
+## Testing caching and cache refreshers
+
+`UmbracoIntegrationTest` is wired for isolation and speed, **not** cache fidelity. Three harness
+defaults will silently make a cache-related test pass **regardless of the code under test** (a false
+green — it passes with and without the fix). When the behaviour under test involves repository
+caching, cache invalidation, or a `*DistributedCacheNotificationHandler`, override them in
+`CustomTestSetup(IUmbracoBuilder builder)`:
+
+1. **`AppCaches.NoCache` is registered**, so repositories never actually cache and a stale-cache
+   scenario cannot be reproduced. Register a real cache (pattern: `Umbraco.Core/Cache/RuntimeCacheTests`):
+   ```csharp
+   builder.Services.AddUnique(_ => new AppCaches(
+       new DeepCloneAppCache(new ObjectCacheAppCache()),
+       NoAppCache.Instance,
+       new IsolatedCaches(_ => new DeepCloneAppCache(new ObjectCacheAppCache()))));
+   ```
+
+2. **A no-op server messenger is registered** (`NoopServerMessenger`, in
+   `DependencyInjection/UmbracoBuilderExtensions.cs`), so `DistributedCache.Refresh*/RefreshAll`
+   never actually runs the cache refreshers. Register a synchronous local messenger so refreshers
+   execute in-process:
+   ```csharp
+   builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+   ```
+   `LocalServerMessenger` (in `Umbraco.Infrastructure/Services/ContentEventsTests.cs`) uses
+   `distributedEnabled: false`, so `ServerMessengerBase` delivers locally and invokes the refresher
+   synchronously.
+
+3. **The `*DistributedCacheNotificationHandler` set is NOT auto-registered** by the harness — these
+   are wired in `UmbracoBuilder.CoreServices` for the real app only. To test that a notification
+   invalidates a cache, register the handler under test explicitly (pattern:
+   `Umbraco.Core/Services/ContentTypeEditingServiceTests`):
+   ```csharp
+   builder.AddNotificationHandler<LanguageDeletedNotification, LanguageDeletedDistributedCacheNotificationHandler>();
+   ```
+
+Always confirm the test fails before the fix and passes after (root `CLAUDE.md` → "Tests for a bug
+fix must fail before the fix"). With the defaults above left in place, a cache test cannot fail, so
+it proves nothing.

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupLanguageCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupLanguageCacheTests.cs
@@ -1,0 +1,92 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
+
+/// <summary>
+/// Tests the correctness of the user group service's caching of allowed languages.
+/// </summary>
+/// <remarks>
+/// Lives in its own fixture because the cache/messenger overrides in CustomTestSetup change the
+/// environment for every test in a fixture, and the rest of UserGroupServiceTests should keep running
+/// against the default (no-cache) harness.
+/// </remarks>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class UserGroupLanguageCacheTests : UmbracoIntegrationTest
+{
+    private IUserGroupService UserGroupService => GetRequiredService<IUserGroupService>();
+
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    // The integration harness registers AppCaches.NoCache (so user groups are never actually cached)
+    // and a no-op server messenger (so cache refreshers never run). Use a real cache and a local,
+    // synchronous messenger - as the web pipeline effectively does - so the stale-cache scenario and
+    // its invalidation can be exercised.
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.Services.AddUnique(_ => new AppCaches(
+            new DeepCloneAppCache(new ObjectCacheAppCache()),
+            NoAppCache.Instance,
+            new IsolatedCaches(_ => new DeepCloneAppCache(new ObjectCacheAppCache()))));
+        builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+
+        // The harness does not wire up the *DistributedCacheNotificationHandler set (those are only
+        // registered for the real app in UmbracoBuilder.CoreServices), so register the handler under
+        // test explicitly.
+        builder.AddNotificationHandler<LanguageDeletedNotification, LanguageDeletedDistributedCacheNotificationHandler>();
+    }
+
+    [Test]
+    public async Task Deleting_Language_Evicts_It_From_Cached_User_Group()
+    {
+        var language = new LanguageBuilder().WithCultureInfo("nb-NO").Build();
+        await LanguageService.CreateAsync(language, Constants.Security.SuperUserKey);
+
+        var userGroup = new UserGroup(ShortStringHelper)
+        {
+            Name = "Language Group",
+            Alias = "languageGroup",
+            HasAccessToAllLanguages = false,
+        };
+        userGroup.AddAllowedLanguage(language.Id);
+
+        var created = await UserGroupService.CreateAsync(userGroup, Constants.Security.SuperUserKey);
+        Assert.IsTrue(created.Success);
+        var userGroupId = created.Result!.Id;
+
+        // Populate both the per-id cache and the "get all" cache (the list/filter endpoint that
+        // actually surfaced the bug uses the latter) while the language still exists.
+        var cachedById = await UserGroupService.GetAsync(userGroupId);
+        Assert.IsNotNull(cachedById);
+        Assert.IsTrue(cachedById!.AllowedLanguages.Contains(language.Id));
+
+        var cachedFromAll = (await UserGroupService.GetAllAsync(0, int.MaxValue)).Items.First(x => x.Id == userGroupId);
+        Assert.IsTrue(cachedFromAll.AllowedLanguages.Contains(language.Id));
+
+        var deleted = await LanguageService.DeleteAsync(language.IsoCode, Constants.Security.SuperUserKey);
+        Assert.IsTrue(deleted.Success);
+
+        // Both cached read paths must drop the now-deleted language.
+        var reloadedById = await UserGroupService.GetAsync(userGroupId);
+        Assert.IsNotNull(reloadedById);
+        Assert.IsFalse(
+            reloadedById!.AllowedLanguages.Contains(language.Id),
+            "A deleted language should not remain on the cached user group (get-by-id path).");
+
+        var reloadedFromAll = (await UserGroupService.GetAllAsync(0, int.MaxValue)).Items.First(x => x.Id == userGroupId);
+        Assert.IsFalse(
+            reloadedFromAll.AllowedLanguages.Contains(language.Id),
+            "A deleted language should not remain on the cached user group (get-all path).");
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupLanguageCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupLanguageCacheTests.cs
@@ -48,10 +48,11 @@ internal sealed class UserGroupLanguageCacheTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public async Task Deleting_Language_Evicts_It_From_Cached_User_Group()
+    public async Task Can_Evict_Deleted_Language_From_Cached_User_Group()
     {
         var language = new LanguageBuilder().WithCultureInfo("nb-NO").Build();
-        await LanguageService.CreateAsync(language, Constants.Security.SuperUserKey);
+        var languageCreated = await LanguageService.CreateAsync(language, Constants.Security.SuperUserKey);
+        Assert.IsTrue(languageCreated.Success);
 
         var userGroup = new UserGroup(ShortStringHelper)
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserGroupServiceTests.cs
@@ -15,8 +15,6 @@ internal sealed class UserGroupServiceTests : UmbracoIntegrationTest
 {
     private IUserGroupService UserGroupService => GetRequiredService<IUserGroupService>();
 
-    private IShortStringHelper ShortStringHelper => GetRequiredService<IShortStringHelper>();
-
     [Test]
     public async Task Can_Create_User_Group()
     {


### PR DESCRIPTION
## Description

Opening a user group that had a language assigned — after that language was subsequently deleted — threw `System.ArgumentException: Id {n} does not correspond to an existing language` and the user group page (and the user group list) failed to load.

This is reported as a regression in the latest 18, but I can see the problem exists in the main 17 code base, so have addressed it there.

Fixes #23121

The causes was a caching issue.  The database record is removed as expected based on a foreign key cascade.

To fix the `LanguageDeletedDistributedCacheNotificationHandler` now also refreshes the user group cache (`RefreshAllUserGroupCache()`) when a language is deleted, so the stale reference is evicted and the group reloads cleanly from the database. This is a deliberately coarse refresh (it clears the user group and user caches): we can't know which groups reference the language without a query, and language deletion is rare.

## Testing

### Automated

Added an integration test `UserGroupLanguageCacheTests.Deleting_Language_Evicts_It_From_Cached_User_Group` to verify the fix.

I also included some memory files to help the AI with generating these integration tests that need to exercise the cache to  create an initially failing test.

### Manual

1. Create a new language (e.g. Norwegian, `nb-NO`).
2. Edit a user group, add the new language as its only allowed language, and save.
3. Go to **Languages** and delete that language.
4. Re-open the user group.

- **Before:** the user group page shows an error (HTTP 500; `ArgumentException` in the logs).
- **After:** the page opens normally and the deleted language is simply no longer listed.