### PR TITLE
Caching: Extend in-memory cache observability and stale-set guard to elements

### DIFF
--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.cs
@@ -390,6 +390,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             Services.AddUnique<ElementNavigationService, ElementNavigationService>();
             Services.AddUnique<IElementNavigationQueryService>(x => x.GetRequiredService<ElementNavigationService>());
             Services.AddUnique<IElementNavigationManagementService>(x => x.GetRequiredService<ElementNavigationService>());
+            Services.AddSingleton<IMemoryCacheSizeReporter>(x => x.GetRequiredService<ElementNavigationService>());
 
             Services.AddUnique<DocumentPublishStatusService, DocumentPublishStatusService>();
             Services.AddUnique<IDocumentPublishStatusQueryService>(x => x.GetRequiredService<DocumentPublishStatusService>());

--- a/src/Umbraco.Core/Services/Navigation/ElementNavigationService.cs
+++ b/src/Umbraco.Core/Services/Navigation/ElementNavigationService.cs
@@ -1,3 +1,4 @@
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Scoping;
@@ -18,13 +19,23 @@ namespace Umbraco.Cms.Core.Services.Navigation;
 internal sealed class ElementNavigationService :
     ContentNavigationServiceBase<IContentType, IContentTypeService>,
     IElementNavigationQueryService,
