### PR TITLE
Block Editors: Hide "Transfer to Library" action when not allowed

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/action/common/transfer-to-element-library/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/action/common/transfer-to-element-library/manifests.ts
@@ -1,5 +1,6 @@
 import {
 	UMB_BLOCK_ENTRY_HAS_EXTERNAL_CONTENT_CONDITION_ALIAS,
+	UMB_BLOCK_ENTRY_IS_ALLOWED_IN_LIBRARY_CONDITION_ALIAS,
 	UMB_BLOCK_ENTRY_IS_READ_ONLY_CONDITION_ALIAS,
 } from '../../../conditions/constants.js';
 import { UMB_BLOCK_ACTION_TRANSFER_TO_ELEMENT_LIBRARY_ALIAS } from './constants.js';
@@ -24,6 +25,10 @@ export const manifests: Array<UmbExtensionManifest> = [
 			{
 				alias: UMB_BLOCK_ENTRY_HAS_EXTERNAL_CONTENT_CONDITION_ALIAS,
 				match: false,
+			},
+			{
+				alias: UMB_BLOCK_ENTRY_IS_ALLOWED_IN_LIBRARY_CONDITION_ALIAS,
+				match: true,
 			},
 		],
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/block-entry-is-allowed-in-library.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/block-entry-is-allowed-in-library.condition.ts
@@ -1,0 +1,32 @@
+import { UMB_BLOCK_ENTRY_CONTEXT } from '../context/block-entry.context-token.js';
+import type { BlockEntryIsAllowedInLibraryConditionConfig } from './types.js';
+import { UmbConditionBase } from '@umbraco-cms/backoffice/extension-registry';
+import type { UmbConditionControllerArguments, UmbExtensionCondition } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+export class UmbBlockEntryIsAllowedInLibraryCondition
+	extends UmbConditionBase<BlockEntryIsAllowedInLibraryConditionConfig>
+	implements UmbExtensionCondition
+{
+	constructor(
+		host: UmbControllerHost,
+		args: UmbConditionControllerArguments<BlockEntryIsAllowedInLibraryConditionConfig>,
+	) {
+		super(host, args);
+
+		this.consumeContext(UMB_BLOCK_ENTRY_CONTEXT, (context) => {
+			if (!context) return;
+			this.observe(
+				context.isAllowedInLibrary,
+				(isAllowedInLibrary) => {
+					if (isAllowedInLibrary !== undefined) {
+						this.permitted = isAllowedInLibrary === (this.config.match !== undefined ? this.config.match : true);
+					}
+				},
+				'observeIsAllowedInLibrary',
+			);
+		});
+	}
+}
+
+export default UmbBlockEntryIsAllowedInLibraryCondition;

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/constants.ts
@@ -2,5 +2,6 @@ export const UMB_BLOCK_ENTRY_HAS_SETTINGS_CONDITION_ALIAS = 'Umb.Condition.Block
 export const UMB_BLOCK_ENTRY_IS_EXPOSED_CONDITION_ALIAS = 'Umb.Condition.BlockEntryIsExposed';
 export const UMB_BLOCK_ENTRY_HAS_EXTERNAL_CONTENT_CONDITION_ALIAS = 'Umb.Condition.BlockEntryHasExternalContent';
 export const UMB_BLOCK_ENTRY_IS_READ_ONLY_CONDITION_ALIAS = 'Umb.Condition.BlockEntryIsReadOnly';
