### PR TITLE
Document: Allow tree navigation through no-access collection ancestors to reach start nodes (closes #22353)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.context.test.ts
@@ -1,0 +1,83 @@
+import { UmbDocumentTreeItemContext } from './document-tree-item.context.js';
+import type { UmbDocumentTreeItemModel } from '../types.js';
+import { expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
+
+@customElement('umb-test-document-tree-item-host')
+class UmbTestDocumentTreeItemHostElement extends UmbElementMixin(HTMLElement) {}
+
+function treeItem(overrides: Partial<UmbDocumentTreeItemModel>): UmbDocumentTreeItemModel {
+	return {
+		unique: 'test-unique-id',
+		entityType: 'document',
+		name: 'Test Item',
+		hasChildren: true,
+		isFolder: false,
+		noAccess: false,
+		isTrashed: false,
+		isProtected: false,
+		ancestors: [],
+		createDate: '2024-01-01',
+		variants: [],
+		flags: [],
+		parent: {
+			unique: null,
+			entityType: 'document-root',
+		},
+		documentType: {
+			unique: 'document-type-unique',
+			icon: 'icon-document',
+			collection: null,
+		},
+		...overrides,
+	} as UmbDocumentTreeItemModel;
+}
+
+describe('UmbDocumentTreeItemContext - collection start node access', () => {
+	let host: UmbTestDocumentTreeItemHostElement;
+	let context: UmbDocumentTreeItemContext;
+	let originalPushState: typeof history.pushState;
+	let pushedUrls: Array<string>;
+
+	beforeEach(() => {
+		host = new UmbTestDocumentTreeItemHostElement();
+		document.body.appendChild(host);
+		context = new UmbDocumentTreeItemContext(host);
+		// Avoid depending on the section context for path construction.
+		(context as unknown as { getPath: () => string }).getPath = () => '/test-path';
+
+		pushedUrls = [];
+		originalPushState = history.pushState;
+		history.pushState = ((data: unknown, unused: string, url?: string | URL | null) => {
+			if (url != null) pushedUrls.push(url.toString());
+		}) as typeof history.pushState;
+	});
+
+	afterEach(() => {
+		history.pushState = originalPushState;
+		document.body.removeChild(host);
+	});
+
+	const collection = { unique: 'collection-unique' };
+
+	it('opens the collection view instead of expanding for an accessible collection', () => {
+		context.setIsMenu(true);
+		context.setTreeItem(treeItem({ noAccess: false, documentType: { unique: 'dt', icon: 'icon', collection } }));
+
+		context.showChildren();
+
+		expect(pushedUrls.some((url) => url.includes('openCollection=true'))).to.be.true;
+	});
+
+	it('expands the tree (does not divert to the collection view) for a no-access collection ancestor', () => {
+		// A "no access" collection node is an ancestor of the user's start node and must remain
+		// expandable so the user can browse down to their start node.
+		context.setIsMenu(true);
+		context.setTreeItem(treeItem({ noAccess: true, documentType: { unique: 'dt', icon: 'icon', collection } }));
+
+		context.showChildren();
+
+		expect(pushedUrls.some((url) => url.includes('openCollection=true'))).to.be.false;
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.context.ts
@@ -37,13 +37,21 @@ export class UmbDocumentTreeItemContext extends UmbDefaultTreeItemContext<
 	readonly isTrashed = this._treeItem.asObservablePart((item) => item?.isTrashed ?? false);
 	readonly noAccess = this._treeItem.asObservablePart((item) => item?.noAccess ?? false);
 
+	// A collection is only browsed via its Collection view when the user can actually access it.
+	// When the node is a "no access" ancestor of the user's start node, it must remain expandable
+	// in the tree so the user can browse down to their start node.
+	readonly #collapsibleCollection = mergeObservables(
+		[this.hasCollection, this.noAccess],
+		([hasCollection, noAccess]) => hasCollection && !noAccess,
+	);
+
 	override setIsMenu(isMenu: boolean) {
 		super.setIsMenu(isMenu);
 		if (isMenu) {
 			this.observe(
-				this.hasCollection,
-				(hasCollection) => {
-					if (hasCollection) {
+				this.#collapsibleCollection,
+				(collapsibleCollection) => {
+					if (collapsibleCollection) {
 						this._treeItemChildrenManager.setTargetTakeSize(1, 1);
 
 						this.observe(
@@ -55,6 +63,8 @@ export class UmbDocumentTreeItemContext extends UmbDefaultTreeItemContext<
 							},
 							'observeCollectionHasActiveDescendant',
 						);
+					} else {
+						this.removeUmbControllerByAlias('observeCollectionHasActiveDescendant');
 					}
 				},
 				'_whenMenuObserveHasCollection',
@@ -89,7 +99,7 @@ export class UmbDocumentTreeItemContext extends UmbDefaultTreeItemContext<
 	}
 
 	public override showChildren() {
-		if (this.getIsMenu() && this.#item.getHasCollection()) {
+		if (this.getIsMenu() && this.#getCollapsibleCollection()) {
 			// Collections cannot be expanded via a menu, instead we open the Collection for the user.
 			this.#openCollection();
 			return;
@@ -98,11 +108,15 @@ export class UmbDocumentTreeItemContext extends UmbDefaultTreeItemContext<
 	}
 
 	public override hideChildren() {
-		if (this.getIsMenu() && this.#item.getHasCollection()) {
+		if (this.getIsMenu() && this.#getCollapsibleCollection()) {
 			// Collections in a menu will collapse when already showing children, and instead we open the Collection for the user.
 			this.#openCollection();
 		}
 		super.hideChildren();
+	}
+
+	#getCollapsibleCollection(): boolean {
+		return this.#item.getHasCollection() && this.getTreeItem()?.noAccess !== true;
 	}
 
 	#openCollection() {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/tree-item/document-tree-item.element.ts
@@ -60,7 +60,9 @@ export class UmbDocumentTreeItemElement extends UmbTreeItemElementBase<
 	override _renderExpandSymbol = () => {
 		// If this in the menu and it is a collection, then we will enforce the user to the Collection view instead of expanding.
 		// `this._forceShowExpand` is equivalent to hasCollection for this element.
-		if (this._isMenu && this._forceShowExpand) {
+		// Exception: a "no access" collection is an ancestor of the user's start node, so it must stay
+		// expandable in the tree (render the normal caret) to let the user browse down to it.
+		if (this._isMenu && this._forceShowExpand && !this._noAccess) {
 			return html`<umb-icon data-mark="open-collection" name="icon-list" style="font-size: 8px;"></umb-icon>`;
 		} else {
 			return undefined;


### PR DESCRIPTION
Fixes #22353

When a user/group is given a content start node that is a descendant of a document configured to show its children as a collection (list view), that start node is unreachable through the content tree. The tree drills down to the collection ancestor and stops — the collection node won't expand, and clicking it does nothing useful for the restricted user. The only workaround was direct URL access.

Example of a user with a start node within a collection

Before
<img width="1276" height="1035" alt="Screenshot 2026-06-30 at 15 49 18" src="https://github.com/user-attachments/assets/588fc057-06dc-4815-a123-18fae5e2cd4b" />

After
<img width="1377" height="1172" alt="Screenshot 2026-07-01 at 09 19 04" src="https://github.com/user-attachments/assets/6f9d26a9-f7c1-4a50-a030-670b0ff13985" />

Test notes in issue description