-    IElementNavigationManagementService
+    IElementNavigationManagementService,
+    IMemoryCacheSizeReporter
 {
     private static readonly Guid[] ElementObjectTypes =
     [
         Constants.ObjectTypes.Element,
         Constants.ObjectTypes.ElementContainer,
     ];
+
+    /// <inheritdoc />
+    public string CacheName => "Element navigation";
+
+    /// <inheritdoc />
+    public long GetApproximateCount() => GetNavigationNodeCount();
+
+    /// <inheritdoc />
+    public long? GetApproximateBytes() => GetNavigationApproximateBytes();
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="ElementNavigationService"/> class.

--- a/src/Umbraco.PublishedCache.HybridCache/CLAUDE.md
+++ b/src/Umbraco.PublishedCache.HybridCache/CLAUDE.md
@@ -275,9 +275,10 @@ Before returning cached content, verifies ancestor path is published via `_publi
 
 ### In-Memory Content Cache (the L0 converted-content cache)
 
-The converted `IPublishedContent` objects are cached in `ConvertedPublishedContentCache<TKey>`
-(`Services/ConvertedPublishedContentCache.cs`), used by `DocumentCacheService` (`<string>`) and
-`MediaCacheService` (`<Guid>`), since `ContentCacheNode` → `IPublishedContent` conversion is expensive.
+The converted `IPublishedElement` objects are cached in `ConvertedPublishedContentCache<TKey, TValue>`
+(`Services/ConvertedPublishedContentCache.cs`), used by `DocumentCacheService` (`<string, IPublishedContent>`),
+`MediaCacheService` (`<Guid, IPublishedContent>`) and `ElementCacheService` (`<string, IPublishedElement>`),
+since `ContentCacheNode` → `IPublishedElement`/`IPublishedContent` conversion is expensive.
 This is the single insert/remove/clear path for the L0 cache (the seam a later bounded/eviction-aware
 implementation slots into), and it tracks both the entry count and an approximate retained byte total.
 The cache is currently **unbounded** — only evicted on content change / explicit clear, so walking the
@@ -294,8 +295,9 @@ The in-memory structures whose footprint scales with the size of the content tre
 |------------------------|-----------|---------------|
 | `Published content (converted, L0)` | `DocumentCacheService` L0 cache | running total of per-entry node-size estimates |
 | `Published media (converted, L0)` | `MediaCacheService` L0 cache | running total of per-entry node-size estimates |
+| `Published elements (converted, L0)` | `ElementCacheService` L0 cache | running total of per-entry node-size estimates |
 | `Document URL segments` | `DocumentUrlService._documentUrlCache` (≈ documents × cultures × draft/published) | sampled structural estimate |
-| `Document navigation` / `Media navigation` | the in-memory navigation trees (active + recycle bin) | sampled structural estimate |
+| `Document navigation` / `Media navigation` / `Element navigation` | the in-memory navigation trees (active + recycle bin) | sampled structural estimate |
 
 `MemoryCacheSizeReportingJob` (a recurring job, all server roles, 1-minute period) logs each count and byte
 estimate plus `GC.GetTotalMemory` and `Environment.WorkingSet` **at `Debug` level** — enable `Debug` for

--- a/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/DependencyInjection/UmbracoBuilderExtensions.cs
@@ -52,7 +52,9 @@ public static class UmbracoBuilderExtensions
         builder.Services.AddSingleton<IMemoryCacheSizeReporter>(s => s.GetRequiredService<DocumentCacheService>());
         builder.Services.AddSingleton<IMemoryCacheSizeReporter>(s => s.GetRequiredService<MediaCacheService>());
         builder.Services.AddSingleton<IMemberCacheService, MemberCacheService>();
-        builder.Services.AddSingleton<IElementCacheService, ElementCacheService>();
+        builder.Services.AddSingleton<ElementCacheService>();
+        builder.Services.AddSingleton<IElementCacheService>(s => s.GetRequiredService<ElementCacheService>());
+        builder.Services.AddSingleton<IMemoryCacheSizeReporter>(s => s.GetRequiredService<ElementCacheService>());
         builder.Services.AddSingleton<IBlockElementService, BlockElementService>();
         builder.Services.AddSingleton<IDomainCacheService, DomainCacheService>();
         builder.Services.AddSingleton<IPublishedContentFactory, PublishedContentFactory>();

--- a/src/Umbraco.PublishedCache.HybridCache/Services/ConvertedPublishedContentCache.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/ConvertedPublishedContentCache.cs
@@ -4,7 +4,7 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
 /// <summary>
-///     Encapsulates the in-process (L0) cache of converted <see cref="IPublishedContent" /> behind a single
+///     Encapsulates the in-process (L0) cache of converted <see cref="IPublishedElement" /> behind a single
 ///     insert/remove/clear path, tracking both the entry count and an approximate retained byte total.
 /// </summary>
 /// <remarks>
@@ -14,9 +14,11 @@ namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 ///     without locking the whole structure), suitable for diagnostics, not exact accounting.
 ///     This is also the seam the later bounded/eviction-aware implementation slots into.
 /// </remarks>
-/// <typeparam name="TKey">The cache key type (string for documents, Guid for media).</typeparam>
-internal sealed class ConvertedPublishedContentCache<TKey>
+/// <typeparam name="TKey">The cache key type.</typeparam>
+/// <typeparam name="TValue">The cached converted type.</typeparam>
+internal sealed class ConvertedPublishedContentCache<TKey, TValue>
     where TKey : notnull
+    where TValue : class, IPublishedElement
 {
     private readonly ConcurrentDictionary<TKey, CacheEntry> _cache = new();
     private long _approximateSizeInBytes;
@@ -34,7 +36,7 @@ internal sealed class ConvertedPublishedContentCache<TKey>
     /// <summary>
     ///     Attempts to get a cached converted content item.
     /// </summary>
-    public bool TryGet(TKey key, out IPublishedContent? content)
+    public bool TryGet(TKey key, out TValue? content)
     {
         if (_cache.TryGetValue(key, out CacheEntry entry))
         {
@@ -50,7 +52,7 @@ internal sealed class ConvertedPublishedContentCache<TKey>
     ///     Adds or replaces a cached converted content item, adjusting the running byte total by the supplied
     ///     per-entry size estimate.
     /// </summary>
-    public void Set(TKey key, IPublishedContent content, long approximateSizeInBytes)
+    public void Set(TKey key, TValue content, long approximateSizeInBytes)
     {
         var entry = new CacheEntry(content, approximateSizeInBytes);
 
@@ -84,7 +86,7 @@ internal sealed class ConvertedPublishedContentCache<TKey>
     /// <summary>
     ///     Removes every entry whose content matches the predicate, subtracting their sizes from the total.
     /// </summary>
-    public void RemoveWhere(Func<IPublishedContent, bool> predicate)
+    public void RemoveWhere(Func<TValue, bool> predicate)
     {
         foreach (KeyValuePair<TKey, CacheEntry> kvp in _cache)
         {
@@ -104,5 +106,5 @@ internal sealed class ConvertedPublishedContentCache<TKey>
         Interlocked.Exchange(ref _approximateSizeInBytes, 0);
     }
 
-    private readonly record struct CacheEntry(IPublishedContent Content, long Size);
+    private readonly record struct CacheEntry(TValue Content, long Size);
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/DocumentCacheService.cs
@@ -36,7 +36,7 @@ internal sealed class DocumentCacheService : IDocumentCacheService, IMemoryCache
     private readonly ILogger<DocumentCacheService> _logger;
     private HashSet<Guid>? _seedKeys;
 
-    private readonly ConvertedPublishedContentCache<string> _publishedContentCache = new();
+    private readonly ConvertedPublishedContentCache<string, IPublishedContent> _publishedContentCache = new();
 
     // Monotonic counter bumped whenever the in-memory cache (L0/L1) is invalidated or refreshed.
     // GetNodeAsync captures it before reading the backing store and re-checks it before writing

--- a/src/Umbraco.PublishedCache.HybridCache/Services/ElementCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/ElementCacheService.cs
@@ -1,8 +1,8 @@
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -16,7 +16,7 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.HybridCache.Services;
 
-internal sealed class ElementCacheService : IElementCacheService
+internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSizeReporter
 {
     private readonly IDatabaseCacheRepository _databaseCacheRepository;
     private readonly ICoreScopeProvider _scopeProvider;
@@ -30,7 +30,7 @@ internal sealed class ElementCacheService : IElementCacheService
     private readonly ILogger<ElementCacheService> _logger;
     private HashSet<Guid>? _seedKeys;
 
-    private readonly ConcurrentDictionary<string, IPublishedElement> _publishedElementCache = [];
+    private readonly ConvertedPublishedContentCache<string, IPublishedElement> _publishedElementCache = new();
 
     private HashSet<Guid> SeedKeys
     {
@@ -76,6 +76,15 @@ internal sealed class ElementCacheService : IElementCacheService
         _logger = logger;
     }
 
+    /// <inheritdoc />
+    public string CacheName => "Published elements (converted, L0)";
+
+    /// <inheritdoc />
+    public long GetApproximateCount() => _publishedElementCache.Count;
+
+    /// <inheritdoc />
+    public long? GetApproximateBytes() => _publishedElementCache.ApproximateSizeInBytes;
+
     public async Task<IPublishedElement?> GetByKeyAsync(Guid key, bool? preview = null)
     {
         bool calculatedPreview = preview ?? _previewService.IsInPreview();
@@ -85,7 +94,7 @@ internal sealed class ElementCacheService : IElementCacheService
     public bool TryGetCached(Guid key, bool preview, out IPublishedElement? element)
     {
         // Mirror the L0 (published element cache) fast path in GetNodeAsync.
-        if (preview is false && _publishedElementCache.TryGetValue(GetCacheKey(key, preview), out element))
+        if (preview is false && _publishedElementCache.TryGet(GetCacheKey(key, preview), out element))
         {
             return true;
         }
@@ -98,7 +107,7 @@ internal sealed class ElementCacheService : IElementCacheService
     {
         var cacheKey = GetCacheKey(key, preview);
 
-        if (preview is false && _publishedElementCache.TryGetValue(cacheKey, out IPublishedElement? cached))
+        if (preview is false && _publishedElementCache.TryGet(cacheKey, out IPublishedElement? cached))
         {
             return cached;
         }
@@ -122,7 +131,10 @@ internal sealed class ElementCacheService : IElementCacheService
         IPublishedElement? result = _publishedContentFactory.ToIPublishedElement(contentCacheNode, preview)?.CreateModel(_publishedModelFactory);
         if (result is not null)
         {
-            _publishedElementCache[cacheKey] = result;
+            // The size estimate is cheap (O(properties), no IO/decompression) and only runs on the
+            // cache-miss path, so keeping the running total always-current means it is accurate the
+            // moment debug reporting is switched on.
+            _publishedElementCache.Set(cacheKey, result, ContentCacheNodeSizeEstimator.EstimateBytes(contentCacheNode));
         }
 
         return result;
@@ -240,7 +252,7 @@ internal sealed class ElementCacheService : IElementCacheService
         {
             var cacheKey = GetCacheKey(publishedNode.Key, false);
             await _hybridCache.SetAsync(cacheKey, publishedNode, GetEntryOptions(publishedNode.Key, false), GenerateTags(publishedNode));
-            _publishedElementCache.Remove(cacheKey, out _);
+            _publishedElementCache.Remove(cacheKey);
         }
         else
         {
@@ -325,7 +337,7 @@ internal sealed class ElementCacheService : IElementCacheService
     public void ClearConvertedContentCache(IReadOnlyCollection<int> elementTypeIds)
     {
         var ids = elementTypeIds as int[] ?? elementTypeIds.ToArray();
-        _publishedElementCache.RemoveAll(element => ids.Contains(element.Value.ContentType.Id));
+        _publishedElementCache.RemoveWhere(element => ids.Contains(element.ContentType.Id));
     }
 
     private static string GetCacheKey(Guid key, bool preview) => preview ? $"{key}+draft" : $"{key}";
@@ -373,7 +385,7 @@ internal sealed class ElementCacheService : IElementCacheService
     {
         var cacheKey = GetCacheKey(key, false);
         await _hybridCache.RemoveAsync(cacheKey);
-        _publishedElementCache.Remove(cacheKey, out _);
+        _publishedElementCache.Remove(cacheKey);
     }
 
     private static string ElementTypeIdTag(int elementTypeId)

--- a/src/Umbraco.PublishedCache.HybridCache/Services/ElementCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/ElementCacheService.cs
@@ -32,6 +32,20 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
 
     private readonly ConvertedPublishedContentCache<string, IPublishedElement> _publishedElementCache = new();
 
+    // Monotonic counter bumped whenever the in-memory cache (L0/L1) is invalidated or refreshed.
+    // GetNodeAsync captures it before reading the backing store and re-checks it before writing
+    // back, so a snapshot read before a concurrent refresh is never written over the refreshed
+    // entry — preventing the stale-set clobber that otherwise persists until a full clear.
+    //
+    // Deliberately a single global counter, not per-key: any invalidation invalidates every in-flight
+    // read-through. The only cost is an occasional skipped cache population when a read-through for one
+    // key overlaps an unrelated refresh — a re-miss on the next request, never stale data. A per-key
+    // scheme would avoid that but needs a global epoch for bulk clears plus an exact per-key bump on
+    // every mutated cache key, which is easy to get wrong and would silently reintroduce the clobber.
+    // Global is correctness-robust; only revisit if read-through churn under heavy concurrent
+    // refreshing ever shows up in profiling.
+    private long _cacheGeneration;
+
     private HashSet<Guid> SeedKeys
     {
         get
@@ -113,14 +127,31 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
         }
 
         (bool exists, ContentCacheNode? contentCacheNode) = await _hybridCache.TryGetValueAsync<ContentCacheNode?>(cacheKey, CancellationToken.None);
+
+        // A value found in the backing store is already current, so it can always populate the caches
+        // below; only a value built from the read-through DB fetch needs the generation guard.
+        bool snapshotIsCurrent = true;
         if (exists is false)
         {
+            // Capture the cache generation before reading the backing store. If a concurrent refresh or
+            // invalidation bumps the generation while we read and build below, the snapshot we hold is
+            // stale and must not be written back over the refreshed entries (the clobber that leaves
+            // memory permanently stale until a full clear).
+            long generation = Interlocked.Read(ref _cacheGeneration);
+
             contentCacheNode = await GetContentCacheNodeFromRepo();
-            await _hybridCache.SetAsync(
-                cacheKey,
-                contentCacheNode,
-                GetEntryOptions(key, preview),
-                GenerateTags(contentCacheNode));
+            snapshotIsCurrent = IsCacheGenerationCurrent(generation);
+
+            // Skip the write when the generation moved — a refresh has superseded this snapshot. A null
+            // node is still written when current (negative caching, tagged so it can be cleared).
+            if (snapshotIsCurrent)
+            {
+                await _hybridCache.SetAsync(
+                    cacheKey,
+                    contentCacheNode,
+                    GetEntryOptions(key, preview),
+                    GenerateTags(contentCacheNode));
+            }
         }
 
         if (contentCacheNode is null)
@@ -129,7 +160,10 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
         }
 
         IPublishedElement? result = _publishedContentFactory.ToIPublishedElement(contentCacheNode, preview)?.CreateModel(_publishedModelFactory);
-        if (result is not null)
+
+        // Only populate the L0 cache when our snapshot is still current; otherwise a concurrent
+        // refresh has already written fresher content and we must not overwrite it with this one.
+        if (result is not null && snapshotIsCurrent)
         {
             // The size estimate is cheap (O(properties), no IO/decompression) and only runs on the
             // cache-miss path, so keeping the running total always-current means it is accurate the
@@ -146,6 +180,13 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
         }
     }
 
+    // Bumped after every in-memory cache invalidation/refresh so in-flight read-through snapshots
+    // (see GetNodeAsync) can detect they have been superseded and skip writing back stale content.
+    private void InvalidateMemoryCacheGeneration() => Interlocked.Increment(ref _cacheGeneration);
+
+    private bool IsCacheGenerationCurrent(long capturedGeneration)
+        => Interlocked.Read(ref _cacheGeneration) == capturedGeneration;
+
     public IEnumerable<IPublishedElement> GetByContentType(IPublishedContentType contentType)
     {
         using ICoreScope scope = _scopeProvider.CreateCoreScope();
@@ -159,6 +200,10 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
 
     public async Task ClearMemoryCacheAsync(CancellationToken cancellationToken)
     {
+        // Bump first so any read-through that read the backing store before this clear is rejected
+        // when it tries to write back, even while the reseed below is still running.
+        InvalidateMemoryCacheGeneration();
+
         _publishedElementCache.Clear();
         await _hybridCache.RemoveByTagAsync(Constants.Cache.Tags.Element, cancellationToken);
 
@@ -253,10 +298,12 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
             var cacheKey = GetCacheKey(publishedNode.Key, false);
             await _hybridCache.SetAsync(cacheKey, publishedNode, GetEntryOptions(publishedNode.Key, false), GenerateTags(publishedNode));
             _publishedElementCache.Remove(cacheKey);
+            InvalidateMemoryCacheGeneration();
         }
         else
         {
-            // No published node in the database cache — remove any stale published entry from the local memory cache.
+            // No published node in the database cache — remove any stale published entry from the local
+            // memory cache. ClearPublishedCacheAsync bumps the generation itself, so this path is covered.
             await ClearPublishedCacheAsync(key);
         }
 
@@ -332,12 +379,17 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
         ClearConvertedContentCache(elementTypeIdsAsArray);
     }
 
-    public void ClearConvertedContentCache() => _publishedElementCache.Clear();
+    public void ClearConvertedContentCache()
+    {
+        _publishedElementCache.Clear();
+        InvalidateMemoryCacheGeneration();
+    }
 
     public void ClearConvertedContentCache(IReadOnlyCollection<int> elementTypeIds)
     {
         var ids = elementTypeIds as int[] ?? elementTypeIds.ToArray();
         _publishedElementCache.RemoveWhere(element => ids.Contains(element.ContentType.Id));
+        InvalidateMemoryCacheGeneration();
     }
 
     private static string GetCacheKey(Guid key, bool preview) => preview ? $"{key}+draft" : $"{key}";
@@ -386,6 +438,7 @@ internal sealed class ElementCacheService : IElementCacheService, IMemoryCacheSi
         var cacheKey = GetCacheKey(key, false);
         await _hybridCache.RemoveAsync(cacheKey);
         _publishedElementCache.Remove(cacheKey);
+        InvalidateMemoryCacheGeneration();
     }
 
     private static string ElementTypeIdTag(int elementTypeId)

--- a/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Services/MediaCacheService.cs
@@ -32,7 +32,7 @@ internal sealed class MediaCacheService : IMediaCacheService, IMemoryCacheSizeRe
     private readonly ILogger<MediaCacheService> _logger;
     private readonly CacheSettings _cacheSettings;
 
-    private readonly ConvertedPublishedContentCache<Guid> _publishedContentCache = new();
+    private readonly ConvertedPublishedContentCache<Guid, IPublishedContent> _publishedContentCache = new();
 
     // Monotonic counter bumped whenever the in-memory cache (L0/L1) is invalidated or refreshed.
     // GetNodeAsync captures it before reading the backing store and re-checks it before writing

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/ElementHybridCacheStaleSetRaceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/ElementHybridCacheStaleSetRaceTests.cs
@@ -1,0 +1,172 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.HybridCache;
+using Umbraco.Cms.Infrastructure.HybridCache.Factories;
+using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
+using Umbraco.Cms.Infrastructure.HybridCache.Services;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
+
+/// <summary>
+/// Reproduces the read-through "stale-set clobber" race in <see cref="ElementCacheService"/>:
+/// a request reads a pre-publish snapshot from the backing store and then writes it back into the
+/// in-memory cache *after* a concurrent publish has already refreshed it, leaving memory permanently
+/// stale (or, for Block List, empty) until a full cache clear. The generation guard must reject the
+/// stale write-back so the refreshed value survives.
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class ElementHybridCacheStaleSetRaceTests : UmbracoIntegrationTest
+{
+    private const string OldName = "Old Element";
+    private const string OldTitle = "Old Title";
+    private const string NewName = "New Element";
+    private const string NewTitle = "New Title";
+
+    private Mock<IDatabaseCacheRepository> _databaseCacheRepository;
+    private ElementCacheService _elementCacheService;
+    private Microsoft.Extensions.Caching.Hybrid.HybridCache _hybridCache;
+    private Element _element;
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder) => builder.AddUmbracoHybridCache();
+
+    private ContentCacheNode BuildPublishedNode(string name, string title)
+    {
+        var data = new ContentData(
+            name,
+            null,
+            1,
+            _element.UpdateDate,
+            _element.CreatorId,
+            -1,
+            true,
+            new Dictionary<string, PropertyData[]>
+            {
+                ["title"] = [new PropertyData { Culture = string.Empty, Segment = string.Empty, Value = title }],
+            },
+            null);
+
+        return new ContentCacheNode
+        {
+            ContentTypeId = _element.ContentTypeId,
+            CreatorId = _element.CreatorId,
+            CreateDate = _element.CreateDate,
+            Id = _element.Id,
+            Key = _element.Key,
+            SortOrder = 0,
+            Data = data,
+            IsDraft = false,
+        };
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        var elementType = ContentTypeBuilder.CreateSimpleElementType();
+        await GetRequiredService<IContentTypeService>().CreateAsync(elementType, Constants.Security.SuperUserKey);
+
+        _element = ElementBuilder.CreateSimpleElement(elementType);
+        GetRequiredService<IElementService>().Save(_element);
+
+        _databaseCacheRepository = new Mock<IDatabaseCacheRepository>();
+        _hybridCache = GetRequiredService<Microsoft.Extensions.Caching.Hybrid.HybridCache>();
+
+        _elementCacheService = new ElementCacheService(
+            _databaseCacheRepository.Object,
+            GetRequiredService<ICoreScopeProvider>(),
+            _hybridCache,
+            GetRequiredService<IPublishedContentFactory>(),
+            GetRequiredService<ICacheNodeFactory>(),
+            Array.Empty<IElementSeedKeyProvider>(),
+            GetRequiredService<IPublishedModelFactory>(),
+            GetRequiredService<IPreviewService>(),
+            GetRequiredService<IOptions<CacheSettings>>(),
+            new NullLogger<ElementCacheService>());
+    }
+
+    [Test]
+    public async Task Read_Through_Does_Not_Clobber_A_Concurrent_Refresh()
+    {
+        ContentCacheNode oldNode = BuildPublishedNode(OldName, OldTitle);
+        ContentCacheNode newNode = BuildPublishedNode(NewName, NewTitle);
+
+        // The first read-through reads the pre-publish (old) snapshot, then parks before writing back —
+        // simulating the request suspending on an await while a publish completes.
+        var readReachedDatabase = new TaskCompletionSource();
+        var releaseRead = new TaskCompletionSource();
+        _databaseCacheRepository
+            .Setup(x => x.GetElementSourceAsync(_element.Key, false))
+            .Returns(async () =>
+            {
+                readReachedDatabase.TrySetResult();
+                await releaseRead.Task;
+                return oldNode;
+            });
+
+        // The publish-time memory refresh reads the new snapshot from the database cache.
+        _databaseCacheRepository
+            .Setup(x => x.GetElementSourceForPublishStatesAsync(_element.Key))
+            .ReturnsAsync((null, newNode));
+
+        // Ensure the published entry is absent so the request below is a genuine read-through.
+        await _hybridCache.RemoveAsync($"{_element.Key}");
+
+        // 1. Start the request; it reads the old snapshot and parks before the cache write-back.
+        Task<IPublishedElement?> staleRead = Task.Run(() => _elementCacheService.GetByKeyAsync(_element.Key, false));
+        await readReachedDatabase.Task;
+
+        // 2. A publish refreshes the in-memory cache with the new snapshot (and bumps the generation).
+        await _elementCacheService.RefreshMemoryCacheAsync(_element.Key);
+
+        // 3. Let the parked request resume and perform its (now stale) write-back.
+        releaseRead.TrySetResult();
+        await staleRead;
+
+        // Verify the stale read (returns the old content)
+        var staleResult = staleRead.Result;
+        Assert.IsNotNull(staleResult);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(OldName, staleResult!.Name, "Name should be served from the stale snapshot.");
+            Assert.AreEqual(
+                OldTitle,
+                staleResult.GetProperty("title")?.GetSourceValue(),
+                "Property value should be served from the stale snapshot.");
+        });
+
+        // 4. A fresh lookup must observe the refreshed content, not the clobbered stale snapshot.
+        IPublishedElement? result = await _elementCacheService.GetByKeyAsync(_element.Key, false);
+
+        Assert.IsNotNull(result);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(NewName, result!.Name, "Name was served from the clobbered stale snapshot.");
+            Assert.AreEqual(
+                NewTitle,
+                result.GetProperty("title")?.GetSourceValue(),
+                "Property value was served from the clobbered stale snapshot.");
+        });
+
+        // Verify that the published node has been added to the hybrid cache using the assumed key.
+        var cachedNode = await _hybridCache.GetOrCreateAsync(
+            $"{_element.Key}",
+            _ => new ValueTask<ContentCacheNode?>((ContentCacheNode?)null));
+
+        Assert.IsNotNull(cachedNode);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(newNode.Key, cachedNode!.Key, "Cached node should be the refreshed node.");
+            Assert.AreEqual(NewName, cachedNode!.Data?.Name, "Cached node should hold the refreshed name.");
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/NavigationServiceMemoryReportingTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/NavigationServiceMemoryReportingTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.Navigation;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
+
+[TestFixture]
+public class NavigationServiceMemoryReportingTests
+{
+    [Test]
+    public void Can_Report_Cache_Name_For_Documents()
+        => Assert.That(AsReporter(CreateDocumentNavigationService()).CacheName, Is.EqualTo("Document navigation"));
+
+    [Test]
+    public void Can_Report_Cache_Name_For_Media()
+        => Assert.That(AsReporter(CreateMediaNavigationService()).CacheName, Is.EqualTo("Media navigation"));
+
+    [Test]
+    public void Can_Report_Cache_Name_For_Elements()
+        => Assert.That(AsReporter(CreateElementNavigationService()).CacheName, Is.EqualTo("Element navigation"));
+
+    [Test]
+    public void Can_Report_Node_Count_Including_Recycle_Bin_For_Documents()
+        => AssertReportsNodeCountIncludingRecycleBin(CreateDocumentNavigationService());
+
+    [Test]
+    public void Can_Report_Node_Count_Including_Recycle_Bin_For_Media()
+        => AssertReportsNodeCountIncludingRecycleBin(CreateMediaNavigationService());
+
+    [Test]
+    public void Can_Report_Node_Count_Including_Recycle_Bin_For_Elements()
+        => AssertReportsNodeCountIncludingRecycleBin(CreateElementNavigationService());
+
+    private static DocumentNavigationService CreateDocumentNavigationService()
+        => new(Mock.Of<ICoreScopeProvider>(), Mock.Of<INavigationRepository>(), Mock.Of<IContentTypeService>());
+
+    private static MediaNavigationService CreateMediaNavigationService()
+        => new(Mock.Of<ICoreScopeProvider>(), Mock.Of<INavigationRepository>(), Mock.Of<IMediaTypeService>());
+
+    private static ElementNavigationService CreateElementNavigationService()
+        => new(Mock.Of<ICoreScopeProvider>(), Mock.Of<INavigationRepository>(), Mock.Of<IContentTypeService>());
+
+    private static IMemoryCacheSizeReporter AsReporter(object service) => (IMemoryCacheSizeReporter)service;
+
+    private static void AssertReportsNodeCountIncludingRecycleBin<TContentType, TContentTypeService>(
+        ContentNavigationServiceBase<TContentType, TContentTypeService> sut)
+        where TContentType : class, IContentTypeComposition
+        where TContentTypeService : IContentTypeBaseService<TContentType>
+    {
+        var reporter = AsReporter(sut);
+
+        Assert.That(reporter.GetApproximateCount(), Is.EqualTo(0), "Expected an empty navigation tree to report zero nodes.");
+
+        var contentTypeKey = Guid.NewGuid();
+        var root = Guid.NewGuid();
+        var child = Guid.NewGuid();
+        sut.Add(root, contentTypeKey);
+        sut.Add(child, contentTypeKey, root);
+
+        Assert.That(reporter.GetApproximateCount(), Is.EqualTo(2), "Expected both added nodes to be counted.");
+
+        // Moving a node to the recycle bin must keep it counted — the reporter spans the active tree and the bin.
+        sut.MoveToBin(child);
+
+        Assert.That(reporter.GetApproximateCount(), Is.EqualTo(2), "Expected a binned node to still be counted (active tree + recycle bin).");
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HybridCache/ConvertedPublishedContentCacheTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/HybridCache/ConvertedPublishedContentCacheTests.cs
@@ -14,7 +14,7 @@ public class ConvertedPublishedContentCacheTests
     [Test]
     public void Can_Track_Count_And_Bytes_On_Set_And_Remove()
     {
-        var cache = new ConvertedPublishedContentCache<string>();
+        var cache = new ConvertedPublishedContentCache<string, IPublishedContent>();
 
         cache.Set("a", Content(), 100);
         cache.Set("b", Content(), 50);
@@ -37,7 +37,7 @@ public class ConvertedPublishedContentCacheTests
     [Test]
     public void Can_Adjust_Bytes_When_Overwriting_Existing_Key()
     {
-        var cache = new ConvertedPublishedContentCache<string>();
+        var cache = new ConvertedPublishedContentCache<string, IPublishedContent>();
 
         cache.Set("a", Content(), 100);
         cache.Set("a", Content(), 30);
@@ -52,7 +52,7 @@ public class ConvertedPublishedContentCacheTests
     [Test]
     public void Can_Reset_Bytes_On_Clear()
     {
-        var cache = new ConvertedPublishedContentCache<string>();
+        var cache = new ConvertedPublishedContentCache<string, IPublishedContent>();
 
         cache.Set("a", Content(), 100);
         cache.Clear();
@@ -67,7 +67,7 @@ public class ConvertedPublishedContentCacheTests
     [Test]
     public void Can_Remove_Matching_Entries_With_RemoveWhere()
     {
-        var cache = new ConvertedPublishedContentCache<string>();
+        var cache = new ConvertedPublishedContentCache<string, IPublishedContent>();
 
         cache.Set("a", ContentOfType(1), 100);
         cache.Set("b", ContentOfType(2), 40);
@@ -81,7 +81,25 @@ public class ConvertedPublishedContentCacheTests
         });
     }
 
+    [Test]
+    public void Can_Track_Element_Values()
+    {
+        var cache = new ConvertedPublishedContentCache<string, IPublishedElement>();
+
+        cache.Set("a", Element(), 100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.Count, Is.EqualTo(1));
+            Assert.That(cache.ApproximateSizeInBytes, Is.EqualTo(100));
+            Assert.That(cache.TryGet("a", out IPublishedElement? element), Is.True);
+            Assert.That(element, Is.Not.Null);
+        });
+    }
+
     private static IPublishedContent Content() => new Mock<IPublishedContent>().Object;
+
+    private static IPublishedElement Element() => new Mock<IPublishedElement>().Object;
 
     private static IPublishedContent ContentOfType(int contentTypeId)
     {


### PR DESCRIPTION
## Description

The recent merge-up from `v17/dev` → `main` brought PR #23149 (in-memory cache size observability) into a `main` that had since gained the first-class **Element** services (`ElementNavigationService`, `ElementCacheService`, etc.). The merge resolved cleanly, but the new observability — and the related stale-set race guard from #23169 — only covered documents and media. This PR brings elements up to parity on both fronts.

### 1. Memory cache observability for elements

`MemoryCacheSizeReportingJob` logs the approximate entry count / byte size of every `IMemoryCacheSizeReporter` at `Debug`. Documents and media reported their navigation trees and their L0 converted-content caches; elements now do too:

- **`ElementNavigationService`** implements `IMemoryCacheSizeReporter` (`CacheName` = `"Element navigation"`), reusing the base-class node-count / sampled-byte logic already shared by document and media navigation.
- **`ElementCacheService`** implements `IMemoryCacheSizeReporter` (`CacheName` = `"Published elements (converted, L0)"`). Its L0 cache was migrated from a raw `ConcurrentDictionary` to the shared `ConvertedPublishedContentCache`, so it now tracks both entry count and an approximate retained byte total through the single insert/remove/clear path.
- **`ConvertedPublishedContentCache<TKey>` → `ConvertedPublishedContentCache<TKey, TValue>`** (`TValue : class, IPublishedElement`). Documents/media instantiate it as `<…, IPublishedContent>`, elements as `<string, IPublishedElement>`. The extra type parameter keeps each consumer strongly typed (no downcasts on the L0 read path) while letting elements — which hold the wider `IPublishedElement` — share the same count/byte-tracking implementation.
- DI registration mirrors the document/media pattern (concrete singleton + interface forwarders + reporter registration) in `UmbracoBuilder.cs` and the HybridCache `UmbracoBuilderExtensions.cs`.
- Docs: the observability table in the HybridCache `CLAUDE.md` gains the element rows.

Verified at runtime — all reporters fire, including the two new element ones:

```
In-memory cache size: Document navigation = 125 entries (~18690 bytes)
In-memory cache size: Media navigation = 49 entries (~7399 bytes)
In-memory cache size: Element navigation = 5 entries (~720 bytes)
In-memory cache size: Document URL segments = 275 entries (~23925 bytes)
In-memory cache size: Published content (converted, L0) = 34 entries (~64152 bytes)
In-memory cache size: Published media (converted, L0) = 19 entries (~8508 bytes)
In-memory cache size: Published elements (converted, L0) = 0 entries (~0 bytes)
```

### 2. Stale-set generation guard for elements

`DocumentCacheService` and `MediaCacheService` carry a monotonic `_cacheGeneration` guard (added in #23169) that prevents the read-through **stale-set clobber** race: a request reads a pre-refresh snapshot from the backing store and writes it back *after* a concurrent publish/refresh has already updated the cache, leaving memory stale until a full clear. `ElementCacheService` had no such protection.

This ports the identical guard to elements: capture the generation before the backing-store read, re-check before writing back to the hybrid + L0 caches, and bump it on every invalidation/refresh path (`ClearMemoryCacheAsync`, `RefreshMemoryCacheAsync`, `ClearConvertedContentCache`, `ClearPublishedCacheAsync`). Element-specific negative (null) cache entries are still written through when the snapshot is current.

## Tests

**Added / updated:**
- **`NavigationServiceMemoryReportingTests`** (new) — for documents, media **and** elements: asserts each navigation service exposes the expected `CacheName`, and that `GetApproximateCount()` reflects nodes across both the active tree and the recycle bin (move-to-bin keeps the entry counted).
- **`ConvertedPublishedContentCacheTests`** — updated to the two-type-parameter form and extended with an `IPublishedElement`-typed case, so the shared L0 count/byte tracking is proven for both value types.

**Deliberately omitted:**
- **No per-service stale-set race integration test for elements** (and none back-filled for media). The `_cacheGeneration` mechanism is identical across all three services and is already proven end-to-end by `DocumentHybridCacheStaleSetRaceTests`; media has shipped the same guard since #23169 without a dedicated test, so omitting adding one for elements seems reasonable here.