### PR TITLE
Rich Text Editor: Migrate inline RTE blocks from data-content-udi to data-content-key (closes #23224)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/RteBlockHelper.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/RteBlockHelper.cs
@@ -10,12 +10,15 @@ namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_15_0_0.LocalLinks;
 public static partial class RteBlockHelper
 {
     /// <summary>
-    /// Returns a <see cref="Regex"/> that matches <c>umb-rte-block</c> elements containing a <c>data-content-udi</c> attribute in the input HTML.
+    /// Returns a <see cref="Regex"/> that matches <c>umb-rte-block</c> and <c>umb-rte-block-inline</c>
+    /// elements containing a <c>data-content-udi</c> attribute in the input HTML.
     /// </summary>
-    /// <returns>A <see cref="Regex"/> instance for identifying <c>umb-rte-block</c> elements with a <c>data-content-udi</c> attribute.</returns>
-    // Non-greedy on both [^>]*? and .*? so consecutive sibling <umb-rte-block> elements are matched
-    // individually rather than collapsed into one span (which left all-but-last sibling UDIs un-converted).
-    [GeneratedRegex("<umb-rte-block\\b[^>]*?(?<attribute>data-content-udi)=\"(?<udi>[^\"]+)\"[^>]*>.*?<\\/umb-rte-block>")]
+    /// <returns>A <see cref="Regex"/> instance for identifying <c>umb-rte-block</c>/<c>umb-rte-block-inline</c> elements with a <c>data-content-udi</c> attribute.</returns>
+    // Non-greedy on both [^>]*? and .*? so consecutive sibling blocks are matched individually rather
+    // than collapsed into one span (which left all-but-last sibling UDIs un-converted). The (?:-inline)?
+    // on both the opening and closing tag lets .*? stop at the nearest close of either variant, so a
+    // mix of block and inline siblings never collapse together and isolated inline blocks still match.
+    [GeneratedRegex("<umb-rte-block(?:-inline)?\\b[^>]*?(?<attribute>data-content-udi)=\"(?<udi>[^\"]+)\"[^>]*>.*?<\\/umb-rte-block(?:-inline)?>")]
     public static partial Regex BlockRegex();
 
     /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/RteBlockHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/RteBlockHelperTests.cs
@@ -190,6 +190,26 @@ public class RteBlockHelperTests
     }
 
     /// <summary>
+    /// Two direct-sibling inline blocks must each be converted independently — the inline parallel to
+    /// <see cref="ConvertBlockUdisToKeys_TwoConsecutiveSiblingBlocks_ConvertsEachIndividually"/>.
+    /// </summary>
+    [Test]
+    public void ConvertBlockUdisToKeys_TwoConsecutiveInlineSiblings_ConvertsEachIndividually()
+    {
+        var input =
+            @"<umb-rte-block-inline data-content-udi=""umb://element/5e499fc237be4b1d974670526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline>" +
+            @"<umb-rte-block-inline data-content-udi=""umb://element/9db16c0d251e414c874967090f2cf3cc""><!--Umbraco-Block--></umb-rte-block-inline>";
+
+        var result = RteBlockHelper.ConvertBlockUdisToKeys(input);
+
+        Assert.AreEqual(
+            @"<umb-rte-block-inline data-content-key=""5e499fc2-37be-4b1d-9746-70526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline>" +
+            @"<umb-rte-block-inline data-content-key=""9db16c0d-251e-414c-8749-67090f2cf3cc""><!--Umbraco-Block--></umb-rte-block-inline>",
+            result);
+        StringAssert.DoesNotContain("umb://element/", result);
+    }
+
+    /// <summary>
     /// An inline block carrying an optional <c>class</c> attribute must be converted, preserving the class.
     /// </summary>
     [Test]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/RteBlockHelperTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/RteBlockHelperTests.cs
@@ -134,6 +134,94 @@ public class RteBlockHelperTests
             result);
     }
 
