### PR TITLE
Code Quality: Fixing some warnings relating to XML documentation and whitespace

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Dictionary/Tree/DictionaryTreeControllerBase.cs
@@ -46,8 +46,8 @@ public class DictionaryTreeControllerBase : NamedEntityTreeControllerBase<NamedE
     /// <param name="flagProviders">A collection of providers for entity flags.</param>
     /// <param name="dictionaryItemService">Service for managing dictionary items.</param>
     public DictionaryTreeControllerBase(
-        IEntityService entityService, 
-        FlagProviderCollection flagProviders, 
+        IEntityService entityService,
+        FlagProviderCollection flagProviders,
         IDictionaryItemService dictionaryItemService)
         : base(entityService, flagProviders) =>
         DictionaryItemService = dictionaryItemService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/DomainsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/DomainsController.cs
@@ -25,12 +25,12 @@ public class DomainsController : DocumentControllerBase
     private readonly IDomainService _domainService;
     private readonly IUmbracoMapper _umbracoMapper;
 
-    [ActivatorUtilitiesConstructor]
     /// <summary>
     /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Controllers.Document.DomainsController"/> class.
     /// </summary>
     /// <param name="domainService">Service used to manage domain-related operations.</param>
     /// <param name="umbracoMapper">The mapper used to map Umbraco objects to API models.</param>
