### PR TITLE
Numeric property editor: preset only when relevant (closes #21787, #20382)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-builder.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-builder.controller.ts
@@ -124,7 +124,8 @@ export class UmbPropertyValuePresetBuilderController<
 		// Only process value if it is `undefined`, if a property has a value we do not want to process it. [NL]
 		// TODO: For v.19, we should run presets for all value always. Make it up to the preset to decide if it should process the value or not. [NL]
 		// Consider how we should communicate such change, as some might have build their own presets that rely on the current behavior. [NL]
-		if (value === undefined || value === null) {
+		// notice the important difference between `undefined` and `null` here, as `null` is a valid value for a property, while `undefined` means that the property has no value. [NL]
+		if (value === undefined) {
 			const callArgs: UmbPropertyValuePresetApiCallArgs = {
 				...this.#baseCreateArgs!,
 				alias: propertyType.alias,

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-builder.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/property-value-preset/property-value-preset-builder.controller.ts
@@ -122,7 +122,9 @@ export class UmbPropertyValuePresetBuilderController<
 		let value: unknown = incomingCallArgs.value;
 
 		// Only process value if it is `undefined`, if a property has a value we do not want to process it. [NL]
-		if (value === undefined) {
+		// TODO: For v.19, we should run presets for all value always. Make it up to the preset to decide if it should process the value or not. [NL]
+		// Consider how we should communicate such change, as some might have build their own presets that rely on the current behavior. [NL]
+		if (value === undefined || value === null) {
 			const callArgs: UmbPropertyValuePresetApiCallArgs = {
 				...this.#baseCreateArgs!,
 				alias: propertyType.alias,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/decimal-property-value-preset.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/decimal-property-value-preset.ts
@@ -1,15 +1,17 @@
 import type { UmbDecimalPropertyEditorUiValue } from './types.js';
+import { umbResolveNumberPresetValue } from './resolve-number-preset-value.function.js';
 import type { UmbPropertyValuePreset } from '@umbraco-cms/backoffice/property';
 import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
 
-export class UmbDecimalPropertyValuePreset
-	implements UmbPropertyValuePreset<UmbDecimalPropertyEditorUiValue, UmbPropertyEditorConfig>
-{
+export class UmbDecimalPropertyValuePreset implements UmbPropertyValuePreset<
+	UmbDecimalPropertyEditorUiValue,
+	UmbPropertyEditorConfig
+> {
 	async processValue(value: undefined | UmbDecimalPropertyEditorUiValue, config: UmbPropertyEditorConfig) {
-		const min = Number(config.find((x) => x.alias === 'min')?.value ?? 0);
-		const minVerified = isNaN(min) ? 0 : min;
-
-		return value !== undefined ? value : minVerified;
+		if (value !== undefined && value !== null) {
+			return value;
+		}
+		return umbResolveNumberPresetValue(config);
 	}
 
 	destroy(): void {}

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/integer-property-value-preset.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/integer-property-value-preset.ts
@@ -1,15 +1,21 @@
 import type { UmbIntegerPropertyEditorUiValue } from './types.js';
+import { umbResolveNumberPresetValue } from './resolve-number-preset-value.function.js';
 import type { UmbPropertyValuePreset } from '@umbraco-cms/backoffice/property';
 import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
 
-export class UmbIntegerPropertyValuePreset
-	implements UmbPropertyValuePreset<UmbIntegerPropertyEditorUiValue, UmbPropertyEditorConfig>
-{
+export class UmbIntegerPropertyValuePreset implements UmbPropertyValuePreset<
+	UmbIntegerPropertyEditorUiValue,
+	UmbPropertyEditorConfig
+> {
 	async processValue(value: undefined | UmbIntegerPropertyEditorUiValue, config: UmbPropertyEditorConfig) {
-		const min = Number(config.find((x) => x.alias === 'min')?.value ?? 0);
-		const minVerified = isNaN(min) ? 0 : Math.round(min);
-
-		return value !== undefined ? value : minVerified;
+		if (value !== undefined && value !== null) {
+			return value;
+		}
+		const fallbackValue = umbResolveNumberPresetValue(config);
+		if (fallbackValue !== undefined) {
+			return Math.round(fallbackValue);
+		}
+		return undefined;
 	}
 
 	destroy(): void {}

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/number-property-value-preset.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/number-property-value-preset.test.ts
@@ -1,0 +1,160 @@
+import { expect } from '@open-wc/testing';
+import { UmbIntegerPropertyValuePreset } from './integer-property-value-preset.js';
+import { UmbDecimalPropertyValuePreset } from './decimal-property-value-preset.js';
+import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
+
+const typeArgs = {} as any;
+const callArgs = {} as any;
+
+const config = (values: Record<string, unknown>): UmbPropertyEditorConfig =>
+	Object.entries(values).map(([alias, value]) => ({ alias, value }));
+
+describe('UmbIntegerPropertyValuePreset', () => {
+	const preset = new UmbIntegerPropertyValuePreset();
+	const process = (value: number | undefined, cfg: UmbPropertyEditorConfig = []) =>
+		preset.processValue(value, cfg, typeArgs, callArgs);
+
+	describe('min configuration', () => {
+		it('keeps the value undefined when min is zero (#21787)', async () => {
+			expect(await process(undefined, config({ min: 0 }))).to.equal(undefined);
+		});
+
+		it('keeps the value undefined when min is undefined', async () => {
+			expect(await process(undefined, [])).to.equal(undefined);
+		});
+
+		it('uses min when min is higher than zero', async () => {
+			expect(await process(undefined, config({ min: 5 }))).to.equal(5);
+		});
+
+		it('keeps the value undefined when min is negative (zero is within range)', async () => {
+			expect(await process(undefined, config({ min: -5 }))).to.equal(undefined);
+		});
+	});
+
+	describe('max configuration (min undefined)', () => {
+		it('keeps the value undefined when max is zero', async () => {
+			expect(await process(undefined, config({ max: 0 }))).to.equal(undefined);
+		});
+
+		it('keeps the value undefined when max is a positive number', async () => {
+			expect(await process(undefined, config({ max: 10 }))).to.equal(undefined);
+		});
+
+		it('uses max when max is a negative number', async () => {
+			expect(await process(undefined, config({ max: -5 }))).to.equal(-5);
+		});
+	});
+
+	describe('min and max combined', () => {
+		it('prefers min when min is above zero', async () => {
+			expect(await process(undefined, config({ min: 5, max: 10 }))).to.equal(5);
+		});
+
+		it('uses max when the whole range is below zero', async () => {
+			expect(await process(undefined, config({ min: -10, max: -5 }))).to.equal(-5);
+		});
+
+		it('keeps the value undefined when zero is within the range', async () => {
+			expect(await process(undefined, config({ min: -10, max: 10 }))).to.equal(undefined);
+		});
+	});
+
+	describe('rounding and parsing', () => {
+		it('rounds a fractional min to a whole number', async () => {
+			expect(await process(undefined, config({ min: 2.6 }))).to.equal(3);
+		});
+
+		it('rounds a fractional negative max to a whole number', async () => {
+			expect(await process(undefined, config({ max: -2.4 }))).to.equal(-2);
+		});
+
+		it('parses string config values', async () => {
+			expect(await process(undefined, config({ min: '5' }))).to.equal(5);
+		});
+
+		it('keeps the value undefined when min is an empty string', async () => {
+			expect(await process(undefined, config({ min: '' }))).to.equal(undefined);
+		});
+
+		it('keeps the value undefined when min is null', async () => {
+			expect(await process(undefined, config({ min: null }))).to.equal(undefined);
+		});
+
+		it('keeps the value undefined when min is not a number', async () => {
+			expect(await process(undefined, config({ min: 'abc' }))).to.equal(undefined);
+		});
+	});
+
+	describe('existing values', () => {
+		it('does not override an existing value', async () => {
+			expect(await process(42, config({ min: 5 }))).to.equal(42);
+		});
+
+		it('does not override an existing value of zero', async () => {
+			expect(await process(0, config({ min: 5 }))).to.equal(0);
+		});
+	});
+});
+
+describe('UmbDecimalPropertyValuePreset', () => {
+	const preset = new UmbDecimalPropertyValuePreset();
+	const process = (value: number | undefined, cfg: UmbPropertyEditorConfig = []) =>
+		preset.processValue(value, cfg, typeArgs, callArgs);
+
+	describe('min configuration', () => {
+		it('keeps the value undefined when min is zero (#21787)', async () => {
+			expect(await process(undefined, config({ min: 0 }))).to.equal(undefined);
+		});
+
+		it('keeps the value undefined when min is undefined', async () => {
+			expect(await process(undefined, [])).to.equal(undefined);
+		});
+
+		it('uses min when min is higher than zero, keeping the fractional part', async () => {
+			expect(await process(undefined, config({ min: 2.5 }))).to.equal(2.5);
+		});
+
+		it('keeps the value undefined when min is negative (zero is within range)', async () => {
+			expect(await process(undefined, config({ min: -2.5 }))).to.equal(undefined);
+		});
+	});
+
+	describe('max configuration (min undefined)', () => {
+		it('keeps the value undefined when max is zero', async () => {
+			expect(await process(undefined, config({ max: 0 }))).to.equal(undefined);
+		});
+
+		it('keeps the value undefined when max is a positive number', async () => {
+			expect(await process(undefined, config({ max: 10.5 }))).to.equal(undefined);
+		});
+
+		it('uses max when max is a negative number, keeping the fractional part', async () => {
+			expect(await process(undefined, config({ max: -2.5 }))).to.equal(-2.5);
+		});
+	});
+
+	describe('min and max combined', () => {
+		it('prefers min when min is above zero', async () => {
+			expect(await process(undefined, config({ min: 2.5, max: 10 }))).to.equal(2.5);
+		});
+
+		it('uses max when the whole range is below zero', async () => {
+			expect(await process(undefined, config({ min: -10, max: -2.5 }))).to.equal(-2.5);
+		});
+
+		it('keeps the value undefined when zero is within the range', async () => {
+			expect(await process(undefined, config({ min: -10, max: 10 }))).to.equal(undefined);
+		});
+	});
+
+	describe('existing values', () => {
+		it('does not override an existing value', async () => {
+			expect(await process(9.9, config({ min: 2.5 }))).to.equal(9.9);
+		});
+
+		it('does not override an existing value of zero', async () => {
+			expect(await process(0, config({ min: 2.5 }))).to.equal(0);
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/resolve-number-preset-value.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/resolve-number-preset-value.function.ts
@@ -1,0 +1,29 @@
+import type { UmbPropertyEditorConfig } from '@umbraco-cms/backoffice/property-editor';
+
+function parseNumberConfig(config: UmbPropertyEditorConfig, alias: string): number | undefined {
+	const value = config.find((x) => x.alias === alias)?.value;
+	if (value === undefined || value === null || value === '') {
+		return undefined;
+	}
+	const num = Number(value);
+	return Number.isFinite(num) ? num : undefined;
+}
+
+/**
+ * Resolves the value a numeric property should be preset with, based on its `min`/`max` configuration.
+ * @param {UmbPropertyEditorConfig} config - The property editor configuration.
+ * @returns {number | undefined} The value to preset, or `undefined` to leave the field empty.
+ */
+export function umbResolveNumberPresetValue(config: UmbPropertyEditorConfig): number | undefined {
+	const min = parseNumberConfig(config, 'min');
+	if (min !== undefined && min > 0) {
+		return min;
+	}
+
+	const max = parseNumberConfig(config, 'max');
+	if (max !== undefined && max < 0) {
+		return max;
+	}
+
+	return undefined;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/number/types.ts
@@ -1,2 +1,2 @@
-export type UmbIntegerPropertyEditorUiValue = number;
-export type UmbDecimalPropertyEditorUiValue = number;
+export type UmbIntegerPropertyEditorUiValue = number | undefined;
+export type UmbDecimalPropertyEditorUiValue = number | undefined;


### PR DESCRIPTION
Fixes #21787 and #20382

This changes the preset logic for the Integer and Decimal property editors, so they only get a preset if the min/max configuration does not cover 0 in their range.

If config is undefined or expanding 0, like -10–10, then it keeps being undefined.

If someone needs the value to be set, they must use the mandatory validation for that.

Is this breaking? Good question; please consider it, but it is also a problem to be fixed. Type-wise, the value can be undefined, so it feels right to adjust UX and front-end code to handle this, also in relation to Blocks we do not process their values unless the user opens the workspace, so this will bring more consistency.