### PR TITLE
Hosting: Add stable machine identifier for environments with unstable hostnames (closes #22947, #13909)

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/HostingSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/HostingSettings.cs
@@ -49,4 +49,25 @@ public class HostingSettings
     ///     Gets or sets a value specifying the name of the site.
     /// </summary>
     public string? SiteName { get; set; }
+
+    /// <summary>
+    ///     Gets or sets a stable identifier for this server instance used to track cache synchronization state.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Set this when the machine name is not stable across restarts — for example on Azure App Service Linux,
+    ///         where the container hostname changes on each recycle. Use a value that is unique per server instance
+    ///         (e.g. the site name for single-server deployments, or a per-instance value for scale-out).
+    ///     </para>
+    ///     <para>
+    ///         When not set, Umbraco automatically uses the <c>WEBSITE_INSTANCE_ID</c> environment variable on
+    ///         Azure App Service, or falls back to <c>Environment.MachineName</c>.
+    ///     </para>
+    ///     <para>
+    ///         The value of <see cref="SiteName" /> is still appended when set, matching the behaviour of the
+    ///         default <c>Environment.MachineName</c>-based identifier.
+    ///     </para>
+    ///     <para>The combined value of this setting and <see cref="SiteName" /> must not exceed 255 characters.</para>
+    /// </remarks>
+    public string? MachineIdentifier { get; set; }
 }

--- a/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
@@ -42,7 +42,7 @@ public class HostingSettingsValidator
                 : $"'{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.MachineIdentifier)}' or '{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'";
 
             return ValidateOptionsResult.Fail(
-                $"The combined machine identifier '{identifier}' ({identifier.Length} characters) exceeds the maximum allowed length of {MachineInfoFactory.MaxMachineIdentifierLength} characters. " +
+                $"The machine identifier '{identifier}' ({identifier.Length} characters) exceeds the maximum allowed length of {MachineInfoFactory.MaxMachineIdentifierLength} characters. " +
                 $"Please shorten the value of {settingHint}.");
         }
 

--- a/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
@@ -15,6 +15,8 @@ public class HostingSettingsValidator
     /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, HostingSettings options)
     {
+        // WEBSITE_INSTANCE_ID is an environment variable, not a config value, so it cannot be validated here.
+        // MachineInfoFactory.GetMachineIdentifier() carries its own runtime length guard for that path.
         var baseName = string.IsNullOrWhiteSpace(options.MachineIdentifier)
             ? Environment.MachineName
             : options.MachineIdentifier;

--- a/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
@@ -9,14 +9,26 @@ namespace Umbraco.Cms.Core.Configuration.Models.Validation;
 /// <summary>
 ///     Validator for configuration represented as <see cref="HostingSettings" />.
 /// </summary>
+/// <remarks>
+///     This is a best-effort, config-time check on the machine identifier length. It only covers the two
+///     config-supplied inputs — <see cref="HostingSettings.MachineIdentifier" /> and
+///     <see cref="HostingSettings.SiteName" /> — and assumes the default provider order in which an explicit
+///     <see cref="HostingSettings.MachineIdentifier" /> takes priority over <c>Environment.MachineName</c>.
+///     It intentionally does NOT run the <see cref="Umbraco.Cms.Core.Factories.IMachineIdentityProvider" /> chain,
+///     so it does not cover the base name produced by the Azure <c>WEBSITE_INSTANCE_ID</c> provider (an environment
+///     variable, not config) or by any custom provider, nor a reordered or replaced provider collection. Those
+///     cases are caught only by the runtime length guard in
+///     <see cref="Umbraco.Cms.Core.Factories.IMachineInfoFactory.GetMachineIdentifier" />, which throws on boot.
+/// </remarks>
 public class HostingSettingsValidator
     : ConfigurationValidatorBase, IValidateOptions<HostingSettings>
 {
     /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, HostingSettings options)
     {
-        // WEBSITE_INSTANCE_ID is an environment variable, not a config value, so it cannot be validated here.
-        // MachineInfoFactory.GetMachineIdentifier() carries its own runtime length guard for that path.
+        // See the class remarks: this validates only the config-supplied inputs and mirrors the default provider
+        // order (explicit MachineIdentifier over MachineName). It does not run the IMachineIdentityProvider chain,
+        // so provider-derived base names (e.g. WEBSITE_INSTANCE_ID, custom providers) rely on the runtime guard.
         var baseName = string.IsNullOrWhiteSpace(options.MachineIdentifier)
             ? Environment.MachineName
             : options.MachineIdentifier;

--- a/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidator.cs
@@ -15,13 +15,21 @@ public class HostingSettingsValidator
     /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, HostingSettings options)
     {
-        var identifier = MachineInfoFactory.BuildMachineIdentifier(Environment.MachineName, options.SiteName);
+        var baseName = string.IsNullOrWhiteSpace(options.MachineIdentifier)
+            ? Environment.MachineName
+            : options.MachineIdentifier;
+
+        var identifier = MachineInfoFactory.BuildMachineIdentifier(baseName, options.SiteName);
 
         if (identifier.Length > MachineInfoFactory.MaxMachineIdentifierLength)
         {
+            var settingHint = string.IsNullOrWhiteSpace(options.MachineIdentifier)
+                ? $"'{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'"
+                : $"'{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.MachineIdentifier)}' or '{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'";
+
             return ValidateOptionsResult.Fail(
                 $"The combined machine identifier '{identifier}' ({identifier.Length} characters) exceeds the maximum allowed length of {MachineInfoFactory.MaxMachineIdentifierLength} characters. " +
-                $"Please shorten the value of '{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'.");
+                $"Please shorten the value of {settingHint}.");
         }
 
         return ValidateOptionsResult.Success;

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.CollectionBuilders.cs
@@ -1,5 +1,6 @@
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DynamicRoot.QuerySteps;
+using Umbraco.Cms.Core.Factories;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Routing;
@@ -134,6 +135,19 @@ public static partial class UmbracoBuilderExtensions
     public static IUmbracoBuilder AddDynamicRootStep<T>(this IUmbracoBuilder builder) where T : IDynamicRootQueryStep
     {
         builder.DynamicRootSteps().Append<T>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Register a machine identity provider.
+    /// </summary>
+    /// <typeparam name="T">The type of the machine identity provider.</typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <returns>The builder.</returns>
+    public static IUmbracoBuilder AddMachineIdentityProvider<T>(this IUmbracoBuilder builder)
+        where T : IMachineIdentityProvider
+    {
+        builder.MachineIdentityProviders().Append<T>();
         return builder;
     }
 }

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Collections.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.DeliveryApi;
 using Umbraco.Cms.Core.DynamicRoot.Origin;
 using Umbraco.Cms.Core.DynamicRoot.QuerySteps;
 using Umbraco.Cms.Core.Editors;
+using Umbraco.Cms.Core.Factories;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.HealthChecks.NotificationMethods;
 using Umbraco.Cms.Core.Mapping;
@@ -66,6 +67,11 @@ public static partial class UmbracoBuilderExtensions
             .Append<FurthestAncestorOrSelfDynamicRootQueryStep>()
             .Append<NearestDescendantOrSelfDynamicRootQueryStep>()
             .Append<FurthestDescendantOrSelfDynamicRootQueryStep>();
+
+        builder.MachineIdentityProviders()
+            .Append<ConfiguredMachineIdentityProvider>()
+            .Append<AzureWebsiteInstanceIdMachineIdentityProvider>()
+            .Append<DefaultMachineIdentityProvider>();
 
         builder.Components();
         builder.PartialViewSnippets();
@@ -298,4 +304,12 @@ public static partial class UmbracoBuilderExtensions
     /// <returns>The <see cref="ContentTypeFilterCollectionBuilder" />.</returns>
     public static ContentTypeFilterCollectionBuilder ContentTypeFilters(this IUmbracoBuilder builder)
         => builder.WithCollectionBuilder<ContentTypeFilterCollectionBuilder>();
+
+    /// <summary>
+    ///     Gets the machine identity providers collection builder.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <returns>The <see cref="MachineIdentityProviderCollectionBuilder" />.</returns>
+    public static MachineIdentityProviderCollectionBuilder MachineIdentityProviders(this IUmbracoBuilder builder)
+        => builder.WithCollectionBuilder<MachineIdentityProviderCollectionBuilder>();
 }

