### PR TITLE
Backoffice: Fix core circular import (fetchAllPages) breaking the test check

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/index.ts
@@ -2,6 +2,7 @@ export * from './constants.js';
 export * from './data-mapper/index.js';
 export * from './detail/index.js';
 export * from './item/index.js';
+export * from './pagination/index.js';
 export * from './repository-base.js';
 export * from './repository-details.manager.js';
 export * from './repository-items.manager.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/pagination/fetch-all-pages.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/pagination/fetch-all-pages.function.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 import { fetchAllPages } from './fetch-all-pages.function.js';
-import type { UmbDataSourceResponse, UmbPagedModel } from '@umbraco-cms/backoffice/repository';
+import type { UmbDataSourceResponse } from '../data-source-response.interface.js';
+import type { UmbPagedModel } from '../types.js';
 
 interface TestItem {
 	id: number;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/pagination/fetch-all-pages.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/pagination/fetch-all-pages.function.ts
@@ -1,4 +1,5 @@
-import type { UmbDataSourceResponse, UmbPagedModel } from '@umbraco-cms/backoffice/repository';
+import type { UmbDataSourceResponse } from '../data-source-response.interface.js';
+import type { UmbPagedModel } from '../types.js';
 
 /**
  * A function that returns a single page of an offset-paginated collection.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/pagination/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/pagination/index.ts
@@ -1,0 +1,1 @@
+export * from './fetch-all-pages.function.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/utils/pagination/offset/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/utils/pagination/offset/index.ts
@@ -1,2 +1,1 @@
-export * from './fetch-all-pages.function.js';
 export * from './is-offset-request.guard.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/language/collection/repository/language-collection.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/language/collection/repository/language-collection.repository.ts
@@ -2,10 +2,9 @@ import type { UmbLanguageCollectionFilterModel } from '../types.js';
 import type { UmbLanguageDetailModel } from '../../types.js';
 import { UmbLanguageCollectionServerDataSource } from './language-collection.server.data-source.js';
 import type { UmbLanguageCollectionDataSource } from './types.js';
-import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
+import { UmbRepositoryBase, fetchAllPages } from '@umbraco-cms/backoffice/repository';
 import type { UmbCollectionRepository } from '@umbraco-cms/backoffice/collection';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import { fetchAllPages } from '@umbraco-cms/backoffice/utils';
 
 // Mirrors the server's default page size for `GET /language` — chosen so the underlying request matches
 // the unconfigured server contract.


### PR DESCRIPTION
## What and why

The `test` CI job is currently failing on every open PR with:

> Error: Bidirectional imports found in 17 modules. 1 more than the threshold.

`check:module-dependencies` allows **16** bidirectional core-module imports; a recent merge pushed it to **17**.

## Root cause

#22765 added the offset pagination helper `fetchAllPages` under `@umbraco-cms/backoffice/utils`. Its contract is expressed entirely in **repository-owned** types — `UmbDataSourceResponse<UmbPagedModel<T>>` (declared in `packages/core/repository/`). That made the `utils` module import the `repository` module, while `repository` already imports `utils` → a new `repository ↔ utils` bidirectional pair (the 17th).

## Fix

Move the helper (and its test) into the `repository` module, which legitimately owns those types, and export it from `@umbraco-cms/backoffice/repository`. The sole consumer — `UmbLanguageCollectionRepository` — already imports from that module, so its import just moves from `@umbraco-cms/backoffice/utils` to `@umbraco-cms/backoffice/repository`. No type changes, no behaviour change.

Core bidirectional imports are back to **16**.

## Verification

- [x] `node ./devops/module-dependencies/index.js` → exits 0 (Core 16/16, Packages 14/14, illegal 5/5, self 0).
- [x] `tsc` (`npm run compile`) → 0 errors (confirms no other consumer's import broke).
- [x] Relocated unit test → 8/8 pass.

Unblocks the `test` check on all open PRs (e.g. #23094).