### PR TITLE
Content & Media: Enforce content type filters and allowed children/root rules when validating a create

### DIFF
--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -105,7 +105,15 @@ internal sealed class ContentEditingService
 
     /// <inheritdoc />
     public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCreateAsync(ContentCreateModel createModel, Guid userKey)
-        => await ValidateCulturesAndPropertiesAsync(createModel, createModel.ContentTypeKey, await GetCulturesToValidate(createModel.Variants.Select(variant => variant.Culture), userKey));
+    {
+        ContentEditingOperationStatus creationAllowedStatus = await ValidateCreationAllowedAsync(createModel);
+        if (creationAllowedStatus != ContentEditingOperationStatus.Success)
+        {
+            return Attempt.FailWithStatus(creationAllowedStatus, new ContentValidationResult());
+        }
+
+        return await ValidateCulturesAndPropertiesAsync(createModel, createModel.ContentTypeKey, await GetCulturesToValidate(createModel.Variants.Select(variant => variant.Culture), userKey));
+    }
 
     private async Task<IEnumerable<string?>?> GetCulturesToValidate(IEnumerable<string?>? cultures, Guid userKey)
     {

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -623,6 +623,25 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
         return filteredContentTypes.Any();
     }
 
+    /// <summary>
+    /// Validates that content of the requested type is allowed to be created under the requested parent, applying the
+    /// same "allowed at root", "allowed as child" and content type filter rules that are enforced when the content is
+    /// actually created. This allows the validation endpoints to be consistent with creation.
+    /// </summary>
+    /// <param name="createModel">The content creation model.</param>
+    /// <returns>The operation status; <see cref="ContentEditingOperationStatus.Success"/> when creation is allowed.</returns>
+    protected async Task<ContentEditingOperationStatus> ValidateCreationAllowedAsync(ContentCreationModelBase createModel)
+    {
+        TContentType? contentType = ContentTypeService.Get(createModel.ContentTypeKey);
+        if (contentType is null)
+        {
+            return ContentEditingOperationStatus.ContentTypeNotFound;
+        }
+
+        (int? _, ContentEditingOperationStatus operationStatus) = await TryGetAndValidateParentIdAsync(createModel.ParentKey, contentType);
+        return operationStatus;
+    }
+
     private void UpdateNames(ContentEditingModelBase contentEditingModelBase, TContent content, TContentType contentType)
     {
         if (contentType.VariesByCulture())

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -83,7 +83,15 @@ internal sealed class MediaEditingService
 
     /// <inheritdoc />
     public async Task<Attempt<ContentValidationResult, ContentEditingOperationStatus>> ValidateCreateAsync(MediaCreateModel createModel)
-        => await ValidatePropertiesAsync(createModel, createModel.ContentTypeKey);
+    {
+        ContentEditingOperationStatus creationAllowedStatus = await ValidateCreationAllowedAsync(createModel);
+        if (creationAllowedStatus != ContentEditingOperationStatus.Success)
+        {
+            return Attempt.FailWithStatus(creationAllowedStatus, new ContentValidationResult());
+        }
+
+        return await ValidatePropertiesAsync(createModel, createModel.ContentTypeKey);
+    }
 
     /// <inheritdoc />
     public async Task<Attempt<MediaCreateResult, ContentEditingOperationStatus>> CreateAsync(MediaCreateModel createModel, Guid userKey)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
@@ -239,8 +239,41 @@ public partial class ContentEditingServiceTests
     }
 
     [Test]