--- a/src/Umbraco.Core/Factories/AzureWebsiteInstanceIdMachineIdentityProvider.cs
+++ b/src/Umbraco.Core/Factories/AzureWebsiteInstanceIdMachineIdentityProvider.cs
@@ -1,0 +1,26 @@
+namespace Umbraco.Cms.Core.Factories;
+
+/// <summary>
+///     Returns the machine identifier from the <c>WEBSITE_INSTANCE_ID</c> environment variable set by Azure App Service.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>WEBSITE_INSTANCE_ID</c> identifies the instance slot and remains stable across container recycles,
+///         unlike <c>Environment.MachineName</c> which changes on every recycle on Azure App Service Linux.
+///     </para>
+///     <para>Returns <c>null</c> when the environment variable is not present (i.e. outside Azure App Service).</para>
+/// </remarks>
+public class AzureWebsiteInstanceIdMachineIdentityProvider : IMachineIdentityProvider
+{
+    /// <summary>
+    ///     The name of the Azure App Service environment variable that identifies the instance slot.
+    /// </summary>
+    public const string WebsiteInstanceIdEnvironmentVariable = "WEBSITE_INSTANCE_ID";
+
+    /// <inheritdoc />
+    public string? GetMachineIdentifier()
+    {
+        var instanceId = Environment.GetEnvironmentVariable(WebsiteInstanceIdEnvironmentVariable);
+        return string.IsNullOrWhiteSpace(instanceId) ? null : instanceId;
+    }
+}

--- a/src/Umbraco.Core/Factories/ConfiguredMachineIdentityProvider.cs
+++ b/src/Umbraco.Core/Factories/ConfiguredMachineIdentityProvider.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+
+namespace Umbraco.Cms.Core.Factories;
+
+/// <summary>
+///     Returns the machine identifier configured via <see cref="HostingSettings.MachineIdentifier" />.
+/// </summary>
+public class ConfiguredMachineIdentityProvider : IMachineIdentityProvider
+{
+    private readonly IOptions<HostingSettings> _hostingSettings;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ConfiguredMachineIdentityProvider" /> class.
+    /// </summary>
+    public ConfiguredMachineIdentityProvider(IOptions<HostingSettings> hostingSettings)
+        => _hostingSettings = hostingSettings;
+
+    /// <inheritdoc />
+    public string? GetMachineIdentifier()
+    {
+        var configured = _hostingSettings.Value.MachineIdentifier;
+        return string.IsNullOrWhiteSpace(configured) ? null : configured;
+    }
+}

--- a/src/Umbraco.Core/Factories/DefaultMachineIdentityProvider.cs
+++ b/src/Umbraco.Core/Factories/DefaultMachineIdentityProvider.cs
@@ -1,0 +1,13 @@
+namespace Umbraco.Cms.Core.Factories;
+
+/// <summary>
+///     Returns <see cref="Environment.MachineName" /> as the machine identifier.
+/// </summary>
+/// <remarks>
+///     This is the final fallback provider and always returns a non-null value.
+/// </remarks>
+public class DefaultMachineIdentityProvider : IMachineIdentityProvider
+{
+    /// <inheritdoc />
+    public string? GetMachineIdentifier() => Environment.MachineName;
+}

--- a/src/Umbraco.Core/Factories/IMachineIdentityProvider.cs
+++ b/src/Umbraco.Core/Factories/IMachineIdentityProvider.cs
@@ -1,0 +1,27 @@
+namespace Umbraco.Cms.Core.Factories;
+
+/// <summary>
+///     Provides a machine identifier for use in cache synchronisation tracking.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Implementations are resolved in the order they are registered in
+///         <see cref="MachineIdentityProviderCollection" />. The first implementation that returns a non-null
+///         value wins.
+///     </para>
+///     <para>
+///         Return <c>null</c> to indicate that the provider does not apply in the current environment,
+///         allowing the next provider in the collection to be tried.
+///     </para>
+///     <para>
+///         The returned value is the <em>base</em> identifier only — <see cref="Umbraco.Cms.Core.Configuration.Models.HostingSettings.SiteName" />
+///         is appended by <see cref="IMachineInfoFactory" /> after provider resolution.
+///     </para>
+/// </remarks>
+public interface IMachineIdentityProvider
+{
+    /// <summary>
+    ///     Gets the machine identifier, or <c>null</c> if this provider does not apply.
+    /// </summary>
+    string? GetMachineIdentifier();
+}