+    [ActivatorUtilitiesConstructor]
     public DomainsController(IAuthorizationService authorizationService, IDomainService domainService, IUmbracoMapper umbracoMapper)
     {
         _authorizationService = authorizationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateDomainsController.cs
@@ -29,13 +29,13 @@ public class UpdateDomainsController : DocumentControllerBase
     private readonly IUmbracoMapper _umbracoMapper;
     private readonly IDomainPresentationFactory _domainPresentationFactory;
 
-    [ActivatorUtilitiesConstructor]
     /// <summary>
     /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Controllers.Document.UpdateDomainsController"/> class.
     /// </summary>
     /// <param name="domainService">Service used to manage domain entities within the Umbraco CMS.</param>
     /// <param name="umbracoMapper">The mapper responsible for converting between Umbraco domain models and API models.</param>
     /// <param name="domainPresentationFactory">Factory for creating presentation models for domains.</param>
+    [ActivatorUtilitiesConstructor]
     public UpdateDomainsController(IAuthorizationService authorizationService, IDomainService domainService, IUmbracoMapper umbracoMapper, IDomainPresentationFactory domainPresentationFactory)
     {
         _authorizationService = authorizationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateNotificationsController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/UpdateNotificationsController.cs
@@ -26,13 +26,13 @@ public class UpdateNotificationsController : DocumentControllerBase
     private readonly INotificationService _notificationService;
     private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
 
-    [ActivatorUtilitiesConstructor]
     /// <summary>
     /// Initializes a new instance of the <see cref="UpdateNotificationsController"/> class, which manages update notifications for documents.
     /// </summary>
     /// <param name="contentEditingService">Service used for editing content.</param>
     /// <param name="notificationService">Service responsible for handling notifications.</param>
     /// <param name="backOfficeSecurityAccessor">Provides access to back office security features.</param>
+    [ActivatorUtilitiesConstructor]
     public UpdateNotificationsController(IAuthorizationService authorizationService, IContentEditingService contentEditingService, INotificationService notificationService, IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
     {
         _authorizationService = authorizationService;

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/EmptyMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/EmptyMediaRecycleBinController.cs
@@ -50,7 +50,6 @@ public class EmptyMediaRecycleBinController : MediaRecycleBinControllerBase
     /// </summary>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>An <see cref="IActionResult"/> indicating the result of the operation.</returns>
-    
     [HttpDelete]
     [MapToApiVersion("1.0")]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DomainAssignmentModel.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DomainAssignmentModel.cs
@@ -6,7 +6,6 @@ namespace Umbraco.Cms.Api.Management.ViewModels.Document;
 public sealed class DomainAssignmentModel
 {
     /// <summary>Gets or sets the domain name assigned to the document.</summary>
-    
     public required string DomainName { get; set; }
 
     /// <summary>

--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -306,5 +306,6 @@ public class SecuritySettings
     ///         TODO (V18): Remove the standalone <see cref="MemberPasswordConfigurationSettings"/>
     ///         registration and consolidate all consumers to use this property.
     ///     </para>
+    /// </remarks>
     public MemberPasswordConfigurationSettings MemberPassword { get; set; } = new();
 }

--- a/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
+++ b/src/Umbraco.Core/Persistence/Constants-DatabaseSchema.cs
@@ -160,8 +160,7 @@ public static partial class Constants
             ///     The document URL alias.
             /// </summary>
             public const string DocumentUrlAlias = TableNamePrefix + "DocumentUrlAlias";
-          
-          
+
             /// <summary>
             ///     The media version table name.
             /// </summary>

--- a/src/Umbraco.Infrastructure/IPublishedContentQueryAccessor.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQueryAccessor.cs
@@ -1,10 +1,10 @@
-/// <summary>
-/// Provides access to the current <see cref="Umbraco.Cms.Core.PublishedCache.IPublishedContentQuery" /> instance for the active request context.
-/// </summary>
 using System.Diagnostics.CodeAnalysis;
 
 namespace Umbraco.Cms.Core;
 
+/// <summary>
+/// Provides access to the current <see cref="Umbraco.Cms.Core.PublishedCache.IPublishedContentQuery" /> instance for the active request context.
+/// </summary>
 /// <remarks>
 ///     Not intended for use in background threads where you should make use of
 ///     <see cref="Umbraco.Cms.Core.Web.IUmbracoContextFactory.EnsureUmbracoContext" />

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
@@ -173,7 +173,7 @@ public class MigrationPlan
     /// </summary>
     /// <typeparam name="TMigration">The type of migration to apply for this transition.</typeparam>
     /// <param name="targetState">The unique identifier of the target state.</param>
-    /// <returns>The updated <see cref="MigrationPlan"/> instance.</returns
+    /// <returns>The updated <see cref="MigrationPlan"/> instance.</returns>
     public MigrationPlan To<TMigration>(Guid targetState)
         where TMigration : AsyncMigrationBase
         => To(targetState, typeof(TMigration));

--- a/src/Umbraco.Infrastructure/Persistence/Factories/RelationTypeFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/RelationTypeFactory.cs
@@ -37,7 +37,7 @@ internal static class RelationTypeFactory
     /// Creates a <see cref="RelationTypeDto"/> instance from the specified <see cref="IRelationType"/> entity.
     /// </summary>
     /// <param name="entity">The <see cref="IRelationType"/> entity to convert.</param>
-    /// <returns>A <see cref="RelationTypeDto"/> that represents the provided relation type entity.</returns
+    /// <returns>A <see cref="RelationTypeDto"/> that represents the provided relation type entity.</returns>
     public static RelationTypeDto BuildDto(IRelationType entity)
     {
         var isDependency = false;

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -1530,7 +1530,7 @@ namespace Umbraco.Extensions
         /// Appends an UPDATE statement to the specified SQL query.
         /// </summary>
         /// <param name="sql">The SQL query to which the UPDATE statement will be appended.</param>
-        /// <returns>The SQL query with the appended UPDATE statement.</returns
+        /// <returns>The SQL query with the appended UPDATE statement.</returns>
         public static Sql<ISqlContext> Update<TDto>(this Sql<ISqlContext> sql, Func<SqlUpd<TDto>, SqlUpd<TDto>> updates)
         {
             Type type = typeof(TDto);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
@@ -450,7 +450,7 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     /// </summary>
     /// <param name="objectType">The unique identifier of the object type to retrieve entities for.</param>
     /// <param name="ids">An optional array of integer IDs to filter the entities. If not provided, all entities of the specified type are returned.</param>
-    /// <returns>An enumerable collection of entities matching the specified criteria.</returns
+    /// <returns>An enumerable collection of entities matching the specified criteria.</returns>
     public IEnumerable<IEntitySlim> GetAll(Guid objectType, params Guid[] keys) =>
         keys.Length > 0
             ? PerformGetAll(objectType, sql => sql.WhereIn<NodeDto>(x => x.UniqueId, keys.Distinct()))

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/RedirectUrlRepository.cs
@@ -196,7 +196,7 @@ internal sealed class RedirectUrlRepository : EntityRepositoryBase<Guid, IRedire
     /// <param name="pageIndex">The zero-based index of the page to retrieve.</param>
     /// <param name="pageSize">The number of items per page.</param>
     /// <param name="total">Outputs the total number of redirect URLs available.</param>
-    /// <returns>An enumerable collection of redirect URLs for the specified page.</returns
+    /// <returns>An enumerable collection of redirect URLs for the specified page.</returns>
     public IEnumerable<IRedirectUrl> GetAllUrls(int rootContentId, long pageIndex, int pageSize, out long total)
     {
         Sql<ISqlContext> sql = GetBaseQuery(false)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/WebhookRepository.cs
@@ -183,7 +183,7 @@ public class WebhookRepository : IWebhookRepository
     /// Asynchronously updates the specified webhook and its related references in the database.
     /// </summary>
     /// <param name="webhook">The webhook entity to update.</param>
-    /// <returns>A task that represents the asynchronous update operation.</returns
+    /// <returns>A task that represents the asynchronous update operation.</returns>
     public async Task UpdateAsync(IWebhook webhook)
     {
         webhook.UpdatingEntity();

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -301,7 +301,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
     /// Returns the specified name quoted with double quotes for use in SQL statements.
     /// </summary>
     /// <param name="name">The name to quote. Can be <c>null</c>.</param>
-    /// <returns>The quoted name as a string, or <c>"null"</c> if <paramref name="name"/> is <c>null</c>.</returns
+    /// <returns>The quoted name as a string, or <c>"null"</c> if <paramref name="name"/> is <c>null</c>.</returns>
     public virtual string GetQuotedName(string? name) => $"\"{name}\"";
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/EntityDataPickerValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/EntityDataPickerValueConverter.cs
@@ -42,7 +42,7 @@ public sealed class EntityDataPickerValueConverter : PropertyValueConverterBase
     /// Gets the cache level for the property, which is always <see cref="PropertyCacheLevel.Element"/> for this value converter.
     /// </summary>
     /// <param name="propertyType">The published property type.</param>
-    /// <returns>The property cache level, always <see cref="PropertyCacheLevel.Element"/>.</returns
+    /// <returns>The property cache level, always <see cref="PropertyCacheLevel.Element"/>.</returns>
     public override PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
         => PropertyCacheLevel.Element;
 

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -274,7 +274,7 @@ namespace Umbraco.Cms.Infrastructure.Scoping
         /// <summary>
         /// Gets the <see cref="IScopeContext"/> associated with this scope, which is used for attaching and detaching resources or state during the scope's lifetime.
         /// </summary>
-        /// <remarks>the context (for attaching & detaching only)</remarks>
+        /// <remarks>the context (for attaching &amp; detaching only)</remarks>
         public IScopeContext? Context { get; }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
+++ b/src/Umbraco.Infrastructure/Services/CacheInstructionService.cs
@@ -169,7 +169,6 @@ namespace Umbraco.Cms
                 }
             }
 
-            [Obsolete("Please use ProcessAllInstructions instead. Scheduled for removal in Umbraco 19.")]
             /// <summary>
             /// Processes cache instructions from the database using the provided cache refreshers.
             /// </summary>
@@ -178,6 +177,7 @@ namespace Umbraco.Cms
             /// <param name="localIdentity">A string identifying the local instance or caller.</param>
             /// <param name="lastId">The last processed instruction ID; this value is updated to reflect the most recent processed instruction.</param>
             /// <returns>A <see cref="ProcessInstructionsResult"/> representing the result of the processing operation.</returns>
+            [Obsolete("Please use ProcessAllInstructions instead. Scheduled for removal in Umbraco 19.")]
             public ProcessInstructionsResult ProcessInstructions(
                 CacheRefresherCollection cacheRefreshers,
                 CancellationToken cancellationToken,

--- a/tests/Umbraco.Tests.Benchmarks/CollectionBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/CollectionBenchmarks.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Tests.Benchmarks
         public int[] NativeArrayToArray() => Array.ConvertAll(_shortArray, value => _shortArray.Length ^ value);
 
         /// <summary>
-        /// Use LINQ to convert an array, with type checks, extra allocations & extra branches that the branch predictor has to keep track of
+        /// Use LINQ to convert an array, with type checks, extra allocations &amp; extra branches that the branch predictor has to keep track of
         /// </summary>
         /// <returns>Something to not optimize it away.</returns>
         [Benchmark]


### PR DESCRIPTION
### Description
Fixed some warnings
All instances of 
- CS1570 badly formed XML documentation
- SA1028 trailing whitespaces
- CS1587 XML documentation on invalid element


### Question
Would you guys be happy with people going through your build warnings and fixing them, and ignoring the ones which seems irrelevant? Right now there are around 4700 on a full build, which results in any actually interesting warnings getting buried in the rest ¯\\_(ツ)_/¯
