### PR TITLE
Health Probes: Return 503 from the readiness probe when Umbraco is not ready (closes #22020)

### DIFF
--- a/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/ApplicationBuilderExtensions.cs
@@ -180,7 +180,7 @@ public static class ApplicationBuilderExtensions
     ///     </para>
     ///     <para>
     ///         <c>GET /umbraco/api/health/ready</c> — 200 only when <see cref="RuntimeLevel.Run"/>,
-    ///         503 Degraded during <see cref="RuntimeLevel.Upgrading"/> and other non-Run states.
+    ///         503 (Unhealthy) during <see cref="RuntimeLevel.Upgrading"/> and other non-Run states.
     ///     </para>
     /// </remarks>
     public static IApplicationBuilder UseUmbracoHealthChecks(this IApplicationBuilder app)

--- a/src/Umbraco.Web.Common/HealthChecks/UmbracoReadinessHealthCheck.cs
+++ b/src/Umbraco.Web.Common/HealthChecks/UmbracoReadinessHealthCheck.cs
@@ -9,6 +9,8 @@ namespace Umbraco.Cms.Web.Common.HealthChecks;
 /// Reports <see cref="HealthCheckResult.Healthy"/> when the runtime level is <see cref="RuntimeLevel.Run"/>,
 /// otherwise <see cref="HealthCheckResult.Unhealthy"/> (mapped to HTTP 503 by the default status-code mapping)
 /// so the endpoint signals "not ready" during startup and unattended upgrades.
+/// A <see cref="RuntimeLevel.BootFailed"/> runtime never reaches this check: BootFailedMiddleware is
+/// registered ahead of the health checks and short-circuits the request with HTTP 500.
 /// </summary>
 internal sealed class UmbracoReadinessHealthCheck : IHealthCheck
 {

--- a/src/Umbraco.Web.Common/HealthChecks/UmbracoReadinessHealthCheck.cs
+++ b/src/Umbraco.Web.Common/HealthChecks/UmbracoReadinessHealthCheck.cs
@@ -6,7 +6,9 @@ namespace Umbraco.Cms.Web.Common.HealthChecks;
 
 /// <summary>
 /// ASP.NET Core health check that reports readiness based on the Umbraco runtime level.
-/// Reports <see cref="HealthCheckResult.Healthy"/> only when the runtime level is <see cref="RuntimeLevel.Run"/>.
+/// Reports <see cref="HealthCheckResult.Healthy"/> when the runtime level is <see cref="RuntimeLevel.Run"/>,
+/// otherwise <see cref="HealthCheckResult.Unhealthy"/> (mapped to HTTP 503 by the default status-code mapping)
+/// so the endpoint signals "not ready" during startup and unattended upgrades.
 /// </summary>
 internal sealed class UmbracoReadinessHealthCheck : IHealthCheck
 {
@@ -21,5 +23,5 @@ internal sealed class UmbracoReadinessHealthCheck : IHealthCheck
         => Task.FromResult(
             _runtimeState.Level == RuntimeLevel.Run
                 ? HealthCheckResult.Healthy("Umbraco is ready.")
-                : HealthCheckResult.Degraded($"Umbraco is not yet ready. Level: {_runtimeState.Level}"));
+                : HealthCheckResult.Unhealthy($"Umbraco is not yet ready. Level: {_runtimeState.Level}"));
 }

--- a/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
+++ b/src/Umbraco.Web.Common/Umbraco.Web.Common.csproj
@@ -41,5 +41,8 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Umbraco.Tests.UnitTests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Umbraco.Tests.Integration</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.Common/ApplicationBuilder/UseUmbracoHealthChecksTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.Common/ApplicationBuilder/UseUmbracoHealthChecksTests.cs
@@ -50,6 +50,8 @@ public class UseUmbracoHealthChecksTests
     }
 
     [TestCase(RuntimeLevel.Run)]
+    [TestCase(RuntimeLevel.Boot)]
+    [TestCase(RuntimeLevel.Install)]
     [TestCase(RuntimeLevel.Upgrading)]
     public async Task Live_RegardlessOfLevel_Returns200(RuntimeLevel level)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.Common/ApplicationBuilder/UseUmbracoHealthChecksTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.Common/ApplicationBuilder/UseUmbracoHealthChecksTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.HealthChecks;
