### PR TITLE
Document URLs: Persist URL segments and aliases under distributed-cache-only notification publishers (closes #23214)

### DIFF
--- a/src/Umbraco.Core/CLAUDE.md
+++ b/src/Umbraco.Core/CLAUDE.md
@@ -133,6 +133,23 @@ builder.AddNotificationHandler<ContentSavedNotification, MyNotificationHandler>(
 
 **Key interface**: `IEventAggregator` - publishes notifications to handlers
 
+#### Durable handlers vs. distributed-cache-only publishers
+
+A handler that only implements `INotificationHandler<T>` / `INotificationAsyncHandler<T>`
+is **silently skipped** when the notification is dispatched through a publisher restricted to
+distributed-cache handlers — i.e. `ScopedNotificationPublisher<IDistributedCacheNotificationHandler>`.
+Umbraco Deploy installs exactly such a publisher on its restore/import scopes, and `EventAggregator`
+filters handlers with `.Where(x => x is TNotificationHandler)`.
+
+If a handler must run for **every** change — especially durable database writes that back the
+in-memory cache — implement `IDistributedCacheNotificationHandler` (sync) or
+`IDistributedCacheAsyncNotificationHandler<T>` (async) instead. These derive from the plain handler
+interfaces, so the handler still fires on normal publishes *and* survives the distributed-cache-only
+filter. No DI change is needed — filtering is by resolved instance type.
+
+When you do this, ensure the handler is safe in the extra scopes it now runs in — e.g. guard against
+DB writes on read-only `Subscriber` servers (see `DocumentUrlService.SkipDatabaseWrites()`).
+
 ### 3. Composer Pattern (DI Registration)
 
 Composers register services and configure the application, this is to make the system easily extendible by package developers and implementors.
@@ -499,6 +516,7 @@ Internal types are accessible in test projects for more thorough testing.
 6. **Culture handling** - Many operations require explicit culture parameter
 7. **Published vs Draft** - `IContent` is draft, `IPublishedContent` is published
 8. **Constants** - Use constants instead of magic strings (property editor aliases, etc.)
+9. **Distributed-cache-only publishers skip plain handlers** - handlers doing durable work (e.g. DB writes) must implement `IDistributedCacheNotificationHandler` / `IDistributedCacheAsyncNotificationHandler<T>`, or they won't fire under Umbraco Deploy and similar restricted scopes.
 
 ## Navigation Tips
 

--- a/src/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandler.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeNotificationHandler.cs
@@ -1,4 +1,4 @@
-using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services.Changes;
@@ -12,7 +12,7 @@ namespace Umbraco.Cms.Core.Services;
 /// is delivered to other servers, ensuring URL data is in the database before any server processes the instruction.
 /// </summary>
 public class DocumentUrlServiceContentTreeChangeNotificationHandler
-    : INotificationAsyncHandler<ContentTreeChangeNotification>
+    : IDistributedCacheAsyncNotificationHandler<ContentTreeChangeNotification>
 {
     private readonly IDocumentUrlService _documentUrlService;
     private readonly IDocumentUrlAliasService _documentUrlAliasService;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlServiceContentTreeChangeTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Persistence.Repositories;
@@ -37,6 +38,8 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
     private ICoreScopeProvider CoreScopeProvider => GetRequiredService<ICoreScopeProvider>();
 
     private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IEventAggregator EventAggregator => GetRequiredService<IEventAggregator>();
 
     private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
 
@@ -137,6 +140,38 @@ internal sealed class DocumentUrlServiceContentTreeChangeTests : UmbracoIntegrat
                 .Where(r => r.DocumentKey == documentKey)
                 .ToList();
         }
+    }
+
+    /// <summary>
+    /// When operations run under a scoped notification publisher restricted to
+    /// <see cref="IDistributedCacheNotificationHandler"/>, the handler must still persist URL segments and
+    /// aliases to the database; otherwise the data only reaches the in-memory cache and routing is lost on restart.
+    /// </summary>
+    [Test]
+    public void Publish_UnderDistributedCacheOnlyPublisher_StillWritesUrlSegmentsAndAliasesToDatabase()
+    {
+        var page = ContentBuilder.CreateSimpleContent(ContentType, "Distributed Cache Page", RootPage.Id);
+        page.SetValue(Constants.Conventions.Content.UrlAlias, "distributed-cache-alias");
+
+        var publisher = new ScopedNotificationPublisher<IDistributedCacheNotificationHandler>(EventAggregator);
+        using (ICoreScope scope = CoreScopeProvider.CreateCoreScope(scopedNotificationPublisher: publisher))
+        {
+            ContentService.Save(page, -1);
+            ContentService.Publish(page, []);
+            scope.Complete();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                GetDbSegments(page.Key),
+                Is.Not.Empty,
+                "URL segments must be persisted to the database even when publishing under a distributed-cache-only notification publisher.");
+            Assert.That(
+                GetDbAliases(page.Key).Any(a => a.Alias == "distributed-cache-alias"),
+                Is.True,
+                "URL aliases must be persisted to the database even when publishing under a distributed-cache-only notification publisher.");
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #23214

## Problem

When content is created/published inside a scope whose notification publisher is restricted to `IDistributedCacheNotificationHandler` (e.g. via `ScopedNotificationPublisher<IDistributedCacheNotificationHandler>`), document URL segments and aliases were written to the in-memory cache but **never persisted to the `umbracoDocumentUrl` table**.

Everything works until the application restarts. On the next startup the in-memory cache is empty, the table was never populated, and `DocumentUrlService.InitAsync` does not rebuild (the URL-provider fingerprint is unchanged, so `ShouldRebuildUrls()` returns `false`). The result is unroutable content: front-end pages 404 and the backoffice Info tab shows "Not Created" / "URL cannot be routed". A republish-with-descendants repairs it permanently.

This is a regression from the URL persistence split: `ContentCacheRefresher.HandleRouting` was changed to update the in-memory cache only, while the database write moved to `DocumentUrlServiceContentTreeChangeNotificationHandler`. That handler was a plain `INotificationAsyncHandler<ContentTreeChangeNotification>`, so publishers that filter to distributed-cache handlers skipped it entirely (`EventAggregator` resolves handlers with `.Where(x => x is TNotificationHandler)`).

## Fix

`DocumentUrlServiceContentTreeChangeNotificationHandler` now implements `IDistributedCacheAsyncNotificationHandler<ContentTreeChangeNotification>`. That marker derives from both `INotificationAsyncHandler<T>` and the `IDistributedCacheNotificationHandler` marker, so the handler still fires on normal publishes **and** passes the distributed-cache-only filter. No DI registration change is needed — filtering is by resolved instance type.

This remains safe for read-only subscribers: they receive a cache *instruction* rather than the `ContentTreeChangeNotification`, and `CreateOrUpdateUrlSegmentsAsync` keeps its internal subscriber-role guard against database writes.

## Tests

Added an integration test that publishes content inside a `ScopedNotificationPublisher<IDistributedCacheNotificationHandler>` scope and asserts both URL segments and aliases land in the database. Verified it fails before the fix and passes after.
