### PR TITLE
Relations: Allow `Element` and `ElementContainer` as allowed object types for relation creation

### DIFF
--- a/src/Umbraco.Core/Services/RelationService.cs
+++ b/src/Umbraco.Core/Services/RelationService.cs
@@ -803,6 +803,8 @@ public class RelationService : RepositoryService, IRelationService
             UmbracoObjectTypes.MemberType,
             UmbracoObjectTypes.DataType,
             UmbracoObjectTypes.MemberGroup,
+            UmbracoObjectTypes.Element,
+            UmbracoObjectTypes.ElementContainer,
             UmbracoObjectTypes.ROOT,
             UmbracoObjectTypes.RecycleBin,
         ];

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RelationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/RelationServiceTests.cs
@@ -49,6 +49,8 @@ internal sealed class RelationServiceTests : UmbracoIntegrationTest
     [TestCase(Constants.ObjectTypes.Strings.DataType, Constants.ObjectTypes.Strings.MemberGroup)]
     [TestCase(Constants.ObjectTypes.Strings.Document, Constants.ObjectTypes.Strings.ContentRecycleBin)]
     [TestCase(Constants.ObjectTypes.Strings.Document, Constants.ObjectTypes.Strings.SystemRoot)]
+    [TestCase(Constants.ObjectTypes.Strings.Element, Constants.ObjectTypes.Strings.ElementContainer)]
+    [TestCase(Constants.ObjectTypes.Strings.ElementContainer, Constants.ObjectTypes.Strings.ElementContainer)]
     public async Task Can_Create_Relation_Types_With_Allowed_Object_Types(string childObjectTypeGuid, string parentObjectTypeGuid)
     {
         IRelationTypeWithIsDependency relationType = new RelationTypeBuilder()


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23216

### Description

v18 seeds three built-in element relation types (parent/child object types `Element` / `ElementContainer`) directly into the database via `DatabaseDataCreator` (install) and the `V_18_0_0.AddElements` migration (upgrade), bypassing `IRelationService`. But `RelationService.SaveAsync` validates object types against `GetAllowedObjectTypes()`, which never had `Element`/`ElementContainer` added. As a result the service rejects any `CreateAsync`/`UpdateAsync` of these relation types with `InvalidParentObjectType`/`InvalidChildObjectType` — breaking the backoffice Relations list and Umbraco Deploy import/transfer (which re-saves built-in relation types through the service).

This adds `Element` and `ElementContainer` to `GetAllowedObjectTypes()`.

**How to test:**

1. On a clean 18.0.0 install, resolve `IRelationService`, load `relateParentElementContainerOnElementDelete` via `GetRelationTypeByAlias`, and call `UpdateAsync` — it now returns `RelationTypeOperationStatus.Success` (previously `InvalidParentObjectType`).
2. Or run the added integration tests: `Can_Create_Relation_Types_With_Allowed_Object_Types` now covers `ElementContainer`→`Element` and `ElementContainer`→`ElementContainer`.

**Changes:**

- `src/Umbraco.Core/Services/RelationService.cs` — add `UmbracoObjectTypes.Element` and `UmbracoObjectTypes.ElementContainer` to the allowed set.
- `tests/Umbraco.Tests.Integration/.../RelationServiceTests.cs` — two new test cases.
