### PR TITLE
Timeout Settings: Cap session timeout timer to prevent JavaScript overflow (closes #23246)

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
@@ -54,14 +54,15 @@ public class GlobalSettingsValidator
 
     private bool ValidateTimeOutSetting(TimeSpan configuredTimeOut, out string message)
     {
-        // JavaScript's setTimeout maximum delay is 2^31 - 1 milliseconds (~24.85 days).
-        // Values exceeding this cause timers to fire immediately, breaking session management.
-        var maxTimeOut = TimeSpan.FromMilliseconds(2_147_483_647);
+        // JavaScript's setTimeout maximum delay is 2^31 - 1 milliseconds (~24.85 days); values
+        // exceeding it cause timers to fire immediately, breaking session management.
+        // Cap at a clean 24 days, comfortably below the limit.
+        var maxTimeOut = TimeSpan.FromDays(24);
 
         if (configuredTimeOut > maxTimeOut)
         {
             message =
-                $"The `{Constants.Configuration.ConfigGlobal}:{nameof(GlobalSettings.TimeOut)}` must not exceed {maxTimeOut.TotalDays:F0} days (~24.85 days). " +
+                $"The `{Constants.Configuration.ConfigGlobal}:{nameof(GlobalSettings.TimeOut)}` must not exceed {maxTimeOut.TotalDays:F0} days. " +
                 $"Values larger than this overflow the browser's maximum timer delay and break session management. " +
                 $"Consider using the `KeepUserLoggedIn` setting instead.";
             return false;

--- a/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
+++ b/src/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidator.cs
@@ -24,6 +24,11 @@ public class GlobalSettingsValidator
             return ValidateOptionsResult.Fail(message2);
         }
 
+        if (!ValidateTimeOutSetting(options.TimeOut, out var message3))
+        {
+            return ValidateOptionsResult.Fail(message3);
+        }
+
         return ValidateOptionsResult.Success;
     }
 
@@ -40,6 +45,25 @@ public class GlobalSettingsValidator
         {
             message =
                 $"The `{Constants.Configuration.ConfigGlobal}:{nameof(GlobalSettings.DistributedLockingWriteLockDefaultTimeout)}` should not be configured as less than {minimumTimeOut} ms";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    private bool ValidateTimeOutSetting(TimeSpan configuredTimeOut, out string message)
+    {
+        // JavaScript's setTimeout maximum delay is 2^31 - 1 milliseconds (~24.85 days).
+        // Values exceeding this cause timers to fire immediately, breaking session management.
+        var maxTimeOut = TimeSpan.FromMilliseconds(2_147_483_647);
+
+        if (configuredTimeOut > maxTimeOut)
+        {
+            message =
+                $"The `{Constants.Configuration.ConfigGlobal}:{nameof(GlobalSettings.TimeOut)}` must not exceed {maxTimeOut.TotalDays:F0} days (~24.85 days). " +
+                $"Values larger than this overflow the browser's maximum timer delay and break session management. " +
+                $"Consider using the `KeepUserLoggedIn` setting instead.";
             return false;
         }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
@@ -11,7 +11,7 @@ import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
  */
 const EXPIRY_SAFETY_MARGIN_IN_SECONDS = 5;
 
-/** Maximum delay (in ms) that setTimeout supports (2^31 - 1). Values above this fire immediately in browsers. */
+/** Maximum delay (in ms) that setTimeout supports (2^31 - 1). Larger delays fire immediately in browsers. */
 const MAX_TIMEOUT_MS = 2_147_483_647;
 
 export class UmbAuthSessionTimeoutController extends UmbControllerBase {
@@ -91,10 +91,23 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 		if (secondsUntilWarning <= 0) {
 			// Already in the buffer zone
 			this.#onSessionExpiring(expiresAt);
-		} else {
-			const delayMs = Math.min(secondsUntilWarning * 1000, MAX_TIMEOUT_MS);
-			this.#timeoutId = setTimeout(() => this.#onSessionExpiring(expiresAt), delayMs);
+			return;
 		}
+
+		let delayMs = secondsUntilWarning * 1000;
+		if (delayMs > MAX_TIMEOUT_MS) {
+			// Not expected in practice: both session.expiresAt and session.accessTokenExpiresAt derive
+			// from the server-issued token lifetime that Global:TimeOut governs, and server-side
+			// validation bounds Global:TimeOut below setTimeout's ceiling.
+			// Clamp and warn so a regression producing an out-of-range session lifetime surfaces here,
+			// rather than setTimeout silently firing the check immediately.
+			console.warn(
+				`[Auth] Session warning delay ${delayMs}ms exceeds the maximum supported setTimeout delay; clamping to ${MAX_TIMEOUT_MS}ms.`,
+			);
+			delayMs = MAX_TIMEOUT_MS;
+		}
+
+		this.#timeoutId = setTimeout(() => this.#onSessionExpiring(expiresAt), delayMs);
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/controllers/auth-session-timeout.controller.ts
@@ -11,6 +11,9 @@ import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
  */
 const EXPIRY_SAFETY_MARGIN_IN_SECONDS = 5;
 
+/** Maximum delay (in ms) that setTimeout supports (2^31 - 1). Values above this fire immediately in browsers. */
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
 export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 	#host: UmbAuthContext;
 	#timeoutId?: ReturnType<typeof setTimeout>;
@@ -89,7 +92,8 @@ export class UmbAuthSessionTimeoutController extends UmbControllerBase {
 			// Already in the buffer zone
 			this.#onSessionExpiring(expiresAt);
 		} else {
-			this.#timeoutId = setTimeout(() => this.#onSessionExpiring(expiresAt), secondsUntilWarning * 1000);
+			const delayMs = Math.min(secondsUntilWarning * 1000, MAX_TIMEOUT_MS);
+			this.#timeoutId = setTimeout(() => this.#onSessionExpiring(expiresAt), delayMs);
 		}
 	}
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/Models/Validation/GlobalSettingsValidatorTests.cs
@@ -48,4 +48,24 @@ public class GlobalSettingsValidatorTests
         var result = validator.Validate("settings", options);
         Assert.True(result.Succeeded);
     }
+
+    [Test]
+    public void Returns_Fail_For_Configuration_With_TimeOut_Exceeding_Browser_Max()
+    {
+        var validator = new GlobalSettingsValidator();
+        var options = new GlobalSettings { TimeOut = TimeSpan.FromDays(25) };
+
+        var result = validator.Validate("settings", options);
+        Assert.False(result.Succeeded);
+    }
+
+    [Test]
+    public void Returns_Success_For_Configuration_With_Valid_TimeOut()
+    {
+        var validator = new GlobalSettingsValidator();
+        var options = new GlobalSettings { TimeOut = TimeSpan.FromHours(12) };
+
+        var result = validator.Validate("settings", options);
+        Assert.True(result.Succeeded);
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Closes #23246

## Summary
When `Umbraco:CMS:Global:TimeOut` is set to a large value (e.g., "99:00:00" which .NET interprets as 99 days), the computed session expiry exceeds JavaScript's maximum` setTimeout` delay of 2^31 - 1 milliseconds (~24.85 days). Browsers handle this by firing the timer immediately, causing the backoffice to enter a tight token-refresh loop that collapses into a persistent "Session timeout" modal on login.

## What was changed
Capped the `setTimeout `delay in `UmbAuthSessionTimeoutController` to the browser's maximum safe value using `Math.min()`. This prevents the timer from firing immediately when large timeout values are configured.

```
const MAX_TIMEOUT_MS = 2_147_483_647;
// ...
const delayMs = Math.min(secondsUntilWarning * 1000, MAX_TIMEOUT_MS);
this.#timeoutId = setTimeout(() => this.#onSessionExpiring(expiresAt), delayMs);
```
When the capped timer eventually fires, `#onSessionExpiring` recalculates remaining time from the wall clock and either re-schedules (if still valid) or shows the timeout modal (if actually expiring).

Additionally, added server-side validation in `GlobalSettingsValidator `to reject `TimeOut `values exceeding the browser's maximum timer delay (`~24.85 days`) at startup. This fails early with a clear error message suggesting the `KeepUserLoggedIn `setting as an alternative, so users don't configure a value that silently breaks session management.

```
// In GlobalSettingsValidator.cs
var maxTimeOut = TimeSpan.FromMilliseconds(2_147_483_647);
if (configuredTimeOut > maxTimeOut)
    return fail("...must not exceed 25 days...");
```
Unit tests added for both valid and invalid `TimeOut `values.

## Testing

1. Set `"Umbraco:CMS:Global:TimeOut": "99:00:00"` in appsettings.json
2. Run the site and log into the backoffice
3. Before fix: "Session timeout" modal appears immediately on login in a loop
4. After fix: Login works normally, no timeout modal

## Server-side validation test:

1. Set `"Umbraco:CMS:Global:TimeOut": "99:00:00"` in appsettings.json
2. Run dotnet run
3. Server fails on startup with: The `Umbraco:CMS:Global:TimeOut` must not exceed 25 days (`~24.85 days`). Values larger than this overflow the browser's maximum timer delay and break session management. Consider using the `KeepUserLoggedIn` setting instead.

## Unit tests:
`dotnet test tests/Umbraco.Tests.UnitTests --filter "GlobalSettingsValidatorTests"`

**Expected**: All 6 tests pass (including 2 new: Returns_Fail_For_Configuration_With_TimeOut_Exceeding_Browser_Max and Returns_Success_For_Configuration_With_Valid_TimeOut).


## Before adding the fix
<img width="1895" height="938" alt="Before_adding_fix_for_timeout" src="https://github.com/user-attachments/assets/9e2ab948-a78e-47fd-b58a-84db174a4c62" />



## After adding the fix
<img width="1895" height="938" alt="After_adding_fix_for_timeout" src="https://github.com/user-attachments/assets/f44475f4-0ae8-4fd8-ae05-459b9d0fc181" />

