### PR TITLE
Published Cache: Guard against cache poisoning from a render-vs-publish race

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -262,15 +262,16 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             var cacheKey = GetCacheKey(publishedNode.Key, false);
             await _hybridCache.SetAsync(cacheKey, publishedNode, GetEntryOptions(publishedNode.Key, false), GenerateTags(publishedNode));
             _publishedContentCache.Remove(cacheKey, out _);
+            InvalidateMemoryCacheGeneration();
         }
         else
         {
             // Either no published node in the database cache, or the ancestor path is no longer published —
-            // remove any stale published entry from the local memory cache.
+            // remove any stale published entry from the local memory cache. ClearPublishedCacheAsync
+            // bumps the generation itself, so this path is already covered.
             await ClearPublishedCacheAsync(key);
         }
 
-        InvalidateMemoryCacheGeneration();
         scope.Complete();
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -142,23 +142,29 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             return cached;
         }
 
-        // Capture the cache generation before reading the backing store. If a concurrent publish or
-        // invalidation bumps the generation while we read and build below, the snapshot we hold is
-        // stale and must not be written back over the refreshed entries (the clobber that leaves
-        // memory permanently stale until a full clear).
-        long generation = Interlocked.Read(ref _cacheGeneration);
-
         (bool exists, ContentCacheNode? contentCacheNode) = await _hybridCache.TryGetValueAsync<ContentCacheNode?>(cacheKey, CancellationToken.None);
