### PR TITLE
Packages: Fix Created Package routing

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/created-packages-section-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/created-packages-section-view.element.ts
@@ -38,7 +38,7 @@ export class UmbCreatedPackagesSectionViewElement extends UmbLitElement implemen
 		// TODO: find a way to make this reuseable across:
 		this.#workspaces?.map((workspace: ManifestWorkspace) => {
 			routes.push({
-				path: `${workspace.meta.entityType}/:unique`,
+				path: `${workspace.meta.entityType}/edit/:unique`,
 				component: () => createExtensionElement(workspace),
 				setup: (component, info) => {
 					if (component) {
@@ -47,7 +47,7 @@ export class UmbCreatedPackagesSectionViewElement extends UmbLitElement implemen
 				},
 			});
 			routes.push({
-				path: workspace.meta.entityType,
+				path: `${workspace.meta.entityType}/create`,
 				component: () => createExtensionElement(workspace),
 			});
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/packages-created-overview.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/packages/package-section/views/created/packages-created-overview.element.ts
@@ -68,7 +68,7 @@ export class UmbPackagesCreatedOverviewElement extends UmbLitElement {
 		return html`
 			<uui-button
 				look="primary"
-				href="section/packages/view/created/package-builder"
+				href="section/packages/view/created/package-builder/create"
 				label=${this.localize.term('packager_createPackage')}></uui-button>
 			${when(
 				this._loading,
@@ -112,7 +112,7 @@ export class UmbPackagesCreatedOverviewElement extends UmbLitElement {
 
 	#packageBuilder(pkg: UmbCreatedPackage) {
 		if (!pkg.unique) return;
-		window.history.pushState({}, '', `section/packages/view/created/package-builder/${pkg.unique}`);
+		window.history.pushState({}, '', `section/packages/view/created/package-builder/edit/${pkg.unique}`);
 	}
 
 	#renderPagination() {


### PR DESCRIPTION
## Description

With PR #23254, when creating a brand new package in the Package Builder, the Element Picker would misbehave - the screen would do a little refresh, clear the package name you'd typed, and if you clicked "Choose" again the picker would open but the URL path would be incorrect.

It turned out to be a routing quirk: the URL for a brand new package and the URL a picker modal wants to use looked too similar to each other, so the app got confused about which one it was looking at. This only ever happened on the "create new package" screen - editing an already-saved package was fine.

This PR gives the "new package" and "edit package" screens their own distinct URLs, so there's no more mix-up.

I've targeted v17.x, as to provide the approach fix, but also make any future merging up to v18 a little smoother.

## How to test

1. Go to **Packages → Created packages → Create package**... confirm that the workspace loads up.
2. Open an already-existing created package and confirm the workspace loads up.