+    public async Task Cannot_Validate_Create_As_Child_When_Not_Allowed_By_Parent()
+    {
+        var createModel = await BuildTextPageChildCreateModel(parentAllowsChild: false);
+
+        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    [Test]
+    public async Task Can_Validate_Create_As_Child_When_Allowed_By_Parent()
+    {
+        var createModel = await BuildTextPageChildCreateModel(parentAllowsChild: true);
+
+        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+    }
+
+    [Test]
     [ConfigureBuilder(ActionName = nameof(ConfigureContentTypeFilterToDisallowTextPageAsChild))]
     public async Task Cannot_Validate_Create_As_Child_With_Content_Type_Filter()
+    {
+        // The parent allows the child type, so the only reason creation is disallowed is the content type filter.
+        var createModel = await BuildTextPageChildCreateModel(parentAllowsChild: true);
+
+        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    private async Task<ContentCreateModel> BuildTextPageChildCreateModel(bool parentAllowsChild)
     {
         var template = TemplateBuilder.CreateTextPageTemplate();
         await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
@@ -251,10 +284,14 @@ public partial class ContentEditingServiceTests
 
         var rootContentType = ContentTypeBuilder.CreateBasicContentType();
         rootContentType.AllowedAsRoot = true;
-        rootContentType.AllowedContentTypes = new[]
+        if (parentAllowsChild)
         {
-            new ContentTypeSort(childContentType.Key, 1, childContentType.Alias)
-        };
+            rootContentType.AllowedContentTypes = new[]
+            {
+                new ContentTypeSort(childContentType.Key, 1, childContentType.Alias)
+            };
+        }
+
         ContentTypeService.Save(rootContentType);
 
         var rootKey = (await ContentEditingService.CreateAsync(
@@ -269,7 +306,7 @@ public partial class ContentEditingServiceTests
             },
             Constants.Security.SuperUserKey)).Result.Content!.Key;
 
-        var createModel = new ContentCreateModel
+        return new ContentCreateModel
         {
             ContentTypeKey = childContentType.Key,
             TemplateKey = template.Key,
@@ -284,11 +321,6 @@ public partial class ContentEditingServiceTests
                 new PropertyValueModel { Alias = "bodyText", Value = "The child body text" }
             ]
         };
-
-        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
-
-        Assert.IsFalse(result.Success);
-        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
     }
 
     private async Task<ContentCreateModel> BuildTextPageRootCreateModel(bool allowedAsRoot)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Validate.cs
@@ -203,6 +203,120 @@ public partial class ContentEditingServiceTests
         Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
     }
 