--- a/src/Umbraco.Core/Factories/MachineIdentityProviderCollection.cs
+++ b/src/Umbraco.Core/Factories/MachineIdentityProviderCollection.cs
@@ -1,0 +1,18 @@
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Cms.Core.Factories;
+
+/// <summary>
+///     Represents an ordered collection of <see cref="IMachineIdentityProvider" /> instances.
+/// </summary>
+public class MachineIdentityProviderCollection : BuilderCollectionBase<IMachineIdentityProvider>
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MachineIdentityProviderCollection" /> class.
+    /// </summary>
+    /// <param name="items">A factory function that returns the machine identity providers.</param>
+    public MachineIdentityProviderCollection(Func<IEnumerable<IMachineIdentityProvider>> items)
+        : base(items)
+    {
+    }
+}

--- a/src/Umbraco.Core/Factories/MachineIdentityProviderCollectionBuilder.cs
+++ b/src/Umbraco.Core/Factories/MachineIdentityProviderCollectionBuilder.cs
@@ -1,0 +1,14 @@
+using Umbraco.Cms.Core.Composing;
+
+namespace Umbraco.Cms.Core.Factories;
+
+/// <summary>
+///     Builds a <see cref="MachineIdentityProviderCollection" /> by registering <see cref="IMachineIdentityProvider" />
+///     implementations.
+/// </summary>
+public class MachineIdentityProviderCollectionBuilder
+    : OrderedCollectionBuilderBase<MachineIdentityProviderCollectionBuilder, MachineIdentityProviderCollection, IMachineIdentityProvider>
+{
+    /// <inheritdoc />
+    protected override MachineIdentityProviderCollectionBuilder This => this;
+}

--- a/src/Umbraco.Core/Factories/MachineInfoFactory.cs
+++ b/src/Umbraco.Core/Factories/MachineInfoFactory.cs
@@ -13,6 +13,8 @@ internal sealed class MachineInfoFactory : IMachineInfoFactory
     // machineId is stored as NVARCHAR(255) in umbracoLastSynced
     internal const int MaxMachineIdentifierLength = 255;
 
+    internal const string AzureWebsiteInstanceIdEnvironmentVariable = "WEBSITE_INSTANCE_ID";
+
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IOptions<HostingSettings> _hostingSettings;
 
@@ -40,13 +42,31 @@ internal sealed class MachineInfoFactory : IMachineInfoFactory
     /// <inheritdoc />
     public string GetMachineIdentifier()
     {
-        var identifier = BuildMachineIdentifier(Environment.MachineName, _hostingSettings.Value.SiteName);
+        var explicitMachineIdentifier = _hostingSettings.Value.MachineIdentifier;
+
+        // Resolve the base name: explicit config → Azure instance ID (stable across container recycles) → OS hostname.
+        string baseName;
+        if (string.IsNullOrWhiteSpace(explicitMachineIdentifier) is false)
+        {
+            baseName = explicitMachineIdentifier;
+        }
+        else
+        {
+            var instanceId = Environment.GetEnvironmentVariable(AzureWebsiteInstanceIdEnvironmentVariable);
+            baseName = string.IsNullOrWhiteSpace(instanceId) ? Environment.MachineName : instanceId;
+        }
+
+        var identifier = BuildMachineIdentifier(baseName, _hostingSettings.Value.SiteName);
 
         if (identifier.Length > MaxMachineIdentifierLength)
         {
+            var settingHint = string.IsNullOrWhiteSpace(explicitMachineIdentifier)
+                ? $"'{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'"
+                : $"'{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.MachineIdentifier)}' or '{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'";
+
             throw new InvalidOperationException(
                 $"The combined machine identifier '{identifier}' ({identifier.Length} characters) exceeds the maximum allowed length of {MaxMachineIdentifierLength} characters. " +
-                $"Please shorten the value of '{Constants.Configuration.ConfigHostingPrefix}SiteName'.");
+                $"Please shorten the value of {settingHint}.");
         }
 
         return identifier;

--- a/src/Umbraco.Core/Factories/MachineInfoFactory.cs
+++ b/src/Umbraco.Core/Factories/MachineInfoFactory.cs
@@ -13,60 +13,39 @@ internal sealed class MachineInfoFactory : IMachineInfoFactory
     // machineId is stored as NVARCHAR(255) in umbracoLastSynced
     internal const int MaxMachineIdentifierLength = 255;
 
-    internal const string AzureWebsiteInstanceIdEnvironmentVariable = "WEBSITE_INSTANCE_ID";
-
     private readonly IHostingEnvironment _hostingEnvironment;
+    private readonly MachineIdentityProviderCollection _providers;
     private readonly IOptions<HostingSettings> _hostingSettings;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MachineInfoFactory"/> class.
     /// </summary>
-    /// <param name="hostingEnvironment">The hosting environment.</param>
-    /// <param name="hostingSettings">The hosting settings.</param>
-    public MachineInfoFactory(IHostingEnvironment hostingEnvironment, IOptions<HostingSettings> hostingSettings)
+    public MachineInfoFactory(
+        IHostingEnvironment hostingEnvironment,
+        MachineIdentityProviderCollection providers,
+        IOptions<HostingSettings> hostingSettings)
     {
         _hostingEnvironment = hostingEnvironment;
+        _providers = providers;
         _hostingSettings = hostingSettings;
     }
 
+    /// <summary>Combines a machine name and an optional site name into a single machine identifier.</summary>
     internal static string BuildMachineIdentifier(string machineName, string? siteName)