+    /// <summary>
+    /// An isolated inline block (<c>&lt;umb-rte-block-inline&gt;</c>) must be converted. The v13 RTE
+    /// emits both block and inline variants, and the closing tag differs (<c>&lt;/umb-rte-block-inline&gt;</c>).
+    /// </summary>
+    [Test]
+    public void ConvertBlockUdisToKeys_SingleInlineBlock_ConvertsUdiToHyphenatedGuidKey()
+    {
+        var input = @"<p>before</p><umb-rte-block-inline data-content-udi=""umb://element/5e499fc237be4b1d974670526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline><p>after</p>";
+
+        var result = RteBlockHelper.ConvertBlockUdisToKeys(input);
+
+        Assert.AreEqual(
+            @"<p>before</p><umb-rte-block-inline data-content-key=""5e499fc2-37be-4b1d-9746-70526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline><p>after</p>",
+            result);
+    }
+
+    /// <summary>
+    /// An inline block immediately followed by a block-level block must convert each independently —
+    /// the inline closing tag must not let the match span across into the next block's closing tag.
+    /// </summary>
+    [Test]
+    public void ConvertBlockUdisToKeys_InlineFollowedByBlock_ConvertsEachIndividually()
+    {
+        var input =
+            @"<umb-rte-block-inline data-content-udi=""umb://element/5e499fc237be4b1d974670526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline>" +
+            @"<umb-rte-block data-content-udi=""umb://element/9db16c0d251e414c874967090f2cf3cc""><!--Umbraco-Block--></umb-rte-block>";
+
+        var result = RteBlockHelper.ConvertBlockUdisToKeys(input);
+
+        Assert.AreEqual(
+            @"<umb-rte-block-inline data-content-key=""5e499fc2-37be-4b1d-9746-70526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline>" +
+            @"<umb-rte-block data-content-key=""9db16c0d-251e-414c-8749-67090f2cf3cc""><!--Umbraco-Block--></umb-rte-block>",
+            result);
+        StringAssert.DoesNotContain("umb://element/", result);
+    }
+
+    /// <summary>
+    /// A block-level block immediately followed by an inline block must convert each independently.
+    /// </summary>
+    [Test]
+    public void ConvertBlockUdisToKeys_BlockFollowedByInline_ConvertsEachIndividually()
+    {
+        var input =
+            @"<umb-rte-block data-content-udi=""umb://element/5e499fc237be4b1d974670526f3b00b7""><!--Umbraco-Block--></umb-rte-block>" +
+            @"<umb-rte-block-inline data-content-udi=""umb://element/9db16c0d251e414c874967090f2cf3cc""><!--Umbraco-Block--></umb-rte-block-inline>";
+
+        var result = RteBlockHelper.ConvertBlockUdisToKeys(input);
+
+        Assert.AreEqual(
+            @"<umb-rte-block data-content-key=""5e499fc2-37be-4b1d-9746-70526f3b00b7""><!--Umbraco-Block--></umb-rte-block>" +
+            @"<umb-rte-block-inline data-content-key=""9db16c0d-251e-414c-8749-67090f2cf3cc""><!--Umbraco-Block--></umb-rte-block-inline>",
+            result);
+        StringAssert.DoesNotContain("umb://element/", result);
+    }
+
+    /// <summary>
+    /// An inline block carrying an optional <c>class</c> attribute must be converted, preserving the class.
+    /// </summary>
+    [Test]
+    public void ConvertBlockUdisToKeys_InlineBlockWithClassAttribute_ConvertsUdiToKey()
+    {
+        var input = @"<umb-rte-block-inline class=""some-class"" data-content-udi=""umb://element/5e499fc237be4b1d974670526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline>";
+
+        var result = RteBlockHelper.ConvertBlockUdisToKeys(input);
+
+        Assert.AreEqual(
+            @"<umb-rte-block-inline class=""some-class"" data-content-key=""5e499fc2-37be-4b1d-9746-70526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline>",
+            result);
+    }
+
+    /// <summary>
+    /// When an inline block's UDI fails to parse, the block is dropped — consistent with block-level behaviour.
+    /// </summary>
+    [Test]
+    public void ConvertBlockUdisToKeys_MalformedUdiInlineBlock_IsDroppedFromOutput()
+    {
+        var input =
+            @"<p>before</p>" +
+            @"<umb-rte-block-inline data-content-udi=""not-a-valid-udi""><!--Umbraco-Block--></umb-rte-block-inline>" +
+            @"<p>after</p>";
+
+        var result = RteBlockHelper.ConvertBlockUdisToKeys(input);
+
+        Assert.AreEqual(
+            @"<p>before</p><p>after</p>",
+            result);
+    }
+
     [Test]
     public void ConvertBlockUdisToKeys_MarkupWithoutBlocks_ReturnsUnchanged()
     {
@@ -169,6 +257,20 @@ public class RteBlockHelperTests
             @"<umb-rte-block data-content-udi=""umb://element/5e499fc237be4b1d974670526f3b00b7""><!--Umbraco-Block--></umb-rte-block>" +
             @"<umb-rte-block data-content-udi=""umb://element/9db16c0d251e414c874967090f2cf3cc""><!--Umbraco-Block--></umb-rte-block>" +
             @"<umb-rte-block data-content-udi=""umb://element/c2c956b94a0945f29a1a366ad488545b""><!--Umbraco-Block--></umb-rte-block>";
+
+        Assert.AreEqual(3, RteBlockHelper.BlockRegex().Matches(input).Count);
+    }
+
+    /// <summary>
+    /// A mix of block-level and inline sibling blocks produces one match per element (no collapsing).
+    /// </summary>
+    [Test]
+    public void BlockRegex_MixedBlockAndInlineSiblings_ProducesOneMatchPerBlock()
+    {
+        var input =
+            @"<umb-rte-block-inline data-content-udi=""umb://element/5e499fc237be4b1d974670526f3b00b7""><!--Umbraco-Block--></umb-rte-block-inline>" +
+            @"<umb-rte-block data-content-udi=""umb://element/9db16c0d251e414c874967090f2cf3cc""><!--Umbraco-Block--></umb-rte-block>" +
+            @"<umb-rte-block-inline data-content-udi=""umb://element/c2c956b94a0945f29a1a366ad488545b""><!--Umbraco-Block--></umb-rte-block-inline>";
 
         Assert.AreEqual(3, RteBlockHelper.BlockRegex().Matches(input).Count);
     }


