### PR TITLE
Data Types QA: Reproduce documents with 40+ data types failing to load (mock set + tests)

### DIFF
--- a/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/document-type.data.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/document-type.data.ts
@@ -3924,6 +3924,70 @@ const rawData: Array<
 	},
 ];
 
+const TEST_DOCUMENT_TYPES_FOLDER_ID = '25b36f28-5051-4073-a0c7-3887f6f8c695';
+const HOME_DOCUMENT_TYPE_ID = '7184285e-9709-4e13-8c72-1fe52f024b28';
+const ALL_DATA_TYPES_DOCUMENT_TYPE_ID = '8b1d6f2a-7c4e-4a9b-bf13-2e5d9a0c4f76';
+
+// Every data type is normally showcased on its own document type under the "Test Document Types" folder.
+// This aggregate gives a single document type with one tab per data type group (Block Grid, Block List, ...),
+// derived from those individual types so it stays in sync automatically.
+const dataTypeGroups = rawData.filter(
+	(documentType) => documentType.parent?.id === TEST_DOCUMENT_TYPES_FOLDER_ID && documentType.isFolder === false,
+);
+
+rawData.push({
+	allowedTemplates: [],
+	defaultTemplate: null,
+	id: ALL_DATA_TYPES_DOCUMENT_TYPE_ID,
+	alias: 'allDataTypes',
+	name: 'All Data Types',
+	description: null,
+	icon: 'icon-documents color-green',
+	allowedAsRoot: false,
+	variesByCulture: false,
+	variesBySegment: false,
+	isElement: false,
+	hasChildren: false,
+	parent: {
+		id: TEST_DOCUMENT_TYPES_FOLDER_ID,
+	},
+	isFolder: false,
+	properties: dataTypeGroups.flatMap((group) =>
+		group.properties.map((property) => ({
+			...property,
+			id: `pt-adt-${property.id}`,
+			container: {
+				id: `adt-tab-${group.alias}`,
+			},
+		})),
+	),
+	containers: dataTypeGroups.map((group, index) => ({
+		id: `adt-tab-${group.alias}`,
+		parent: null,
+		name: group.name,
+		type: 'Tab',
+		sortOrder: index,
+	})),
+	allowedDocumentTypes: [],
+	compositions: [],
+	cleanup: {
+		preventCleanup: false,
+		keepAllVersionsNewerThanDays: null,
+		keepLatestVersionPerDayForDays: null,
+	},
+	flags: [],
+});
+
+// Allow the aggregate to be created as a child of Home.
+rawData
+	.find((documentType) => documentType.id === HOME_DOCUMENT_TYPE_ID)
+	?.allowedDocumentTypes.push({
+		documentType: {
+			id: ALL_DATA_TYPES_DOCUMENT_TYPE_ID,
+		},
+		sortOrder: 30,
+	});
+
 export const data: Array<UmbMockDocumentTypeModel> = rawData.map((dt) => ({
 	...dt,
 	compositions: dt.compositions.map((c) => ({

--- a/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/document.data.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/document.data.ts
@@ -2548,10 +2548,51 @@ const rawData = [
 	},
 ];
 
-export const data: Array<UmbMockDocumentModel> = rawData.map((doc) => ({
-	...doc,
-	variants: doc.variants.map((v) => ({
-		...v,
-		state: v.state as UmbDocumentVariantState,
+const HOME_DOCUMENT_ID = 'db79156b-3d5b-43d6-ab32-902dc423bec3';
+const ALL_DATA_TYPES_DOCUMENT_TYPE_ID = '8b1d6f2a-7c4e-4a9b-bf13-2e5d9a0c4f76';
+const ALL_DATA_TYPES_DOCUMENT_ID = '3f7c2e9d-5a14-4b8e-9c0a-6d2f8b1e4a37';
+
+// A single document showcasing every data type, reusing the values from the individual showcase documents.
+const allDataTypesValues = rawData
+	.filter((document) => document.parent?.id === HOME_DOCUMENT_ID)
+	.flatMap((document) => document.values as UmbMockDocumentModel['values']);
+
+export const data: Array<UmbMockDocumentModel> = [
+	...rawData.map((doc) => ({
+		...doc,
+		variants: doc.variants.map((v) => ({
+			...v,
+			state: v.state as UmbDocumentVariantState,
+		})),
 	})),
-}));
+	{
+		ancestors: [{ id: HOME_DOCUMENT_ID }],
+		template: null,
+		id: ALL_DATA_TYPES_DOCUMENT_ID,
+		createDate: '2023-02-20 16:30:00',
+		parent: { id: HOME_DOCUMENT_ID },
+		documentType: {
+			id: ALL_DATA_TYPES_DOCUMENT_TYPE_ID,
+			icon: 'icon-documents color-green',
+		},
+		hasChildren: false,
+		noAccess: false,
+		isProtected: false,
+		isTrashed: false,
+		variants: [
+			{
+				state: 'Published' as UmbDocumentVariantState,
+				publishDate: '2026-04-16 11:10:37.0000000',
+				culture: null,
+				segment: null,
+				name: 'All Data Types',
+				createDate: '2023-02-20 16:30:00',
+				updateDate: '2026-04-16 11:10:37.0000000',
+				id: ALL_DATA_TYPES_DOCUMENT_ID,
+				flags: [],
+			},
+		],
+		values: allDataTypesValues,
+		flags: [],
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/data-type-detail.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/data-type-detail.repository.test.ts
@@ -1,0 +1,109 @@
+import type { UmbDataTypeDetailModel } from '../../types.js';
+import { UmbDataTypeDetailRepository } from './data-type-detail.repository.js';
+import { UmbDataTypeDetailStore } from './data-type-detail.store.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { useMockSet, umbMockManager } from '@umbraco-cms/internal/mock-manager';
+
+const MEDIA_PICKER_UI_ALIAS = 'Umb.PropertyEditorUi.MediaPicker';
+
+@customElement('umb-test-data-type-detail-repository-host')
+class UmbTestDataTypeDetailRepositoryHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new UmbDataTypeDetailStore(this);
+	}
+}
+
+describe('UmbDataTypeDetailRepository', () => {
+	let host: UmbTestDataTypeDetailRepositoryHostElement;
+	let repository: UmbDataTypeDetailRepository;
+	let dataTypeIds: Array<string>;
+	let mediaPickerIds: Array<string>;
+
+	before(async () => {
+		await useMockSet('kitchenSink');
+
+		const dataTypes = umbMockManager.getDataSet().dataType!.filter((dataType) => !dataType.isFolder);
+
+		// The kitchen sink set deliberately contains more than the request batch size so a single
+		// requestByUniques has to be split into chunks.
+		dataTypeIds = dataTypes.map((dataType) => dataType.id!);
+		mediaPickerIds = dataTypes
+			.filter((dataType) => dataType.editorUiAlias === MEDIA_PICKER_UI_ALIAS)
+			.map((dataType) => dataType.id!);
+	});
+
+	beforeEach(() => {
+		host = new UmbTestDataTypeDetailRepositoryHostElement();
+		document.body.appendChild(host);
+		repository = new UmbDataTypeDetailRepository(host);
+	});
+
+	afterEach(() => {
+		repository.destroy();
+		document.body.innerHTML = '';
+	});
+
+	describe('requestByUniques', () => {
+		it('returns an empty array without requesting when called with no ids', async () => {
+			const result = await repository.requestByUniques([]);
+			expect(result.data).to.deep.equal([]);
+		});
+
+		it('requests a single data type by its unique', async () => {
+			const result = await repository.requestByUniques([dataTypeIds[0]]);
+
+			expect(result.error).to.be.undefined;
+			expect(result.data).to.have.length(1);
+			expect(result.data![0].unique).to.equal(dataTypeIds[0]);
+		});
+
+		it('requests every data type when there are more than the batch size (chunked requests)', async () => {
+			// Guards the premise of this test: more than the 40 item batch size forces the request to be chunked.
+			expect(dataTypeIds.length).to.be.greaterThan(40);
+
+			const result = await repository.requestByUniques(dataTypeIds);
+
+			expect(result.error).to.be.undefined;
+			expect(result.data).to.have.length(dataTypeIds.length);
+			expect(result.data!.map((dataType) => dataType.unique)).to.have.members(dataTypeIds);
+		});
+
+		it('emits the requested data types through the returned observable', async () => {
+			const result = await repository.requestByUniques([dataTypeIds[0]]);
+
+			const observable = result.asObservable!();
+			expect(observable).to.exist;
+
+			const observed = await new Promise<Array<UmbDataTypeDetailModel>>((resolve) => {
+				observable!.subscribe((items) => {
+					if (items && items.length > 0) resolve(items);
+				});
+			});
+
+			expect(observed.map((dataType) => dataType.unique)).to.deep.equal([dataTypeIds[0]]);
+		});
+	});
+
+	describe('byPropertyEditorUiAlias', () => {
+		it('emits the data types in the store that use the given property editor UI', async () => {
+			expect(mediaPickerIds.length).to.be.greaterThan(0);
+
+			// Populate the store first; byPropertyEditorUiAlias observes what is currently in the store.
+			await repository.requestByUniques(dataTypeIds);
+
+			const observable = await repository.byPropertyEditorUiAlias(MEDIA_PICKER_UI_ALIAS);
+
+			const observed = await new Promise<Array<UmbDataTypeDetailModel>>((resolve) => {
+				observable.subscribe((items) => {
+					if (items.length >= mediaPickerIds.length) resolve(items);
+				});
+			});
+
+			expect(observed.map((dataType) => dataType.unique)).to.have.members(mediaPickerIds);
+			observed.forEach((dataType) => expect(dataType.editorUiAlias).to.equal(MEDIA_PICKER_UI_ALIAS));
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/server-data-source/data-type-detail.server.data-source.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/repository/detail/server-data-source/data-type-detail.server.data-source.test.ts
@@ -1,0 +1,62 @@
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { useMockSet, umbMockManager } from '@umbraco-cms/internal/mock-manager';
+import { UmbDataTypeServerDataSource } from './data-type-detail.server.data-source.js';
+
+@customElement('umb-test-data-type-detail-data-source-host')
+class UmbTestDataTypeDetailDataSourceHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbDataTypeServerDataSource', () => {
+	let host: UmbTestDataTypeDetailDataSourceHostElement;
+	let dataSource: UmbDataTypeServerDataSource;
+	let dataTypeIds: Array<string>;
+
+	before(async () => {
+		await useMockSet('kitchenSink');
+
+		// Every (non-folder) data type id in the active mock set. The kitchen sink set deliberately
+		// contains more than the request batch size so a single readMany has to be split into chunks.
+		dataTypeIds = umbMockManager
+			.getDataSet()
+			.dataType!.filter((dataType) => !dataType.isFolder)
+			.map((dataType) => dataType.id!);
+	});
+
+	beforeEach(() => {
+		host = new UmbTestDataTypeDetailDataSourceHostElement();
+		document.body.appendChild(host);
+		dataSource = new UmbDataTypeServerDataSource(host);
+	});
+
+	afterEach(() => {
+		dataSource.destroy();
+		document.body.innerHTML = '';
+	});
+
+	describe('readMany', () => {
+		it('returns an empty array when called with no ids', async () => {
+			const result = await dataSource.readMany([]);
+			expect(result.data).to.deep.equal([]);
+		});
+
+		it('reads a single data type', async () => {
+			const result = await dataSource.readMany([dataTypeIds[0]]);
+
+			expect(result.error).to.be.undefined;
+			expect(result.data).to.have.length(1);
+			expect(result.data![0].unique).to.equal(dataTypeIds[0]);
+		});
+
+		it('reads every data type when there are more than the batch size (chunked requests)', async () => {
+			// Guards the premise of this test: more than the 40 item batch size forces the request to be chunked.
+			expect(dataTypeIds.length).to.be.greaterThan(40);
+
+			const result = await dataSource.readMany(dataTypeIds);
+
+			expect(result.error).to.be.undefined;
+			expect(result.data).to.have.length(dataTypeIds.length);
+			expect(result.data!.map((dataType) => dataType.unique)).to.have.members(dataTypeIds);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/management-api/detail/detail-data.request-manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/management-api/detail/detail-data.request-manager.test.ts
@@ -415,6 +415,40 @@ describe('UmbManagementApiDetailDataRequestManager', () => {
 			expect(result.data?.items).to.have.lengthOf(2);
 		});
 
+		it('returns all items when the number of IDs exceeds the batch size (chunked requests)', async () => {
+			const requestedIdBatches: Array<Array<string>> = [];
+			mockReadMany = async (ids: Array<string>) => {
+				requestedIdBatches.push([...ids]);
+				return {
+					data: {
+						items: ids.map((id) => ({ id, name: `Item ${id}` })),
+					},
+				};
+			};
+
+			manager = new UmbManagementApiDetailDataRequestManager(hostElement, {
+				create: mockCreate,
+				read: mockRead,
+				update: mockUpdate,
+				delete: mockDelete,
+				readMany: mockReadMany,
+				dataCache,
+				inflightRequestCache,
+			});
+
+			// 45 IDs forces UmbItemDataApiGetRequestController to chunk the request (batch size is 40).
+			const ids = Array.from({ length: 45 }, (_, index) => `item-${index}`);
+
+			const result = await manager.readMany(ids);
+
+			// The request should have been split into more than one chunk.
+			expect(requestedIdBatches.length).to.be.greaterThan(1);
+
+			// Every requested item must be returned, regardless of which chunk it was fetched in.
+			expect(result.data?.items).to.have.lengthOf(45);
+			expect(result.data?.items.map((item) => item.id)).to.include.members(ids);
+		});
+
 		it('uses cached items and only fetches non-cached items when connected', async () => {
 			mockServerEventContext.setIsConnected(true);
 


### PR DESCRIPTION
### Description

**This PR deliberately contains _no fix_.** It adds a reproducible scenario and automated tests that demonstrate an existing bug in bulk detail fetching. The accompanying fix will follow in a separate PR — so the new "chunked" tests here are expected to **fail** (red CI is the proof).

PR with fix https://github.com/umbraco/Umbraco-CMS/pull/23164

Screenshot of Mock data of the Document failing to load because of 40+ unique Data Types

<img width="1504" height="752" alt="Screenshot 2026-06-25 at 22 20 05" src="https://github.com/user-attachments/assets/07d9a882-91d6-49e3-89a0-a6fec760942c" />