### PR TITLE
Navigation: Preserve sort order when rebuilding the in-memory structure (closes #23156, #23230)

### DIFF
--- a/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
+++ b/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
@@ -13,7 +13,6 @@ public sealed class NavigationNode
 
     private readonly ConcurrentHashSet<Guid> _children;
 
-
 #pragma warning disable CS0419 // Ambiguous reference in cref attribute
     /// <summary>
     /// Cached snapshot of <see cref="Children"/> ordered by each child's <c>SortOrder</c>.

--- a/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
+++ b/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
@@ -8,17 +8,8 @@ namespace Umbraco.Cms.Core.Models.Navigation;
 /// </summary>
 public sealed class NavigationNode
 {
-    // Sort by SortOrder, then by Key as a tie-break. The Key tie-break keeps ordering
-    // deterministic across rebuilds when sibling SortOrders collide (which well-formed Umbraco
-    // data avoids, but corrupt/legacy data can produce): the underlying List.Sort is not a stable
-    // sort, so without a total order the relative position of tied siblings would be arbitrary and
-    // could differ from one rebuild to the next.
     private static readonly Comparison<(Guid Key, int SortOrder)> _sortBySortOrder =
-        static (a, b) =>
-        {
-            var bySortOrder = a.SortOrder.CompareTo(b.SortOrder);
-            return bySortOrder != 0 ? bySortOrder : a.Key.CompareTo(b.Key);
-        };
+        static (a, b) => CompareBySortOrderThenKey(a.SortOrder, a.Key, b.SortOrder, b.Key);
 
     private readonly ConcurrentHashSet<Guid> _children;
 
@@ -235,5 +226,21 @@ public sealed class NavigationNode
             _orderedChildren = result;
             return result;
         }
+    }
+
+    /// <summary>
+    ///     Defines the canonical sibling ordering: by <c>SortOrder</c>, then by key as a tie-break.
+    /// </summary>
+    /// <remarks>
+    ///     The key tie-break keeps ordering deterministic across rebuilds when sibling sort orders
+    ///     collide — which well-formed Umbraco data avoids, but corrupt/legacy data can produce.
+    ///     The <see cref="List{T}"/> sort used to order children is not a stable sort, so without a
+    ///     total order the relative position of tied siblings would be arbitrary and could differ
+    ///     from one rebuild to the next. Shared so every sibling-ordering call site stays in sync.
+    /// </remarks>
+    internal static int CompareBySortOrderThenKey(int sortOrderA, Guid keyA, int sortOrderB, Guid keyB)
+    {
+        var bySortOrder = sortOrderA.CompareTo(sortOrderB);
+        return bySortOrder != 0 ? bySortOrder : keyA.CompareTo(keyB);
     }
 }

--- a/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
+++ b/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
@@ -13,6 +13,8 @@ public sealed class NavigationNode
 
     private readonly ConcurrentHashSet<Guid> _children;
 
+
+#pragma warning disable CS0419 // Ambiguous reference in cref attribute
     /// <summary>
     /// Cached snapshot of <see cref="Children"/> ordered by each child's <c>SortOrder</c>.
     /// </summary>
@@ -25,6 +27,7 @@ public sealed class NavigationNode
     /// cannot finish after a concurrent invalidation has cleared it.
     /// </remarks>
     private Guid[]? _orderedChildren;
+#pragma warning restore CS0419 // Ambiguous reference in cref attribute
 
     private readonly Lock _orderedChildrenLock = new();
 
@@ -172,6 +175,8 @@ public sealed class NavigationNode
         return BuildOrderedChildren(navigationStructure);
     }
 
+
+#pragma warning disable CS0419 // Ambiguous reference in cref attribute
     /// <summary>
     ///     Invalidates the cached ordered-children snapshot.
     /// </summary>
@@ -181,6 +186,7 @@ public sealed class NavigationNode
     ///     child <c>SortOrder</c> and so is stale after such an update).
     /// </remarks>
     internal void InvalidateOrderedChildren()
