### PR TITLE
Code Quality: Resolved warnings relating to code documentation

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Extensions/HtmlHelperBackOfficeExtensions.cs
+++ b/src/Umbraco.Cms.Api.Management/Extensions/HtmlHelperBackOfficeExtensions.cs
@@ -12,7 +12,7 @@ using Umbraco.Cms.Web.Common.Hosting;
 namespace Umbraco.Cms.Api.Management.Extensions;
 
 /// <summary>
-/// Provides extension methods for <see cref="HtmlHelper"/> related to Umbraco back office functionality.
+/// Provides extension methods for <see cref="IHtmlHelper"/> related to Umbraco back office functionality.
 /// </summary>
 public static class HtmlHelperBackOfficeExtensions
 {

--- a/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ConfigurationPresentationFactory.cs
@@ -58,10 +58,10 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         };
 
     /// <summary>
-    /// Creates a new <see cref="Umbraco.Cms.Api.Management.Models.DocumentTypeConfigurationResponseModel"/> instance populated with the current document type configuration settings, including data type mutability, template availability, segment usage, and reserved field names.
+    /// Creates a new <see cref="DocumentTypeConfigurationResponseModel"/> instance populated with the current document type configuration settings, including data type mutability, template availability, segment usage, and reserved field names.
     /// </summary>
     /// <returns>
-    /// A <see cref="Umbraco.Cms.Api.Management.Models.DocumentTypeConfigurationResponseModel"/> representing the current document type configuration.
+    /// A <see cref="DocumentTypeConfigurationResponseModel"/> representing the current document type configuration.
     /// </returns>
     public DocumentTypeConfigurationResponseModel CreateDocumentTypeConfigurationResponseModel() =>
         new()
@@ -80,9 +80,9 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         new();
 
     /// <summary>
-    /// Creates a <see cref="Umbraco.Cms.Api.Management.Models.MemberTypeConfigurationResponseModel"/> containing the reserved member field names.
+    /// Creates a <see cref="MemberTypeConfigurationResponseModel"/> containing the reserved member field names.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.MemberTypeConfigurationResponseModel"/> with reserved member field names populated.</returns>
+    /// <returns>A <see cref="MemberTypeConfigurationResponseModel"/> with reserved member field names populated.</returns>
     public MemberTypeConfigurationResponseModel CreateMemberTypeConfigurationResponseModel() =>
         new()
         {
@@ -90,9 +90,9 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         };
 
     /// <summary>
-    /// Creates a new instance of <see cref="Umbraco.Cms.Api.Management.Models.MediaConfigurationResponseModel"/> with media configuration settings.
+    /// Creates a new instance of <see cref="MediaConfigurationResponseModel"/> with media configuration settings.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.MediaConfigurationResponseModel"/> containing the media configuration.</returns>
+    /// <returns>A <see cref="MediaConfigurationResponseModel"/> containing the media configuration.</returns>
     public MediaConfigurationResponseModel CreateMediaConfigurationResponseModel() =>
         new()
         {
@@ -101,10 +101,10 @@ public class ConfigurationPresentationFactory : IConfigurationPresentationFactor
         };
 
     /// <summary>
-    /// Creates a new instance of <see cref="Umbraco.Cms.Api.Management.Models.MediaTypeConfigurationResponseModel"/> containing configuration data for media types.
+    /// Creates a new instance of <see cref="MediaTypeConfigurationResponseModel"/> containing configuration data for media types.
     /// </summary>
     /// <returns>
-    /// A <see cref="Umbraco.Cms.Api.Management.Models.MediaTypeConfigurationResponseModel"/> that includes the list of reserved field names for media types.
+    /// A <see cref="MediaTypeConfigurationResponseModel"/> that includes the list of reserved field names for media types.
     /// </returns>
     public MediaTypeConfigurationResponseModel CreateMediaTypeConfigurationResponseModel() =>
         new()

--- a/src/Umbraco.Cms.Api.Management/Factories/DictionaryPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DictionaryPresentationFactory.cs
@@ -24,11 +24,11 @@ public class DictionaryPresentationFactory : IDictionaryPresentationFactory
     }
 
     /// <summary>
-    /// Asynchronously creates a <see cref="Umbraco.Cms.Api.Management.Models.DictionaryItemResponseModel" /> view model from the specified <see cref="Umbraco.Cms.Core.Models.IDictionaryItem" />.
+    /// Asynchronously creates a <see cref="DictionaryItemResponseModel" /> view model from the specified <see cref="IDictionaryItem" />.
     /// Only translations with valid language ISO codes are included in the resulting model.
     /// </summary>
     /// <param name="dictionaryItem">The dictionary item to convert into a view model.</param>
-    /// <returns>A task representing the asynchronous operation. The task result contains the created <see cref="Umbraco.Cms.Api.Management.Models.DictionaryItemResponseModel" /> with filtered translations.</returns>
+    /// <returns>A task representing the asynchronous operation. The task result contains the created <see cref="DictionaryItemResponseModel" /> with filtered translations.</returns>
     public async Task<DictionaryItemResponseModel> CreateDictionaryItemViewModelAsync(IDictionaryItem dictionaryItem)
     {
         DictionaryItemResponseModel dictionaryResponseModel = _umbracoMapper.Map<DictionaryItemResponseModel>(dictionaryItem)!;

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentPresentationFactory.cs
@@ -218,12 +218,12 @@ internal sealed class DocumentPresentationFactory : IDocumentPresentationFactory
         => _umbracoMapper.Map<DocumentTypeReferenceResponseModel>(entity)!;
 
     /// <summary>
-    /// Creates a list of <see cref="Umbraco.Cms.Api.Management.Models.Content.CulturePublishScheduleModel"/> instances from the specified <see cref="Umbraco.Cms.Api.Management.Models.Content.PublishDocumentRequestModel"/>.
+    /// Creates a list of <see cref="CulturePublishScheduleModel"/> instances from the specified <see cref="PublishDocumentRequestModel"/>.
     /// Validates the publish and unpublish times for each culture's schedule, ensuring they are in the future and that unpublish times are after publish times.
-    /// Returns an <see cref="Umbraco.Cms.Core.Models.Attempt"/> containing the resulting list and a <see cref="Umbraco.Cms.Api.Management.Models.Content.ContentPublishingOperationStatus"/> indicating the outcome of the validation.
+    /// Returns an <see cref="Attempt"/> containing the resulting list and a <see cref="ContentPublishingOperationStatus"/> indicating the outcome of the validation.
     /// </summary>
     /// <param name="requestModel">The request model containing culture-specific publish schedules to process.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Core.Models.Attempt"/> with a list of <see cref="Umbraco.Cms.Api.Management.Models.Content.CulturePublishScheduleModel"/> and the validation status.</returns>
+    /// <returns>An <see cref="Attempt"/> with a list of <see cref="CulturePublishScheduleModel"/> and the validation status.</returns>
     public Attempt<List<CulturePublishScheduleModel>, ContentPublishingOperationStatus> CreateCulturePublishScheduleModels(PublishDocumentRequestModel requestModel)
     {
         var model = new List<CulturePublishScheduleModel>();

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
@@ -44,7 +44,7 @@ public class DocumentUrlFactory : IDocumentUrlFactory
     }
 
     /// <summary>
-    /// Asynchronously generates a collection of <see cref="Umbraco.Cms.Api.Management.Factories.DocumentUrlInfo"/> instances representing the URLs for the specified content item.
+    /// Asynchronously generates a collection of <see cref="DocumentUrlInfo"/> instances representing the URLs for the specified content item.
     /// </summary>
     /// <param name="content">The content item for which to generate URLs.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains an <see cref="IEnumerable{DocumentUrlInfo}"/> with the generated URLs.</returns>

--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentVersionPresentationFactory.cs
@@ -26,11 +26,11 @@ internal sealed class DocumentVersionPresentationFactory : IDocumentVersionPrese
     }
 
     /// <summary>
-    /// Asynchronously creates a <see cref="Umbraco.Cms.Api.Management.Models.DocumentVersionItemResponseModel"/> instance from the specified <see cref="Umbraco.Cms.Core.Models.ContentVersionMeta"/>.
+    /// Asynchronously creates a <see cref="DocumentVersionItemResponseModel"/> instance from the specified <see cref="ContentVersionMeta"/>.
     /// </summary>
     /// <param name="contentVersion">The content version metadata from which to construct the response model.</param>
     /// <returns>
-    /// A task representing the asynchronous operation. The result contains the constructed <see cref="Umbraco.Cms.Api.Management.Models.DocumentVersionItemResponseModel"/> representing the provided content version.
+    /// A task representing the asynchronous operation. The result contains the constructed <see cref="DocumentVersionItemResponseModel"/> representing the provided content version.
     /// </returns>
     public async Task<DocumentVersionItemResponseModel> CreateAsync(ContentVersionMeta contentVersion)
     {

--- a/src/Umbraco.Cms.Api.Management/Factories/FileItemPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/FileItemPresentationFactory.cs
@@ -57,10 +57,10 @@ public class FileItemPresentationFactory : IFileItemPresentationFactory
             (name, path, parent, isFolder) => new() { Name = name, Path = path, Parent = parent, IsFolder = isFolder });
 
     /// <summary>
-    /// Creates a collection of <see cref="Umbraco.Cms.Api.Management.Models.StylesheetItemResponseModel"/> instances from the given stylesheet paths.
+    /// Creates a collection of <see cref="StylesheetItemResponseModel"/> instances from the given stylesheet paths.
     /// </summary>
     /// <param name="paths">The enumerable of stylesheet file paths to create response models for.</param>
