### PR TITLE
User management: Fix exception when user creation is cancelled from a `UserSavingNotification` handler (closes #14830)

### DIFF
--- a/src/Umbraco.Core/Models/Membership/IdentityCreationResult.cs
+++ b/src/Umbraco.Core/Models/Membership/IdentityCreationResult.cs
@@ -14,9 +14,21 @@ public class IdentityCreationResult
         new IdentityCreationResult { ErrorMessage = errorMessage, Succeded = false };
 
     /// <summary>
+    ///     Creates a failed identity creation result indicating the operation was cancelled by a notification handler.
+    /// </summary>
+    /// <returns>A failed <see cref="IdentityCreationResult" /> instance with <see cref="WasCancelledByNotification" /> set.</returns>
+    public static IdentityCreationResult CancelledByNotification() =>
+        new IdentityCreationResult { Succeded = false, WasCancelledByNotification = true };
+
+    /// <summary>
     ///     Gets or initializes a value indicating whether the identity creation succeeded.
     /// </summary>
     public bool Succeded { get; init; }
+
+    /// <summary>
+    ///     Gets or initializes a value indicating whether the operation was cancelled by a notification handler.
+    /// </summary>
+    public bool WasCancelledByNotification { get; init; }
 
     /// <summary>
     ///     Gets or initializes the error message if the operation failed.

--- a/src/Umbraco.Core/Models/Membership/IdentityCreationResult.cs
+++ b/src/Umbraco.Core/Models/Membership/IdentityCreationResult.cs
@@ -11,14 +11,22 @@ public class IdentityCreationResult
     /// <param name="errorMessage">The error message describing the failure.</param>
     /// <returns>A failed <see cref="IdentityCreationResult" /> instance.</returns>
     public static IdentityCreationResult Fail(string errorMessage) =>
-        new IdentityCreationResult { ErrorMessage = errorMessage, Succeded = false };
+        new()
+        {
+            ErrorMessage = errorMessage,
+            Succeded = false,
+        };
 
     /// <summary>
     ///     Creates a failed identity creation result indicating the operation was cancelled by a notification handler.
     /// </summary>
-    /// <returns>A failed <see cref="IdentityCreationResult" /> instance with <see cref="WasCancelledByNotification" /> set.</returns>
-    public static IdentityCreationResult CancelledByNotification() =>
-        new IdentityCreationResult { Succeded = false, WasCancelledByNotification = true };
+    /// <returns>A failed <see cref="IdentityCreationResult" /> instance with <see cref="CancelledByNotification" /> set.</returns>
+    public static IdentityCreationResult Cancel() =>
+        new()
+        {
+            Succeded = false,
+            CancelledByNotification = true,
+        };
 
     /// <summary>
     ///     Gets or initializes a value indicating whether the identity creation succeeded.
@@ -28,7 +36,7 @@ public class IdentityCreationResult
     /// <summary>
     ///     Gets or initializes a value indicating whether the operation was cancelled by a notification handler.
     /// </summary>
-    public bool WasCancelledByNotification { get; init; }
+    public bool CancelledByNotification { get; init; }
 
     /// <summary>
     ///     Gets or initializes the error message if the operation failed.

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -606,7 +606,7 @@ internal partial class UserService : RepositoryService, IUserService
 
     private static Attempt<UserCreationResult, UserOperationStatus> MapCreationFailure(IdentityCreationResult identityCreationResult)
     {
-        if (identityCreationResult.WasCancelledByNotification)
+        if (identityCreationResult.CancelledByNotification)
         {
             return Attempt.FailWithStatus(UserOperationStatus.CancelledByNotification, new UserCreationResult());
         }

--- a/src/Umbraco.Core/Services/UserService.cs
+++ b/src/Umbraco.Core/Services/UserService.cs
@@ -570,11 +570,7 @@ internal partial class UserService : RepositoryService, IUserService
 
         if (identityCreationResult.Succeded is false)
         {
-            // If we fail from something in Identity we can't know exactly why, so we have to resolve to returning an unknown failure.
-            // But there should be more information in the message.
-            return Attempt.FailWithStatus(
-                UserOperationStatus.UnknownFailure,
-                new UserCreationResult { Error = new ValidationResult(identityCreationResult.ErrorMessage) });
+            return MapCreationFailure(identityCreationResult);
         }
 
         // The user is now created, so we can fetch it to map it to a result model with our generated password.
@@ -606,6 +602,20 @@ internal partial class UserService : RepositoryService, IUserService
         };
 
         return Attempt.SucceedWithStatus(UserOperationStatus.Success, creationResult);
+    }
+
+    private static Attempt<UserCreationResult, UserOperationStatus> MapCreationFailure(IdentityCreationResult identityCreationResult)
+    {
+        if (identityCreationResult.WasCancelledByNotification)
+        {
+            return Attempt.FailWithStatus(UserOperationStatus.CancelledByNotification, new UserCreationResult());
+        }
+
+        // If we fail from something in Identity we can't know exactly why, so we have to resolve to returning an unknown failure.
+        // But there should be more information in the message.
+        return Attempt.FailWithStatus(
+            UserOperationStatus.UnknownFailure,
+            new UserCreationResult { Error = new ValidationResult(identityCreationResult.ErrorMessage) });
     }
 
     /// <inheritdoc/>

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -220,9 +220,13 @@ public class BackOfficeUserStore :
 
         UserOperationStatus saveStatus = SaveAsync(userEntity).GetAwaiter().GetResult();
 
