### PR TITLE
Build: Pass npm publish parameters via env to avoid script injection (S7630)

### DIFF
--- a/build/templates/npm-publish.yml
+++ b/build/templates/npm-publish.yml
@@ -15,14 +15,18 @@ steps:
   - checkout: none
   - download: current
     artifact: ${{ parameters.artifactName }}
-  - script: npm config set @umbraco-cms:registry ${{ parameters.registry }} --location=project
+  - bash: npm config set @umbraco-cms:registry "$REGISTRY_URL" --location=project
     displayName: Add scoped registry to .npmrc
     workingDirectory: $(Pipeline.Workspace)/${{ parameters.artifactName }}
+    env:
+      REGISTRY_URL: ${{ parameters.registry }}
   - task: npmAuthenticate@0
     displayName: Authenticate with npm
     inputs:
       workingFile: $(Pipeline.Workspace)/${{ parameters.artifactName }}/.npmrc
       customEndpoint: ${{ parameters.customEndpoint }}
-  - script: npm publish *.tgz --tag ${{ parameters.npmTag }}
+  - bash: npm publish *.tgz --tag "$NPM_TAG"
     displayName: ${{ parameters.displayName }}
     workingDirectory: $(Pipeline.Workspace)/${{ parameters.artifactName }}
+    env:
+      NPM_TAG: ${{ parameters.npmTag }}


### PR DESCRIPTION
## What

Stops the `npm-publish` pipeline template from interpolating template parameters directly into `script:` blocks. The `registry` and `npmTag` values are now passed through each step's `env:` block and referenced as shell variables (`$REGISTRY_URL`, `$NPM_TAG`), so they're never concatenated into the command string.

The two steps were also switched from `script:` to `bash:` so the env-variable syntax and the existing `npm publish *.tgz` glob behave deterministically across agents (the glob already required a globbing shell).

## Why

SonarCloud flags this as a **BLOCKER vulnerability** — `azurepipelines:S7630`, "Change this pipeline to not use user-controlled data directly in a script block" — on `build/templates/npm-publish.yml:18` (and line 26 is the same pattern).

In practice the values are trusted (static registry URLs, and `npmTag` is a pipeline-computed `latest`/`next`), so it isn't actually exploitable — but the rule flags the pattern regardless, and routing the values through `env:` is the sanctioned, low-risk mitigation. This fixes both flagged and sibling occurrences in the file.

Targeting `v17/dev`; merging forward to `main` will clear the SonarCloud flag there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