+
+        // A value found in the backing store is already current, so it can always populate the caches
+        // below; only a value built from the read-through DB fetch needs the generation guard.
+        bool snapshotIsCurrent = true;
         if (exists is false)
         {
+            // Capture the cache generation before reading the backing store. If a concurrent publish or
+            // invalidation bumps the generation while we read and build below, the snapshot we hold is
+            // stale and must not be written back over the refreshed entries (the clobber that leaves
+            // memory permanently stale until a full clear).
+            long generation = Interlocked.Read(ref _cacheGeneration);
+
             bool ancestorCheckFailed;
             (contentCacheNode, ancestorCheckFailed) = await GetContentCacheNodeFromRepo();
+
+            snapshotIsCurrent = IsCacheGenerationCurrent(generation);
 
             // Only cache the result if the ancestor check didn't fail.
             // When content exists in DB but the ancestor check fails, this could be a transient
             // race condition during cache rebuild. Caching null would poison the distributed cache.
             // Skip the write when the generation moved — a refresh has superseded this snapshot.
-            if (ancestorCheckFailed is false && IsCacheGenerationCurrent(generation))
+            if (ancestorCheckFailed is false && snapshotIsCurrent)
             {
                 await _hybridCache.SetAsync(
                     cacheKey,
@@ -177,7 +183,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
         // Only populate the L0 cache when our snapshot is still current; otherwise a concurrent
         // refresh has already written fresher content and we must not overwrite it with this one.
-        if (result is not null && IsCacheGenerationCurrent(generation))
+        if (result is not null && snapshotIsCurrent)
         {
             _publishedContentCache[cacheKey] = result;
         }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -38,6 +38,20 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
     private readonly ConcurrentDictionary<string, IPublishedContent> _publishedContentCache = [];
 
+    // Monotonic counter bumped whenever the in-memory cache (L0/L1) is invalidated or refreshed.
+    // GetNodeAsync captures it before reading the backing store and re-checks it before writing
+    // back, so a snapshot read before a concurrent publish/refresh is never written over the
+    // refreshed entry — preventing the stale-set clobber that otherwise persists until a full clear.
+    //
+    // Deliberately a single global counter, not per-key: any invalidation invalidates every in-flight
+    // read-through. The only cost is an occasional skipped cache population when a read-through for one
+    // key overlaps an unrelated publish — a re-miss on the next request, never stale data. A per-key
+    // scheme would avoid that but needs a global epoch for bulk clears plus an exact per-key bump on
+    // every mutated cache key, which is easy to get wrong and would silently reintroduce the clobber.
+    // Global is correctness-robust; only revisit if read-through churn under heavy concurrent
+    // publishing ever shows up in profiling.
+    private long _cacheGeneration;
+
     private HashSet<Guid> SeedKeys
     {
         get
@@ -128,6 +142,12 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             return cached;
         }
 
+        // Capture the cache generation before reading the backing store. If a concurrent publish or
+        // invalidation bumps the generation while we read and build below, the snapshot we hold is
+        // stale and must not be written back over the refreshed entries (the clobber that leaves
+        // memory permanently stale until a full clear).
+        long generation = Interlocked.Read(ref _cacheGeneration);
+
         (bool exists, ContentCacheNode? contentCacheNode) = await _hybridCache.TryGetValueAsync<ContentCacheNode?>(cacheKey, CancellationToken.None);
         if (exists is false)
         {
@@ -137,7 +157,8 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             // Only cache the result if the ancestor check didn't fail.
             // When content exists in DB but the ancestor check fails, this could be a transient
             // race condition during cache rebuild. Caching null would poison the distributed cache.
-            if (ancestorCheckFailed is false)
+            // Skip the write when the generation moved — a refresh has superseded this snapshot.
+            if (ancestorCheckFailed is false && IsCacheGenerationCurrent(generation))
             {
                 await _hybridCache.SetAsync(
                     cacheKey,
@@ -153,7 +174,10 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         }
 
         IPublishedContent? result = _publishedContentFactory.ToIPublishedContent(contentCacheNode, preview).CreateModel(_publishedModelFactory);
-        if (result is not null)
+
+        // Only populate the L0 cache when our snapshot is still current; otherwise a concurrent
+        // refresh has already written fresher content and we must not overwrite it with this one.
+        if (result is not null && IsCacheGenerationCurrent(generation))
         {
             _publishedContentCache[cacheKey] = result;
         }
@@ -185,6 +209,13 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
     private bool GetPreview() => _previewService.IsInPreview();
 
+    // Bumped after every in-memory cache invalidation/refresh so in-flight read-through snapshots
+    // (see GetNodeAsync) can detect they have been superseded and skip writing back stale content.
+    private void InvalidateMemoryCacheGeneration() => Interlocked.Increment(ref _cacheGeneration);
+
+    private bool IsCacheGenerationCurrent(long capturedGeneration)
+        => Interlocked.Read(ref _cacheGeneration) == capturedGeneration;
+
     public IEnumerable<IPublishedContent> GetByContentType(IPublishedContentType contentType)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
@@ -198,6 +229,10 @@ internal sealed class DocumentCacheService : IDocumentCacheService
 
     public async Task ClearMemoryCacheAsync(CancellationToken cancellationToken)
     {
+        // Bump first so any read-through that read the backing store before this clear is rejected
+        // when it tries to write back, even while the reseed below is still running.
+        InvalidateMemoryCacheGeneration();
+
         _publishedContentCache.Clear();
         await _hybridCache.RemoveByTagAsync(Constants.Cache.Tags.Content, cancellationToken);
 
@@ -235,6 +270,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
             await ClearPublishedCacheAsync(key);
         }
 
+        InvalidateMemoryCacheGeneration();
         scope.Complete();
     }
 
@@ -423,12 +459,17 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         ClearConvertedContentCache(contentTypeIdsAsArray);
     }
 
-    public void ClearConvertedContentCache() => _publishedContentCache.Clear();
+    public void ClearConvertedContentCache()
+    {
+        _publishedContentCache.Clear();
+        InvalidateMemoryCacheGeneration();
+    }
 
     public void ClearConvertedContentCache(IReadOnlyCollection<int> contentTypeIds)
     {
         var ids = contentTypeIds as int[] ?? contentTypeIds.ToArray();
         _publishedContentCache.RemoveAll(content => ids.Contains(content.Value.ContentType.Id));
+        InvalidateMemoryCacheGeneration();
     }
 
     private async Task ClearPublishedCacheAsync(Guid key)
@@ -436,6 +477,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService
         var cacheKey = GetCacheKey(key, false);
         await _hybridCache.RemoveAsync(cacheKey);
         _publishedContentCache.Remove(cacheKey, out _);
+        InvalidateMemoryCacheGeneration();
     }
 
     private static string ContentTypeIdTag(int contentTypeId)

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -34,6 +34,20 @@ internal sealed class MediaCacheService : IMediaCacheService
 
     private readonly ConcurrentDictionary<Guid, IPublishedContent> _publishedContentCache = [];
 
+    // Monotonic counter bumped whenever the in-memory cache (L0/L1) is invalidated or refreshed.
+    // GetNodeAsync captures it before reading the backing store and re-checks it before writing
+    // back, so a snapshot read before a concurrent refresh is never written over the refreshed
+    // entry — preventing the stale-set clobber that otherwise persists until a full clear.
+    //
+    // Deliberately a single global counter, not per-key: any invalidation invalidates every in-flight
+    // read-through. The only cost is an occasional skipped cache population when a read-through for one
+    // key overlaps an unrelated refresh — a re-miss on the next request, never stale data. A per-key
+    // scheme would avoid that but needs a global epoch for bulk clears plus an exact per-key bump on
+    // every mutated cache key, which is easy to get wrong and would silently reintroduce the clobber.
+    // Global is correctness-robust; only revisit if read-through churn under heavy concurrent
+    // refreshing ever shows up in profiling.
+    private long _cacheGeneration;
+
     private HashSet<Guid>? _seedKeys;
     private HashSet<Guid> SeedKeys
     {
@@ -122,13 +136,20 @@ internal sealed class MediaCacheService : IMediaCacheService
             return cached;
         }
 
+        // Capture the cache generation before reading the backing store. If a concurrent refresh or
+        // invalidation bumps the generation while we read and build below, the snapshot we hold is
+        // stale and must not be written back over the refreshed entries (the clobber that leaves
+        // memory permanently stale until a full clear).
+        long generation = Interlocked.Read(ref _cacheGeneration);
+
         string cacheKey = GetCacheKey(key);
         (bool exists, ContentCacheNode? contentCacheNode) = await _hybridCache.TryGetValueAsync<ContentCacheNode?>(cacheKey, CancellationToken.None);
         if (exists is false)
         {
             contentCacheNode = await GetContentCacheNodeFromRepo();
             // We don't want to cache removed items, this may cause issues if the L2 serializer changes.
-            if (contentCacheNode is not null)
+            // Skip the write when the generation moved — a refresh has superseded this snapshot.
+            if (contentCacheNode is not null && IsCacheGenerationCurrent(generation))
             {
                 await _hybridCache.SetAsync(
                     cacheKey,
@@ -144,7 +165,10 @@ internal sealed class MediaCacheService : IMediaCacheService
         }
 
         IPublishedContent? result = _publishedContentFactory.ToIPublishedMedia(contentCacheNode).CreateModel(_publishedModelFactory);
-        if (result is not null)
+
+        // Only populate the L0 cache when our snapshot is still current; otherwise a concurrent
+        // refresh has already written fresher content and we must not overwrite it with this one.
+        if (result is not null && IsCacheGenerationCurrent(generation))
         {
             _publishedContentCache[key] = result;
         }
@@ -159,6 +183,13 @@ internal sealed class MediaCacheService : IMediaCacheService
             return mediaCacheNode;
         }
     }
+
+    // Bumped after every in-memory cache invalidation/refresh so in-flight read-through snapshots
+    // (see GetNodeAsync) can detect they have been superseded and skip writing back stale content.
+    private void InvalidateMemoryCacheGeneration() => Interlocked.Increment(ref _cacheGeneration);
+
+    private bool IsCacheGenerationCurrent(long capturedGeneration)
+        => Interlocked.Read(ref _cacheGeneration) == capturedGeneration;
 
     public async Task<bool> HasContentByIdAsync(int id)
     {
@@ -186,6 +217,7 @@ internal sealed class MediaCacheService : IMediaCacheService
         var cacheNode = _cacheNodeFactory.ToContentCacheNode(media);
         await _databaseCacheRepository.RefreshMediaAsync(cacheNode);
         _publishedContentCache.Remove(media.Key, out _);
+        InvalidateMemoryCacheGeneration();
         scope.Complete();
     }
 
@@ -269,11 +301,16 @@ internal sealed class MediaCacheService : IMediaCacheService
             await RemoveFromMemoryCacheAsync(key);
         }
 
+        InvalidateMemoryCacheGeneration();
         scope.Complete();
     }
 
     public async Task ClearMemoryCacheAsync(CancellationToken cancellationToken)
     {
+        // Bump first so any read-through that read the backing store before this clear is rejected
+        // when it tries to write back, even while the reseed below is still running.
+        InvalidateMemoryCacheGeneration();
+
         _publishedContentCache.Clear();
         await _hybridCache.RemoveByTagAsync(Constants.Cache.Tags.Media, cancellationToken);
 
@@ -295,12 +332,17 @@ internal sealed class MediaCacheService : IMediaCacheService
         ClearConvertedContentCache(mediaTypeIdsAsArray);
     }
 
