### PR TITLE
Improve tag comma preservation

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/Umbraco.Tags.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/Umbraco.Tags.ts
@@ -16,7 +16,7 @@ export const manifest: ManifestPropertyEditorSchema = {
 				},
 				{
 					alias: 'storageType',
-					label: 'Storage Type',
+					label: 'Storage type',
 					description:
 						'Select whether to store the tags in cache as JSON (default) or CSV format. Notice that CSV does not support commas in the tag value.',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Select',
@@ -26,6 +26,12 @@ export const manifest: ManifestPropertyEditorSchema = {
 							value: ['Csv', 'Json'],
 						},
 					],
+				},
+				{
+					alias: 'preserveCommas',
+					label: 'Preserve commas in tags',
+					description: 'Only applicable when tags are stored in the cache in JSON format.',
+					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Toggle',
 				},
 			],
 			defaultData: [

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/property-editor-ui-tags.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/property-editor-ui-tags.element.ts
@@ -47,12 +47,16 @@ export class UmbPropertyEditorUITagsElement
 	private _storageType?: string;
 
 	@state()
+	private _preserveCommas?: boolean;
+
+	@state()
 	private _culture?: string | null;
 	//TODO: Use type from VariantID
 
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		this._group = config?.getValueByAlias('group');
 		this._storageType = config?.getValueByAlias('storageType');
+		this._preserveCommas = config?.getValueByAlias('preserveCommas');
 	}
 
 	constructor() {
@@ -74,7 +78,10 @@ export class UmbPropertyEditorUITagsElement
 	#onChange(event: UmbChangeEvent) {
 		event.stopPropagation();
 		const tagsInput = event.currentTarget as UmbTagsInputElement;
-		this.value = this._storageType?.toLowerCase() === 'csv' ? (tagsInput.value as string).split(',') : tagsInput.items;
+		this.value =
+			this._storageType?.toLowerCase() === 'csv' || !this._preserveCommas
+				? (tagsInput.value as string).split(',')
+				: tagsInput.items;
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/property-editor-ui-tags.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/property-editors/tags/property-editor-ui-tags.test.ts
@@ -3,22 +3,26 @@ import type { UmbTagsInputElement } from '../../components/tags-input/tags-input
 import { expect, fixture, html } from '@open-wc/testing';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 
 describe('UmbPropertyEditorUITagsElement', () => {
 	let element: UmbPropertyEditorUITagsElement;
+	let inputElement: UmbTagsInputElement;
 
 	beforeEach(async () => {
 		element = await fixture(html` <umb-property-editor-ui-tags></umb-property-editor-ui-tags> `);
+		inputElement = element.shadowRoot?.querySelector('umb-tags-input') as UmbTagsInputElement;
 	});
 
 	it('is defined with its own instance', () => {
 		expect(element).to.be.instanceOf(UmbPropertyEditorUITagsElement);
 	});
 
-	it('preserves tags containing commas', async () => {
-		const tagsInput = element.shadowRoot!.querySelector('umb-tags-input') as UmbTagsInputElement;
-		tagsInput.items = ['hello', 'world, with comma', 'foo'];
-		tagsInput.dispatchEvent(new UmbChangeEvent());
+	it('should preserve tags containing commas', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([{ alias: 'preserveCommas', value: true }]);
+		await element.updateComplete;
+		inputElement.items = ['hello', 'world, with comma', 'foo'];
+		inputElement.dispatchEvent(new UmbChangeEvent());
 		await element.updateComplete;
 		expect(element.value).to.deep.equal(['hello', 'world, with comma', 'foo']);
 	});


### PR DESCRIPTION
**Summary**

This PR builds on the work introduced in PR #22432.

The original implementation solved the issue in a straightforward way by adding an additional condition to preserve commas within tags. While this works well for scenarios where commas are intentionally part of tag values, it can be less suitable for content editors who are already accustomed to using commas as tag separators.

A common example is copying and pasting a comma-separated list of tags directly into the tag editor. With the current behavior, editors may experience unexpected results because commas are no longer interpreted as separators in the way they are used to.

The intention of this PR is to improve the editor experience by making this behavior configurable. This allows projects that need comma preservation within tag values to retain that functionality, while also enabling projects that rely on traditional comma-separated tag entry to continue using the workflow their editors are familiar with.

<img width="702" height="754" alt="image" src="https://github.com/user-attachments/assets/27549435-a421-4586-aa6a-43c593e3cb0c" />

**Motivation**

- Preserve the functionality introduced in #22432.
- Improve usability for content editors who commonly enter tags as comma-separated values.
- Support both workflows without forcing a single behavior on all installations.
- Provide a more flexible and configurable solution for different project requirements.