+using Umbraco.Cms.Web.Common.Middleware;
+using Umbraco.Extensions;
+using IHostingEnvironment = Umbraco.Cms.Core.Hosting.IHostingEnvironment;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.Common.ApplicationBuilder;
+
+[TestFixture]
+public class UseUmbracoHealthChecksTests
+{
+    [Test]
+    public async Task Ready_WhenLevelIsRun_Returns200()
+    {
+        using IHost host = await StartHostAsync(RuntimeLevel.Run);
+
+        using HttpResponseMessage response = await host.GetTestClient().GetAsync("/umbraco/api/health/ready");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+    }
+
+    // BootFailed is deliberately excluded: in the real pipeline BootFailedMiddleware is registered
+    // ahead of the health checks and short-circuits a BootFailed runtime before /ready is reached
+    // (see Ready_WhenBootFailed_IsInterceptedAndReturns500). The remaining non-Run levels do reach
+    // the readiness check.
+    [TestCase(RuntimeLevel.Boot)]
+    [TestCase(RuntimeLevel.Install)]
+    [TestCase(RuntimeLevel.Upgrade)]
+    [TestCase(RuntimeLevel.Upgrading)]
+    public async Task Ready_WhenLevelIsNotRun_Returns503(RuntimeLevel level)
+    {
+        using IHost host = await StartHostAsync(level);
+
+        using HttpResponseMessage response = await host.GetTestClient().GetAsync("/umbraco/api/health/ready");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
+    }
+
+    [TestCase(RuntimeLevel.Run)]
+    [TestCase(RuntimeLevel.Upgrading)]
+    public async Task Live_RegardlessOfLevel_Returns200(RuntimeLevel level)
+    {
+        using IHost host = await StartHostAsync(level);
+
+        using HttpResponseMessage response = await host.GetTestClient().GetAsync("/umbraco/api/health/live");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+    }
+
+    [Test]
+    public async Task Ready_WhenBootFailed_IsInterceptedAndReturns500()
+    {
+        // Mirrors the production pipeline order in UseUmbracoRouting: BootFailedMiddleware runs
+        // before the health checks, so a BootFailed runtime never reaches the readiness check and
+        // surfaces as 500 rather than 503.
+        using IHost host = await StartHostAsync(RuntimeLevel.BootFailed, withBootFailedMiddleware: true);
+
+        using HttpResponseMessage response = await host.GetTestClient().GetAsync("/umbraco/api/health/ready");
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+    }
+
+    private static async Task<IHost> StartHostAsync(RuntimeLevel level, bool withBootFailedMiddleware = false)
+    {
+        IHost host = new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddSingleton(Mock.Of<IRuntimeState>(s => s.Level == level));
+                        services.AddHealthChecks()
+                            .AddCheck<UmbracoReadinessHealthCheck>(
+                                "umbraco-ready",
+                                tags: [UmbracoReadinessHealthCheck.ReadyTag]);
+
+                        if (withBootFailedMiddleware)
+                        {
+                            services.AddSingleton(Mock.Of<IHostingEnvironment>(e => e.IsDebugMode == false));
+                            services.AddSingleton(Mock.Of<IWebHostEnvironment>(e => e.WebRootFileProvider == new NullFileProvider()));
+                            services.AddSingleton<BootFailedMiddleware>();
+                        }
+                    })
+                    .Configure(app =>
+                    {
+                        if (withBootFailedMiddleware)
+                        {
+                            app.UseMiddleware<BootFailedMiddleware>();
+                        }
+
+                        app.UseUmbracoHealthChecks();
+                    });
+            })
+            .Build();
+
+        await host.StartAsync();
+        return host;
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/HealthChecks/UmbracoReadinessHealthCheckTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/HealthChecks/UmbracoReadinessHealthCheckTests.cs
@@ -26,11 +26,11 @@ public class UmbracoReadinessHealthCheckTests
     [TestCase(RuntimeLevel.Install)]
     [TestCase(RuntimeLevel.Upgrade)]
     [TestCase(RuntimeLevel.BootFailed)]