-    public void ClearConvertedContentCache() => _publishedContentCache.Clear();
+    public void ClearConvertedContentCache()
+    {
+        _publishedContentCache.Clear();
+        InvalidateMemoryCacheGeneration();
+    }
 
     public void ClearConvertedContentCache(IReadOnlyCollection<int> mediaTypeIds)
     {
         var ids = mediaTypeIds as int[] ?? mediaTypeIds.ToArray();
         _publishedContentCache.RemoveAll(content => ids.Contains(content.Value.ContentType.Id));
+        InvalidateMemoryCacheGeneration();
     }
 
     public void Rebuild(IReadOnlyCollection<int> contentTypeIds)
@@ -357,6 +399,7 @@ internal sealed class MediaCacheService : IMediaCacheService
     {
         await _hybridCache.RemoveAsync(GetCacheKey(key));
         _publishedContentCache.Remove(key, out _);
+        InvalidateMemoryCacheGeneration();
     }
 
     private static string MediaTypeIdTag(int mediaTypeId)

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -295,13 +295,15 @@ internal sealed class MediaCacheService : IMediaCacheService
         {
             await _hybridCache.SetAsync(GetCacheKey(publishedNode.Key), publishedNode, GetEntryOptions(publishedNode.Key));
             _publishedContentCache.Remove(key, out _);
+            InvalidateMemoryCacheGeneration();
         }
         else
         {
+            // RemoveFromMemoryCacheAsync → ClearPublishedCacheAsync bumps the generation itself,
+            // so this path is already covered.
             await RemoveFromMemoryCacheAsync(key);
         }
 