+    [Test]
+    public async Task Cannot_Validate_Create_At_Root_When_Not_Allowed_As_Root()
+    {
+        var createModel = await BuildTextPageRootCreateModel(allowedAsRoot: false);
+
+        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureContentTypeFilterToDisallowTextPageAtRoot))]
+    public async Task Cannot_Validate_Create_At_Root_With_Content_Type_Filter()
+    {
+        var createModel = await BuildTextPageRootCreateModel(allowedAsRoot: true);
+
+        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureContentTypeFilterToAllowTextPageAtRoot))]
+    public async Task Can_Validate_Create_At_Root_With_Content_Type_Filter()
+    {
+        var createModel = await BuildTextPageRootCreateModel(allowedAsRoot: true);
+
+        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureContentTypeFilterToDisallowTextPageAsChild))]
+    public async Task Cannot_Validate_Create_As_Child_With_Content_Type_Filter()
+    {
+        var template = TemplateBuilder.CreateTextPageTemplate();
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        var childContentType = ContentTypeBuilder.CreateTextPageContentType(defaultTemplateId: template.Id);
+        childContentType.AllowedAsRoot = false;
+        ContentTypeService.Save(childContentType);
+
+        var rootContentType = ContentTypeBuilder.CreateBasicContentType();
+        rootContentType.AllowedAsRoot = true;
+        rootContentType.AllowedContentTypes = new[]
+        {
+            new ContentTypeSort(childContentType.Key, 1, childContentType.Alias)
+        };
+        ContentTypeService.Save(rootContentType);
+
+        var rootKey = (await ContentEditingService.CreateAsync(
+            new ContentCreateModel
+            {
+                ContentTypeKey = rootContentType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants =
+                [
+                    new VariantModel { Name = "Root" }
+                ],
+            },
+            Constants.Security.SuperUserKey)).Result.Content!.Key;
+
+        var createModel = new ContentCreateModel
+        {
+            ContentTypeKey = childContentType.Key,
+            TemplateKey = template.Key,
+            ParentKey = rootKey,
+            Variants =
+            [
+                new VariantModel { Name = "Test Create Child" }
+            ],
+            Properties =
+            [
+                new PropertyValueModel { Alias = "title", Value = "The child title value" },
+                new PropertyValueModel { Alias = "bodyText", Value = "The child body text" }
+            ]
+        };
+
+        var result = await ContentEditingService.ValidateCreateAsync(createModel, Constants.Security.SuperUserKey);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    private async Task<ContentCreateModel> BuildTextPageRootCreateModel(bool allowedAsRoot)
+    {
+        var template = TemplateBuilder.CreateTextPageTemplate();
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        var contentType = ContentTypeBuilder.CreateTextPageContentType(defaultTemplateId: template.Id);
+        contentType.AllowedAsRoot = allowedAsRoot;
+        ContentTypeService.Save(contentType);
+
+        return new ContentCreateModel
+        {
+            ContentTypeKey = contentType.Key,
+            TemplateKey = template.Key,
+            ParentKey = Constants.System.RootKey,
+            Variants =
+            [
+                new VariantModel { Name = "Test Create" }
+            ],
+            Properties =
+            [
+                new PropertyValueModel { Alias = "title", Value = "The title value" },
+                new PropertyValueModel { Alias = "bodyText", Value = "The body text" }
+            ]
+        };
+    }
+
     private async Task<IUser> CreateEnglishLanguageOnlyEditor()
     {
         var enUSLanguage = await LanguageService.GetAsync("en-US");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Validate.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Validate.cs
@@ -1,0 +1,80 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services.Filters;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Integration.Attributes;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+internal sealed partial class MediaEditingServiceTests
+{
+    [Test]
+    public async Task Cannot_Validate_Create_At_Root_When_Not_Allowed_As_Root()
+    {
+        var createModel = BuildTestMediaRootCreateModel(allowedAsRoot: false);
+
+        var result = await MediaEditingService.ValidateCreateAsync(createModel);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureContentTypeFilterToDisallowTestMediaAtRoot))]
+    public async Task Cannot_Validate_Create_At_Root_With_Content_Type_Filter()
+    {
+        var createModel = BuildTestMediaRootCreateModel(allowedAsRoot: true);
+
+        var result = await MediaEditingService.ValidateCreateAsync(createModel);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureContentTypeFilterToAllowTestMediaAtRoot))]
+    public async Task Can_Validate_Create_At_Root_With_Content_Type_Filter()
+    {
+        var createModel = BuildTestMediaRootCreateModel(allowedAsRoot: true);
+
+        var result = await MediaEditingService.ValidateCreateAsync(createModel);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+    }
+
+    private MediaCreateModel BuildTestMediaRootCreateModel(bool allowedAsRoot)
+    {
+        var mediaType = MediaTypeBuilder.CreateSimpleMediaType("testMedia", "Test Media");
+        mediaType.AllowedAsRoot = allowedAsRoot;
+        MediaTypeService.Save(mediaType);
+
+        return new MediaCreateModel
+        {
+            ContentTypeKey = mediaType.Key,
+            ParentKey = Constants.System.RootKey,
+            Variants = [new VariantModel { Name = "Test Create" }],
+        };
+    }
+
+    public static void ConfigureContentTypeFilterToAllowTestMediaAtRoot(IUmbracoBuilder builder)
+        => builder.ContentTypeFilters().Append<ContentTypeFilterForAllowedTestMediaAtRoot>();
+
+    public static void ConfigureContentTypeFilterToDisallowTestMediaAtRoot(IUmbracoBuilder builder)
+        => builder.ContentTypeFilters().Append<ContentTypeFilterForDisallowedTestMediaAtRoot>();
+
+    private sealed class ContentTypeFilterForAllowedTestMediaAtRoot() : ContentTypeFilterForTestMediaAtRoot(true);
+
+    private sealed class ContentTypeFilterForDisallowedTestMediaAtRoot() : ContentTypeFilterForTestMediaAtRoot(false);
+
+    private abstract class ContentTypeFilterForTestMediaAtRoot(bool allowed) : IContentTypeFilter
+    {
+        public Task<IEnumerable<TItem>> FilterAllowedAtRootAsync<TItem>(IEnumerable<TItem> contentTypes)
+            where TItem : IContentTypeComposition
+            => Task.FromResult(contentTypes.Where(x => (allowed && x.Alias == "testMedia") || (!allowed && x.Alias != "testMedia")));
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Validate.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Validate.cs
@@ -47,6 +47,41 @@ internal sealed partial class MediaEditingServiceTests
         Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
     }
 
