### PR TITLE
Content: Extract `UmbDocumentPublishedPendingChangesManager` to reusable base class

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/index.ts
@@ -6,6 +6,7 @@ export * from './controller/merge-content-variant-data.controller.js';
 export * from './global-components/index.js';
 export * from './manager/index.js';
 export * from './property-dataset-context/index.js';
+export * from './publishing/index.js';
 export * from './rollback/index.js';
 export * from './workspace/index.js';
 

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/content-published-pending-changes-manager-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/content-published-pending-changes-manager-base.ts
@@ -6,7 +6,7 @@ import { UmbMergeContentVariantDataController } from '../controller/merge-conten
 import { jsonStringComparison, UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbEntityVariantModel } from '@umbraco-cms/backoffice/variant';
 
-export interface UmbPublishedPendingChangesManagerProcessArgs<TDetailModel extends UmbContentDetailModel> {
+export interface UmbContentPublishedPendingChangesManagerProcessArgs<TDetailModel extends UmbContentDetailModel> {
 	persistedData: TDetailModel;
 	publishedData: TDetailModel;
 }
@@ -15,10 +15,10 @@ export interface UmbPublishedPendingChangesManagerProcessArgs<TDetailModel exten
  * Base class for managing pending changes between persisted and published content.
  * @exports
  * @abstract
- * @class UmbPublishedPendingChangesManagerBase
+ * @class UmbContentPublishedPendingChangesManagerBase
  * @augments {UmbControllerBase}
  */
-export abstract class UmbPublishedPendingChangesManagerBase<
+export abstract class UmbContentPublishedPendingChangesManagerBase<
 	TDetailModel extends UmbContentDetailModel<TVariantModel>,
 	TVariantModel extends UmbEntityVariantModel = UmbEntityVariantModel,
 > extends UmbControllerBase {
@@ -28,10 +28,10 @@ export abstract class UmbPublishedPendingChangesManagerBase<
 
 	/**
 	 * Checks each variant if there are any pending changes to publish.
-	 * @param {UmbPublishedPendingChangesManagerProcessArgs<TDetailModel>} args - The arguments for the process.
+	 * @param {UmbContentPublishedPendingChangesManagerProcessArgs<TDetailModel>} args - The arguments for the process.
 	 * @returns {Promise<void>}
 	 */
-	async process(args: UmbPublishedPendingChangesManagerProcessArgs<TDetailModel>): Promise<void> {
+	async process(args: UmbContentPublishedPendingChangesManagerProcessArgs<TDetailModel>): Promise<void> {
 		if (!args.persistedData) throw new Error('Persisted data is missing');
 		if (!args.publishedData) throw new Error('Published data is missing');
 		if (args.persistedData.unique !== args.publishedData.unique)
@@ -44,7 +44,7 @@ export abstract class UmbPublishedPendingChangesManagerBase<
 	}
 
 	async #processVariant(
-		args: UmbPublishedPendingChangesManagerProcessArgs<TDetailModel>,
+		args: UmbContentPublishedPendingChangesManagerProcessArgs<TDetailModel>,
 		variantId: UmbVariantId,
 	): Promise<UmbPublishedVariantWithPendingChanges | null> {
 		const mergedData = await new UmbMergeContentVariantDataController(this).process(

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/index.ts
@@ -1,0 +1,3 @@
+export * from './published-pending-changes-manager-base.js';
+
+export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/index.ts
@@ -1,3 +1,3 @@
-export * from './published-pending-changes-manager-base.js';
+export * from './content-published-pending-changes-manager-base.js';
 
 export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/published-pending-changes-manager-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/published-pending-changes-manager-base.ts
@@ -19,7 +19,7 @@ export interface UmbPublishedPendingChangesManagerProcessArgs<TDetailModel exten
  * @augments {UmbControllerBase}
  */
 export abstract class UmbPublishedPendingChangesManagerBase<
-	TDetailModel extends UmbContentDetailModel,
+	TDetailModel extends UmbContentDetailModel<TVariantModel>,
 	TVariantModel extends UmbEntityVariantModel = UmbEntityVariantModel,
 > extends UmbControllerBase {
 	#variantsWithChanges = new UmbArrayState<UmbPublishedVariantWithPendingChanges>([], (x) => x.variantId.toString());
@@ -38,36 +38,33 @@ export abstract class UmbPublishedPendingChangesManagerBase<
 			throw new Error('Persisted and published data does not have the same unique');
 
 		const variantIds = args.persistedData.variants?.map((x) => UmbVariantId.Create(x)) ?? [];
-
-		const pendingChangesPromises = variantIds.map(async (variantId) => {
-			const mergedData = await new UmbMergeContentVariantDataController(this).process(
-				args.publishedData,
-				args.persistedData,
-				[variantId],
-				[variantId],
-			);
-
-			const mergedDataClone = structuredClone(mergedData);
-			const publishedDataClone = structuredClone(args.publishedData);
-
-			// remove dates from the comparison
-			mergedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant as TVariantModel));
-			publishedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant as TVariantModel));
-
-			this.cleanDataBeforeComparison(mergedDataClone as TDetailModel, publishedDataClone as TDetailModel);
-
-			const hasChanges = jsonStringComparison(mergedDataClone, publishedDataClone) === false;
-
-			if (hasChanges) {
-				return { variantId };
-			} else {
-				return null;
-			}
-		});
-
+		const pendingChangesPromises = variantIds.map((variantId) => this.#processVariant(args, variantId));
 		const variantsWithPendingChanges = (await Promise.all(pendingChangesPromises)).filter((x) => x !== null);
-
 		this.#variantsWithChanges.setValue(variantsWithPendingChanges);
+	}
+
+	async #processVariant(
+		args: UmbPublishedPendingChangesManagerProcessArgs<TDetailModel>,
+		variantId: UmbVariantId,
+	): Promise<UmbPublishedVariantWithPendingChanges | null> {
+		const mergedData = await new UmbMergeContentVariantDataController(this).process(
+			args.publishedData,
+			args.persistedData,
+			[variantId],
+			[variantId],
+		);
+
+		const mergedDataClone = structuredClone(mergedData);
+		const publishedDataClone = structuredClone(args.publishedData);
+
+		// remove dates from the comparison
+		mergedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant));
+		publishedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant));
+
+		this.cleanDataBeforeComparison(mergedDataClone, publishedDataClone);
+
+		const hasChanges = jsonStringComparison(mergedDataClone, publishedDataClone) === false;
+		return hasChanges ? { variantId } : null;
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/published-pending-changes-manager-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/published-pending-changes-manager-base.ts
@@ -1,0 +1,107 @@
+import type { UmbContentDetailModel } from '../types.js';
+import type { UmbPublishedVariantWithPendingChanges } from './types.js';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import { UmbMergeContentVariantDataController } from '../controller/merge-content-variant-data.controller.js';
+import { jsonStringComparison, UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbEntityVariantModel } from '@umbraco-cms/backoffice/variant';
+
+export interface UmbPublishedPendingChangesManagerProcessArgs<TDetailModel extends UmbContentDetailModel> {
+	persistedData: TDetailModel;
+	publishedData: TDetailModel;
+}
+
+/**
+ * Base class for managing pending changes between persisted and published content.
+ * @exports
+ * @abstract
+ * @class UmbPublishedPendingChangesManagerBase
+ * @augments {UmbControllerBase}
+ */
+export abstract class UmbPublishedPendingChangesManagerBase<
+	TDetailModel extends UmbContentDetailModel,
+	TVariantModel extends UmbEntityVariantModel = UmbEntityVariantModel,
+> extends UmbControllerBase {
+	#variantsWithChanges = new UmbArrayState<UmbPublishedVariantWithPendingChanges>([], (x) => x.variantId.toString());
+	/** Observable emitting the list of variants that have unpublished changes. */
+	public readonly variantsWithChanges = this.#variantsWithChanges.asObservable();
+
+	/**
+	 * Checks each variant if there are any pending changes to publish.
+	 * @param {UmbPublishedPendingChangesManagerProcessArgs<TDetailModel>} args - The arguments for the process.
+	 * @returns {Promise<void>}
+	 */
+	async process(args: UmbPublishedPendingChangesManagerProcessArgs<TDetailModel>): Promise<void> {
+		if (!args.persistedData) throw new Error('Persisted data is missing');
+		if (!args.publishedData) throw new Error('Published data is missing');
+		if (args.persistedData.unique !== args.publishedData.unique)
+			throw new Error('Persisted and published data does not have the same unique');
+
+		const variantIds = args.persistedData.variants?.map((x) => UmbVariantId.Create(x)) ?? [];
+
+		const pendingChangesPromises = variantIds.map(async (variantId) => {
+			const mergedData = await new UmbMergeContentVariantDataController(this).process(
+				args.publishedData,
+				args.persistedData,
+				[variantId],
+				[variantId],
+			);
+
+			const mergedDataClone = structuredClone(mergedData);
+			const publishedDataClone = structuredClone(args.publishedData);
+
+			// remove dates from the comparison
+			mergedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant as TVariantModel));
+			publishedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant as TVariantModel));
+
+			this.cleanDataBeforeComparison(mergedDataClone as TDetailModel, publishedDataClone as TDetailModel);
+
+			const hasChanges = jsonStringComparison(mergedDataClone, publishedDataClone) === false;
+
+			if (hasChanges) {
+				return { variantId };
+			} else {
+				return null;
+			}
+		});
+
+		const variantsWithPendingChanges = (await Promise.all(pendingChangesPromises)).filter((x) => x !== null);
+
+		this.#variantsWithChanges.setValue(variantsWithPendingChanges);
+	}
+
+	/**
+	 * Gets the variants with changes.
+	 * @returns {Array<UmbPublishedVariantWithPendingChanges>}
+	 */
+	getVariantsWithChanges(): Array<UmbPublishedVariantWithPendingChanges> {
+		return this.#variantsWithChanges.getValue();
+	}
+
+	/**
+	 * Hook to clean data before comparison. Override to remove properties
+	 * that should not affect the pending-changes calculation.
+	 * @param {TDetailModel} _mergedData - The merged data clone.
+	 * @param {TDetailModel} _publishedData - The published data clone.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	protected cleanDataBeforeComparison(_mergedData: TDetailModel, _publishedData: TDetailModel): void {
+		// No-op by default. Subclasses can override.
+	}
+
+	#cleanVariantForComparison = (variant: TVariantModel) => {
+		// The server seems to have some date mismatches when quickly
+		// fetching content after a save and comparing it to the published version.
+		// This is a temporary workaround to not include these dates in the comparison.
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-expect-error
+		delete variant.updateDate;
+	};
+
+	/**
+	 * Clear all states/values.
+	 */
+	clear() {
+		this.#variantsWithChanges.setValue([]);
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/publishing/types.ts
@@ -1,0 +1,5 @@
+import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+
+export interface UmbPublishedVariantWithPendingChanges {
+	variantId: UmbVariantId;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.test.ts
@@ -106,6 +106,12 @@ describe('UmbSelectionManager', () => {
 				expect(variantsWithChanges).to.have.lengthOf(1);
 				expect(variantsWithChanges[0].variantId.toString()).to.equal('invariant');
 			});
+
+			it('should not have variants with changes when only template differs', async () => {
+				persistedDocument.template = { unique: 'template-1' };
+				await manager.process({ persistedData: persistedDocument, publishedData: publishedDocument });
+				expect(manager.getVariantsWithChanges()).to.be.an('array').that.is.empty;
+			});
 		});
 
 		describe('variant data', () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.ts
@@ -1,94 +1,22 @@
-import type { UmbDocumentVariantModel } from '../../types.js';
-import type {
-	UmbDocumentPublishedPendingChangesManagerProcessArgs,
-	UmbPublishedVariantWithPendingChanges,
-} from './types.js';
-import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
-import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
-import { UmbMergeContentVariantDataController } from '@umbraco-cms/backoffice/content';
-import { jsonStringComparison, UmbArrayState } from '@umbraco-cms/backoffice/observable-api';
+import type { UmbDocumentDetailModel, UmbDocumentVariantModel } from '../../types.js';
+import { UmbPublishedPendingChangesManagerBase } from '@umbraco-cms/backoffice/content';
 
 /**
  * Manages the pending changes for a published document.
  * @exports
  * @class UmbDocumentPublishedPendingChangesManager
- * @augments {UmbControllerBase}
+ * @augments {UmbPublishedPendingChangesManagerBase}
  */
-export class UmbDocumentPublishedPendingChangesManager extends UmbControllerBase {
-	#variantsWithChanges = new UmbArrayState<UmbPublishedVariantWithPendingChanges>([], (x) => x.variantId.toString());
-	public readonly variantsWithChanges = this.#variantsWithChanges.asObservable();
-
-	/**
-	 * Checks each variant if there are any pending changes to publish.
-	 * @param {UmbDocumentPublishedPendingChangesManagerProcessArgs} args - The arguments for the process.
-	 * @param {UmbDocumentDetailModel} args.persistedData - The persisted document data.
-	 * @param {UmbDocumentDetailModel} args.publishedData - The published document data.
-	 * @returns {Promise<void>}
-	 * @memberof UmbDocumentPublishedPendingChangesManager
-	 */
-	async process(args: UmbDocumentPublishedPendingChangesManagerProcessArgs): Promise<void> {
-		if (!args.persistedData) throw new Error('Persisted data is missing');
-		if (!args.publishedData) throw new Error('Published data is missing');
-		if (args.persistedData.unique !== args.publishedData.unique)
-			throw new Error('Persisted and published data does not have the same unique');
-
-		const variantIds = args.persistedData.variants?.map((x) => UmbVariantId.Create(x)) ?? [];
-
-		const pendingChangesPromises = variantIds.map(async (variantId) => {
-			const mergedData = await new UmbMergeContentVariantDataController(this).process(
-				args.publishedData,
-				args.persistedData,
-				[variantId],
-				[variantId],
-			);
-
-			const mergedDataClone = structuredClone(mergedData);
-			const publishedDataClone = structuredClone(args.publishedData);
-
-			// remove dates from the comparison
-			mergedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant));
-			publishedDataClone.variants.forEach((variant) => this.#cleanVariantForComparison(variant));
-
-			// remove template from the comparison (doesn't affect publishable changes, and the published version is coming through as null)
-			mergedDataClone.template = null;
-			publishedDataClone.template = null;
-
-			const hasChanges = jsonStringComparison(mergedDataClone, publishedDataClone) === false;
-
-			if (hasChanges) {
-				return { variantId };
-			} else {
-				return null;
-			}
-		});
-
-		const variantsWithPendingChanges = (await Promise.all(pendingChangesPromises)).filter((x) => x !== null);
-
-		this.#variantsWithChanges.setValue(variantsWithPendingChanges);
-	}
-
-	/**
-	 * Gets the variants with changes.
-	 * @returns {Array<UmbPublishedVariantWithPendingChanges>}  {Array<UmbVariantWithChanges>}
-	 * @memberof UmbDocumentPublishedPendingChangesManager
-	 */
-	getVariantsWithChanges(): Array<UmbPublishedVariantWithPendingChanges> {
-		return this.#variantsWithChanges.getValue();
-	}
-
-	#cleanVariantForComparison = (variant: UmbDocumentVariantModel) => {
-		// The server seems to have some date mismatches when quickly
-		// fetching a document after a save and comparing it to the published version.
-		// This is a temporary workaround to not include these dates in the comparison.
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-expect-error
-		delete variant.updateDate;
-	};
-
-	/**
-	 * Clear all states/values,
-	 */
-	clear() {
-		this.#variantsWithChanges.setValue([]);
+export class UmbDocumentPublishedPendingChangesManager extends UmbPublishedPendingChangesManagerBase<
+	UmbDocumentDetailModel,
+	UmbDocumentVariantModel
+> {
+	protected override cleanDataBeforeComparison(
+		mergedData: UmbDocumentDetailModel,
+		publishedData: UmbDocumentDetailModel,
+	): void {
+		// remove template from the comparison (doesn't affect publishable changes, and the published version is coming through as null)
+		mergedData.template = null;
+		publishedData.template = null;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.ts
@@ -1,13 +1,13 @@
 import type { UmbDocumentDetailModel, UmbDocumentVariantModel } from '../../types.js';
-import { UmbPublishedPendingChangesManagerBase } from '@umbraco-cms/backoffice/content';
+import { UmbContentPublishedPendingChangesManagerBase } from '@umbraco-cms/backoffice/content';
 
 /**
  * Manages the pending changes for a published document.
  * @exports
  * @class UmbDocumentPublishedPendingChangesManager
- * @augments {UmbPublishedPendingChangesManagerBase}
+ * @augments {UmbContentPublishedPendingChangesManagerBase}
  */
-export class UmbDocumentPublishedPendingChangesManager extends UmbPublishedPendingChangesManagerBase<
+export class UmbDocumentPublishedPendingChangesManager extends UmbContentPublishedPendingChangesManagerBase<
 	UmbDocumentDetailModel,
 	UmbDocumentVariantModel
 > {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/types.ts
@@ -1,11 +1,7 @@
 import type { UmbDocumentDetailModel } from '../../types.js';
-import type { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+import type { UmbPublishedPendingChangesManagerProcessArgs } from '@umbraco-cms/backoffice/content';
 
-export interface UmbDocumentPublishedPendingChangesManagerProcessArgs {
-	persistedData: UmbDocumentDetailModel;
-	publishedData: UmbDocumentDetailModel;
-}
+export type UmbDocumentPublishedPendingChangesManagerProcessArgs =
+	UmbPublishedPendingChangesManagerProcessArgs<UmbDocumentDetailModel>;
 
-export interface UmbPublishedVariantWithPendingChanges {
-	variantId: UmbVariantId;
-}
+export type { UmbPublishedVariantWithPendingChanges } from '@umbraco-cms/backoffice/content';

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/pending-changes/types.ts
@@ -1,7 +1,7 @@
 import type { UmbDocumentDetailModel } from '../../types.js';
-import type { UmbPublishedPendingChangesManagerProcessArgs } from '@umbraco-cms/backoffice/content';
+import type { UmbContentPublishedPendingChangesManagerProcessArgs } from '@umbraco-cms/backoffice/content';
 
 export type UmbDocumentPublishedPendingChangesManagerProcessArgs =
-	UmbPublishedPendingChangesManagerProcessArgs<UmbDocumentDetailModel>;
+	UmbContentPublishedPendingChangesManagerProcessArgs<UmbDocumentDetailModel>;
 
 export type { UmbPublishedVariantWithPendingChanges } from '@umbraco-cms/backoffice/content';


### PR DESCRIPTION
## Description

Pulls the published pending changes logic out of the document-specific manager and into a reusable base class in `@umbraco-cms/backoffice/content`.

The document manager now extends the base and overrides a single hook to strip the template field before comparison, everything else is inherited.

This is a progressive change so that it can be reused with Elements in v18.1.

## How to test?

1. **Happy path** — Publish a document, then edit it without republishing. The "pending changes" indicator in the document workspace should appear, signalling there are unpublished edits.
2. **Clears on publish** — Publish those pending changes and confirm the indicator disappears.
3. **Template field ignored** — Change only the template on a published document (without touching content). The pending changes indicator should *not* appear, since `cleanDataBeforeComparison` explicitly strips the template before comparison.
4. **Multilingual** — If you have a multi-language setup, edit one culture variant and confirm the indicator flags only that variant, not the others.
5. **Run the existing unit tests** — There's already a test file covering the manager directly: `npm test -- --files "src/packages/documents/documents/publishing/pending-changes/document-published-pending-changes.manager.test.ts"`