-        InvalidateMemoryCacheGeneration();
         scope.Complete();
     }
 

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -136,20 +136,26 @@ internal sealed class MediaCacheService : IMediaCacheService
             return cached;
         }
 
-        // Capture the cache generation before reading the backing store. If a concurrent refresh or
-        // invalidation bumps the generation while we read and build below, the snapshot we hold is
-        // stale and must not be written back over the refreshed entries (the clobber that leaves
-        // memory permanently stale until a full clear).
-        long generation = Interlocked.Read(ref _cacheGeneration);
-
         string cacheKey = GetCacheKey(key);
         (bool exists, ContentCacheNode? contentCacheNode) = await _hybridCache.TryGetValueAsync<ContentCacheNode?>(cacheKey, CancellationToken.None);
+
+        // A value found in the backing store is already current, so it can always populate the caches
+        // below; only a value built from the read-through DB fetch needs the generation guard.
+        bool snapshotIsCurrent = true;
         if (exists is false)
         {
+            // Capture the cache generation before reading the backing store. If a concurrent refresh or
+            // invalidation bumps the generation while we read and build below, the snapshot we hold is
+            // stale and must not be written back over the refreshed entries (the clobber that leaves
+            // memory permanently stale until a full clear).
+            long generation = Interlocked.Read(ref _cacheGeneration);
+
             contentCacheNode = await GetContentCacheNodeFromRepo();
+            snapshotIsCurrent = IsCacheGenerationCurrent(generation);
+
             // We don't want to cache removed items, this may cause issues if the L2 serializer changes.
             // Skip the write when the generation moved — a refresh has superseded this snapshot.
-            if (contentCacheNode is not null && IsCacheGenerationCurrent(generation))
+            if (contentCacheNode is not null && snapshotIsCurrent)
             {
                 await _hybridCache.SetAsync(
                     cacheKey,
@@ -168,7 +174,7 @@ internal sealed class MediaCacheService : IMediaCacheService
 
         // Only populate the L0 cache when our snapshot is still current; otherwise a concurrent
         // refresh has already written fresher content and we must not overwrite it with this one.
-        if (result is not null && IsCacheGenerationCurrent(generation))
+        if (result is not null && snapshotIsCurrent)
         {
             _publishedContentCache[key] = result;
         }

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheStaleSetRaceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheStaleSetRaceTests.cs
@@ -1,17 +1,15 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.PublishedCache;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.Navigation;
 using Umbraco.Cms.Infrastructure.HybridCache;
 using Umbraco.Cms.Infrastructure.HybridCache.Factories;
 using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
-using Umbraco.Cms.Infrastructure.HybridCache.SeedKeyProviders.Document;
 using Umbraco.Cms.Infrastructure.HybridCache.Services;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -162,6 +160,11 @@ internal sealed class DocumentHybridCacheStaleSetRaceTests : UmbracoIntegrationT
             $"{Textpage.Key}",
             _ => new ValueTask<ContentCacheNode?>((ContentCacheNode?)null));
 
-        Assert.AreEqual(newNode, cachedNode);
+        Assert.IsNotNull(cachedNode);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(newNode.Key, cachedNode!.Key, "Cached node should be the refreshed node.");
+            Assert.AreEqual(NewName, cachedNode!.Data?.Name, "Cached node should hold the refreshed name.");
+        });
     }
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheStaleSetRaceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheStaleSetRaceTests.cs
@@ -1,0 +1,167 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
+using Umbraco.Cms.Infrastructure.HybridCache;
+using Umbraco.Cms.Infrastructure.HybridCache.Factories;
+using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
+using Umbraco.Cms.Infrastructure.HybridCache.SeedKeyProviders.Document;
+using Umbraco.Cms.Infrastructure.HybridCache.Services;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
+
+/// <summary>
+/// Reproduces the read-through "stale-set clobber" race in <see cref="DocumentCacheService"/>:
+/// a request reads a pre-publish snapshot from the backing store and then writes it back into the
+/// in-memory cache *after* a concurrent publish has already refreshed it, leaving memory permanently
+/// stale (or, for Block List, empty) until a full cache clear. The generation guard must reject the
+/// stale write-back so the refreshed value survives.
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class DocumentHybridCacheStaleSetRaceTests : UmbracoIntegrationTestWithContent
+{
+    private const string OldName = "Old Page";
+    private const string OldTitle = "Old Title";
+    private const string NewName = "New Page";
+    private const string NewTitle = "New Title";
+
+    private Mock<IDatabaseCacheRepository> _databaseCacheRepository;
+    private DocumentCacheService _documentCacheService;
+    private Microsoft.Extensions.Caching.Hybrid.HybridCache _hybridCache;
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder) => builder.AddUmbracoHybridCache();
+
+    private ContentCacheNode BuildPublishedNode(string name, string title)
+    {
+        var data = new ContentData(
+            name,
+            null,
+            1,
+            Textpage.UpdateDate,
+            Textpage.CreatorId,
+            -1,
+            true,
+            new Dictionary<string, PropertyData[]>
+            {
+                ["title"] = [new PropertyData { Culture = string.Empty, Segment = string.Empty, Value = title }],
+            },
+            null);
+
+        return new ContentCacheNode
+        {
+            ContentTypeId = Textpage.ContentTypeId,
+            CreatorId = Textpage.CreatorId,
+            CreateDate = Textpage.CreateDate,
+            Id = Textpage.Id,
+            Key = Textpage.Key,
+            SortOrder = 0,
+            Data = data,
+            IsDraft = false,
+        };
+    }
+
+    [SetUp]
+    public void SetUpService()
+    {
+        _databaseCacheRepository = new Mock<IDatabaseCacheRepository>();
+        _hybridCache = GetRequiredService<Microsoft.Extensions.Caching.Hybrid.HybridCache>();
+
+        var publishStatus = new Mock<IPublishStatusQueryService>();
+        publishStatus.Setup(x => x.IsDocumentPublishedInAnyCulture(It.IsAny<Guid>())).Returns(true);
+        publishStatus.Setup(x => x.HasPublishedAncestorPath(It.IsAny<Guid>())).Returns(true);
+
+        _documentCacheService = new DocumentCacheService(
+            _databaseCacheRepository.Object,
+            GetRequiredService<IIdKeyMap>(),
+            GetRequiredService<ICoreScopeProvider>(),
+            _hybridCache,
+            GetRequiredService<IPublishedContentFactory>(),
+            GetRequiredService<ICacheNodeFactory>(),
+            Array.Empty<IDocumentSeedKeyProvider>(),
+            new OptionsWrapper<CacheSettings>(new CacheSettings()),
+            GetRequiredService<IPublishedModelFactory>(),
+            GetRequiredService<IPreviewService>(),
+            publishStatus.Object,
+            new NullLogger<DocumentCacheService>());
+    }
+
+    [Test]
+    public async Task Read_Through_Does_Not_Clobber_A_Concurrent_Refresh()
+    {
+        ContentCacheNode oldNode = BuildPublishedNode(OldName, OldTitle);
+        ContentCacheNode newNode = BuildPublishedNode(NewName, NewTitle);
+
+        // The first read-through reads the pre-publish (old) snapshot, then parks before writing back —
+        // simulating the request suspending on an await while a publish completes.
+        var readReachedDatabase = new TaskCompletionSource();
+        var releaseRead = new TaskCompletionSource();
+        _databaseCacheRepository
+            .Setup(x => x.GetContentSourceAsync(Textpage.Key, false))
+            .Returns(async () =>
+            {
+                readReachedDatabase.TrySetResult();
+                await releaseRead.Task;
+                return oldNode;
+            });
+
+        // The publish-time memory refresh reads the new snapshot from the database cache.
+        _databaseCacheRepository
+            .Setup(x => x.GetContentSourceForPublishStatesAsync(Textpage.Key))
+            .ReturnsAsync((null, newNode));
+
+        // Ensure the published entry is absent so the request below is a genuine read-through.
+        await _hybridCache.RemoveAsync($"{Textpage.Key}");
+
+        // 1. Start the request; it reads the old snapshot and parks before the cache write-back.
+        Task<IPublishedContent?> staleRead = Task.Run(() => _documentCacheService.GetByKeyAsync(Textpage.Key, false));
+        await readReachedDatabase.Task;
+
+        // 2. A publish refreshes the in-memory cache with the new snapshot (and bumps the generation).
+        await _documentCacheService.RefreshMemoryCacheAsync(Textpage.Key);
+
+        // 3. Let the parked request resume and perform its (now stale) write-back.
+        releaseRead.TrySetResult();
+        await staleRead;
+
+        // Verify the stale read (returns the old content)
+        var staleResult = staleRead.Result;
+        Assert.IsNotNull(staleResult);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(OldName, staleResult!.Name, "Name should be served from the stale snapshot.");
+            Assert.AreEqual(
+                OldTitle,
+                staleResult.GetProperty("title")?.GetSourceValue(),
+                "Property value should be served from the stale snapshot.");
+        });
+
+        // 4. A fresh lookup must observe the refreshed content, not the clobbered stale snapshot.
+        IPublishedContent? result = await _documentCacheService.GetByKeyAsync(Textpage.Key, false);
+
+        Assert.IsNotNull(result);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(NewName, result!.Name, "Name was served from the clobbered stale snapshot.");
+            Assert.AreEqual(
+                NewTitle,
+                result.GetProperty("title")?.GetSourceValue(),
+                "Property value was served from the clobbered stale snapshot.");
+        });
+
+        // Verify that the published node has been added to the hybrid cache using the assumed key.
+        var cachedNode = await _hybridCache.GetOrCreateAsync(
+            $"{Textpage.Key}",
+            _ => new ValueTask<ContentCacheNode?>((ContentCacheNode?)null));
+
+        Assert.AreEqual(newNode, cachedNode);
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