+    [Test]
+    public async Task Cannot_Validate_Create_As_Child_When_Not_Allowed_By_Parent()
+    {
+        var createModel = await BuildTestMediaChildCreateModel(parentAllowsChild: false);
+
+        var result = await MediaEditingService.ValidateCreateAsync(createModel);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
+    [Test]
+    public async Task Can_Validate_Create_As_Child_When_Allowed_By_Parent()
+    {
+        var createModel = await BuildTestMediaChildCreateModel(parentAllowsChild: true);
+
+        var result = await MediaEditingService.ValidateCreateAsync(createModel);
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureContentTypeFilterToDisallowChildMediaAsChild))]
+    public async Task Cannot_Validate_Create_As_Child_With_Content_Type_Filter()
+    {
+        // The parent allows the child type, so the only reason creation is disallowed is the content type filter.
+        var createModel = await BuildTestMediaChildCreateModel(parentAllowsChild: true);
+
+        var result = await MediaEditingService.ValidateCreateAsync(createModel);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.NotAllowed, result.Status);
+    }
+
     private MediaCreateModel BuildTestMediaRootCreateModel(bool allowedAsRoot)
     {
         var mediaType = MediaTypeBuilder.CreateSimpleMediaType("testMedia", "Test Media");
@@ -61,20 +96,80 @@ internal sealed partial class MediaEditingServiceTests
         };
     }
 
+    private async Task<MediaCreateModel> BuildTestMediaChildCreateModel(bool parentAllowsChild)
+    {
+        var childMediaType = MediaTypeBuilder.CreateSimpleMediaType("childMedia", "Child Media");
+        childMediaType.AllowedAsRoot = false;
+        MediaTypeService.Save(childMediaType);
+
+        var parentMediaType = MediaTypeBuilder.CreateSimpleMediaType("parentMedia", "Parent Media");
+        parentMediaType.AllowedAsRoot = true;
+        if (parentAllowsChild)
+        {
+            parentMediaType.AllowedContentTypes = new[]
+            {
+                new ContentTypeSort(childMediaType.Key, 1, childMediaType.Alias)
+            };
+        }
+
+        MediaTypeService.Save(parentMediaType);
+
+        var parentKey = (await MediaEditingService.CreateAsync(
+            new MediaCreateModel
+            {
+                ContentTypeKey = parentMediaType.Key,
+                ParentKey = Constants.System.RootKey,
+                Variants = [new VariantModel { Name = "Parent" }],
+            },
+            Constants.Security.SuperUserKey)).Result.Content!.Key;
+
+        return new MediaCreateModel
+        {
+            ContentTypeKey = childMediaType.Key,
+            ParentKey = parentKey,
+            Variants = [new VariantModel { Name = "Test Create Child" }],
+        };
+    }
+
     public static void ConfigureContentTypeFilterToAllowTestMediaAtRoot(IUmbracoBuilder builder)
         => builder.ContentTypeFilters().Append<ContentTypeFilterForAllowedTestMediaAtRoot>();
 
     public static void ConfigureContentTypeFilterToDisallowTestMediaAtRoot(IUmbracoBuilder builder)
         => builder.ContentTypeFilters().Append<ContentTypeFilterForDisallowedTestMediaAtRoot>();
 
-    private sealed class ContentTypeFilterForAllowedTestMediaAtRoot() : ContentTypeFilterForTestMediaAtRoot(true);
+    public static void ConfigureContentTypeFilterToDisallowChildMediaAsChild(IUmbracoBuilder builder)
+        => builder.ContentTypeFilters().Append<ContentTypeFilterForDisallowedChildMediaAsChild>();
 