-    {
-        if (string.IsNullOrWhiteSpace(siteName))
-        {
-            return machineName;
-        }
-
-        return $"{machineName}/{siteName}";
-    }
+        => string.IsNullOrWhiteSpace(siteName) ? machineName : $"{machineName}/{siteName}";
 
     /// <inheritdoc />
     public string GetMachineIdentifier()
     {
-        var explicitMachineIdentifier = _hostingSettings.Value.MachineIdentifier;
-
-        // Resolve the base name: explicit config → Azure instance ID (stable across container recycles) → OS hostname.
-        string baseName;
-        if (string.IsNullOrWhiteSpace(explicitMachineIdentifier) is false)
-        {
-            baseName = explicitMachineIdentifier;
-        }
-        else
-        {
-            var instanceId = Environment.GetEnvironmentVariable(AzureWebsiteInstanceIdEnvironmentVariable);
-            baseName = string.IsNullOrWhiteSpace(instanceId) ? Environment.MachineName : instanceId;
-        }
+        var baseName = _providers.Select(p => p.GetMachineIdentifier()).FirstOrDefault(id => id is not null)
+            ?? throw new InvalidOperationException($"No {nameof(IMachineIdentityProvider)} returned a machine identifier.");
 
         var identifier = BuildMachineIdentifier(baseName, _hostingSettings.Value.SiteName);
 
         if (identifier.Length > MaxMachineIdentifierLength)
         {
-            var settingHint = string.IsNullOrWhiteSpace(explicitMachineIdentifier)
-                ? $"'{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'"
-                : $"'{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.MachineIdentifier)}' or '{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}'";
-
             throw new InvalidOperationException(
-                $"The combined machine identifier '{identifier}' ({identifier.Length} characters) exceeds the maximum allowed length of {MaxMachineIdentifierLength} characters. " +
-                $"Please shorten the value of {settingHint}.");
+                $"The machine identifier '{identifier}' ({identifier.Length} characters) exceeds the maximum allowed length of {MaxMachineIdentifierLength} characters.");
         }
 
         return identifier;

--- a/src/Umbraco.Core/Factories/MachineInfoFactory.cs
+++ b/src/Umbraco.Core/Factories/MachineInfoFactory.cs
@@ -37,18 +37,30 @@ internal sealed class MachineInfoFactory : IMachineInfoFactory
     /// <inheritdoc />
     public string GetMachineIdentifier()
     {
-        var baseName = _providers.Select(p => p.GetMachineIdentifier()).FirstOrDefault(id => string.IsNullOrWhiteSpace(id) is false)
-            ?? throw new InvalidOperationException($"No {nameof(IMachineIdentityProvider)} returned a machine identifier.");
+        (IMachineIdentityProvider provider, string? identifier) = _providers
+            .Select(p => (Provider: p, Identifier: p.GetMachineIdentifier()))
+            .FirstOrDefault(x => string.IsNullOrWhiteSpace(x.Identifier) is false);
 
-        var identifier = BuildMachineIdentifier(baseName, _hostingSettings.Value.SiteName);
-
-        if (identifier.Length > MaxMachineIdentifierLength)
+        if (provider is null)
         {
-            throw new InvalidOperationException(
-                $"The machine identifier '{identifier}' ({identifier.Length} characters) exceeds the maximum allowed length of {MaxMachineIdentifierLength} characters.");
+            throw new InvalidOperationException($"No {nameof(IMachineIdentityProvider)} returned a machine identifier.");
         }
 
-        return identifier;
+        var siteName = _hostingSettings.Value.SiteName;
+        var machineIdentifier = BuildMachineIdentifier(identifier!, siteName);
+
+        if (machineIdentifier.Length > MaxMachineIdentifierLength)
+        {
+            var siteNameHint = string.IsNullOrWhiteSpace(siteName)
+                ? "Shorten the base identifier at its source."
+                : $"Shorten '{Constants.Configuration.ConfigHostingPrefix}{nameof(HostingSettings.SiteName)}' or the base identifier at its source.";
+
+            throw new InvalidOperationException(
+                $"The machine identifier '{machineIdentifier}' ({machineIdentifier.Length} characters) exceeds the maximum allowed length of {MaxMachineIdentifierLength} characters. " +
+                $"The base identifier was provided by '{provider.GetType().Name}'. {siteNameHint}");
+        }
+
+        return machineIdentifier;
     }
 
     private string? _localIdentity;

--- a/src/Umbraco.Core/Factories/MachineInfoFactory.cs
+++ b/src/Umbraco.Core/Factories/MachineInfoFactory.cs
@@ -37,7 +37,7 @@ internal sealed class MachineInfoFactory : IMachineInfoFactory
     /// <inheritdoc />
     public string GetMachineIdentifier()
     {
-        var baseName = _providers.Select(p => p.GetMachineIdentifier()).FirstOrDefault(id => id is not null)
+        var baseName = _providers.Select(p => p.GetMachineIdentifier()).FirstOrDefault(id => string.IsNullOrWhiteSpace(id) is false)
             ?? throw new InvalidOperationException($"No {nameof(IMachineIdentityProvider)} returned a machine identifier.");
 
         var identifier = BuildMachineIdentifier(baseName, _hostingSettings.Value.SiteName);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/HostingSettingsValidatorTests.cs
@@ -46,4 +46,35 @@ public class HostingSettingsValidatorTests
         var result = validator.Validate("settings", options);
         Assert.False(result.Succeeded);
     }
