### PR TITLE
Routing: guard form reads against malformed request bodies

### DIFF
--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessor.cs
@@ -85,15 +85,7 @@ public class AspNetCoreRequestAccessor : IRequestAccessor, IDisposable
     }
 
     private string? GetFormValue(string name)
-    {
-        HttpRequest? request = _httpContextAccessor.HttpContext?.Request;
-        if (request?.HasFormContentType is not true)
-        {
-            return null;
-        }
-
-        return request.Form[name];
-    }
+        => _httpContextAccessor.HttpContext?.Request.GetFormValueOrNull(name);
 
     public void Dispose() => _onChangeDisposable?.Dispose();
 }

--- a/src/Umbraco.Web.Common/Extensions/HttpContextExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpContextExtensions.cs
@@ -89,13 +89,7 @@ public static class HttpContextExtensions
     public static string? GetRequestValue(this HttpContext context, string key)
     {
         HttpRequest request = context.Request;
-        if (!request.HasFormContentType)
-        {
-            return request.Query[key];
-        }
-
-        string? value = request.Form[key];
-        return value ?? request.Query[key];
+        return request.GetFormValueOrNull(key) ?? request.Query[key];
     }
 
     public static void SetPrincipalForRequest(this HttpContext context, ClaimsPrincipal? principal)