-        if (TryCreateCancelledResult(saveStatus, out Task<IdentityResult>? cancelledResult))
+        if (saveStatus == UserOperationStatus.CancelledByNotification)
         {
-            return cancelledResult!;
+            return Task.FromResult(IdentityResult.Failed(new IdentityError
+            {
+                Code = nameof(UserOperationStatus.CancelledByNotification),
+                Description = "User creation was cancelled by a notification handler.",
+            }));
         }
 
         if (!userEntity.HasIdentity)
@@ -234,12 +238,12 @@ public class BackOfficeUserStore :
         user.Id = UserIdToString(userEntity.Id);
         user.Key = userEntity.Key;
 
-        SaveDirtyExternalLoginsAndTokens(userEntity.Key, user, isLoginsPropertyDirty, isTokensPropertyDirty);
+        SaveExternalLoginsAndTokens(userEntity.Key, user, isLoginsPropertyDirty, isTokensPropertyDirty);
 
         return Task.FromResult(IdentityResult.Success);
     }
 
-    private void SaveDirtyExternalLoginsAndTokens(
+    private void SaveExternalLoginsAndTokens(
         Guid userKey,
         BackOfficeIdentityUser user,
         bool isLoginsPropertyDirty,
@@ -264,22 +268,6 @@ public class BackOfficeUserStore :
                     x.Name,
                     x.Value)));
         }
-    }
-
-    private static bool TryCreateCancelledResult(UserOperationStatus saveStatus, out Task<IdentityResult>? result)
-    {
-        if (saveStatus != UserOperationStatus.CancelledByNotification)
-        {
-            result = null;
-            return false;
-        }
-
-        result = Task.FromResult(IdentityResult.Failed(new IdentityError
-        {
-            Code = nameof(UserOperationStatus.CancelledByNotification),
-            Description = "User creation was cancelled by a notification handler."
-        }));
-        return true;
     }
 
     /// <inheritdoc />
@@ -464,25 +452,7 @@ public class BackOfficeUserStore :
                     SaveAsync(found).GetAwaiter().GetResult();
                 }
 