+#pragma warning restore CS0419 // Ambiguous reference in cref attribute
     {
         lock (_orderedChildrenLock)
         {
@@ -231,6 +237,14 @@ public sealed class NavigationNode
     /// <summary>
     ///     Defines the canonical sibling ordering: by <c>SortOrder</c>, then by key as a tie-break.
     /// </summary>
+    /// <param name="sortOrderA">The sort order of the first node.</param>
+    /// <param name="keyA">The key of the first node, used as the tie-break when sort orders are equal.</param>
+    /// <param name="sortOrderB">The sort order of the second node.</param>
+    /// <param name="keyB">The key of the second node, used as the tie-break when sort orders are equal.</param>
+    /// <returns>
+    ///     A negative value if the first node sorts before the second, a positive value if it sorts
+    ///     after, and zero only when both the sort order and key are equal.
+    /// </returns>
     /// <remarks>
     ///     The key tie-break keeps ordering deterministic across rebuilds when sibling sort orders
     ///     collide — which well-formed Umbraco data avoids, but corrupt/legacy data can produce.

--- a/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
+++ b/src/Umbraco.Core/Models/Navigation/NavigationNode.cs
@@ -8,8 +8,17 @@ namespace Umbraco.Cms.Core.Models.Navigation;
 /// </summary>
 public sealed class NavigationNode
 {
+    // Sort by SortOrder, then by Key as a tie-break. The Key tie-break keeps ordering
+    // deterministic across rebuilds when sibling SortOrders collide (which well-formed Umbraco
+    // data avoids, but corrupt/legacy data can produce): the underlying List.Sort is not a stable
+    // sort, so without a total order the relative position of tied siblings would be arbitrary and
+    // could differ from one rebuild to the next.
     private static readonly Comparison<(Guid Key, int SortOrder)> _sortBySortOrder =
-        static (a, b) => a.SortOrder.CompareTo(b.SortOrder);
+        static (a, b) =>
+        {
+            var bySortOrder = a.SortOrder.CompareTo(b.SortOrder);
+            return bySortOrder != 0 ? bySortOrder : a.Key.CompareTo(b.Key);
+        };
 
     private readonly ConcurrentHashSet<Guid> _children;
 
@@ -91,6 +100,22 @@ public sealed class NavigationNode
     /// <param name="childKey">The key of the child node to add.</param>
     /// <exception cref="KeyNotFoundException">Thrown when the child key is not found in the navigation structure.</exception>
     public void AddChild(ConcurrentDictionary<Guid, NavigationNode> navigationStructure, Guid childKey)
+        => AddChild(navigationStructure, childKey, appendAsLastItem: true);
+
+    /// <summary>
+    ///     Adds a child node to this node, optionally preserving the child's existing <see cref="SortOrder"/>.
+    /// </summary>
+    /// <param name="navigationStructure">The navigation structure dictionary containing all nodes.</param>
+    /// <param name="childKey">The key of the child node to add.</param>
+    /// <param name="appendAsLastItem">
+    ///     When <c>true</c>, the child's <see cref="SortOrder"/> is set so it sorts after its existing
+    ///     siblings (the behaviour required when a node is newly created or moved). When <c>false</c>,
+    ///     the child's <see cref="SortOrder"/> is left untouched — used when rebuilding the structure
+    ///     from persisted data, where each node already carries the sort order loaded from the database
+    ///     and the load order (parent-first, by path) must not be allowed to redefine it.
+    /// </param>
+    /// <exception cref="KeyNotFoundException">Thrown when the child key is not found in the navigation structure.</exception>
+    internal void AddChild(ConcurrentDictionary<Guid, NavigationNode> navigationStructure, Guid childKey, bool appendAsLastItem)
     {
         if (navigationStructure.TryGetValue(childKey, out NavigationNode? child) is false)
         {
@@ -99,8 +124,10 @@ public sealed class NavigationNode
 
         child.Parent = Key;
 
-        // Add it as the last item
-        child.SortOrder = _children.Count;
+        if (appendAsLastItem)
+        {
+            child.SortOrder = _children.Count;
+        }
 
         _children.Add(childKey);
 

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -1023,7 +1023,12 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             childrenWithSortOrder.Add((childNodeKey, childNode.SortOrder));
         }
 
-        childrenWithSortOrder.Sort((a, b) => a.SortOrder.CompareTo(b.SortOrder));
+        // Tie-break by key so tied sibling SortOrders sort deterministically across rebuilds.
+        childrenWithSortOrder.Sort((a, b) =>
+        {
+            var bySortOrder = a.SortOrder.CompareTo(b.SortOrder);
+            return bySortOrder != 0 ? bySortOrder : a.ChildNodeKey.CompareTo(b.ChildNodeKey);
+        });
         return childrenWithSortOrder.ConvertAll(childWithSortOrder => childWithSortOrder.ChildNodeKey);
     }
 
@@ -1072,10 +1077,12 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
                 continue;
             }
 
-            // If the parent node exists in the nodesStructure, add the node to the parent's children (parent is set as well)
+            // If the parent node exists in the nodesStructure, add the node to the parent's children (parent is set as well).
+            // The node already carries its persisted SortOrder (set on construction above), so the child is linked without
+            // reassigning it — the load order here is by path (parent-first), not sort order, and must not redefine it.
             if (nodesStructure.TryGetValue(parentKey, out NavigationNode? parentNode))
             {
-                parentNode.AddChild(nodesStructure, entity.Key);
+                parentNode.AddChild(nodesStructure, entity.Key, appendAsLastItem: false);
             }
         }
     }

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -1023,12 +1023,10 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             childrenWithSortOrder.Add((childNodeKey, childNode.SortOrder));
         }
 