-    private sealed class ContentTypeFilterForDisallowedTestMediaAtRoot() : ContentTypeFilterForTestMediaAtRoot(false);
-
-    private abstract class ContentTypeFilterForTestMediaAtRoot(bool allowed) : IContentTypeFilter
+    private sealed class ContentTypeFilterForDisallowedChildMediaAsChild : IContentTypeFilter
     {
+        public Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(IEnumerable<ContentTypeSort> contentTypes, Guid parentContentTypeKey, Guid? parentContentKey)
+            => Task.FromResult(contentTypes.Where(x => x.Alias != "childMedia"));
+    }
+
+    private sealed class ContentTypeFilterForAllowedTestMediaAtRoot : ContentTypeFilterForTestMediaAtRoot
+    {
+        public ContentTypeFilterForAllowedTestMediaAtRoot()
+            : base(true)
+        {
+        }
+    }
+
+    private sealed class ContentTypeFilterForDisallowedTestMediaAtRoot : ContentTypeFilterForTestMediaAtRoot
+    {
+        public ContentTypeFilterForDisallowedTestMediaAtRoot()
+            : base(false)
+        {
+        }
+    }
+
+    private abstract class ContentTypeFilterForTestMediaAtRoot : IContentTypeFilter
+    {
+        private readonly bool _allowed;
+
+        protected ContentTypeFilterForTestMediaAtRoot(bool allowed) => _allowed = allowed;
+
         public Task<IEnumerable<TItem>> FilterAllowedAtRootAsync<TItem>(IEnumerable<TItem> contentTypes)
             where TItem : IContentTypeComposition
-            => Task.FromResult(contentTypes.Where(x => (allowed && x.Alias == "testMedia") || (!allowed && x.Alias != "testMedia")));
+            => Task.FromResult(contentTypes.Where(x => (_allowed && x.Alias == "testMedia") || (!_allowed && x.Alias != "testMedia")));
     }
 }


### PR DESCRIPTION
## Description

While adding parent-aware "allowed in library" filtering for elements (#23161), I found that the **validate-create** endpoints for documents and media did not enforce the content type rules that the actual *create* path does.

So a request that would be rejected by `CreateAsync` (correctly guarded since #19903) could still pass validation. This PR makes the validate endpoints consistent with create.

In practice this is unlikely to be a problem, as the backoffice UI will not present the option for creating a document of a type that's not allowed due to the registered content type filters.  But a direct management API call could be made and would incorrectly allow the operation via the validate, but fail it on the actual create.

This is the document/media counterpart of the element-side work in #23161 — that PR closed the same loop for the new Library/elements feature and noted the document/media gap should be addressed separately for 17.

## Testing

### Automated

Integration tests are added to test the validation (each verified to fail before the fix and pass after):

### Manual

**1. Register a content type filter** that, for example, removes any allowed child whose alias begins with "a":

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.DependencyInjection;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services.Filters;

public class RemoveChildrenStartingWithAContentTypeFilterComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
        => builder.ContentTypeFilters().Append<RemoveChildrenStartingWithAContentTypeFilter>();
}

public class RemoveChildrenStartingWithAContentTypeFilter : IContentTypeFilter
{
    public Task<IEnumerable<ContentTypeSort>> FilterAllowedChildrenAsync(
        IEnumerable<ContentTypeSort> contentTypes,
        Guid parentContentTypeKey,
        Guid? parentContentKey)
        => Task.FromResult(contentTypes.Where(x =>
            x.Alias.StartsWith("a", StringComparison.OrdinalIgnoreCase) is false));
}
```

**2. Set up content** (Settings → Document Types):
- `Article` (alias `article`).
- `Container` (alias `container`) — *Allow at root*, and under *Structure* allow `Article` as a child.

Create a `Container` node at the content root and note its key. Because `Container` explicitly allows `Article`, the only thing that can reject `Article` is the filter — which isolates the behaviour under test.

**3. Confirm the create menu** under the `Container` node does not list `Article` (existing filter behaviour).

**4. Test the validate endpoint** (the fix). The UI hides `Article`, so call it directly via `/umbraco/swagger`:

`POST /umbraco/management/api/v1/document/validate`

```json
{
  "documentType": { "id": "<ARTICLE_DOCTYPE_KEY>" },
  "parent": { "id": "<CONTAINER_NODE_KEY>" },
  "variants": [ { "culture": null, "segment": null, "name": "Test Article" } ],
  "values": [],
  "template": null
}
```

- **With this PR:** `400 Bad Request` with the `NotAllowed` operation status.
- **Before this PR:** `200 OK` (the gap).

Posting the same body to `POST /umbraco/management/api/v1/document` (create) returns the same `400 NotAllowed`, confirming validate now matches create.