### PR TITLE
Fix detail data request manager failing when items hit 40, making document unusable (closes #23198, #23458, #23362)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/detail/detail-data.request-manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/detail/detail-data.request-manager.ts
@@ -192,12 +192,12 @@ export class UmbManagementApiDetailDataRequestManager<
 		if (newIds.length > 0) {
 			try {
 				const getItemsController = new UmbItemDataApiGetRequestController(this, {
-					api: (args) => this.#readMany!(args.uniques),
+					api: async (args) => ({ data: (await this.#readMany!(args.uniques)).data.items }),
 					uniques: newIds,
 				});
 
 				const { data: serverData, error: serverError } = await getItemsController.request();
-				const serverItems = serverData?.items ?? [];
+				const serverItems = serverData ?? [];
 				error = serverError;
 
 				if (this.#isConnectedToServerEvents) {


### PR DESCRIPTION
Fix detail data request manager failing as soon as the number of items requested hits the UmbItemDataApiGetRequestController batch limit (40)

### Issue
When navigating to some documents in our Umbraco 17 installation the document would never load, the spinner would spin continuously and nothing would happen. Some initial investigations indicated that it was an issue loading the data types - but the network tab showed the requests to and from the server completing successfully and as expected.

Issues to be fixed: #23198, #23458, #23362

### Description
After investigation through all the various layers, I have tracked the issue to UmbManagementApiDetailDataRequestManager, which is making the requests to the server for the data types. It in turn uses UmbItemDataApiGetRequestController, which will make one direct request if the number of items is under the batch limit (hardcoded as 40), but splits it into multiple requests if over that limit.

When using one request, there is no issue. The request is made and the result that comes back is an object with an items property, that is read in:
 ```
const { data: serverData, error: serverError } = await getItemsController.request();
const serverItems = serverData?.items ?? [];
```

However, in a batched request, the result will not have an items property because the resulting data in each batch request was not an array, so the flatMap call in UmbItemDataApiGetRequestController does not return as expected. The result of the request() call is therefore instead an array of batch result objects, which the second line doesn't expect, so the result is an empty array. Therefore, although the data types returned from the server without issue, they are never loaded, so the document can never load.

Although this was observed via data types, it would affect anything using UmbManagementApiDetailDataRequestManager so may have caused other bugs.

My fix is to remove the access of the "items" property in the call above, and move it to the parameter to the controller that reads each batch. Therefore the result of each batch is an array, as UmbItemDataApiGetRequestController expects, and it can combine them into one result successfully.
```
const getItemsController = new UmbItemDataApiGetRequestController(this, {
	api: async (args) => ({ data: (await this.#readMany!(args.uniques)).data.items }),
	uniques: newIds,
});
```

### Testing

You will need a document using more than 40 data types, you can then try to refresh the document in your browser and it will fail to load. It can also be reproduced by changing the batch size in the UmbItemDataApiGetRequestController class source code to a lower number than the default 40, so that it uses the batch code that causes the issue with less data types.