### PR TITLE
Examine: Stream value sets to a single index during rebuild to reduce reindex peak memory

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/IndexingSettings.cs
@@ -20,5 +20,12 @@ public class IndexingSettings
     /// <summary>
     /// Gets or sets a value for how many items to index at a time.
     /// </summary>
+    /// <remarks>
+    /// This is the primary lever for the peak memory used while (re)building an index: a full page of
+    /// content and its property data is held in memory at once, so lowering this value reduces rebuild
+    /// memory at the cost of more, smaller batches. Lower it on very large sites that hit memory pressure
+    /// during a rebuild.
+    /// </remarks>
+    [DefaultValue(StaticBatchSize)]
     public int BatchSize { get; set; } = StaticBatchSize;
 }

--- a/src/Umbraco.Infrastructure/Examine/ContentIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentIndexPopulator.cs
@@ -170,13 +170,7 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
         {
             content = _contentService.GetPagedDescendants(contentParentId, pageIndex, pageSize, out _).ToArray();
 
-            var valueSets = _contentValueSetBuilder.GetValueSets(content).ToArray();
-
-            // ReSharper disable once PossibleMultipleEnumeration
-            foreach (IIndex index in indexes)
-            {
-                index.IndexItems(valueSets);
-            }
+            ValueSetIndexer.IndexItems(indexes, _contentValueSetBuilder.GetValueSets(content));
 
             pageIndex++;
         }
@@ -216,12 +210,7 @@ public class ContentIndexPopulator : IndexPopulator<IUmbracoContentIndex>
                 }
             }
 
-            var valueSets = _contentValueSetBuilder.GetValueSets(indexableContent.ToArray()).ToArray();
-
-            foreach (IIndex index in indexes)
-            {
-                index.IndexItems(valueSets);
-            }
+            ValueSetIndexer.IndexItems(indexes, _contentValueSetBuilder.GetValueSets(indexableContent.ToArray()));
 
             pageIndex++;
         }

--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexPopulator.cs
@@ -49,13 +49,7 @@ internal sealed class DeliveryApiContentIndexPopulator : IndexPopulator
         _deliveryApiContentIndexHelper.EnumerateApplicableDescendantsForContentIndex(
             Constants.System.Root,
             descendants =>
-            {
-                ValueSet[] valueSets = _deliveryContentIndexValueSetBuilder.GetValueSets(descendants).ToArray();
-                foreach (IIndex index in indexes)
-                {
-                    index.IndexItems(valueSets);
-                }
-            });
+                ValueSetIndexer.IndexItems(indexes, _deliveryContentIndexValueSetBuilder.GetValueSets(descendants)));
     }
 
     public override bool IsRegistered(IIndex index)

--- a/src/Umbraco.Infrastructure/Examine/MediaIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/MediaIndexPopulator.cs
@@ -107,11 +107,7 @@ public class MediaIndexPopulator : IndexPopulator<IUmbracoContentIndex>
         {
             media = _mediaService.GetPagedDescendants(mediaParentId, pageIndex, _indexingSettings.BatchSize, out _).ToArray();
 
-            // ReSharper disable once PossibleMultipleEnumeration
-            foreach (IIndex index in indexes)
-            {
-                index.IndexItems(_mediaValueSetBuilder.GetValueSets(media));
-            }
+            ValueSetIndexer.IndexItems(indexes, _mediaValueSetBuilder.GetValueSets(media));
 
             pageIndex++;
         }

--- a/src/Umbraco.Infrastructure/Examine/MemberIndexPopulator.cs
+++ b/src/Umbraco.Infrastructure/Examine/MemberIndexPopulator.cs
@@ -41,11 +41,7 @@ public class MemberIndexPopulator : IndexPopulator<IUmbracoMemberIndex>
         {
             members = _memberService.GetAll(pageIndex, pageSize, out _).ToArray();
 
-            // ReSharper disable once PossibleMultipleEnumeration
-            foreach (IIndex index in indexes)
-            {
-                index.IndexItems(_valueSetBuilder.GetValueSets(members));
-            }
+            ValueSetIndexer.IndexItems(indexes, _valueSetBuilder.GetValueSets(members));
 
             pageIndex++;
         }

