### PR TITLE
Code Editor: Fix crash when loading saved JSON values (closes #23180)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/PlainStringPropertyEditor.cs
+++ b/src/Umbraco.Core/PropertyEditors/PlainStringPropertyEditor.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Cms.Core.PropertyEditors;
 
@@ -17,6 +18,10 @@ public class PlainStringPropertyEditor : DataEditor, IValueSchemaProvider
     public PlainStringPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
         : base(dataValueEditorFactory)
         => SupportsReadOnly = true;
+
+    /// <inheritdoc />
+    protected override IDataValueEditor CreateValueEditor() =>
+        DataValueEditorFactory.Create<TextOnlyValueEditor>(Attribute!);
 
     /// <inheritdoc />
     public Type? GetValueType(object? configuration) => typeof(string);

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
@@ -69,15 +69,11 @@ export class UmbPropertyEditorUICodeEditorElement
 	}
 
 	override render() {
-		// Ensure the value is always a string — the API may deserialize JSON values into objects
-		const code =
-			typeof this.value === 'string' ? this.value : this.value != null ? JSON.stringify(this.value, null, 2) : '';
-
 		return html`
 			<umb-code-editor
 				style=${styleMap({ height: `${this._height}px` })}
 				.language=${this._language ?? this.#defaultLanguage}
-				.code=${code}
+				.code=${this.value ?? ''}
 				?disable-line-numbers=${!this._lineNumbers}
 				?disable-minimap=${!this._minimap}
 				?word-wrap=${this._wordWrap}

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
@@ -69,11 +69,15 @@ export class UmbPropertyEditorUICodeEditorElement
 	}
 
 	override render() {
+		// Ensure the value is always a string — the API may deserialize JSON values into objects
+		const code =
+			typeof this.value === 'string' ? this.value : this.value != null ? JSON.stringify(this.value, null, 2) : '';
+
 		return html`
 			<umb-code-editor
 				style=${styleMap({ height: `${this._height}px` })}
 				.language=${this._language ?? this.#defaultLanguage}
-				.code=${this.value ?? ''}
+				.code=${code}
 				?disable-line-numbers=${!this._lineNumbers}
 				?disable-minimap=${!this._minimap}
 				?word-wrap=${this._wordWrap}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PlainStringPropertyEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PlainStringPropertyEditorTests.cs
@@ -12,26 +12,33 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
 [TestFixture]
 public class PlainStringPropertyEditorTests
 {
+    [Test]
+    public void Can_Create_Text_Only_Value_Editor()
+    {
+        IDataValueEditor valueEditor = CreatePropertyEditor().GetValueEditor();
+
+        Assert.IsInstanceOf<TextOnlyValueEditor>(valueEditor);
+    }
+
     [TestCase("{\"test\":\"test\"}")]
     [TestCase("{}")]
     [TestCase("[1,2,3]")]
     [TestCase("{\"nested\":{\"key\":\"value\"}}")]
     [TestCase("hello world")]
     [TestCase("123")]
-    public void ToEditor_Returns_Raw_String_For_Json_Looking_Values(string storedValue)
+    public void Can_Parse_Json_Looking_Value_To_Editor_As_Raw_String(string storedValue)
     {
         var result = ToEditor(storedValue);
 
-        Assert.IsNotNull(result);
-        Assert.IsInstanceOf<string>(result);
-        Assert.AreEqual(storedValue, result);
+        Assert.That(result, Is.EqualTo(storedValue));
     }
 
     [Test]
-    public void ToEditor_Returns_Null_Or_Empty_For_Null_Value()
+    public void Null_To_Editor_Yields_Empty_String()
     {
         var result = ToEditor(null);
-        Assert.That(result is null or (string and ""), Is.True);
+
+        Assert.That(result, Is.Empty);
     }
 
     private static object? ToEditor(object? value)
@@ -41,17 +48,22 @@ public class PlainStringPropertyEditorTests
             .Setup(x => x.GetValue(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>()))
             .Returns(value);
 
-        return CreateValueEditor().ToEditor(property.Object);
+        return CreatePropertyEditor().GetValueEditor().ToEditor(property.Object);
     }
 
-    private static IDataValueEditor CreateValueEditor()
+    private static PlainStringPropertyEditor CreatePropertyEditor()
     {
-        var attribute = new DataEditorAttribute("Umbraco.Plain.String");
-        return new TextOnlyValueEditor(
-            attribute,
-            Mock.Of<ILocalizedTextService>(),
-            Mock.Of<IShortStringHelper>(),
-            Mock.Of<IJsonSerializer>(),
-            Mock.Of<IIOHelper>());
+        var factory = new Mock<IDataValueEditorFactory>();
+
+        factory
+            .Setup(x => x.Create<TextOnlyValueEditor>(It.IsAny<DataEditorAttribute>()))
+            .Returns((object[] args) => new TextOnlyValueEditor(
+                (DataEditorAttribute)args[0],
+                Mock.Of<ILocalizedTextService>(),
+                Mock.Of<IShortStringHelper>(),
+                Mock.Of<IJsonSerializer>(),
+                Mock.Of<IIOHelper>()));
+
+        return new PlainStringPropertyEditor(factory.Object);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PlainStringPropertyEditorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/PlainStringPropertyEditorTests.cs
@@ -1,0 +1,57 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.PropertyEditors;
+
+[TestFixture]
+public class PlainStringPropertyEditorTests
+{
+    [TestCase("{\"test\":\"test\"}")]
+    [TestCase("{}")]
+    [TestCase("[1,2,3]")]
+    [TestCase("{\"nested\":{\"key\":\"value\"}}")]
+    [TestCase("hello world")]
+    [TestCase("123")]
+    public void ToEditor_Returns_Raw_String_For_Json_Looking_Values(string storedValue)
+    {
+        var result = ToEditor(storedValue);
+
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<string>(result);
+        Assert.AreEqual(storedValue, result);
+    }
+
+    [Test]
+    public void ToEditor_Returns_Null_Or_Empty_For_Null_Value()
+    {
+        var result = ToEditor(null);
+        Assert.That(result is null or (string and ""), Is.True);
+    }
+
+    private static object? ToEditor(object? value)
+    {
+        var property = new Mock<IProperty>();
+        property
+            .Setup(x => x.GetValue(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Returns(value);
+
+        return CreateValueEditor().ToEditor(property.Object);
+    }
+
+    private static IDataValueEditor CreateValueEditor()
+    {
+        var attribute = new DataEditorAttribute("Umbraco.Plain.String");
+        return new TextOnlyValueEditor(
+            attribute,
+            Mock.Of<ILocalizedTextService>(),
+            Mock.Of<IShortStringHelper>(),
+            Mock.Of<IJsonSerializer>(),
+            Mock.Of<IIOHelper>());
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

This fixes #23180 

### Description

**The Issue:** Saving valid JSON (e.g., `{"test":"test"}`) in a Code Editor property and then reloading the page causes a crash with `TypeError: t.create is not a function`. The editor fails to display or let you edit the value.

**The Cause:** The Management API deserializes property values using `System.Text.Json`. When a Code Editor value contains valid JSON, the API returns it as a parsed JSON object rather than a raw string. Monaco's text model expects a string, so it crashes when receiving an object.

**The Fix:** Added defensive type checking in the Code Editor property editor's render method. If the value is not a string (i.e., the API deserialized it into an object), it is converted back to a formatted JSON string using `JSON.stringify(value, null, 2)` before passing to Monaco.

### Visual Proof (before fix):

<img width="1898" height="938" alt="Before_adding_fix_for_codeEditor" src="https://github.com/user-attachments/assets/a7e520f7-3d3b-4845-998a-b32a1a2918a0" />


### Visual Proof (after fix):

<img width="1895" height="938" alt="After_adding_fix_for_codeEditor" src="https://github.com/user-attachments/assets/491c3907-d602-4722-b96c-f40b7c93a1d2" />


### How to test

1. Go to Settings → Document Types → create/edit a document type.
2. Add a property with the **Code Editor** property editor.
3. Save the document type.
4. Go to Content → create/open a node of that type.
5. In the Code Editor, type `{"test":"test"}` and save.
6. Reload the page (F5).
7. The Code Editor should display the JSON value correctly (pretty-printed).
8. You should be able to edit it without errors.

Also verify these values work: `{}`, `[1,2,3]`, `{"nested":{"key":"value"}}`, `123`, `hello world`.
