### PR TITLE
Markdown Editor: Auto-expands with content and enables word-wrap (closes #23203)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/code-editor.controller.ts
@@ -157,7 +157,7 @@ export class UmbCodeEditorController extends UmbControllerBase {
 		const hasMinimap = Object.prototype.hasOwnProperty.call(options, 'minimap');
 		const hasLightbulb = Object.prototype.hasOwnProperty.call(options, 'lightbulb');
 
-		return {
+		const mapped: monaco.editor.IStandaloneEditorConstructionOptions = {
 			...options,
 			lineNumbers: hasLineNumbers ? (options.lineNumbers ? 'on' : 'off') : undefined,
 			minimap: hasMinimap ? (options.minimap ? { enabled: true } : { enabled: false }) : undefined,
@@ -167,6 +167,14 @@ export class UmbCodeEditorController extends UmbControllerBase {
 					: { enabled: monaco.editor.ShowLightbulbIconMode.Off }
 				: undefined,
 		};
+
+		if (options.autoHeight) {
+			mapped.scrollbar = { vertical: 'hidden', horizontal: 'hidden', handleMouseWheel: false };
+			mapped.overviewRulerLanes = 0;
+		}
+
+		delete (mapped as Record<string, unknown>).autoHeight;
+		return mapped;
 	}
 	/**
 	 * Updates the options of the editor. This is useful for updating the options after the editor has been created.

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/components/code-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/components/code-editor.element.ts
@@ -125,6 +125,13 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 	wordWrap = false;
 
 	/**
+	 * Whether to enable auto-height mode where the editor grows to fit content.
+	 * @memberof UmbCodeEditorElement
+	 */
+	@property({ type: Boolean, attribute: 'auto-height' })
+	autoHeight = false;
+
+	/**
 	 * Whether to enable folding. Default is true.
 	 * @memberof UmbCodeEditorElement
 	 */
@@ -160,8 +167,30 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 		// Options
 		this.#editor = new UmbCodeEditorController(this, this.#constructorOptions());
 
+		if (this.autoHeight) {
+			this.#setupAutoHeight();
+		}
+
 		this._loading = false;
 		this.dispatchEvent(new UmbCodeEditorLoadedEvent());
+	}
+
+	#setupAutoHeight() {
+		const monacoEditor = this.#editor?.monacoEditor;
+		if (!monacoEditor) return;
+
+		monacoEditor.onDidContentSizeChange((e) => {
+			if (e.contentHeightChanged) {
+				const contentHeight = monacoEditor.getContentHeight();
+				this.container.style.height = `${contentHeight}px`;
+				monacoEditor.layout();
+			}
+		});
+
+		// Set initial height
+		const contentHeight = monacoEditor.getContentHeight();
+		this.container.style.height = `${contentHeight}px`;
+		monacoEditor.layout();
 	}
 
 	protected override updated(_changedProperties: PropertyValues<this>): void {
@@ -174,6 +203,7 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 			_changedProperties.has('readonly') ||
 			_changedProperties.has('code') ||
 			_changedProperties.has('label') ||
+			_changedProperties.has('autoHeight') ||
 			_changedProperties.has('disableFolding')
 		) {
 			this.#editor?.updateOptions(this.#constructorOptions());
@@ -190,6 +220,7 @@ export class UmbCodeEditorElement extends UmbLitElement implements UmbCodeEditor
 			wordWrap: this.wordWrap ? 'on' : 'off',
 			readOnly: this.readonly,
 			folding: !this.disableFolding,
+			autoHeight: this.autoHeight,
 			value: this.code,
 		};
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/models/code-editor.model.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/models/code-editor.model.ts
@@ -177,6 +177,11 @@ export interface CodeEditorConstructorOptions {
 	 */
 	lightbulb?: boolean;
 	/**
+	 * Enable auto-height mode where the editor grows to fit content.
+	 * Defaults to false.
+	 */
+	autoHeight?: boolean;
+	/**
 	 * Enable code folding.
 	 * Defaults to true.
 	 */

--- a/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/components/input-markdown-editor/input-markdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/components/input-markdown-editor/input-markdown.element.ts
@@ -455,6 +455,8 @@ export class UmbInputMarkdownElement extends UmbFormControlMixin<string, typeof 
 				disable-line-numbers
 				disable-minimap
 				disable-folding
+				word-wrap
+				auto-height
 				@input=${this.#onInput}
 				@keypress=${this.#onKeyPress}
 				@loaded=${this.#onCodeEditorLoaded}>
@@ -647,7 +649,7 @@ export class UmbInputMarkdownElement extends UmbFormControlMixin<string, typeof 
 			}
 
 			umb-code-editor {
-				height: 200px;
+				min-height: 200px;
 				border-radius: var(--uui-border-radius);
 				border: 1px solid var(--uui-color-border);
 				border-top: 0;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Closes #23203

## Summary
The Markdown Editor was constrained to a fixed 200px height, causing an internal scrollbar when content grew beyond that limit. Long lines also overflowed horizontally. Per @nielslyngsoe's guidance, the correct UX is auto-expand + word-wrap instead of a resize handler.

## What was changed

- Added an opt-in `auto-height` attribute to `<umb-code-editor>` that listens to Monaco's `onDidContentSizeChange` and dynamically resizes the editor container to match content height
- When `auto-height` is active, both vertical and horizontal scrollbars are hidden and mouse wheel events pass through to the page
- Enabled `word-wrap` on the Markdown Editor's code editor instance
- Replaced the fixed` height: 200px` CSS with` min-height: 200px` so the editor never collapses below a usable size

## How it works
The `<umb-code-editor>` component now accepts an auto-height boolean attribute. When set, it:

1. Passes `scrollbar: { vertical: 'hidden', horizontal: 'hidden', handleMouseWheel: false } `to Monaco
2. Subscribes to `editor.onDidContentSizeChange` and updates the container height to match `editor.getContentHeight()`
3. Calls `editor.layout()` to re-render Monaco at the new dimensions
4. This is fully opt-in — other usages of `<umb-code-editor>` (templates, stylesheets, scripts, Code Editor property) are unaffected.

## Before adding the fix:
<img width="1895" height="938" alt="Before_adding_fix_for_markdownEditor" src="https://github.com/user-attachments/assets/68fc787f-b742-4598-933d-9b4f63c2ee0a" />

## After adding the fix:
<img width="1895" height="938" alt="After_adding_fix_for_markdownEditor" src="https://github.com/user-attachments/assets/9833ddf8-2fd6-4cb0-9862-f4b06d263a6e" />

## How to test:

1. Add a Markdown Editor property to a document type
2. Create/edit content with that property
3. Type multiple lines → editor expands smoothly, no internal scrollbar
4. Type a long line → text wraps at the editor boundary
5. Delete content → editor shrinks back (respecting min-height)
6. Verify Code Editor property, templates, stylesheets, scripts editors still behave as before (fixed height, scrollbars present)