### PR TITLE
Build: Port SonarCloud analysis workflow to v17

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -71,18 +71,6 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 ##########################################
-# File Header (Uncomment to support file headers)
-# https://docs.microsoft.com/visualstudio/ide/reference/add-file-header
-##########################################
-
-# [*.{cs,csx,cake,vb,vbx}]
-file_header_template = Copyright (c) Umbraco.\nSee LICENSE for more details.
-
-# SA1636: File header copyright text should match
-# Justification: .editorconfig supports file headers. If this is changed to a value other than "none", a stylecop.json file will need to added to the project.
-# dotnet_diagnostic.SA1636.severity = none
-
-##########################################
 # .NET Language Conventions
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions
 ##########################################
@@ -136,6 +124,10 @@ dotnet_code_quality_unused_parameters = all:warning
 dotnet_style_operator_placement_when_wrapping = end_of_line
 # https://github.com/dotnet/roslyn/pull/40070
 dotnet_style_prefer_simplified_interpolation = true:warning
+# File header preferences
+file_header_template = Copyright (c) Umbraco.\nSee LICENSE for more details.
+dotnet_diagnostic.SA1633.severity = none # Suppressed until we decide to enforce it
+dotnet_diagnostic.SA1636.severity = none # Suppressed since we are using StyleCop
 
 # C# Code Style Settings
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#c-code-style-settings

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -1,0 +1,99 @@
+name: "SonarQube Cloud - Analysis"
+
+# This workflow runs the full SonarCloud analysis with the SONAR_TOKEN secret.
+# It is skipped for fork PRs since secrets are not available in that context.
+
+on:
+  push:
+    branches:
+      - main
+      - "v*/dev"
+      - "v*/main"
+      - "release/*"
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  SONAR_PROJECT_KEY: umbraco_Umbraco-CMS
+  SONAR_ORGANIZATION: umbraco
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET from global.json
+        uses: actions/setup-dotnet@v5
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Install tools
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          dotnet tool install --global dotnet-coverage
+
+      - name: Load sonar params
+        run: echo "SONARQUBE_SCANNER_PARAMS=$(jq -c . .github/workflows/sonarcloud/sonar-params.json)" >> $GITHUB_ENV
+
+      - name: Begin analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet-sonarscanner begin \
+            /k:"$SONAR_PROJECT_KEY" \
+            /o:"$SONAR_ORGANIZATION" \
+            /d:sonar.token="$SONAR_TOKEN" \
+            /d:sonar.scanner.skipJreProvisioning=true
+
+      - name: Restore
+        run: dotnet restore umbraco.sln
+
+      - name: Build solution
+        run: GITHUB_ENV=/dev/null dotnet build umbraco.sln --no-restore -clp:ErrorsOnly # prevent sonar MSBuild integration from writing malformed values to $GITHUB_ENV
+
+      - name: Run unit tests with coverage
+        id: tests
+        continue-on-error: true
+        run: |
+          dotnet-coverage collect \
+            "dotnet test tests/Umbraco.Tests.UnitTests/Umbraco.Tests.UnitTests.csproj --no-build" \
+            --output TestResults/coverage.xml \
+            --output-format xml
+
+      - name: Warn on test failure
+        if: steps.tests.outcome == 'failure'
+        run: |
+          if [ -f TestResults/coverage.xml ]; then
+            echo "::warning::Unit tests failed - SonarCloud analysis will proceed with the collected coverage data"
+          else
+            echo "::warning::Unit tests failed and no coverage data was collected"
+          fi
+
+      - name: End analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"

--- a/.github/workflows/sonarcloud/sonar-params.json
+++ b/.github/workflows/sonarcloud/sonar-params.json
@@ -1,0 +1,7 @@
+{
+  "sonar.cs.vscoveragexml.reportsPaths": "TestResults/coverage.xml",
+  "sonar.inclusions": "src/**,templates/**,tools/**,tests/**,.github/**,build/**",
+  "sonar.exclusions": "**/bin/**,**/obj/**,**/node_modules/**,**/lang/*.ts,**/mocks/**,**/wwwroot/**,**/dist-cms/**,**/*.generated.cs,src/Umbraco.Web.UI/umbraco/**,src/Umbraco.Cms.Persistence.EFCore.*/Migrations/**,src/Umbraco.Web.UI.Client/src/packages/core/backend-api/**,**/.nuget/**",
+  "sonar.test.inclusions": "tests/**,**/*.test.ts,**/*.spec.ts",
+  "sonar.typescript.tsconfigPaths": "src/Umbraco.Web.UI.Client/tsconfig.json,src/Umbraco.Web.UI.Client/tsconfig.node.json,src/Umbraco.Web.UI.Login/tsconfig.json"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ trace.zip
 /tests/Umbraco.Tests.Integration/appsettings-schema.*.json
 /tests/Umbraco.Tests.Integration/umbraco-package-schema.json
 /src/Umbraco.Cms/appsettings-schema.json
+
+# SonarQube local analysis cache
+.sonarqube/

--- a/.globalconfig
+++ b/.globalconfig
@@ -48,7 +48,6 @@ dotnet_analyzer_diagnostic.category-StyleCop.CSharp.OrderingRules.severity = sug
 dotnet_analyzer_diagnostic.category-StyleCop.CSharp.MaintainabilityRules.severity = suggestion
 dotnet_analyzer_diagnostic.category-StyleCop.CSharp.LayoutRules.severity = suggestion
 
-dotnet_diagnostic.SA1636.severity = none # SA1636: File header copyright text should match
 dotnet_diagnostic.SA1101.severity = none # PrefixLocalCallsWithThis - stylecop appears to be ignoring dotnet_style_qualification_for_*
 dotnet_diagnostic.SA1309.severity = none # FieldNamesMustNotBeginWithUnderscore
 


### PR DESCRIPTION
Ports the SonarCloud GitHub Actions workflow from `main` to `v17/dev`. This brings v17 to parity with the analysis setup already running on the main branch.

## Changes

- Adds `.github/workflows/sonarcloud-analysis.yml` — the SonarCloud analysis workflow (build, unit test coverage, scan); skips fork PRs where `SONAR_TOKEN` is unavailable
- Adds `.github/workflows/sonarcloud/sonar-params.json` — Sonar scanner parameters (inclusions, exclusions, TypeScript tsconfig paths)
- Adds `.sonarqube/` to `.gitignore` to exclude the local analysis cache
- Moves `file_header_template` and SA1633/SA1636 suppressions from the commented-out block in `.editorconfig` into the active `.NET Language Conventions` section
- Removes `dotnet_diagnostic.SA1636.severity = none` from `.globalconfig` since it is now declared in `.editorconfig`