### PR TITLE
Installer: Set appropriate autocomplete hints on install forms

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/installer/consent/installer-consent.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/consent/installer-consent.element.ts
@@ -80,6 +80,7 @@ export class UmbInstallerConsentElement extends UmbLitElement {
 		return html`
 			<uui-slider
 				${umbFocus()}
+				autocomplete="off"
 				@input=${this._handleChange}
 				name="telemetryLevel"
 				label="telemetry-level"

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
@@ -246,7 +246,6 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 				@input=${this._handleChange}
 				.value=${this.databaseFormData.server ?? ''}
 				.placeholder=${this._selectedDatabase?.serverPlaceholder ?? ''}
-				autocomplete="off"
 				required
 				required-message="Server is required"></uui-input>
 		</uui-form-layout-item>

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/database/installer-database.element.ts
@@ -246,6 +246,7 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 				@input=${this._handleChange}
 				.value=${this.databaseFormData.server ?? ''}
 				.placeholder=${this._selectedDatabase?.serverPlaceholder ?? ''}
+				autocomplete="off"
 				required
 				required-message="Server is required"></uui-input>
 		</uui-form-layout-item>
@@ -263,6 +264,7 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 				label="Database name"
 				@input=${this._handleChange}
 				placeholder="umbraco"
+				autocomplete="off"
 				required
 				required-message="Database name is required"></uui-input>
 		</uui-form-layout-item>`;
@@ -284,6 +286,7 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 									name="username"
 									label="Username"
 									@input=${this._handleChange}
+									autocomplete="off"
 									required
 									required-message="Username is required"></uui-input>
 							</uui-form-layout-item>
@@ -297,7 +300,7 @@ export class UmbInstallerDatabaseElement extends UmbLitElement {
 									name="password"
 									label="Password"
 									@input=${this._handleChange}
-									autocomplete="new-password"
+									autocomplete="off"
 									required
 									required-message="Password is required"></uui-input>
 							</uui-form-layout-item>`

--- a/src/Umbraco.Web.UI.Client/src/apps/installer/user/installer-user.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/installer/user/installer-user.element.ts
@@ -68,6 +68,7 @@ export class UmbInstallerUserElement extends UmbLitElement {
 						<uui-label id="nameLabel" for="name" slot="label" required>Name</uui-label>
 						<uui-input
 							${umbFocus()}
+							autocomplete="name"
 							type="text"
 							id="name"
 							.value=${this._userFormData?.name ?? ''}
@@ -80,6 +81,7 @@ export class UmbInstallerUserElement extends UmbLitElement {
 					<uui-form-layout-item>
 						<uui-label id="emailLabel" for="email" slot="label" required>Email</uui-label>
 						<uui-input
+							autocomplete="email"
 							type="email"
 							id="email"
 							.value=${this._userFormData?.email ?? ''}
@@ -92,6 +94,7 @@ export class UmbInstallerUserElement extends UmbLitElement {
 					<uui-form-layout-item>
 						<uui-label id="passwordLabel" for="password" slot="label" required>Password</uui-label>
 						<uui-input-password
+							autocomplete="new-password"
 							id="password"
 							name="password"
 							label="password"


### PR DESCRIPTION
## What

Sets `autocomplete` hints on the installer forms so password managers behave predictably:

- **User step** (admin account creation): `autocomplete="name"`, `email`, and `new-password`. This is a genuinely new login, so password managers should recognise it and offer to save it.
- **Database step** (connection config): `autocomplete="off"` on server, database name, username and password. These are existing infrastructure credentials, not a new password, and shouldn't be captured by a personal password manager. The password field previously used `new-password`, which is incorrect here.
- **Consent step**: `autocomplete="off"` on the telemetry `uui-slider`. This has no effect today (see follow-up) but documents intent.

## Why

Relates to **AB#68794** — password managers (e.g. LastPass) attaching autofill UX to installer fields where it isn't wanted, notably the telemetry slider.

Honest caveat: the specific slider behaviour could not be reproduced locally — it depends on password-manager heuristics/version, https, and stored credentials. These changes are the correct declarative hints regardless, and they make password-manager behaviour on the installer predictable.

## Follow-up

The slider can't be fully fixed from here: `uui-slider` neither exposes nor forwards `autocomplete` to its inner `<input>` (unlike `uui-input`). A follow-up in **Umbraco.UI** to forward `autocomplete` on `uui-slider` will let the `autocomplete="off"` added here take effect and close out AB#68794. Note that `autocomplete="off"` alone is weak against some managers (LastPass ignores it on some fields), so the UI-library work may also want to support the vendor opt-out attributes (`data-lpignore`, `data-1p-ignore`, …) on form-associated controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
