### PR TITLE
Element Picker: Adds `valueSummary` display and value resolver

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/constants.ts
@@ -4,6 +4,7 @@ export * from './entity-bulk-actions/constants.js';
 export * from './folder/constants.js';
 export * from './item/constants.js';
 export * from './modals/constants.js';
+export * from './property-editor/constants.js';
 export * from './recycle-bin/constants.js';
 export * from './reference/constants.js';
 export * from './repository/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/constants.ts
@@ -1,0 +1,1 @@
+export * from './element-picker/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/constants.ts
@@ -1,0 +1,1 @@
+export * from './value-type/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/manifests.ts
@@ -1,4 +1,5 @@
 ﻿import { manifest as schemaManifest } from './Umbraco.ElementPicker.js';
+import { manifests as valueSummaryManifests } from './value-summary/manifests.js';
 import type { ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/property-editor';
 
 const propertyEditorUi: ManifestPropertyEditorUi = {
@@ -46,4 +47,4 @@ const propertyEditorUi: ManifestPropertyEditorUi = {
 	},
 };
 
-export const manifests: Array<UmbExtensionManifest> = [propertyEditorUi, schemaManifest];
+export const manifests: Array<UmbExtensionManifest> = [propertyEditorUi, schemaManifest, ...valueSummaryManifests];

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/manifests.ts
@@ -1,0 +1,13 @@
+import { UMB_ELEMENT_PICKER_PROPERTY_EDITOR_VALUE_TYPE } from '../value-type/constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'valueSummary',
+		kind: 'default',
+		alias: 'Umb.ValueSummary.PropertyEditor.ElementPicker',
+		name: 'Element Picker Property Editor Value Summary',
+		forValueType: UMB_ELEMENT_PICKER_PROPERTY_EDITOR_VALUE_TYPE,
+		element: () => import('./value-summary.js'),
+		valueResolver: () => import('./value-summary.js'),
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
@@ -27,32 +27,41 @@ export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueS
 
 		for (const unique of this.#resolvers.keys()) {
 			if (!value.some((item) => item.unique === unique)) {
-				this.#resolvers.get(unique)?.destroy();
-				this.#resolvers.delete(unique);
-				this.#resolvedNames.delete(unique);
-				this.removeUmbControllerByAlias(`element-${unique}`);
+				this.#removeResolver(unique);
 			}
 		}
 
 		for (const item of value) {
-			if (this.#resolvers.has(item.unique)) {
-				this.#resolvers.get(item.unique)!.setData(item);
-			} else {
-				const resolver = new UmbElementItemDataResolver<UmbElementItemModel>(this);
-				resolver.setData(item);
-				this.#resolvers.set(item.unique, resolver);
-				this.observe(
-					resolver.name,
-					(name) => {
-						this.#resolvedNames.set(item.unique, name ?? '');
-						this.#buildNames();
-					},
-					`element-${item.unique}`,
-				);
-			}
+			this.#addOrUpdateResolver(item);
 		}
 
 		this.#buildNames();
+	}
+
+	#removeResolver(unique: string) {
+		this.#resolvers.get(unique)?.destroy();
+		this.#resolvers.delete(unique);
+		this.#resolvedNames.delete(unique);
+		this.removeUmbControllerByAlias(`element-${unique}`);
+	}
+
+	#addOrUpdateResolver(item: UmbElementItemModel) {
+		if (this.#resolvers.has(item.unique)) {
+			this.#resolvers.get(item.unique)!.setData(item);
+			return;
+		}
+
+		const resolver = new UmbElementItemDataResolver<UmbElementItemModel>(this);
+		resolver.setData(item);
+		this.#resolvers.set(item.unique, resolver);
+		this.observe(
+			resolver.name,
+			(name) => {
+				this.#resolvedNames.set(item.unique, name ?? '');
+				this.#buildNames();
+			},
+			`element-${item.unique}`,
+		);
 	}
 
 	#buildNames() {

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
@@ -30,6 +30,7 @@ export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueS
 				this.#resolvers.get(unique)?.destroy();
 				this.#resolvers.delete(unique);
 				this.#resolvedNames.delete(unique);