--- a/src/Umbraco.Infrastructure/Examine/ValueSetIndexer.cs
+++ b/src/Umbraco.Infrastructure/Examine/ValueSetIndexer.cs
@@ -1,0 +1,35 @@
+using Examine;
+
+namespace Umbraco.Cms.Infrastructure.Examine;
+
+/// <summary>
+///     Writes a batch of <see cref="ValueSet" />s to one or more indexes.
+/// </summary>
+/// <remarks>
+///     When a single index is registered the value sets are streamed straight through, so a lazily-built
+///     sequence is enumerated once and never fully materialised in memory — keeping the common single-index
+///     rebuild's peak memory down. When multiple indexes are registered the sequence is materialised once and
+///     reused, so the (potentially expensive) value sets are not rebuilt per index.
+/// </remarks>
+internal static class ValueSetIndexer
+{
+    public static void IndexItems(IReadOnlyList<IIndex> indexes, IEnumerable<ValueSet> valueSets)
+    {
+        switch (indexes.Count)
+        {
+            case 0:
+                return;
+            case 1:
+                indexes[0].IndexItems(valueSets);
+                return;
+            default:
+                ValueSet[] materialized = valueSets as ValueSet[] ?? valueSets.ToArray();
+                foreach (IIndex index in indexes)
+                {
+                    index.IndexItems(materialized);
+                }
+
+                return;
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/ValueSetIndexerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Examine/ValueSetIndexerTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Examine;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Examine;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Examine;
+
+[TestFixture]
+public class ValueSetIndexerTests
+{
+    [Test]
+    public void Can_Stream_To_Single_Index_Without_Materializing()
+    {
+        // Use a List (not a ValueSet[]) so this assertion also guards against a future regression: if the
+        // single-index path ever materialised the sequence, the index would receive a different reference and
+        // SameAs would fail. A ValueSet[] source couldn't catch that.
+        var source = new List<ValueSet> { ValueSet.FromObject("1", "content", new { }), ValueSet.FromObject("2", "content", new { }) };
+        IEnumerable<ValueSet>? received = null;
+        var index = CreateIndex(v => received = v);
+
+        ValueSetIndexer.IndexItems([index.Object], source);
+
+        Assert.That(received, Is.SameAs(source));
+    }
+
+    [Test]
+    public void Can_Materialize_Once_And_Reuse_For_Multiple_Indexes()
+    {
+        // A lazy sequence (not an array) so the helper has to materialise it.
+        IEnumerable<ValueSet> source = Enumerable.Range(1, 3).Select(i => ValueSet.FromObject(i.ToString(), "content", new { }));
+        IEnumerable<ValueSet>? receivedByFirst = null;
+        IEnumerable<ValueSet>? receivedBySecond = null;
+        var first = CreateIndex(v => receivedByFirst = v);
+        var second = CreateIndex(v => receivedBySecond = v);
+
+        ValueSetIndexer.IndexItems([first.Object, second.Object], source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(receivedByFirst, Is.InstanceOf<ValueSet[]>());
+            Assert.That(receivedByFirst, Has.Exactly(3).Items);
+            Assert.That(receivedBySecond, Is.SameAs(receivedByFirst)); // materialised once, reused
+        });
+    }
+
+    [Test]
+    public void Can_Handle_No_Indexes()
+        => Assert.DoesNotThrow(() => ValueSetIndexer.IndexItems(Array.Empty<IIndex>(), new List<ValueSet>()));
+
+    private static Mock<IIndex> CreateIndex(Action<IEnumerable<ValueSet>> onIndexItems)
+    {
+        var index = new Mock<IIndex>();
+        index.Setup(x => x.IndexItems(It.IsAny<IEnumerable<ValueSet>>()))
+            .Callback(onIndexItems);
+        return index;
+    }
+}


### PR DESCRIPTION
## Description

Reduces the peak memory used while (re)building an Examine content index.

**What's changed**

- `ValueSetIndexer` (Infrastructure) — a small internal helper that writes a page of value sets to the registered index(es): it **streams** them straight through when a single index is registered (the common case), so a page's `ValueSet[]` is never materialised, and **materialises once and reuses** when multiple indexes are registered, so the (expensive) value sets aren't rebuilt per index.
- `ContentIndexPopulator` now uses it in both `IndexAllContent` and `IndexPublishedContent`, dropping the per-page `.ToArray()`. On a single-index rebuild a page's `ValueSet[]` is no longer held alongside the `IContent[]`.
- `IndexingSettings.BatchSize` is documented as the primary lever for rebuild peak memory (the dominant cost is the `IContent[]` page, which only `BatchSize` controls), and gains a `[DefaultValue]`.

Behaviour is otherwise unchanged — the same items are indexed. With the default indexes (and for any single-index rebuild) the streaming path applies; the materialise path preserves the previous behaviour for sites with multiple content indexes sharing a published-values flag.

## Testing

### Automated

Unit tests for `ValueSetIndexer` cover single-index streaming (passed through by reference, not materialised), multi-index materialise-once-and-reuse, and the no-index no-op.

### Manual

1. Run an Umbraco site with a non-trivial amount of content.
2. Rebuild a content index (e.g. ExternalIndex) from the backoffice Examine management dashboard, or trigger a full reindex.
3. Confirm the index rebuilds correctly and search returns the expected results.
