### PR TITLE
Cache: Populate the domain cache eagerly during start-up

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -77,6 +77,7 @@ public static class UmbracoBuilderExtensions
         builder.AddNotificationHandler<ContentTypeChangedNotification, DeferredCacheRebuildNotificationHandler>();
         builder.AddNotificationHandler<MediaTypeChangedNotification, DeferredCacheRebuildNotificationHandler>();
         builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, SeedingNotificationHandler>();
+        builder.AddNotificationHandler<UmbracoApplicationStartingNotification, DomainCacheSeedingNotificationHandler>();
         builder.AddCacheSeeding();
         return builder;
     }

--- a/src/Umbraco.PublishedCache.HybridCache/Extensions/RuntimeStateExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Extensions/RuntimeStateExtensions.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.HybridCache.Extensions;
+
+/// <summary>
+/// Provides extension methods for <see cref="IRuntimeState"/> used by the cache startup notification handlers.
+/// </summary>
+internal static class RuntimeStateExtensions
+{
+    /// <summary>
+    /// Returns true when startup cache seeding should be skipped because the site is not yet serving
+    /// front-end content, i.e. it is installing (or below) or upgrading with the maintenance page shown.
+    /// </summary>
+    /// <param name="state">The runtime state.</param>
+    /// <param name="globalSettings">The global settings.</param>
+    public static bool ShouldSkipStartupSeeding(this IRuntimeState state, GlobalSettings globalSettings)
+        => state.Level <= RuntimeLevel.Install
+           || (state.Level == RuntimeLevel.Upgrade && globalSettings.ShowMaintenancePageWhenInUpgradeState);
+}

--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/DomainCacheSeedingNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/DomainCacheSeedingNotificationHandler.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Infrastructure.HybridCache.NotificationHandlers;
+
+internal sealed class DomainCacheSeedingNotificationHandler : INotificationHandler<UmbracoApplicationStartingNotification>
+{
+    private readonly IDomainCacheService _domainCacheService;
+    private readonly IRuntimeState _runtimeState;
+    private readonly GlobalSettings _globalSettings;
+
+    public DomainCacheSeedingNotificationHandler(IDomainCacheService domainCacheService, IRuntimeState runtimeState, IOptions<GlobalSettings> globalSettings)
+    {
+        _domainCacheService = domainCacheService;
+        _runtimeState = runtimeState;
+        _globalSettings = globalSettings.Value;
+    }
+
+    public void Handle(UmbracoApplicationStartingNotification notification)
+    {
+        if (_runtimeState.Level <= RuntimeLevel.Install || (_runtimeState.Level == RuntimeLevel.Upgrade && _globalSettings.ShowMaintenancePageWhenInUpgradeState))
+        {
+            return;
+        }
+
+        _domainCacheService.GetAll(includeWildcards: true);
+    }
+}

--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/DomainCacheSeedingNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/DomainCacheSeedingNotificationHandler.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.HybridCache.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.NotificationHandlers;
 
@@ -23,11 +23,12 @@ internal sealed class DomainCacheSeedingNotificationHandler : INotificationHandl
 
     public void Handle(UmbracoApplicationStartingNotification notification)
     {
-        if (_runtimeState.Level <= RuntimeLevel.Install || (_runtimeState.Level == RuntimeLevel.Upgrade && _globalSettings.ShowMaintenancePageWhenInUpgradeState))
+        if (_runtimeState.ShouldSkipStartupSeeding(_globalSettings))
         {
             return;
         }
 
+        // Force eager population of the lazily-loaded domain cache.
         _domainCacheService.GetAll(includeWildcards: true);
     }
 }

--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/SeedingNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/SeedingNotificationHandler.cs
@@ -1,11 +1,10 @@
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Infrastructure.HybridCache.Services;
+using Umbraco.Cms.Infrastructure.HybridCache.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.NotificationHandlers;
 
