### PR TITLE
SignalR: Automatically reconnect backoffice preview and server-event connections (closes #21648)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -2645,6 +2645,8 @@ export default {
 		connectionFailed:
 			'Kunne ikke etablere forbindelse til serveren, forhåndsvisning af liveopdateringer vil ikke fungere.',
 		connectionLost: 'Forbindelse til serveren mistet, forhåndsvisning af liveopdateringer vil ikke fungere.',
+		connectionReconnecting: 'Forbindelse til serveren mistet, forsøger at genoprette forbindelsen…',
+		connectionRestored: 'Forbindelse til serveren genoprettet, forhåndsvisning af liveopdateringer fungerer igen.',
 	},
 	permissions: {
 		FolderCreation: 'Mappeoprettelse',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -2850,6 +2850,8 @@ export default {
 		viewPublishedContentDeclineButton: 'Stay in preview mode',
 		connectionFailed: 'Could not establish a connection to the server, preview live updates will not work.',
 		connectionLost: 'Connection to the server lost, preview live updates will not work.',
+		connectionReconnecting: 'Connection to the server lost, trying to reconnect…',
+		connectionRestored: 'Connection to the server restored, preview live updates are working again.',
 	},
 	permissions: {
 		FolderCreation: 'Folder creation',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/index.ts
@@ -1,6 +1,7 @@
 export * from './server-connection.js';
 export * from './server.context-token.js';
 export * from './server.context.js';
+export * from './signalr-reconnect-policy.js';
 export * from './conditions/index.js';
 
 export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.test.ts
@@ -1,0 +1,35 @@
+import { UmbSignalRReconnectPolicy } from './signalr-reconnect-policy.js';
+import type { RetryContext } from '@umbraco-cms/backoffice/external/signalr';
+import { expect } from '@open-wc/testing';
+
+const retryContext = (previousRetryCount: number): RetryContext => ({
+	previousRetryCount,
+	elapsedMilliseconds: 0,
+	retryReason: new Error('test'),
+});
+
+describe('UmbSignalRReconnectPolicy', () => {
+	let policy: UmbSignalRReconnectPolicy;
+
+	beforeEach(() => {
+		policy = new UmbSignalRReconnectPolicy();
+	});
+
+	it('reconnects immediately on the first attempt', () => {
+		expect(policy.nextRetryDelayInMilliseconds(retryContext(0))).to.equal(0);
+	});
+
+	it('backs off over the next attempts', () => {
+		expect(policy.nextRetryDelayInMilliseconds(retryContext(1))).to.equal(2000);
+		expect(policy.nextRetryDelayInMilliseconds(retryContext(2))).to.equal(5000);
+		expect(policy.nextRetryDelayInMilliseconds(retryContext(3))).to.equal(10000);
+	});
+
+	it('caps the delay and keeps retrying indefinitely', () => {
+		// Beyond the explicit schedule the delay is capped, and a number (never null) is always
+		// returned so the connection never gives up.
+		for (const count of [4, 10, 100, 10000]) {
+			expect(policy.nextRetryDelayInMilliseconds(retryContext(count))).to.equal(30000);
+		}
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.ts
@@ -6,8 +6,7 @@ const MAX_RECONNECT_DELAY_MS = 30000;
 /**
  * A SignalR retry policy that reconnects indefinitely with a capped backoff.
  * The default `withAutomaticReconnect()` policy gives up after ~60 seconds, which leaves an idle
- * backoffice (preview, server events) permanently disconnected after a transient drop — common when
- * SignalR has fallen back to Server-Sent Events and a keepalive is delayed by response buffering.
+ * backoffice (preview, server events) permanently disconnected.
  */
 export class UmbSignalRReconnectPolicy implements IRetryPolicy {
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.ts
@@ -1,0 +1,16 @@
+import type { IRetryPolicy, RetryContext } from '@umbraco-cms/backoffice/external/signalr';
+
+const RECONNECT_DELAYS_MS = [0, 2000, 5000, 10000];
+const MAX_RECONNECT_DELAY_MS = 30000;
+
+/**
+ * A SignalR retry policy that reconnects indefinitely with a capped backoff.
+ * The default `withAutomaticReconnect()` policy gives up after ~60 seconds, which leaves an idle
+ * backoffice (preview, server events) permanently disconnected after a transient drop — common when
+ * SignalR has fallen back to Server-Sent Events and a keepalive is delayed by response buffering.
+ */
+export class UmbSignalRReconnectPolicy implements IRetryPolicy {
+	nextRetryDelayInMilliseconds(retryContext: RetryContext): number {
+		return RECONNECT_DELAYS_MS[retryContext.previousRetryCount] ?? MAX_RECONNECT_DELAY_MS;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/server/signalr-reconnect-policy.ts
@@ -10,6 +10,12 @@ const MAX_RECONNECT_DELAY_MS = 30000;
  * SignalR has fallen back to Server-Sent Events and a keepalive is delayed by response buffering.
  */
 export class UmbSignalRReconnectPolicy implements IRetryPolicy {
+	/**
+	 * Gets the delay before the next reconnect attempt, following the capped backoff schedule.
+	 * @param {RetryContext} retryContext - The context for the current retry, including the previous retry count.
+	 * @returns {number} The delay in milliseconds before the next reconnect attempt (never null, so retries continue indefinitely).
+	 * @memberof UmbSignalRReconnectPolicy
+	 */
 	nextRetryDelayInMilliseconds(retryContext: RetryContext): number {
 		return RECONNECT_DELAYS_MS[retryContext.previousRetryCount] ?? MAX_RECONNECT_DELAY_MS;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/server-event/global-context/server-event.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/server-event/global-context/server-event.context.ts
@@ -9,7 +9,7 @@ import {
 	type HubConnection,
 	type IHttpConnectionOptions,
 } from '@umbraco-cms/backoffice/external/signalr';
-import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
+import { UMB_SERVER_CONTEXT, UmbSignalRReconnectPolicy } from '@umbraco-cms/backoffice/server';
 import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
 import { filter, Subject } from '@umbraco-cms/backoffice/external/rxjs';
 import { UmbBooleanState } from '@umbraco-cms/backoffice/observable-api';
@@ -82,6 +82,13 @@ export class UmbManagementApiServerEventContext extends UmbContextBase {
 	}
 
 	#initHubConnection(token: string) {
+		// Make sure that no previous connection exists, otherwise an orphaned connection would keep
+		// reconnecting in the background and emitting events.
+		if (this.#connection) {
+			this.#connection.stop();
+			this.#connection = undefined;
+		}
+
 		const serverURL = this.#serverContext?.getServerUrl();
 
 		if (!serverURL) {
@@ -102,7 +109,10 @@ export class UmbManagementApiServerEventContext extends UmbContextBase {
 			hubOptions.transport = HttpTransportType.WebSockets;
 		}
 
-		this.#connection = new HubConnectionBuilder().withUrl(serverEventHubUrl, hubOptions).build();
+		this.#connection = new HubConnectionBuilder()
+			.withUrl(serverEventHubUrl, hubOptions)
+			.withAutomaticReconnect(new UmbSignalRReconnectPolicy())
+			.build();
 
 		this.#connection.on('notify', (payload) => {
 			const event: UmbManagementApiServerEventModel = {
@@ -112,6 +122,11 @@ export class UmbManagementApiServerEventContext extends UmbContextBase {
 
 			this.#events.next(event);
 		});
+
+		// While reconnecting we treat the connection as down so cache invalidation consumers refetch
+		// rather than trust a cache that may have missed events during the gap.
+		this.#connection.onreconnecting(() => this.#isConnected.setValue(false));
+		this.#connection.onreconnected(() => this.#isConnected.setValue(true));
 
 		this.#connection
 			.start()

--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/server-event/global-context/server-event.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/server-event/global-context/server-event.context.ts
@@ -81,11 +81,12 @@ export class UmbManagementApiServerEventContext extends UmbContextBase {
 		});
 	}
 
-	#initHubConnection(token: string) {
+	async #initHubConnection(token: string) {
 		// Make sure that no previous connection exists, otherwise an orphaned connection would keep
-		// reconnecting in the background and emitting events.
+		// reconnecting in the background and emitting events. Await the stop so it can't race with
+		// building the new connection.
 		if (this.#connection) {
-			this.#connection.stop();
+			await this.#connection.stop();
 			this.#connection = undefined;
 		}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/preview/context/preview.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/preview/context/preview.context.ts
@@ -5,7 +5,7 @@ import { UmbBooleanState, UmbStringState } from '@umbraco-cms/backoffice/observa
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
-import { UMB_SERVER_CONTEXT } from '@umbraco-cms/backoffice/server';
+import { UMB_SERVER_CONTEXT, UmbSignalRReconnectPolicy } from '@umbraco-cms/backoffice/server';
 import type { HubConnection, IHttpConnectionOptions } from '@umbraco-cms/backoffice/external/signalr';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
@@ -27,6 +27,7 @@ interface UmbPreviewUrlArgs {
 
 export class UmbPreviewContext extends UmbContextBase {
 	#connection?: HubConnection;
+	#intentionalClose = false;
 	#currentArgs: UmbPreviewIframeArgs = {};
 	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
 	#resizeController?: AbortController;
@@ -96,6 +97,7 @@ export class UmbPreviewContext extends UmbContextBase {
 
 		// Clean up SignalR connection
 		if (this.#connection) {
+			this.#intentionalClose = true;
 			this.#connection.stop();
 			this.#connection = undefined;
 		}
@@ -106,8 +108,10 @@ export class UmbPreviewContext extends UmbContextBase {
 
 		// Make sure that no previous connection exists.
 		if (this.#connection) {
+			this.#intentionalClose = true;
 			await this.#connection.stop();
 			this.#connection = undefined;
+			this.#intentionalClose = false;
 		}
 
 		const skipNegotiation = serverContext?.getServerConnection()?.getSignalRSkipNegotiation() ?? false;
@@ -119,7 +123,10 @@ export class UmbPreviewContext extends UmbContextBase {
 			hubOptions.transport = HttpTransportType.WebSockets;
 		}
 
-		this.#connection = new HubConnectionBuilder().withUrl(previewHubUrl, hubOptions).build();
+		this.#connection = new HubConnectionBuilder()
+			.withUrl(previewHubUrl, hubOptions)
+			.withAutomaticReconnect(new UmbSignalRReconnectPolicy())
+			.build();
 
 		this.#connection.on('refreshed', (payload) => {
 			if (payload === this.#unique.getValue()) {
@@ -127,7 +134,33 @@ export class UmbPreviewContext extends UmbContextBase {
 			}
 		});
 
+		this.#connection.onreconnecting(() => {
+			this.#notificationContext?.peek('warning', {
+				data: {
+					headline: this.#localize.term('general_preview'),
+					message: this.#localize.term('preview_connectionReconnecting'),
+				},
+			});
+		});
+
+		this.#connection.onreconnected(() => {
+			// A 'refreshed' event may have been missed while disconnected, so reload the iframe to catch up.
+			this.#setPreviewUrl({ rnd: Math.random() });
+			this.#notificationContext?.peek('positive', {
+				data: {
+					headline: this.#localize.term('general_preview'),
+					message: this.#localize.term('preview_connectionRestored'),
+				},
+			});
+		});
+
 		this.#connection.onclose(() => {
+			// With automatic reconnect, onclose only fires for an intentional stop (teardown/exit) or a
+			// close that cannot be recovered. Don't warn when we closed the connection ourselves.
+			if (this.#intentionalClose) {
+				return;
+			}
+
 			this.#notificationContext?.peek('warning', {
 				data: {
 					headline: this.#localize.term('general_preview'),
@@ -211,6 +244,7 @@ export class UmbPreviewContext extends UmbContextBase {
 
 		// Stop SignalR connection without waiting - window will close anyway
 		if (this.#connection) {
+			this.#intentionalClose = true;
 			this.#connection.stop();
 			this.#connection = undefined;
 		}

--- a/src/Umbraco.Web.UI.Client/src/packages/preview/context/preview.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/preview/context/preview.context.ts
@@ -27,7 +27,6 @@ interface UmbPreviewUrlArgs {
 
 export class UmbPreviewContext extends UmbContextBase {
 	#connection?: HubConnection;
-	#intentionalClose = false;
 	#currentArgs: UmbPreviewIframeArgs = {};
 	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
 	#resizeController?: AbortController;
@@ -97,7 +96,6 @@ export class UmbPreviewContext extends UmbContextBase {
 
 		// Clean up SignalR connection
 		if (this.#connection) {
-			this.#intentionalClose = true;
 			this.#connection.stop();
 			this.#connection = undefined;
 		}
@@ -106,12 +104,13 @@ export class UmbPreviewContext extends UmbContextBase {
 	async #initHubConnection(serverUrl: string, serverContext?: typeof UMB_SERVER_CONTEXT.TYPE) {
 		const previewHubUrl = `${serverUrl}/umbraco/PreviewHub`;
 
-		// Make sure that no previous connection exists.
+		// Make sure that no previous connection exists, otherwise an orphaned connection would keep
+		// reconnecting in the background. Clear the reference before stopping so the old connection's
+		// onclose handler sees it is no longer the active one and stays silent.
 		if (this.#connection) {
-			this.#intentionalClose = true;
-			await this.#connection.stop();
+			const previousConnection = this.#connection;
 			this.#connection = undefined;
-			this.#intentionalClose = false;
+			await previousConnection.stop();
 		}
 
 		const skipNegotiation = serverContext?.getServerConnection()?.getSignalRSkipNegotiation() ?? false;
@@ -127,6 +126,10 @@ export class UmbPreviewContext extends UmbContextBase {
 			.withUrl(previewHubUrl, hubOptions)
 			.withAutomaticReconnect(new UmbSignalRReconnectPolicy())
 			.build();
+
+		// Capture this specific connection so its onclose handler can tell whether it is still the active
+		// one; if it has since been replaced or cleared, the close was deliberate and should stay silent.
+		const connection = this.#connection;
 
 		this.#connection.on('refreshed', (payload) => {
 			if (payload === this.#unique.getValue()) {
@@ -155,9 +158,10 @@ export class UmbPreviewContext extends UmbContextBase {
 		});
 
 		this.#connection.onclose(() => {
-			// With automatic reconnect, onclose only fires for an intentional stop (teardown/exit) or a
-			// close that cannot be recovered. Don't warn when we closed the connection ourselves.
-			if (this.#intentionalClose) {
+			// With automatic reconnect, onclose only fires when we stop the connection ourselves (teardown,
+			// exit, or replacing it) or for a close that cannot be recovered. Only warn when this is still
+			// the active connection — i.e. an unexpected drop we did not initiate.
+			if (this.#connection !== connection) {
 				return;
 			}
 
@@ -244,7 +248,6 @@ export class UmbPreviewContext extends UmbContextBase {
 
 		// Stop SignalR connection without waiting - window will close anyway
 		if (this.#connection) {
-			this.#intentionalClose = true;
 			this.#connection.stop();
 			this.#connection = undefined;
 		}


### PR DESCRIPTION
## Description

The backoffice opens two SignalR connections — the **preview hub** (`/umbraco/PreviewHub`, live-reloads the preview iframe when content changes) and the **server-event hub** (`/umbraco/serverEventHub`, drives live cache invalidation across the backoffice). Both hubs are idle most of the time, so the only thing keeping the connection alive between events is SignalR's keepalive ping.

When WebSockets aren't available and the connection negotiates down to Server-Sent Events (common on IIS without the WebSocket Protocol feature, or behind proxies that buffer responses), the keepalive ping can be delayed past the client's 30s `serverTimeout`. The client then closes the connection — and because there was **no automatic reconnect**, it stayed closed until the window was reloaded. For preview this surfaced as the persistent "Could not establish a connection to the server" warning reported in #21648.

The [docs PR follow-up](https://github.com/umbraco/UmbracoDocs/pull/8135) to this was to advise ensuring that WebSockets are available, which is still good advice.  But there is not a hard requirement (SignalR negotiates and falls back), so rather than mandating WebSockets we can make the client resilient to a flaky/slow non-WebSocket transport.

To do that I've added a reconnection policy and configured both clients to use it automatically.

Fixes #21648.

## Testing

### Automated

Unit tests are added for the policy in `signalr-reconnect-policy.test.ts`.

### Manual

This change targets **transient** connection drops. It's not straightforward to test on a single developer machine with the server local, but the cleanest way I found to test it locally was to forcefully kill the server process (which closes the connection immediately and refuses connections while down) and then restart it promptly.

Just shutting down and restarting the site didn't work - you would get a message that the connection was "lost" but then it was quickly "found" again as the server takes a while to gracefully shut down.  And using "Go offline" in the browser tools doesn't help as that triggers a different backoffice message.

I think this approach is reasonable though as the target here is transient disconnections.

1. Run the site and log in to the backoffice.
2. Open a document and click **Save and preview** to open the preview window. Confirm preview live updates work (edit + save in another tab → the preview iframe reloads).
3. Forcefully kill the server, then restart it:
   - `taskkill /F /IM dotnet.exe` (or the specific PID — use `iisexpress.exe` if hosting via IIS Express). A forceful kill closes the socket immediately, so the drop is detected within a second or two.
   - The preview window shows **"Connection to the server lost, trying to reconnect…"**.
   - Start the server again **within ~10 seconds** (to stay in the fast-retry window). The client reconnects automatically → the preview iframe reloads and a **"connection restored"** notice appears. Before this change the warning was permanent until the window was reloaded.
   - The retry backoff is 0s → 2s → 5s → 10s, then every 30s, so if the server is down longer, allow up to ~30s after it is back for the reconnect.

## Notes

- A separate PR (#23171) addresses an unrelated dev-only shutdown race in `InMemoryModelFactory` (an `ObjectDisposedException` from in-flight requests during app shutdown), surfaced while testing this change.
