### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,5 +98,11 @@
       Pin it forward until both of those dependencies reference a fixed version.
     -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <!--
+      Microsoft.AspNetCore.OpenApi and Swashbuckle only require Microsoft.OpenApi >= 2.0.0, which otherwise
+      resolves to a vulnerable 2.0.0 (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc). Pin forward to a patched 2.x
+      until the referencing packages raise their floor.
+    -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,8 +92,11 @@
     <!-- Markdown references vulnerable version of the following: -->
     <!-- TODO (V19): Remove these pinned dependencies when the Markdown dependency is removed. -->
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <!-- Examine (via Microsoft.AspNetCore.DataProtection 8.0.4) references a vulnerable version of the following: -->
-    <!-- TODO: Remove this pinned dependency when Examine updates its Microsoft.AspNetCore.DataProtection reference. -->
+    <!--
+      Examine (via Microsoft.AspNetCore.DataProtection) and OpenIddict's *.DataProtection packages otherwise
+      resolve System.Security.Cryptography.Xml down to a vulnerable 8.0.0 (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf).
+      Pin it forward until both of those dependencies reference a fixed version.
+    -->
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <!-- Global packages (private, build-time packages for all projects) -->
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.85" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- TODO (V18): Bump Umbraco.Code to 3.0.0 stable before release of 18.0.0 -->
     <GlobalPackageReference Include="Umbraco.Code" Version="3.0.0-beta" />
@@ -14,35 +14,35 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
     <!-- When updating this version, also update templates/UmbracoExtension/Umbraco.Extension.csproj -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <!-- Umbraco packages -->
   <ItemGroup>
-    <PackageVersion Include="Umbraco.JsonSchema.Extensions" Version="0.4.0" />
+    <PackageVersion Include="Umbraco.JsonSchema.Extensions" Version="0.4.3" />
   </ItemGroup>
   <!-- Third-party packages -->
   <ItemGroup>
@@ -50,13 +50,13 @@
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="BitFaster.Caching" Version="2.6.0" />
     <PackageVersion Include="Dazinator.Extensions.FileProviders" Version="2.0.0" />
-    <PackageVersion Include="Examine" Version="3.8.0" />
-    <PackageVersion Include="Examine.Core" Version="3.8.0" />
+    <PackageVersion Include="Examine" Version="3.9.0" />
+    <PackageVersion Include="Examine.Core" Version="3.9.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="JsonPatch.Net" Version="3.3.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-    <PackageVersion Include="MailKit" Version="4.16.0" />
-    <PackageVersion Include="Markdig" Version="1.1.3" />
+    <PackageVersion Include="MailKit" Version="4.17.0" />
+    <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
@@ -75,13 +75,13 @@
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageVersion Include="Serilog.Formatting.Compact.Reader" Version="4.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.2.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
   </ItemGroup>
   <!-- Transitive pinned versions (only required because our direct dependencies have vulnerable versions of transitive dependencies) -->
   <ItemGroup>
@@ -94,6 +94,6 @@
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <!-- Examine (via Microsoft.AspNetCore.DataProtection 8.0.4) references a vulnerable version of the following: -->
     <!-- TODO: Remove this pinned dependency when Examine updates its Microsoft.AspNetCore.DataProtection reference. -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -38,6 +38,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+    Umbraco.Web.UI opts out of central package management, so the Microsoft.OpenApi transitive pin in
+    Directory.Packages.props does not reach it. Reference it directly to force the patched version instead
+    of the vulnerable 2.0.0 that Swashbuckle / Microsoft.AspNetCore.OpenApi otherwise resolve
+    (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc).
+    -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Ensure the AppLocalIcu setting is the same as the referenced ICU package version and changes are also done to the template project! -->
     <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,12 +26,12 @@
 
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.9" />
     <!--
     Added the following direct dependency due to Microsoft.EntityFrameworkCore.Design having a dependency on an insecure version.
     Review for removal when Microsoft.EntityFrameworkCore.Design is updated to a newer version.
     -->
-    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="18.7.1" />
     <!--
     Added to align Microsoft.CodeAnalysis.* transitive versions brought in by Microsoft.EntityFrameworkCore.Design,
     which otherwise pulls in Microsoft.CodeAnalysis.CSharp 5.3.0 alongside Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -28,11 +28,6 @@
     <!-- Add design/build time support for EF Core migrations -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.9" />
     <!--
