### PR TITLE
Entity Data Picker: Implement interaction memory + sync picker memory across all picker inputs

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity/index.ts
@@ -3,5 +3,6 @@ export { UmbEntityContext } from './entity.context.js';
 export * from './constants.js';
 export * from './contexts/ancestors/index.js';
 export * from './contexts/parent/index.js';
+export * from './input/index.js';
 
 export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/entity-input-interaction-memory.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/entity-input-interaction-memory.manager.test.ts
@@ -1,0 +1,55 @@
+import { UmbEntityInputInteractionMemoryManager } from './entity-input-interaction-memory.manager.js';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { expect, oneEvent } from '@open-wc/testing';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbInteractionMemoriesChangeEvent, UmbInteractionMemoryManager } from '@umbraco-cms/backoffice/interaction-memory';
+
+@customElement('test-entity-input-interaction-memory-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbEntityInputInteractionMemoryManager', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let interactionMemory: UmbInteractionMemoryManager;
+	let manager: UmbEntityInputInteractionMemoryManager;
+
+	beforeEach(() => {
+		hostElement = new UmbTestControllerHostElement();
+		interactionMemory = new UmbInteractionMemoryManager(hostElement);
+		manager = new UmbEntityInputInteractionMemoryManager(hostElement, interactionMemory);
+	});
+
+	describe('setMemories()', () => {
+		it('seeds the interaction memory from the incoming snapshot', () => {
+			manager.setMemories([{ unique: 'a' }, { unique: 'b' }]);
+			expect(manager.getMemories().map((memory) => memory.unique)).to.eql(['a', 'b']);
+		});
+
+		it('removes memories that are no longer present when the snapshot shrinks', () => {
+			manager.setMemories([{ unique: 'a' }, { unique: 'b' }]);
+			manager.setMemories([{ unique: 'a' }]);
+			expect(manager.getMemories().map((memory) => memory.unique)).to.eql(['a']);
+		});
+
+		it('clears all memories when the snapshot is emptied', () => {
+			manager.setMemories([{ unique: 'a' }, { unique: 'b' }]);
+			manager.setMemories([]);
+			expect(manager.getMemories()).to.eql([]);
+		});
+
+		it('treats undefined as an empty snapshot', () => {
+			manager.setMemories([{ unique: 'a' }]);
+			manager.setMemories(undefined);
+			expect(manager.getMemories()).to.eql([]);
+		});
+	});
+
+	describe('change event', () => {
+		it('dispatches a change event from the host when the interaction memory changes externally', async () => {
+			const listener = oneEvent(hostElement, UmbInteractionMemoriesChangeEvent.TYPE);
+			interactionMemory.setMemory({ unique: 'expansion', value: { expansion: ['a'] } });
+			const event = await listener;
+			expect(event).to.exist;
+			expect(manager.getMemories().map((memory) => memory.unique)).to.eql(['expansion']);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/entity-input-interaction-memory.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/entity-input-interaction-memory.manager.ts
@@ -1,0 +1,77 @@
+import { jsonStringComparison } from '@umbraco-cms/backoffice/observable-api';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import {
+	UmbInteractionMemoriesChangeEvent,
+	type UmbInteractionMemoryManager,
+	type UmbInteractionMemoryModel,
+} from '@umbraco-cms/backoffice/interaction-memory';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+/**
+ * Bridges a picker input's interaction-memory manager to its host element's `interactionMemories`
+ * property and `interaction-memories-change` event, keeping the two in sync.
+ *
+ * Used by entity input elements (e.g. `umb-input-document`, `umb-input-media`, `umb-input-entity-data`)
+ * to avoid duplicating the snapshot-sync and change-event logic.
+ * @exports
+ * @class UmbEntityInputInteractionMemoryManager
+ * @augments {UmbControllerBase}
+ */
+export class UmbEntityInputInteractionMemoryManager extends UmbControllerBase {
+	#interactionMemory: UmbInteractionMemoryManager;
+	#snapshot: Array<UmbInteractionMemoryModel> = [];
+
+	/**
+	 * Creates an instance of UmbEntityInputInteractionMemoryManager.
+	 * @param {UmbControllerHost} host - The host element; the change event is dispatched from it.
+	 * @param {UmbInteractionMemoryManager} interactionMemory - The picker input context's interaction-memory manager to bridge.
+	 * @memberof UmbEntityInputInteractionMemoryManager
+	 */
+	constructor(host: UmbControllerHost, interactionMemory: UmbInteractionMemoryManager) {
+		super(host);
+		this.#interactionMemory = interactionMemory;
+
+		this.observe(
+			this.#interactionMemory.memories,
+			(memories) => {
+				// only dispatch the event if the interaction memories have actually changed
+				if (jsonStringComparison(memories, this.#snapshot)) return;
+				this.#snapshot = memories;
+				this.getHostElement().dispatchEvent(new UmbInteractionMemoriesChangeEvent());
+			},
+			'_observeMemories',
+		);
+	}
+
+	/**
+	 * Gets all interaction memories currently held by the picker input context.
+	 * @returns {Array<UmbInteractionMemoryModel>} The current interaction memories.
+	 * @memberof UmbEntityInputInteractionMemoryManager
+	 */
+	getMemories(): Array<UmbInteractionMemoryModel> {
+		return this.#interactionMemory.getAllMemories();
+	}
+
+	/**
+	 * Syncs the picker input context to the provided snapshot. The incoming array is authoritative:
+	 * memories no longer present are removed, the rest are added or updated. Short-circuits when the
+	 * snapshot already matches to avoid redundant writes and the re-entrant change events they trigger.
+	 * @param {Array<UmbInteractionMemoryModel> | undefined} value - The authoritative snapshot of interaction memories.
+	 * @memberof UmbEntityInputInteractionMemoryManager
+	 */
+	setMemories(value: Array<UmbInteractionMemoryModel> | undefined): void {
+		const next = value ?? [];
+		const current = this.#interactionMemory.getAllMemories();
+
+		this.#snapshot = next;
+
+		if (jsonStringComparison(next, current)) return;
+
+		const nextUniques = new Set(next.map((memory) => memory.unique));
+		current
+			.filter((memory) => !nextUniques.has(memory.unique))
+			.forEach((memory) => this.#interactionMemory.deleteMemory(memory.unique));
+
+		next.forEach((memory) => this.#interactionMemory.setMemory(memory));
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/entity-input-interaction-memory.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/entity-input-interaction-memory.manager.ts
@@ -10,9 +10,6 @@ import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 /**
  * Bridges a picker input's interaction-memory manager to its host element's `interactionMemories`
  * property and `interaction-memories-change` event, keeping the two in sync.
- *
- * Used by entity input elements (e.g. `umb-input-document`, `umb-input-media`, `umb-input-entity-data`)
- * to avoid duplicating the snapshot-sync and change-event logic.
  * @exports
  * @class UmbEntityInputInteractionMemoryManager
  * @augments {UmbControllerBase}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity/input/index.ts
@@ -1,0 +1,1 @@
+export { UmbEntityInputInteractionMemoryManager } from './entity-input-interaction-memory.manager.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/components/input-document/input-document.element.ts
@@ -1,11 +1,10 @@
 import type { UmbDocumentItemModel } from '../../item/types.js';
 import { UmbDocumentPickerInputContext } from './input-document.context.js';
 import { css, customElement, html, nothing, property, repeat, state, when } from '@umbraco-cms/backoffice/external/lit';
-import { jsonStringComparison } from '@umbraco-cms/backoffice/observable-api';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
-import { UmbInteractionMemoriesChangeEvent } from '@umbraco-cms/backoffice/interaction-memory';
+import { UmbEntityInputInteractionMemoryManager } from '@umbraco-cms/backoffice/entity';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '@umbraco-cms/backoffice/document-type';
@@ -132,14 +131,11 @@ export class UmbInputDocumentElement extends UmbFormControlMixin<string, typeof 
 
 	@property({ type: Array, attribute: false })
 	public get interactionMemories(): Array<UmbInteractionMemoryModel> | undefined {
-		return this.#pickerInputContext.interactionMemory.getAllMemories();
+		return this.#interactionMemoryManager.getMemories();
 	}
 	public set interactionMemories(value: Array<UmbInteractionMemoryModel> | undefined) {
-		this.#interactionMemories = value;
-		value?.forEach((memory) => this.#pickerInputContext.interactionMemory.setMemory(memory));
+		this.#interactionMemoryManager.setMemories(value);
 	}
-
-	#interactionMemories?: Array<UmbInteractionMemoryModel> = [];
 
 	@state()
 	private _items?: Array<UmbDocumentItemModel>;
@@ -148,6 +144,10 @@ export class UmbInputDocumentElement extends UmbFormControlMixin<string, typeof 
 	private _statuses?: Array<UmbRepositoryItemsStatus>;
 
 	#pickerInputContext = new UmbDocumentPickerInputContext(this);
+	#interactionMemoryManager = new UmbEntityInputInteractionMemoryManager(
+		this,
+		this.#pickerInputContext.interactionMemory,
+	);
 
 	constructor() {
 		super();
@@ -183,20 +183,6 @@ export class UmbInputDocumentElement extends UmbFormControlMixin<string, typeof 
 		);
 
 		this.observe(this.#pickerInputContext.statuses, (statuses) => (this._statuses = statuses), '_observerStatuses');
-
-		this.observe(
-			this.#pickerInputContext.interactionMemory.memories,
-			(memories) => {
-				// only dispatch the event if the interaction memories have actually changed
-				const isIdentical = jsonStringComparison(memories, this.#interactionMemories);
-
-				if (!isIdentical) {
-					this.#interactionMemories = memories;
-					this.dispatchEvent(new UmbInteractionMemoriesChangeEvent());
-				}
-			},
-			'_observeMemories',
-		);
 	}
 
 	#openPicker() {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
@@ -10,11 +10,10 @@ import {
 	repeat,
 	state,
 } from '@umbraco-cms/backoffice/external/lit';
-import { jsonStringComparison } from '@umbraco-cms/backoffice/observable-api';
 import { splitStringToArray } from '@umbraco-cms/backoffice/utils';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
-import { UmbInteractionMemoriesChangeEvent } from '@umbraco-cms/backoffice/interaction-memory';
+import { UmbEntityInputInteractionMemoryManager } from '@umbraco-cms/backoffice/entity';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalRouteRegistrationController } from '@umbraco-cms/backoffice/router';
 import { UmbSorterController, UmbSorterResolvePlacementAsGrid } from '@umbraco-cms/backoffice/sorter';
@@ -154,14 +153,11 @@ export class UmbInputMediaElement extends UmbFormControlMixin<string | undefined
 
 	@property({ type: Array, attribute: false })
 	public get interactionMemories(): Array<UmbInteractionMemoryModel> | undefined {
-		return this.#pickerInputContext.interactionMemory.getAllMemories();
+		return this.#interactionMemoryManager.getMemories();
 	}
 	public set interactionMemories(value: Array<UmbInteractionMemoryModel> | undefined) {
-		this.#interactionMemories = value;
-		value?.forEach((memory) => this.#pickerInputContext.interactionMemory.setMemory(memory));
+		this.#interactionMemoryManager.setMemories(value);
 	}
-
-	#interactionMemories?: Array<UmbInteractionMemoryModel> = [];
 
 	@state()
 	private _editMediaPath = '';
@@ -170,6 +166,10 @@ export class UmbInputMediaElement extends UmbFormControlMixin<string | undefined
 	private _cards: Array<UmbMediaCardItemModel> = [];
 
 	#pickerInputContext = new UmbMediaPickerInputContext(this);
+	#interactionMemoryManager = new UmbEntityInputInteractionMemoryManager(
+		this,
+		this.#pickerInputContext.interactionMemory,
+	);
 
 	constructor() {
 		super();
@@ -191,20 +191,6 @@ export class UmbInputMediaElement extends UmbFormControlMixin<string | undefined
 
 			this._cards = selectedItems ?? [];
 		});
-
-		this.observe(
-			this.#pickerInputContext.interactionMemory.memories,
-			(memories) => {
-				// only dispatch the event if the interaction memories have actually changed
-				const isIdentical = jsonStringComparison(memories, this.#interactionMemories);
-
-				if (!isIdentical) {
-					this.#interactionMemories = memories;
-					this.dispatchEvent(new UmbInteractionMemoriesChangeEvent());
-				}
-			},
-			'_observeMemories',
-		);
 
 		this.addValidator(
 			'rangeUnderflow',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.test.ts
@@ -13,6 +13,25 @@ describe('UmbInputMediaElement', () => {
 		expect(element).to.be.instanceOf(UmbInputMediaElement);
 	});
 
+	describe('interactionMemories', () => {
+		it('seeds the picker context from the incoming snapshot', () => {
+			element.interactionMemories = [{ unique: 'a' }, { unique: 'b' }];
+			expect(element.interactionMemories?.map((memory) => memory.unique)).to.eql(['a', 'b']);
+		});
+
+		it('removes memories that are no longer present when the snapshot shrinks', () => {
+			element.interactionMemories = [{ unique: 'a' }, { unique: 'b' }];
+			element.interactionMemories = [{ unique: 'a' }];
+			expect(element.interactionMemories?.map((memory) => memory.unique)).to.eql(['a']);
+		});
+
+		it('clears all memories when the snapshot is emptied', () => {
+			element.interactionMemories = [{ unique: 'a' }, { unique: 'b' }];
+			element.interactionMemories = [];
+			expect(element.interactionMemories).to.eql([]);
+		});
+	});
+
 	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {
 		it('passes the a11y audit', async () => {
 			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.element.ts
@@ -17,11 +17,8 @@ import { UmbRepositoryItemsManager } from '@umbraco-cms/backoffice/repository';
 import { UMB_MEDIA_TYPE_ENTITY_TYPE } from '@umbraco-cms/backoffice/media-type';
 
 import '@umbraco-cms/backoffice/imaging';
-import {
-	UmbInteractionMemoriesChangeEvent,
-	type UmbInteractionMemoryModel,
-} from '@umbraco-cms/backoffice/interaction-memory';
-import { jsonStringComparison } from '@umbraco-cms/backoffice/observable-api';
+import { UmbEntityInputInteractionMemoryManager } from '@umbraco-cms/backoffice/entity';
+import type { UmbInteractionMemoryModel } from '@umbraco-cms/backoffice/interaction-memory';
 
 type UmbRichMediaCardModel = {
 	unique: string;
@@ -159,14 +156,11 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 
 	@property({ type: Array, attribute: false })
 	public get interactionMemories(): Array<UmbInteractionMemoryModel> | undefined {
-		return this.#pickerInputContext.interactionMemory.getAllMemories();
+		return this.#interactionMemoryManager.getMemories();
 	}
 	public set interactionMemories(value: Array<UmbInteractionMemoryModel> | undefined) {
-		this.#interactionMemories = value;
-		value?.forEach((memory) => this.#pickerInputContext.interactionMemory.setMemory(memory));
+		this.#interactionMemoryManager.setMemories(value);
 	}
-
-	#interactionMemories?: Array<UmbInteractionMemoryModel> = [];
 
 	@state()
 	private _cards: Array<UmbRichMediaCardModel> = [];
@@ -177,6 +171,10 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 	readonly #itemManager = new UmbRepositoryItemsManager<UmbMediaItemModel>(this, UMB_MEDIA_ITEM_REPOSITORY_ALIAS);
 
 	readonly #pickerInputContext = new UmbMediaPickerInputContext(this);
+	readonly #interactionMemoryManager = new UmbEntityInputInteractionMemoryManager(
+		this,
+		this.#pickerInputContext.interactionMemory,
+	);
 
 	constructor() {
 		super();
@@ -234,20 +232,6 @@ export class UmbInputRichMediaElement extends UmbFormControlMixin<
 		this.observe(this.#pickerInputContext.selection, (selection) => {
 			this.#addItems(selection);
 		});
-
-		this.observe(
-			this.#pickerInputContext.interactionMemory.memories,
-			(memories) => {
-				// only dispatch the event if the interaction memories have actually changed
-				const isIdentical = jsonStringComparison(memories, this.#interactionMemories);
-
-				if (!isIdentical) {
-					this.#interactionMemories = memories;
-					this.dispatchEvent(new UmbInteractionMemoriesChangeEvent());
-				}
-			},
-			'_observeMemories',
-		);
 
 		this.addValidator(
 			'valueMissing',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-rich-media/input-rich-media.test.ts
@@ -1,15 +1,16 @@
-import { UmbInputDocumentElement } from './input-document.element.js';
+import { UmbInputRichMediaElement } from './input-rich-media.element.js';
 import { expect, fixture, html } from '@open-wc/testing';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
-describe('UmbInputDocumentElement', () => {
-	let element: UmbInputDocumentElement;
+
+describe('UmbInputRichMediaElement', () => {
+	let element: UmbInputRichMediaElement;
 
 	beforeEach(async () => {
-		element = await fixture(html` <umb-input-document></umb-input-document> `);
+		element = await fixture(html` <umb-input-rich-media></umb-input-rich-media> `);
 	});
 
 	it('is defined with its own instance', () => {
-		expect(element).to.be.instanceOf(UmbInputDocumentElement);
+		expect(element).to.be.instanceOf(UmbInputRichMediaElement);
 	});
 
 	describe('interactionMemories', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.context.ts
@@ -77,6 +77,10 @@ export class UmbEntityDataPickerInputContext extends UmbPickerInputContext<
 	 * @memberof UmbEntityDataPickerInputContext
 	 */
 	setDataSourceApi(api: UmbPickerDataSource | undefined) {
+		// Skip if unchanged: re-setting the same API rebuilds the modal token/route, which would
+		// close and reopen an already-open picker modal on every re-render. [MR]
+		if (api === this.#dataSourceApi) return;
+
 		if (api) {
 			this.#dataSourceApi = api;
 			api.setConfig?.(this.#dataSourceConfig);

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.test.ts
@@ -1,15 +1,16 @@
-import { UmbInputDocumentElement } from './input-document.element.js';
+import { UmbInputEntityDataElement } from './input-entity-data.element.js';
 import { expect, fixture, html } from '@open-wc/testing';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
-describe('UmbInputDocumentElement', () => {
-	let element: UmbInputDocumentElement;
+
+describe('UmbInputEntityDataElement', () => {
+	let element: UmbInputEntityDataElement;
 
 	beforeEach(async () => {
-		element = await fixture(html` <umb-input-document></umb-input-document> `);
+		element = await fixture(html` <umb-input-entity-data></umb-input-entity-data> `);
 	});
 
 	it('is defined with its own instance', () => {
-		expect(element).to.be.instanceOf(UmbInputDocumentElement);
+		expect(element).to.be.instanceOf(UmbInputEntityDataElement);
 	});
 
 	describe('interactionMemories', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.ts
@@ -11,9 +11,8 @@ import {
 	ifDefined,
 } from '@umbraco-cms/backoffice/external/lit';
 import { splitStringToArray, type UmbConfigCollectionModel } from '@umbraco-cms/backoffice/utils';
-import { jsonStringComparison } from '@umbraco-cms/backoffice/observable-api';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
-import { UmbInteractionMemoriesChangeEvent } from '@umbraco-cms/backoffice/interaction-memory';
+import { UmbEntityInputInteractionMemoryManager } from '@umbraco-cms/backoffice/entity';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
 import type { UmbInteractionMemoryModel } from '@umbraco-cms/backoffice/interaction-memory';
@@ -150,14 +149,11 @@ export class UmbInputEntityDataElement extends UmbFormControlMixin<string | unde
 
 	@property({ type: Array, attribute: false })
 	public get interactionMemories(): Array<UmbInteractionMemoryModel> | undefined {
-		return this.#pickerInputContext.interactionMemory.getAllMemories();
+		return this.#interactionMemoryManager.getMemories();
 	}
 	public set interactionMemories(value: Array<UmbInteractionMemoryModel> | undefined) {
-		this.#interactionMemories = value;
-		value?.forEach((memory) => this.#pickerInputContext.interactionMemory.setMemory(memory));
+		this.#interactionMemoryManager.setMemories(value);
 	}
-
-	#interactionMemories?: Array<UmbInteractionMemoryModel> = [];
 
 	@state()
 	private _items: Array<UmbItemModel> = [];
@@ -169,6 +165,10 @@ export class UmbInputEntityDataElement extends UmbFormControlMixin<string | unde
 	private _modalRoute?: string;
 
 	#pickerInputContext = new UmbEntityDataPickerInputContext(this);
+	#interactionMemoryManager = new UmbEntityInputInteractionMemoryManager(
+		this,
+		this.#pickerInputContext.interactionMemory,
+	);
 
 	constructor() {
 		super();
@@ -202,20 +202,6 @@ export class UmbInputEntityDataElement extends UmbFormControlMixin<string | unde
 		this.observe(this.#pickerInputContext.modalRoute, (modalRoute) => {
 			this._modalRoute = modalRoute;
 		});
-
-		this.observe(
-			this.#pickerInputContext.interactionMemory.memories,
-			(memories) => {
-				// only dispatch the event if the interaction memories have actually changed
-				const isIdentical = jsonStringComparison(memories, this.#interactionMemories);
-
-				if (!isIdentical) {
-					this.#interactionMemories = memories;
-					this.dispatchEvent(new UmbInteractionMemoriesChangeEvent());
-				}
-			},
-			'_observeMemories',
-		);
 	}
 
 	protected override getFormElement() {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/input/input-entity-data.element.ts
@@ -11,9 +11,12 @@ import {
 	ifDefined,
 } from '@umbraco-cms/backoffice/external/lit';
 import { splitStringToArray, type UmbConfigCollectionModel } from '@umbraco-cms/backoffice/utils';
+import { jsonStringComparison } from '@umbraco-cms/backoffice/observable-api';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbInteractionMemoriesChangeEvent } from '@umbraco-cms/backoffice/interaction-memory';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
+import type { UmbInteractionMemoryModel } from '@umbraco-cms/backoffice/interaction-memory';
 import type { UmbRepositoryItemsStatus } from '@umbraco-cms/backoffice/repository';
 import type { UmbItemModel } from '@umbraco-cms/backoffice/entity-item';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
@@ -145,6 +148,17 @@ export class UmbInputEntityDataElement extends UmbFormControlMixin<string | unde
 	}
 	#readonly = false;
 
+	@property({ type: Array, attribute: false })
+	public get interactionMemories(): Array<UmbInteractionMemoryModel> | undefined {
+		return this.#pickerInputContext.interactionMemory.getAllMemories();
+	}
+	public set interactionMemories(value: Array<UmbInteractionMemoryModel> | undefined) {
+		this.#interactionMemories = value;
+		value?.forEach((memory) => this.#pickerInputContext.interactionMemory.setMemory(memory));
+	}
+
+	#interactionMemories?: Array<UmbInteractionMemoryModel> = [];
+
 	@state()
 	private _items: Array<UmbItemModel> = [];
 
@@ -188,6 +202,20 @@ export class UmbInputEntityDataElement extends UmbFormControlMixin<string | unde
 		this.observe(this.#pickerInputContext.modalRoute, (modalRoute) => {
 			this._modalRoute = modalRoute;
 		});
+
+		this.observe(
+			this.#pickerInputContext.interactionMemory.memories,
+			(memories) => {
+				// only dispatch the event if the interaction memories have actually changed
+				const isIdentical = jsonStringComparison(memories, this.#interactionMemories);
+
+				if (!isIdentical) {
+					this.#interactionMemories = memories;
+					this.dispatchEvent(new UmbInteractionMemoriesChangeEvent());
+				}
+			},
+			'_observeMemories',
+		);
 	}
 
 	protected override getFormElement() {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/entity-data-picker-property-editor-ui.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/entity-data-picker/property-editor/entity-data-picker-property-editor-ui.element.ts
@@ -4,10 +4,12 @@ import type { UmbEntityDataPickerPickerViewsConfigurationPropertyValue } from '.
 import { customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
+import { UmbPropertyEditorUiInteractionMemoryManager } from '@umbraco-cms/backoffice/property-editor';
 import type {
 	UmbPropertyEditorConfigCollection,
 	UmbPropertyEditorUiElement,
 } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbInteractionMemoryModel } from '@umbraco-cms/backoffice/interaction-memory';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import type { UmbConfigCollectionModel } from '@umbraco-cms/backoffice/utils';
 import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
@@ -71,8 +73,24 @@ export class UmbEntityDataPickerPropertyEditorUIElement
 	@state()
 	private _pickerViews?: UmbEntityDataPickerPickerViewsConfigurationPropertyValue;
 
+	@state()
+	private _interactionMemories: Array<UmbInteractionMemoryModel> = [];
+
+	#interactionMemoryManager = new UmbPropertyEditorUiInteractionMemoryManager(this, {
+		memoryUniquePrefix: 'UmbEntityDataPicker',
+	});
+
+	constructor() {
+		super();
+
+		this.observe(this.#interactionMemoryManager.memoriesForPropertyEditor, (interactionMemories) => {
+			this._interactionMemories = interactionMemories ?? [];
+		});
+	}
+
 	public set config(config: UmbPropertyEditorConfigCollection | undefined) {
 		this.#propertyEditorConfigCollection = config;
+		this.#interactionMemoryManager.setPropertyEditorConfig(config);
 
 		const minMax = config?.getValueByAlias<UmbNumberRangeValueType>('validationLimit');
 		this._min = minMax?.min ?? 0;
@@ -167,6 +185,17 @@ export class UmbEntityDataPickerPropertyEditorUIElement
 		}
 	}
 
+	async #onInputInteractionMemoriesChange(event: UmbChangeEvent) {
+		const target = event.target as UmbInputEntityDataElement;
+		const interactionMemories = target.interactionMemories;
+
+		if (interactionMemories && interactionMemories.length > 0) {
+			await this.#interactionMemoryManager.saveMemoriesForPropertyEditor(interactionMemories);
+		} else {
+			await this.#interactionMemoryManager.deleteMemoriesForPropertyEditor();
+		}
+	}
+
 	override render() {
 		return html`<umb-input-entity-data
 			.selection=${this.value?.ids ?? []}
@@ -178,7 +207,9 @@ export class UmbEntityDataPickerPropertyEditorUIElement
 			.max=${this._max}
 			.max-message=${this._maxMessage}
 			?readonly=${this.readonly}
-			@change=${this.#onChange}></umb-input-entity-data>`;
+			@change=${this.#onChange}
+			.interactionMemories=${this._interactionMemories}
+			@interaction-memories-change=${this.#onInputInteractionMemoriesChange}></umb-input-entity-data>`;
 	}
 }
 


### PR DESCRIPTION
**What & why**

The Entity Data Picker property editor didn't persist its picker interaction memory (e.g. tree expansion state), so reopening the picker always started fresh. This PR adds that, fixes two bugs found while building it, and extracts the now-shared logic into a reusable core primitive so the Document, Media and Rich-Media pickers behave identically.

**The PR includes 3 fixes:**
1. Implement interaction memory for the Entity Data Picker
2. Fix: picker modal closed and reopened on every tree expansion
3. Fix: stale interaction memory when the snapshot shrinks (reviewer finding)

**Refactoring:**
The snapshot-sync + change-event logic was duplicated ~20 lines across four inputs. Extracted into a new core primitive at core/entity/input/ (exported via @umbraco-cms/backoffice/entity):

**Follow-up task:**
* When this has been merged and merged to v18, we need to do a similar PR for the Element Picker.

https://github.com/user-attachments/assets/f09de71e-d9ec-4bf9-a3bd-96120c8bd366

**Manually Testing:** 
* Set up an Entity Data Picker by running the `picker-data-source` example
* Ensure that the tree expansion state is remembered for the Data Type when navigating between documents.