@@ -29,7 +28,7 @@ internal sealed class SeedingNotificationHandler : INotificationAsyncHandler<Umb
         CancellationToken cancellationToken)
     {
 
-        if (_runtimeState.Level <= RuntimeLevel.Install || (_runtimeState.Level == RuntimeLevel.Upgrade && _globalSettings.ShowMaintenancePageWhenInUpgradeState))
+        if (_runtimeState.ShouldSkipStartupSeeding(_globalSettings))
         {
             return;
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/Extensions/RuntimeStateExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/Extensions/RuntimeStateExtensionsTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.HybridCache.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.PublishedCache.HybridCache.Extensions;
+
+[TestFixture]
+public class RuntimeStateExtensionsTests
+{
+    /// <summary>
+    /// At or below <see cref="RuntimeLevel.Install"/> the front-end cannot serve content, so seeding is
+    /// always skipped regardless of the maintenance-page setting.
+    /// </summary>
+    [TestCase(RuntimeLevel.BootFailed, true)]
+    [TestCase(RuntimeLevel.BootFailed, false)]
+    [TestCase(RuntimeLevel.Unknown, true)]
+    [TestCase(RuntimeLevel.Unknown, false)]
+    [TestCase(RuntimeLevel.Boot, true)]
+    [TestCase(RuntimeLevel.Boot, false)]
+    [TestCase(RuntimeLevel.Install, true)]
+    [TestCase(RuntimeLevel.Install, false)]
+    public void ShouldSkipStartupSeeding_WhenLevelIsInstallOrBelow_ReturnsTrue(
+        RuntimeLevel level, bool showMaintenancePage)
+    {
+        var state = MockState(level);
+        var globalSettings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = showMaintenancePage };
+        Assert.That(state.ShouldSkipStartupSeeding(globalSettings), Is.True);
+    }
+
+    /// <summary>
+    /// During <see cref="RuntimeLevel.Upgrade"/> the result follows the maintenance-page setting: shown means
+    /// the front-end is blocked, so seeding is skipped; hidden means content is served, so seeding proceeds.
+    /// </summary>
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public void ShouldSkipStartupSeeding_WhenLevelIsUpgrade_FollowsMaintenancePageSetting(
+        bool showMaintenancePage, bool expected)
+    {
+        var state = MockState(RuntimeLevel.Upgrade);
+        var globalSettings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = showMaintenancePage };
+        Assert.That(state.ShouldSkipStartupSeeding(globalSettings), Is.EqualTo(expected));
+    }
+
+    /// <summary>
+    /// <see cref="RuntimeLevel.Upgrading"/> (background upgrade, server already serving) and
+    /// <see cref="RuntimeLevel.Run"/> are content-serving states, so seeding proceeds even when the
+    /// maintenance page is configured to show during upgrades.
+    /// </summary>
+    [TestCase(RuntimeLevel.Upgrading)]
+    [TestCase(RuntimeLevel.Run)]
+    public void ShouldSkipStartupSeeding_WhenLevelIsUpgradingOrRun_ReturnsFalse(RuntimeLevel level)
+    {
+        var state = MockState(level);
+        var globalSettings = new GlobalSettings { ShowMaintenancePageWhenInUpgradeState = true };
+        Assert.That(state.ShouldSkipStartupSeeding(globalSettings), Is.False);
+    }
+
+    private static IRuntimeState MockState(RuntimeLevel level)
+        => Mock.Of<IRuntimeState>(s => s.Level == level);
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR adds eager loading of the domain cache during start-up, as discussed in https://github.com/umbraco/Umbraco-CMS/pull/23084.

The domain cache (`DomainCacheService`) is lazily populated by request. It typically happens on the first front-end request (first usage of hostname resolution), so this request "pays" for the load with increased response time.

What's more, if multiple concurrent requests flood the application immediately after boot, they all hang until the domain cache has been populated.

In contrast, other services (e.g. `DocumentUrlService`, `DocumentUrlAliasService`) are eagerly initialized by notification handlers during start-up. The same pattern can be applied to the domain cache, which is what this PR is all about.

No behavioral changes have been made. This is solely a matter of initializing the domain cache in an `UmbracoApplicationStartingNotification` handler. The handler follows the pattern from the [`SeedingNotificationHandler`](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/SeedingNotificationHandler.cs).

## Testing this PR

1. Setup hostname bindings on existing content.
2. Restart the site in debug with a breakpoint in [DomainCacheService.LoadDomains()](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.PublishedCache.HybridCache/Services/DomainCacheService.cs#L150).
3. Verify that the breakpoint is hit while the application starts.
4. Verify that the hostname bindings work after start-up.