-                if (isLoginsPropertyDirty)
-                {
-                    _externalLoginService.Save(
-                        found.Key,
-                        user.Logins.Select(x => new ExternalLogin(
-                            x.LoginProvider,
-                            x.ProviderKey,
-                            x.UserData)));
-                }
-
-                if (isTokensPropertyDirty)
-                {
-                    _externalLoginService.Save(
-                        found.Key,
-                        user.LoginTokens.Select(x => new ExternalLoginToken(
-                            x.LoginProvider,
-                            x.Name,
-                            x.Value)));
-                }
+                SaveExternalLoginsAndTokens(found.Key, user, isLoginsPropertyDirty, isTokensPropertyDirty);
             }
 
             scope.Complete();

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -218,7 +218,12 @@ public class BackOfficeUserStore :
 
         UpdateMemberProperties(userEntity, user);
 
-        SaveAsync(userEntity).GetAwaiter().GetResult();
+        UserOperationStatus saveStatus = SaveAsync(userEntity).GetAwaiter().GetResult();
+
+        if (TryCreateCancelledResult(saveStatus, out Task<IdentityResult>? cancelledResult))
+        {
+            return cancelledResult!;
+        }
 
         if (!userEntity.HasIdentity)
         {
@@ -229,10 +234,21 @@ public class BackOfficeUserStore :
         user.Id = UserIdToString(userEntity.Id);
         user.Key = userEntity.Key;
 
+        SaveDirtyExternalLoginsAndTokens(userEntity.Key, user, isLoginsPropertyDirty, isTokensPropertyDirty);
+
+        return Task.FromResult(IdentityResult.Success);
+    }
+
+    private void SaveDirtyExternalLoginsAndTokens(
+        Guid userKey,
+        BackOfficeIdentityUser user,
+        bool isLoginsPropertyDirty,
+        bool isTokensPropertyDirty)
+    {
         if (isLoginsPropertyDirty)
         {
             _externalLoginService.Save(
-                userEntity.Key,
+                userKey,
                 user.Logins.Select(x => new ExternalLogin(
                     x.LoginProvider,
                     x.ProviderKey,
@@ -242,14 +258,28 @@ public class BackOfficeUserStore :
         if (isTokensPropertyDirty)
         {
             _externalLoginService.Save(
-                userEntity.Key,
+                userKey,
                 user.LoginTokens.Select(x => new ExternalLoginToken(
                     x.LoginProvider,
                     x.Name,
                     x.Value)));
         }
+    }
 
-        return Task.FromResult(IdentityResult.Success);
+    private static bool TryCreateCancelledResult(UserOperationStatus saveStatus, out Task<IdentityResult>? result)
+    {
+        if (saveStatus != UserOperationStatus.CancelledByNotification)
+        {
+            result = null;
+            return false;
+        }
+
+        result = Task.FromResult(IdentityResult.Failed(new IdentityError
+        {
+            Code = nameof(UserOperationStatus.CancelledByNotification),
+            Description = "User creation was cancelled by a notification handler."
+        }));
+        return true;
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -280,6 +280,11 @@ public class BackOfficeUserManager : UmbracoUserManager<BackOfficeIdentityUser, 
 
         if (created.Succeeded is false)
         {
+            if (created.Errors.Any(e => e.Code == nameof(UserOperationStatus.CancelledByNotification)))
+            {
+                return IdentityCreationResult.CancelledByNotification();
+            }
+
             return IdentityCreationResult.Fail(created.Errors.ToErrorMessage());
         }
 

--- a/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
+++ b/src/Umbraco.Web.Common/Security/BackOfficeUserManager.cs
@@ -282,7 +282,7 @@ public class BackOfficeUserManager : UmbracoUserManager<BackOfficeIdentityUser, 
         {
             if (created.Errors.Any(e => e.Code == nameof(UserOperationStatus.CancelledByNotification)))
             {
-                return IdentityCreationResult.CancelledByNotification();
+                return IdentityCreationResult.Cancel();
             }
 
             return IdentityCreationResult.Fail(created.Errors.ToErrorMessage());

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Create.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/UserServiceCrudTests.Create.cs
@@ -1,8 +1,10 @@
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Services.OperationStatus;
 
@@ -10,6 +12,43 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 
 internal sealed partial class UserServiceCrudTests
 {
+    private const string CancelledUserEmailDomain = "@saveblocked.com";
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+        => builder.AddNotificationHandler<UserSavingNotification, CancelUserSavingNotificationHandler>();
+
+    [Test]
+    public async Task Cannot_Create_User_When_Cancelled_By_Notification()
+    {
+        var userGroup = await UserGroupService.GetAsync(Constants.Security.AdminGroupAlias);
+        var creationModel = new UserCreateModel
+        {
+            UserName = "cancelled@saveblocked.com",
+            Email = "cancelled@saveblocked.com",
+            Name = "Cancelled Mc. Gee",
+            UserGroupKeys = new HashSet<Guid> { userGroup.Key }
+        };
+
+        var userService = CreateUserService();
+
+        var result = await userService.CreateAsync(Constants.Security.SuperUserKey, creationModel, true);
+
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual(UserOperationStatus.CancelledByNotification, result.Status);
+    }
+
+    private sealed class CancelUserSavingNotificationHandler : INotificationHandler<UserSavingNotification>
+    {
+        public void Handle(UserSavingNotification notification)
+        {
+            if (notification.SavedEntities.Any(user =>
+                    user.Email?.EndsWith(CancelledUserEmailDomain, StringComparison.OrdinalIgnoreCase) == true))
+            {
+                notification.Cancel = true;
+            }
+        }
+    }
+
     [Test]
     [TestCase("test@email.com", "test@email.com", true, true)]
     [TestCase("test@email.com", "notTheUserName@email.com", true, false)]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/BackOfficeUserStoreTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Security/BackOfficeUserStoreTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
@@ -7,9 +5,11 @@ using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Mapping;
 using Umbraco.Cms.Core.Models.Membership;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
 using Umbraco.Cms.Tests.Common;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
@@ -42,6 +42,12 @@ internal sealed class BackOfficeUserStoreTests : UmbracoIntegrationTest
 
     private readonly ILogger<BackOfficeUserStore> _logger = NullLogger<BackOfficeUserStore>.Instance;
 
+    [SetUp]
+    public void ResetNotificationHandler() => UserNotificationHandler.SavingUser = null;
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+        => builder.AddNotificationHandler<UserSavingNotification, UserNotificationHandler>();
+
     private BackOfficeUserStore GetUserStore()
         => new(
             ScopeProvider,
@@ -63,11 +69,11 @@ internal sealed class BackOfficeUserStoreTests : UmbracoIntegrationTest
     public async Task Can_Persist_Is_Approved()
     {
         var userStore = GetUserStore();
-        var user = new BackOfficeIdentityUser(GlobalSettings, 1, new List<IReadOnlyUserGroup>())
+        var user = new BackOfficeIdentityUser(GlobalSettings, 1, [])
         {
             Name = "Test",
             Email = "test@test.com",
-            UserName = "test@test.com"
+            UserName = "test@test.com",
         };
         var createResult = await userStore.CreateAsync(user);
         Assert.IsTrue(createResult.Succeeded);
@@ -82,5 +88,34 @@ internal sealed class BackOfficeUserStoreTests : UmbracoIntegrationTest
         // get get
         user = await userStore.FindByIdAsync(user.Id);
         Assert.IsTrue(user.IsApproved);
+    }
+
+    [Test]
+    public async Task CreateAsync_Returns_Failed_Result_When_Cancelled_By_Notification()
+    {
+        UserNotificationHandler.SavingUser = notification => notification.Cancel = true;
+
+        var userStore = GetUserStore();
+        var user = new BackOfficeIdentityUser(GlobalSettings, 1, [])
+        {
+            Name = "Test",
+            Email = "test@test.com",
+            UserName = "test@test.com",
+        };
+
+        var result = await userStore.CreateAsync(user);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(result.Succeeded);
+            Assert.IsTrue(result.Errors.Any(e => e.Code == nameof(UserOperationStatus.CancelledByNotification)));
+        });
+    }
+
+    private class UserNotificationHandler : INotificationHandler<UserSavingNotification>
+    {
+        public static Action<UserSavingNotification>? SavingUser { get; set; }
+
+        public void Handle(UserSavingNotification notification) => SavingUser?.Invoke(notification);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/Membership/IdentityCreationResultTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/Membership/IdentityCreationResultTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models.Membership;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models.Membership;
+
+[TestFixture]
+public class IdentityCreationResultTests
+{
+    [Test]
+    public void Fail_Creates_Unsuccessful_Result_With_Error_Message()
+    {
+        IdentityCreationResult result = IdentityCreationResult.Fail("something went wrong");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Succeded, Is.False);
+            Assert.That(result.CancelledByNotification, Is.False);
+            Assert.That(result.ErrorMessage, Is.EqualTo("something went wrong"));
+        });
+    }
+
+    [Test]
+    public void Cancel_Creates_Unsuccessful_Result_Flagged_As_Cancelled_By_Notification()
+    {
+        IdentityCreationResult result = IdentityCreationResult.Cancel();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Succeded, Is.False);
+            Assert.That(result.CancelledByNotification, Is.True);
+            Assert.That(result.ErrorMessage, Is.Null);
+        });
+    }
+
+    [Test]
+    public void New_Result_Is_Neither_Succeeded_Nor_Cancelled_By_Default()
+    {
+        var result = new IdentityCreationResult();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Succeded, Is.False);
+            Assert.That(result.CancelledByNotification, Is.False);
+            Assert.That(result.ErrorMessage, Is.Null);
+            Assert.That(result.InitialPassword, Is.Null);
+        });
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added an explanation of what the changes do and why they should be included
- [x] I have followed the contribution guidelines for this project
- [x] I have commented on the issue and received approval from a maintainer before raising this PR