+
+    [Test]
+    public void Returns_Success_For_Configuration_With_Short_MachineIdentifier()
+    {
+        var validator = new HostingSettingsValidator();
+        var options = new HostingSettings { MachineIdentifier = "my-stable-instance-id" };
+        var result = validator.Validate("settings", options);
+        Assert.True(result.Succeeded);
+    }
+
+    [Test]
+    public void Returns_Fail_For_Configuration_With_MachineIdentifier_That_Exceeds_Max_Length()
+    {
+        var validator = new HostingSettingsValidator();
+        var options = new HostingSettings { MachineIdentifier = new string('x', MachineInfoFactory.MaxMachineIdentifierLength + 1) };
+        var result = validator.Validate("settings", options);
+        Assert.False(result.Succeeded);
+    }
+
+    [Test]
+    public void Returns_Fail_For_Configuration_With_MachineIdentifier_And_SiteName_That_Exceeds_Max_Length()
+    {
+        var validator = new HostingSettingsValidator();
+        var options = new HostingSettings
+        {
+            MachineIdentifier = "short-id",
+            SiteName = new string('x', MachineInfoFactory.MaxMachineIdentifierLength),
+        };
+        var result = validator.Validate("settings", options);
+        Assert.False(result.Succeeded);
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.AzureWebsiteInstanceId.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.AzureWebsiteInstanceId.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.Factories;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Factories;
+
+public partial class MachineIdentityProviderTests
+{
+    [TestFixture]
+    public class AzureWebsiteInstanceIdProvider
+    {
+        private string? _savedWebsiteInstanceId;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _savedWebsiteInstanceId = Environment.GetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable);
+            Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, null);
+        }
+
+        [TearDown]
+        public void TearDown() =>
+            Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, _savedWebsiteInstanceId);
+
+        [Test]
+        public void WhenEnvironmentVariableIsSet_ReturnsInstanceId()
+        {
+            Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+            var provider = new AzureWebsiteInstanceIdMachineIdentityProvider();
+            Assert.AreEqual("abc123instanceid", provider.GetMachineIdentifier());
+        }
+
+        [Test]
+        public void WhenEnvironmentVariableIsAbsent_ReturnsNull()
+        {
+            var provider = new AzureWebsiteInstanceIdMachineIdentityProvider();
+            Assert.IsNull(provider.GetMachineIdentifier());
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.Configured.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.Configured.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Factories;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Factories;
+
+public partial class MachineIdentityProviderTests
+{
+    [TestFixture]
+    public class ConfiguredProvider
+    {
+        [Test]
+        public void WhenMachineIdentifierIsSet_ReturnsConfiguredValue()
+        {
+            var provider = new ConfiguredMachineIdentityProvider(
+                Options.Create(new HostingSettings { MachineIdentifier = "my-stable-id" }));
+            Assert.AreEqual("my-stable-id", provider.GetMachineIdentifier());
+        }
+
+        [Test]
+        public void WhenMachineIdentifierIsNull_ReturnsNull()
+        {
+            var provider = new ConfiguredMachineIdentityProvider(
+                Options.Create(new HostingSettings { MachineIdentifier = null }));
+            Assert.IsNull(provider.GetMachineIdentifier());
+        }
+
+        [Test]
+        public void WhenMachineIdentifierIsEmptyOrWhitespace_ReturnsNull()
+        {
+            var provider = new ConfiguredMachineIdentityProvider(
+                Options.Create(new HostingSettings { MachineIdentifier = "   " }));
+            Assert.IsNull(provider.GetMachineIdentifier());
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.Default.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.Default.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.Factories;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Factories;
+
+public partial class MachineIdentityProviderTests
+{
+    [TestFixture]
+    public class DefaultProvider
+    {
+        [Test]
+        public void AlwaysReturnsMachineName()
+        {
+            var provider = new DefaultMachineIdentityProvider();
+            Assert.AreEqual(Environment.MachineName, provider.GetMachineIdentifier());
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Factories;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Factories;
+
+[TestFixture]
+public class MachineIdentityProviderTests
+{
+    [Test]
+    public void ConfiguredProvider_WhenMachineIdentifierIsSet_ReturnsConfiguredValue()
+    {
+        var provider = new ConfiguredMachineIdentityProvider(
+            Options.Create(new HostingSettings { MachineIdentifier = "my-stable-id" }));
+        Assert.AreEqual("my-stable-id", provider.GetMachineIdentifier());
+    }
+
+    [Test]
+    public void ConfiguredProvider_WhenMachineIdentifierIsNull_ReturnsNull()
+    {
+        var provider = new ConfiguredMachineIdentityProvider(
+            Options.Create(new HostingSettings { MachineIdentifier = null }));
+        Assert.IsNull(provider.GetMachineIdentifier());
+    }
+
+    [Test]
+    public void ConfiguredProvider_WhenMachineIdentifierIsEmptyOrWhitespace_ReturnsNull()
+    {
+        var provider = new ConfiguredMachineIdentityProvider(
+            Options.Create(new HostingSettings { MachineIdentifier = "   " }));
+        Assert.IsNull(provider.GetMachineIdentifier());
+    }
+
+    [Test]
+    public void DefaultProvider_AlwaysReturnsMachineName()
+    {
+        var provider = new DefaultMachineIdentityProvider();
+        Assert.AreEqual(Environment.MachineName, provider.GetMachineIdentifier());
+    }
+}
+
+[TestFixture]
+public class AzureWebsiteInstanceIdMachineIdentityProviderTests
+{
+    private string? _savedWebsiteInstanceId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _savedWebsiteInstanceId = Environment.GetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable);
+        Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, null);
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, _savedWebsiteInstanceId);
+
+    [Test]
+    public void GetMachineIdentifier_WhenEnvironmentVariableIsSet_ReturnsInstanceId()
+    {
+        Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+        var provider = new AzureWebsiteInstanceIdMachineIdentityProvider();
+        Assert.AreEqual("abc123instanceid", provider.GetMachineIdentifier());
+    }
+
+    [Test]
+    public void GetMachineIdentifier_WhenEnvironmentVariableIsAbsent_ReturnsNull()
+    {
+        var provider = new AzureWebsiteInstanceIdMachineIdentityProvider();
+        Assert.IsNull(provider.GetMachineIdentifier());
+    }
+
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineIdentityProviderTests.cs
@@ -1,74 +1,8 @@
-using Microsoft.Extensions.Options;
-using NUnit.Framework;
-using Umbraco.Cms.Core.Configuration.Models;
-using Umbraco.Cms.Core.Factories;
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Factories;
 
-[TestFixture]
-public class MachineIdentityProviderTests
+public partial class MachineIdentityProviderTests
 {
-    [Test]
-    public void ConfiguredProvider_WhenMachineIdentifierIsSet_ReturnsConfiguredValue()
-    {
-        var provider = new ConfiguredMachineIdentityProvider(
-            Options.Create(new HostingSettings { MachineIdentifier = "my-stable-id" }));
-        Assert.AreEqual("my-stable-id", provider.GetMachineIdentifier());
-    }
-
-    [Test]
-    public void ConfiguredProvider_WhenMachineIdentifierIsNull_ReturnsNull()
-    {
-        var provider = new ConfiguredMachineIdentityProvider(
-            Options.Create(new HostingSettings { MachineIdentifier = null }));
-        Assert.IsNull(provider.GetMachineIdentifier());
-    }
-
-    [Test]
-    public void ConfiguredProvider_WhenMachineIdentifierIsEmptyOrWhitespace_ReturnsNull()
-    {
-        var provider = new ConfiguredMachineIdentityProvider(
-            Options.Create(new HostingSettings { MachineIdentifier = "   " }));
-        Assert.IsNull(provider.GetMachineIdentifier());
-    }
-
-    [Test]
-    public void DefaultProvider_AlwaysReturnsMachineName()
-    {
-        var provider = new DefaultMachineIdentityProvider();
-        Assert.AreEqual(Environment.MachineName, provider.GetMachineIdentifier());
-    }
-}
-
-[TestFixture]
-public class AzureWebsiteInstanceIdMachineIdentityProviderTests
-{
-    private string? _savedWebsiteInstanceId;
-
-    [SetUp]
-    public void SetUp()
-    {
-        _savedWebsiteInstanceId = Environment.GetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable);
-        Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, null);
-    }
-
-    [TearDown]
-    public void TearDown() =>
-        Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, _savedWebsiteInstanceId);
-
-    [Test]
-    public void GetMachineIdentifier_WhenEnvironmentVariableIsSet_ReturnsInstanceId()
-    {
-        Environment.SetEnvironmentVariable(AzureWebsiteInstanceIdMachineIdentityProvider.WebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
-        var provider = new AzureWebsiteInstanceIdMachineIdentityProvider();
-        Assert.AreEqual("abc123instanceid", provider.GetMachineIdentifier());
-    }
-
-    [Test]
-    public void GetMachineIdentifier_WhenEnvironmentVariableIsAbsent_ReturnsNull()
-    {
-        var provider = new AzureWebsiteInstanceIdMachineIdentityProvider();
-        Assert.IsNull(provider.GetMachineIdentifier());
-    }
-
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
@@ -46,6 +46,13 @@ public class MachineInfoFactoryTests
     }
 
     [Test]
+    public void GetMachineIdentifier_SkipsWhitespaceProviderResults()
+    {
+        var factory = CreateFactory(siteName: null, Provider("   "), Provider("real-id"));
+        Assert.AreEqual("real-id", factory.GetMachineIdentifier());
+    }
+
+    [Test]
     public void GetMachineIdentifier_AppendsSiteNameToProviderResult()
     {
         var factory = CreateFactory(siteName: "site1", Provider("base-id"));

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
@@ -83,10 +83,79 @@ public class MachineInfoFactoryTests
         Assert.Throws<InvalidOperationException>(() => factory.GetMachineIdentifier());
     }
 
-    private static MachineInfoFactory CreateFactory(string? siteName)
+    [Test]
+    public void GetMachineIdentifier_WithMachineIdentifier_ReturnsMachineIdentifierDirectly()
+    {
+        var factory = CreateFactory(siteName: null, machineIdentifier: "my-stable-id");
+        Assert.AreEqual("my-stable-id", factory.GetMachineIdentifier());
+    }
+
+    [Test]
+    public void GetMachineIdentifier_WithMachineIdentifier_AppendsSiteName()
+    {
+        var factory = CreateFactory(siteName: "site1", machineIdentifier: "my-stable-id");
+        Assert.AreEqual("my-stable-id/site1", factory.GetMachineIdentifier());
+    }
+
+    [Test]
+    public void GetMachineIdentifier_WithMachineIdentifierThatExceedsMaxLength_ThrowsInvalidOperationException()
+    {
+        var factory = CreateFactory(siteName: null, machineIdentifier: new string('x', MachineInfoFactory.MaxMachineIdentifierLength + 1));
+        Assert.Throws<InvalidOperationException>(() => factory.GetMachineIdentifier());
+    }
+
+    [Test]
+    public void GetMachineIdentifier_WithWebsiteInstanceId_UsesInstanceId()
+    {
+        string? original = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+            var factory = CreateFactory(siteName: null);
+            Assert.AreEqual("abc123instanceid", factory.GetMachineIdentifier());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, original);
+        }
+    }
+
+    [Test]
+    public void GetMachineIdentifier_WithWebsiteInstanceIdAndSiteName_UsesInstanceIdSlashSiteName()
+    {
+        string? original = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+            var factory = CreateFactory(siteName: "mysite");
+            Assert.AreEqual("abc123instanceid/mysite", factory.GetMachineIdentifier());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, original);
+        }
+    }
+
+    [Test]
+    public void GetMachineIdentifier_WithMachineIdentifierAndWebsiteInstanceId_PrefersMachineIdentifier()
+    {
+        string? original = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+            var factory = CreateFactory(siteName: null, machineIdentifier: "explicit-override");
+            Assert.AreEqual("explicit-override", factory.GetMachineIdentifier());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, original);
+        }
+    }
+
+    private static MachineInfoFactory CreateFactory(string? siteName, string? machineIdentifier = null)
     {
         var hostingEnvironment = Mock.Of<IHostingEnvironment>();
-        var hostingSettings = Options.Create(new HostingSettings { SiteName = siteName });
+        var hostingSettings = Options.Create(new HostingSettings { SiteName = siteName, MachineIdentifier = machineIdentifier });
         return new MachineInfoFactory(hostingEnvironment, hostingSettings);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
@@ -1,6 +1,3 @@
-// Copyright (c) Umbraco.
-// See LICENSE for more details.
-
 using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
@@ -13,19 +10,6 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Factories;
 [TestFixture]
 public class MachineInfoFactoryTests
 {
-    private string? _savedWebsiteInstanceId;
-
-    [SetUp]
-    public void SetUp()
-    {
-        _savedWebsiteInstanceId = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
-        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, null);
-    }
-
-    [TearDown]
-    public void TearDown() =>
-        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, _savedWebsiteInstanceId);
-
     [Test]
     public void BuildMachineIdentifier_WithNoSiteName_ReturnsMachineNameOnly()
     {
@@ -55,96 +39,49 @@ public class MachineInfoFactoryTests
     }
 
     [Test]