+export const UMB_BLOCK_ENTRY_IS_ALLOWED_IN_LIBRARY_CONDITION_ALIAS = 'Umb.Condition.BlockEntryIsAllowedInLibrary';
 export const UMB_BLOCK_ENTRY_SHOW_CONTENT_EDIT_CONDITION_ALIAS = 'Umb.Condition.BlockEntryShowContentEdit';
 export const UMB_BLOCK_WORKSPACE_HAS_CONTENT_CONDITION_ALIAS = 'Umb.Condition.BlockWorkspaceHasContent';

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/manifests.ts
@@ -1,12 +1,14 @@
 import {
 	UMB_BLOCK_ENTRY_HAS_SETTINGS_CONDITION_ALIAS,
 	UMB_BLOCK_ENTRY_HAS_EXTERNAL_CONTENT_CONDITION_ALIAS,
+	UMB_BLOCK_ENTRY_IS_ALLOWED_IN_LIBRARY_CONDITION_ALIAS,
 	UMB_BLOCK_ENTRY_IS_EXPOSED_CONDITION_ALIAS,
 	UMB_BLOCK_ENTRY_IS_READ_ONLY_CONDITION_ALIAS,
 	UMB_BLOCK_WORKSPACE_HAS_CONTENT_CONDITION_ALIAS,
 } from './constants.js';
 import UmbBlockEntryHasSettingsCondition from './block-entry-has-settings.condition.js';
 import UmbBlockEntryHasExternalContentCondition from './block-entry-has-external-content.condition.js';
+import UmbBlockEntryIsAllowedInLibraryCondition from './block-entry-is-allowed-in-library.condition.js';
 import UmbBlockEntryIsExposedCondition from './block-entry-is-exposed.condition.js';
 import UmbBlockEntryIsReadOnlyCondition from './block-entry-is-read-only.condition.js';
 import UmbBlockEntryShowContentEditCondition from './block-entry-show-content-edit.condition.js';
@@ -70,5 +72,11 @@ export const manifests: Array<ManifestCondition> = [
 		name: 'Block Entry Is ReadOnly Condition',
 		alias: UMB_BLOCK_ENTRY_IS_READ_ONLY_CONDITION_ALIAS,
 		api: UmbBlockEntryIsReadOnlyCondition,
+	},
+	{
+		type: 'condition',
+		name: 'Block Entry Is Allowed In Library Condition',
+		alias: UMB_BLOCK_ENTRY_IS_ALLOWED_IN_LIBRARY_CONDITION_ALIAS,
+		api: UmbBlockEntryIsAllowedInLibraryCondition,
 	},
 ];

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/conditions/types.ts
@@ -35,6 +35,11 @@ export interface BlockEntryIsReadOnlyConditionConfig extends UmbConditionConfigB
 	match?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface BlockEntryIsAllowedInLibraryConditionConfig extends UmbConditionConfigBase<'Umb.Condition.BlockEntryIsAllowedInLibrary'> {
+	match?: boolean;
+}
+
 // NOTE: Named with a `Umb` prefix, as clashed with `BlockEntryIsExposedConditionConfig`,
 // but that one is a misnomer as the condition targets the block workspace. [LK]
 export interface UmbBlockEntryIsExposedConditionConfig extends UmbConditionConfigBase<'Umb.Condition.BlockEntryIsExposed'> {
@@ -52,6 +57,7 @@ declare global {
 			| BlockWorkspaceIsReadOnlyConditionConfig
 			| BlockEntryIsReadOnlyConditionConfig
 			| BlockEntryHasSettingsConditionConfig
+			| BlockEntryIsAllowedInLibraryConditionConfig
 			| UmbBlockEntryIsExposedConditionConfig;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
@@ -37,7 +37,7 @@ export abstract class UmbBlockEntriesContext<
 
 	#libraryAllowedElementTypeKeys = new UmbArrayState<string>([], (x) => x);
 	readonly libraryAllowedElementTypeKeys = this.#libraryAllowedElementTypeKeys.asObservable();
-	#libraryAllowedLoaded: Promise<void>;
+	#libraryAllowedElementTypeKeysPromise: Promise<Array<string>>;
 
 	getLength() {
 		return this._layoutEntries.getValue().length;
@@ -60,15 +60,15 @@ export abstract class UmbBlockEntriesContext<
 			this._gotBlockManager();
 		}).asPromise({ preventTimeout: true });
 
-		this.#libraryAllowedLoaded = this.#loadLibraryAllowedElementTypeKeys();
+		this.#libraryAllowedElementTypeKeysPromise = this.#loadLibraryAllowedElementTypeKeys();
 	}
 
