### PR TITLE
Property Editor UI: Schema configuration corrections

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action-menu/workspace-action-menu.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-action-menu/workspace-action-menu.element.ts
@@ -67,7 +67,7 @@ export class UmbWorkspaceActionMenuElement extends UmbLitElement {
 				margin="6"
 				placement="top-end"
 				@toggle=${this.#onPopoverToggle}
-				@click="${this._onPopoverClickCapture}}">
+				@click=${this._onPopoverClickCapture}>
 				<umb-popover-layout id="workspace-action-popover-layout">
 					<uui-scroll-container>
 						${repeat(

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/Umbraco.Dropdown.Flexible.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/Umbraco.Dropdown.Flexible.ts
@@ -18,11 +18,6 @@ export const manifest: ManifestPropertyEditorSchema = {
 					label: 'Add options',
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.MultipleTextString',
 				},
-				{
-					alias: 'placeholder',
-					label: '#general_placeholder',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TextBox',
-				},
 			],
 		},
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/dropdown/manifests.ts
@@ -13,6 +13,15 @@ export const manifests: Array<UmbExtensionManifest> = [
 			group: '#propertyEditorUIGroups_lists',
 			keywords: ['select', 'dropdown', 'choice', 'option', 'list'],
 			supportsReadOnly: true,
+			settings: {
+				properties: [
+					{
+						alias: 'placeholder',
+						label: '#general_placeholder',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.TextBox',
+					},
+				],
+			},
 		},
 	},
 	schemaManifest,

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/Umbraco.TextBox.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/Umbraco.TextBox.ts
@@ -18,26 +18,6 @@ export const manifest: ManifestPropertyEditorSchema = {
 						{ alias: 'placeholder', value: '512' },
 					],
 				},
-				{
-					alias: 'autocomplete',
-					label: '#textbox_autocompleteLabel',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Dropdown',
-					config: [
-						{
-							alias: 'items',
-							value: [
-								{ name: 'On', value: 'on' },
-								{ name: 'Off', value: 'off' },
-							],
-						},
-					],
-				},
-				{
-					alias: 'placeholder',
-					label: '#general_placeholder',
-					description: 'Placeholder text shown inside the input when empty',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TextBox',
-				},
 			],
 			defaultData: [
 				{

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/text-box/manifests.ts
@@ -42,7 +42,29 @@ export const manifests: Array<UmbExtensionManifest> = [
 			],
 			supportsReadOnly: true,
 			settings: {
-				properties: [inputTypeConfig],
+				properties: [
+					inputTypeConfig,
+					{
+						alias: 'autocomplete',
+						label: '#textbox_autocompleteLabel',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Dropdown',
+						config: [
+							{
+								alias: 'items',
+								value: [
+									{ name: 'On', value: 'on' },
+									{ name: 'Off', value: 'off' },
+								],
+							},
+						],
+					},
+					{
+						alias: 'placeholder',
+						label: '#general_placeholder',
+						description: 'Placeholder text shown inside the input when empty',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.TextBox',
+					},
+				],
 				defaultData: [
 					{
 						alias: 'inputType',

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/Umbraco.TextArea.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/Umbraco.TextArea.ts
@@ -15,12 +15,6 @@ export const manifest: ManifestPropertyEditorSchema = {
 					propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
 					config: [{ alias: 'min', value: 0 }],
 				},
-				{
-					alias: 'placeholder',
-					label: '#general_placeholder',
-					description: 'Placeholder text shown inside the textarea when empty',
-					propertyEditorUiAlias: 'Umb.PropertyEditorUi.TextBox',
-				},
 			],
 		},
 	},

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/textarea/manifests.ts
@@ -37,6 +37,12 @@ export const manifests: Array<UmbExtensionManifest> = [
 						propertyEditorUiAlias: 'Umb.PropertyEditorUi.Integer',
 						config: [{ alias: 'min', value: 0 }],
 					},
+					{
+						alias: 'placeholder',
+						label: '#general_placeholder',
+						description: 'Placeholder text shown inside the textarea when empty',
+						propertyEditorUiAlias: 'Umb.PropertyEditorUi.TextBox',
+					},
 				],
 				defaultData: [{ alias: 'rows', value: 10 }],
 			},


### PR DESCRIPTION
## Description

Following up on my comments on PR #23205, this PR relocates some of the `propertyEditorSchema` setting properties to the `propertyEditorUi` manifests, (since those properties are not required by the server-side schema (`ConfigurationEditor` models).

I have added an unrelated fix for a rogue double-brace issue: see: https://github.com/umbraco/Umbraco-CMS/pull/23253#pullrequestreview-4620521001

### How to test?

There isn't much to test. Check the Dropdown, TextArea and TextBox data-type configurations show the new placeholder configurations.