-        // Tie-break by key so tied sibling SortOrders sort deterministically across rebuilds.
+        // Shares NavigationNode's canonical sibling ordering (SortOrder, then key tie-break) so the
+        // content-type-filtered path stays in sync with the unfiltered, cached path.
         childrenWithSortOrder.Sort((a, b) =>
-        {
-            var bySortOrder = a.SortOrder.CompareTo(b.SortOrder);
-            return bySortOrder != 0 ? bySortOrder : a.ChildNodeKey.CompareTo(b.ChildNodeKey);
-        });
+            NavigationNode.CompareBySortOrderThenKey(a.SortOrder, a.ChildNodeKey, b.SortOrder, b.ChildNodeKey));
         return childrenWithSortOrder.ConvertAll(childWithSortOrder => childWithSortOrder.ChildNodeKey);
     }
 

--- a/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
+++ b/src/Umbraco.Core/Services/Navigation/ContentNavigationServiceBase.cs
@@ -493,7 +493,8 @@ internal abstract class ContentNavigationServiceBase<TContentType, TContentTypeS
             return false; // Node with this key already exists
         }
 
-        parentNode?.AddChild(_navigation.Structure, key);
+        // If sortOrder supplied → caller is asserting the position, preserve it; otherwise append last.
+        parentNode?.AddChild(_navigation.Structure, key, appendAsLastItem: sortOrder is null);
 
         _navigation.Invalidate();
         return true;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceTest.cs
@@ -159,6 +159,32 @@ public class ContentNavigationServiceTest
             Is.EqualTo(new[] { childAKey, grandA2Key, grandA1Key, childBKey, grandB2Key, grandB1Key }));
     }
 
