### PR TITLE
UFM: Add `umbElementName` component

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/elements/item/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/elements/item/index.ts
@@ -1,1 +1,2 @@
 export { UmbElementItemRepository } from './repository/index.js';
+export * from './data-resolver/element-item-data-resolver.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.component.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.component.ts
@@ -1,0 +1,14 @@
+import type { UfmToken } from '../../plugins/types.js';
+import { UmbUfmComponentBase } from '../ufm-component-base.js';
+
+import './element-name.element.js';
+
+export class UmbUfmElementNameComponent extends UmbUfmComponentBase {
+	render(token: UfmToken) {
+		if (!token.text) return;
+		const attributes = super.getAttributes(token.text);
+		return `<ufm-element-name ${attributes}></ufm-element-name>`;
+	}
+}
+
+export { UmbUfmElementNameComponent as api };

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.element.ts
@@ -1,0 +1,68 @@
+import { UmbUfmElementBase } from '../ufm-element-base.js';
+import { UMB_UFM_RENDER_CONTEXT } from '../ufm-render/ufm-render.context.js';
+import { customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbElementItemDataResolver, UmbElementItemRepository } from '@umbraco-cms/backoffice/element';
+import { UmbId } from '@umbraco-cms/backoffice/id';
+
+@customElement('ufm-element-name')
+export class UmbUfmElementNameElement extends UmbUfmElementBase {
+	#repository?: UmbElementItemRepository;
+
+	@property()
+	alias?: string;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_UFM_RENDER_CONTEXT, (context) => {
+			this.observe(
+				context?.value,
+				async (value) => {
+					const temp =
+						this.alias && typeof value === 'object'
+							? (value as Record<string, unknown>)[this.alias]
+							: (value as unknown);
+
+					if (!temp) return;
+
+					const uniques = this.#getUniques(temp);
+					this.value = await this.#getNames(uniques);
+				},
+				'observeValue',
+			);
+		});
+	}
+
+	#getUniques(value: unknown) {
+		if (Array.isArray(value)) {
+			return value.map((x) => x.unique ?? x).filter((x) => UmbId.validate(x));
+		}
+		return typeof value === 'string' && UmbId.validate(value) ? [value] : [];
+	}
+
+	async #getNames(uniques?: Array<string>) {
+		if (uniques?.length) {
+			if (!this.#repository) this.#repository = new UmbElementItemRepository(this);
+			const { data } = await this.#repository.requestItems(uniques);
+
+			if (Array.isArray(data) && data.length > 0) {
+				const namePromises = data.map(async (item) => {
+					const resolver = new UmbElementItemDataResolver(this);
+					resolver.setData(item);
+					return await resolver.getName();
+				});
+				const names = await Promise.all(namePromises);
+				return names.join(', ');
+			}
+		}
+		return '';
+	}
+}
+
+export { UmbUfmElementNameElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'ufm-element-name': UmbUfmElementNameElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.element.ts
@@ -57,7 +57,7 @@ export class UmbUfmElementNameElement extends UmbUfmElementBase {
 					return name;
 				});
 				const names = await Promise.all(namePromises);
-				return names.join(', ');
+				return names.filter(Boolean).join(', ');
 			}
 		}
 		return '';

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/element-name.element.ts
@@ -23,7 +23,10 @@ export class UmbUfmElementNameElement extends UmbUfmElementBase {
 							? (value as Record<string, unknown>)[this.alias]
 							: (value as unknown);
 
-					if (!temp) return;
+					if (!temp) {
+						this.value = '';
+						return;
+					}
 
 					const uniques = this.#getUniques(temp);
 					this.value = await this.#getNames(uniques);
@@ -49,7 +52,9 @@ export class UmbUfmElementNameElement extends UmbUfmElementBase {
 				const namePromises = data.map(async (item) => {
 					const resolver = new UmbElementItemDataResolver(this);
 					resolver.setData(item);
-					return await resolver.getName();
+					const name = await resolver.getName();
+					resolver.destroy();
+					return name;
 				});
 				const names = await Promise.all(namePromises);
 				return names.join(', ');

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/element-name/manifests.ts
@@ -1,0 +1,11 @@
+import type { ManifestUfmComponent } from '../../extensions/ufm-component.extension.js';
+
+export const manifests: Array<ManifestUfmComponent> = [
+	{
+		type: 'ufmComponent',
+		alias: 'Umb.Markdown.ElementName',
+		name: 'Element Name UFM Component',
+		api: () => import('./element-name.component.js'),
+		meta: { alias: 'umbElementName' },
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/manifests.ts
@@ -1,4 +1,5 @@
 import type { ManifestUfmComponent } from '../extensions/ufm-component.extension.js';
+import { manifests as elementNameManifests } from './element-name/manifests.js';
 
 export const manifests: Array<ManifestUfmComponent> = [
 	{
@@ -22,6 +23,7 @@ export const manifests: Array<ManifestUfmComponent> = [
 		api: () => import('./content-name/content-name.component.js'),
 		meta: { alias: 'umbContentName' },
 	},
+	...elementNameManifests,
 	{
 		type: 'ufmComponent',
 		alias: 'Umb.Markdown.Link',

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@open-wc/testing';
 import { ufm } from './marked-ufm.plugin.js';
 import { UmbMarked } from '../contexts/ufm.context.js';
 import { UmbUfmContentNameComponent } from '../components/content-name/content-name.component.js';
+import { UmbUfmElementNameComponent } from '../components/element-name/element-name.component.js';
 import { UmbUfmLabelValueComponent } from '../components/label-value/label-value.component.js';
 import { UmbUfmLocalizeComponent } from '../components/localize/localize.component.js';
 
@@ -26,12 +27,18 @@ describe('UmbMarkedUfm', () => {
 				ufm: '{umbContentName: contentPicker}',
 				expected: '<ufm-content-name alias="contentPicker"></ufm-content-name>',
 			},
+			{ ufm: '{umbElementName:elementPicker}', expected: '<ufm-element-name alias="elementPicker"></ufm-element-name>' },
+			{
+				ufm: '{ umbElementName: elementPicker }',
+				expected: '<ufm-element-name alias="elementPicker"></ufm-element-name>',
+			},
 		];
 
 		// Manually configuring the UFM components for testing.
 		UmbMarked.use(
 			ufm([
 				{ alias: 'umbContentName', marker: '~', render: new UmbUfmContentNameComponent().render },
+				{ alias: 'umbElementName', render: new UmbUfmElementNameComponent().render },
 				{ alias: 'umbValue', marker: '=', render: new UmbUfmLabelValueComponent().render },
 				{ alias: 'umbLocalize', marker: '#', render: new UmbUfmLocalizeComponent().render },
 			]),


### PR DESCRIPTION
Adds a new `umbElementName` UFM component for use in label and description markdown within the backoffice.

Usage: `{umbElementName:<element-key>}`

This mirrors the existing `umbContentName` component but targets Element entities — useful for property editors and UI that reference block editor elements by key. Supports single keys and arrays, comma-joins multiple names, and handles culture variants with a fallback to `(Untitled)`.

Also exposes `UmbElementItemDataResolver` from the public `@umbraco-cms/backoffice/element` entry point.