### PR TITLE
UFM: Add `umbMemberName` component (closes #22147)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/manifests.ts
@@ -29,4 +29,11 @@ export const manifests: Array<ManifestUfmComponent> = [
 		api: () => import('./link/link.component.js'),
 		meta: { alias: 'umbLink' },
 	},
+	{
+		type: 'ufmComponent',
+		alias: 'Umb.Markdown.MemberName',
+		name: 'Member Name UFM Component',
+		api: () => import('./member-name/member-name.component.js'),
+		meta: { alias: 'umbMemberName' },
+	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/member-name/member-name.component.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/member-name/member-name.component.ts
@@ -1,0 +1,15 @@
+import { UmbUfmComponentBase } from '../ufm-component-base.js';
+import type { UfmToken } from '../../plugins/types.js';
+
+import './member-name.element.js';
+
+export class UmbUfmMemberNameComponent extends UmbUfmComponentBase {
+	render(token: UfmToken) {
+		if (!token.text) return;
+
+		const attributes = super.getAttributes(token.text);
+		return `<ufm-member-name ${attributes}></ufm-member-name>`;
+	}
+}
+
+export { UmbUfmMemberNameComponent as api };

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/member-name/member-name.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/member-name/member-name.element.ts
@@ -24,7 +24,10 @@ export class UmbUfmMemberNameElement extends UmbUfmElementBase {
 							? (value as Record<string, unknown>)[this.alias]
 							: (value as unknown);
 
-					if (!temp) return;
+					if (!temp) {
+						this.value = '';
+						return;
+					}
 
 					const uniques = this.#getUniques(temp);
 
@@ -58,7 +61,8 @@ export class UmbUfmMemberNameElement extends UmbUfmElementBase {
 	#extractGuid(token: string): string | undefined {
 		if (token.startsWith('umb://')) {
 			try {
-				return getGuidFromUdi(token);
+				const guid = getGuidFromUdi(token);
+				return UmbId.validate(guid) ? guid : undefined;
 			} catch {
 				return undefined;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/components/member-name/member-name.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/components/member-name/member-name.element.ts
@@ -1,0 +1,92 @@
+import { UmbUfmElementBase } from '../ufm-element-base.js';
+import { UMB_UFM_RENDER_CONTEXT } from '../ufm-render/ufm-render.context.js';
+import { customElement, property } from '@umbraco-cms/backoffice/external/lit';
+import { getGuidFromUdi } from '@umbraco-cms/backoffice/utils';
+import { UmbId } from '@umbraco-cms/backoffice/id';
+import { UmbMemberItemRepository } from '@umbraco-cms/backoffice/member';
+
+@customElement('ufm-member-name')
+export class UmbUfmMemberNameElement extends UmbUfmElementBase {
+	@property()
+	alias?: string;
+
+	#memberRepository?: UmbMemberItemRepository;
+
+	constructor() {
+		super();
+
+		this.consumeContext(UMB_UFM_RENDER_CONTEXT, (context) => {
+			this.observe(
+				context?.value,
+				async (value) => {
+					const temp =
+						this.alias && typeof value === 'object'
+							? (value as Record<string, unknown>)[this.alias]
+							: (value as unknown);
+
+					if (!temp) return;
+
+					const uniques = this.#getUniques(temp);
+
+					this.value = await this.#getNames(uniques);
+				},
+				'observeValue',
+			);
+		});
+	}
+
+	#getUniques(value: unknown): Array<string> {
+		const entries = Array.isArray(value) ? value : [value];
+		return entries.flatMap((entry) => this.#normalizeEntry(entry)).filter((x) => x.length > 0);
+	}
+
+	// Returns an array because a single string entry may be comma-separated.
+	#normalizeEntry(entry: unknown): Array<string> {
+		if (entry && typeof entry === 'object') {
+			const unique = (entry as Record<string, unknown>).unique;
+			return typeof unique === 'string' ? this.#normalizeEntry(unique) : [];
+		}
+		if (typeof entry === 'string') {
+			return entry
+				.split(',')
+				.map((token) => this.#extractGuid(token.trim()))
+				.filter((x): x is string => !!x);
+		}
+		return [];
+	}
+
+	#extractGuid(token: string): string | undefined {
+		if (token.startsWith('umb://')) {
+			try {
+				return getGuidFromUdi(token);
+			} catch {
+				return undefined;
+			}
+		}
+		return UmbId.validate(token) ? token : undefined;
+	}
+
+	async #getNames(uniques?: Array<string>) {
+		if (uniques?.length) {
+			if (!this.#memberRepository) {
+				this.#memberRepository = new UmbMemberItemRepository(this);
+			}
+
+			const { data } = await this.#memberRepository.requestItems(uniques);
+			if (Array.isArray(data) && data.length > 0) {
+				// TODO: Review usage of `item.variants[0].name` as this needs to be implemented properly for member items [LK]
+				return data.map((item) => item.variants[0]?.name ?? item.name).join(', ');
+			}
+		}
+
+		return '';
+	}
+}
+
+export { UmbUfmMemberNameElement as element };
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'ufm-member-name': UmbUfmMemberNameElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/ufm/plugins/marked-ufm.test.ts
@@ -4,6 +4,7 @@ import { UmbMarked } from '../contexts/ufm.context.js';
 import { UmbUfmContentNameComponent } from '../components/content-name/content-name.component.js';
 import { UmbUfmLabelValueComponent } from '../components/label-value/label-value.component.js';
 import { UmbUfmLocalizeComponent } from '../components/localize/localize.component.js';
+import { UmbUfmMemberNameComponent } from '../components/member-name/member-name.component.js';
 
 describe('UmbMarkedUfm', () => {
 	describe('UFM parsing', () => {
@@ -26,6 +27,11 @@ describe('UmbMarkedUfm', () => {
 				ufm: '{umbContentName: contentPicker}',
 				expected: '<ufm-content-name alias="contentPicker"></ufm-content-name>',
 			},
+			{ ufm: '{umbMemberName:memberPicker}', expected: '<ufm-member-name alias="memberPicker"></ufm-member-name>' },
+			{
+				ufm: '{umbMemberName: memberPicker}',
+				expected: '<ufm-member-name alias="memberPicker"></ufm-member-name>',
+			},
 		];
 
 		// Manually configuring the UFM components for testing.
@@ -34,6 +40,7 @@ describe('UmbMarkedUfm', () => {
 				{ alias: 'umbContentName', marker: '~', render: new UmbUfmContentNameComponent().render },
 				{ alias: 'umbValue', marker: '=', render: new UmbUfmLabelValueComponent().render },
 				{ alias: 'umbLocalize', marker: '#', render: new UmbUfmLocalizeComponent().render },
+				{ alias: 'umbMemberName', render: new UmbUfmMemberNameComponent().render },
 			]),
 		);
 


### PR DESCRIPTION
### Description

Fixes #22147.

Adds a new `{umbMemberName:alias}` UFM (Umbraco Flavored Markdown) component that resolves a Member Picker property value to the member's display name.

**Why a dedicated component?** `{umbContentName}` already imports `UmbMemberItemRepository` but defaults to the document entity type when the value has no `type`/`mediaKey` discriminator. A Member Picker persists a bare GUID — ambiguous without the marker to signal intent — so a separate marker is the correct design.

#### Value structure support

The component resolves member references regardless of how they are stored, handling each of the following (as a single value or an array):

- Bare GUID: `"3f2504e0-4f89-11d3-9a0c-0305e82c3301"`
- Comma-separated GUIDs: `"guid1,guid2"`
- UDI: `umb://member/{GUID}`
- Content Picker object: `{ type, unique }` (where `unique` may itself be a GUID or UDI)

Names are joined by `, ` when multiple members resolve.

#### Known duplication (intentional)

The observe/alias-extraction logic is structurally similar to `content-name.element.ts`. A shared base was considered and deferred — if a third name-resolving UFM component appears, that's the moment to extract it.

#### Steps to test

1. Add a Member Picker property (`alias: memberPicker`) to a document type.
2. Set the property's label or description to `{umbMemberName:memberPicker}`.
3. Open a content node, pick a member, and confirm the member's name renders in the label/description.
4. To test multi-value support, temporarily point the marker at a custom value containing two comma-separated member GUIDs and confirm both names render.