fixes #14830

### Description

When a `UserSavingNotification` handler cancels a user creation operation, `BackOfficeUserStore.CreateAsync` ignored the `UserOperationStatus` returned by `SaveAsync` and fell through to a `!userEntity.HasIdentity` guard, throwing a `DataException`. This surfaced to the editor as a generic, unhelpful "Unknown failure" error rather than a clear indication that the operation was intentionally cancelled.

This change:

- Captures the `UserOperationStatus` returned by `SaveAsync` in `BackOfficeUserStore.CreateAsync`
- When the status is `CancelledByNotification`, returns a recognisable `IdentityResult.Failed` instead of throwing
- Adds a `WasCancelledByNotification` flag to `IdentityCreationResult` so `BackOfficeUserManager.CreateAsync` can detect the cancellation and short-circuit before attempting password creation (this also avoids a downstream failure that occurred in an earlier attempt at this issue)
- Updates `UserService.CreateAsync` to map this back to `UserOperationStatus.CancelledByNotification`, giving the editor a clean, accurate `400` response instead of a generic failure

This was originally raised against `contrib`; per feedback this has been retargeted to fix the latest LTS (`v17/dev`).

### Testing steps

1. Register a notification handler for `UserSavingNotification` that sets `notification.Cancel = true`
2. Navigate to the Users section in the backoffice and attempt to create a new user
3. **Before this fix:** a "fatal server error" toast is shown, and the server log records a `DataException`
4. **After this fix:** the request returns a clean `400` response with `operationStatus: "CancelledByNotification"` and no exception is thrown

Screenshots of both behaviours (reproduced locally) are attached.


<img width="1907" height="950" alt="Bug Reproduced" src="https://github.com/user-attachments/assets/cd033d11-2375-4144-82e8-3e3be6b488b0" />

<img width="1920" height="928" alt="Bug Fix" src="https://github.com/user-attachments/assets/062b8bd2-50d3-44b3-93cc-3fd693a3f4e3" />
