### PR TITLE
Media picker: Allows cancellation of folder creation, and adds buttons for better accessibility (closes #20452)

### DIFF
--- a/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/media-type.data.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/data/sets/kitchen-sink/media-type.data.ts
@@ -60,7 +60,7 @@ export const data: Array<UmbMockMediaTypeModel> = [
 			},
 		],
 		compositions: [],
-		isFolder: false,
+		isFolder: true,
 		hasChildren: false,
 		collection: {
 			id: '3a0156c4-3b8c-4803-bdc1-6871faa83fff',

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
@@ -161,8 +161,8 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 
 	#onSubmit(e: SubmitEvent) {
 		e.preventDefault();
-		const formData = new FormData(e.target as HTMLFormElement);
-		this.#addFolder(formData.get('folderName')?.toString());
+		const folderName = new FormData(e.target as HTMLFormElement).get('folderName');
+		this.#addFolder(typeof folderName === 'string' ? folderName : undefined);
 	}
 
 	async #addFolder(newName?: string) {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
@@ -154,6 +154,7 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 
 	async #addFolder(e: UUIInputEvent) {
 		e.stopPropagation();
+		if (!this._typingNewFolder) return;
 
 		const newName = e.target.value as string;
 		this._typingNewFolder = false;
@@ -196,12 +197,18 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
-	#onKeypress(e: KeyboardEvent) {
+	#cancelFolderCreation() {
+		this._typingNewFolder = false;
+		this._selectingFolderType = false;
+	}
+
+	#onKeydown(e: KeyboardEvent) {
 		if (e.key === 'Enter') {
-			requestAnimationFrame(() => {
-				const element = this.getHostElement().shadowRoot!.querySelector('#new-folder') as UUIInputElement;
-				element.blur();
-			});
+			this.#addFolder(e as unknown as UUIInputEvent);
+		} else if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopImmediatePropagation();
+			this.#cancelFolderCreation();
 		}
 	}
 
