### PR TITLE
Resolve link picker item name at click time to prevent "undefined" in…

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/multi-url-picker/components/input-multi-url/input-multi-url.element.ts
@@ -315,13 +315,15 @@ export class UmbInputMultiUrlElement extends UmbFormControlMixin<string, typeof 
 		return data?.[0]?.name ?? '';
 	}
 
-	async #requestRemoveItem(index: number, name?: string) {
+	async #requestRemoveItem(index: number) {
 		const item = this.#urls[index];
 		if (!item) throw new Error('Could not find item at index: ' + index);
 
+		const name = this.#getResolvedItemName(item);
+
 		await umbConfirmModal(this, {
 			color: 'danger',
-			headline: `Remove ${name || item.name || 'item'}?`,
+			headline: `Remove ${name || 'item'}?`,
 			content: 'Are you sure you want to remove this item?',
 			confirmLabel: '#general_remove',
 		});
@@ -422,7 +424,7 @@ export class UmbInputMultiUrlElement extends UmbFormControlMixin<string, typeof 
 						<uui-action-bar slot="actions">
 							<uui-button
 								label=${this.localize.term('general_remove')}
-								@click=${() => this.#requestRemoveItem(index, name)}></uui-button>
+								@click=${() => this.#requestRemoveItem(index)}></uui-button>
 						</uui-action-bar>
 					`,
 				)}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #23194

### Description

**The Issue:** After saving a page with a link picker (Multi URL Picker) linked to a content node and reloading, clicking "Remove" on the link shows "Remove undefined?" instead of the actual content node name.

**The Cause:** The remove button's click handler captured the `name` variable from the template's render-time closure. After page reload, the server returns link data without the `name` property populated. The component resolves names asynchronously via `#populateLinksNameAndUrl()`, but by the time it completes, the click handler still holds the stale empty value from the initial render.

**The Fix:** Changed `#requestRemoveItem` to resolve the item name fresh at click time using `#getResolvedItemName(item)` instead of relying on the stale closure value. By the time a user clicks "Remove" (seconds after page load), the async name resolution has completed and the correct name is available.

### Visual Proof (before fix):

<img width="1898" height="938" alt="Before_adding_fix_for_linkPicker" src="https://github.com/user-attachments/assets/e8ddb8f3-873a-4ec5-8fd1-56377939913e" />


### Visual Proof (after fix):

<img width="1898" height="938" alt="After_adding_fix_for_linkPicker" src="https://github.com/user-attachments/assets/4712f70e-32ef-4739-92ca-9f70ef643193" />


### How to test

1. Add a Multi URL Picker property to a document type (Settings → Document Types → add property → choose "Multi URL Picker").
2. Open a content node of that type.
3. Click "Add" on the link picker → select a content node → Submit.
4. Save the page.
5. Reload the page (F5).
6. Click the remove button (X) on the link item.
7. The confirmation dialog should show the correct content node name (e.g., "Remove Home?"), not "Remove undefined?".