-	async #loadLibraryAllowedElementTypeKeys() {
+	async #loadLibraryAllowedElementTypeKeys(): Promise<Array<string>> {
 		const repo = new UmbElementTypeStructureRepository(this);
 		const { data: allowedTypes } = await repo.requestAllowedChildrenOf(null, null);
-		this.#libraryAllowedElementTypeKeys.setValue(
-			allowedTypes?.items.filter((t) => t.unique).map((t) => t.unique!) ?? [],
-		);
+		const keys = allowedTypes?.items.filter((t) => t.unique).map((t) => t.unique!) ?? [];
+		this.#libraryAllowedElementTypeKeys.setValue(keys);
+		return keys;
 	}
 
 	async getManager() {
@@ -114,9 +114,9 @@ export abstract class UmbBlockEntriesContext<
 	 * @returns {Promise<Array<string>>} The allowed element type uniques.
 	 */
 	protected async _getLibraryAllowedElementTypeKeys(blockTypes: Array<BlockType>): Promise<Array<string>> {
-		await this.#libraryAllowedLoaded;
+		const allowedKeys = await this.#libraryAllowedElementTypeKeysPromise;
 		const blockTypeKeys = new Set(blockTypes.map((bt) => bt.contentElementTypeKey));
-		return this.#libraryAllowedElementTypeKeys.getValue().filter((key) => blockTypeKeys.has(key));
+		return allowedKeys.filter((key) => blockTypeKeys.has(key));
 	}
 
 	public abstract create(

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entries.context.ts
@@ -35,6 +35,10 @@ export abstract class UmbBlockEntriesContext<
 	readonly layoutEntries = this._layoutEntries.asObservable();
 	readonly layoutEntriesLength = this._layoutEntries.asObservablePart((x) => x.length);
 
+	#libraryAllowedElementTypeKeys = new UmbArrayState<string>([], (x) => x);
+	readonly libraryAllowedElementTypeKeys = this.#libraryAllowedElementTypeKeys.asObservable();
+	#libraryAllowedLoaded: Promise<void>;
+
 	getLength() {
 		return this._layoutEntries.getValue().length;
 	}
@@ -55,6 +59,16 @@ export abstract class UmbBlockEntriesContext<
 			this._manager = blockGridManager;
 			this._gotBlockManager();
 		}).asPromise({ preventTimeout: true });