-    /// <returns>An enumerable of <see cref="Umbraco.Cms.Api.Management.Models.StylesheetItemResponseModel"/> representing the stylesheet items.</returns>
+    /// <returns>An enumerable of <see cref="StylesheetItemResponseModel"/> representing the stylesheet items.</returns>
     public IEnumerable<StylesheetItemResponseModel> CreateStylesheetItemResponseModels(IEnumerable<string> paths)
         => CreateItemResponseModels<StylesheetItemResponseModel>(
             paths,

--- a/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IConfigurationPresentationFactory.cs
@@ -19,35 +19,35 @@ public interface IConfigurationPresentationFactory
     DocumentConfigurationResponseModel CreateDocumentConfigurationResponseModel();
 
     /// <summary>
-    /// Creates a new instance of <see cref="Umbraco.Cms.Api.Management.Models.DocumentTypeConfigurationResponseModel"/>.
+    /// Creates a new instance of <see cref="DocumentTypeConfigurationResponseModel"/>.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.DocumentTypeConfigurationResponseModel"/> representing the document type configuration.</returns>
+    /// <returns>A <see cref="DocumentTypeConfigurationResponseModel"/> representing the document type configuration.</returns>
     DocumentTypeConfigurationResponseModel CreateDocumentTypeConfigurationResponseModel()
         => throw new NotImplementedException();
 
     /// <summary>
     /// Creates a response model representing the member configuration.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.MemberConfigurationResponseModel"/> instance.</returns>
+    /// <returns>A <see cref="MemberConfigurationResponseModel"/> instance.</returns>
     MemberConfigurationResponseModel CreateMemberConfigurationResponseModel();
 
     /// <summary>
-    /// Creates and returns a new <see cref="Umbraco.Cms.Api.Management.Models.MemberTypeConfigurationResponseModel"/> instance.
+    /// Creates and returns a new <see cref="MemberTypeConfigurationResponseModel"/> instance.
     /// </summary>
-    /// <returns>The created <see cref="Umbraco.Cms.Api.Management.Models.MemberTypeConfigurationResponseModel"/>.</returns>
+    /// <returns>The created <see cref="MemberTypeConfigurationResponseModel"/>.</returns>
     MemberTypeConfigurationResponseModel CreateMemberTypeConfigurationResponseModel()
         => throw new NotImplementedException();
 
     /// <summary>
     /// Creates a media configuration response model.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.MediaConfigurationResponseModel"/> representing the media configuration.</returns>
+    /// <returns>A <see cref="MediaConfigurationResponseModel"/> representing the media configuration.</returns>
     MediaConfigurationResponseModel CreateMediaConfigurationResponseModel();
 
     /// <summary>
-    /// Creates a <see cref="Umbraco.Cms.Api.Management.Models.MediaTypeConfigurationResponseModel"/> representing the media type configuration.
+    /// Creates a <see cref="MediaTypeConfigurationResponseModel"/> representing the media type configuration.
     /// </summary>
-    /// <returns>The created <see cref="Umbraco.Cms.Api.Management.Models.MediaTypeConfigurationResponseModel"/>.</returns>
+    /// <returns>The created <see cref="MediaTypeConfigurationResponseModel"/>.</returns>
     MediaTypeConfigurationResponseModel CreateMediaTypeConfigurationResponseModel()
         => throw new NotImplementedException();
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/IMediaTypeEditingPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IMediaTypeEditingPresentationFactory.cs
@@ -17,10 +17,10 @@ public interface IMediaTypeEditingPresentationFactory
     MediaTypeCreateModel MapCreateModel(CreateMediaTypeRequestModel requestModel);
 
     /// <summary>
-    /// Maps the given <see cref="Umbraco.Cms.Api.Management.Models.UpdateMediaTypeRequestModel"/> to a <see cref="Umbraco.Cms.Api.Management.Models.MediaTypeUpdateModel"/>.
+    /// Maps the given <see cref="UpdateMediaTypeRequestModel"/> to a <see cref="MediaTypeUpdateModel"/>.
     /// </summary>
     /// <param name="requestModel">The update request model containing media type data.</param>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.MediaTypeUpdateModel"/> representing the updated media type.</returns>
+    /// <returns>A <see cref="MediaTypeUpdateModel"/> representing the updated media type.</returns>
     MediaTypeUpdateModel MapUpdateModel(UpdateMediaTypeRequestModel requestModel);
 
     /// <summary>

--- a/src/Umbraco.Cms.Api.Management/Factories/IPackagePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IPackagePresentationFactory.cs
@@ -18,9 +18,9 @@ public interface IPackagePresentationFactory
     PackageDefinition CreatePackageDefinition(CreatePackageRequestModel createPackageRequestModel);
 
     /// <summary>
-    /// Creates and returns a new <see cref="Umbraco.Cms.Api.Management.Models.PackageConfigurationResponseModel"/> instance representing the package configuration response.
+    /// Creates and returns a new <see cref="PackageConfigurationResponseModel"/> instance representing the package configuration response.
     /// </summary>
-    /// <returns>The created <see cref="Umbraco.Cms.Api.Management.Models.PackageConfigurationResponseModel"/>.</returns>
+    /// <returns>The created <see cref="PackageConfigurationResponseModel"/>.</returns>
     PackageConfigurationResponseModel CreateConfigurationResponseModel();
 
     /// <summary>

--- a/src/Umbraco.Cms.Api.Management/Factories/IPasswordConfigurationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/IPasswordConfigurationPresentationFactory.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Api.Management.Factories;
 public interface IPasswordConfigurationPresentationFactory
 {
     /// <summary>
-    /// Creates and returns a <see cref="Umbraco.Cms.Api.Management.Models.PasswordConfigurationResponseModel" /> representing the current password configuration.
+    /// Creates and returns a <see cref="PasswordConfigurationResponseModel" /> representing the current password configuration.
     /// </summary>
     /// <returns>The password configuration response model.</returns>
     PasswordConfigurationResponseModel CreatePasswordConfigurationResponseModel();

--- a/src/Umbraco.Cms.Api.Management/Factories/MemberTypeEditingPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/MemberTypeEditingPresentationFactory.cs
@@ -8,7 +8,7 @@ namespace Umbraco.Cms.Api.Management.Factories;
 internal sealed class MemberTypeEditingPresentationFactory : ContentTypeEditingPresentationFactory<IMemberType>, IMemberTypeEditingPresentationFactory
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Factories.MemberTypeEditingPresentationFactory"/> class,
+    /// Initializes a new instance of the <see cref="MemberTypeEditingPresentationFactory"/> class,
     /// providing functionality for creating member type editing presentations.
     /// </summary>
     /// <param name="memberTypeService">The service used to manage and retrieve member types.</param>
@@ -46,11 +46,11 @@ internal sealed class MemberTypeEditingPresentationFactory : ContentTypeEditingP
     }
 
     /// <summary>
-    /// Maps an <see cref="Umbraco.Cms.Api.Management.Models.UpdateMemberTypeRequestModel" /> to a <see cref="Umbraco.Cms.Api.Management.Models.MemberTypeUpdateModel" />.
+    /// Maps an <see cref="UpdateMemberTypeRequestModel" /> to a <see cref="MemberTypeUpdateModel" />.
     /// This includes mapping compositions and updating property sensitivity and visibility based on the request model.
     /// </summary>
     /// <param name="requestModel">The request model containing the updated member type information.</param>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.MemberTypeUpdateModel" /> that reflects the changes specified in the request model.</returns>
+    /// <returns>A <see cref="MemberTypeUpdateModel" /> that reflects the changes specified in the request model.</returns>
     public MemberTypeUpdateModel MapUpdateModel(UpdateMemberTypeRequestModel requestModel)
     {
         MemberTypeUpdateModel updateModel = MapContentTypeEditingModel<

--- a/src/Umbraco.Cms.Api.Management/Factories/ObjectTypePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/ObjectTypePresentationFactory.cs
@@ -21,7 +21,7 @@ public class ObjectTypePresentationFactory : IObjectTypePresentationFactory
     }
 
     /// <summary>
-    /// Creates a collection of <see cref="Umbraco.Cms.Api.Management.Models.ObjectTypeResponseModel"/> instances representing the allowed object types retrieved from the relation service.
+    /// Creates a collection of <see cref="ObjectTypeResponseModel"/> instances representing the allowed object types retrieved from the relation service.
     /// </summary>
     /// <returns>
     /// An <see cref="IEnumerable{ObjectTypeResponseModel}"/> containing response models for each allowed object type.

--- a/src/Umbraco.Cms.Api.Management/Factories/PackagePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/PackagePresentationFactory.cs
@@ -50,9 +50,9 @@ internal sealed class PackagePresentationFactory : IPackagePresentationFactory
     }
 
     /// <summary>
-    /// Creates a <see cref="Umbraco.Cms.Api.Management.Models.PackageConfigurationResponseModel" /> instance populated with package configuration data, including the marketplace URL.
+    /// Creates a <see cref="PackageConfigurationResponseModel" /> instance populated with package configuration data, including the marketplace URL.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.PackageConfigurationResponseModel" /> containing the package's configuration details.</returns>
+    /// <returns>A <see cref="PackageConfigurationResponseModel" /> containing the package's configuration details.</returns>
     public PackageConfigurationResponseModel CreateConfigurationResponseModel() =>
         new()
         {

--- a/src/Umbraco.Cms.Api.Management/Factories/RedirectUrlStatusPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/RedirectUrlStatusPresentationFactory.cs
@@ -8,7 +8,7 @@ using Umbraco.Extensions;
 namespace Umbraco.Cms.Api.Management.Factories;
 
 /// <summary>
-/// Factory responsible for creating instances of <see cref="RedirectUrlStatusPresentation"/>,
+/// Factory responsible for creating instances of <see cref="RedirectUrlStatusResponseModel"/>,
 /// which represent the presentation details of redirect URL statuses in the management API.
 /// </summary>
 public class RedirectUrlStatusPresentationFactory : IRedirectUrlStatusPresentationFactory
@@ -32,7 +32,7 @@ public class RedirectUrlStatusPresentationFactory : IRedirectUrlStatusPresentati
     /// <summary>
     /// Creates a view model containing the current redirect URL tracking status and whether the current user is an administrator.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Api.Management.Models.RedirectUrlStatusResponseModel" /> with the redirect URL tracking status and admin state of the current user.</returns>
+    /// <returns>A <see cref="RedirectUrlStatusResponseModel" /> with the redirect URL tracking status and admin state of the current user.</returns>
     public RedirectUrlStatusResponseModel CreateViewModel()
     {
         RedirectStatus status = _webRoutingSettings.CurrentValue.DisableRedirectUrlTracking switch

--- a/src/Umbraco.Cms.Api.Management/Factories/RelationPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/RelationPresentationFactory.cs
@@ -60,9 +60,9 @@ public class RelationPresentationFactory : IRelationPresentationFactory
     }
 
     /// <summary>
-    /// Creates multiple <see cref="Umbraco.Cms.Api.Management.Models.RelationResponseModel"/> instances from the given relations.
+    /// Creates multiple <see cref="RelationResponseModel"/> instances from the given relations.
     /// </summary>
     /// <param name="relations">The collection of relations to convert.</param>
-    /// <returns>An enumerable of <see cref="Umbraco.Cms.Api.Management.Models.RelationResponseModel"/>.</returns>
+    /// <returns>An enumerable of <see cref="RelationResponseModel"/>.</returns>
     public IEnumerable<RelationResponseModel> CreateMultiple(IEnumerable<IRelation> relations) => relations.Select(Create);
 }

--- a/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/TemplatePresentationFactory.cs
@@ -15,7 +15,7 @@ public class TemplatePresentationFactory : ITemplatePresentationFactory
     private readonly IUmbracoMapper _mapper;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Umbraco.Cms.Api.Management.Factories.TemplatePresentationFactory"/> class.
+    /// Initializes a new instance of the <see cref="TemplatePresentationFactory"/> class.
     /// </summary>
     /// <param name="templateService">An instance of <see cref="ITemplateService"/> used for template operations.</param>
     /// <param name="mapper">An instance of <see cref="IUmbracoMapper"/> used for mapping objects.</param>
@@ -28,12 +28,12 @@ public class TemplatePresentationFactory : ITemplatePresentationFactory
     }
 
     /// <summary>
-    /// Asynchronously creates a <see cref="Umbraco.Cms.Api.Management.Models.TemplateResponseModel" /> from the specified <see cref="Umbraco.Cms.Core.Models.ITemplate" />.
+    /// Asynchronously creates a <see cref="TemplateResponseModel" /> from the specified <see cref="ITemplate" />.
     /// If the template has a master template, its reference will be included in the response model.
     /// </summary>
     /// <param name="template">The template from which to create the response model.</param>
     /// <returns>
