### PR TITLE
Let the external login button show "sign in with {providername}" in languages

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/de.ts
@@ -1057,7 +1057,7 @@ export default {
 		greeting5: 'Willkommen',
 		greeting6: 'Willkommen',
 		instruction: 'Hier anmelden:',
-		signInWith: 'Anmelden mit',
+		signInWith: 'Anmelden mit {0}',
 		timeout: 'Sitzung abgelaufen',
 		forgottenPassword: 'Kennwort vergessen?',
 		forgottenPasswordInstruction:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/fr.ts
@@ -924,7 +924,7 @@ export default {
 		greeting5: 'Bienvenue',
 		greeting6: 'Bienvenue',
 		instruction: 'Connectez-vous ci-dessous',
-		signInWith: 'Identifiez-vous avec',
+		signInWith: 'Identifiez-vous avec {0}',
 		timeout: 'La session a expiré',
 		forgottenPassword: 'Mot de passe oublié?',
 		forgottenPasswordInstruction:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
@@ -713,7 +713,7 @@ export default {
 		greeting5: 'Velkommen',
 		greeting6: 'Velkommen',
 		instruction: 'Logg på nedenfor',
-		signInWith: 'Logg på med',
+		signInWith: 'Logg på med {0}',
 		timeout: 'Din sesjon er utløpt',
 		continue: 'Fortsett',
 		validate: 'Valider',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nl.ts
@@ -946,7 +946,7 @@ export default {
 		greeting5: 'Welkom',
 		greeting6: 'Welkom',
 		instruction: 'log hieronder in',
-		signInWith: 'Inloggen met',
+		signInWith: 'Inloggen met {0}',
 		timeout: 'Sessie is verlopen',
 		forgottenPassword: 'Wachtwoord vergeten?',
 		forgottenPasswordInstruction:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/sv.ts
@@ -695,7 +695,7 @@ export default {
 		greeting5: 'Välkommen',
 		greeting6: 'Välkommen',
 		instruction: 'Logga in nedan',
-		signInWith: 'Logga in med',
+		signInWith: 'Logga in med {0}',
 		timeout: 'Sessionen har nått sin maxgräns',
 		continue: 'Fortsätt',
 		validate: 'Validera',


### PR DESCRIPTION
This updates the "external login provider" button for 
- german (de)
- french (fr)
- Norwegian bokmål (nb)
- dutch (nl)
- swedish (sw)


### Prerequisites

Add a new auth manifest, switch DefaultUILanguage to de

### Description
I saw that adding a new external login provider would show "Sign in with ProviderName" in english, but only show "Anmelden mit" in german (missing the ProviderName).

This seems to be missing on multiple languages, but I only tried to apply a fix to the languages where I felt comfortable to fix it. 
The fix follows the en translation file


<!-- Thanks for contributing to Umbraco CMS! -->
