### PR TITLE
Collection Views: Apply `UmbTableColumn` `align` setting to head cell (closes #22582)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -374,10 +374,8 @@ export class UmbTableElement extends UmbLitElement {
 
 	private _renderHeaderCell(column: UmbTableColumn) {
 		return html`
-			<uui-table-head-cell style="--uui-table-cell-padding: 0 var(--uui-size-5)">
-				${column.allowSorting
-					? html`${this._renderSortingUI(column)}`
-					: html`<span style="text-align:${column.align ?? 'left'};">${column.name}</span>`}
+			<uui-table-head-cell style="--uui-table-cell-padding: 0 var(--uui-size-5); text-align:${column.align ?? 'left'};">
+				${column.allowSorting ? html`${this._renderSortingUI(column)}` : html`<span>${column.name}</span>`}
 			</uui-table-head-cell>
 		`;
 	}
@@ -387,7 +385,7 @@ export class UmbTableElement extends UmbLitElement {
 			<button
 				style="padding: var(--uui-size-5) var(--uui-size-1);"
 				@click="${() => this._handleOrderingChange(column)}">
-				<span style="text-align:${column.align ?? 'left'};">${column.name}</span>
+				<span>${column.name}</span>
 				<uui-symbol-sort ?active=${this.orderingColumn === column.alias} ?descending=${this.orderingDesc}>
 				</uui-symbol-sort>
 			</button>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Closes #22582

## Summary
Setting align on an `UmbTableColumn `correctly aligns the row cells but not the header cells. The` text-align` style was applied to an inner `<span> `element which, being inline, has no effect on text alignment within the full-width table header cell.

## What was changed
Moved `text-align` from the inner `<span>` (and sort `<button>` span) to the parent `<uui-table-head-cell>` element. Since `<uui-table-head-cell>` is a block-level table cell spanning the full column width, `text-align` works correctly and inherits into all child elements.

## Before

`text-align` is on the `<span>` instead of `<uui-table-head-cell>`:

<img width="365" height="251" alt="image" src="https://github.com/user-attachments/assets/e27049bd-8eb7-4ab5-96d3-8f7f1dc0c382" />

## After

`text-align`on `<uui-table-head-cell>`:

<img width="254" height="221" alt="image" src="https://github.com/user-attachments/assets/cf8c30b7-c3ca-483c-a176-0159e3e4c22a" />


## Testing
1. To verify, temporarily add align: 'right' to a named column (e.g., in webhook-delivery-table-collection-view.element.ts):
`{
  name: this.localize.term('webhooks_retryCount'),
  alias: 'retryCount',
  align: 'right',
}`

2. Then navigate to Settings → Webhooks → (click any webhook) → Deliveries tab.
3. **Expected result:** The "Retry count" header text is right-aligned, matching the row cell values below it.