-    public void GetMachineIdentifier_WithNoSiteName_ReturnsSameResultAsBuildMachineIdentifier()
+    public void GetMachineIdentifier_UsesFirstNonNullProvider()
     {
-        var factory = CreateFactory(siteName: null);
-        var result = factory.GetMachineIdentifier();
-        Assert.AreEqual(MachineInfoFactory.BuildMachineIdentifier(Environment.MachineName, null), result);
+        var factory = CreateFactory(siteName: null, Provider(null), Provider("second-provider"));
+        Assert.AreEqual("second-provider", factory.GetMachineIdentifier());
     }
 
     [Test]
-    public void GetMachineIdentifier_WithEmptySiteName_ReturnsSameResultAsBuildMachineIdentifier()
+    public void GetMachineIdentifier_AppendsSiteNameToProviderResult()
     {
-        var factory = CreateFactory(siteName: string.Empty);
-        var result = factory.GetMachineIdentifier();
-        Assert.AreEqual(MachineInfoFactory.BuildMachineIdentifier(Environment.MachineName, string.Empty), result);
+        var factory = CreateFactory(siteName: "site1", Provider("base-id"));
+        Assert.AreEqual("base-id/site1", factory.GetMachineIdentifier());
     }
 
     [Test]
-    public void GetMachineIdentifier_WithWhitespaceSiteName_ReturnsSameResultAsBuildMachineIdentifier()
+    public void GetMachineIdentifier_WhenAllProvidersReturnNull_ThrowsInvalidOperationException()
     {
-        var factory = CreateFactory(siteName: "   ");
-        var result = factory.GetMachineIdentifier();
-        Assert.AreEqual(MachineInfoFactory.BuildMachineIdentifier(Environment.MachineName, "   "), result);
-    }
-
-    [Test]
-    public void GetMachineIdentifier_WithSiteName_ReturnsSameResultAsBuildMachineIdentifier()
-    {
-        var factory = CreateFactory(siteName: "site1");
-        var result = factory.GetMachineIdentifier();
-        Assert.AreEqual(MachineInfoFactory.BuildMachineIdentifier(Environment.MachineName, "site1"), result);
-    }
-
-    [Test]
-    public void GetMachineIdentifier_WithSiteNameThatExceedsMaxLength_ThrowsInvalidOperationException()
-    {
-        var siteName = new string('x', MachineInfoFactory.MaxMachineIdentifierLength);
-
-        var factory = CreateFactory(siteName);
-
+        var factory = CreateFactory(siteName: null, Provider(null), Provider(null));
         Assert.Throws<InvalidOperationException>(() => factory.GetMachineIdentifier());
     }
 
     [Test]