-    public async Task CheckHealthAsync_WhenLevelIsNotRun_ReturnsDegraded(RuntimeLevel level)
+    public async Task CheckHealthAsync_WhenLevelIsNotRun_ReturnsUnhealthy(RuntimeLevel level)
     {
         var check = CreateCheck(level);
         HealthCheckResult result = await check.CheckHealthAsync(null!);
-        Assert.That(result.Status, Is.EqualTo(HealthStatus.Degraded));
+        Assert.That(result.Status, Is.EqualTo(HealthStatus.Unhealthy));
     }
 
     [Test]


### PR DESCRIPTION
## Description

The readiness health probe at `GET /umbraco/api/health/ready` (introduced in 17.3, #22020) returned **HTTP 200 during startup and unattended upgrades**, when it should return **503**.

`UmbracoReadinessHealthCheck` reported `HealthCheckResult.Degraded` for any non-`Run` runtime level, and the endpoint is mapped with no `ResultStatusCodes` override. Under ASP.NET Core's default health-check status mapping, `Degraded → 200` (only `Unhealthy → 503`). So a node that was still booting or mid-upgrade answered `200 OK` on `/ready` — contradicting both the doc-comment above the endpoint mapping and the [public docs](https://docs.umbraco.com/umbraco-cms/run-in-production/infrastructure-and-ops/server-setup/health-probes) ("503 during startup / unattended upgrades"), and defeating the probe's purpose as a traffic gate for load balancers / Kubernetes / Cloudflare.

The existing unit test only asserted `HealthCheckResult.Status`, so the HTTP status code was never covered and the mismatch went unnoticed.

## Fix

Return `HealthCheckResult.Unhealthy` (instead of `Degraded`) for non-`Run` runtime levels. `Unhealthy` maps to HTTP 503 under the default status-code mapping, so no endpoint `ResultStatusCodes` override is needed. Readiness is binary — an instance that is not at `RuntimeLevel.Run` is genuinely not ready to serve traffic — so `Unhealthy` is the semantically correct status; `Degraded` conventionally means "still serving, sub-optimally" and would (correctly) map to 200.

Test coverage added/updated:
- **Unit:** `UmbracoReadinessHealthCheckTests` now asserts `Unhealthy` for non-`Run` levels.
- **Integration:** new `UseUmbracoHealthChecksTests` exercises the real endpoint wiring via a `TestServer` (no database) and asserts the actual HTTP codes — `/ready` 200 at `Run`, 503 for `Boot`/`Install`/`Upgrade`/`Upgrading`, and `/live` 200 regardless. It also locks the edge that a `BootFailed` runtime is intercepted upstream by `BootFailedMiddleware` and surfaces as 500 (not 503), since that path never reaches the readiness check.
- `InternalsVisibleTo` for `Umbraco.Tests.Integration` is added to `Umbraco.Web.Common` so the integration test can register the internal health check.

Verified the tests fail before the fix and pass after.

## Behavioural change

`/ready` now returns **503** (was 200) during non-`Run` states. Anyone relying on the previous (incorrect) 200 should be aware, but this restores the documented contract. The in-repo docs already state 503, so no docs change is required.

## Testing

### Automated

Unit and integration tests have been updated to reflect the new behaviour.

### Manual

Run the site, then call the probe with `curl -i -k https://localhost:44339/umbraco/api/health/ready` (anonymous endpoint — no auth needed). `-i` prints the status line.

**Scenario 1 — Running normally**
- Boot a fully-installed site (`RuntimeLevel.Run`).
- `/ready` → **200 OK**, before and after this change (baseline — proves the happy path is unaffected).

**Scenario 2 — Pending upgrade (the fix)**
- Force a pending migration: stop the site, then in the database set the stored migration-plan state to a mismatching value so Umbraco detects a pending upgrade:
  ```sql
   update umbracoKeyValue
   set value = '{D7E8F9A0-B1C2-4D3E-A5F6-7890ABCDEF12}'
   where [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core'
  ```
  Ensure unattended upgrades are off so the site parks on the upgrade screen.
- Restart. The site is now in `Upgrade`/`Upgrading` (the upgrade screen shows; the probe bypasses that re-route).
- **Before this change:** `/ready` → `200 OK` (the bug).
- **After this change:** `/ready` → **503 Service Unavailable**.
- `/live` → `200 OK` in both cases (liveness is unaffected by readiness).