@@ -230,7 +237,7 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 				label=${this.localize.term('create_enterFolderName')}
 				placeholder=${this.localize.term('create_enterFolderName')}
 				@blur=${this.#addFolder}
-				@keypress=${this.#onKeypress}></uui-input>`;
+				@keydown=${this.#onKeydown}></uui-input>`;
 		}
 
 		if (this._selectingFolderType) {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
@@ -261,7 +261,7 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 								<uui-icon name="remove"></uui-icon>
 							</uui-button>
 						</uui-input>
-						<uui-button compact type="submit" label=${this.localize.term('actions_create')}></uui-button>
+						<uui-button look="outline" type="submit" label=${this.localize.term('actions_create')}></uui-button>
 					</form>
 				</uui-form>
 			`;
@@ -302,7 +302,6 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 				display: flex;
 				align-items: center;
 				margin: 0 var(--uui-size-3);
-				overflow: hidden;
 				min-width: 0;
 			}
 
@@ -316,7 +315,6 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 
 			#new-folder {
 				width: 220px;
-				height: 100%;
 			}
 
 			#folder-type-selection {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/components/media-picker-folder-path.element.ts
@@ -13,7 +13,7 @@ import {
 	property,
 	type PropertyValues,
 } from '@umbraco-cms/backoffice/external/lit';
-import type { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
+import type { UUIInputElement } from '@umbraco-cms/backoffice/external/uui';
 import { UmbId } from '@umbraco-cms/backoffice/id';
 import { UmbMediaTypeStructureRepository, type UmbAllowedMediaTypeModel } from '@umbraco-cms/backoffice/media-type';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
@@ -150,14 +150,26 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 
 	#cancelFolderTypeSelection() {
 		this._selectingFolderType = false;
+		this.#focusAddFolderButton();
 	}
 
-	async #addFolder(e: UUIInputEvent) {
-		e.stopPropagation();
+	#focusAddFolderButton() {
+		requestAnimationFrame(() => {
+			this.getHostElement().shadowRoot!.querySelector<HTMLElement>('#add-folder')?.focus();
+		});
+	}
+
+	#onSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		const formData = new FormData(e.target as HTMLFormElement);
+		this.#addFolder(formData.get('folderName')?.toString());
+	}
+
+	async #addFolder(newName?: string) {
 		if (!this._typingNewFolder) return;
 
-		const newName = e.target.value as string;
 		this._typingNewFolder = false;
+		this.#focusAddFolderButton();
 		if (!newName || !this.#selectedFolderType?.unique) return;
 
 		const newUnique = UmbId.new();
@@ -200,12 +212,11 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 	#cancelFolderCreation() {
 		this._typingNewFolder = false;
 		this._selectingFolderType = false;
+		this.#focusAddFolderButton();
 	}
 
 	#onKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter') {
-			this.#addFolder(e as unknown as UUIInputEvent);
-		} else if (e.key === 'Escape') {
+		if (e.key === 'Escape') {
 			e.preventDefault();
 			e.stopImmediatePropagation();
 			this.#cancelFolderCreation();
@@ -232,12 +243,28 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 
 	#renderFolderCreation() {
 		if (this._typingNewFolder) {
-			return html`<uui-input
-				id="new-folder"
-				label=${this.localize.term('create_enterFolderName')}
-				placeholder=${this.localize.term('create_enterFolderName')}
-				@blur=${this.#addFolder}
-				@keydown=${this.#onKeydown}></uui-input>`;
+			return html`
+				<uui-form>
+					<form id="new-folder-form" novalidate @submit=${this.#onSubmit}>
+						<uui-input
+							id="new-folder"
+							name="folderName"
+							label=${this.localize.term('create_enterFolderName')}
+							placeholder=${this.localize.term('create_enterFolderName')}
+							@keydown=${this.#onKeydown}>
+							<uui-button
+								slot="append"
+								type="button"
+								compact
+								label=${this.localize.term('general_cancel')}
+								@click=${this.#cancelFolderCreation}>
+								<uui-icon name="remove"></uui-icon>
+							</uui-button>
+						</uui-input>
+						<uui-button compact type="submit" label=${this.localize.term('actions_create')}></uui-button>
+					</form>
+				</uui-form>
+			`;
 		}
 
 		if (this._selectingFolderType) {
@@ -261,6 +288,7 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 		}
 
 		return html`<uui-button
+			id="add-folder"
 			label=${this.localize.term('visuallyHiddenTexts_createNewFolder')}
 			compact
 			@click=${this.#onAddFolderClick}>
@@ -278,11 +306,17 @@ export class UmbMediaPickerFolderPathElement extends UmbLitElement {
 				min-width: 0;
 			}
 
-			#new-folder {
+			#new-folder-form {
+				display: flex;
+				align-items: center;
+				gap: var(--uui-size-2);
 				margin-left: var(--uui-size-2);
-				width: 150px;
-				height: 100%;
 				flex-shrink: 0;
+			}
+
+			#new-folder {
+				width: 220px;
+				height: 100%;
 			}
 
 			#folder-type-selection {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/media-picker/media-picker-modal.element.ts
@@ -754,7 +754,6 @@ export class UmbMediaPickerModalElement extends UmbPickerModalBaseElement<
 			}
 
 			umb-media-picker-folder-path {
-				overflow: hidden;
 				min-width: 0;
 				flex: 1 1 0%;
 			}


### PR DESCRIPTION
### Prerequisites

Fixes #20452

### Description

Adds a key listener to presses of the <kbd>ESC</kbd> button to allow cancelling a folder creation.

Adds a Create button and a real `<form>` element surrounding the folder creation input for accessibility.

Adds an inline appended Cancel button (with an X icon) to additionally allow cancelling creation through a mouse click.

### Screenshots


https://github.com/user-attachments/assets/65d7c7b4-473c-4652-8705-d55d369fdacb

<img width="797" height="77" alt="image" src="https://github.com/user-attachments/assets/70edb291-38ba-4f72-b8e3-0317bd88f284" />