-    public void GetMachineIdentifier_WithMachineIdentifier_ReturnsMachineIdentifierDirectly()
+    public void GetMachineIdentifier_WhenIdentifierExceedsMaxLength_ThrowsInvalidOperationException()
     {
-        var factory = CreateFactory(siteName: null, machineIdentifier: "my-stable-id");
-        Assert.AreEqual("my-stable-id", factory.GetMachineIdentifier());
-    }
-
-    [Test]
-    public void GetMachineIdentifier_WithMachineIdentifier_AppendsSiteName()
-    {
-        var factory = CreateFactory(siteName: "site1", machineIdentifier: "my-stable-id");
-        Assert.AreEqual("my-stable-id/site1", factory.GetMachineIdentifier());
-    }
-
-    [Test]
-    public void GetMachineIdentifier_WithMachineIdentifierThatExceedsMaxLength_ThrowsInvalidOperationException()
-    {
-        var factory = CreateFactory(siteName: null, machineIdentifier: new string('x', MachineInfoFactory.MaxMachineIdentifierLength + 1));
+        var factory = CreateFactory(siteName: null, Provider(new string('x', MachineInfoFactory.MaxMachineIdentifierLength + 1)));
         Assert.Throws<InvalidOperationException>(() => factory.GetMachineIdentifier());
     }
 
     [Test]
-    public void GetMachineIdentifier_WithWebsiteInstanceId_UsesInstanceId()
+    public void GetMachineIdentifier_WhenCombinedWithSiteNameExceedsMaxLength_ThrowsInvalidOperationException()
     {
-        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
-        var factory = CreateFactory(siteName: null);
-        Assert.AreEqual("abc123instanceid", factory.GetMachineIdentifier());
+        var factory = CreateFactory(
+            siteName: new string('s', MachineInfoFactory.MaxMachineIdentifierLength),
+            Provider(new string('x', MachineInfoFactory.MaxMachineIdentifierLength)));
+        Assert.Throws<InvalidOperationException>(() => factory.GetMachineIdentifier());
     }
 
-    [Test]
-    public void GetMachineIdentifier_WithWebsiteInstanceIdAndSiteName_UsesInstanceIdSlashSiteName()
-    {
-        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
-        var factory = CreateFactory(siteName: "mysite");
-        Assert.AreEqual("abc123instanceid/mysite", factory.GetMachineIdentifier());
-    }
+    private static IMachineIdentityProvider Provider(string? value)
+        => Mock.Of<IMachineIdentityProvider>(p => p.GetMachineIdentifier() == value);
 
-    [Test]
-    public void GetMachineIdentifier_WithMachineIdentifierAndWebsiteInstanceId_PrefersMachineIdentifier()
+    private static MachineInfoFactory CreateFactory(string? siteName, params IMachineIdentityProvider[] providers)
     {
-        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
-        var factory = CreateFactory(siteName: null, machineIdentifier: "explicit-override");
-        Assert.AreEqual("explicit-override", factory.GetMachineIdentifier());
-    }
-
-    private static MachineInfoFactory CreateFactory(string? siteName, string? machineIdentifier = null)
-    {
-        var hostingEnvironment = Mock.Of<IHostingEnvironment>();
-        var hostingSettings = Options.Create(new HostingSettings { SiteName = siteName, MachineIdentifier = machineIdentifier });
-        return new MachineInfoFactory(hostingEnvironment, hostingSettings);
+        var collection = new MachineIdentityProviderCollection(() => providers);
+        var settings = Options.Create(new HostingSettings { SiteName = siteName });
+        return new MachineInfoFactory(Mock.Of<IHostingEnvironment>(), collection, settings);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Factories/MachineInfoFactoryTests.cs
@@ -13,6 +13,19 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Factories;
 [TestFixture]
 public class MachineInfoFactoryTests
 {
+    private string? _savedWebsiteInstanceId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _savedWebsiteInstanceId = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
+        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, null);
+    }
+
+    [TearDown]
+    public void TearDown() =>
+        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, _savedWebsiteInstanceId);
+
     [Test]
     public void BuildMachineIdentifier_WithNoSiteName_ReturnsMachineNameOnly()
     {
@@ -107,49 +120,25 @@ public class MachineInfoFactoryTests
     [Test]
     public void GetMachineIdentifier_WithWebsiteInstanceId_UsesInstanceId()
     {
-        string? original = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
-        try
-        {
-            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
-            var factory = CreateFactory(siteName: null);
-            Assert.AreEqual("abc123instanceid", factory.GetMachineIdentifier());
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, original);
-        }
+        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+        var factory = CreateFactory(siteName: null);
+        Assert.AreEqual("abc123instanceid", factory.GetMachineIdentifier());
     }
 
     [Test]
     public void GetMachineIdentifier_WithWebsiteInstanceIdAndSiteName_UsesInstanceIdSlashSiteName()
     {
-        string? original = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
-        try
-        {
-            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
-            var factory = CreateFactory(siteName: "mysite");
-            Assert.AreEqual("abc123instanceid/mysite", factory.GetMachineIdentifier());
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, original);
-        }
+        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+        var factory = CreateFactory(siteName: "mysite");
+        Assert.AreEqual("abc123instanceid/mysite", factory.GetMachineIdentifier());
     }
 
     [Test]
     public void GetMachineIdentifier_WithMachineIdentifierAndWebsiteInstanceId_PrefersMachineIdentifier()
     {
-        string? original = Environment.GetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable);
-        try
-        {
-            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
-            var factory = CreateFactory(siteName: null, machineIdentifier: "explicit-override");
-            Assert.AreEqual("explicit-override", factory.GetMachineIdentifier());
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, original);
-        }
+        Environment.SetEnvironmentVariable(MachineInfoFactory.AzureWebsiteInstanceIdEnvironmentVariable, "abc123instanceid");
+        var factory = CreateFactory(siteName: null, machineIdentifier: "explicit-override");
+        Assert.AreEqual("explicit-override", factory.GetMachineIdentifier());
     }
 
     private static MachineInfoFactory CreateFactory(string? siteName, string? machineIdentifier = null)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj
@@ -65,5 +65,14 @@
     <Compile Update="Umbraco.Core\Extensions\ContentExtensionsTests.GetStatus.cs">
       <DependentUpon>ContentExtensionsTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Core\Factories\MachineIdentityProviderTests.Configured.cs">
+      <DependentUpon>MachineIdentityProviderTests.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Umbraco.Core\Factories\MachineIdentityProviderTests.Default.cs">
+      <DependentUpon>MachineIdentityProviderTests.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Umbraco.Core\Factories\MachineIdentityProviderTests.AzureWebsiteInstanceId.cs">
+      <DependentUpon>MachineIdentityProviderTests.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #22947 and #13909 

Adds a best effort fix by using the `WEBSITE_INSTANCE_ID` environment variable when it's present, this variable is the ID of the underlying VM running the appservice on Azure, which is stable across reboots on Linux/Docker. This variable may change the worker VM changes, but this is the same behaviour as Windows. If you want it guaranteed that the machine identifier doesn't change unless you really want it to, a new app setting has been added where you can manually specify a machine name.


## Problem

On **Azure App Service Linux**, `Environment.MachineName` is the container hostname and changes on every container recycle (deploy, restart, scale event). The `umbracoLastSynced` table is keyed by this value, so after a restart no existing row is found, `GetLastSyncedExternalAsync()` returns `null`, and `SyncBootStateAccessor` always triggers a **cold boot** — rebuilding Examine indexes and the full published content cache on every restart.

The same issue would affect any containerised or dynamic environment where the hostname is reassigned on restart.

## Solutions considered

### Count-based row adoption
On startup, if exactly one `umbracoLastSynced` row exists (an "orphan" from the previous container), adopt it instead of cold-booting. **Rejected**: in a multi-server cluster a genuinely new node would see the single existing row and incorrectly warm-boot, skipping the Examine index rebuild it requires.

### Heartbeat + stale-row adoption
Update `lastSyncedDate` on every sync cycle as a heartbeat. On startup, adopt the single row whose heartbeat has gone stale. **Rejected**: requires choosing a staleness threshold that is longer than the restart time but shorter than the heartbeat interval — fragile for fast restarts, and adds a DB write every sync cycle regardless of activity.

### Seal-on-shutdown + adopt-sealed-row
On graceful shutdown (SIGTERM / MainDom release), stamp the row with a `sealedDate`. On startup, adopt the single sealed row. **Rejected**: a scale-*down* gracefully shuts down a server and leaves its sealed row in the database permanently. When any other server later restarts, it finds that orphaned sealed row and incorrectly warm-boots.

## Solution

Two complementary mechanisms, both using `SiteName` append behaviour consistently:

**1. `WEBSITE_INSTANCE_ID` auto-detection (zero config for Azure)**
Azure App Service provides the `WEBSITE_INSTANCE_ID` environment variable to identify the instance *slot*. Unlike the container hostname, it is stable across container recycles (same worker) and changes only on scale-out or worker reassignment — exactly the semantics needed. When this env var is present, Umbraco uses it in place of `Environment.MachineName`.

**2. `Hosting:MachineIdentifier` config option (explicit override)**
For any environment where the hostname is not stable, users can now set `UMBRACO__CMS__HOSTING__MACHINEIDENTIFIER` (or the equivalent JSON config) to a stable, instance-unique value. This takes priority over both `WEBSITE_INSTANCE_ID` and `MachineName`. The `SiteName` setting is still appended when set, matching existing behaviour.

Priority order in `MachineInfoFactory.GetMachineIdentifier()`:
1. `Hosting:MachineIdentifier` (explicit config) + `SiteName`
2. `WEBSITE_INSTANCE_ID` (Azure auto-detect) + `SiteName`
3. `Environment.MachineName` + `SiteName` (existing fallback)

## Changes

- `HostingSettings` — new nullable `MachineIdentifier` property
- `MachineInfoFactory.GetMachineIdentifier()` — priority chain above; single `BuildMachineIdentifier` call; `WEBSITE_INSTANCE_ID` env var name extracted to `AzureWebsiteInstanceIdEnvironmentVariable` constant
- `HostingSettingsValidator` — validates combined `MachineIdentifier`+`SiteName` length when `MachineIdentifier` is set
- `appsettings-schema.Umbraco.Cms.json` — `MachineIdentifier` added to `HostingSettings` schema
- Unit tests for all priority-chain cases, length validation, and env-var override

## Test plan

- [ ] Existing unit tests pass: `MachineInfoFactoryTests`, `HostingSettingsValidatorTests`
- [ ] Setting `UMBRACO__CMS__HOSTING__MACHINEIDENTIFIER=my-stable-id` results in `my-stable-id` (or `my-stable-id/sitename`) as the `machineId` in `umbracoLastSynced` after boot
- [ ] Setting `WEBSITE_INSTANCE_ID=abc123` (without `MachineIdentifier`) results in `abc123` as `machineId`
- [ ] With neither set, existing `MachineName`-based behaviour is unchanged
- [ ] On a restart with the same identifier, Umbraco warm-boots (no Examine rebuild)