+    [Test]
+    public void Can_Add_Children_With_Explicit_Sort_Order()
+    {
+        // The cache refreshers pass the real content.SortOrder to Add(). When children are added in an
+        // order that differs from their sort order — as a RefreshBranch walking descendants in path
+        // order can do — the supplied sort order must be honoured rather than overwritten with the
+        // insertion position. Children are added C, A, B here but with sort orders that yield A, B, C.
+        var contentType = Guid.NewGuid();
+        var parentKey = Guid.NewGuid();
+        var childCKey = Guid.NewGuid();
+        var childAKey = Guid.NewGuid();
+        var childBKey = Guid.NewGuid();
+
+        var contentNavigationService = new DocumentNavigationService(GetScopeProvider(), Mock.Of<INavigationRepository>(), Mock.Of<IContentTypeService>());
+
+        contentNavigationService.Add(parentKey, contentType);
+        contentNavigationService.Add(childCKey, contentType, parentKey, sortOrder: 2);
+        contentNavigationService.Add(childAKey, contentType, parentKey, sortOrder: 0);
+        contentNavigationService.Add(childBKey, contentType, parentKey, sortOrder: 1);
+
+        var success = contentNavigationService.TryGetChildrenKeys(parentKey, out IEnumerable<Guid> childrenKeys);
+
+        Assert.IsTrue(success);
+        Assert.That(childrenKeys, Is.EqualTo(new[] { childAKey, childBKey, childCKey }));
+    }
+
     public ICoreScopeProvider GetScopeProvider()
     {
         var mockScope = new Mock<IScope>();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceTest.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/ContentNavigationServiceTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
@@ -79,6 +79,84 @@ public class ContentNavigationServiceTest
 
         Assert.IsTrue(success);
         Assert.That(level, Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task Can_Get_Children_In_Sort_Order_After_Rebuild()
+    {
+        // Regression test for #23156 / #23230: after a rebuild, TryGetChildrenKeys must return
+        // children in their persisted SortOrder, not in the order the repository yields rows.
+        // The repository orders by path (parent-first), which is effectively node-id/creation
+        // order; here the children are created C, B, A (ascending id) but sorted A, B, C
+        // (descending id).
+        var rootKey = Guid.NewGuid();
+        var childCKey = Guid.NewGuid();
+        var childBKey = Guid.NewGuid();
+        var childAKey = Guid.NewGuid();
+
+        // Returned in path/id order (the order the repository produces), with SortOrder reversed.
+        IEnumerable<INavigationModel> navigationNodes =
+        [
+            new NavigationDto { Key = rootKey, ParentId = -1, Id = 1, SortOrder = 0, Trashed = false },
+            new NavigationDto { Key = childCKey, ParentId = 1, Id = 2, SortOrder = 2, Trashed = false },
+            new NavigationDto { Key = childBKey, ParentId = 1, Id = 3, SortOrder = 1, Trashed = false },
+            new NavigationDto { Key = childAKey, ParentId = 1, Id = 4, SortOrder = 0, Trashed = false },
+        ];
+
+        var navigationRepoMock = new Mock<INavigationRepository>();
+        navigationRepoMock.Setup(x => x.GetContentNodesByObjectType(Constants.ObjectTypes.Document))
+            .Returns(navigationNodes);
+
+        var contentNavigationService = new DocumentNavigationService(GetScopeProvider(), navigationRepoMock.Object, Mock.Of<IContentTypeService>());
+        await contentNavigationService.RebuildAsync();
+
+        var success = contentNavigationService.TryGetChildrenKeys(rootKey, out IEnumerable<Guid> childrenKeys);
+
+        Assert.IsTrue(success);
+        Assert.That(childrenKeys, Is.EqualTo(new[] { childAKey, childBKey, childCKey }));
+    }
+
+    [Test]
+    public async Task Can_Get_Descendants_In_Sort_Order_After_Rebuild()
+    {
+        // #23156 calls out Descendants() specifically: descendants are walked depth-first using
+        // each parent's ordered children, so a rebuild that loses SortOrder corrupts the whole
+        // walk. Here both levels have SortOrder reversed relative to id/path order, so the
+        // depth-first result only matches if SortOrder survives the rebuild at every level.
+        var rootKey = Guid.NewGuid();
+        var childBKey = Guid.NewGuid();
+        var childAKey = Guid.NewGuid();
+        var grandB2Key = Guid.NewGuid();
+        var grandB1Key = Guid.NewGuid();
+        var grandA2Key = Guid.NewGuid();
+        var grandA1Key = Guid.NewGuid();
+
+        // Supplied parent-first (as the repository's path ordering guarantees), ids ascending,
+        // SortOrder reversed at each level so A sorts before B and *2 sorts before *1.
+        IEnumerable<INavigationModel> navigationNodes =
+        [
+            new NavigationDto { Key = rootKey, ParentId = -1, Id = 1, SortOrder = 0, Trashed = false },
+            new NavigationDto { Key = childBKey, ParentId = 1, Id = 2, SortOrder = 1, Trashed = false },
+            new NavigationDto { Key = childAKey, ParentId = 1, Id = 3, SortOrder = 0, Trashed = false },
+            new NavigationDto { Key = grandB1Key, ParentId = 2, Id = 4, SortOrder = 1, Trashed = false },
+            new NavigationDto { Key = grandB2Key, ParentId = 2, Id = 5, SortOrder = 0, Trashed = false },
+            new NavigationDto { Key = grandA1Key, ParentId = 3, Id = 6, SortOrder = 1, Trashed = false },
+            new NavigationDto { Key = grandA2Key, ParentId = 3, Id = 7, SortOrder = 0, Trashed = false },
+        ];
+
+        var navigationRepoMock = new Mock<INavigationRepository>();
+        navigationRepoMock.Setup(x => x.GetContentNodesByObjectType(Constants.ObjectTypes.Document))
+            .Returns(navigationNodes);
+
+        var contentNavigationService = new DocumentNavigationService(GetScopeProvider(), navigationRepoMock.Object, Mock.Of<IContentTypeService>());
+        await contentNavigationService.RebuildAsync();
+
+        var success = contentNavigationService.TryGetDescendantsKeys(rootKey, out IEnumerable<Guid> descendantsKeys);
+
+        Assert.IsTrue(success);
+        Assert.That(
+            descendantsKeys,
+            Is.EqualTo(new[] { childAKey, grandA2Key, grandA1Key, childBKey, grandB2Key, grandB1Key }));
     }
 
     public ICoreScopeProvider GetScopeProvider()


### PR DESCRIPTION
## Description

After a site restart, `IPublishedContent.Children()` can be shown to return siblings in the wrong order — node-id / creation order instead of the persisted sort order editors had set. This PR fixes the root cause in the in-memory navigation structure.

Fixes #23156
Fixes #23230

### The underlying bug

When the navigation structure is rebuilt from the database (`ContentNavigationServiceBase.BuildNavigationDictionary`), each `NavigationNode` is constructed with its correct persisted `SortOrder`. But the very next step — linking the child to its parent via `NavigationNode.AddChild` — overwrote it:

```csharp
// Add it as the last item
child.SortOrder = _children.Count;
```

So every non-root node's effective `SortOrder` became its *insertion position during the rebuild*, discarding the value just loaded from the database.

Insertion order during a rebuild is driven by the repository query, which orders by `umbracoNode.path` to guarantee parents are processed before their children:

```csharp
.OrderBy<NodeDto>(n => n.Path, "n"); // make sure that we get the parent items first
```

For siblings under one parent, `path` is `<parentPath>,<childId>`, so they end up ordered by **node id ≈ creation order** — *not* by sort order. The result: after any full rebuild, children come back in creation order. This rebuild runs on every startup via `NavigationInitializationNotificationHandler`, which is why the reporters saw correct order until they restarted, and why republishing (which drives the live `UpdateSortOrder` path) temporarily "fixed" it.

This `AddChild` behaviour was deliberate for the scenario it was written for (#17280 — "implement sorting for the in-memory navigation structures"): when a node is genuinely **created or moved**, appending it as the last item *is* its new sort order. The flaw is that the same method is reused by the rebuild-from-DB path, where the persisted order must be preserved instead.

### Why the optimisation PR exposed it

This bug was latent for a long time because `PublishedContentExtensions.GetChildren` ended with a defensive `.OrderBy(x => x.SortOrder)` over the materialised `IPublishedContent` items. Crucially, `IPublishedContent.SortOrder` comes from the **published content cache node**, not the navigation node — so it always held the correct persisted value and re-sorted the corrupted navigation order back into shape.

That `OrderBy` was originally added in #17844 as a band-aid for exactly this symptom, without addressing the root cause. The performance work in #22742 (addressing #22646) then **removed** it, on the reasonable-looking assumption that *"`TryGetChildrenKeys` already returns child keys ordered by `SortOrder`"*. That assumption is true in a live-edited session but false after a rebuild — so removing the masking `OrderBy` re-exposed the underlying navigation bug.

### The fix

Separate the two `AddChild` use-cases instead of restoring the `OrderBy` (which would re-defeat the #22742 optimisation):

- The public `AddChild(structure, childKey)` is unchanged and still appends as the last item — the correct behaviour for live `Add` / `Move` / restore.
- A new `internal AddChild(structure, childKey, bool appendAsLastItem)` overload links the child **without** touching its `SortOrder` when `appendAsLastItem: false`.
- `BuildNavigationDictionary` now calls it with `appendAsLastItem: false`, so each node keeps the `SortOrder` it was constructed with from the database. This covers both the main tree and the recycle-bin rebuild (both go through `BuildNavigationDictionary`).

Additionally, the children are now ordered by `(SortOrder, Key)` rather than `SortOrder` alone. The underlying `List.Sort` is not a stable sort, and now that the rebuild preserves raw database values, tied sibling sort orders (which well-formed data avoids, but corrupt/legacy data can produce) would otherwise sort arbitrarily and could differ from one rebuild to the next. The `Key` tie-break keeps ordering deterministic.

## Testing

### Automated

Two regression tests were added to `ContentNavigationServiceTest` (they rebuild the structure from mocked navigation models whose sort order is the reverse of id/path order, then assert ordering):

- `Can_Get_Children_In_Sort_Order_After_Rebuild` — children created C, B, A (ascending id) but sorted A, B, C; asserts `TryGetChildrenKeys` returns A, B, C after `RebuildAsync()`.
- `Can_Get_Descendants_In_Sort_Order_After_Rebuild` — a 2-level tree with sort order reversed at *every* level; asserts the depth-first `TryGetDescendantsKeys` walk respects sort order throughout.

Both were confirmed to **fail before the production change and pass after**.

### Manual

The two things that matter for reproducing: **sort order must diverge from creation order**, and you must **restart** between setup and observation (do *not* republish/reload cache in between — that masks the bug via the live update path).

1. Run the site and create a Document Type with a template (allowed at root and as a child of itself), e.g. `Page`.
2. Create a root node **Home**.
3. Under Home, create three children **in this order**: `Apple`, then `Banana`, then `Cherry` (creation order = ascending node id).
4. In the tree, **drag to re-sort** them to a different order, e.g. **Cherry, Apple, Banana**.
5. **Publish Home including descendants.**
6. Browse to Home and confirm the template lists **Cherry, Apple, Banana** (correct — still the live structure).
7. **Restart the application.** Do not republish or reload the memory cache.
8. Browse to Home again:
   - **Without the fix:** order reverts to **Apple, Banana, Cherry** (creation/id order). ❌
   - **With the fix:** stays **Cherry, Apple, Banana**. ✅

Template used for observation (on the `Page` template):

```cshtml
@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
@using Umbraco.Extensions
@{
    Layout = null;
}
<ul>
@foreach (var child in Model.Children())
{
    <li>@child.Name (sort @child.SortOrder)</li>
}
</ul>
```

To watch it break for contrast, temporarily change the one line in `BuildNavigationDictionary` back to `parentNode.AddChild(nodesStructure, entity.Key);` and restart — the order should flip, with no other difference.