-    /// A task representing the asynchronous operation. The task result contains the created <see cref="Umbraco.Cms.Api.Management.Models.TemplateResponseModel" />.
+    /// A task representing the asynchronous operation. The task result contains the created <see cref="TemplateResponseModel" />.
     /// </returns>
     public async Task<TemplateResponseModel> CreateTemplateResponseModelAsync(ITemplate template)
     {

--- a/src/Umbraco.Cms.Api.Management/Factories/UdtFileContentFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/UdtFileContentFactory.cs
@@ -36,7 +36,7 @@ public class UdtFileContentFactory : IUdtFileContentFactory
     /// <summary>
     /// Creates a <see cref="FileContentResult"/> from the specified content type by serializing it to XML.
     /// </summary>
-    /// <param name="contentType">The content type to serialize and create the file content from.</param>
+    /// <param name="mediaType">The media type to serialize and create the file content from.</param>
     /// <returns>A <see cref="FileContentResult"/> representing the serialized content type as a file.</returns>
     public FileContentResult Create(IMediaType mediaType)
     {
@@ -47,7 +47,7 @@ public class UdtFileContentFactory : IUdtFileContentFactory
     /// <summary>
     /// Creates a <see cref="FileContentResult"/> from the specified content type.
     /// </summary>
-    /// <param name="contentType">The content type to create the file content from.</param>
+    /// <param name="memberType">The member type to create the file content from.</param>
     /// <returns>A <see cref="FileContentResult"/> representing the serialized XML content of the content type.</returns>
     public FileContentResult Create(IMemberType memberType)
     {

--- a/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
@@ -77,8 +77,8 @@ internal sealed class WebhookPresentationFactory : IWebhookPresentationFactory
     /// <summary>
     /// Creates a new instance of <see cref="WebhookResponseModel"/> based on the specified <see cref="IWebhook"/>.
     /// </summary>
-    /// <param name="webhook">The <see cref="IWebhook"/> instance from which to create the response model.</param>
-    /// <returns>A <see cref="WebhookResponseModel"/> populated with data from the provided webhook.</returns>
+    /// <param name="webhookLog">The <see cref="WebhookLog"/> instance from which to create the response model.</param>
+    /// <returns>A <see cref="WebhookLogResponseModel"/> populated with data from the provided webhook.</returns>
     public WebhookLogResponseModel CreateResponseModel(WebhookLog webhookLog)
     {
         var webhookLogResponseModel = new WebhookLogResponseModel

--- a/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/WebhookPresentationFactory.cs
@@ -75,10 +75,10 @@ internal sealed class WebhookPresentationFactory : IWebhookPresentationFactory
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="WebhookResponseModel"/> based on the specified <see cref="IWebhook"/>.
+    /// Creates a new instance of <see cref="WebhookLogResponseModel"/> based on the specified <see cref="WebhookLog"/>.
     /// </summary>
     /// <param name="webhookLog">The <see cref="WebhookLog"/> instance from which to create the response model.</param>
-    /// <returns>A <see cref="WebhookLogResponseModel"/> populated with data from the provided webhook.</returns>
+    /// <returns>A <see cref="WebhookLogResponseModel"/> populated with data from the provided webhook log.</returns>
     public WebhookLogResponseModel CreateResponseModel(WebhookLog webhookLog)
     {
         var webhookLogResponseModel = new WebhookLogResponseModel

--- a/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
+++ b/src/Umbraco.Cms.Api.Management/Mapping/Package/PackageViewModelMapDefinition.cs
@@ -6,7 +6,7 @@ using Umbraco.Cms.Core.Packaging;
 namespace Umbraco.Cms.Api.Management.Mapping.Package;
 
 /// <summary>
-/// Provides mapping configuration for converting package data to and from the <see cref="PackageViewModel"/>.
+/// Provides mapping configuration for converting package data to and from the package view models.
 /// </summary>
 public class PackageViewModelMapDefinition : IMapDefinition
 {

--- a/src/Umbraco.Cms.Api.Management/Services/FileSystem/FileSystemTreeServiceBase.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/FileSystem/FileSystemTreeServiceBase.cs
@@ -19,7 +19,7 @@ public abstract class FileSystemTreeServiceBase : IFileSystemTreeService
     /// <param name="path">The file system path for which to retrieve ancestor models.</param>
     /// <param name="includeSelf">If <c>true</c>, includes the model representing the specified path itself as the last element in the result; otherwise, only ancestors are included.</param>
     /// <returns>
-    /// An array of <see cref="Umbraco.Cms.Api.Management.Services.FileSystem.FileSystemTreeItemPresentationModel"/> objects, each representing a directory in the ancestor chain of the specified path, ordered from the root to the specified path (if <paramref name="includeSelf"/> is <c>true</c>).
+    /// An array of <see cref="FileSystemTreeItemPresentationModel"/> objects, each representing a directory in the ancestor chain of the specified path, ordered from the root to the specified path (if <paramref name="includeSelf"/> is <c>true</c>).
     /// </returns>
     public FileSystemTreeItemPresentationModel[] GetAncestorModels(string path, bool includeSelf)
     {

--- a/src/Umbraco.Cms.Api.Management/Services/FileSystem/IFileSystemTreeService.cs
+++ b/src/Umbraco.Cms.Api.Management/Services/FileSystem/IFileSystemTreeService.cs
@@ -12,7 +12,7 @@ public interface IFileSystemTreeService
     /// </summary>
     /// <param name="path">The path to get ancestors for.</param>
     /// <param name="includeSelf">Whether to include the item at the specified path itself in the results.</param>
-    /// <returns>An array of <see cref="Umbraco.Cms.Api.Management.Services.FileSystem.FileSystemTreeItemPresentationModel"/> representing the ancestor items.</returns>
+    /// <returns>An array of <see cref="FileSystemTreeItemPresentationModel"/> representing the ancestor items.</returns>
     FileSystemTreeItemPresentationModel[] GetAncestorModels(string path, bool includeSelf);
 
     /// <summary>

--- a/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/SecuritySettings.cs
@@ -281,7 +281,7 @@ public class SecuritySettings
     ///     for the <c>Umbraco:CMS:Security:UserPassword</c> configuration section.
     ///     <para>
     ///         Do not use this property to read password configuration at runtime.
-    ///         Inject <see cref="IOptions{UserPasswordConfigurationSettings}"/> directly instead,
+    ///         Inject <see cref="Microsoft.Extensions.Options.IOptions{UserPasswordConfigurationSettings}"/> directly instead,
     ///         as that is the canonical registration used by all consumers.
     ///     </para>
     ///     <para>
@@ -299,7 +299,7 @@ public class SecuritySettings
     ///     for the <c>Umbraco:CMS:Security:MemberPassword</c> configuration section.
     ///     <para>
     ///         Do not use this property to read password configuration at runtime.
-    ///         Inject <see cref="IOptions{MemberPasswordConfigurationSettings}"/> directly instead,
+    ///         Inject <see cref="Microsoft.Extensions.Options.IOptions{MemberPasswordConfigurationSettings}"/> directly instead,
     ///         as that is the canonical registration used by all consumers.
     ///     </para>
     ///     <para>

--- a/src/Umbraco.Core/Extensions/GuidExtensions.cs
+++ b/src/Umbraco.Core/Extensions/GuidExtensions.cs
@@ -6,7 +6,7 @@ namespace Umbraco.Cms.Core.Extensions;
 public static class GuidExtensions
 {
     /// <summary>
-    /// Determines whether the GUID was created from an integer using <see cref="IntExtensions.ToGuid(int)"/>.
+    /// Determines whether the GUID was created from an integer using <see cref="Umbraco.Extensions.IntExtensions.ToGuid(int)"/>.
     /// </summary>
     /// <param name="guid">The GUID to check.</param>
     /// <returns><c>true</c> if the GUID was created from an integer; otherwise, <c>false</c>.</returns>
@@ -29,7 +29,7 @@ public static class GuidExtensions
     /// <param name="guid">The GUID to convert.</param>
     /// <returns>The integer value.</returns>
     /// <remarks>
-    /// This method should only be used on GUIDs that were created using <see cref="IntExtensions.ToGuid(int)"/>.
+    /// This method should only be used on GUIDs that were created using <see cref="Umbraco.Extensions.IntExtensions.ToGuid(int)"/>.
     /// </remarks>
     public static int ToInt(this Guid guid)
     {

--- a/src/Umbraco.Core/Extensions/XmlExtensions.cs
+++ b/src/Umbraco.Core/Extensions/XmlExtensions.cs
@@ -237,7 +237,7 @@ public static class XmlExtensions
     /// <param name="xml">The XML element to convert.</param>
     /// <returns>A string representation of the XML element with preserved line endings.</returns>
     /// <remarks>
-    ///     This method exists because <see cref="XElement.ToString()"/> with SaveOptions changes line endings.
+    ///     This method exists because <see cref="XNode.ToString()"/> with SaveOptions changes line endings.
     ///     When saving data, we want the exact characters to be preserved.
     /// </remarks>
     public static string ToDataString(this XElement xml)

--- a/src/Umbraco.Core/Notifications/RelationDeletedNotification.cs
+++ b/src/Umbraco.Core/Notifications/RelationDeletedNotification.cs
@@ -38,7 +38,7 @@ public class RelationDeletedNotification : DeletedNotification<IRelation>
     /// <summary>
     ///     Gets or sets a value indicating whether the relations were deleted automatically
     ///     as a side-effect of content being saved (e.g. umbMedia, umbDocument, umbMember),
-    ///     rather than explicitly via <see cref="IRelationService"/>.
+    ///     rather than explicitly via <see cref="Services.IRelationService"/>.
     /// </summary>
     public bool IsAutomatic { get; set; }
 }

--- a/src/Umbraco.Core/Notifications/RelationSavedNotification.cs
+++ b/src/Umbraco.Core/Notifications/RelationSavedNotification.cs
@@ -3,6 +3,7 @@
 
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
 
 namespace Umbraco.Cms.Core.Notifications;
 /// <summary>
@@ -38,10 +39,10 @@ public class RelationSavedNotification : SavedNotification<IRelation>
     /// <summary>
     ///     Gets or sets a value indicating whether the relations were saved automatically
     ///     as a side-effect of content being saved (e.g. umbMedia, umbDocument, umbMember),
-    ///     rather than explicitly via <see cref="IRelationService"/>.
+    ///     rather than explicitly via <see cref="Services.IRelationService"/>.
     /// </summary>
     /// <remarks>
-    ///     When <c>true</c>, the <see cref="IRelation.Id"/> of each saved entity may be <c>0</c>
+    ///     When <c>true</c>, the <see cref="IEntity.Id"/> of each saved entity may be <c>0</c>
     ///     because automatic relations are persisted via a bulk operation that does not return
     ///     database identities. <see cref="IRelation.ParentId"/>, <see cref="IRelation.ChildId"/>,
     ///     and <see cref="IRelation.RelationType"/> are always populated.

--- a/src/Umbraco.Core/PropertyEditors/IValueSchemaProvider.cs
+++ b/src/Umbraco.Core/PropertyEditors/IValueSchemaProvider.cs
@@ -11,9 +11,9 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// for programmatic content creation, validation, and tooling support.
 /// </para>
 /// <para>
-/// Implementations should return the schema for the incoming value (what <see cref="IDataValueEditor.FromEditor"/>
-/// receives via <see cref="ContentPropertyData.Value"/>), not the stored/database model (what
-/// <see cref="IDataValueEditor.FromEditor"/> produces) or the published model (what
+/// Implementations should return the schema for the incoming value (what <see cref="Models.IDataValueEditor.FromEditor"/>
+/// receives via <see cref="Models.Editors.ContentPropertyData.Value"/>), not the stored/database model (what
+/// <see cref="Models.IDataValueEditor.FromEditor"/> produces) or the published model (what
 /// <see cref="IPropertyValueConverter"/> produces).
 /// </para>
 /// </remarks>
@@ -46,7 +46,7 @@ public interface IValueSchemaProvider
     /// </returns>
     /// <remarks>
     /// <para>
-    /// The returned schema should describe the structure that <see cref="IDataValueEditor.FromEditor"/> receives
+    /// The returned schema should describe the structure that <see cref="Models.IDataValueEditor.FromEditor"/> receives
     /// (i.e., what the Management API accepts).
     /// </para>
     /// <para>

--- a/src/Umbraco.Core/Services/DataTypeService.cs
+++ b/src/Umbraco.Core/Services/DataTypeService.cs
@@ -1042,11 +1042,6 @@ namespace Umbraco.Cms.Core.Services.Implement
         }
 
         /// <summary>
-        ///     Gets a data type from the repository by its unique key.
-        /// </summary>
-        /// <param name="id">The unique key of the data type.</param>
-        /// <returns>The data type, or null if not found.</returns>
-        /// <summary>
         ///     Creates an audit entry for a data type operation.
         /// </summary>
         /// <param name="type">The audit type.</param>

--- a/src/Umbraco.Core/Services/MediaPermissionService.cs
+++ b/src/Umbraco.Core/Services/MediaPermissionService.cs
@@ -16,7 +16,6 @@ internal sealed class MediaPermissionService : IMediaPermissionService
     /// <summary>
     ///     Initializes a new instance of the <see cref="MediaPermissionService" /> class.
     /// </summary>
-    /// <param name="mediaService">The media service.</param>
     /// <param name="entityService">The entity service.</param>
     /// <param name="appCaches">The application caches.</param>
     public MediaPermissionService(

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -82,7 +82,7 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> for creating loggers.</param>
         /// <param name="eventMessagesFactory">The <see cref="IEventMessagesFactory"/> for creating event messages.</param>
         /// <param name="mediaRepository">The <see cref="IMediaRepository"/> for media persistence.</param>
-        /// <param name="auditRepository">The audit repository (obsolete, not used).</param>
+        /// <param name="auditService">The <see cref="IAuditService"/> for audit handling.</param>
         /// <param name="mediaTypeRepository">The <see cref="IMediaTypeRepository"/> for media type persistence.</param>
         /// <param name="entityRepository">The <see cref="IEntityRepository"/> for entity operations.</param>
         /// <param name="shortStringHelper">The <see cref="IShortStringHelper"/> for string operations.</param>

--- a/src/Umbraco.Core/Services/TemplateService.cs
+++ b/src/Umbraco.Core/Services/TemplateService.cs
@@ -317,7 +317,7 @@ public class TemplateService : RepositoryService, ITemplateService
     /// <param name="template">The template to save.</param>
     /// <param name="auditType">The type of audit entry to create.</param>
     /// <param name="userKey">The key of the user performing the operation.</param>
-    /// <param name="scopeValidator">An optional validation function to execute within the scope.</param>
+    /// <param name="scopeValidatorAsync">An optional validation function to execute within the scope.</param>
     /// <param name="contentTypeAlias">The optional content type alias for the saving notification.</param>
     /// <returns>An attempt result containing the template and operation status.</returns>
     private async Task<Attempt<ITemplate, TemplateOperationStatus>> SaveAsync(

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -192,8 +192,7 @@ public sealed partial class HtmlLocalLinkParser
                 null,
                 new GuidUdi(typeMatch.Groups["type"].Value.ToLowerInvariant(), guid),
                 linkTag.Groups["locallink"].Value,
-                cultureMatch.Success ? cultureMatch.Groups["culture"].Value : null
-            );
+                cultureMatch.Success ? cultureMatch.Groups["culture"].Value : null);
         }
 
         // also return legacy results for values that have not been migrated

--- a/src/Umbraco.Infrastructure/DeliveryApi/IApiMediaWithCropsBuilder.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/IApiMediaWithCropsBuilder.cs
@@ -9,13 +9,13 @@ namespace Umbraco.Cms.Infrastructure.DeliveryApi;
 /// </summary>
 public interface IApiMediaWithCropsBuilder
 {
-    /// <summary>Builds an <see cref="Umbraco.Cms.Infrastructure.DeliveryApi.IApiMediaWithCrops"/> instance from the specified <see cref="Umbraco.Cms.Core.Models.MediaWithCrops"/> media.</summary>
+    /// <summary>Builds an <see cref="IApiMediaWithCrops"/> instance from the specified <see cref="MediaWithCrops"/> media.</summary>
     /// <param name="media">The media with crops to build from.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.DeliveryApi.IApiMediaWithCrops"/> representing the built media with crops.</returns>
+    /// <returns>An <see cref="IApiMediaWithCrops"/> representing the built media with crops.</returns>
     IApiMediaWithCrops Build(MediaWithCrops media);
 
-    /// <summary>Builds an <see cref="Umbraco.Cms.Infrastructure.DeliveryApi.IApiMediaWithCrops"/> instance from the specified <see cref="Umbraco.Cms.Core.Models.IPublishedContent"/> media.</summary>
+    /// <summary>Builds an <see cref="IApiMediaWithCrops"/> instance from the specified <see cref="IPublishedContent"/> media.</summary>
     /// <param name="media">The published media content to build from.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.DeliveryApi.IApiMediaWithCrops"/> representing the built media with crops.</returns>
+    /// <returns>An <see cref="IApiMediaWithCrops"/> representing the built media with crops.</returns>
     IApiMediaWithCrops Build(IPublishedContent media);
 }

--- a/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
+++ b/src/Umbraco.Infrastructure/Examine/ContentValueSetValidator.cs
@@ -153,15 +153,15 @@ public class ContentValueSetValidator : ValueSetValidator, IContentValueSetValid
     }
 
     /// <summary>
-    /// Validates the specified <see cref="Umbraco.Cms.Core.Models.ValueSet"/> to determine if it meets the requirements for indexing in Examine.
+    /// Validates the specified <see cref="ValueSet"/> to determine if it meets the requirements for indexing in Examine.
     /// <para>
     /// Validation includes checks for published status (including culture variants), the presence and validity of the content path, and whether the content is in the recycle bin or protected.
     /// If the value set fails any of these checks, it is either marked as failed (not indexable) or filtered (excluded from the index), depending on the nature of the issue.
     /// </para>
     /// </summary>
-    /// <param name="valueSet">The <see cref="Umbraco.Cms.Core.Models.ValueSet"/> to validate.</param>
+    /// <param name="valueSet">The <see cref="ValueSet"/> to validate.</param>
     /// <returns>
-    /// A <see cref="Umbraco.Cms.Infrastructure.Examine.ValueSetValidationResult"/> indicating the outcome of the validation:
+    /// A <see cref="ValueSetValidationResult"/> indicating the outcome of the validation:
     /// <list type="bullet">
     ///   <item>
     ///     <description><c>Valid</c>: The value set passed all checks and is suitable for indexing.</description>

--- a/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/DeliveryApiContentIndexFieldDefinitionBuilder.cs
@@ -28,7 +28,7 @@ internal sealed class DeliveryApiContentIndexFieldDefinitionBuilder : IDeliveryA
     /// Builds a collection of field definitions used for the delivery API content index.
     /// </summary>
     /// <returns>
-    /// A <see cref="Umbraco.Cms.Infrastructure.Examine.FieldDefinitionCollection"/> containing the generated field definitions.
+    /// A <see cref="FieldDefinitionCollection"/> containing the generated field definitions.
     /// </returns>
     public FieldDefinitionCollection Build()
     {

--- a/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
+++ b/src/Umbraco.Infrastructure/Examine/ExamineIndexRebuilder.cs
@@ -32,7 +32,7 @@ internal class ExamineIndexRebuilder : IIndexRebuilder
     /// <param name="logger">The <see cref="ILogger{ExamineIndexRebuilder}"/> used for logging operations and errors.</param>
     /// <param name="examineManager">The <see cref="IExamineManager"/> responsible for managing Examine indexes.</param>
     /// <param name="populators">A collection of <see cref="IIndexPopulator"/> instances used to populate the indexes.</param>
-    /// <param name="longRunningOperationService">The <see cref="ILongRunningOperationService"/> used to manage and track long-running operations.</param>
+    /// <param name="backgroundTaskQueue">The <see cref="IBackgroundTaskQueue"/> used to manage and track long-running operations.</param>
     public ExamineIndexRebuilder(
         IMainDom mainDom,
         IRuntimeState runtimeState,

--- a/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQuery.cs
@@ -56,7 +56,7 @@ public interface IPublishedContentQuery
     IEnumerable<IPublishedContent> Content(IEnumerable<object> ids);
 
     /// <summary>Gets the published content items at the root level of the content tree.</summary>
-    /// <returns>An enumerable collection of root-level <see cref="Umbraco.Cms.Core.Models.IPublishedContent"/> items.</returns>
+    /// <returns>An enumerable collection of root-level <see cref="IPublishedContent"/> items.</returns>
     IEnumerable<IPublishedContent> ContentAtRoot();
 
     /// <summary>
@@ -89,14 +89,14 @@ public interface IPublishedContentQuery
 
     /// <summary>Gets the media items corresponding to the specified IDs.</summary>
     /// <param name="ids">The collection of media item IDs to retrieve.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Umbraco.Cms.Core.Models.IPublishedContent"/> representing the found media items.</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IPublishedContent"/> representing the found media items.</returns>
     IEnumerable<IPublishedContent> Media(IEnumerable<int> ids);
 
     /// <summary>
     /// Retrieves media items corresponding to the specified identifiers.
     /// </summary>
     /// <param name="ids">A collection of identifiers for the media items to retrieve.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Umbraco.Cms.Core.Models.IPublishedContent"/> representing the found media items.</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IPublishedContent"/> representing the found media items.</returns>
     IEnumerable<IPublishedContent> Media(IEnumerable<object> ids);
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/IPublishedContentQueryAccessor.cs
+++ b/src/Umbraco.Infrastructure/IPublishedContentQueryAccessor.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Umbraco.Cms.Core;
 
 /// <summary>
-/// Provides access to the current <see cref="Umbraco.Cms.Core.PublishedCache.IPublishedContentQuery" /> instance for the active request context.
+/// Provides access to the current <see cref="IPublishedContentQuery" /> instance for the active request context.
 /// </summary>
 /// <remarks>
 ///     Not intended for use in background threads where you should make use of

--- a/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/LoggerConfigExtensions.cs
@@ -97,9 +97,9 @@ namespace Umbraco.Extensions
         /// It is highly recommended to retain this default configuration when customizing your own logging setup.
         /// </summary>
         /// <param name="logConfig">The <see cref="LoggerConfiguration"/> instance to configure.</param>
-        /// <param name="hostingEnvironment">The Umbraco hosting environment.</param>
+        /// <param name="hostEnvironment">The Umbraco hosting environment.</param>
         /// <param name="loggingConfiguration">The logging configuration settings.</param>
-        /// <param name="configuration">The application configuration.</param>
+        /// <param name="umbracoFileConfiguration">The application configuration.</param>
         /// <returns>The configured <see cref="LoggerConfiguration"/> instance.</returns>
         public static LoggerConfiguration MinimalConfiguration(
             this LoggerConfiguration logConfig,

--- a/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/SerilogLogger.cs
@@ -141,7 +141,6 @@ public class SerilogLogger : IDisposable
     /// </summary>
     /// <param name="reporting">The <see cref="Type"/> representing the component reporting the error.</param>
     /// <param name="exception">The <see cref="Exception"/> instance to log.</param>
-    /// <param name="message">The error message describing the context of the exception.</param>
     public void Error(Type reporting, Exception exception)
     {
         ILogger logger = LoggerFor(reporting);
@@ -160,8 +159,8 @@ public class SerilogLogger : IDisposable
     /// Logs an error message for the specified reporting type, including an exception and a message.
     /// </summary>
     /// <param name="reporting">The <see cref="Type"/> that is reporting the error.</param>
-    /// <param name="exception">The <see cref="Exception"/> associated with the error.</param>
-    /// <param name="message">The error message to log.</param>
+    /// <param name="messageTemplate">A message template describing the error, which may include placeholders for property values.</param>
+    /// <param name="propertyValues">An array of objects to format the message template.</param>
     public void Error(Type reporting, string messageTemplate, params object[] propertyValues) =>
         LoggerFor(reporting).Error(messageTemplate, propertyValues);
 

--- a/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/ILogViewer.cs
@@ -75,7 +75,7 @@ public interface ILogViewer
     /// <param name="logLevels">An optional array of log levels to include.</param>
     /// <returns>A paged result containing the log messages.</returns>
     /// <remarks>
-    /// This method is obsolete. Use <see cref="ILogViewerService.GetPagedLogs"/> instead. Scheduled for removal in Umbraco 15.
+    /// This method is obsolete. Use <see cref="Services.ILogViewerService.GetPagedLogsAsync"/> instead. Scheduled for removal in Umbraco 15.
     /// </remarks>
     [Obsolete("Use ILogViewerService.GetPagedLogs instead. Scheduled for removal in Umbraco 15.")]
     PagedResult<LogMessage> GetLogs(

--- a/src/Umbraco.Infrastructure/Logging/Viewer/LogViewerConfig.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/LogViewerConfig.cs
@@ -29,7 +29,7 @@ public class LogViewerConfig : ILogViewerConfig
     /// </summary>
     /// <returns>A read-only list of saved log searches.</returns>
     /// <remarks>
-    /// This method is obsolete. Use <see cref="ILogViewerService.GetSavedLogQueriesAsync"/> instead.
+    /// This method is obsolete. Use <see cref="Services.ILogViewerService.GetSavedLogQueriesAsync"/> instead.
     /// </remarks>
     [Obsolete("Use ILogViewerService.GetSavedLogQueriesAsync instead. Scheduled for removal in Umbraco 15.")]
     public IReadOnlyList<SavedLogSearch> GetSavedSearches()
@@ -47,7 +47,7 @@ public class LogViewerConfig : ILogViewerConfig
     /// <param name="query">The query string for the saved search.</param>
     /// <returns>A read-only list of all saved log searches.</returns>
     /// <remarks>
-    /// This method is obsolete. Use <see cref="ILogViewerService.AddSavedLogQueryAsync"/> instead. Scheduled for removal in Umbraco 15.
+    /// This method is obsolete. Use <see cref="Services.ILogViewerService.AddSavedLogQueryAsync"/> instead. Scheduled for removal in Umbraco 15.
     /// </remarks>
     [Obsolete("Use ILogViewerService.AddSavedLogQueryAsync instead. Scheduled for removal in Umbraco 15.")]
     public IReadOnlyList<SavedLogSearch> AddSavedSearch(string name, string query)
@@ -65,7 +65,7 @@ public class LogViewerConfig : ILogViewerConfig
     /// <param name="name">The name of the saved search to delete.</param>
     /// <returns>A read-only list containing the remaining saved log searches after the specified search has been deleted.</returns>
     /// <remarks>
-    /// This method is obsolete. Use <see cref="ILogViewerService.DeleteSavedLogQueryAsync"/> instead. Scheduled for removal in Umbraco 15.
+    /// This method is obsolete. Use <see cref="Services.ILogViewerService.DeleteSavedLogQueryAsync"/> instead. Scheduled for removal in Umbraco 15.
     /// If no saved search with the specified name exists, the method returns the current list of saved searches unchanged.
     /// </remarks>
     [Obsolete("Use ILogViewerService.DeleteSavedLogQueryAsync instead. Scheduled for removal in Umbraco 15.")]

--- a/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
+++ b/src/Umbraco.Infrastructure/Logging/Viewer/SerilogLogViewerSourceBase.cs
@@ -39,7 +39,7 @@ public abstract class SerilogLogViewerSourceBase : ILogViewer
     /// </summary>
     /// <returns>A read-only list of saved log searches.</returns>
     /// <remarks>
-    /// This method is obsolete. Use <see cref="ILogViewerService.GetSavedLogQueriesAsync"/> instead.
+    /// This method is obsolete. Use <see cref="Services.ILogViewerService.GetSavedLogQueriesAsync"/> instead.
     /// </remarks>
     [Obsolete("Use ILogViewerService.GetSavedLogQueriesAsync instead. Scheduled for removal in Umbraco 15.")]
     public virtual IReadOnlyList<SavedLogSearch> GetSavedSearches()
@@ -52,7 +52,7 @@ public abstract class SerilogLogViewerSourceBase : ILogViewer
     /// <param name="query">The query string for the saved search.</param>
     /// <returns>A read-only list of saved log searches including the newly added one.</returns>
     /// <remarks>
-    /// This method is obsolete. Use <see cref="ILogViewerService.AddSavedLogQueryAsync"/> instead.
+    /// This method is obsolete. Use <see cref="Services.ILogViewerService.AddSavedLogQueryAsync"/> instead.
     /// </remarks>
     [Obsolete("Use ILogViewerService.AddSavedLogQueryAsync instead. Scheduled for removal in Umbraco 15.")]
     public virtual IReadOnlyList<SavedLogSearch> AddSavedSearch(string name, string query)

--- a/src/Umbraco.Infrastructure/Manifest/IPackageManifestReader.cs
+++ b/src/Umbraco.Infrastructure/Manifest/IPackageManifestReader.cs
@@ -10,6 +10,6 @@ public interface IPackageManifestReader
     /// <summary>
     /// Asynchronously reads and returns all available package manifests.
     /// </summary>
-    /// <returns>A task representing the asynchronous operation, with a result of an enumerable collection of <see cref="Umbraco.Cms.Infrastructure.Manifest.PackageManifest"/>.</returns>
+    /// <returns>A task representing the asynchronous operation, with a result of an enumerable collection of <see cref="PackageManifest"/>.</returns>
     Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync();
 }

--- a/src/Umbraco.Infrastructure/Manifest/PackageManifestReader.cs
+++ b/src/Umbraco.Infrastructure/Manifest/PackageManifestReader.cs
@@ -37,10 +37,10 @@ internal class PackageManifestReader : IPackageManifestReader
     }
 
     /// <summary>
-    /// Asynchronously reads all package manifests from the configured file provider and returns a collection of <see cref="Umbraco.Cms.Infrastructure.Manifest.PackageManifest"/> instances.
+    /// Asynchronously reads all package manifests from the configured file provider and returns a collection of <see cref="PackageManifest"/> instances.
     /// </summary>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains an enumerable of <see cref="Umbraco.Cms.Infrastructure.Manifest.PackageManifest"/> objects.
+    /// A task that represents the asynchronous operation. The task result contains an enumerable of <see cref="PackageManifest"/> objects.
     /// </returns>
     /// <exception cref="System.ArgumentNullException">Thrown if the file provider cannot be created.</exception>
     public async Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync()

--- a/src/Umbraco.Infrastructure/Manifest/PackageManifestService.cs
+++ b/src/Umbraco.Infrastructure/Manifest/PackageManifestService.cs
@@ -35,7 +35,7 @@ internal sealed class PackageManifestService : IPackageManifestService
     /// The cache duration depends on the runtime mode: 30 days in production, 10 seconds otherwise.
     /// </summary>
     /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains an <see cref="IEnumerable{T}"/> of <see cref="Umbraco.Cms.Infrastructure.Manifest.PackageManifest"/> instances.
+    /// A task that represents the asynchronous operation. The task result contains an <see cref="IEnumerable{T}"/> of <see cref="PackageManifest"/> instances.
     /// </returns>
     public async Task<IEnumerable<PackageManifest>> GetAllPackageManifestsAsync()
         => await _cache.GetCacheItemAsync(
@@ -65,7 +65,7 @@ internal sealed class PackageManifestService : IPackageManifestService
     /// <summary>
     /// Asynchronously retrieves all private package manifests, i.e., manifests that do not allow public access.
     /// </summary>
-    /// <returns>A task representing the asynchronous operation, with a result of an enumerable collection of private <see cref="Umbraco.Cms.Infrastructure.Manifest.PackageManifest"/> instances.</returns>
+    /// <returns>A task representing the asynchronous operation, with a result of an enumerable collection of private <see cref="PackageManifest"/> instances.</returns>
     public async Task<IEnumerable<PackageManifest>> GetPrivatePackageManifestsAsync()
         => (await GetAllPackageManifestsAsync()).Where(manifest => manifest.AllowPublicAccess == false);
 
@@ -73,7 +73,7 @@ internal sealed class PackageManifestService : IPackageManifestService
     /// Asynchronously retrieves and combines the import maps from all available package manifests.
     /// </summary>
     /// <returns>
-    /// A task representing the asynchronous operation. The task result contains a <see cref="Umbraco.Cms.Infrastructure.Manifest.PackageManifestImportmap"/> instance
+    /// A task representing the asynchronous operation. The task result contains a <see cref="PackageManifestImportmap"/> instance
     /// that merges the <c>imports</c> and <c>scopes</c> from all non-null import maps found in the loaded package manifests.
     /// </returns>
     public async Task<PackageManifestImportmap> GetPackageManifestImportmapAsync()

--- a/src/Umbraco.Infrastructure/Mapping/RelationModelMapDefinition.cs
+++ b/src/Umbraco.Infrastructure/Mapping/RelationModelMapDefinition.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 namespace Umbraco.Cms.Infrastructure.Mapping;
 
 /// <summary>
-/// Provides mapping configuration for the <see cref="RelationModel"/> entity within the Umbraco infrastructure.
+/// Provides mapping configuration for the <see cref="RelationItemModel"/> entity within the Umbraco infrastructure.
 /// </summary>
 public class RelationModelMapDefinition : IMapDefinition
 {

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Alter/Table/AlterTableBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Alter/Table/AlterTableBuilder.cs
@@ -271,8 +271,6 @@ public class AlterTableBuilder : ExpressionBuilderBase<AlterTableExpression, IAl
     /// <summary>
     /// Creates a foreign key constraint from the current table to the specified primary table and column.
     /// </summary>
-    /// <param name="primaryTableName">The name of the primary (referenced) table.</param>
-    /// <param name="primaryColumnName">The name of the primary (referenced) column.</param>
     /// <returns>An object to configure cascade options for the foreign key constraint.</returns>
     public IAlterTableColumnOptionForeignKeyCascadeBuilder ForeignKey()
     {

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Create/ICreateBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Create/ICreateBuilder.cs
@@ -36,20 +36,20 @@ public interface ICreateBuilder : IFluentBuilder
     ///     Begins building a CREATE TABLE expression for the specified table.
     /// </summary>
     /// <param name="tableName">The name of the table to create.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateTableWithColumnBuilder"/> to define columns for the new table.</returns>
+    /// <returns>An <see cref="ICreateTableWithColumnBuilder"/> to define columns for the new table.</returns>
     ICreateTableWithColumnBuilder Table(string tableName);
 
     /// <summary>
     ///     Begins building an expression to create a new column in a database table.
     /// </summary>
     /// <param name="columnName">The name of the column to create.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateColumnOnTableBuilder" /> to continue building the column definition on the table.</returns>
+    /// <returns>An <see cref="ICreateColumnOnTableBuilder" /> to continue building the column definition on the table.</returns>
     ICreateColumnOnTableBuilder Column(string columnName);
 
     /// <summary>
     /// Begins building a 'Create Foreign Key' expression for a database migration.
     /// </summary>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateForeignKeyFromTableBuilder" /> that allows further configuration of the foreign key.</returns>
+    /// <returns>An <see cref="ICreateForeignKeyFromTableBuilder" /> that allows further configuration of the foreign key.</returns>
     ICreateForeignKeyFromTableBuilder ForeignKey();
 
     /// <summary>
@@ -57,34 +57,34 @@ public interface ICreateBuilder : IFluentBuilder
     /// </summary>
     /// <param name="foreignKeyName">The name of the foreign key to create.</param>
     /// <returns>
-    /// An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateForeignKeyFromTableBuilder" /> that allows further configuration of the foreign key.
+    /// An <see cref="ICreateForeignKeyFromTableBuilder" /> that allows further configuration of the foreign key.
     /// </returns>
     ICreateForeignKeyFromTableBuilder ForeignKey(string foreignKeyName);
 
     /// <summary>
     /// Creates and returns a builder for constructing a Create Index expression.
     /// </summary>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateIndexForTableBuilder" /> used to further define the index creation.</returns>
+    /// <returns>An <see cref="ICreateIndexForTableBuilder" /> used to further define the index creation.</returns>
     ICreateIndexForTableBuilder Index();
 
     /// <summary>
     /// Creates and returns a builder for constructing a Create Index expression with the specified name.
     /// </summary>
     /// <param name="indexName">The name of the index to create.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateIndexForTableBuilder" /> used to further define the index creation.</returns>
+    /// <returns>An <see cref="ICreateIndexForTableBuilder" /> used to further define the index creation.</returns>
     ICreateIndexForTableBuilder Index(string indexName);
 
     /// <summary>
     ///     Builds a Create Primary Key expression.
     /// </summary>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateConstraintOnTableBuilder" /> to further define the primary key constraint.</returns>
+    /// <returns>An <see cref="ICreateConstraintOnTableBuilder" /> to further define the primary key constraint.</returns>
     ICreateConstraintOnTableBuilder PrimaryKey();
 
     /// <summary>
     ///     Begins building an expression to create a primary key constraint with the specified name.
     /// </summary>
     /// <param name="primaryKeyName">The name of the primary key constraint to create.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateConstraintOnTableBuilder" /> for further configuration of the primary key constraint.</returns>
+    /// <returns>An <see cref="ICreateConstraintOnTableBuilder" /> for further configuration of the primary key constraint.</returns>
     ICreateConstraintOnTableBuilder PrimaryKey(string primaryKeyName);
 
     /// <summary>
@@ -102,7 +102,7 @@ public interface ICreateBuilder : IFluentBuilder
     /// <summary>
     ///     Builds a Create Unique Constraint expression.
     /// </summary>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateConstraintOnTableBuilder" /> to further define the unique constraint.</returns>
+    /// <returns>An <see cref="ICreateConstraintOnTableBuilder" /> to further define the unique constraint.</returns>
     ICreateConstraintOnTableBuilder UniqueConstraint();
 
     /// <summary>
@@ -116,6 +116,6 @@ public interface ICreateBuilder : IFluentBuilder
     ///     Begins building a CREATE CONSTRAINT expression for the specified constraint name.
     /// </summary>
     /// <param name="constraintName">The name of the constraint to create.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Create.ICreateConstraintOnTableBuilder" /> that can be used to further define the constraint.</returns>
+    /// <returns>An <see cref="ICreateConstraintOnTableBuilder" /> that can be used to further define the constraint.</returns>
     ICreateConstraintOnTableBuilder Constraint(string constraintName);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Create/Table/CreateTableBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Create/Table/CreateTableBuilder.cs
@@ -282,6 +282,6 @@ public class CreateTableBuilder : ExpressionBuilderBase<CreateTableExpression, I
     }
 
     /// <summary>Gets the column definition for the current column type.</summary>
-    /// <returns>The <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.ColumnDefinition"/> representing the current column.</returns>
+    /// <returns>The <see cref="ColumnDefinition"/> representing the current column.</returns>
     public override ColumnDefinition GetColumnForType() => CurrentColumn;
 }

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/DefaultConstraint/IDeleteDefaultConstraintOnColumnBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/DefaultConstraint/IDeleteDefaultConstraintOnColumnBuilder.cs
@@ -11,6 +11,6 @@ public interface IDeleteDefaultConstraintOnColumnBuilder : IFluentBuilder
     /// Specifies the column from which to delete the default constraint.
     /// </summary>
     /// <param name="columnName">The name of the column that has the default constraint to be deleted.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.IExecutableBuilder" /> to execute the delete operation.</returns>
+    /// <returns>An <see cref="IExecutableBuilder" /> to execute the delete operation.</returns>
     IExecutableBuilder OnColumn(string columnName);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/IDeleteBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Delete/IDeleteBuilder.cs
@@ -36,7 +36,7 @@ public interface IDeleteBuilder : IFluentBuilder
     /// Specifies the column to be deleted in the current delete expression.
     /// </summary>
     /// <param name="columnName">The name of the column to delete.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Delete.IDeleteColumnBuilder" /> to continue building the delete expression.</returns>
+    /// <returns>An <see cref="IDeleteColumnBuilder" /> to continue building the delete expression.</returns>
     IDeleteColumnBuilder Column(string columnName);
 
     /// <summary>
@@ -49,7 +49,7 @@ public interface IDeleteBuilder : IFluentBuilder
     ///     Specifies the foreign key to be deleted in the migration.
     /// </summary>
     /// <param name="foreignKeyName">The name of the foreign key to delete.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Delete.IDeleteForeignKeyOnTableBuilder" /> that allows further configuration of the delete operation.</returns>
+    /// <returns>An <see cref="IDeleteForeignKeyOnTableBuilder" /> that allows further configuration of the delete operation.</returns>
     IDeleteForeignKeyOnTableBuilder ForeignKey(string foreignKeyName);
 
     /// <summary>
@@ -69,7 +69,7 @@ public interface IDeleteBuilder : IFluentBuilder
     ///     Specifies the name of the index to delete as part of a migration expression.
     /// </summary>
     /// <param name="indexName">The name of the index to delete.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Delete.IDeleteIndexForTableBuilder" /> to continue building the delete expression.</returns>
+    /// <returns>An <see cref="IDeleteIndexForTableBuilder" /> to continue building the delete expression.</returns>
     IDeleteIndexForTableBuilder Index(string indexName);
 
     /// <summary>
@@ -83,14 +83,14 @@ public interface IDeleteBuilder : IFluentBuilder
     /// Specifies which unique constraint should be deleted from the database schema.
     /// </summary>
     /// <param name="constraintName">The name of the unique constraint to delete.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Delete.IDeleteConstraintBuilder" /> to continue building the delete expression.</returns>
+    /// <returns>An <see cref="IDeleteConstraintBuilder" /> to continue building the delete expression.</returns>
     IDeleteConstraintBuilder UniqueConstraint(string constraintName);
 
     /// <summary>
     ///     Begins building an expression to delete a default constraint from a table.
     /// </summary>
     /// <returns>
-    /// An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Delete.IDeleteDefaultConstraintOnTableBuilder" /> to continue building the delete expression.
+    /// An <see cref="IDeleteDefaultConstraintOnTableBuilder" /> to continue building the delete expression.
     /// </returns>
     IDeleteDefaultConstraintOnTableBuilder DefaultConstraint();
 }

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/ExpressionBuilderBase{TExpression,TNext}.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/ExpressionBuilderBase{TExpression,TNext}.cs
@@ -21,9 +21,9 @@ public abstract class ExpressionBuilderBase<TExpression, TNext> : ExpressionBuil
     private ColumnDefinition? Column => GetColumnForType();
 
     /// <summary>
-    /// Retrieves the <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.ColumnDefinition"/> associated with the current expression's type, if one exists.
+    /// Retrieves the <see cref="ColumnDefinition"/> associated with the current expression's type, if one exists.
     /// </summary>
-    /// <returns>The corresponding <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.ColumnDefinition"/> if available; otherwise, <c>null</c>.</returns>
+    /// <returns>The corresponding <see cref="ColumnDefinition"/> if available; otherwise, <c>null</c>.</returns>
     public abstract ColumnDefinition? GetColumnForType();
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Rename/Column/IRenameColumnToBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Rename/Column/IRenameColumnToBuilder.cs
@@ -11,6 +11,6 @@ public interface IRenameColumnToBuilder : IFluentBuilder
     /// Specifies the new name of the column.
     /// </summary>
     /// <param name="name">The new name to assign to the column.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.IExecutableBuilder" /> that can be used to execute the rename operation.</returns>
+    /// <returns>An <see cref="IExecutableBuilder" /> that can be used to execute the rename operation.</returns>
     IExecutableBuilder To(string name);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Expressions/Rename/IRenameBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Expressions/Rename/IRenameBuilder.cs
@@ -12,13 +12,13 @@ public interface IRenameBuilder : IFluentBuilder
     ///     Begins a table rename operation by specifying the current name of the table.
     /// </summary>
     /// <param name="oldName">The current name of the table to rename.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Rename.IRenameTableBuilder" /> to continue the rename operation.</returns>
+    /// <returns>An <see cref="IRenameTableBuilder" /> to continue the rename operation.</returns>
     IRenameTableBuilder Table(string oldName);
 
     /// <summary>
     /// Specifies the column to rename in a database table.
     /// </summary>
     /// <param name="oldName">The current name of the column to be renamed.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Migrations.Expressions.Rename.IRenameColumnBuilder" /> for specifying the new column name.</returns>
+    /// <returns>An <see cref="IRenameColumnBuilder" /> for specifying the new column name.</returns>
     IRenameColumnBuilder Column(string oldName);
 }

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseBuilder.cs
@@ -413,7 +413,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         /// <param name="plan">The Umbraco plan describing the upgrade steps.</param>
         /// <returns>A <see cref="Result"/> indicating the outcome of the upgrade, or <c>null</c> if no result is available.</returns>
         /// <remarks>
-        /// This method is obsolete. Use <see cref="UpgradeSchemaAndDataAsync"/> instead.
+        /// This method is obsolete. Use <see cref="UpgradeSchemaAndDataAsync(UmbracoPlan)"/> instead.
         /// </remarks>
         [Obsolete("Use UpgradeSchemaAndDataAsync instead. Scheduled for removal in Umbraco 18.")]
         public Result? UpgradeSchemaAndData(UmbracoPlan plan) => UpgradeSchemaAndData((MigrationPlan)plan);
@@ -424,7 +424,7 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Install
         /// <param name="plan">The migration plan to apply for upgrading the schema and data.</param>
         /// <returns>A <see cref="Result"/> indicating the outcome of the upgrade operation, or <c>null</c> if the upgrade did not produce a result.</returns>
         /// <remarks>
-        /// This method is obsolete. Use <see cref="UpgradeSchemaAndDataAsync"/> instead. Scheduled for removal in Umbraco 18.
+        /// This method is obsolete. Use <see cref="UpgradeSchemaAndDataAsync(MigrationPlan)"/> instead. Scheduled for removal in Umbraco 18.
         /// </remarks>
         [Obsolete("Use UpgradeSchemaAndDataAsync instead. Scheduled for removal in Umbraco 18.")]
         public Result? UpgradeSchemaAndData(MigrationPlan plan) => UpgradeSchemaAndDataAsync(plan).GetAwaiter().GetResult();

--- a/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/MigrationPlan.cs
@@ -161,7 +161,7 @@ public class MigrationPlan
     /// <summary>
     /// Adds a transition from the current state to the specified target state using the specified migration type.
     /// </summary>
-    /// <typeparam name="TMigration">The type of <see cref="IMigration"/> to execute for the transition.</typeparam>
+    /// <typeparam name="TMigration">The type of <see cref="AsyncMigrationBase"/> to execute for the transition.</typeparam>
     /// <param name="targetState">The name of the target state to transition to.</param>
     /// <returns>The current <see cref="MigrationPlan"/> instance, allowing for method chaining.</returns>
     public MigrationPlan To<TMigration>(string targetState)
@@ -333,13 +333,12 @@ public class MigrationPlan
     /// <summary>
     ///     Initiates the process of merging multiple migration branches into a single branch within the migration plan.
     /// </summary>
-    /// <returns>A <see cref="Umbraco.Cms.Infrastructure.Migrations.MigrationPlan.MergeBuilder" /> instance used to configure and define the merge operation.</returns>
+    /// <returns>A <see cref="MergeBuilder" /> instance used to configure and define the merge operation.</returns>
     public MergeBuilder Merge() => new(this);
 
     /// <summary>
     ///     Validates the plan.
     /// </summary>
-    /// <returns>The plan's final state.</returns>
     public void Validate()
     {
         if (_finalState != null)

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/ConvertLocalLinkComposer.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/ConvertLocalLinkComposer.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0.LocalLinks;
 
 /// <summary>
-/// Registers the <see cref="ConvertLocalLink"/> migration with the Umbraco composer pipeline.
+/// Registers the <see cref="ConvertLocalLinks"/> migration with the Umbraco composer pipeline.
 /// </summary>
 [Obsolete("Scheduled for removal in Umbraco 18.")]
 public class ConvertLocalLinkComposer : IComposer

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/RebuildCacheMigration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/RebuildCacheMigration.cs
@@ -15,8 +15,8 @@ public class RebuildCacheMigration : MigrationBase
     /// Initializes a new instance of the <see cref="Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_1_0.RebuildCacheMigration"/> class.
     /// </summary>
     /// <param name="context">The migration context. <see cref="Umbraco.Cms.Infrastructure.Migrations.IMigrationContext"/></param>
-    /// <param name="documentCacheService">The document cache service. <see cref="Umbraco.Cms.Core.Cache.IDocumentCacheService"/></param>
-    /// <param name="mediaCacheService">The media cache service. <see cref="Umbraco.Cms.Core.Cache.IMediaCacheService"/></param>
+    /// <param name="documentCacheService">The document cache service. <see cref="IDocumentCacheService"/></param>
+    /// <param name="mediaCacheService">The media cache service. <see cref="IMediaCacheService"/></param>
     public RebuildCacheMigration(IMigrationContext context, IDocumentCacheService documentCacheService, IMediaCacheService mediaCacheService) : base(context)
     {
         _documentCacheService = documentCacheService;

--- a/src/Umbraco.Infrastructure/ModelsBuilder/UmbracoServices.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/UmbracoServices.cs
@@ -60,7 +60,7 @@ public sealed class UmbracoServices
     /// Retrieves all content, media, and member type models from the respective Umbraco services.
     /// </summary>
     /// <returns>
-    /// A list of <see cref="Umbraco.Cms.Infrastructure.ModelsBuilder.TypeModel"/> objects representing all content, media, and member types defined in the system.
+    /// A list of <see cref="TypeModel"/> objects representing all content, media, and member types defined in the system.
     /// </returns>
     public IList<TypeModel> GetAllTypes()
     {

--- a/src/Umbraco.Infrastructure/Packaging/ImportPackageBuilder.cs
+++ b/src/Umbraco.Infrastructure/Packaging/ImportPackageBuilder.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
@@ -20,7 +21,7 @@ internal sealed class ImportPackageBuilder : ExpressionBuilderBase<ImportPackage
     /// <param name="packagingService">An instance of <see cref="IPackagingService"/> used for package operations.</param>
     /// <param name="mediaService">An instance of <see cref="IMediaService"/> for managing media items.</param>
     /// <param name="mediaFileManager">The <see cref="MediaFileManager"/> responsible for handling media files.</param>
-    /// <param name="mediaUrlGenerators">A collection of <see cref="MediaUrlGenerator"/> used to generate media URLs.</param>
+    /// <param name="mediaUrlGenerators">A collection of <see cref="IMediaUrlGenerator"/> used to generate media URLs.</param>
     /// <param name="shortStringHelper">The <see cref="IShortStringHelper"/> used for string manipulation and formatting.</param>
     /// <param name="contentTypeBaseServiceProvider">The <see cref="IContentTypeBaseServiceProvider"/> for accessing content type services.</param>
     /// <param name="context">The <see cref="IMigrationContext"/> providing context for the migration process.</param>

--- a/src/Umbraco.Infrastructure/Persistence/DbProviderFactoryCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/DbProviderFactoryCreator.cs
@@ -61,7 +61,7 @@ public class DbProviderFactoryCreator : IDbProviderFactoryCreator
     /// </summary>
     /// <remarks>gets the sql syntax provider that corresponds, from attribute</remarks>
     /// <param name="providerName">The name of the database provider.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Infrastructure.Persistence.ISqlSyntaxProvider" /> instance for the specified provider.</returns>
+    /// <returns>An <see cref="ISqlSyntaxProvider" /> instance for the specified provider.</returns>
     public ISqlSyntaxProvider GetSqlSyntaxProvider(string providerName)
     {
         if (!_syntaxProviders.TryGetValue(providerName, out ISqlSyntaxProvider? result))

--- a/src/Umbraco.Infrastructure/Persistence/Factories/AuditItemFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/AuditItemFactory.cs
@@ -31,10 +31,10 @@ internal static class AuditItemFactory
             dto.Datestamp.EnsureUtc());
 
     /// <summary>
-    /// Builds a <see cref="Umbraco.Cms.Core.Models.Membership.LogDto"/> from the given <see cref="Umbraco.Cms.Core.Models.IAuditItem"/> entity.
+    /// Builds a <see cref="LogDto"/> from the given <see cref="Umbraco.Cms.Core.Models.IAuditItem"/> entity.
     /// </summary>
     /// <param name="entity">The audit item entity to convert.</param>
-    /// <returns>A <see cref="Umbraco.Cms.Core.Models.Membership.LogDto"/> representing the audit item.</returns>
+    /// <returns>A <see cref="LogDto"/> representing the audit item.</returns>
     public static LogDto BuildDto(IAuditItem entity) =>
         new LogDto
         {

--- a/src/Umbraco.Infrastructure/Persistence/Factories/ContentTypeFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/ContentTypeFactory.cs
@@ -73,13 +73,13 @@ internal static class ContentTypeFactory
     #region IMemberType
 
     /// <summary>
-    /// Constructs an <see cref="Umbraco.Cms.Core.Models.IMemberType"/> entity from the specified <see cref="ContentTypeDto"/>,
+    /// Constructs an <see cref="IMemberType"/> entity from the specified <see cref="ContentTypeDto"/>,
     /// initializing it with data from the DTO and using the provided <see cref="IShortStringHelper"/> for string operations.
     /// </summary>
     /// <param name="shortStringHelper">An instance of <see cref="IShortStringHelper"/> used to assist with string manipulation during entity creation.</param>
     /// <param name="dto">A <see cref="ContentTypeDto"/> containing the data required to build the member type entity.</param>
     /// <returns>
-    /// A new <see cref="Umbraco.Cms.Core.Models.IMemberType"/> instance populated with values from the provided DTO.
+    /// A new <see cref="IMemberType"/> instance populated with values from the provided DTO.
     /// </returns>
     public static IMemberType BuildMemberTypeEntity(IShortStringHelper shortStringHelper, ContentTypeDto dto)
     {
@@ -99,10 +99,10 @@ internal static class ContentTypeFactory
     }
 
     /// <summary>
-    /// Creates a collection of <see cref="Umbraco.Cms.Core.Models.Membership.MemberPropertyTypeDto"/> objects representing the property types defined on the specified <see cref="Umbraco.Cms.Core.Models.IMemberType"/>.
+    /// Creates a collection of <see cref="MemberPropertyTypeDto"/> objects representing the property types defined on the specified <see cref="IMemberType"/>.
     /// </summary>
     /// <param name="entity">The member type entity whose property types will be converted to DTOs.</param>
-    /// <returns>An enumerable of <see cref="Umbraco.Cms.Core.Models.Membership.MemberPropertyTypeDto"/> for each property type on the member type, or an empty collection if none exist.</returns>
+    /// <returns>An enumerable of <see cref="MemberPropertyTypeDto"/> for each property type on the member type, or an empty collection if none exist.</returns>
     public static IEnumerable<MemberPropertyTypeDto> BuildMemberPropertyTypeDtos(IMemberType entity)
     {
         if (entity is not MemberType memberType || memberType.PropertyTypes.Any() == false)

--- a/src/Umbraco.Infrastructure/Persistence/Factories/DataTypeFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/DataTypeFactory.cs
@@ -78,7 +78,7 @@ internal static class DataTypeFactory
     /// Creates a <see cref="Umbraco.Cms.Infrastructure.Persistence.Dtos.DataTypeDto"/> from the specified <see cref="Umbraco.Cms.Core.Models.IDataType"/> entity, serializing its configuration using the provided JSON serializer.
     /// </summary>
     /// <param name="entity">The <see cref="Umbraco.Cms.Core.Models.IDataType"/> to convert.</param>
-    /// <param name="serializer">The <see cref="Umbraco.Cms.Core.PropertyEditors.IConfigurationEditorJsonSerializer"/> used to serialize the configuration data.</param>
+    /// <param name="serializer">The <see cref="IConfigurationEditorJsonSerializer"/> used to serialize the configuration data.</param>
     /// <returns>A <see cref="Umbraco.Cms.Infrastructure.Persistence.Dtos.DataTypeDto"/> representing the converted data type entity.</returns>
     public static DataTypeDto BuildDto(IDataType entity, IConfigurationEditorJsonSerializer serializer)
     {

--- a/src/Umbraco.Infrastructure/Persistence/FaultHandling/RetryDbConnection.cs
+++ b/src/Umbraco.Infrastructure/Persistence/FaultHandling/RetryDbConnection.cs
@@ -238,7 +238,7 @@ internal sealed class FaultHandlingDbCommand : DbCommand
     }
 
     /// <summary>
-    /// Gets or sets a value indicating how the results of a command are applied to a <see cref="DataRow"/> when used by the <see cref="DbDataAdapter.Update"/> method.
+    /// Gets or sets a value indicating how the results of a command are applied to a <see cref="DataRow"/> when used by the <see cref="DbDataAdapter.Update(DataRow[], DataTableMapping)"/> method.
     /// This property determines whether output parameters and/or the first returned row are mapped to the changed row in the data table.
     /// </summary>
     public override UpdateRowSource UpdatedRowSource

--- a/src/Umbraco.Infrastructure/Persistence/IDbProviderFactoryCreator.cs
+++ b/src/Umbraco.Infrastructure/Persistence/IDbProviderFactoryCreator.cs
@@ -19,7 +19,7 @@ public interface IDbProviderFactoryCreator
     /// Gets the SQL syntax provider for the specified database provider name.
     /// </summary>
     /// <param name="providerName">The name of the database provider.</param>
-    /// <returns>An instance of <see cref="Umbraco.Cms.Infrastructure.Persistence.ISqlSyntaxProvider"/> corresponding to the provider name.</returns>
+    /// <returns>An instance of <see cref="ISqlSyntaxProvider"/> corresponding to the provider name.</returns>
     ISqlSyntaxProvider GetSqlSyntaxProvider(string providerName);
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -199,7 +199,7 @@ namespace Umbraco.Extensions
         /// <param name="sql">The base <see cref="Sql{ISqlContext}"/> instance to which the join will be appended.</param>
         /// <param name="nestedQuery">The nested <see cref="Sql{ISqlContext}"/> subquery to join.</param>
         /// <param name="alias">The alias to assign to the nested subquery in the join clause. The alias will be quoted according to the SQL syntax provider.</param>
-        /// <returns>A <see cref="SqlJoinClause{ISqlContext}"/> representing the INNER JOIN with the nested subquery and alias.</returns>
+        /// <returns>A <see cref="Sql{ISqlContext}.SqlJoinClause{ISqlContext}"/> representing the INNER JOIN with the nested subquery and alias.</returns>
         public static Sql<ISqlContext>.SqlJoinClause<ISqlContext> InnerJoinNested(this Sql<ISqlContext> sql, Sql<ISqlContext> nestedQuery, string alias)
         {
             return new Sql<ISqlContext>.SqlJoinClause<ISqlContext>(sql.Append("INNER JOIN (").Append(nestedQuery)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -728,7 +728,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         /// </summary>
         /// <param name="options">Specifies options for the integrity check, such as whether to automatically fix issues found.</param>
         /// <returns>
-        /// A <see cref="Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.ContentDataIntegrityReport"/> detailing any nodes with invalid paths or levels, and indicating which issues were fixed if applicable.
+        /// A <see cref="ContentDataIntegrityReport"/> detailing any nodes with invalid paths or levels, and indicating which issues were fixed if applicable.
         /// </returns>
         public ContentDataIntegrityReport CheckDataIntegrity(ContentDataIntegrityReportOptions options)
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityContainerRepository.cs
@@ -189,9 +189,9 @@ internal class EntityContainerRepository : EntityRepositoryBase<int, EntityConta
     }
 
     /// <summary>
-    /// Determines whether an entity container with the specified <paramref name="name"/> exists under the parent container identified by <paramref name="parentKey"/>.
+    /// Determines whether an entity container with the specified <paramref name="name"/> exists under the parent container identified by <paramref name="parentId"/>.
     /// </summary>
-    /// <param name="parentKey">The unique identifier (GUID) of the parent container.</param>
+    /// <param name="parentId">The id of the parent container.</param>
     /// <param name="name">The name to check for duplicates within the parent container.</param>
     /// <returns><c>true</c> if a container with the same name exists under the specified parent; otherwise, <c>false</c>.</returns>
     public bool HasDuplicateName(int parentId, string name)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
@@ -521,7 +521,7 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     /// </summary>
     /// <param name="objectType">The unique identifier of the object type.</param>
     /// <param name="keys">Optional array of entity keys to filter the paths. If not provided, paths for all entities of the specified type are returned.</param>
-    /// <returns>An enumerable of <see cref="Umbraco.Cms.Core.Models.TreeEntityPath"/> representing the entity paths.</returns>
+    /// <returns>An enumerable of <see cref="TreeEntityPath"/> representing the entity paths.</returns>
     public IEnumerable<TreeEntityPath> GetAllPaths(Guid objectType, params Guid[] keys) =>
         keys.Any()
             ? keys.Distinct().SelectByGroups(

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EntityRepository.cs
@@ -449,7 +449,7 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     /// Gets all entities of the specified object type, optionally filtered by the provided integer IDs.
     /// </summary>
     /// <param name="objectType">The unique identifier of the object type to retrieve entities for.</param>
-    /// <param name="ids">An optional array of integer IDs to filter the entities. If not provided, all entities of the specified type are returned.</param>
+    /// <param name="keys">An optional array of keys to filter the entities. If not provided, all entities of the specified type are returned.</param>
     /// <returns>An enumerable collection of entities matching the specified criteria.</returns>
     public IEnumerable<IEntitySlim> GetAll(Guid objectType, params Guid[] keys) =>
         keys.Length > 0
@@ -520,7 +520,7 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     /// Gets all paths for entities of the specified object type, optionally filtered by the provided entity IDs.
     /// </summary>
     /// <param name="objectType">The unique identifier of the object type.</param>
-    /// <param name="ids">Optional array of entity IDs to filter the paths. If not provided, paths for all entities of the specified type are returned.</param>
+    /// <param name="keys">Optional array of entity keys to filter the paths. If not provided, paths for all entities of the specified type are returned.</param>
     /// <returns>An enumerable of <see cref="Umbraco.Cms.Core.Models.TreeEntityPath"/> representing the entity paths.</returns>
     public IEnumerable<TreeEntityPath> GetAllPaths(Guid objectType, params Guid[] keys) =>
         keys.Any()
@@ -594,7 +594,7 @@ internal sealed class EntityRepository : RepositoryBase, IEntityRepositoryExtend
     /// <summary>
     /// Gets the Umbraco object type for the entity with the specified integer ID.
     /// </summary>
-    /// <param name="id">The unique integer identifier (ID) of the entity.</param>
+    /// <param name="key">The unique key of the entity.</param>
     /// <returns>The <see cref="UmbracoObjectTypes"/> value representing the object's type.</returns>
     public UmbracoObjectTypes GetObjectType(Guid key)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/FileRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/FileRepository.cs
@@ -184,7 +184,7 @@ internal abstract class FileRepository<TId, TEntity> : IReadRepository<TId, TEnt
 
     /// <summary>
     /// Deletes the specified entity from the repository.
-    /// This virtual method calls <see cref="PersistDeletedItem"/> to perform the deletion.
+    /// This virtual method calls <see cref="PersistDeletedItem(TEntity)"/> to perform the deletion.
     /// </summary>
     /// <param name="entity">The entity to delete.</param>
     public virtual void Delete(TEntity entity) => PersistDeletedItem(entity);

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/LogViewerQueryRepository.cs
@@ -143,10 +143,10 @@ internal sealed class LogViewerQueryRepository : EntityRepositoryBase<int, ILogV
     internal sealed class LogViewerQueryModelFactory
     {
         /// <summary>
-        /// Creates an <see cref="Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.LogViewerQueryRepository.ILogViewerQuery" /> instance from the specified <see cref="Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.LogViewerQueryRepository.LogViewerQueryDto" />.
+        /// Creates an <see cref="ILogViewerQuery" /> instance from the specified <see cref="LogViewerQueryDto" />.
         /// </summary>
         /// <param name="dto">The DTO containing the log viewer query information.</param>
-        /// <returns>A new <see cref="Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.LogViewerQueryRepository.ILogViewerQuery" /> instance.</returns>
+        /// <returns>A new <see cref="ILogViewerQuery" /> instance.</returns>
         public ILogViewerQuery BuildEntity(LogViewerQueryDto dto)
         {
             var logViewerQuery = new LogViewerQuery(dto.Name, dto.Query) { Id = dto.Id };

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/UserRepository.cs
@@ -244,10 +244,10 @@ internal sealed class UserRepository : EntityRepositoryBase<Guid, IUser>, IUserR
     }
 
     /// <summary>
-    /// Retrieves a dictionary containing the number of users for each <see cref="Umbraco.Core.Models.Membership.UserState"/>.
+    /// Retrieves a dictionary containing the number of users for each <see cref="UserState"/>.
     /// </summary>
     /// <returns>
-    /// A dictionary where each key is a <see cref="Umbraco.Core.Models.Membership.UserState"/> value representing a user state, and the corresponding value is the count of users in that state.
+    /// A dictionary where each key is a <see cref="UserState"/> value representing a user state, and the corresponding value is the count of users in that state.
     /// </returns>
     public IDictionary<UserState, int> GetUserStates()
     {

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/ISqlSyntaxProvider.cs
@@ -183,7 +183,7 @@ public interface ISqlSyntaxProvider
     /// </summary>
     /// <param name="current">The current <see cref="DatabaseType"/>.</param>
     /// <param name="connectionString">An optional connection string used to help determine the updated database type.</param>
-    /// <returns>The resolved <see cref="Umbraco.Cms.Infrastructure.Persistence.DatabaseType"/>.</returns>
+    /// <returns>The resolved <see cref="DatabaseType"/>.</returns>
     DatabaseType GetUpdatedDatabaseType(DatabaseType current, string? connectionString) =>
         current; // Default implementation.
 

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -227,9 +227,9 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
     /// <summary>
     /// Determines the database type to use, potentially updating it based on the provided connection string.
     /// </summary>
-    /// <param name="current">The current <see cref="Umbraco.Cms.Infrastructure.Persistence.DatabaseType"/>.</param>
+    /// <param name="current">The current <see cref="DatabaseType"/>.</param>
     /// <param name="connectionString">An optional connection string that may influence the database type.</param>
-    /// <returns>The resulting <see cref="Umbraco.Cms.Infrastructure.Persistence.DatabaseType"/>.</returns>
+    /// <returns>The resulting <see cref="DatabaseType"/>.</returns>
     public virtual DatabaseType GetUpdatedDatabaseType(DatabaseType current, string? connectionString) => current;
 
     /// <summary>
@@ -504,7 +504,7 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
     /// <param name="sql">The base SQL query to which the left join and nested join will be applied.</param>
     /// <param name="nestedJoin">A function that defines the nested join logic to be included within the left join.</param>
     /// <param name="alias">An optional alias for the joined table.</param>
-    /// <returns>A <see cref="SqlJoinClause{ISqlContext}"/> representing the constructed left join with the nested join applied.</returns>
+    /// <returns>A <see cref="Sql{ISqlContext}.SqlJoinClause{ISqlContext}"/> representing the constructed left join with the nested join applied.</returns>
     public abstract Sql<ISqlContext>.SqlJoinClause<ISqlContext> LeftJoinWithNestedJoin<TDto>(
         Sql<ISqlContext> sql,
         Func<Sql<ISqlContext>, Sql<ISqlContext>> nestedJoin,

--- a/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/DateTimePropertyEditorBase.cs
@@ -103,7 +103,7 @@ public abstract class DateTimePropertyEditorBase : DataEditor, IValueSchemaProvi
         /// <param name="attribute">The data editor attribute that defines editor metadata.</param>
         /// <param name="localizedTextService">Service for retrieving localized text resources.</param>
         /// <param name="logger">Logger instance for logging events and errors.</param>
-        /// <param name="mappingFunc">A function that maps a <see cref="DateTimeDto"/> to its string representation.</param>
+        /// <param name="mappingFunc">A function that maps a <see cref="DateTimeValueConverterBase.DateTimeDto"/> to its string representation.</param>
         public DateTimeDataValueEditor(
             IShortStringHelper shortStringHelper,
             IJsonSerializer jsonSerializer,

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/BlockGridPropertyValueCreator.cs
@@ -41,7 +41,7 @@ internal sealed class BlockGridPropertyValueCreator : BlockPropertyValueCreatorB
     /// <param name="referenceCacheLevel">The <see cref="PropertyCacheLevel"/> to use when resolving references within the block grid.</param>
     /// <param name="intermediateBlockModelValue">A string containing the intermediate (typically JSON) representation of the block grid's data.</param>
     /// <param name="preview">True if the model should be created in preview mode; otherwise, false.</param>
-    /// <param name="blockConfigurations">An array of <see cref="BlockGridBlockConfiguration"/> objects that define the available block types and their settings.</param>
+    /// <param name="blockConfigurations">An array of <see cref="BlockGridConfiguration.BlockGridBlockConfiguration"/> objects that define the available block types and their settings.</param>
     /// <param name="gridColumns">The number of columns in the grid layout, or null to use the default configuration.</param>
     /// <returns>A <see cref="BlockGridModel"/> representing the structured block grid data for the given property and configuration.</returns>
     public async Task<BlockGridModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, string intermediateBlockModelValue, bool preview, BlockGridConfiguration.BlockGridBlockConfiguration[] blockConfigurations, int? gridColumns)

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/ImageCropperValue.cs
@@ -56,7 +56,7 @@ public class ImageCropperValue :TemporaryFileUploadValueBase, IHtmlEncodedString
     /// <param name="url">The URL of the image.</param>
     /// <param name="crop">The crop information to apply to the image, or <c>null</c> if not specified.</param>
     /// <param name="preferFocalPoint">If <c>true</c>, prefer using the focal point over crop coordinates when both are available.</param>
-    /// <returns>An <see cref="Umbraco.Cms.Core.PropertyEditors.ValueConverters.ImageUrlGenerationOptions"/> instance configured with either the focal point, crop coordinates, or default settings based on the input parameters.</returns>
+    /// <returns>An <see cref="ImageUrlGenerationOptions"/> instance configured with either the focal point, crop coordinates, or default settings based on the input parameters.</returns>
     public ImageUrlGenerationOptions GetCropBaseOptions(string? url, ImageCropperCrop? crop, bool preferFocalPoint)
     {
         if ((preferFocalPoint && HasFocalPoint()) || (crop is not null && crop.Coordinates is null && HasFocalPoint()))

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueConstructorCache.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueConstructorCache.cs
@@ -3,7 +3,7 @@ using Umbraco.Cms.Core.Models.Blocks;
 namespace Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
 /// <summary>
-/// Caches constructor instances used by the <see cref="RichTextBlockPropertyValueConverter"/> to optimize property value conversion.
+/// Caches constructor instances used by the <see cref="RichTextBlockPropertyValueCreator"/> to optimize property value conversion.
 /// </summary>
 public class RichTextBlockPropertyValueConstructorCache : BlockEditorPropertyValueConstructorCacheBase<RichTextBlockItem>
 {

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RichTextBlockPropertyValueCreator.cs
@@ -43,7 +43,7 @@ internal sealed class RichTextBlockPropertyValueCreator : BlockPropertyValueCrea
     /// <param name="referenceCacheLevel">The cache level to use for property references during model creation.</param>
     /// <param name="blockValue">The <see cref="RichTextBlockValue"/> representing the value to convert.</param>
     /// <param name="preview">True to create the model in preview mode; otherwise, false.</param>
-    /// <param name="blockConfigurations">An array of <see cref="RichTextBlockConfiguration"/> objects that define the configuration for each block type.</param>
+    /// <param name="blockConfigurations">An array of <see cref="RichTextConfiguration.RichTextBlockConfiguration"/> objects that define the configuration for each block type.</param>
     /// <returns>A <see cref="RichTextBlockModel"/> that represents the parsed and configured block content, or <see cref="RichTextBlockModel.Empty"/> if the value is invalid or empty.</returns>
     public async Task<RichTextBlockModel> CreateBlockModelAsync(IPublishedElement owner, PropertyCacheLevel referenceCacheLevel, RichTextBlockValue blockValue, bool preview, RichTextConfiguration.RichTextBlockConfiguration[] blockConfigurations)
     {

--- a/src/Umbraco.Infrastructure/PublishedContentQuery.cs
+++ b/src/Umbraco.Infrastructure/PublishedContentQuery.cs
@@ -276,7 +276,7 @@ public class PublishedContentQuery : IPublishedContentQuery
     /// Retrieves the media items corresponding to the specified IDs.
     /// </summary>
     /// <param name="ids">A collection of media item IDs to retrieve.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Umbraco.Cms.Core.Models.IPublishedContent"/> representing the found media items.</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IPublishedContent"/> representing the found media items.</returns>
     public IEnumerable<IPublishedContent> Media(IEnumerable<int> ids)
         => ItemsByIds(_publishedMediaCache, ids);
 
@@ -284,7 +284,7 @@ public class PublishedContentQuery : IPublishedContentQuery
     /// Retrieves a collection of media items corresponding to the specified identifiers.
     /// </summary>
     /// <param name="ids">A collection of identifiers for the media items to retrieve.</param>
-    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Umbraco.Cms.Core.Models.IPublishedContent"/> representing the found media items.</returns>
+    /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="IPublishedContent"/> representing the found media items.</returns>
     public IEnumerable<IPublishedContent> Media(IEnumerable<object> ids)
         => ids.Select(Media).WhereNotNull();
 

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -236,7 +236,7 @@ namespace Umbraco.Cms.Infrastructure.Scoping
         }
 
         /// <summary>
-        /// Gets a value indicating whether this scope was created by <see cref="CreateDetachedScope"/>, making it detachable.
+        /// Gets a value indicating whether this scope was created by <see cref="ScopeProvider.CreateDetachedScope"/>, making it detachable.
         /// </summary>
         /// <remarks>
         /// a value indicating whether the scope is detachable

--- a/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
+++ b/src/Umbraco.Infrastructure/Security/BackOfficeUserStore.cs
@@ -333,7 +333,7 @@ public class BackOfficeUserStore :
     /// <summary>
     /// Asynchronously retrieves the users with the specified IDs.
     /// </summary>
-    /// <param name="ids">An array of user IDs to retrieve. If <c>null</c> or empty, an empty collection is returned.</param>
+    /// <param name="keys">An array of user IDs to retrieve. If <c>null</c> or empty, an empty collection is returned.</param>
     /// <returns>
     /// A task that represents the asynchronous operation. The task result contains an <see cref="IEnumerable{IUser}"/> of users matching the specified IDs.
     /// </returns>

--- a/src/Umbraco.Infrastructure/Security/MemberIdentityUser.cs
+++ b/src/Umbraco.Infrastructure/Security/MemberIdentityUser.cs
@@ -41,7 +41,7 @@ public class MemberIdentityUser : UmbracoIdentityUser
 
     /// <summary>
     /// Gets or sets the date and time when the member account was most recently locked out.
-    /// This value is set when the <see cref="IsLockedOut"/> flag is updated.
+    /// This value is set when the <see cref="UmbracoIdentityUser.IsLockedOut"/> flag is updated.
     /// </summary>
     /// <remarks>No change tracking because the persisted value is only set with the IsLockedOut flag</remarks>
     public DateTime? LastLockoutDate { get; set; }

--- a/src/Umbraco.Infrastructure/Serialization/ContentJsonTypeResolverBase.cs
+++ b/src/Umbraco.Infrastructure/Serialization/ContentJsonTypeResolverBase.cs
@@ -12,12 +12,12 @@ namespace Umbraco.Cms.Infrastructure.Serialization;
 public abstract class ContentJsonTypeResolverBase : DefaultJsonTypeInfoResolver
 {
     /// <summary>
-    /// Gets the <see cref="System.Text.Json.Serialization.JsonTypeInfo"/> for the specified <see cref="System.Type"/>,
+    /// Gets the <see cref="JsonTypeInfo"/> for the specified <see cref="Type"/>,
     /// configuring polymorphic serialization options for derived types if applicable.
     /// </summary>
-    /// <param name="type">The type to get the <see cref="System.Text.Json.Serialization.JsonTypeInfo"/> for.</param>
-    /// <param name="options">The <see cref="System.Text.Json.JsonSerializerOptions"/> to use when getting the type info.</param>
-    /// <returns>The <see cref="System.Text.Json.Serialization.JsonTypeInfo"/> for the specified type, with polymorphism options configured if derived types are present.</returns>
+    /// <param name="type">The type to get the <see cref="JsonTypeInfo"/> for.</param>
+    /// <param name="options">The <see cref="JsonSerializerOptions"/> to use when getting the type info.</param>
+    /// <returns>The <see cref="JsonTypeInfo"/> for the specified type, with polymorphism options configured if derived types are present.</returns>
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
     {
         JsonTypeInfo jsonTypeInfo = base.GetTypeInfo(type, options);
@@ -32,11 +32,11 @@ public abstract class ContentJsonTypeResolverBase : DefaultJsonTypeInfoResolver
     }
 
     /// <summary>
-    /// Returns the concrete types that are derived from the type described by the specified <see cref="System.Text.Json.Serialization.JsonTypeInfo" />.
+    /// Returns the concrete types that are derived from the type described by the specified <see cref="JsonTypeInfo" />.
     /// </summary>
     /// <param name="jsonTypeInfo">The JSON type information representing the base type for which to resolve derived types.</param>
     /// <returns>
-    /// An array of <see cref="System.Type" /> objects representing the known derived types for the given JSON type info.
+    /// An array of <see cref="Type" /> objects representing the known derived types for the given JSON type info.
     /// Returns an empty array if there are no known derived types.
     /// </returns>
     public virtual Type[] GetDerivedTypes(JsonTypeInfo jsonTypeInfo)

--- a/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
@@ -79,12 +79,12 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
     }
 
     /// <summary>
-    /// Writes the JSON representation of the specified <see cref="Umbraco.Cms.Core.Models.BlockValue" /> to the provided <see cref="System.Text.Json.Utf8JsonWriter" />.
+    /// Writes the JSON representation of the specified <see cref="BlockValue" /> to the provided <see cref="Utf8JsonWriter" />.
     /// The output includes the content data, optional settings data, expose data, and a layout object containing block layout items grouped by property editor alias.
     /// </summary>
-    /// <param name="writer">The <see cref="System.Text.Json.Utf8JsonWriter" /> to write the JSON to.</param>
-    /// <param name="value">The <see cref="Umbraco.Cms.Core.Models.BlockValue" /> instance to serialize.</param>
-    /// <param name="options">The <see cref="System.Text.Json.JsonSerializerOptions" /> to use when serializing the value.</param>
+    /// <param name="writer">The <see cref="Utf8JsonWriter" /> to write the JSON to.</param>
+    /// <param name="value">The <see cref="BlockValue" /> instance to serialize.</param>
+    /// <param name="options">The <see cref="JsonSerializerOptions" /> to use when serializing the value.</param>
     public override void Write(Utf8JsonWriter writer, BlockValue value, JsonSerializerOptions options)
     {
         value.Layout.TryGetValue(value.PropertyEditorAlias, out IEnumerable<IBlockLayoutItem>? blockLayoutItems);

--- a/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
+++ b/src/Umbraco.Infrastructure/Services/Implement/PackagingService.cs
@@ -125,7 +125,7 @@ public class PackagingService : IPackagingService
     /// <summary>
     /// Installs compiled package data from the specified package XML document.
     /// </summary>
-    /// <param name="packageXml">The XML document containing the compiled package data to install.</param>
+    /// <param name="packageXmlFile">The XML document containing the compiled package data to install.</param>
     /// <param name="userId">The ID of the user performing the installation. Defaults to the super user ID.</param>
     /// <returns>An <see cref="InstallationSummary"/> representing the result of the installation process.</returns>
     public InstallationSummary InstallCompiledPackageData(FileInfo packageXmlFile, int userId = Constants.Security.SuperUserId)

--- a/src/Umbraco.Infrastructure/Sync/SyncBootStateAccessor.cs
+++ b/src/Umbraco.Infrastructure/Sync/SyncBootStateAccessor.cs
@@ -90,7 +90,7 @@ public class SyncBootStateAccessor : ISyncBootStateAccessor
     /// <summary>
     /// Returns the current synchronization boot state, initializing it if it has not already been created.
     /// </summary>
-    /// <returns>The <see cref="Umbraco.Cms.Infrastructure.Sync.SyncBootState"/> representing the current synchronization boot state.</returns>
+    /// <returns>The <see cref="SyncBootState"/> representing the current synchronization boot state.</returns>
     public SyncBootState GetSyncBootState()
         => LazyInitializer.EnsureInitialized(
             ref _syncBootState,

--- a/src/Umbraco.Infrastructure/Telemetry/Interfaces/IDetailedTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Interfaces/IDetailedTelemetryProvider.cs
@@ -10,6 +10,6 @@ public interface IDetailedTelemetryProvider
     /// <summary>
     /// Retrieves detailed telemetry usage information.
     /// </summary>
-    /// <returns>An enumerable collection of <see cref="Umbraco.Cms.Infrastructure.Telemetry.UsageInformation"/> objects containing usage data.</returns>
+    /// <returns>An enumerable collection of <see cref="UsageInformation"/> objects containing usage data.</returns>
     IEnumerable<UsageInformation> GetInformation();
 }

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/BlocksInRichTextTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/BlocksInRichTextTelemetryProvider.cs
@@ -26,7 +26,7 @@ public class BlocksInRichTextTelemetryProvider : IDetailedTelemetryProvider
     /// Retrieves telemetry usage statistics related to blocks within rich text editors.
     /// </summary>
     /// <returns>
-    /// An <see cref="IEnumerable{T}"/> of <see cref="Umbraco.Cms.Infrastructure.Telemetry.UsageInformation"/> objects, where each entry contains statistics such as the total number of rich text editors and the total number of registered blocks within those editors.
+    /// An <see cref="IEnumerable{T}"/> of <see cref="UsageInformation"/> objects, where each entry contains statistics such as the total number of rich text editors and the total number of registered blocks within those editors.
     /// </returns>
     public IEnumerable<UsageInformation> GetInformation()
     {

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/DomainTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/DomainTelemetryProvider.cs
@@ -21,7 +21,7 @@ public class DomainTelemetryProvider : IDetailedTelemetryProvider
     /// <summary>
     /// Gets usage information related to domains.
     /// </summary>
-    /// <returns>An enumerable of <see cref="Umbraco.Cms.Infrastructure.Telemetry.UsageInformation"/> containing domain usage data.</returns>
+    /// <returns>An enumerable of <see cref="UsageInformation"/> containing domain usage data.</returns>
     public IEnumerable<UsageInformation> GetInformation()
     {
         var domains = _domainService.GetAll(true).Count();

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/NodeCountTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/NodeCountTelemetryProvider.cs
@@ -20,7 +20,7 @@ public class NodeCountTelemetryProvider : IDetailedTelemetryProvider
     /// Retrieves telemetry usage information about the number of nodes for various Umbraco object types.
     /// </summary>
     /// <returns>
-    /// An enumerable collection of <see cref="Umbraco.Cms.Infrastructure.Telemetry.UsageInformation"/> instances, each representing the count of a specific node type (such as members, templates, content, and document types) in the system.
+    /// An enumerable collection of <see cref="UsageInformation"/> instances, each representing the count of a specific node type (such as members, templates, content, and document types) in the system.
     /// </returns>
     public IEnumerable<UsageInformation> GetInformation()
     {

--- a/src/Umbraco.Infrastructure/Telemetry/Providers/SystemTroubleshootingInformationTelemetryProvider.cs
+++ b/src/Umbraco.Infrastructure/Telemetry/Providers/SystemTroubleshootingInformationTelemetryProvider.cs
@@ -77,7 +77,7 @@ internal sealed class SystemTroubleshootingInformationTelemetryProvider : IDetai
     private string CurrentServerRole => _serverRoleAccessor.CurrentServerRole.ToString();
 
     /// <summary>
-    /// Retrieves a collection of system troubleshooting information, each represented as a <see cref="Umbraco.Cms.Core.Telemetry.UsageInformation"/> instance.
+    /// Retrieves a collection of system troubleshooting information, each represented as a <see cref="UsageInformation"/> instance.
     /// </summary>
     /// <returns>An <see cref="IEnumerable{UsageInformation}"/> containing key-value pairs with details about the server environment, configuration, and runtime state for troubleshooting purposes.</returns>
     public IEnumerable<UsageInformation> GetInformation() =>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockListElementLevelVariationTests.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.PropertyEditors;
 
 internal sealed partial class BlockListElementLevelVariationTests : BlockEditorElementVariationTestBase
 {
-    public static new void ConfigureAllowEditInvariantFromNonDefaultTrue(IUmbracoBuilder builder)
+    public static void ConfigureAllowEditInvariantFromNonDefaultTrue(IUmbracoBuilder builder)
     {
         builder.Services.Configure<ContentSettings>(config =>
             config.AllowEditInvariantFromNonDefault = true);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/CacheInstructionServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/CacheInstructionServiceTests.cs
@@ -286,7 +286,6 @@ internal sealed class CacheInstructionServiceTests : UmbracoIntegrationTest
 
         lastSynced = await lastSyncedManager.GetLastSyncedExternalAsync();
         Assert.AreEqual(2, lastSynced);
-        var debug = true;
     }
 
     private void CreateAndDeliveryMultipleInstructions(CacheInstructionService sut)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Unpublish.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentPublishingServiceTests.Unpublish.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
 public partial class ContentPublishingServiceTests
 {
-    public static new void ConfigureDisableUnpublishWhenReferencedTrue(IUmbracoBuilder builder)
+    public static void ConfigureDisableUnpublishWhenReferencedTrue(IUmbracoBuilder builder)
         => builder.Services.Configure<ContentSettings>(config =>
             config.DisableUnpublishWhenReferenced = true);
 


### PR DESCRIPTION
### Description
Another PR focusing on fixing warnings.
Each commit focus on a separate type of warning, and it should be somewhat easy to split up this PR if needed.

The warning which have been focused on this time is
- SA1600 missing documentation
- CS0419 ambiguous cref reference
- CS1572 no param by that name
- CS1574 cref could not be resolved
- other warnings which only appeared a couple of times

The most unusual thing I've done would be the warnings I've solved by changing the severity level in the .editorconfig. I wonder if you consider this a valid way to solve it, but also if you agree with the severity level I've changed them to. (they could also directly be ignored)