This PR plugs a race condition in `DocumentCacheService` and `MediaCacheService`.

As-is, a front-end request that misses the in-memory cache during a concurrent publish request will read `cmsContentNu` directly, and gets the previously published value. It then risks writing the (now-stale) value back to `cmsContentNu`, effectively replacing the entry that the publish request _just_ updated. The last-in entry stays stale in memory until a full cache clear (e.g. by reloading the memory cache).

> [!NOTE]
> This PR likely will need amending for V18 to handle Elements. A task has been added to the backlog

### The fix

A single counter per service (`_cacheGeneration`, bumped via `Interlocked`):

- Captured in `GetNodeAsync` **before** the read from 'cmsContentNu`.
- Re-checked **before** writing back to both the L1 `HybridCache` (`SetAsync`) and the L0 `_publishedContentCache` dictionary — if the generation moved while the request was reading/building, the write-back is skipped and the (now-stale)  result is returned to that one caller only.
- Bumped at the end of every in-memory mutation: `RefreshMemoryCacheAsync`, `ClearMemoryCacheAsync`, `ClearConvertedContentCache`, `ClearPublishedCacheAsync`, and (media) `RefreshMediaAsync`.

A stale write-back is now rejected instead of poisoning the cache; the next request re-reads the refreshed entry.

### Testing

It's really hard to provoke the issue manually, as it's a concurrency issue, and also because both seeding and the backoffice UI repopulates caches very quickly.

I have been able to reproduce it locally by:

1. Removing all cache seeding, disable redirect URL tracking and unroutable content warnings:

```
"Umbraco": {
    "CMS": {
        "Cache": {
            "DocumentBreadthFirstSeedCount": 0,
            "MediaBreadthFirstSeedCount": 0
        },
        "WebRouting": {
            "DisableRedirectUrlTracking": true
        },
        "Content": {
            "ShowUnroutableContentWarnings": false,
        }
    }
}
```

2. Inserting a delay [here](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs#L136).
3. Requesting a page from the frontend.
4. While the delay hangs, update and publish the same page (with changes) using the Management API
5. Upon completion of the delay, refresh the page; it will continue to yield stale values.

I have added an integration test that basically performs these steps.