### PR DESCRIPTION
## Description

Rich Text Editor **inline** blocks (`<umb-rte-block-inline>`) created in Umbraco 13 were not being migrated from the legacy `data-content-udi="umb://element/{guid}"` attribute to the v15+ `data-content-key="{dashed-guid}"` attribute during upgrade. As a result the block could not be matched to its content on load, so it was pulled out of the text flow and hoisted elsewhere in the document (and dropped on the next save).

The fix is a one-line change to the migration regex in `RteBlockHelper.BlockRegex()` so it also matches the `-inline` tag variant.

Fixes #23224

### Where the issue came from

This is a regression introduced by #22980 (shipped in 17.5), which fixed the *block-level* sibling-collapse bug from #22979.

The tell is in the closing-tag part of the regex:

| | Closing-tag pattern | Isolated `umb-rte-block-inline` |
|---|---|---|
| **Before #22980** | `.*<\/umb-rte-block` — greedy, **no trailing `>`** | matched & converted (the `<\/umb-rte-block` prefix matches inside `</umb-rte-block-inline>`) |
| **#22980 (17.5)** | `.*?<\/umb-rte-block>` — non-greedy, **added `>`** | 0 matches — `</umb-rte-block>` cannot match `</umb-rte-block-inline>` |

Making the pattern non-greedy and adding the trailing `>` correctly fixed the block-level sibling collapse, but the added `>` meant the closing tag of the inline variant (`</umb-rte-block-inline>`) no longer matched — so isolated inline blocks stopped being converted. In other words, #22980 traded one failure mode for another on the inline variant.

Note the block metadata (`blocks.contentData[].key`) has always been normalized correctly; only the markup attribute was left behind, which is why an unmigrated inline block becomes "unplaced" and is hoisted out of position by the editor on load.

### The fix

`src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/LocalLinks/RteBlockHelper.cs` — add `(?:-inline)?` to both tag ends of the migration regex (mirrors the runtime parser in `RichTextParsingRegexes.cs` and the v13 parser):

```
<umb-rte-block(?:-inline)?\b[^>]*?(?<attribute>data-content-udi)="(?<udi>[^"]+)"[^>]*>.*?<\/umb-rte-block(?:-inline)?>
```

The non-greedy `.*?` combined with the two-variant closing tag means the match always stops at the nearest closing tag of either variant, so a mix of inline and block-level siblings never collapse together, and isolated inline blocks still match.

Consistent with #22980, this corrects the existing `V_15_0_0` migration rather than adding a new forward migration.

## Testing

### Automated

Extended `RteBlockHelperTests` with inline coverage:

- single isolated inline block converts to a dashed-GUID `data-content-key`;
- inline-followed-by-block and block-followed-by-inline siblings each convert independently (asserting no leftover `umb://element/` in either);
- inline block with a `class` attribute converts, preserving the class;
- inline block with a malformed UDI is dropped (consistent with block-level behaviour);
- `BlockRegex` produces one match per element for a mixed inline/block-level sequence.

Red/green verified: with the original 17.5 regex the 6 new tests fail; with the fix all tests pass.

### Manual (v13 → v17 upgrade)

Created a v13 RTE with an inline block (Element Type added as a block on the RTE data type, "Display inline with text" enabled), placed it inline within a paragraph, then upgraded.

**Before (v13 stored markup):**

```html
<p>Test</p>
<p>abcd <umb-rte-block-inline class="ng-scope ng-isolate-scope" data-content-udi="umb://element/f05b255596584ea88a2f35064097f2a4"><!--Umbraco-Block--></umb-rte-block-inline> abcd</p>
<p>Test</p>
```

**After upgrade — WITHOUT the fix (`v17/dev`):** the block is hoisted to the top of the document and its original inline position is lost:

```html
<p><umb-rte-block-inline data-content-key="f05b2555-9658-4ea8-8a2f-35064097f2a4"></umb-rte-block-inline>Test</p>
<p>Test</p>
<p>abcd abcd</p>
<p>Test</p>
```

(The `data-content-key` here is the editor re-emitting the now-unplaced block from `contentData` at the document start — not the migration doing its job. The stored markup still had `data-content-udi` at the real position.)

**After upgrade — WITH the fix (this branch):** the block is migrated in place and stays inline where it belongs:

```html
<p>Test</p>
<p>abcd <umb-rte-block-inline data-content-key="f05b2555-9658-4ea8-8a2f-35064097f2a4"></umb-rte-block-inline> abcd</p>
<p>Test</p>
```

(The transient `ng-scope ng-isolate-scope` class and the `<!--Umbraco-Block-->` placeholder comment are stripped downstream by the Tiptap editor on load/save, not by the migration.)
