### PR TITLE
Migration fix for #23224 Converting RichText Block Udis to Keys

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -99,6 +99,9 @@ public partial class UmbracoPlan : MigrationPlan
         To<V_17_4_0.AddExternalMemberTables>("{D7E8F9A0-B1C2-4D3E-A5F6-7890ABCDEF12}");
         To<V_17_4_0.FixLabelDataTypeDbTypeFromConfiguration>("{3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}");
 
+        // To 17.5.0
+        To<V_17_5_0.ConvertRichTextBlockUdisToKeys>("{C1A9F4E2-6B73-4D85-9E1A-2F0B8C3D5A41}");
+
         // To 18.0.0
         To<V_18_0_0.AddElementContainerPermissions>("{D00BB11A-DDF8-47C4-B58E-150C123BB3BB}");
         To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_5_0/ConvertRichTextBlockUdisToKeys.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_5_0/ConvertRichTextBlockUdisToKeys.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Text.RegularExpressions;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Persistence.SqlSyntax;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_5_0;
+
+/// <summary>
+/// Converts legacy Rich Text Editor block references stored in property data from the deprecated
+/// <c>data-content-udi="umb://element/{guid}"</c> attribute to the current
+/// <c>data-content-key="{guid}"</c> attribute.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before the new (Tiptap) Rich Text Editor, in-line and block-level RTE blocks were persisted in the
+/// <c>markup</c> with a <c>data-content-udi</c> attribute holding a full entity identifier
+/// (<c>umb://element/{guid-without-dashes}</c>). The current editor and the server-side value parser
+/// (<c>RichTextParsingRegexes.BlockRegex</c>) only recognise <c>data-content-key="{guid-with-dashes}"</c>,
+/// where the key matches <c>blocks.contentData[].key</c>.
+/// </para>
+/// <para>
+/// When the attribute is left in the legacy form the blocks can no longer be matched to their content, so
+/// they fall out-of-band: on load they are hoisted out of the text flow and the surrounding markup collapses.
+/// This migration rewrites the attribute in every affected property value.
+/// </para>
+/// <para>
+/// The conversion is performed as a string replacement directly against <c>umbracoPropertyData.textValue</c>
+/// so it is agnostic of the hosting property editor and works at any nesting depth (for example a Rich Text
+/// Editor nested inside a Block List or Block Grid). It is idempotent: once an attribute has been converted to
+/// <c>data-content-key</c> it is no longer matched.
+/// </para>
+/// </remarks>
+public partial class ConvertRichTextBlockUdisToKeys : AsyncMigrationBase
+{
+    // The legacy attribute is only ever emitted in Rich Text Editor block markup, which makes it a safe and
+    // selective filter for the rows we need to inspect.
+    private const string LegacyAttribute = "data-content-udi=";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConvertRichTextBlockUdisToKeys"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public ConvertRichTextBlockUdisToKeys(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override Task MigrateAsync() => ExecuteMigration(Database);
+
+    /// <summary>
+    /// Performs the migration: rewrites legacy <c>data-content-udi</c> Rich Text Editor block references to the
+    /// current <c>data-content-key</c> form in every property data row that contains them.
+    /// </summary>
+    /// <remarks>Extracted into an internal static method to support integration testing.</remarks>
+    internal static async Task ExecuteMigration(IUmbracoDatabase database)
+    {
+        // On large umbracoPropertyData tables the scan/update could exceed the default command timeout.
+        EnsureLongCommandTimeout(database);
+
+        ISqlSyntaxProvider syntax = database.SqlContext.SqlSyntax;
+        var table = syntax.GetQuotedTableName(PropertyDataDto.TableName);
+        var idColumn = syntax.GetQuotedColumnName(PropertyDataDto.PrimaryKeyColumnName);
+        var textValueColumn = syntax.GetQuotedColumnName(PropertyDataDto.TextValueColumnName);
+
+        Sql<ISqlContext> selectSql = database.SqlContext.Sql(
+            $"SELECT {idColumn}, {textValueColumn} FROM {table} WHERE {textValueColumn} LIKE @0",
+            $"%{LegacyAttribute}%");
+
+        List<PropertyDataDto> rows = await database.FetchAsync<PropertyDataDto>(selectSql);
+
+        foreach (PropertyDataDto row in rows)
+        {
+            if (string.IsNullOrEmpty(row.TextValue))
+            {
+                continue;
+            }
+
+            var converted = ConvertLegacyBlockReferences(row.TextValue);
+            if (string.Equals(converted, row.TextValue, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Sql<ISqlContext> updateSql = database.SqlContext.Sql(
+                $"UPDATE {table} SET {textValueColumn} = @0 WHERE {idColumn} = @1",
+                converted,
+                row.Id);
+
+            await database.ExecuteAsync(updateSql);
+        }
+    }
+
+    /// <summary>
+    /// Rewrites every legacy <c>data-content-udi="umb://element/{guid}"</c> Rich Text Editor block reference in the
+    /// supplied value to <c>data-content-key="{guid}"</c>, normalising the identifier to the dashed GUID form used
+    /// by <c>blocks.contentData[].key</c>.
+    /// </summary>
+    /// <param name="value">The raw property data value (typically the serialized Rich Text Editor value JSON).</param>
+    /// <returns>The value with all legacy block references converted.</returns>
+    /// <remarks>
+    /// The captured <c>esc</c> group preserves any JSON-escaping backslashes in front of the attribute's quotes, so
+    /// the same replacement works whether the markup is stored directly or nested (and therefore escaped multiple
+    /// times) inside another editor's value.
+    /// </remarks>
+    internal static string ConvertLegacyBlockReferences(string value)
+        => LegacyBlockReferenceRegex().Replace(value, static match =>
+        {
+            var quote = match.Groups["q"].Value;
+            var key = Guid.Parse(match.Groups["guid"].Value).ToString("D");
+            return $"data-content-key={quote}{key}{quote}";
+        });
+
+    // The attribute-value quote is whatever delimiter the stored markup uses, captured so it can be
+    // reproduced verbatim on both sides. Depending on how the value was serialized (and how deeply it
+    // is nested) that delimiter may be a literal quote, a JSON-escaped quote (\") or a unicode-escaped
+    // quote ("), each optionally preceded by extra escaping backslashes when nested.
+    [GeneratedRegex("data-content-udi=(?<q>\\\\*(?:u0022|\"))umb://element/(?<guid>[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12})\\k<q>")]
+    private static partial Regex LegacyBlockReferenceRegex();
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_5_0/ConvertRichTextBlockUdisToKeysTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_5_0/ConvertRichTextBlockUdisToKeysTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NPoco;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_5_0;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V17_5_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class ConvertRichTextBlockUdisToKeysTests : UmbracoIntegrationTest
+{
+    // Mirrors the real stored format: the markup's attribute quotes are serialized as the JSON unicode
+    // escape (backslash + u0022), written here with a doubled backslash so the literal sequence is stored.
+    private const string LegacyValue =
+        "{\"markup\":\"<p><umb-rte-block-inline data-content-udi=\\u0022umb://element/ccda6d01e3cd44dd883fdf9f5c84d3a7\\u0022></umb-rte-block-inline></p>\",\"blocks\":{}}";
+
+    private const string MigratedValue =
+        "{\"markup\":\"<p><umb-rte-block-inline data-content-key=\\u0022ccda6d01-e3cd-44dd-883f-df9f5c84d3a7\\u0022></umb-rte-block-inline></p>\",\"blocks\":{}}";
+
+    private IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
+
+    private PropertyEditorCollection PropertyEditors => GetRequiredService<PropertyEditorCollection>();
+
+    private IConfigurationEditorJsonSerializer ConfigurationEditorJsonSerializer
+        => GetRequiredService<IConfigurationEditorJsonSerializer>();
+
+    [Test]
+    public async Task Converts_Legacy_Block_Reference_In_TextValue()
+    {
+        var propertyTypeId = await CreatePropertyDataWithValue(LegacyValue);
+
+        await ExecuteMigration();
+
+        await AssertTextValue(propertyTypeId, MigratedValue);
+    }
+
+    [Test]
+    public async Task Leaves_Already_Migrated_Value_Untouched()
+    {
+        var propertyTypeId = await CreatePropertyDataWithValue(MigratedValue);
+
+        await ExecuteMigration();
+
+        await AssertTextValue(propertyTypeId, MigratedValue);
+    }
+
+    private async Task<int> CreatePropertyDataWithValue(string textValue)
+    {
+        IDataType dataType = await CreateRichTextDataType();
+        IContentType contentType = await CreateContentTypeWithProperty(dataType);
+        IContent content = await CreateContent(contentType);
+
+        var propertyTypeId = contentType.PropertyTypes.Single(pt => pt.Alias == "bodyText").Id;
+        await InsertPropertyDataTextValue(content.Id, propertyTypeId, textValue);
+
+        return propertyTypeId;
+    }
+
+    private async Task<IDataType> CreateRichTextDataType()
+    {
+        IDataEditor editor = PropertyEditors.First(e => e.Alias == Constants.PropertyEditors.Aliases.RichText);
+        var dataType = new DataType(editor, ConfigurationEditorJsonSerializer)
+        {
+            Name = "Test Rich Text",
+            DatabaseType = ValueStorageType.Ntext,
+        };
+
+        await DataTypeService.CreateAsync(dataType, Constants.Security.SuperUserKey);
+        return (await DataTypeService.GetAsync(dataType.Key))!;
+    }
+
+    private async Task<IContentType> CreateContentTypeWithProperty(IDataType dataType)
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("migrationTestContentType")
+            .WithName("Migration Test Content Type")
+            .WithIsElement(false)
+            .AddPropertyType()
+                .WithAlias("bodyText")
+                .WithName("Body Text")
+                .WithDataTypeId(dataType.Id)
+                .Done()
+            .Build();
+        contentType.AllowedAsRoot = true;
+
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+        return (await ContentTypeService.GetAsync(contentType.Key))!;
+    }
+
+    private async Task<IContent> CreateContent(IContentType contentType)
+    {
+        var createModel = new ContentCreateModel
+        {
+            Key = Guid.NewGuid(),
+            ContentTypeKey = contentType.Key,
+            ParentKey = Constants.System.RootKey,
+            Variants = [new VariantModel { Name = "Migration Test Content" }],
+        };
+
+        var result = await ContentEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey);
+        Assert.IsTrue(result.Success, $"Failed to create content: {result.Status}");
+        return result.Result.Content!;
+    }
+
+    private async Task InsertPropertyDataTextValue(int contentId, int propertyTypeId, string value)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+
+        var versionId = await scope.Database.ExecuteScalarAsync<int>(
+            "SELECT id FROM umbracoContentVersion WHERE nodeId = @0 AND [current] = 1",
+            contentId);
+
+        var propertyDataDto = new PropertyDataDto
+        {
+            VersionId = versionId,
+            PropertyTypeId = propertyTypeId,
+            LanguageId = null,
+            Segment = null,
+            TextValue = value,
+        };
+        await scope.Database.InsertAsync(propertyDataDto);
+
+        scope.Complete();
+    }
+
+    private async Task AssertTextValue(int propertyTypeId, string expected)
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+        var actual = await scope.Database.ExecuteScalarAsync<string>(
+            "SELECT textValue FROM umbracoPropertyData WHERE propertyTypeId = @0",
+            propertyTypeId);
+        scope.Complete();
+        Assert.AreEqual(expected, actual);
+    }
+
+    private async Task ExecuteMigration()
+    {
+        using IScope scope = ScopeProvider.CreateScope();
+        await ConvertRichTextBlockUdisToKeys.ExecuteMigration(scope.Database);
+        scope.Complete();
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/Upgrade/V_17_5_0/ConvertRichTextBlockUdisToKeysTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/Upgrade/V_17_5_0/ConvertRichTextBlockUdisToKeysTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_5_0;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Migrations.Upgrade.V_17_5_0;
+
+[TestFixture]
+public class ConvertRichTextBlockUdisToKeysTests
+{
+    private const string LegacyKey = "ccda6d01e3cd44dd883fdf9f5c84d3a7";
+    private const string DashedKey = "ccda6d01-e3cd-44dd-883f-df9f5c84d3a7";
+
+    // The JSON unicode escape for a double quote: backslash + "u0022". Built with a doubled backslash so the
+    // literal six-character sequence ends up in the string.
+    private const string U = "\\u0022";        // "   (one nesting level)
+    private const string Uu = "\\\\u0022";      // \\u0022  (nested one level deeper)
+
+    private static string Convert(string value) => ConvertRichTextBlockUdisToKeys.ConvertLegacyBlockReferences(value);
+
+    [Test]
+    public void Converts_Inline_Block_Reference()
+    {
+        var input = $"<p><umb-rte-block-inline data-content-udi=\"umb://element/{LegacyKey}\"><!--Umbraco-Block--></umb-rte-block-inline></p>";
+        var expected = $"<p><umb-rte-block-inline data-content-key=\"{DashedKey}\"><!--Umbraco-Block--></umb-rte-block-inline></p>";
+
+        Assert.AreEqual(expected, Convert(input));
+    }
+
+    [Test]
+    public void Converts_Block_Level_Reference()
+    {
+        var input = $"<umb-rte-block data-content-udi=\"umb://element/{LegacyKey}\"><!--Umbraco-Block--></umb-rte-block>";
+        var expected = $"<umb-rte-block data-content-key=\"{DashedKey}\"><!--Umbraco-Block--></umb-rte-block>";
+
+        Assert.AreEqual(expected, Convert(input));
+    }
+
+    [Test]
+    public void Converts_Reference_With_Class_Attribute_Preserved()
+    {
+        var input = $"<umb-rte-block-inline class=\"foo\" data-content-udi=\"umb://element/{LegacyKey}\"></umb-rte-block-inline>";
+        var expected = $"<umb-rte-block-inline class=\"foo\" data-content-key=\"{DashedKey}\"></umb-rte-block-inline>";
+
+        Assert.AreEqual(expected, Convert(input));
+    }
+
+    [Test]
+    public void Converts_All_References_In_Value()
+    {
+        var input =
+            "<umb-rte-block-inline data-content-udi=\"umb://element/7b28c91c65324912b9f799df6a52fc65\"></umb-rte-block-inline>" +
+            "some text" +
+            "<umb-rte-block-inline data-content-udi=\"umb://element/9134954467c44e4ca6c45b8d9392c707\"></umb-rte-block-inline>";
+
+        var result = Convert(input);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Does.Contain("data-content-key=\"7b28c91c-6532-4912-b9f7-99df6a52fc65\""));
+            Assert.That(result, Does.Contain("data-content-key=\"91349544-67c4-4e4c-a6c4-5b8d9392c707\""));
+            Assert.That(result, Does.Not.Contain("data-content-udi"));
+        });
+    }
+
+    [Test]
+    public void Preserves_Single_Level_Json_Escaping()
+    {
+        // As stored directly in umbracoPropertyData.textValue: the markup lives inside a JSON string, so the
+        // attribute quotes are escaped once (\").
+        var input = $@"{{""markup"":""<p><umb-rte-block-inline data-content-udi=\""umb://element/{LegacyKey}\""></umb-rte-block-inline></p>""}}";
+        var expected = $@"{{""markup"":""<p><umb-rte-block-inline data-content-key=\""{DashedKey}\""></umb-rte-block-inline></p>""}}";
+
+        Assert.AreEqual(expected, Convert(input));
+    }
+
+    [Test]
+    public void Preserves_Nested_Double_Level_Json_Escaping()
+    {
+        // When a Rich Text Editor is nested inside another editor (e.g. a Block List) its markup is escaped
+        // twice (\\\"). The leading backslash run must be preserved identically on both quotes.
+        var input = $@"data-content-udi=\\\""umb://element/{LegacyKey}\\\""";
+        var expected = $@"data-content-key=\\\""{DashedKey}\\\""";
+
+        Assert.AreEqual(expected, Convert(input));
+    }
+
+    [Test]
+    public void Converts_When_Quote_Is_Unicode_Escaped()
+    {
+        // Real-world form: the attribute quote is serialized as the JSON unicode escape (backslash u0022)
+        // rather than as an escaped double-quote.
+        var input = $"<umb-rte-block-inline data-content-udi={U}umb://element/{LegacyKey}{U}></umb-rte-block-inline>";
+        var expected = $"<umb-rte-block-inline data-content-key={U}{DashedKey}{U}></umb-rte-block-inline>";
+
+        Assert.AreEqual(expected, Convert(input));
+    }
+
+    [Test]
+    public void Converts_When_Quote_Is_Nested_Unicode_Escaped()
+    {
+        // Nested one level deeper: the unicode-escaped quote gains an extra escaping backslash.
+        var input = $"data-content-udi={Uu}umb://element/{LegacyKey}{Uu}";
+        var expected = $"data-content-key={Uu}{DashedKey}{Uu}";
+
+        Assert.AreEqual(expected, Convert(input));
+    }
+
+    [Test]
+    public void Leaves_Malformed_Identifier_Untouched()
+    {
+        const string input = "<umb-rte-block-inline data-content-udi=\"umb://element/not-a-guid\"></umb-rte-block-inline>";
+
+        Assert.AreEqual(input, Convert(input));
+    }
+
+    [Test]
+    public void Is_Idempotent()
+    {
+        var alreadyMigrated = $"<umb-rte-block-inline data-content-key=\"{DashedKey}\"></umb-rte-block-inline>";
+
+        Assert.AreEqual(alreadyMigrated, Convert(alreadyMigrated));
+    }
+
+    [Test]
+    public void Leaves_Value_Without_Block_References_Untouched()
+    {
+        const string input = "<p>Just some <strong>rich</strong> text with no blocks.</p>";
+
+        Assert.AreEqual(input, Convert(input));
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23224 

**This is a draft/proposed PR to resolve the above existing issue - Umbraco team may want to "move" the migration to earlier in the steps or update an existing migration**. As Claude generated the code, there may be better ways to resolve this!

### Description

Sites upgraded from v13 to the new (Tiptap) Rich Text Editor can end up with **half-migrated** RTE block values: `blocks.contentData[].key` is stored in the new dashed-GUID format, but the `markup` still references blocks with the deprecated **`data-content-udi="umb://element/{guid}"`** attribute.

The v14+ editor and the server-side parser (`RichTextParsingRegexes.BlockRegex`) only recognise `data-content-key="{dashed-guid}"`, and there is no backwards-compatibility handling for `data-content-udi`. As a result the inline/block placeholders never bind to their content: on load the blocks are hoisted out of the text flow and the surrounding markup collapses, and saving the content then drops the blocks entirely.

This PR adds an upgrade migration that rewrites the legacy attribute in stored property data:

```
data-content-udi="umb://element/{guid}"  →  data-content-key="{dashed-guid}"
```

### Approach

The conversion is a string replacement performed directly against `umbracoPropertyData.textValue`, which makes it:

- **Editor-agnostic and nesting-agnostic** — it also fixes Rich Text Editors nested inside a Block List / Block Grid at any depth, because the legacy attribute only ever appears in RTE block markup.
- **Tolerant of the stored quote form** — depending on how the value was serialized (and how deeply it is nested) the attribute-value quote may be stored as a literal `"`, an escaped quote `\"`, or a **unicode escape `"`**, each optionally preceded by extra escaping backslashes. The regex captures the delimiter and reproduces it verbatim on both sides, so the stored JSON stays valid:

  ```
  data-content-udi=(?<q>\\*(?:u0022|"))umb://element/(?<guid>…)\k<q>
  ```

- **Idempotent** — once an attribute is `data-content-key` it is no longer matched, so the migration is safe to re-run.

The identifier is normalised to the dashed GUID form (`Guid.Parse(...).ToString("D")`) so it matches `blocks.contentData[].key`.

### Files

- `src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_5_0/ConvertRichTextBlockUdisToKeys.cs` — the migration (`AsyncMigrationBase`), with a testable static `ConvertLegacyBlockReferences` helper.
- `src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs` — registered as a `// To 17.5.0` step.
- `tests/Umbraco.Tests.UnitTests/.../V_17_5_0/ConvertRichTextBlockUdisToKeysTests.cs` — unit tests for the transform.
- `tests/Umbraco.Tests.Integration/.../V_17_5_0/ConvertRichTextBlockUdisToKeysTests.cs` — DB round-trip test.

> **Branch note:** the migration is placed in a `V_17_5_0` folder targeting the 17 release line; it is currently on a `main`-based branch and may need rebasing onto the appropriate 17.x branch.

### How to test

1. On Umbraco 13, create a Rich Text Editor (with blocks) property, and add content with text interleaved with inline and/or block-level blocks.
2. Upgrade the site to a build containing this PR.
3. On startup the migration runs as part of the upgrade.
4. Confirm the blocks render in their original in-line positions in the editor and on the front-end, and that the stored `markup` now uses `data-content-key`.

To confirm via SQL that no legacy references remain:

```sql
SELECT COUNT(*) FROM umbracoPropertyData WHERE textValue LIKE '%data-content-udi=%';  -- expect 0
```

### Tests

- Unit tests cover: inline and block-level references, preserved `class` attribute, multiple references per value, single- and double-level JSON escaping, the real-world `"` (and nested `\\u0022`) unicode-escaped quote form, malformed identifiers left untouched, idempotency, and no-op values.
- Integration test inserts a property-data value in the real stored (`"`) format, runs the migration, and asserts the conversion (and that an already-migrated value is untouched).

All passing locally (unit + integration).

### Notes / questions for reviewers

- The migration sweeps every property-data row whose `textValue` contains the legacy attribute (current and historic versions), rather than restricting to specific editors — this is intentional so nested cases are covered. Happy to scope it to current/published versions only if preferred.
- The regex accepts both 32-char and dashed GUIDs in the source attribute and normalises to dashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)