### PR TITLE
Tests: Remove AutoFixture from the shipped Umbraco.Cms.Tests package

### DIFF
--- a/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
+++ b/tests/Umbraco.Tests.Common/Umbraco.Tests.Common.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" />
-    <PackageReference Include="AutoFixture.NUnit3" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
   </ItemGroup>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -27,6 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoMoq" />
+    <PackageReference Include="AutoFixture.NUnit3" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit3TestAdapter" />


### PR DESCRIPTION
## Description

Removes the `AutoFixture.AutoMoq` and `AutoFixture.NUnit3` package references from `Umbraco.Tests.Common` and adds them to `Umbraco.Tests.UnitTests` instead.

### Why

`Umbraco.Tests.Common` is **packaged and shipped publicly as the `Umbraco.Cms.Tests` NuGet package** (`<PackageId>Umbraco.Cms.Tests</PackageId>`), so every dependency it carries is forced onto downstream consumers who write tests against Umbraco.

`AutoFixture.NUnit3` pins `NUnit < 4`. By having it in the shipped package, we transitively constrained all consumers of `Umbraco.Cms.Tests` to NUnit 3.x, blocking them (and us) from moving to NUnit 4.

AutoFixture is only actually used by our internal unit tests, not by the public test-tooling surface (builders, etc.) that the package is meant to provide. Moving the references to `Umbraco.Tests.UnitTests` removes the constraint from the shipped package while keeping our own tests working.

### Follow-up (future improvement)

The project name `Umbraco.Tests.Common` looks like an internal-only project, but it is actually the public, shipped `Umbraco.Cms.Tests` package — which is exactly what made this dependency leak easy to miss. We should align the **project name with the package ID** (e.g. rename the project to match `Umbraco.Cms.Tests`) so it's obvious that anything added here ships to consumers.
