### PR TITLE
ModelsBuilder: Avoid `ObjectDisposedException` in `InMemoryModelFactory` during shutdown

### DIFF
--- a/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/InMemoryModelFactory.cs
+++ b/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/InMemoryModelFactory.cs
@@ -368,10 +368,10 @@ namespace Umbraco.Cms.DevelopmentMode.Backoffice.InMemoryAuto
 
                 return _infos;
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException ex)
             {
-                // The factory was disposed concurrently (application shutdown) while acquiring the lock.
-                // Treat it the same as the early-out above and return the current models.
+                // Expected when the factory is disposed during shutdown mid-request; log so an unexpected disposal stays traceable.
+                _logger.LogDebug(ex, "EnsureModels interrupted by object disposal (assumed application shutdown); returning current models.");
                 return _infos;
             }
             finally

--- a/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/InMemoryModelFactory.cs
+++ b/src/Umbraco.Cms.DevelopmentMode.Backoffice/InMemoryAuto/InMemoryModelFactory.cs
@@ -59,7 +59,7 @@ namespace Umbraco.Cms.DevelopmentMode.Backoffice.InMemoryAuto
         private int? _skipver;
         private RoslynCompiler? _roslynCompiler;
         private ModelsBuilderSettings _config;
-        private bool _disposedValue;
+        private volatile bool _disposedValue;
 
         public InMemoryModelFactory(
             Lazy<UmbracoServices> umbracoServices,
@@ -280,25 +280,34 @@ namespace Umbraco.Cms.DevelopmentMode.Backoffice.InMemoryAuto
                 }
             }
 
-            // don't use an upgradeable lock here because only 1 thread at a time could enter it
-            try
+            // The factory is disposed on application shutdown (via IRegisteredObject.Stop), but in-flight
+            // requests can still reach this point. Bail out with the current models rather than touching
+            // the disposed lock. The catch below covers the small window where disposal happens after this
+            // check but before (or while) the lock is acquired.
+            if (_disposedValue)
             {
-                _locker.EnterReadLock();
-                if (_hasModels)
-                {
-                    return _infos;
-                }
-            }
-            finally
-            {
-                if (_locker.IsReadLockHeld)
-                {
-                    _locker.ExitReadLock();
-                }
+                return _infos;
             }
 
             try
             {
+                // don't use an upgradeable lock here because only 1 thread at a time could enter it
+                try
+                {
+                    _locker.EnterReadLock();
+                    if (_hasModels)
+                    {
+                        return _infos;
+                    }
+                }
+                finally
+                {
+                    if (_locker.IsReadLockHeld)
+                    {
+                        _locker.ExitReadLock();
+                    }
+                }
+
                 _locker.EnterUpgradeableReadLock();
 
                 if (_hasModels)
@@ -357,6 +366,12 @@ namespace Umbraco.Cms.DevelopmentMode.Backoffice.InMemoryAuto
                     _hasModels = true;
                 }
 
+                return _infos;
+            }
+            catch (ObjectDisposedException)
+            {
+                // The factory was disposed concurrently (application shutdown) while acquiring the lock.
+                // Treat it the same as the early-out above and return the current models.
                 return _infos;
             }
             finally


### PR DESCRIPTION
## Description

Fixes a development-only race during application shutdown that surfaces as an `ObjectDisposedException`.

`InMemoryModelFactory` is an `IRegisteredObject`; on shutdown ASP.NET Core calls `Stop()` → `Dispose()`, which disposes the factory's `ReaderWriterLockSlim`. An HTTP request still in flight at that moment can reach `EnsureModels()` and call `EnterReadLock()` on the now-disposed lock, throwing:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Threading.ReaderWriterLockSlim'.
   at System.Threading.ReaderWriterLockSlim.EnterReadLock()
   at ...InMemoryAuto.InMemoryModelFactory.EnsureModels()
   at ...InMemoryAuto.InMemoryModelFactory.CreateModel(IPublishedElement element)
   at ...HybridCache.Services.DocumentCacheService.GetNodeAsync(...)
   at ...Core.Routing.PublishedRouter.RouteRequestAsync(...)
   ...
```

It comes from a request for a website/preview page being routed through `PublishedRouter` as the host tears down.  I could see this in testing #23170 when looking to verify that the SignalR connection recovered between application restarts.  

Only affects `InMemoryAuto` ModelsBuilder mode under `BackofficeDevelopment` runtime mode.

To fix we now bail out of `EnsureModels()` with the current models when the factory is already disposed (`_disposedValue`), so the common shutdown case never touches the lock.  There's also a `try/catch (ObjectDisposedException)` around the lock-acquiring section in a  to cover the small window where disposal happens after the check but while the lock is being acquired.

## Testing

### Manual

**Before the fix:**

1. Run a site configured for development models:
   - `Umbraco:CMS:Runtime:Mode` = `BackofficeDevelopment`
   - `Umbraco:CMS:ModelsBuilder:ModelsMode` = `InMemoryAuto`
2. Open the backoffice and start a preview of a document (so a website/preview page request is active, and an open preview connection keeps requesting).
3. Stop the running application (Ctrl+C / stop debugging) while that request is in flight.
4. Intermittently the developer exception page / console shows the `ObjectDisposedException` from `InMemoryModelFactory.EnsureModels()` shown above.

**After the fix:**

Repeat the steps above; the application shuts down cleanly and the `ObjectDisposedException` no longer occurs.
