### PR TITLE
add standalone attr to input-multi-url.element to align ex. input-doc…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -414,7 +414,8 @@ export class UmbInputMultiUrlElement extends UmbFormControlMixin<string, typeof 
 				href=${ifDefined(href)}
 				name=${name || url}
 				detail=${ifDefined(name ? url : undefined)}
-				?readonly=${this.readonly}>
+				?readonly=${this.readonly}
+				?standalone=${this.max === 1 && this.urls?.length === 1}>
 				<umb-icon slot="icon" name=${link.icon || 'icon-link'}></umb-icon>
 				${when(
 					!this.readonly,


### PR DESCRIPTION
…ument.element

### Prerequisites
- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes https://github.com/umbraco/Umbraco-CMS/issues/23173

### Description
As the issues says, the link picker when single dont follow the other pickers eg. input-document.element.ts when the configuration max is set to 1 it use the `standalone` style. 

This PR makes the input-multi-url.element align with other pickers to use this `standalone` style. When max is set to 1.