### PR TITLE
Aviod stale publishedValues when node is Unpublished

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
@@ -25,14 +25,30 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
 
     /// <summary>
     /// Gets all unique references from the specified properties.
+    /// Includes both <see cref="IPropertyValue.EditedValue" /> and <see cref="IPropertyValue.PublishedValue" /> for each property.
     /// </summary>
     /// <param name="properties">The properties.</param>
     /// <param name="propertyEditors">The property editors.</param>
-    /// <param name="trackPublishedValues">Whether to include <see cref="IPropertyValue.PublishedValue" /> when collecting references (disable to avoid stale published values on unpublished entities).</param>
     /// <returns>
     /// The unique references from the specified properties.
     /// </returns>
-    public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors, bool trackPublishedValues = true)
+    public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors)
+        => GetAllReferences(properties, propertyEditors, trackPublishedValues: true);
+
+    /// <summary>
+    /// Gets all unique references from the specified properties.
+    /// </summary>
+    /// <param name="properties">The properties.</param>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="trackPublishedValues">
+    /// When <c>true</c>, both <see cref="IPropertyValue.EditedValue" /> and <see cref="IPropertyValue.PublishedValue" /> are included.
+    /// When <c>false</c>, only <see cref="IPropertyValue.EditedValue" /> is included — use this for unpublished content
+    /// to avoid retaining stale relations from the previously-published property snapshot.
+    /// </param>
+    /// <returns>
+    /// The unique references from the specified properties.
+    /// </returns>
+    public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors, bool trackPublishedValues)
     {
         var references = new HashSet<UmbracoEntityReference>();
 

--- a/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
@@ -28,10 +28,11 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
     /// </summary>
     /// <param name="properties">The properties.</param>
     /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="trackPublishedValues">Flag to excluded the PublishedValue to aviod stale date in unpublished nodes.</param>
     /// <returns>
     /// The unique references from the specified properties.
     /// </returns>
-    public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors)
+    public ISet<UmbracoEntityReference> GetAllReferences(IPropertyCollection properties, PropertyEditorCollection propertyEditors, bool trackPublishedValues = true)
     {
         var references = new HashSet<UmbracoEntityReference>();
 
@@ -48,7 +49,11 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
             foreach (IPropertyValue propertyValue in propertyValuesByPropertyEditorAlias.SelectMany(x => x))
             {
                 values.Add(propertyValue.EditedValue);
-                values.Add(propertyValue.PublishedValue);
+
+                if (trackPublishedValues)
+                {
+                    values.Add(propertyValue.PublishedValue);
+                }
             }
 
             references.UnionWith(GetReferences(dataEditor, values, propertyValuesByPropertyEditorAlias.Key));

--- a/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
+++ b/src/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollection.cs
@@ -28,7 +28,7 @@ public class DataValueReferenceFactoryCollection : BuilderCollectionBase<IDataVa
     /// </summary>
     /// <param name="properties">The properties.</param>
     /// <param name="propertyEditors">The property editors.</param>
-    /// <param name="trackPublishedValues">Flag to excluded the PublishedValue to aviod stale date in unpublished nodes.</param>
+    /// <param name="trackPublishedValues">Whether to include <see cref="IPropertyValue.PublishedValue" /> when collecting references (disable to avoid stale published values on unpublished entities).</param>
     /// <returns>
     /// The unique references from the specified properties.
     /// </returns>

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.CoreServices.cs
@@ -498,6 +498,7 @@ public static partial class UmbracoBuilderExtensions
         builder
             .AddNotificationHandler<ContentSavedNotification, ContentRelationsUpdate>()
             .AddNotificationHandler<ContentPublishedNotification, ContentRelationsUpdate>()
+            .AddNotificationHandler<ContentUnpublishedNotification, ContentRelationsUpdate>()
             .AddNotificationHandler<MediaSavedNotification, ContentRelationsUpdate>()
             .AddNotificationHandler<MemberSavedNotification, ContentRelationsUpdate>()
             .AddNotificationHandler<ElementSavedNotification, ContentRelationsUpdate>()

--- a/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
@@ -101,8 +101,13 @@ internal sealed class ContentRelationsUpdate :
 
     private void PersistRelations(IScope scope, IContentBase entity)
     {
+        // When we are working with a IContent node that are published we need to track both the editedValues and publishedValues to GetAllReferences
+        // But for IMember and IMedia witch don´t have a published state we can exclude the publishedValues
+        // But also for IContent witch are unpublished, we only need to consider the editedValues to aviod stale publishedValues data.
+        var trackPublishedValues = entity is IContent content && content.Published;
+
         // Get all references and automatic relation type aliases.
-        ISet<UmbracoEntityReference> references = _dataValueReferenceFactories.GetAllReferences(entity.Properties, _propertyEditors);
+        ISet <UmbracoEntityReference> references = _dataValueReferenceFactories.GetAllReferences(entity.Properties, _propertyEditors, trackPublishedValues);
         ISet<string> automaticRelationTypeAliases = _dataValueReferenceFactories.GetAllAutomaticRelationTypesAliases(_propertyEditors);
 
         if (references.Count == 0)

--- a/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
@@ -21,6 +21,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Relations;
 internal sealed class ContentRelationsUpdate :
     IDistributedCacheNotificationHandler<ContentSavedNotification>,
     IDistributedCacheNotificationHandler<ContentPublishedNotification>,
+    IDistributedCacheNotificationHandler<ContentUnpublishedNotification>,
     IDistributedCacheNotificationHandler<MediaSavedNotification>,
     IDistributedCacheNotificationHandler<MemberSavedNotification>,
     IDistributedCacheNotificationHandler<ElementSavedNotification>,
@@ -63,6 +64,12 @@ internal sealed class ContentRelationsUpdate :
 
     /// <inheritdoc/>
     public void Handle(IEnumerable<ContentPublishedNotification> notifications) => PersistRelations(notifications.SelectMany(x => x.PublishedEntities));
+
+    /// <inheritdoc/>
+    public void Handle(ContentUnpublishedNotification notification) => PersistRelations(notification.UnpublishedEntities);
+
+    /// <inheritdoc/>
+    public void Handle(IEnumerable<ContentUnpublishedNotification> notifications) => PersistRelations(notifications.SelectMany(x => x.UnpublishedEntities));
 
     /// <inheritdoc/>
     public void Handle(MediaSavedNotification notification) => PersistRelations(notification.SavedEntities);

--- a/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Relations/ContentRelationsUpdate.cs
@@ -101,13 +101,12 @@ internal sealed class ContentRelationsUpdate :
 
     private void PersistRelations(IScope scope, IContentBase entity)
     {
-        // When we are working with a IContent node that are published we need to track both the editedValues and publishedValues to GetAllReferences
-        // But for IMember and IMedia witch don´t have a published state we can exclude the publishedValues
-        // But also for IContent witch are unpublished, we only need to consider the editedValues to aviod stale publishedValues data.
-        var trackPublishedValues = entity is IContent content && content.Published;
+        // Track PublishedValue only for entities that have a published state and are currently published.
+        // For unpublished entities (or entities without a published state) we only track EditedValue to avoid stale PublishedValue relations.
+        var trackPublishedValues = entity is IPublishableContentBase publishable && publishable.Published;
 
         // Get all references and automatic relation type aliases.
-        ISet <UmbracoEntityReference> references = _dataValueReferenceFactories.GetAllReferences(entity.Properties, _propertyEditors, trackPublishedValues);
+        ISet<UmbracoEntityReference> references = _dataValueReferenceFactories.GetAllReferences(entity.Properties, _propertyEditors, trackPublishedValues);
         ISet<string> automaticRelationTypeAliases = _dataValueReferenceFactories.GetAllAutomaticRelationTypesAliases(_propertyEditors);
 
         if (references.Count == 0)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/PropertyEditors/DataValueReferenceFactoryCollectionTests.cs
@@ -137,6 +137,95 @@ public class DataValueReferenceFactoryCollectionTests
     }
 
     [Test]
+    public void GetAllReferences_All_Variants_For_Published_And_UnPublished_States_With_IDataValueReference_Editor()
+    {
+        var collection = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>(), new NullLogger<DataValueReferenceFactoryCollection>());
+
+        var mediaPicker = new MediaPicker3PropertyEditor(
+            DataValueEditorFactory,
+            IOHelper);
+        var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => mediaPicker.Yield()));
+        var trackedUdi1 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi4 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi5 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultJsonSerializerEncoderFactory());
+        var property =
+            new Property(
+                new PropertyType(ShortStringHelper, new DataType(mediaPicker, serializer))
+                {
+                    Variations = ContentVariation.CultureAndSegment,
+                })
+            {
+                Values = new List<PropertyValue>
+                {
+                    // Ignored (no culture)
+                    new() { EditedValue = trackedUdi1 },
+                    new() { Culture = "en-US", EditedValue = trackedUdi2 },
+                    new() { Culture = "en-US", Segment = "A", EditedValue = trackedUdi3, PublishedValue= trackedUdi5 },
+
+                    // Ignored (no culture)
+                    new() { Segment = "A", EditedValue = trackedUdi4 },
+
+                    // Duplicate
+                    new() { Culture = "en-US", Segment = "B", EditedValue = trackedUdi3 },
+                },
+            };
+        var properties = new PropertyCollection { property };
+        var result = collection.GetAllReferences(properties, propertyEditors, true).ToArray();
+
+        Assert.AreEqual(3, result.Count());
+        Assert.AreEqual(trackedUdi2, result.ElementAt(0).Udi.ToString());
+        Assert.AreEqual(trackedUdi3, result.ElementAt(1).Udi.ToString());
+        Assert.AreEqual(trackedUdi5, result.ElementAt(2).Udi.ToString());
+    }
+
+    [Test]
+    public void GetAllReferences_All_Variants_For_UnPublished_State_With_IDataValueReference_Editor()
+    {
+        var collection = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>(), new NullLogger<DataValueReferenceFactoryCollection>());
+
+        var mediaPicker = new MediaPicker3PropertyEditor(
+            DataValueEditorFactory,
+            IOHelper);
+        var propertyEditors = new PropertyEditorCollection(new DataEditorCollection(() => mediaPicker.Yield()));
+        var trackedUdi1 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi2 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi3 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi4 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var trackedUdi5 = Udi.Create(Constants.UdiEntityType.Media, Guid.NewGuid()).ToString();
+        var serializer = new SystemTextConfigurationEditorJsonSerializer(new DefaultJsonSerializerEncoderFactory());
+        var property =
+            new Property(
+                new PropertyType(ShortStringHelper, new DataType(mediaPicker, serializer))
+                {
+                    Variations = ContentVariation.CultureAndSegment,
+                })
+            {
+                Values = new List<PropertyValue>
+                {
+                    // Ignored (no culture)
+                    new() { EditedValue = trackedUdi1 },
+                    new() { Culture = "en-US", EditedValue = trackedUdi2 },
+                    new() { Culture = "en-US", Segment = "A", EditedValue = trackedUdi3, PublishedValue= trackedUdi5 },
+
+                    // Ignored (no culture)
+                    new() { Segment = "A", EditedValue = trackedUdi4 },
+
+                    // Duplicate
+                    new() { Culture = "en-US", Segment = "B", EditedValue = trackedUdi3 },
+                },
+            };
+        var properties = new PropertyCollection { property };
+        var result = collection.GetAllReferences(properties, propertyEditors, false).ToArray();
+
+        Assert.AreEqual(2, result.Count());
+        Assert.AreEqual(trackedUdi2, result.ElementAt(0).Udi.ToString());
+        Assert.AreEqual(trackedUdi3, result.ElementAt(1).Udi.ToString());
+    }
+
+    [Test]
     public void GetAllReferences_Invariant_With_IDataValueReference_Editor()
     {
         var collection = new DataValueReferenceFactoryCollection(() => Enumerable.Empty<IDataValueReferenceFactory>(), new NullLogger<DataValueReferenceFactoryCollection>());


### PR DESCRIPTION
### Prerequisites
- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: https://github.com/umbraco/Umbraco-CMS/issues/23255

### Description
The PR fix that stale data getting considere to the ref. tracker. When a node is published we need to consider both the editedValues and publishedData, to the tracker. The current publishe can have a relation to node a, where the draft state can have a relation to node b.

See unit test GetAllReferences_All_Variants_For_Published_And_UnPublished_States_With_IDataValueReference_Editor 
`new() { Culture = "en-US", Segment = "A", EditedValue = trackedUdi3, PublishedValue= trackedUdi5 },`

But if the node is unpublished the the property state is the same, the trackedUdi5 should no longer be consider to the tracker. see unit test `GetAllReferences_All_Variants_For_UnPublished_State_With_IDataValueReference_Editor`

Steps to test
* Create three documents "Home 1", "Home 2" and "Home 3" - "Home 1" should have a content picker
* From "Home 1" - point the picker to "Home 2" and published it
* "Home 2" have now a relation with "Home 1"
* From "Home 1" - point the picker to "Home 3" and published it
*  "Home 2" still have a relation to "Home 1" and "Home 3" now also have a relation with "Home 1"
* Unpublish "Home 1" and stil see "home 2" and "home 3" stil is have the relation.
* From "Home 1" - remove the pointer to "Home 2" and "SAVE"
* "Home 2" don´t have any relations but "Home 3" still have. (bug fixed)