-    Added the following direct dependency due to Microsoft.EntityFrameworkCore.Design having a dependency on an insecure version.
-    Review for removal when Microsoft.EntityFrameworkCore.Design is updated to a newer version.
-    -->
-    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" Version="18.7.1" />
-    <!--
     Added to align Microsoft.CodeAnalysis.* transitive versions brought in by Microsoft.EntityFrameworkCore.Design,
     which otherwise pulls in Microsoft.CodeAnalysis.CSharp 5.3.0 alongside Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0
     and Microsoft.CodeAnalysis.Workspaces.MSBuild 5.0.0, resulting in conflicting Microsoft.CodeAnalysis.Common /

--- a/templates/UmbracoExtension/Directory.Packages.props
+++ b/templates/UmbracoExtension/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="Umbraco.Cms.Api.Management" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/templates/UmbracoExtension/Umbraco.Extension.csproj
+++ b/templates/UmbracoExtension/Umbraco.Extension.csproj
@@ -64,7 +64,7 @@
       their types directly - only Microsoft.AspNetCore.OpenApi / Microsoft.OpenApi types are
       referenced in the composer.
     -->
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
   </ItemGroup>
   <!--#endif -->
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,13 +5,13 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="10.0.7" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.7" />
+    <PackageVersion Include="System.Data.Odbc" Version="10.0.9" />
+    <PackageVersion Include="System.Data.OleDb" Version="10.0.9" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Routine dependency maintenance for the **18.1** release (targets `main`). Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

Versions are managed centrally in the two `Directory.Packages.props` files, plus the inline versions in `Umbraco.Web.UI.csproj` and the `templates/UmbracoExtension` project.

A direct dependency to `Microsoft.OpenApi` has been added to resolve what is otherwise reported as a vulnerability.

### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Nerdbank.GitVersioning | 3.9.50 | 3.10.85 |
| Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation | 10.0.7 | 10.0.9 |
| Microsoft.AspNetCore.OpenApi | 10.0.7 | 10.0.9 |
| Microsoft.Data.Sqlite | 10.0.7 | 10.0.9 |
| Microsoft.EntityFrameworkCore.Sqlite / .SqlServer | 10.0.7 | 10.0.9 |
| Microsoft.Extensions.* (Caching, Configuration, DependencyInjection, FileProviders, Hosting, Http, Identity, Logging, Options) | 10.0.7 | 10.0.9 |
| Microsoft.Extensions.Caching.Hybrid | 10.5.0 | 10.7.0 |
| Umbraco.JsonSchema.Extensions | 0.4.0 | 0.4.3 |
| Examine / Examine.Core | 3.8.0 | 3.9.0 |
| MailKit | 4.16.0 | 4.17.0 |
| Markdig | 1.1.3 | 1.3.2 |
| Serilog.Settings.Configuration | 10.0.0 | 10.0.1 |
| Swashbuckle.AspNetCore.SwaggerUI | 10.1.7 | 10.2.3 |
| System.Security.Cryptography.Xml (transitive pin) | 10.0.7 | 10.0.9 |

### Test packages (`tests/Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| Microsoft.AspNetCore.Mvc.Testing | 10.0.7 | 10.0.9 |
| Microsoft.Extensions.Logging.Debug | 10.0.7 | 10.0.9 |
| Microsoft.Extensions.TimeProvider.Testing | 10.6.0 | 10.7.0 |
| Microsoft.NET.Test.Sdk | 18.5.1 | 18.7.0 |
| System.Data.Odbc / System.Data.OleDb | 10.0.7 | 10.0.9 |

### Inline / template versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: `Microsoft.EntityFrameworkCore.Design` 10.0.7 → 10.0.9, `Microsoft.Build.Tasks.Core` 18.4.0 → 18.7.1
- `templates/UmbracoExtension`: `Microsoft.AspNetCore.OpenApi` 10.0.7 → 10.0.9 (both the csproj and its `Directory.Packages.props`, keeping it aligned with the root file)

### Deliberately left unchanged

- Any package where only a **major** update is available (out of scope for this PR).
- Pre-release / held packages: `Umbraco.Code` (`3.0.0-beta`, per existing TODO), `StyleCop.Analyzers` (beta).
- Transitive security pins for `Dazinator.Extensions.FileProviders` and `Markdown`.

The `System.Security.Cryptography.Xml` transitive pin was bumped alongside the other Microsoft `10.0.x` packages because the updated `Examine` and `OpenIddict` now require it at `>= 10.0.7`; keeping it at the old version caused a NuGet downgrade error.

## Testing

Solution should build and CI checks pass.