+				this.removeUmbControllerByAlias(`element-${unique}`);
 			}
 		}
 
@@ -46,6 +47,8 @@ export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueS
 					},
 					`element-${item.unique}`,
 				);
+			} else {
+				this.#resolvers.get(item.unique)!.setData(item);
 			}
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
@@ -1,0 +1,73 @@
+import { customElement, html, nothing, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbValueSummaryElementBase } from '@umbraco-cms/backoffice/value-summary';
+import { UmbElementItemDataResolver } from '../../../item/data-resolver/element-item-data-resolver.js';
+import type { UmbElementItemModel } from '../../../types.js';
+import type { PropertyValueMap } from '@umbraco-cms/backoffice/external/lit';
+
+/** Renders picked element names (variant-aware, comma-joined) for collection view cells. */
+@customElement('umb-element-picker-property-editor-value-summary')
+export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueSummaryElementBase<
+	Array<UmbElementItemModel>
+> {
+	@state()
+	private _names: Array<string> = [];
+
+	#resolvers = new Map<string, UmbElementItemDataResolver<UmbElementItemModel>>();
+	#resolvedNames = new Map<string, string>();
+
+	protected override willUpdate(changedProperties: PropertyValueMap<this>): void {
+		super.willUpdate(changedProperties);
+		if (changedProperties.has('_value' as keyof this)) {
+			this.#syncResolvers();
+		}
+	}
+
+	#syncResolvers() {
+		const value = this._value ?? [];
+
+		for (const unique of this.#resolvers.keys()) {
+			if (!value.find((item) => item.unique === unique)) {
+				this.#resolvers.get(unique)?.destroy();
+				this.#resolvers.delete(unique);
+				this.#resolvedNames.delete(unique);
+			}
+		}
+
+		for (const item of value) {
+			if (!this.#resolvers.has(item.unique)) {
+				const resolver = new UmbElementItemDataResolver<UmbElementItemModel>(this);
+				resolver.setData(item);
+				this.#resolvers.set(item.unique, resolver);
+				this.observe(
+					resolver.name,
+					(name) => {
+						this.#resolvedNames.set(item.unique, name ?? '');
+						this.#buildNames();
+					},
+					`element-${item.unique}`,
+				);
+			}
+		}
+
+		this.#buildNames();
+	}
+
+	#buildNames() {
+		this._names = (this._value ?? []).map((item) => this.#resolvedNames.get(item.unique) ?? '');
+	}
+
+	override render() {
+		if (!this._value?.length) return nothing;
+		const text = this._names.filter(Boolean).join(', ');
+		if (!text) return nothing;
+		return html`<span title="${text}">${text}</span>`;
+	}
+}
+
+export { UmbElementPickerPropertyEditorValueSummaryElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-element-picker-property-editor-value-summary': UmbElementPickerPropertyEditorValueSummaryElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.element.ts
@@ -12,8 +12,8 @@ export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueS
 	@state()
 	private _names: Array<string> = [];
 
-	#resolvers = new Map<string, UmbElementItemDataResolver<UmbElementItemModel>>();
-	#resolvedNames = new Map<string, string>();
+	readonly #resolvers = new Map<string, UmbElementItemDataResolver<UmbElementItemModel>>();
+	readonly #resolvedNames = new Map<string, string>();
 
 	protected override willUpdate(changedProperties: PropertyValueMap<this>): void {
 		super.willUpdate(changedProperties);
@@ -26,7 +26,7 @@ export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueS
 		const value = this._value ?? [];
 
 		for (const unique of this.#resolvers.keys()) {
-			if (!value.find((item) => item.unique === unique)) {
+			if (!value.some((item) => item.unique === unique)) {
 				this.#resolvers.get(unique)?.destroy();
 				this.#resolvers.delete(unique);
 				this.#resolvedNames.delete(unique);
@@ -35,7 +35,9 @@ export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueS
 		}
 
 		for (const item of value) {
-			if (!this.#resolvers.has(item.unique)) {
+			if (this.#resolvers.has(item.unique)) {
+				this.#resolvers.get(item.unique)!.setData(item);
+			} else {
 				const resolver = new UmbElementItemDataResolver<UmbElementItemModel>(this);
 				resolver.setData(item);
 				this.#resolvers.set(item.unique, resolver);
@@ -47,8 +49,6 @@ export class UmbElementPickerPropertyEditorValueSummaryElement extends UmbValueS
 					},
 					`element-${item.unique}`,
 				);
-			} else {
-				this.#resolvers.get(item.unique)!.setData(item);
 			}
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.test.ts
@@ -1,0 +1,129 @@
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { useMockSet } from '@umbraco-cms/internal/mock-manager';
+import { UmbElementItemStore } from '../../../item/repository/element-item.store.js';
+import { UmbElementPickerValueSummaryResolver } from './value-summary.resolver.js';
+
+// IDs from mocks/data/sets/default/element.data.ts
+const SIMPLE_ELEMENT_ID = 'simple-element-id';
+const ELEMENT_IN_FOLDER_ID = 'element-in-folder-id';
+const ELEMENT_IN_SUBFOLDER_ID = 'element-in-subfolder-1-id';
+
+@customElement('umb-test-element-picker-value-summary-host')
+class UmbTestElementPickerValueSummaryHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new UmbElementItemStore(this);
+	}
+}
+
+describe('UmbElementPickerValueSummaryResolver', () => {
+	let host: UmbTestElementPickerValueSummaryHostElement;
+	let resolver: UmbElementPickerValueSummaryResolver;
+
+	before(async () => {
+		await useMockSet('default');
+	});
+
+	beforeEach(() => {
+		host = new UmbTestElementPickerValueSummaryHostElement();
+		document.body.appendChild(host);
+		resolver = new UmbElementPickerValueSummaryResolver(host);
+	});
+
+	afterEach(() => {
+		resolver.destroy();
+		document.body.innerHTML = '';
+	});
+
+	it('returns empty arrays when called with no values', async () => {
+		const result = await resolver.resolveValues([]);
+		expect(result.data).to.deep.equal([]);
+	});
+
+	it('returns an empty array per entry when all values are undefined', async () => {
+		const result = await resolver.resolveValues([undefined, undefined]);
+		expect(result.data).to.deep.equal([[], []]);
+	});
+
+	it('returns an empty array per entry when all values are empty arrays', async () => {
+		const result = await resolver.resolveValues([[], []]);
+		expect(result.data).to.deep.equal([[], []]);
+	});
+
+	it('resolves a single element ID to its item', async () => {
+		const result = await resolver.resolveValues([[SIMPLE_ELEMENT_ID]]);
+
+		expect(result.data).to.have.length(1);
+		expect(result.data[0]).to.have.length(1);
+		expect(result.data[0][0].unique).to.equal(SIMPLE_ELEMENT_ID);
+		expect(result.data[0][0].variants[0].name).to.equal('Simple Element');
+	});
+
+	it('resolves multiple separate values to their respective items', async () => {
+		const result = await resolver.resolveValues([[SIMPLE_ELEMENT_ID], [ELEMENT_IN_FOLDER_ID]]);
+
+		expect(result.data).to.have.length(2);
+
+		expect(result.data[0]).to.have.length(1);
+		expect(result.data[0][0].unique).to.equal(SIMPLE_ELEMENT_ID);
+		expect(result.data[0][0].variants[0].name).to.equal('Simple Element');
+
+		expect(result.data[1]).to.have.length(1);
+		expect(result.data[1][0].unique).to.equal(ELEMENT_IN_FOLDER_ID);
+		expect(result.data[1][0].variants[0].name).to.equal('Element In Folder');
+	});
+
+	it('resolves a multi-pick value (array of IDs) to multiple items', async () => {
+		const result = await resolver.resolveValues([[SIMPLE_ELEMENT_ID, ELEMENT_IN_FOLDER_ID]]);
+
+		expect(result.data).to.have.length(1);
+		expect(result.data[0]).to.have.length(2);
+
+		const uniques = result.data[0].map((item) => item.unique);
+		expect(uniques).to.include(SIMPLE_ELEMENT_ID);
+		expect(uniques).to.include(ELEMENT_IN_FOLDER_ID);
+	});
+
+	it('returns an empty array for an unknown element ID', async () => {
+		const result = await resolver.resolveValues([['00000000-0000-0000-0000-000000000000']]);
+
+		expect(result.data).to.have.length(1);
+		expect(result.data[0]).to.deep.equal([]);
+	});
+
+	it('returns an empty array for the unknown ID while still resolving the known ID', async () => {
+		const result = await resolver.resolveValues([['00000000-0000-0000-0000-000000000000'], [SIMPLE_ELEMENT_ID]]);
+
+		expect(result.data).to.have.length(2);
+		expect(result.data[0]).to.deep.equal([]);
+		expect(result.data[1][0].unique).to.equal(SIMPLE_ELEMENT_ID);
+	});
+
+	it('deduplicates IDs used across multiple values when fetching', async () => {
+		const result = await resolver.resolveValues([[SIMPLE_ELEMENT_ID], [SIMPLE_ELEMENT_ID]]);
+
+		expect(result.data).to.have.length(2);
+		expect(result.data[0][0].unique).to.equal(SIMPLE_ELEMENT_ID);
+		expect(result.data[1][0].unique).to.equal(SIMPLE_ELEMENT_ID);
+	});
+
+	it('includes an asObservable function in the result when items are found', async () => {
+		const result = await resolver.resolveValues([[SIMPLE_ELEMENT_ID]]);
+		expect(result.asObservable).to.be.a('function');
+	});
+
+	it('emits resolved items via the observable', async () => {
+		const result = await resolver.resolveValues([[ELEMENT_IN_SUBFOLDER_ID]]);
+
+		const observed = await new Promise<typeof result.data>((resolve) => {
+			result.asObservable!().subscribe((value) => {
+				if (value.length > 0) resolve(value);
+			});
+		});
+
+		expect(observed[0][0].unique).to.equal(ELEMENT_IN_SUBFOLDER_ID);
+		expect(observed[0][0].variants[0].name).to.equal('Element In Subfolder 1');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.ts
@@ -1,0 +1,43 @@
+import type { UmbValueSummaryResolveResult, UmbValueSummaryResolver } from '@umbraco-cms/backoffice/value-summary';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import { createObservablePart } from '@umbraco-cms/backoffice/observable-api';
+import { UmbElementItemRepository } from '../../../item/repository/index.js';
+import type { UmbElementItemModel } from '../../../types.js';
+
+/** Batch-resolves Element Picker value (array of element uniques) to their item models. */
+export class UmbElementPickerValueSummaryResolver
+	extends UmbControllerBase
+	implements UmbValueSummaryResolver<Array<string> | undefined, Array<UmbElementItemModel>>
+{
+	#repo = new UmbElementItemRepository(this);
+
+	async resolveValues(
+		values: ReadonlyArray<Array<string> | undefined>,
+	): Promise<UmbValueSummaryResolveResult<Array<UmbElementItemModel>>> {
+		const allKeys = [...new Set(values.flatMap((v) => v ?? []))];
+		if (!allKeys.length) return { data: values.map(() => []) };
+
+		const { data, asObservable } = await this.#repo.requestItems(allKeys);
+		const items = Array.isArray(data) ? (data as Array<UmbElementItemModel>) : [];
+
+		return {
+			data: this.#map(values, items),
+			asObservable: asObservable
+				? () =>
+						createObservablePart(asObservable()!, (latest) => this.#map(values, latest as Array<UmbElementItemModel>))
+				: undefined,
+		};
+	}
+
+	#map(
+		values: ReadonlyArray<Array<string> | undefined>,
+		items: ReadonlyArray<UmbElementItemModel>,
+	): ReadonlyArray<Array<UmbElementItemModel>> {
+		const itemByKey = new Map(items.map((item) => [item.unique, item]));
+		return values.map((v) =>
+			(v ?? []).map((key) => itemByKey.get(key)).filter((item): item is UmbElementItemModel => !!item),
+		);
+	}
+}
+
+export { UmbElementPickerValueSummaryResolver as valueResolver };

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.ts
@@ -39,5 +39,3 @@ export class UmbElementPickerValueSummaryResolver
 		);
 	}
 }
-
-export { UmbElementPickerValueSummaryResolver as valueResolver };

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.ts
@@ -9,7 +9,7 @@ export class UmbElementPickerValueSummaryResolver
 	extends UmbControllerBase
 	implements UmbValueSummaryResolver<Array<string> | undefined, Array<UmbElementItemModel>>
 {
-	#repo = new UmbElementItemRepository(this);
+	readonly #repo = new UmbElementItemRepository(this);
 
 	async resolveValues(
 		values: ReadonlyArray<Array<string> | undefined>,
@@ -18,13 +18,13 @@ export class UmbElementPickerValueSummaryResolver
 		if (!allKeys.length) return { data: values.map(() => []) };
 
 		const { data, asObservable } = await this.#repo.requestItems(allKeys);
-		const items = Array.isArray(data) ? (data as Array<UmbElementItemModel>) : [];
+		const items = Array.isArray(data) ? data : [];
 
 		return {
 			data: this.#map(values, items),
 			asObservable: asObservable
 				? () =>
-						createObservablePart(asObservable()!, (latest) => this.#map(values, latest as Array<UmbElementItemModel>))
+						createObservablePart(asObservable()!, (latest) => this.#map(values, latest))
 				: undefined,
 		};
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-summary/value-summary.ts
@@ -1,0 +1,2 @@
+export { UmbElementPickerPropertyEditorValueSummaryElement as element } from './value-summary.element.js';
+export { UmbElementPickerValueSummaryResolver as valueResolver } from './value-summary.resolver.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-type/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/property-editor/element-picker/value-type/constants.ts
@@ -1,0 +1,7 @@
+export const UMB_ELEMENT_PICKER_PROPERTY_EDITOR_VALUE_TYPE = 'Umbraco.ElementPicker' as const;
+
+declare global {
+	interface UmbValueTypeMap {
+		[UMB_ELEMENT_PICKER_PROPERTY_EDITOR_VALUE_TYPE]: Array<string>;
+	}
+}


### PR DESCRIPTION
## Description

Following up on PRs #22871/#23027, this PR adds a `valueSummary` for the Element Picker (for Umbraco 18).

_Kudos to @engijlr for the original code, ref: de4683f6dabccb13ff3cfdcb607cefad3990d0d4._ ✌️ 

## Summary _(AI/Claude generated)_ 🤖 

- Adds a `valueSummary` extension for the `Umbraco.ElementPicker` property editor so picked element names are rendered in collection view columns
- Introduces `UMB_ELEMENT_PICKER_PROPERTY_EDITOR_VALUE_TYPE` constant (exported from `@umbraco-cms/backoffice/elements`) and wires it through the standard `property-editor → element-picker` constants chain
- Batch resolver deduplicates GUIDs, fetches via `UmbElementItemRepository`, and returns positionally-aligned `Array<UmbElementItemModel>` with `asObservable` support; element renders all names variant-aware and comma-joined

## Test plan

- [ ] Run resolver unit tests: `npm test -- --files "src/packages/elements/property-editor/element-picker/value-summary/value-summary.resolver.test.ts"` — all 11 cases pass
- [ ] Manual: add an Element Picker property to a content type, pick 2+ elements, surface that property as a collection column, and verify the cell shows the element names joined by `, `
- [ ] Verify the raw value arriving at the resolver is a pre-parsed `Array<string>` (not a JSON string) — if it arrives as a string, the `TValue` and `UmbValueTypeMap` entry will need updating