### PR TITLE
Rich Text Editor: Use padding-left instead of text-indent for Tiptap indent (closes #23038)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-indent/text-indent.tiptap-extension.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tiptap/extensions/text-indent/text-indent.tiptap-extension.ts
@@ -40,13 +40,16 @@ export const TextIndent = Extension.create<UmbTiptapTextIndentOptions>({
 						parseHTML: (element) => {
 							const minLevel = this.options.minLevel;
 							const maxLevel = this.options.maxLevel;
-							const indent = element.style.textIndent;
-							return indent ? Math.max(minLevel, Math.min(maxLevel, parseInt(indent, 10))) : null;
+							// Support both padding-left (current) and text-indent (legacy) for parsing
+							const paddingLeft = element.style.paddingLeft;
+							const textIndent = element.style.textIndent;
+							const value = paddingLeft || textIndent;
+							return value ? Math.max(minLevel, Math.min(maxLevel, parseInt(value, 10))) : null;
 						},
 						renderHTML: (attributes) => {
 							if (!attributes.indent) return {};
 							return {
-								style: `text-indent: ${attributes.indent}rem;`,
+								style: `padding-left: ${attributes.indent}rem;`,
 							};
 						},
 					},


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #23038

### Description

**The Issue:** The Tiptap indent button only indents the first line of a paragraph. This is because the implementation uses the CSS `text-indent` property, which by definition only affects the first line of a block element.

In Umbraco v13 (TinyMCE), indentation used `padding-left` which correctly indents the entire block content including all lines.

**The Fix:** Changed the `renderHTML` output from `text-indent` to `padding-left` in the `TextIndent` Tiptap extension. This makes all lines in a paragraph indent consistently, matching the behavior users expect from v13.

Also updated `parseHTML` to read both `padding-left` (new) and `text-indent` (legacy) so that any existing content saved with the old `text-indent` style is still correctly parsed and displayed.

### Visual Proof (after fix):

<img width="1898" height="938" alt="after-adding-fix-for-indent" src="https://github.com/user-attachments/assets/91970bfc-4b40-41b1-846f-9cfc1374e8a6" />


### How to test

1. Log into the backoffice.
2. Open or create a content item with a Rich Text Editor (Tiptap).
3. Type multiple lines of text in a single paragraph (use Shift+Enter for line breaks, or just let text wrap naturally).
4. Select the text and click the Indent button.
5. Observe that **all lines** are indented, not just the first line.
6. Click Indent again to increase the level.
7. Click Outdent to decrease.
8. Save and verify the HTML output uses `padding-left` style.