--- a/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
@@ -143,7 +143,7 @@ public static class HttpRequestExtensions
     /// <returns>The extracted `ufprt` token.</returns>
     public static string? GetUfprt(this HttpRequest request)
     {
-        if (request.HasFormContentType && request.Form.TryGetValue("ufprt", out StringValues formVal) &&
+        if (request.GetFormOrNull() is { } form && form.TryGetValue("ufprt", out StringValues formVal) &&
             formVal != StringValues.Empty)
         {
             return formVal.ToString();
@@ -155,6 +155,40 @@ public static class HttpRequestExtensions
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///     Gets the value of the specified form field, or <c>null</c> when the request has no form content
+    ///     or the form body cannot be read.
+    /// </summary>
+    internal static string? GetFormValueOrNull(this HttpRequest request, string name)
+        => request.GetFormOrNull() is { } form ? (string?)form[name] : null;
+
+    /// <summary>
+    ///     Returns the parsed form for the request, or <c>null</c> when the request has no form content type
+    ///     or the body cannot be parsed.
+    /// </summary>
+    /// <remarks>
+    ///     The synchronous <see cref="HttpRequest.Form" /> getter parses the body on first access and throws when it
+    ///     is malformed (e.g. a truncated multipart body) or exceeds the configured form limits. Routing-pipeline
+    ///     callers only probe for specific keys, so a parse failure must fall through to normal routing rather than
+    ///     surface as an unhandled exception (HTTP 500).
+    /// </remarks>
+    internal static IFormCollection? GetFormOrNull(this HttpRequest request)
+    {
+        if (request.HasFormContentType is not true)
+        {
+            return null;
+        }
+
+        try
+        {
+            return request.Form;
+        }
+        catch (Exception exception) when (exception is IOException or InvalidDataException)
+        {
+            return null;
+        }
     }
 
     private static bool IsSet(this IPAddress address)

--- a/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/HttpRequestExtensions.cs
@@ -170,9 +170,10 @@ public static class HttpRequestExtensions
     /// </summary>
     /// <remarks>
     ///     The synchronous <see cref="HttpRequest.Form" /> getter parses the body on first access and throws when it
-    ///     is malformed (e.g. a truncated multipart body) or exceeds the configured form limits. Routing-pipeline
-    ///     callers only probe for specific keys, so a parse failure must fall through to normal routing rather than
-    ///     surface as an unhandled exception (HTTP 500).
+    ///     is malformed (e.g. a truncated multipart body) or exceeds the configured form limits. Returning
+    ///     <c>null</c> in that case lets a caller that only probes the form for specific keys treat an unparseable
+    ///     body as "no form present" and continue, rather than let the parse failure surface as an unhandled
+    ///     exception (HTTP 500).
     /// </remarks>
     internal static IFormCollection? GetFormOrNull(this HttpRequest request)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Routing/MalformedFormRoutingTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Routing/MalformedFormRoutingTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Tests.Integration.TestServerTest;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.Website.Routing;
+
+[TestFixture]
+internal sealed class MalformedFormRoutingTests : UmbracoTestServerTestBase
+{
+    // Reproduces the reported repro at the routing layer: a request that declares a multipart form content type
+    // but carries a truncated body (no closing boundary). The first content finder, ContentFinderByPageIdQuery,
+    // reads the form looking for "umbPageID"; before the fix the synchronous HttpRequest.Form getter threw an
+    // IOException that propagated out of RouteRequestAsync as an unhandled 500. It must now route gracefully.
+    [Test]
+    public void RouteRequestAsync_DoesNotThrow_WhenRequestHasMalformedMultipartBody()
+    {
+        const string boundary = "----testboundary";
+        var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"test\"\r\n\r\nsomevalue";
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+        var httpContextAccessor = GetRequiredService<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext = new DefaultHttpContext
+        {
+            Request =
+            {
+                Scheme = "https",
+                Host = new HostString("localhost"),
+                Path = "/",
+                Method = HttpMethods.Post,
+                ContentType = $"multipart/form-data; boundary={boundary}",
+                ContentLength = bodyBytes.Length,
+                Body = new MemoryStream(bodyBytes),
+            },
+        };
+
+        GetRequiredService<IUmbracoContextFactory>().EnsureUmbracoContext();
+
+        var router = GetRequiredService<IPublishedRouter>();
+
+        Assert.DoesNotThrowAsync(async () =>
+        {
+            IPublishedRequestBuilder request = await router.CreateRequestAsync(new Uri("https://localhost/"));
+            await router.RouteRequestAsync(request, new RouteRequestOptions(RouteDirection.Inbound));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Routing/MalformedFormRoutingTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.Website/Routing/MalformedFormRoutingTests.cs
@@ -13,10 +13,11 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.Website.Routing;
 [TestFixture]
 internal sealed class MalformedFormRoutingTests : UmbracoTestServerTestBase
 {
-    // Reproduces the reported repro at the routing layer: a request that declares a multipart form content type
-    // but carries a truncated body (no closing boundary). The first content finder, ContentFinderByPageIdQuery,
-    // reads the form looking for "umbPageID"; before the fix the synchronous HttpRequest.Form getter threw an
-    // IOException that propagated out of RouteRequestAsync as an unhandled 500. It must now route gracefully.
+    // Content finders probe the request form for keys during routing (e.g. ContentFinderByPageIdQuery reads
+    // "umbPageID"). When a request declares a form content type but carries a body the synchronous
+    // HttpRequest.Form getter cannot parse (here a truncated multipart body with no closing boundary), that probe
+    // must treat the form as absent and let routing continue, rather than let the parse failure escape as an
+    // unhandled exception (which surfaces to the client as an HTTP 500).
     [Test]
     public void RouteRequestAsync_DoesNotThrow_WhenRequestHasMalformedMultipartBody()
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/AspNetCore/AspNetCoreRequestAccessorTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Web.Common.AspNetCore;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.AspNetCore;
+
+[TestFixture]
+public class AspNetCoreRequestAccessorTests
+{
+    [Test]
+    public void GetRequestValue_DoesNotThrow_WhenFormBodyIsMalformed()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "multipart/form-data; boundary=----test";
+        context.Features.Set<IFormFeature>(new ThrowingFormFeature(new IOException(
+            "Unexpected end of Stream, the content may have already been read by another component.")));
+
+        var accessor = CreateAccessor(context);
+
+        Assert.DoesNotThrow(() => accessor.GetRequestValue("umbPageID"));
+        Assert.IsNull(accessor.GetRequestValue("umbPageID"));
+    }
+
+    [Test]
+    public void GetRequestValue_FallsBackToQueryString_WhenFormBodyIsMalformed()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "multipart/form-data; boundary=----test";
+        context.Request.QueryString = new QueryString("?umbPageID=1046");
+        context.Features.Set<IFormFeature>(new ThrowingFormFeature(new InvalidDataException("Form value count limit exceeded.")));
+
+        var accessor = CreateAccessor(context);
+
+        Assert.AreEqual("1046", accessor.GetRequestValue("umbPageID"));
+    }
+
+    [Test]
+    public void GetRequestValue_ReadsFormValue_WhenFormIsWellFormed()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/x-www-form-urlencoded";
+        context.Request.Form = new FormCollection(new Dictionary<string, StringValues> { ["umbPageID"] = "1046" });
+
+        var accessor = CreateAccessor(context);
+
+        Assert.AreEqual("1046", accessor.GetRequestValue("umbPageID"));
+    }
+
+    private static AspNetCoreRequestAccessor CreateAccessor(HttpContext context)
+    {
+        var httpContextAccessor = new Mock<IHttpContextAccessor>();
+        httpContextAccessor.Setup(x => x.HttpContext).Returns(context);
+
+        var webRoutingSettings = new Mock<IOptionsMonitor<WebRoutingSettings>>();
+        webRoutingSettings.Setup(x => x.CurrentValue).Returns(new WebRoutingSettings());
+
+        return new AspNetCoreRequestAccessor(httpContextAccessor.Object, webRoutingSettings.Object);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpContextExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpContextExtensionsTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Extensions;
+
+[TestFixture]
+public class HttpContextExtensionsTests
+{
+    [Test]
+    public void GetRequestValue_DoesNotThrow_WhenFormBodyIsMalformed()
+    {
+        HttpContext context = ContextWithUnreadableForm(new IOException(
+            "Unexpected end of Stream, the content may have already been read by another component."));
+
+        Assert.DoesNotThrow(() => context.GetRequestValue("umbdebugshowtrace"));
+        Assert.IsNull(context.GetRequestValue("umbdebugshowtrace"));
+    }
+
+    [Test]
+    public void GetRequestValue_DoesNotThrow_WhenFormLimitIsExceeded()
+    {
+        HttpContext context = ContextWithUnreadableForm(new InvalidDataException("Form value count limit exceeded."));
+
+        Assert.DoesNotThrow(() => context.GetRequestValue("umbdebugshowtrace"));
+        Assert.IsNull(context.GetRequestValue("umbdebugshowtrace"));
+    }
+
+    [Test]
+    public void GetRequestValue_FallsBackToQueryString_WhenFormBodyIsMalformed()
+    {
+        HttpContext context = ContextWithUnreadableForm(new IOException("Unexpected end of Stream."));
+        context.Request.QueryString = new QueryString("?umbdebugshowtrace=true");
+
+        Assert.AreEqual("true", context.GetRequestValue("umbdebugshowtrace"));
+    }
+
+    [Test]
+    public void GetRequestValue_ReadsFormValue_WhenFormIsWellFormed()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/x-www-form-urlencoded";
+        context.Request.Form = new FormCollection(new Dictionary<string, StringValues> { ["key"] = "from-form" });
+
+        Assert.AreEqual("from-form", context.GetRequestValue("key"));
+    }
+
+    private static HttpContext ContextWithUnreadableForm(Exception exception)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "multipart/form-data; boundary=----test";
+        context.Features.Set<IFormFeature>(new ThrowingFormFeature(exception));
+        return context;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpRequestExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpRequestExtensionsTests.cs
@@ -51,8 +51,9 @@ public class HttpRequestExtensionsTests
         Assert.AreEqual("from-form", context.Request.GetUfprt());
     }
 
-    // Exercises the real ASP.NET Core form parser (not a fake) against a truncated multipart body, mirroring
-    // the reported repro: a missing closing boundary makes the synchronous Form getter throw a real IOException.
+    // The other DoesNotThrow tests inject a fake form feature that throws a chosen exception; this one drives
+    // the real ASP.NET Core form parser with a genuinely truncated multipart body (no closing boundary), so it
+    // confirms the parser's actual failure mode is one the guard catches, rather than relying on an assumed type.
     [Test]
     public void GetUfprt_DoesNotThrow_WhenRealMultipartBodyIsTruncated()
     {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpRequestExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/Extensions/HttpRequestExtensionsTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
+using NUnit.Framework;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common.Extensions;
+
+[TestFixture]
+public class HttpRequestExtensionsTests
+{
+    [Test]
+    public void GetUfprt_DoesNotThrow_WhenFormBodyIsMalformed()
+    {
+        HttpRequest request = RequestWithUnreadableForm(new IOException(
+            "Unexpected end of Stream, the content may have already been read by another component."));
+
+        Assert.DoesNotThrow(() => request.GetUfprt());
+        Assert.IsNull(request.GetUfprt());
+    }
+
+    [Test]
+    public void GetUfprt_DoesNotThrow_WhenFormLimitIsExceeded()
+    {
+        HttpRequest request = RequestWithUnreadableForm(new InvalidDataException("Form value count limit exceeded."));
+
+        Assert.DoesNotThrow(() => request.GetUfprt());
+        Assert.IsNull(request.GetUfprt());
+    }
+
+    [Test]
+    public void GetUfprt_FallsBackToQueryString_WhenFormBodyIsMalformed()
+    {
+        HttpRequest request = RequestWithUnreadableForm(new IOException("Unexpected end of Stream."));
+        request.QueryString = new QueryString("?ufprt=from-query");
+
+        Assert.AreEqual("from-query", request.GetUfprt());
+    }
+
+    [Test]
+    public void GetUfprt_ReadsFormValue_WhenFormIsWellFormed()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/x-www-form-urlencoded";
+        context.Request.Form = new FormCollection(new Dictionary<string, StringValues> { ["ufprt"] = "from-form" });
+
+        Assert.AreEqual("from-form", context.Request.GetUfprt());
+    }
+
+    // Exercises the real ASP.NET Core form parser (not a fake) against a truncated multipart body, mirroring
+    // the reported repro: a missing closing boundary makes the synchronous Form getter throw a real IOException.
+    [Test]
+    public void GetUfprt_DoesNotThrow_WhenRealMultipartBodyIsTruncated()
+    {
+        const string boundary = "----testboundary";
+        var body = $"--{boundary}\r\nContent-Disposition: form-data; name=\"test\"\r\n\r\nsomevalue";
+        HttpRequest request = RequestWithRawMultipartBody(body, boundary);
+
+        Assert.DoesNotThrow(() => request.GetUfprt());
+        Assert.IsNull(request.GetUfprt());
+    }
+
+    // BadHttpRequestException (raised for body/size faults) derives from IOException, so it must be swallowed too.
+    [Test]
+    public void GetUfprt_DoesNotThrow_WhenBodyExceedsSizeLimit()
+    {
+        HttpRequest request = RequestWithUnreadableForm(new BadHttpRequestException("Request body too large."));
+
+        Assert.DoesNotThrow(() => request.GetUfprt());
+        Assert.IsNull(request.GetUfprt());
+    }
+
+    // Guards against the filter being loosened to a bare catch: only form-parse failures are swallowed,
+    // every other exception must still propagate.
+    [Test]
+    public void GetUfprt_Rethrows_WhenExceptionIsUnexpected()
+    {
+        HttpRequest request = RequestWithUnreadableForm(new InvalidOperationException("unexpected"));
+
+        Assert.Throws<InvalidOperationException>(() => request.GetUfprt());
+    }
+
+    private static HttpRequest RequestWithUnreadableForm(Exception exception)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "multipart/form-data; boundary=----test";
+        context.Features.Set<IFormFeature>(new ThrowingFormFeature(exception));
+        return context.Request;
+    }
+
+    private static HttpRequest RequestWithRawMultipartBody(string body, string boundary)
+    {
+        var bytes = Encoding.UTF8.GetBytes(body);
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = $"multipart/form-data; boundary={boundary}";
+        context.Request.Body = new MemoryStream(bytes);
+        context.Request.ContentLength = bytes.Length;
+        return context.Request;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ThrowingFormFeature.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/ThrowingFormFeature.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Web.Common;
+
+/// <summary>
+///     An <see cref="IFormFeature" /> whose form access always throws, simulating a request that declares a form
+///     content type but carries a body the framework cannot parse (e.g. a truncated multipart POST), where the
+///     synchronous <see cref="HttpRequest.Form" /> getter throws.
+/// </summary>
+internal sealed class ThrowingFormFeature : IFormFeature
+{
+    private readonly Exception _exception;
+
+    public ThrowingFormFeature(Exception exception) => _exception = exception;
+
+    public bool HasFormContentType => true;
+
+    public IFormCollection? Form
+    {
+        get => throw _exception;
+        set => throw new NotSupportedException();
+    }
+
+    public IFormCollection ReadForm() => throw _exception;
+
+    public Task<IFormCollection> ReadFormAsync(CancellationToken cancellationToken) => throw _exception;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

<!-- No existing GitHub issue; reported via the forum threads linked below. Replace with "This fixes #1234" if a tracking issue exists. -->

### Description

**What**

Several components in the front-end routing pipeline read the synchronous `HttpRequest.Form` getter — content finders (`ContentFinderByPageIdQuery` looking for `umbPageID`), alternate-template resolution (`PublishedRouter.FindTemplate`), and surface-controller `ufprt` detection (`GetUfprt`). On a request that declares a form content type but carries a malformed/truncated body (e.g. `multipart/form-data` with no closing boundary), that getter throws `System.IO.IOException` (or `InvalidDataException` for form-limit violations). It was unhandled and surfaced as an **HTTP 500 plus a full logged stack trace**.

This PR routes all three form reads through a single guarded helper (`HttpRequestExtensions.GetFormOrNull`) that catches `IOException`/`InvalidDataException` and returns `null`, so a malformed body falls through to normal routing instead of erroring. The happy path is unchanged — the guard only triggers on bodies that previously threw.

**Why**

A malformed request body is a client error, not a server fault, so it should not produce a 500. In practice this is triggered constantly in the wild by scanners sending malformed multipart POSTs, so every affected site logs a steady stream of exception stack traces (noise that buries real errors) on every routed URL. Reported on 13.x, 16.x and 17.x; this fixes it on `main`.

**How to test**

_Manual repro_ — POST a multipart content type with a truncated body to any routed page:

```powershell
$headers = @{ "Content-Type" = "multipart/form-data; boundary=----testboundary" }
$body = "------testboundary`r`nContent-Disposition: form-data; name=`"test`"`r`n`r`nsomevalue"
Invoke-WebRequest -Uri "https://your-umbraco-site/" -Method POST -Headers $headers -Body $body
```

- **Before:** 500 Internal Server Error + a logged `IOException: Unexpected end of Stream…`
- **After:** the request routes normally (no unhandled exception). A well-formed multipart body is unaffected.

_Automated_ — added regression tests, each verified to fail before the fix and pass after:

- Unit: `HttpRequestExtensionsTests`, `HttpContextExtensionsTests`, `AspNetCoreRequestAccessorTests` (cover `IOException`, `InvalidDataException`, `BadHttpRequestException`, query-string fall-through, the happy path, and an over-catch guard).
- Integration: `MalformedFormRoutingTests` drives the real `IPublishedRouter` with a genuine truncated multipart body and asserts routing no longer throws.

### Related forum discussions

- https://forum.umbraco.com/t/unexpected-end-of-stream-the-content-may-have-already-been-read-by-another-component/7012
- https://forum.umbraco.com/t/azure-hosted-umbraco-site-occassionally-fails/8070
