### PR TITLE
Fix exception when user creation is cancelled from a UserSavingNotification handler

### DIFF
--- a/src/Umbraco.Core/Models/Membership/IdentityCreationResult.cs
+++ b/src/Umbraco.Core/Models/Membership/IdentityCreationResult.cs
@@ -5,7 +5,12 @@ public class IdentityCreationResult
     public static IdentityCreationResult Fail(string errorMessage) =>
         new IdentityCreationResult { ErrorMessage = errorMessage, Succeded = false };
 
+    public static IdentityCreationResult CancelledByNotification() =>
+        new IdentityCreationResult { Succeded = false, WasCancelledByNotification = true };
+
     public bool Succeded { get; init; }
+
+    public bool WasCancelledByNotification { get; init; }
 
     public string? ErrorMessage { get; init; }
 

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -695,6 +695,11 @@ internal partial class UserService : RepositoryService, IUserService
 
         if (identityCreationResult.Succeded is false)
         {
+            if (identityCreationResult.WasCancelledByNotification)
+            {
+                return Attempt.FailWithStatus(UserOperationStatus.CancelledByNotification, new UserCreationResult());
+            }
+
             // If we fail from something in Identity we can't know exactly why, so we have to resolve to returning an unknown failure.
             // But there should be more information in the message.
             return Attempt.FailWithStatus(

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -152,7 +152,16 @@ public class BackOfficeUserStore :
 
         UpdateMemberProperties(userEntity, user);
 
-        SaveAsync(userEntity).GetAwaiter().GetResult();
+        UserOperationStatus saveStatus = SaveAsync(userEntity).GetAwaiter().GetResult();
+
+        if (saveStatus == UserOperationStatus.CancelledByNotification)
+        {
+            return Task.FromResult(IdentityResult.Failed(new IdentityError
+            {
+                Code = nameof(UserOperationStatus.CancelledByNotification),
+                Description = "User creation was cancelled by a notification handler."
+            }));
+        }
 
         if (!userEntity.HasIdentity)
         {

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -280,6 +280,11 @@ public class BackOfficeUserManager : UmbracoUserManager<BackOfficeIdentityUser, 
 
         if (created.Succeeded is false)
         {
+            if (created.Errors.Any(e => e.Code == nameof(UserOperationStatus.CancelledByNotification)))
+            {
+                return IdentityCreationResult.CancelledByNotification();
+            }
+
             return IdentityCreationResult.Fail(created.Errors.ToErrorMessage());
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have added an explanation of what the changes do and why they should be included
- [x] I have followed the contribution guidelines for this project
- [x] I have commented on the issue and received approval from a maintainer before raising this PR

fixes #14830

### Description

When a `UserSavingNotification` handler cancels a user creation operation, `BackOfficeUserStore.CreateAsync` ignored the `UserOperationStatus` returned by `SaveAsync` and fell through to a `!userEntity.HasIdentity` guard, throwing a `DataException`. This surfaced to the editor as a generic, unhelpful "Unknown failure" error rather than a clear indication that the operation was intentionally cancelled.

This change:

- Captures the `UserOperationStatus` returned by `SaveAsync` in `BackOfficeUserStore.CreateAsync`
- When the status is `CancelledByNotification`, returns a recognisable `IdentityResult.Failed` instead of throwing
- Adds a `WasCancelledByNotification` flag to `IdentityCreationResult` so `BackOfficeUserManager.CreateAsync` can detect the cancellation and short-circuit before attempting password creation (this also avoids a downstream failure that occurred in an earlier attempt at this issue)
- Updates `UserService.CreateAsync` to map this back to `UserOperationStatus.CancelledByNotification`, giving the editor a clean, accurate `400` response instead of a generic failure

### Testing steps

1. Register a notification handler for `UserSavingNotification` that sets `notification.Cancel = true`
2. Navigate to the Users section in the backoffice and attempt to create a new user
3. **Before this fix:** a "fatal server error" toast is shown, and the server log records a `DataException`
4. **After this fix:** the request returns a clean `400` response with `operationStatus: "CancelledByNotification"` and no exception is thrown

Screenshots of both behaviours (reproduced locally on the `contrib` branch) are attached.



<img width="1920" height="928" alt="Bug Fix" src="https://github.com/user-attachments/assets/cb5f81e1-2626-4418-9583-3c32cbd2d67b" />


<img width="1907" height="950" alt="Bug Reproduced" src="https://github.com/user-attachments/assets/4a214fab-6246-4f24-8d34-9459b6ef7f87" />