+
+		this.#libraryAllowedLoaded = this.#loadLibraryAllowedElementTypeKeys();
+	}
+
+	async #loadLibraryAllowedElementTypeKeys() {
+		const repo = new UmbElementTypeStructureRepository(this);
+		const { data: allowedTypes } = await repo.requestAllowedChildrenOf(null, null);
+		this.#libraryAllowedElementTypeKeys.setValue(
+			allowedTypes?.items.filter((t) => t.unique).map((t) => t.unique!) ?? [],
+		);
 	}
 
 	async getManager() {
@@ -96,12 +110,13 @@ export abstract class UmbBlockEntriesContext<
 	 * Returns the element type uniques allowed at the library root that overlap
 	 * with the given block types — used to filter the library picker in the
 	 * block catalogue modal.
+	 * @param {Array<BlockType>} blockTypes The block types to filter by.
+	 * @returns {Promise<Array<string>>} The allowed element type uniques.
 	 */
 	protected async _getLibraryAllowedElementTypeKeys(blockTypes: Array<BlockType>): Promise<Array<string>> {
+		await this.#libraryAllowedLoaded;
 		const blockTypeKeys = new Set(blockTypes.map((bt) => bt.contentElementTypeKey));
-		const repo = new UmbElementTypeStructureRepository(this);
-		const { data: allowedTypes } = await repo.requestAllowedChildrenOf(null, null);
-		return allowedTypes?.items.filter((t) => t.unique && blockTypeKeys.has(t.unique)).map((t) => t.unique!) ?? [];
+		return this.#libraryAllowedElementTypeKeys.getValue().filter((key) => blockTypeKeys.has(key));
 	}
 
 	public abstract create(

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -583,19 +583,19 @@ export abstract class UmbBlockEntryContext<
 			'observeWorkspacePath',
 		);
 
-		this.observe(
-			mergeObservables(
-				[this.contentElementTypeKey, this._entries!.libraryAllowedElementTypeKeys],
-				([contentElementTypeKey, libraryAllowedElementTypeKeys]) =>
-					contentElementTypeKey === undefined
-						? undefined
-						: libraryAllowedElementTypeKeys.includes(contentElementTypeKey),
-			),
-			(isAllowedInLibrary) => {
-				this.#isAllowedInLibrary.setValue(isAllowedInLibrary);
-			},
-			'observeIsAllowedInLibrary',
-		);
+		if (this._entries) {
+			this.observe(
+				mergeObservables(
+					[this.contentElementTypeKey, this._entries.libraryAllowedElementTypeKeys],
+					([contentElementTypeKey, libraryAllowedElementTypeKeys]) =>
+						contentElementTypeKey ? libraryAllowedElementTypeKeys.includes(contentElementTypeKey) : undefined,
+				),
+				(isAllowedInLibrary) => {
+					this.#isAllowedInLibrary.setValue(isAllowedInLibrary);
+				},
+				'observeIsAllowedInLibrary',
+			);
+		}
 
 		new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)
 			.addAdditionalPath('element')

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/context/block-entry.context.ts
@@ -65,6 +65,9 @@ export abstract class UmbBlockEntryContext<
 	#isExternalContent = new UmbBooleanState(false);
 	readonly isExternalContent = this.#isExternalContent.asObservable();
 
+	#isAllowedInLibrary = new UmbBooleanState(undefined);
+	readonly isAllowedInLibrary = this.#isAllowedInLibrary.asObservable();
+
 	#externalContentVariantState = new UmbStringState(undefined);
 	readonly externalContentVariantState = this.#externalContentVariantState.asObservable();
 
@@ -578,6 +581,20 @@ export abstract class UmbBlockEntryContext<
 				this.#workspacePath.setValue(workspacePath);
 			},
 			'observeWorkspacePath',
+		);
+
+		this.observe(
+			mergeObservables(
+				[this.contentElementTypeKey, this._entries!.libraryAllowedElementTypeKeys],
+				([contentElementTypeKey, libraryAllowedElementTypeKeys]) =>
+					contentElementTypeKey === undefined
+						? undefined
+						: libraryAllowedElementTypeKeys.includes(contentElementTypeKey),
+			),
+			(isAllowedInLibrary) => {
+				this.#isAllowedInLibrary.setValue(isAllowedInLibrary);
+			},
+			'observeIsAllowedInLibrary',
 		);
 
 		new UmbModalRouteRegistrationController(this, UMB_WORKSPACE_MODAL)


### PR DESCRIPTION
## Description

Following #22448, every local block in a Block List/Grid/RTE editor shows a "Transfer to Library" action, even if the block's Element Type doesn't actually allow being turned into a Library item. So you could click it, only for it to throw an error.

This fix adds a new extension manifest condition to hide the "Transfer to Library" action for blocks whose Element Type isn't allowed in the Library, so you only see it for the support Element Types.

This is loosely related to PR #23161, for when a developer can programmatically restrict the allowed Element Types.

### How to test

- [ ] Open a Element Type used by a block, and make sure "Allow in Library" is turned **off**
- [ ] Add a block of that type to a Block List, Block Grid, or Rich Text block editor
- [ ] Confirm the "Transfer to Library" action does **not** show up for that block
- [ ] Turn "Allow in Library" back **on** for the Element Type
- [ ] Refresh/reopen the content and confirm the action **does** show up now
- [ ] Sanity check nothing else regressed: read-only blocks and blocks that are already Library content should still have the action hidden, and the Block Catalogue's "Library" tab should still work as before