### PR TITLE
HybridCache: rebuild deferred content type changes under distributed-cache-only publishers

### DIFF
--- a/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/DeferredCacheRebuildNotificationHandler.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/NotificationHandlers/DeferredCacheRebuildNotificationHandler.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Options;
-using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PublishedCache;
@@ -16,8 +16,8 @@ namespace Umbraco.Cms.Infrastructure.HybridCache.NotificationHandlers;
 ///     deferred rebuild's background transaction and the original save transaction.
 /// </remarks>
 internal sealed class DeferredCacheRebuildNotificationHandler :
-    INotificationHandler<ContentTypeChangedNotification>,
-    INotificationHandler<MediaTypeChangedNotification>
+    IDistributedCacheNotificationHandler<ContentTypeChangedNotification>,
+    IDistributedCacheNotificationHandler<MediaTypeChangedNotification>
 {
     private readonly IDeferredCacheRebuildService _deferredCacheRebuildService;
     private readonly CacheSettings _cacheSettings;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DeferredCacheRebuildNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.PublishedCache.HybridCache/DeferredCacheRebuildNotificationHandlerTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -119,6 +121,73 @@ public class DeferredCacheRebuildNotificationHandlerTests
         _deferredCacheRebuildService.Verify(
             x => x.QueueContentTypeRebuild(It.IsAny<IReadOnlyCollection<int>>()),
             Times.Never);
+    }
+
+    /// <summary>
+    ///     Verifies the handler still queues a rebuild when the notification is dispatched through a
+    ///     distributed-cache-only publisher (e.g. the publisher Umbraco Deploy installs on restore/import
+    ///     scopes). This is the dispatch-filtering path that the direct <see cref="DeferredCacheRebuildNotificationHandler.Handle(ContentTypeChangedNotification)" />
+    ///     tests above cannot exercise, since <see cref="EventAggregator" /> filters handlers by
+    ///     <see cref="IDistributedCacheNotificationHandler" /> before invoking them.
+    /// </summary>
+    [Test]
+    public void Content_Type_Change_Via_Distributed_Cache_Publisher_Queues_Deferred_Rebuild()
+    {
+        // Arrange
+        _deferredCacheRebuildService
+            .Setup(x => x.QueueContentTypeRebuild(It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(100))));
+
+        IScopedNotificationPublisher publisher = CreateDistributedCacheOnlyPublisher();
+        var notification = new ContentTypeChangedNotification(
+            new ContentTypeChange<IContentType>(CreateContentType(100), ContentTypeChangeTypes.RefreshMain),
+            new EventMessages());
+
+        // Act — publish through the distributed-cache-only publisher, then complete the scope to flush it.
+        publisher.Publish(notification);
+        publisher.ScopeExit(true);
+
+        // Assert
+        _deferredCacheRebuildService.Verify(
+            x => x.QueueContentTypeRebuild(It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(100))),
+            Times.Once);
+    }
+
+    /// <summary>
+    ///     As <see cref="Content_Type_Change_Via_Distributed_Cache_Publisher_Queues_Deferred_Rebuild" />, but for media type changes.
+    /// </summary>
+    [Test]
+    public void Media_Type_Change_Via_Distributed_Cache_Publisher_Queues_Deferred_Rebuild()
+    {
+        // Arrange
+        _deferredCacheRebuildService
+            .Setup(x => x.QueueMediaTypeRebuild(It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(200))));
+
+        IScopedNotificationPublisher publisher = CreateDistributedCacheOnlyPublisher();
+        var notification = new MediaTypeChangedNotification(
+            new ContentTypeChange<IMediaType>(CreateMediaType(200), ContentTypeChangeTypes.RefreshMain),
+            new EventMessages());
+
+        // Act
+        publisher.Publish(notification);
+        publisher.ScopeExit(true);
+
+        // Assert
+        _deferredCacheRebuildService.Verify(
+            x => x.QueueMediaTypeRebuild(It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(200))),
+            Times.Once);
+    }
+
+    private ScopedNotificationPublisher<IDistributedCacheNotificationHandler> CreateDistributedCacheOnlyPublisher()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_deferredCacheRebuildService.Object);
+        services.AddSingleton(Options.Create(new CacheSettings { ContentTypeRebuildMode = ContentTypeRebuildMode.Deferred }));
+        services.AddTransient<INotificationHandler<ContentTypeChangedNotification>, DeferredCacheRebuildNotificationHandler>();
+        services.AddTransient<INotificationHandler<MediaTypeChangedNotification>, DeferredCacheRebuildNotificationHandler>();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        var eventAggregator = new EventAggregator(type => provider.GetService(type)!);
+        return new ScopedNotificationPublisher<IDistributedCacheNotificationHandler>(eventAggregator);
     }
 
     private static IContentType CreateContentType(int id)


### PR DESCRIPTION
Related to #23215 / #23227, found during an audit of notification handlers that perform durable work but could be skipped under a distributed-cache-only notification publisher (e.g. Umbraco Deploy's restore/import scopes).

## Problem

`DeferredCacheRebuildNotificationHandler` queues the published-cache rebuild for **structural** content-type / media-type changes when `CacheSettings.ContentTypeRebuildMode = Deferred`. In that mode `CacheRefreshingNotificationHandler` deliberately skips the immediate rebuild (`structuralChangeIds.Length > 0 && ContentTypeRebuildMode != Deferred`) and relies on this handler to queue it from the post-commit `ContentTypeChangedNotification` / `MediaTypeChangedNotification`.

It was a plain `INotificationHandler<…>`, so when those notifications are dispatched through a publisher restricted to `IDistributedCacheNotificationHandler` it is silently skipped (`EventAggregator` resolves handlers with `.Where(x => x is TNotificationHandler)`). The result: in **Deferred** mode, a structural content/media-type change applied under such a publisher clears the content-type cache but **never rebuilds the HybridCache**, so content of that type can be stale/broken until a manual rebuild or restart.

In the default (immediate) mode this is not an issue — the rebuild runs from `ContentTypeRefreshedNotification`, which is published downstream by the cache refresher (via `IEventAggregator`, not the scoped publisher) and therefore still runs.

## Fix

`DeferredCacheRebuildNotificationHandler` now implements `IDistributedCacheNotificationHandler<ContentTypeChangedNotification>` / `IDistributedCacheNotificationHandler<MediaTypeChangedNotification>` (these derive from `INotificationHandler<T>` + the marker), so it survives the distributed-cache-only filter while still firing on normal publishes. No DI change is needed — filtering is by resolved instance type.

This is safe: the handler only enqueues work (`IDeferredCacheRebuildService.QueueContentTypeRebuild` / `QueueMediaTypeRebuild`); the actual rebuild runs on a background task after the scope is disposed, and the notifications only fire on the originating server.

See `src/Umbraco.Core/CLAUDE.md` ("Durable handlers vs. distributed-cache-only publishers"), added in #23215.

## Testing

Mirrors the #23215 / #23227 fix. A dedicated integration test (set `ContentTypeRebuildMode.Deferred`, apply a structural content-type change under a `ScopedNotificationPublisher<IDistributedCacheNotificationHandler>`, assert a rebuild is queued) needs a real build + database and is a recommended follow-up rather than asserted blind here.
