### PR TITLE
EFCore: Common type repository migration

### DIFF
--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260630024001_MemberPropertyTypeToEFCore.Designer.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260630024001_MemberPropertyTypeToEFCore.Designer.cs
@@ -2,98 +2,91 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.Cms.Infrastructure.Persistence.EFCore;
 
 #nullable disable
 
-namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
+namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
 {
     [DbContext(typeof(UmbracoDbContext))]
-    partial class UmbracoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630024001_MemberPropertyTypeToEFCore")]
+    partial class MemberPropertyTypeToEFCore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "10.0.7")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("OpenIddict.EntityFrameworkCore.Models.OpenIddictEntityFrameworkCoreApplication", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ApplicationType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("ClientId")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("ClientSecret")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ClientType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("ConsentType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayNames")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("JsonWebKeySet")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Permissions")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PostLogoutRedirectUris")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("RedirectUris")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Requirements")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Settings")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ClientId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[ClientId] IS NOT NULL");
 
                     b.ToTable("umbracoOpenIddictApplications", (string)null);
                 });
@@ -102,44 +95,36 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ApplicationId")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<DateTime?>("CreationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Scopes")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Subject")
                         .HasMaxLength(400)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(400)");
 
                     b.Property<string>("Type")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 
@@ -152,48 +137,40 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Descriptions")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayNames")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Resources")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Name")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[Name] IS NOT NULL");
 
                     b.ToTable("umbracoOpenIddictScopes", (string)null);
                 });
@@ -202,66 +179,57 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ApplicationId")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AuthorizationId")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ConcurrencyToken")
                         .IsConcurrencyToken()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<DateTime?>("CreationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("ExpirationDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Payload")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTime?>("RedemptionDate")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("ReferenceId")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Status")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("Subject")
                         .HasMaxLength(400)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(400)");
 
                     b.Property<string>("Type")
                         .HasMaxLength(150)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(150)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("AuthorizationId");
 
                     b.HasIndex("ReferenceId")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[ReferenceId] IS NOT NULL");
 
                     b.HasIndex("ApplicationId", "Status", "Subject", "Type");
 
@@ -271,27 +239,27 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.AccessDto", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("id");
 
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<int>("LoginNodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("loginNodeId");
 
                     b.Property<int>("NoAccessNodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("noAccessNodeId");
 
                     b.Property<int>("NodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("nodeId");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updateDate");
 
                     b.HasKey("Id")
@@ -311,29 +279,27 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.AccessRuleDto", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("id");
 
                     b.Property<Guid>("AccessId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("accessId");
 
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<string>("RuleType")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("ruleType")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("ruleType");
 
                     b.Property<string>("RuleValue")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("ruleValue")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("ruleValue");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updateDate");
 
                     b.HasKey("Id")
@@ -343,7 +309,8 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
 
                     b.HasIndex("RuleValue", "RuleType", "AccessId")
                         .IsUnique()
-                        .HasDatabaseName("IX_umbracoAccessRule");
+                        .HasDatabaseName("IX_umbracoAccessRule")
+                        .HasFilter("[ruleValue] IS NOT NULL AND [ruleType] IS NOT NULL");
 
                     b.ToTable("umbracoAccessRule", (string)null);
                 });
@@ -352,57 +319,54 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AffectedDetails")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("affectedDetails")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1024)")
+                        .HasColumnName("affectedDetails");
 
                     b.Property<int>("AffectedUserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("affectedUserId");
 
                     b.Property<Guid?>("AffectedUserKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("affectedUserKey");
 
                     b.Property<DateTime>("EventDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("eventDateUtc");
 
                     b.Property<string>("EventDetails")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("eventDetails")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1024)")
+                        .HasColumnName("eventDetails");
 
                     b.Property<string>("EventType")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("eventType")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("eventType");
 
                     b.Property<string>("PerformingDetails")
                         .HasMaxLength(1024)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("performingDetails")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1024)")
+                        .HasColumnName("performingDetails");
 
                     b.Property<string>("PerformingIp")
                         .HasMaxLength(64)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("performingIp")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(64)")
+                        .HasColumnName("performingIp");
 
                     b.Property<int>("PerformingUserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("performingUserId");
 
                     b.Property<Guid?>("PerformingUserKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("performingUserKey");
 
                     b.HasKey("Id");
@@ -414,30 +378,30 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("InstructionCount")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasDefaultValue(1)
                         .HasColumnName("instructionCount");
 
                     b.Property<string>("Instructions")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("jsonInstruction")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("jsonInstruction");
 
                     b.Property<string>("OriginIdentity")
                         .IsRequired()
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("originated")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("originated");
 
                     b.Property<DateTime>("UtcStamp")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("utcStamp");
 
                     b.HasKey("Id");
@@ -449,42 +413,40 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Action")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("action")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(512)")
+                        .HasColumnName("action");
 
                     b.Property<string>("Comment")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("comment")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("comment");
 
                     b.Property<string>("Context")
                         .HasMaxLength(128)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("context")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(128)")
+                        .HasColumnName("context");
 
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<bool>("Current")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("current");
 
                     b.Property<string>("Source")
                         .HasMaxLength(512)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("source")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(512)")
+                        .HasColumnName("source");
 
                     b.Property<int>("State")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("state");
 
                     b.HasKey("Id");
@@ -495,11 +457,11 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.ContentType2ContentTypeDto", b =>
                 {
                     b.Property<int>("ParentId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("parentContentTypeId");
 
                     b.Property<int>("ChildId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("childContentTypeId");
 
                     b.HasKey("ParentId", "ChildId")
@@ -513,16 +475,16 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.ContentTypeAllowedContentTypeDto", b =>
                 {
                     b.Property<int>("Id")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("Id");
 
                     b.Property<int>("AllowedId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("AllowedId");
 
                     b.Property<int>("SortOrder")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasDefaultValue(0)
                         .HasColumnName("SortOrder");
 
@@ -536,58 +498,56 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("PrimaryKey")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("pk");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("PrimaryKey"));
+
                     b.Property<string>("Alias")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("alias")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("alias");
 
                     b.Property<bool>("AllowAtRoot")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("allowAtRoot");
 
                     b.Property<bool>("AllowedInLibrary")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("allowedInLibrary");
 
                     b.Property<string>("Description")
                         .HasMaxLength(1500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("description")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1500)")
+                        .HasColumnName("description");
 
                     b.Property<string>("Icon")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("icon")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("icon");
 
                     b.Property<bool>("IsElement")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("isElement");
 
                     b.Property<Guid?>("ListView")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("listView");
 
                     b.Property<int>("NodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("nodeId");
 
                     b.Property<string>("Thumbnail")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("thumbnail")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("thumbnail");
 
                     b.Property<int>("Variations")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("variations");
 
                     b.HasKey("PrimaryKey");
@@ -605,16 +565,16 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.ContentTypeTemplateDto", b =>
                 {
                     b.Property<int>("ContentTypeNodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("contentTypeNodeId");
 
                     b.Property<int>("TemplateNodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("templateNodeId");
 
                     b.Property<bool>("IsDefault")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("IsDefault");
 
@@ -627,23 +587,23 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.ContentVersionCleanupPolicyDto", b =>
                 {
                     b.Property<int>("ContentTypeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("contentTypeId");
 
                     b.Property<int?>("KeepAllVersionsNewerThanDays")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("keepAllVersionsNewerThanDays");
 
                     b.Property<int?>("KeepLatestVersionPerDayForDays")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("keepLatestVersionPerDayForDays");
 
                     b.Property<bool>("PreventCleanup")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("preventCleanup");
 
                     b.Property<DateTime>("Updated")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updated");
 
                     b.HasKey("ContentTypeId")
@@ -655,31 +615,27 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DataTypeDto", b =>
                 {
                     b.Property<int>("NodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("nodeId");
 
                     b.Property<string>("Configuration")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("config")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("config");
 
                     b.Property<string>("DbType")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("dbType")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("dbType");
 
                     b.Property<string>("EditorAlias")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("propertyEditorAlias")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("propertyEditorAlias");
 
                     b.Property<string>("EditorUiAlias")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("propertyEditorUiAlias")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("propertyEditorUiAlias");
 
                     b.HasKey("NodeId");
 
@@ -690,22 +646,23 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("pk");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Key")
                         .IsRequired()
                         .HasMaxLength(450)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("key")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("key");
 
                     b.Property<Guid?>("Parent")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("parent");
 
                     b.Property<Guid>("UniqueId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("id");
 
                     b.HasKey("Id");
@@ -728,29 +685,30 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<bool>("IsRunning")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("IsRunning");
 
                     b.Property<DateTime>("LastAttemptedRun")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastAttemptedRun");
 
                     b.Property<DateTime>("LastRun")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastRun");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Name")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("Name");
 
                     b.Property<long>("Period")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bigint")
                         .HasColumnName("period");
 
                     b.HasKey("Id");
@@ -762,29 +720,30 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<int?>("DefaultLanguage")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("domainDefaultLanguage");
 
                     b.Property<string>("DomainName")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("domainName")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("domainName");
 
                     b.Property<Guid>("Key")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("key");
 
                     b.Property<int?>("RootStructureId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("domainRootStructureID");
 
                     b.Property<int>("SortOrder")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("sortOrder");
 
                     b.HasKey("Id");
@@ -799,18 +758,16 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<string>("Key")
                         .HasMaxLength(256)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("key")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(256)")
+                        .HasColumnName("key");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updated");
 
                     b.Property<string>("Value")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("value")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("value");
 
                     b.HasKey("Key");
 
@@ -821,39 +778,39 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CultureName")
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("languageCultureName")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(100)")
+                        .HasColumnName("languageCultureName");
 
                     b.Property<int?>("FallbackLanguageId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("fallbackLanguageId");
 
                     b.Property<bool>("IsDefault")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("isDefaultVariantLang");
 
                     b.Property<bool>("IsMandatory")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("mandatory");
 
                     b.Property<string>("IsoCode")
                         .HasMaxLength(14)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("languageISOCode")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(14)")
+                        .HasColumnName("languageISOCode");
 
                     b.Property<Guid>("LanguageKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("languageKey");
 
                     b.HasKey("Id");
@@ -861,7 +818,8 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                     b.HasIndex("FallbackLanguageId");
 
                     b.HasIndex("IsoCode")
-                        .IsUnique();
+                        .IsUnique()
+                        .HasFilter("[languageISOCode] IS NOT NULL");
 
                     b.HasIndex("LanguageKey")
                         .IsUnique();
@@ -873,23 +831,24 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("pk");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<int>("LanguageId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("languageId");
 
                     b.Property<Guid>("UniqueId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("UniqueId");
 
                     b.Property<string>("Value")
                         .IsRequired()
                         .HasMaxLength(1000)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("value")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1000)")
+                        .HasColumnName("value");
 
                     b.HasKey("Id");
 
@@ -905,19 +864,18 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.LastSyncedDto", b =>
                 {
                     b.Property<string>("MachineId")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("machineId")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("machineId");
 
                     b.Property<DateTime>("LastSyncedDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastSyncedDate");
 
                     b.Property<int?>("LastSyncedExternalId")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("int");
 
                     b.Property<int?>("LastSyncedInternalId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("lastSyncedInternalId");
 
                     b.HasKey("MachineId");
@@ -929,44 +887,42 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Comment")
                         .HasMaxLength(4000)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("logComment")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(4000)")
+                        .HasColumnName("logComment");
 
                     b.Property<DateTime>("Datestamp")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("Datestamp");
 
                     b.Property<string>("EntityType")
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("entityType")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("entityType");
 
                     b.Property<string>("Header")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("logHeader")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("logHeader");
 
                     b.Property<int>("NodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("NodeId");
 
                     b.Property<string>("Parameters")
                         .HasMaxLength(4000)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("parameters")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(4000)")
+                        .HasColumnName("parameters");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("userId");
 
                     b.HasKey("Id");
@@ -988,38 +944,35 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.LongRunningOperationDto", b =>
                 {
                     b.Property<Guid>("Id")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("id");
 
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<DateTime>("ExpirationDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("expirationDate");
 
                     b.Property<string>("Result")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("result")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("result");
 
                     b.Property<string>("Status")
                         .IsRequired()
                         .HasMaxLength(50)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("status")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("status");
 
                     b.Property<string>("Type")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("type")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(200)")
+                        .HasColumnName("type");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updateDate");
 
                     b.HasKey("Id")
@@ -1032,32 +985,34 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("PrimaryKey")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("pk");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("PrimaryKey"));
 
                     b.Property<bool>("CanEdit")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("memberCanEdit");
 
                     b.Property<bool>("IsSensitive")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("isSensitive");
 
                     b.Property<int>("NodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("NodeId");
 
                     b.Property<int>("PropertyTypeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("propertytypeId");
 
                     b.Property<bool>("ViewOnProfile")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("viewOnProfile");
 
@@ -1073,53 +1028,53 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("NodeId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("NodeId"));
+
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<int>("Level")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("level");
 
                     b.Property<Guid?>("NodeObjectType")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("nodeObjectType");
 
                     b.Property<int>("ParentId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("parentId");
 
                     b.Property<string>("Path")
                         .IsRequired()
                         .HasMaxLength(150)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("path")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(150)")
+                        .HasColumnName("path");
 
                     b.Property<int>("SortOrder")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("sortOrder");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("text")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("text");
 
                     b.Property<bool>("Trashed")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("trashed");
 
                     b.Property<Guid>("UniqueId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("uniqueId");
 
                     b.Property<int?>("UserId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("nodeUser");
 
                     b.HasKey("NodeId");
@@ -1153,78 +1108,74 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<string>("Alias")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Alias")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("Alias");
 
                     b.Property<int>("ContentTypeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("contentTypeId");
 
                     b.Property<int>("DataTypeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("dataTypeId");
 
                     b.Property<string>("Description")
                         .HasMaxLength(2000)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Description")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(2000)")
+                        .HasColumnName("Description");
 
                     b.Property<bool>("LabelOnTop")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("labelOnTop");
 
                     b.Property<bool>("Mandatory")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("mandatory");
 
                     b.Property<string>("MandatoryMessage")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("mandatoryMessage")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("mandatoryMessage");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Name")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("Name");
 
                     b.Property<int?>("PropertyTypeGroupId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("propertyTypeGroupId");
 
                     b.Property<int>("SortOrder")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasDefaultValue(0)
                         .HasColumnName("sortOrder");
 
                     b.Property<Guid>("UniqueId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("UniqueId");
 
                     b.Property<string>("ValidationRegExp")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("validationRegExp")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("validationRegExp");
 
                     b.Property<string>("ValidationRegExpMessage")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("validationRegExpMessage")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("validationRegExpMessage");
 
                     b.Property<int>("Variations")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("variations");
 
                     b.HasKey("Id");
@@ -1247,36 +1198,36 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Alias")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("alias")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("alias");
 
                     b.Property<int>("ContentTypeNodeId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("contenttypeNodeId");
 
                     b.Property<int>("SortOrder")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("sortorder");
 
                     b.Property<string>("Text")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("text")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("text");
 
                     b.Property<int>("Type")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasDefaultValue(0)
                         .HasColumnName("type");
 
                     b.Property<Guid>("UniqueId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("uniqueID");
 
                     b.HasKey("Id");
@@ -1292,29 +1243,30 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<int>("ChildId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("childId");
 
                     b.Property<string>("Comment")
                         .HasMaxLength(1000)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("comment")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(1000)")
+                        .HasColumnName("comment");
 
                     b.Property<DateTime>("Datetime")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("datetime");
 
                     b.Property<int>("ParentId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("parentId");
 
                     b.Property<int>("RelationType")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("relType");
 
                     b.HasKey("Id");
@@ -1334,42 +1286,42 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Alias")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("alias")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(100)")
+                        .HasColumnName("alias");
 
                     b.Property<Guid?>("ChildObjectType")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("childObjectType");
 
                     b.Property<bool>("Dual")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("dual");
 
                     b.Property<bool>("IsDependency")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("isDependency");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("name")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("name");
 
                     b.Property<Guid?>("ParentObjectType")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("parentObjectType");
 
                     b.Property<Guid>("UniqueId")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("typeUniqueId");
 
                     b.HasKey("Id");
@@ -1393,110 +1345,104 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Avatar")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("avatar")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("avatar");
 
                     b.Property<DateTime>("CreateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("createDate");
 
                     b.Property<bool>("Disabled")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("userDisabled");
 
                     b.Property<string>("Email")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userEmail")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("userEmail");
 
                     b.Property<DateTime?>("EmailConfirmedDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("emailConfirmedDate");
 
                     b.Property<int?>("FailedLoginAttempts")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("failedLoginAttempts");
 
                     b.Property<DateTime?>("InvitedDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("invitedDate");
 
                     b.Property<Guid>("Key")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("key");
 
                     b.Property<int>("Kind")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasDefaultValue(0)
                         .HasColumnName("kind");
 
                     b.Property<DateTime?>("LastLockoutDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastLockoutDate");
 
                     b.Property<DateTime?>("LastLoginDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastLoginDate");
 
                     b.Property<DateTime?>("LastPasswordChangeDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("lastPasswordChangeDate");
 
                     b.Property<string>("Login")
                         .HasMaxLength(125)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userLogin")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(125)")
+                        .HasColumnName("userLogin");
 
                     b.Property<bool>("NoConsole")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false)
                         .HasColumnName("userNoConsole");
 
                     b.Property<string>("Password")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userPassword")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("userPassword");
 
                     b.Property<string>("PasswordConfig")
                         .HasMaxLength(500)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("passwordConfig")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(500)")
+                        .HasColumnName("passwordConfig");
 
                     b.Property<string>("SecurityStampToken")
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("securityStampToken")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(255)")
+                        .HasColumnName("securityStampToken");
 
                     b.Property<DateTime>("UpdateDate")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("datetime2")
                         .HasColumnName("updateDate");
 
                     b.Property<string>("UserLanguage")
                         .HasMaxLength(10)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userLanguage")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(10)")
+                        .HasColumnName("userLanguage");
 
                     b.Property<string>("UserName")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("userName")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("userName");
 
                     b.HasKey("Id")
                         .HasName("PK_user");
@@ -1513,11 +1459,11 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Webhook2ContentTypeKeysDto", b =>
                 {
                     b.Property<int>("WebhookId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("webhookId");
 
                     b.Property<Guid>("ContentTypeKey")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("entityKey");
 
                     b.HasKey("WebhookId", "ContentTypeKey")
@@ -1529,14 +1475,13 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Webhook2EventsDto", b =>
                 {
                     b.Property<int>("WebhookId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("webhookId");
 
                     b.Property<string>("Event")
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
-                        .HasColumnName("event")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(255)")
+                        .HasColumnName("event");
 
                     b.HasKey("WebhookId", "Event")
                         .HasName("PK_webhookEvent2WebhookDto");
@@ -1547,18 +1492,16 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Webhook2HeadersDto", b =>
                 {
                     b.Property<int>("WebhookId")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("webhookId");
 
                     b.Property<string>("Key")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Key")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(450)")
+                        .HasColumnName("Key");
 
                     b.Property<string>("Value")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("WebhookId", "Key")
                         .HasName("PK_headers2WebhookDto");
@@ -1570,32 +1513,31 @@ namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("int")
                         .HasColumnName("id");
 
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
                     b.Property<string>("Description")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("description")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("description");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER")
+                        .HasColumnType("bit")
                         .HasColumnName("enabled");
 
                     b.Property<Guid>("Key")
-                        .HasColumnType("TEXT")
+                        .HasColumnType("uniqueidentifier")
                         .HasColumnName("key");
 
                     b.Property<string>("Name")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("name")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("name");
 
                     b.Property<string>("Url")
                         .IsRequired()
-                        .HasColumnType("TEXT")
-                        .HasColumnName("url")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("url");
 
                     b.HasKey("Id");
 

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260630024001_MemberPropertyTypeToEFCore.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/20260630024001_MemberPropertyTypeToEFCore.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class MemberPropertyTypeToEFCore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/UmbracoDbContextModelSnapshot.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/Migrations/UmbracoDbContextModelSnapshot.cs
@@ -609,6 +609,36 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
                     b.ToTable("umbracoContentVersionCleanupPolicy", (string)null);
                 });
 
+            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DataTypeDto", b =>
+                {
+                    b.Property<int>("NodeId")
+                        .HasColumnType("int")
+                        .HasColumnName("nodeId");
+
+                    b.Property<string>("Configuration")
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("config");
+
+                    b.Property<string>("DbType")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)")
+                        .HasColumnName("dbType");
+
+                    b.Property<string>("EditorAlias")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("propertyEditorAlias");
+
+                    b.Property<string>("EditorUiAlias")
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnName("propertyEditorUiAlias");
+
+                    b.HasKey("NodeId");
+
+                    b.ToTable("umbracoDataType", (string)null);
+                });
+
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DictionaryDto", b =>
                 {
                     b.Property<int>("Id")
@@ -681,36 +711,6 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("umbracoDistributedJob", (string)null);
-                });
-
-            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DataTypeDto", b =>
-                {
-                    b.Property<int>("NodeId")
-                        .HasColumnType("int")
-                        .HasColumnName("nodeId");
-
-                    b.Property<string>("Configuration")
-                        .HasColumnType("nvarchar(max)")
-                        .HasColumnName("config");
-
-                    b.Property<string>("DbType")
-                        .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)")
-                        .HasColumnName("dbType");
-
-                    b.Property<string>("EditorAlias")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)")
-                        .HasColumnName("propertyEditorAlias");
-
-                    b.Property<string>("EditorUiAlias")
-                        .HasColumnType("nvarchar(max)")
-                        .HasColumnName("propertyEditorUiAlias");
-
-                    b.HasKey("NodeId");
-
-                    b.ToTable("umbracoDataType", (string)null);
                 });
 
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DomainDto", b =>
@@ -976,6 +976,49 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
                         .HasName("PK_umbracoLongRunningOperation");
 
                     b.ToTable("umbracoLongRunningOperation", (string)null);
+                });
+
+            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.MemberPropertyTypeDto", b =>
+                {
+                    b.Property<int>("PrimaryKey")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int")
+                        .HasColumnName("pk");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("PrimaryKey"));
+
+                    b.Property<bool>("CanEdit")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bit")
+                        .HasDefaultValue(false)
+                        .HasColumnName("memberCanEdit");
+
+                    b.Property<bool>("IsSensitive")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bit")
+                        .HasDefaultValue(false)
+                        .HasColumnName("isSensitive");
+
+                    b.Property<int>("NodeId")
+                        .HasColumnType("int")
+                        .HasColumnName("NodeId");
+
+                    b.Property<int>("PropertyTypeId")
+                        .HasColumnType("int")
+                        .HasColumnName("propertytypeId");
+
+                    b.Property<bool>("ViewOnProfile")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bit")
+                        .HasDefaultValue(false)
+                        .HasColumnName("viewOnProfile");
+
+                    b.HasKey("PrimaryKey");
+
+                    b.HasIndex("PropertyTypeId")
+                        .IsUnique();
+
+                    b.ToTable("cmsMemberType", (string)null);
                 });
 
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.NodeDto", b =>
@@ -1557,17 +1600,6 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
                     b.Navigation("Access");
                 });
 
-            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DictionaryDto", b =>
-                {
-                    b.HasOne("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DictionaryDto", "ParentEntry")
-                        .WithMany()
-                        .HasForeignKey("Parent")
-                        .HasPrincipalKey("UniqueId")
-                        .OnDelete(DeleteBehavior.NoAction);
-
-                    b.Navigation("ParentEntry");
-                });
-
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.ContentType2ContentTypeDto", b =>
                 {
                     b.HasOne("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.NodeDto", "ChildNode")
@@ -1588,7 +1620,6 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
 
                     b.Navigation("ParentNode");
                 });
-
 
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.ContentTypeDto", b =>
                 {
@@ -1612,6 +1643,17 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
                         .HasConstraintName("FK_umbracoDataType_umbracoNode");
 
                     b.Navigation("NodeDto");
+                });
+
+            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DictionaryDto", b =>
+                {
+                    b.HasOne("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DictionaryDto", "ParentEntry")
+                        .WithMany()
+                        .HasForeignKey("Parent")
+                        .HasPrincipalKey("UniqueId")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.Navigation("ParentEntry");
                 });
 
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.LanguageDto", b =>
@@ -1652,6 +1694,18 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
                         .OnDelete(DeleteBehavior.NoAction);
 
                     b.Navigation("User");
+                });
+
+            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.MemberPropertyTypeDto", b =>
+                {
+                    b.HasOne("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.PropertyTypeDto", "PropertyTypeDto")
+                        .WithOne("MemberPropertyTypeDto")
+                        .HasForeignKey("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.MemberPropertyTypeDto", "PropertyTypeId")
+                        .OnDelete(DeleteBehavior.NoAction)
+                        .IsRequired()
+                        .HasConstraintName("FK_cmsMemberType_cmsPropertyType");
+
+                    b.Navigation("PropertyTypeDto");
                 });
 
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.NodeDto", b =>
@@ -1765,6 +1819,11 @@ namespace Umbraco.Cms.Persistence.EFCore.SqlServer.Migrations
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.DictionaryDto", b =>
                 {
                     b.Navigation("LanguageText");
+                });
+
+            modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.PropertyTypeDto", b =>
+                {
+                    b.Navigation("MemberPropertyTypeDto");
                 });
 
             modelBuilder.Entity("Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.PropertyTypeGroupDto", b =>

--- a/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.SqlServer/SqlServerMigrationProvider.cs
@@ -65,6 +65,7 @@ public class SqlServerMigrationProvider : IMigrationProvider
             EFCoreMigration.AddConsentDto => typeof(Migrations.AddConsentDto),
             EFCoreMigration.AddDictionaryDto => typeof(Migrations.AddDictionaryDtos),
             EFCoreMigration.AddContentTypeDtos => typeof(Migrations.AddContentTypeDtos),
+            EFCoreMigration.MemberPropertyTypeToEFCore => typeof(Migrations.MemberPropertyTypeToEFCore),
             _ => throw new ArgumentOutOfRangeException(nameof(migration), $@"Not expected migration value: {migration}")
         };
 }

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260630024037_MemberPropertyTypeToEFCore.Designer.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260630024037_MemberPropertyTypeToEFCore.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Umbraco.Cms.Infrastructure.Persistence.EFCore;
 
@@ -10,9 +11,11 @@ using Umbraco.Cms.Infrastructure.Persistence.EFCore;
 namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
 {
     [DbContext(typeof(UmbracoDbContext))]
-    partial class UmbracoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630024037_MemberPropertyTypeToEFCore")]
+    partial class MemberPropertyTypeToEFCore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260630024037_MemberPropertyTypeToEFCore.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/Migrations/20260630024037_MemberPropertyTypeToEFCore.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Umbraco.Cms.Persistence.EFCore.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class MemberPropertyTypeToEFCore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs
+++ b/src/Umbraco.Cms.Persistence.EFCore.Sqlite/SqliteMigrationProvider.cs
@@ -66,6 +66,7 @@ public class SqliteMigrationProvider : IMigrationProvider
             EFCoreMigration.AddDomainDto => typeof(Migrations.AddDomainDto),
             EFCoreMigration.AddDictionaryDto => typeof(Migrations.AddDictionaryDtos),
             EFCoreMigration.AddContentTypeDtos => typeof(Migrations.AddContentTypeDtos),
+            EFCoreMigration.MemberPropertyTypeToEFCore => typeof(Migrations.MemberPropertyTypeToEFCore),
             _ => throw new ArgumentOutOfRangeException(nameof(migration), $@"Not expected migration value: {migration}")
         };
 }

--- a/src/Umbraco.Core/Persistence/Repositories/IContentTypeCommonRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IContentTypeCommonRepository.cs
@@ -12,9 +12,9 @@ namespace Umbraco.Cms.Core.Persistence.Repositories;
 public interface IContentTypeCommonRepository
 {
     /// <summary>
-    ///     Gets and cache all types.
+    ///     Gets and caches all types.
     /// </summary>
-    IEnumerable<IContentTypeComposition>? GetAllTypes();
+    Task<IEnumerable<IContentTypeComposition>?> GetAllTypesAsync();
 
     /// <summary>
     ///     Clears the cache.

--- a/src/Umbraco.Infrastructure/Migrations/EFCoreMigration.cs
+++ b/src/Umbraco.Infrastructure/Migrations/EFCoreMigration.cs
@@ -24,4 +24,5 @@ public enum EFCoreMigration
     AddConsentDto = 16,
     AddDictionaryDto = 17,
     AddContentTypeDtos = 18,
+    MemberPropertyTypeToEFCore = 19,
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -120,6 +120,7 @@ public partial class UmbracoPlan : MigrationPlan
         To<V_18_0_0.AddDistributedJobDto>("{62FE7B44-AA9A-4B2F-8ECF-263E4E6C2AFA}");
         To<V_18_0_0.AddConsentDto>("{34EEA465-0378-4319-85B7-DBD2C7613741}");
         To<V_18_0_0.AddContentTypeDtos>("{56319F0E-879F-43DE-9865-3B85A63D3C5B}");
+        To<V_18_0_0.AddMemberPropertyTypeDto>("{11905736-2BC5-492C-8DCA-17500E774855}");
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/AddMemberPropertyTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/AddMemberPropertyTypeDto.cs
@@ -1,0 +1,22 @@
+using Umbraco.Cms.Persistence.EFCore.Migrations;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_18_0_0;
+
+public class AddMemberPropertyTypeDto : AsyncMigrationBase
+{
+    private readonly IEFCoreMigrationExecutor _migrationExecutor;
+
+    public AddMemberPropertyTypeDto(
+        IMigrationContext context,
+        IEFCoreMigrationExecutor migrationExecutor)
+        : base(context)
+    {
+        _migrationExecutor = migrationExecutor;
+    }
+
+    protected override async Task MigrateAsync()
+    {
+        // NO-OP migration to ensure that EF Core doesn't complain about missing migrations.
+        await _migrationExecutor.ExecuteSingleMigrationAsync(EFCoreMigration.MemberPropertyTypeToEFCore);
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/MemberPropertyTypeDtoConfiguration.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/Configurations/MemberPropertyTypeDtoConfiguration.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Configurations;
+
+public class MemberPropertyTypeDtoConfiguration : IEntityTypeConfiguration<MemberPropertyTypeDto>
+{
+    public void Configure(EntityTypeBuilder<MemberPropertyTypeDto> builder)
+    {
+        builder.ToTable(MemberPropertyTypeDto.TableName);
+
+        builder.HasKey(x => x.PrimaryKey);
+
+        builder.Property(x => x.PrimaryKey)
+            .HasColumnName(MemberPropertyTypeDto.PrimaryKeyColumnName)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(x => x.NodeId)
+            .HasColumnName("NodeId");
+
+        builder.Property(x => x.PropertyTypeId)
+            .HasColumnName(MemberPropertyTypeDto.PropertyTypeIdColumnName);
+
+        builder.Property(x => x.CanEdit)
+            .HasColumnName("memberCanEdit")
+            .HasDefaultValue(false);
+
+        builder.Property(x => x.ViewOnProfile)
+            .HasColumnName("viewOnProfile")
+            .HasDefaultValue(false);
+
+        builder.Property(x => x.IsSensitive)
+            .HasColumnName("isSensitive")
+            .HasDefaultValue(false);
+
+        builder.HasOne(x => x.PropertyTypeDto)
+            .WithOne(x => x.MemberPropertyTypeDto)
+            .HasForeignKey<MemberPropertyTypeDto>(x => x.PropertyTypeId)
+            .OnDelete(DeleteBehavior.NoAction)
+            .HasConstraintName($"FK_{MemberPropertyTypeDto.TableName}_{PropertyTypeDto.TableName}");
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/MemberPropertyTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/MemberPropertyTypeDto.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore.Configurations;
+
+namespace Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore;
+
+[EntityTypeConfiguration(typeof(MemberPropertyTypeDtoConfiguration))]
+public sealed class MemberPropertyTypeDto
+{
+    public const string TableName = Constants.DatabaseSchema.Tables.MemberPropertyType;
+    public const string PrimaryKeyColumnName = Constants.DatabaseSchema.Columns.PrimaryKeyNamePk;
+    public const string PropertyTypeIdColumnName = "propertytypeId";
+
+    public int PrimaryKey { get; set; }
+
+    public int NodeId { get; set; }
+
+    public int PropertyTypeId { get; set; }
+
+    public bool CanEdit { get; set; }
+
+    public bool ViewOnProfile { get; set; }
+
+    public bool IsSensitive { get; set; }
+
+    public PropertyTypeDto PropertyTypeDto { get; set; } = null!;
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/PropertyTypeDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/EFCore/PropertyTypeDto.cs
@@ -110,4 +110,10 @@ public class PropertyTypeDto
     /// Gets or sets the <see cref="EFCore.PropertyTypeGroupDto"/> this property type belongs to, if any.
     /// </summary>
     public PropertyTypeGroupDto? PropertyTypeGroupDto { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="EFCore.MemberPropertyTypeDto"/> extending this property type with member-specific
+    /// metadata, if any (only present for property types on member types).
+    /// </summary>
+    public MemberPropertyTypeDto? MemberPropertyTypeDto { get; set; }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Factories/EFCore/ContentTypeFactory.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Factories/EFCore/ContentTypeFactory.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Extensions;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Strings;
 using Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Factories.EFCore;
@@ -9,6 +11,92 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Factories.EFCore;
 // EF Core factory for IContentType (document types), IMediaType (media types) and IMemberType (member types).
 internal static class ContentTypeFactory
 {
+    /// <summary>
+    /// Creates and initializes an <see cref="IContentType"/> entity from the specified <see cref="ContentTypeDto"/>.
+    /// </summary>
+    public static IContentType BuildContentTypeEntity(IShortStringHelper shortStringHelper, ContentTypeDto dto)
+    {
+        var contentType = new ContentType(shortStringHelper, dto.NodeDto.ParentId);
+        try
+        {
+            contentType.DisableChangeTracking();
+            BuildCommonEntity(contentType, dto);
+            contentType.ResetDirtyProperties(false);
+            return contentType;
+        }
+        finally
+        {
+            contentType.EnableChangeTracking();
+        }
+    }
+
+    /// <summary>
+    /// Creates and initializes an <see cref="IMediaType"/> entity from the specified <see cref="ContentTypeDto"/>.
+    /// </summary>
+    public static IMediaType BuildMediaTypeEntity(IShortStringHelper shortStringHelper, ContentTypeDto dto)
+    {
+        var contentType = new MediaType(shortStringHelper, dto.NodeDto.ParentId);
+        try
+        {
+            contentType.DisableChangeTracking();
+            BuildCommonEntity(contentType, dto);
+            contentType.ResetDirtyProperties(false);
+        }
+        finally
+        {
+            contentType.EnableChangeTracking();
+        }
+
+        return contentType;
+    }
+
+    /// <summary>
+    /// Creates and initializes an <see cref="IMemberType"/> entity from the specified <see cref="ContentTypeDto"/>.
+    /// </summary>
+    public static IMemberType BuildMemberTypeEntity(IShortStringHelper shortStringHelper, ContentTypeDto dto)
+    {
+        var contentType = new MemberType(shortStringHelper, dto.NodeDto.ParentId);
+        try
+        {
+            contentType.DisableChangeTracking();
+            BuildCommonEntity(contentType, dto, setVariations: false);
+            contentType.ResetDirtyProperties(false);
+        }
+        finally
+        {
+            contentType.EnableChangeTracking();
+        }
+
+        return contentType;
+    }
+
+    private static void BuildCommonEntity(ContentTypeBase entity, ContentTypeDto dto, bool setVariations = true)
+    {
+        entity.Id = dto.NodeDto.NodeId;
+        entity.Key = dto.NodeDto.UniqueId;
+        entity.Alias = dto.Alias ?? string.Empty;
+        entity.Name = dto.NodeDto.Text;
+        entity.Icon = dto.Icon;
+        entity.Thumbnail = dto.Thumbnail;
+        entity.SortOrder = dto.NodeDto.SortOrder;
+        entity.Description = dto.Description;
+        entity.CreateDate = dto.NodeDto.CreateDate.EnsureUtc();
+        entity.UpdateDate = dto.NodeDto.CreateDate.EnsureUtc();
+        entity.Path = dto.NodeDto.Path;
+        entity.Level = dto.NodeDto.Level;
+        entity.CreatorId = dto.NodeDto.UserId ?? Constants.Security.UnknownUserId;
+        entity.AllowedAsRoot = dto.AllowAtRoot;
+        entity.ListView = dto.ListView;
+        entity.IsElement = dto.IsElement;
+        entity.AllowedInLibrary = dto.AllowedInLibrary;
+        entity.Trashed = dto.NodeDto.Trashed;
+
+        if (setVariations)
+        {
+            entity.Variations = (ContentVariation)dto.Variations;
+        }
+    }
+
     /// <summary>
     /// Creates a <see cref="ContentTypeDto"/> (including its nested <see cref="NodeDto"/>) from the specified
     /// <see cref="IContentTypeBase"/> entity. Determines the appropriate node object type based on the entity's

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -1,4 +1,4 @@
-using NPoco;
+using Microsoft.EntityFrameworkCore;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Exceptions;
@@ -6,9 +6,10 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Persistence.Repositories;
 using Umbraco.Cms.Core.Strings;
-using Umbraco.Cms.Infrastructure.Persistence.Dtos;
-using Umbraco.Cms.Infrastructure.Persistence.Factories;
-using Umbraco.Cms.Infrastructure.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore;
+using Umbraco.Cms.Infrastructure.Persistence.EFCore.Scoping;
+using Umbraco.Cms.Infrastructure.Persistence.Factories.EFCore;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
@@ -22,7 +23,7 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
         "Umbraco.Core.Persistence.Repositories.Implement.ContentTypeCommonRepository::AllTypes";
 
     private readonly AppCaches _appCaches;
-    private readonly IScopeAccessor _scopeAccessor;
+    private readonly IEFCoreScopeAccessor<UmbracoDbContext> _scopeAccessor;
     private readonly IShortStringHelper _shortStringHelper;
     private readonly ITemplateRepository _templateRepository;
 
@@ -30,7 +31,7 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
     ///     Initializes a new instance of the <see cref="IContentTypeCommonRepository" /> class.
     /// </summary>
     public ContentTypeCommonRepository(
-        IScopeAccessor scopeAccessor,
+        IEFCoreScopeAccessor<UmbracoDbContext> scopeAccessor,
         ITemplateRepository templateRepository,
         AppCaches appCaches,
         IShortStringHelper shortStringHelper)
@@ -41,19 +42,12 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
         _shortStringHelper = shortStringHelper;
     }
 
-    private IScope? AmbientScope => _scopeAccessor.AmbientScope;
-
-    private IUmbracoDatabase? Database => AmbientScope?.Database;
-
-    private ISqlContext? SqlContext => AmbientScope?.SqlContext;
-
-    // private Sql<ISqlContext> Sql(string sql, params object[] args) => SqlContext.Sql(sql, args);
-    // private ISqlSyntaxProvider SqlSyntax => SqlContext.SqlSyntax;
-    // private IQuery<T> Query<T>() => SqlContext.Query<T>();
+    private IEFCoreScope<UmbracoDbContext> AmbientScope
+        => _scopeAccessor.AmbientScope
+           ?? throw new InvalidOperationException("Cannot run a repository without an ambient scope.");
 
     /// <inheritdoc />
     public IEnumerable<IContentTypeComposition>? GetAllTypes() =>
-
         // use a sliding cache - same as FullDataSet cache policy
         _appCaches.RuntimeCache.GetCacheItem(CacheKey, GetAllTypesInternal, RepositoryCacheConstants.DefaultCacheDuration, true);
 
@@ -62,132 +56,141 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
 
     private IEnumerable<IContentTypeComposition> GetAllTypesInternal()
     {
-        var contentTypes = new Dictionary<int, IContentTypeComposition>();
-
-        if (SqlContext is null)
-        {
-            return contentTypes.Values;
-        }
-
-        // get content types
-        Sql<ISqlContext> sql1 = SqlContext.Sql()
-            .Select<ContentTypeDto>(r => r.Select(x => x.NodeDto))
-            .From<ContentTypeDto>()
-            .InnerJoin<NodeDto>().On<ContentTypeDto, NodeDto>((ct, n) => ct.NodeId == n.NodeId)
-            .OrderBy<ContentTypeDto>(x => x.NodeId);
-
-        List<ContentTypeDto>? contentTypeDtos = Database?.Fetch<ContentTypeDto>(sql1);
-
-        // get allowed content types
-        Sql<ISqlContext> sql2 = SqlContext.Sql()
-            .Select<ContentTypeAllowedContentTypeDto>()
-            .From<ContentTypeAllowedContentTypeDto>()
-            .OrderBy<ContentTypeAllowedContentTypeDto>(x => x.Id);
-
-        List<ContentTypeAllowedContentTypeDto>? allowedDtos = Database?.Fetch<ContentTypeAllowedContentTypeDto>(sql2);
-
-        if (contentTypeDtos is null)
-        {
-            return contentTypes.Values;
-        }
-
-        // prepare
-        // note: same alias could be used for media, content... but always different ids = ok
-        var aliases = contentTypeDtos.ToDictionary(x => x.NodeId, x => x.Alias);
-        var keys = contentTypeDtos.ToDictionary(x => x.NodeId, x => x.NodeDto.UniqueId);
-
-        // create
-        var allowedDtoIx = 0;
-        foreach (ContentTypeDto contentTypeDto in contentTypeDtos)
-        {
-            // create content type
-            IContentTypeComposition contentType;
-            if (contentTypeDto.NodeDto.NodeObjectType == Constants.ObjectTypes.MediaType)
-            {
-                contentType = ContentTypeFactory.BuildMediaTypeEntity(_shortStringHelper, contentTypeDto);
-            }
-            else if (contentTypeDto.NodeDto.NodeObjectType == Constants.ObjectTypes.DocumentType)
-            {
-                contentType = ContentTypeFactory.BuildContentTypeEntity(_shortStringHelper, contentTypeDto);
-            }
-            else if (contentTypeDto.NodeDto.NodeObjectType == Constants.ObjectTypes.MemberType)
-            {
-                contentType = ContentTypeFactory.BuildMemberTypeEntity(_shortStringHelper, contentTypeDto);
-            }
-            else
-            {
-                throw new PanicException(
-                    $"The node object type {contentTypeDto.NodeDto.NodeObjectType} is not supported");
-            }
-
-            contentTypes.Add(contentType.Id, contentType);
-
-            // map allowed content types
-            var allowedContentTypes = new List<ContentTypeSort>();
-            while (allowedDtoIx < allowedDtos?.Count && allowedDtos[allowedDtoIx].Id == contentTypeDto.NodeId)
-            {
-                ContentTypeAllowedContentTypeDto allowedDto = allowedDtos[allowedDtoIx];
-                if (!aliases.TryGetValue(allowedDto.AllowedId, out var alias)
-                    || !keys.TryGetValue(allowedDto.AllowedId, out Guid key))
-                {
-                    continue;
-                }
-
-                allowedContentTypes.Add(new ContentTypeSort(
-                    key,
-                    allowedDto.SortOrder,
-                    alias!));
-                allowedDtoIx++;
-            }
-
-            contentType.AllowedContentTypes = allowedContentTypes;
-        }
-
-        MapTemplates(contentTypes);
-        MapComposition(contentTypes);
-        MapGroupsAndProperties(contentTypes);
-        MapHistoryCleanup(contentTypes);
-
-        // finalize
-        foreach (IContentTypeComposition contentType in contentTypes.Values)
-        {
-            contentType.ResetDirtyProperties(false);
-        }
-
-        return contentTypes.Values;
+        // Touch the scope on the synchronous caller context before entering the async flow, ensuring that
+        // async-local scope state (including bridge-scope enlistment) is captured on this execution context.
+        EnsureAmbientScopeOnCallerContext();
+        return GetAllTypesAsync().GetAwaiter().GetResult();
     }
 
-    private void MapHistoryCleanup(Dictionary<int, IContentTypeComposition> contentTypes)
+    private void EnsureAmbientScopeOnCallerContext() => _ = AmbientScope;
+
+    private async Task<IEnumerable<IContentTypeComposition>> GetAllTypesAsync()
     {
-        if (SqlContext is null)
+        return await AmbientScope.ExecuteWithContextAsync<IEnumerable<IContentTypeComposition>>(async db =>
         {
-            return;
-        }
+            // Query 1: content types with their nodes, ordered so pointer-walking below works
+            List<ContentTypeDto> contentTypeDtos = await db.ContentTypes
+                .Include(ct => ct.NodeDto)
+                .OrderBy(ct => ct.NodeId)
+                .ToListAsync();
 
-        // get templates
-        Sql<ISqlContext> sql1 = SqlContext.Sql()
-            .Select<ContentVersionCleanupPolicyDto>()
-            .From<ContentVersionCleanupPolicyDto>()
-            .OrderBy<ContentVersionCleanupPolicyDto>(x => x.ContentTypeId);
+            if (contentTypeDtos.Count == 0)
+            {
+                return [];
+            }
 
-        List<ContentVersionCleanupPolicyDto>? contentVersionCleanupPolicyDtos =
-            Database?.Fetch<ContentVersionCleanupPolicyDto>(sql1);
+            // Query 2: allowed content types (parent content type id is ordered to align with Query 1)
+            List<ContentTypeAllowedContentTypeDto> allowedDtos = await db.ContentTypeAllowedContentTypes
+                .OrderBy(a => a.Id)
+                .ToListAsync();
 
-        var contentVersionCleanupPolicyDictionary =
-            contentVersionCleanupPolicyDtos?.ToDictionary(x => x.ContentTypeId);
+            // Query 3: property type groups, ordered for the group pointer-walk in MapGroupsAndProperties
+            List<PropertyTypeGroupDto> groupDtos = await db.PropertyTypeGroups
+                .OrderBy(g => g.ContentTypeNodeId)
+                .ThenBy(g => g.SortOrder)
+                .ThenBy(g => g.Id)
+                .ToListAsync();
+
+            // Query 4: all property types with data type info and optional member-specific metadata
+            List<PropertyTypeDto> propertyDtos = await db.PropertyTypes
+                .Include(pt => pt.DataTypeDto).ThenInclude(dt => dt.NodeDto)
+                .Include(pt => pt.MemberPropertyTypeDto)
+                .OrderBy(pt => pt.ContentTypeId)
+                .ThenBy(pt => pt.SortOrder)
+                .ThenBy(pt => pt.Id)
+                .ToListAsync();
+
+            // Query 5: composition (parent-child content type hierarchy)
+            List<ContentType2ContentTypeDto> compositionDtos = await db.ContentTypeComposition
+                .OrderBy(c => c.ChildId)
+                .ToListAsync();
+
+            // Query 6: template associations (document types only)
+            List<ContentTypeTemplateDto> templateDtos = await db.ContentTypeTemplates
+                .OrderBy(t => t.ContentTypeNodeId)
+                .ToListAsync();
+
+            // Query 7: per-content-type version cleanup policies (document types only)
+            List<ContentVersionCleanupPolicyDto> cleanupDtos = await db.ContentVersionCleanupPolicies
+                .OrderBy(p => p.ContentTypeId)
+                .ToListAsync();
+
+            // Build alias and key lookups for resolving AllowedContentTypes
+            var aliases = contentTypeDtos.ToDictionary(x => x.NodeId, x => x.Alias);
+            var keys = contentTypeDtos.ToDictionary(x => x.NodeId, x => x.NodeDto.UniqueId);
+
+            // Instantiate content type entities and wire up allowed child types
+            var contentTypes = new Dictionary<int, IContentTypeComposition>(contentTypeDtos.Count);
+            var allowedIx = 0;
+            foreach (ContentTypeDto dto in contentTypeDtos)
+            {
+                IContentTypeComposition contentType;
+                if (dto.NodeDto.NodeObjectType == Constants.ObjectTypes.MediaType)
+                {
+                    contentType = ContentTypeFactory.BuildMediaTypeEntity(_shortStringHelper, dto);
+                }
+                else if (dto.NodeDto.NodeObjectType == Constants.ObjectTypes.DocumentType)
+                {
+                    contentType = ContentTypeFactory.BuildContentTypeEntity(_shortStringHelper, dto);
+                }
+                else if (dto.NodeDto.NodeObjectType == Constants.ObjectTypes.MemberType)
+                {
+                    contentType = ContentTypeFactory.BuildMemberTypeEntity(_shortStringHelper, dto);
+                }
+                else
+                {
+                    throw new PanicException($"The node object type {dto.NodeDto.NodeObjectType} is not supported");
+                }
+
+                contentTypes.Add(contentType.Id, contentType);
+
+                var allowedContentTypes = new List<ContentTypeSort>();
+                while (allowedIx < allowedDtos.Count && allowedDtos[allowedIx].Id == dto.NodeId)
+                {
+                    ContentTypeAllowedContentTypeDto allowedDto = allowedDtos[allowedIx];
+                    if (aliases.TryGetValue(allowedDto.AllowedId, out var alias)
+                        && keys.TryGetValue(allowedDto.AllowedId, out Guid key))
+                    {
+                        allowedContentTypes.Add(new ContentTypeSort(key, allowedDto.SortOrder, alias!));
+                    }
+
+                    allowedIx++;
+                }
+
+                contentType.AllowedContentTypes = allowedContentTypes;
+            }
+
+            MapTemplates(contentTypes, templateDtos);
+            MapComposition(contentTypes, compositionDtos);
+            MapGroupsAndProperties(contentTypes, groupDtos, propertyDtos);
+            MapHistoryCleanup(contentTypes, cleanupDtos);
+
+            foreach (IContentTypeComposition contentType in contentTypes.Values)
+            {
+                contentType.ResetDirtyProperties(false);
+            }
+
+            return contentTypes.Values;
+        });
+    }
+
+    private static void MapHistoryCleanup(
+        Dictionary<int, IContentTypeComposition> contentTypes,
+        List<ContentVersionCleanupPolicyDto> cleanupDtos)
+    {
+        Dictionary<int, ContentVersionCleanupPolicyDto> cleanupByContentTypeId =
+            cleanupDtos.ToDictionary(x => x.ContentTypeId);
+
         foreach (IContentTypeComposition c in contentTypes.Values)
         {
-            if (!(c is ContentType contentType))
+            if (c is not ContentType contentType)
             {
                 continue;
             }
 
             var historyCleanup = new HistoryCleanup();
 
-            if (contentVersionCleanupPolicyDictionary is not null &&
-                contentVersionCleanupPolicyDictionary.TryGetValue(
-                    contentType.Id,
-                    out ContentVersionCleanupPolicyDto? versionCleanup))
+            if (cleanupByContentTypeId.TryGetValue(contentType.Id, out ContentVersionCleanupPolicyDto? versionCleanup))
             {
                 historyCleanup.PreventCleanup = versionCleanup.PreventCleanup;
                 historyCleanup.KeepAllVersionsNewerThanDays = versionCleanup.KeepAllVersionsNewerThanDays;
@@ -198,26 +201,16 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
         }
     }
 
-    private void MapTemplates(Dictionary<int, IContentTypeComposition> contentTypes)
+    private void MapTemplates(
+        Dictionary<int, IContentTypeComposition> contentTypes,
+        List<ContentTypeTemplateDto> templateDtos)
     {
-        if (SqlContext is null)
-        {
-            return;
-        }
-
-        // get templates
-        Sql<ISqlContext> sql1 = SqlContext.Sql()
-            .Select<ContentTypeTemplateDto>()
-            .From<ContentTypeTemplateDto>()
-            .OrderBy<ContentTypeTemplateDto>(x => x.ContentTypeNodeId);
-
-        List<ContentTypeTemplateDto>? templateDtos = Database?.Fetch<ContentTypeTemplateDto>(sql1);
-
-        // var templates = templateRepository.GetMany(templateDtos.Select(x => x.TemplateNodeId).ToArray()).ToDictionary(x => x.Id, x => x);
         IEnumerable<ITemplate>? allTemplates = _templateRepository.GetMany((int[]?)null);
+        Dictionary<int, ITemplate> templates = allTemplates.ToDictionary(x => x.Id, x => x);
 
-        var templates = allTemplates.ToDictionary(x => x.Id, x => x);
-        var templateDtoIx = 0;
+        Dictionary<int, List<ContentTypeTemplateDto>> templatesByContentTypeId = templateDtos
+            .GroupBy(t => t.ContentTypeNodeId)
+            .ToDictionary(g => g.Key, g => g.ToList());
 
         foreach (IContentTypeComposition c in contentTypes.Values)
         {
@@ -226,24 +219,24 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
                 continue;
             }
 
-            // map allowed templates
             var allowedTemplates = new List<ITemplate>();
             var defaultTemplateId = 0;
-            while (templateDtoIx < templateDtos?.Count &&
-                   templateDtos[templateDtoIx].ContentTypeNodeId == contentType.Id)
+
+            if (templatesByContentTypeId.TryGetValue(contentType.Id, out List<ContentTypeTemplateDto>? contentTypeTemplateDtos))
             {
-                ContentTypeTemplateDto allowedDto = templateDtos[templateDtoIx];
-                templateDtoIx++;
-                if (!templates.TryGetValue(allowedDto.TemplateNodeId, out ITemplate? template))
+                foreach (ContentTypeTemplateDto templateDto in contentTypeTemplateDtos)
                 {
-                    continue;
-                }
+                    if (!templates.TryGetValue(templateDto.TemplateNodeId, out ITemplate? template))
+                    {
+                        continue;
+                    }
 
-                allowedTemplates.Add(template);
+                    allowedTemplates.Add(template);
 
-                if (allowedDto.IsDefault)
-                {
-                    defaultTemplateId = template.Id;
+                    if (templateDto.IsDefault)
+                    {
+                        defaultTemplateId = template.Id;
+                    }
                 }
             }
 
@@ -252,130 +245,95 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
         }
     }
 
-    private void MapComposition(IDictionary<int, IContentTypeComposition> contentTypes)
+    private static void MapComposition(
+        IDictionary<int, IContentTypeComposition> contentTypes,
+        List<ContentType2ContentTypeDto> compositionDtos)
     {
-        if (SqlContext is null)
-        {
-            return;
-        }
+        Dictionary<int, List<ContentType2ContentTypeDto>> compositionByChildId = compositionDtos
+            .GroupBy(c => c.ChildId)
+            .ToDictionary(g => g.Key, g => g.ToList());
 
-        // get parent/child
-        Sql<ISqlContext> sql1 = SqlContext.Sql()
-            .Select<ContentType2ContentTypeDto>()
-            .From<ContentType2ContentTypeDto>()
-            .OrderBy<ContentType2ContentTypeDto>(x => x.ChildId);
-
-        List<ContentType2ContentTypeDto>? compositionDtos = Database?.Fetch<ContentType2ContentTypeDto>(sql1);
-
-        // map
-        var compositionIx = 0;
         foreach (IContentTypeComposition contentType in contentTypes.Values)
         {
-            while (compositionIx < compositionDtos?.Count &&
-                   compositionDtos[compositionIx].ChildId == contentType.Id)
+            if (!compositionByChildId.TryGetValue(contentType.Id, out List<ContentType2ContentTypeDto>? parents))
             {
-                ContentType2ContentTypeDto parentDto = compositionDtos[compositionIx];
-                compositionIx++;
+                continue;
+            }
 
-                if (!contentTypes.TryGetValue(parentDto.ParentId, out IContentTypeComposition? parentContentType))
+            foreach (ContentType2ContentTypeDto parentDto in parents)
+            {
+                if (contentTypes.TryGetValue(parentDto.ParentId, out IContentTypeComposition? parentContentType))
                 {
-                    continue;
+                    contentType.AddContentType(parentContentType);
                 }
-
-                contentType.AddContentType(parentContentType);
             }
         }
     }
 
-    private void MapGroupsAndProperties(IDictionary<int, IContentTypeComposition> contentTypes)
+    private void MapGroupsAndProperties(
+        IDictionary<int, IContentTypeComposition> contentTypes,
+        List<PropertyTypeGroupDto> groupDtos,
+        List<PropertyTypeDto> propertyDtos)
     {
-        if (SqlContext is null)
-        {
-            return;
-        }
-
-        Sql<ISqlContext> sql1 = SqlContext.Sql()
-            .Select<PropertyTypeGroupDto>()
-            .From<PropertyTypeGroupDto>()
-            .InnerJoin<ContentTypeDto>()
-            .On<PropertyTypeGroupDto, ContentTypeDto>((ptg, ct) => ptg.ContentTypeNodeId == ct.NodeId)
-            .OrderBy<ContentTypeDto>(x => x.NodeId)
-            .AndBy<PropertyTypeGroupDto>(x => x.SortOrder, x => x.Id);
-
-        List<PropertyTypeGroupDto>? groupDtos = Database?.Fetch<PropertyTypeGroupDto>(sql1);
-
-        Sql<ISqlContext> sql2 = SqlContext.Sql()
-            .Select<PropertyTypeDto>(r => r.Select(x => x.DataTypeDto, r1 => r1.Select(x => x.NodeDto)))
-            .AndSelect<MemberPropertyTypeDto>()
-            .From<PropertyTypeDto>()
-            .InnerJoin<DataTypeDto>().On<PropertyTypeDto, DataTypeDto>((pt, dt) => pt.DataTypeId == dt.NodeId)
-            .InnerJoin<NodeDto>().On<DataTypeDto, NodeDto>((dt, n) => dt.NodeId == n.NodeId)
-            .InnerJoin<ContentTypeDto>()
-            .On<PropertyTypeDto, ContentTypeDto>((pt, ct) => pt.ContentTypeId == ct.NodeId)
-            .LeftJoin<PropertyTypeGroupDto>()
-            .On<PropertyTypeDto, PropertyTypeGroupDto>((pt, ptg) => pt.PropertyTypeGroupId == ptg.Id)
-            .LeftJoin<MemberPropertyTypeDto>()
-            .On<PropertyTypeDto, MemberPropertyTypeDto>((pt, mpt) => pt.Id == mpt.PropertyTypeId)
-            .OrderBy<ContentTypeDto>(x => x.NodeId)
-            .AndBy<
-                PropertyTypeGroupDto>(
-                    x => x.SortOrder,
-                    x => x.Id) // NULLs will come first or last, never mind, we deal with it below
-            .AndBy<PropertyTypeDto>(x => x.SortOrder, x => x.Id);
-
-        List<PropertyTypeCommonDto>? propertyDtos = Database?.Fetch<PropertyTypeCommonDto>(sql2);
         Dictionary<string, PropertyType> builtinProperties =
             ConventionsHelper.GetStandardPropertyTypeStubs(_shortStringHelper);
 
-        var groupIx = 0;
-        var propertyIx = 0;
+        // Index grouped properties by group id, sorted by position within each group
+        Dictionary<int, List<PropertyTypeDto>> propertiesByGroupId = propertyDtos
+            .Where(pt => pt.PropertyTypeGroupId.HasValue)
+            .GroupBy(pt => pt.PropertyTypeGroupId!.Value)
+            .ToDictionary(g => g.Key, g => g.OrderBy(pt => pt.SortOrder).ThenBy(pt => pt.Id).ToList());
+
+        // Index group-less properties by content type id, sorted by position
+        Dictionary<int, List<PropertyTypeDto>> noGroupPropertiesByContentTypeId = propertyDtos
+            .Where(pt => !pt.PropertyTypeGroupId.HasValue)
+            .GroupBy(pt => pt.ContentTypeId)
+            .ToDictionary(g => g.Key, g => g.OrderBy(pt => pt.SortOrder).ThenBy(pt => pt.Id).ToList());
+
+        // Index groups by content type id (already ordered: ContentTypeNodeId → SortOrder → Id)
+        Dictionary<int, List<PropertyTypeGroupDto>> groupsByContentTypeId = groupDtos
+            .GroupBy(g => g.ContentTypeNodeId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
         foreach (IContentTypeComposition contentType in contentTypes.Values)
         {
-            // only IContentType is publishing
             var isPublishing = contentType is IContentType;
 
-            // get group-less properties (in case NULL is ordered first)
+            // Group-less properties
             var noGroupPropertyTypes = new PropertyTypeCollection(isPublishing);
-            while (propertyIx < propertyDtos?.Count && propertyDtos[propertyIx].ContentTypeId == contentType.Id &&
-                   propertyDtos[propertyIx].PropertyTypeGroupId == null)
+            if (noGroupPropertiesByContentTypeId.TryGetValue(contentType.Id, out List<PropertyTypeDto>? ungroupedProps))
             {
-                noGroupPropertyTypes.Add(MapPropertyType(contentType, propertyDtos[propertyIx], builtinProperties));
-                propertyIx++;
+                foreach (PropertyTypeDto pt in ungroupedProps)
+                {
+                    noGroupPropertyTypes.Add(MapPropertyType(contentType, pt, builtinProperties));
+                }
             }
 
-            // get groups and their properties
+            // Property groups and their properties
             var groupCollection = new PropertyGroupCollection();
-            while (groupIx < groupDtos?.Count && groupDtos[groupIx].ContentTypeNodeId == contentType.Id)
+            if (groupsByContentTypeId.TryGetValue(contentType.Id, out List<PropertyTypeGroupDto>? groups))
             {
-                PropertyGroup group = MapPropertyGroup(groupDtos[groupIx], isPublishing);
-                groupCollection.Add(group);
-                groupIx++;
-
-                while (propertyIx < propertyDtos?.Count &&
-                       propertyDtos[propertyIx].ContentTypeId == contentType.Id &&
-                       propertyDtos[propertyIx].PropertyTypeGroupId == group.Id)
+                foreach (PropertyTypeGroupDto groupDto in groups)
                 {
-                    group.PropertyTypes?.Add(MapPropertyType(contentType, propertyDtos[propertyIx], builtinProperties));
-                    propertyIx++;
+                    PropertyGroup group = MapPropertyGroup(groupDto, isPublishing);
+                    groupCollection.Add(group);
+
+                    if (propertiesByGroupId.TryGetValue(groupDto.Id, out List<PropertyTypeDto>? groupProps))
+                    {
+                        foreach (PropertyTypeDto pt in groupProps)
+                        {
+                            group.PropertyTypes?.Add(MapPropertyType(contentType, pt, builtinProperties));
+                        }
+                    }
                 }
             }
 
             contentType.PropertyGroups = groupCollection;
-
-            // get group-less properties (in case NULL is ordered last)
-            while (propertyIx < propertyDtos?.Count && propertyDtos[propertyIx].ContentTypeId == contentType.Id &&
-                   propertyDtos[propertyIx].PropertyTypeGroupId == null)
-            {
-                noGroupPropertyTypes.Add(MapPropertyType(contentType, propertyDtos[propertyIx], builtinProperties));
-                propertyIx++;
-            }
-
             contentType.NoGroupPropertyTypes = noGroupPropertyTypes;
 
-            // ensure builtin properties
+            // Ensure standard built-in property types exist on member types
             if (contentType is IMemberType memberType)
             {
-                // ensure that property types exist (ok if they already exist)
                 foreach ((var alias, PropertyType propertyType) in builtinProperties)
                 {
                     var added = memberType.AddPropertyType(
@@ -407,7 +365,7 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
 
     private PropertyType MapPropertyType(
         IContentTypeComposition contentType,
-        PropertyTypeCommonDto dto,
+        PropertyTypeDto dto,
         IDictionary<string, PropertyType> builtinProperties)
     {
         var groupId = dto.PropertyTypeGroupId;
@@ -419,9 +377,9 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
 
         if (contentType is IMemberType memberType && dto.Alias is not null)
         {
-            memberType.SetIsSensitiveProperty(dto.Alias, dto.IsSensitive);
-            memberType.SetMemberCanEditProperty(dto.Alias, dto.CanEdit);
-            memberType.SetMemberCanViewProperty(dto.Alias, dto.ViewOnProfile);
+            memberType.SetIsSensitiveProperty(dto.Alias, dto.MemberPropertyTypeDto?.IsSensitive ?? false);
+            memberType.SetMemberCanEditProperty(dto.Alias, dto.MemberPropertyTypeDto?.CanEdit ?? false);
+            memberType.SetMemberCanViewProperty(dto.Alias, dto.MemberPropertyTypeDto?.ViewOnProfile ?? false);
         }
 
         return new PropertyType(_shortStringHelper, dto.DataTypeDto.EditorAlias, storageType, readonlyStorageType, dto.Alias)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -48,19 +48,33 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
 
     /// <inheritdoc />
     public Task<IEnumerable<IContentTypeComposition>?> GetAllTypesAsync()
-        => _appCaches.RuntimeCache.GetCacheItemAsync<IEnumerable<IContentTypeComposition>>(
+    {
+        EnsureAmbientScopeOnCallerContext();
+
+        return _appCaches.RuntimeCache.GetCacheItemAsync<IEnumerable<IContentTypeComposition>>(
             CacheKey,
             async () => await FetchAllTypesFromDatabaseAsync(),
             RepositoryCacheConstants.DefaultCacheDuration,
             isSliding: true);
+    }
 
     /// <inheritdoc />
     public void ClearCache() => _appCaches.RuntimeCache.Clear(CacheKey);
 
+    /// <summary>
+    /// Touches the ambient EF Core scope on the caller's execution context before entering the async flow.
+    /// AsyncLocal changes made inside an async method are invisible to its synchronous caller, so when this
+    /// repository is bridged from synchronous callers (e.g. <c>GetAllTypesAsync().GetAwaiter().GetResult()</c>
+    /// in the NPoco media/member type repositories) and the bridge scope were first created inside the async
+    /// flow, the ambient scope stack bookkeeping would diverge, leaving a stale scope ambient for subsequent
+    /// operations.
+    /// </summary>
+    private void EnsureAmbientScopeOnCallerContext() => _ = AmbientScope;
+
     private async Task<IEnumerable<IContentTypeComposition>> FetchAllTypesFromDatabaseAsync() =>
         await AmbientScope.ExecuteWithContextAsync<IEnumerable<IContentTypeComposition>>(async db =>
         {
-            // Query 1: content types with their nodes, ordered so pointer-walking below works
+            // Query 1: content types with their nodes
             List<ContentTypeDto> contentTypeDtos = await db.ContentTypes
                 .Include(ct => ct.NodeDto)
                 .OrderBy(ct => ct.NodeId)
@@ -71,9 +85,8 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
                 return [];
             }
 
-            // Query 2: allowed content types (parent content type id is ordered to align with Query 1)
+            // Query 2: allowed content types
             List<ContentTypeAllowedContentTypeDto> allowedDtos = await db.ContentTypeAllowedContentTypes
-                .OrderBy(a => a.Id)
                 .ToListAsync();
 
             // Query 3: property type groups, ordered for the group pointer-walk in MapGroupsAndProperties
@@ -107,13 +120,8 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
                 .OrderBy(p => p.ContentTypeId)
                 .ToListAsync();
 
-            // Build alias and key lookups for resolving AllowedContentTypes
-            var aliases = contentTypeDtos.ToDictionary(x => x.NodeId, x => x.Alias);
-            var keys = contentTypeDtos.ToDictionary(x => x.NodeId, x => x.NodeDto.UniqueId);
-
-            // Instantiate content type entities and wire up allowed child types
+            // Instantiate content type entities; all relationships are wired up by the Map* calls below
             var contentTypes = new Dictionary<int, IContentTypeComposition>(contentTypeDtos.Count);
-            var allowedIx = 0;
             foreach (ContentTypeDto dto in contentTypeDtos)
             {
                 IContentTypeComposition contentType;
@@ -135,25 +143,11 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
                 }
 
                 contentTypes.Add(contentType.Id, contentType);
-
-                var allowedContentTypes = new List<ContentTypeSort>();
-                while (allowedIx < allowedDtos.Count && allowedDtos[allowedIx].Id == dto.NodeId)
-                {
-                    ContentTypeAllowedContentTypeDto allowedDto = allowedDtos[allowedIx];
-                    if (aliases.TryGetValue(allowedDto.AllowedId, out var alias)
-                        && keys.TryGetValue(allowedDto.AllowedId, out Guid key))
-                    {
-                        allowedContentTypes.Add(new ContentTypeSort(key, allowedDto.SortOrder, alias!));
-                    }
-
-                    allowedIx++;
-                }
-
-                contentType.AllowedContentTypes = allowedContentTypes;
             }
 
+            MapAllowedContentTypes(contentTypes, allowedDtos);
             MapTemplates(contentTypes, templateDtos);
-            MapComposition(contentTypes, compositionDtos);
+            MapCompositions(contentTypes, compositionDtos);
             MapGroupsAndProperties(contentTypes, groupDtos, propertyDtos);
             MapHistoryCleanup(contentTypes, cleanupDtos);
 
@@ -165,30 +159,33 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
             return contentTypes.Values;
         });
 
-    private static void MapHistoryCleanup(
-        Dictionary<int, IContentTypeComposition> contentTypes,
-        List<ContentVersionCleanupPolicyDto> cleanupDtos)
+    private static void MapAllowedContentTypes(
+        IDictionary<int, IContentTypeComposition> contentTypes,
+        List<ContentTypeAllowedContentTypeDto> allowedDtos)
     {
-        Dictionary<int, ContentVersionCleanupPolicyDto> cleanupByContentTypeId =
-            cleanupDtos.ToDictionary(x => x.ContentTypeId);
+        // ContentTypeAllowedContentTypeDto.Id is the *parent* content type's node id
+        Dictionary<int, List<ContentTypeAllowedContentTypeDto>> allowedByParentId = allowedDtos
+            .GroupBy(a => a.Id)
+            .ToDictionary(g => g.Key, g => g.ToList());
 
-        foreach (IContentTypeComposition c in contentTypes.Values)
+        foreach (IContentTypeComposition contentType in contentTypes.Values)
         {
-            if (c is not ContentType contentType)
+            var allowedContentTypes = new List<ContentTypeSort>();
+            if (allowedByParentId.TryGetValue(contentType.Id, out List<ContentTypeAllowedContentTypeDto>? allowed))
             {
-                continue;
+                foreach (ContentTypeAllowedContentTypeDto allowedDto in allowed)
+                {
+                    if (contentTypes.TryGetValue(allowedDto.AllowedId, out IContentTypeComposition? allowedContentType))
+                    {
+                        allowedContentTypes.Add(new ContentTypeSort(
+                            allowedContentType.Key,
+                            allowedDto.SortOrder,
+                            allowedContentType.Alias));
+                    }
+                }
             }
 
-            var historyCleanup = new HistoryCleanup();
-
-            if (cleanupByContentTypeId.TryGetValue(contentType.Id, out ContentVersionCleanupPolicyDto? versionCleanup))
-            {
-                historyCleanup.PreventCleanup = versionCleanup.PreventCleanup;
-                historyCleanup.KeepAllVersionsNewerThanDays = versionCleanup.KeepAllVersionsNewerThanDays;
-                historyCleanup.KeepLatestVersionPerDayForDays = versionCleanup.KeepLatestVersionPerDayForDays;
-            }
-
-            contentType.HistoryCleanup = historyCleanup;
+            contentType.AllowedContentTypes = allowedContentTypes;
         }
     }
 
@@ -236,7 +233,7 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
         }
     }
 
-    private static void MapComposition(
+    private static void MapCompositions(
         IDictionary<int, IContentTypeComposition> contentTypes,
         List<ContentType2ContentTypeDto> compositionDtos)
     {
@@ -390,5 +387,32 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
             Variations = (ContentVariation)dto.Variations,
             LabelOnTop = dto.LabelOnTop,
         };
+    }
+
+    private static void MapHistoryCleanup(
+        Dictionary<int, IContentTypeComposition> contentTypes,
+        List<ContentVersionCleanupPolicyDto> cleanupDtos)
+    {
+        Dictionary<int, ContentVersionCleanupPolicyDto> cleanupByContentTypeId =
+            cleanupDtos.ToDictionary(x => x.ContentTypeId);
+
+        foreach (IContentTypeComposition c in contentTypes.Values)
+        {
+            if (c is not ContentType contentType)
+            {
+                continue;
+            }
+
+            var historyCleanup = new HistoryCleanup();
+
+            if (cleanupByContentTypeId.TryGetValue(contentType.Id, out ContentVersionCleanupPolicyDto? versionCleanup))
+            {
+                historyCleanup.PreventCleanup = versionCleanup.PreventCleanup;
+                historyCleanup.KeepAllVersionsNewerThanDays = versionCleanup.KeepAllVersionsNewerThanDays;
+                historyCleanup.KeepLatestVersionPerDayForDays = versionCleanup.KeepLatestVersionPerDayForDays;
+            }
+
+            contentType.HistoryCleanup = historyCleanup;
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentTypeCommonRepository.cs
@@ -47,26 +47,18 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
            ?? throw new InvalidOperationException("Cannot run a repository without an ambient scope.");
 
     /// <inheritdoc />
-    public IEnumerable<IContentTypeComposition>? GetAllTypes() =>
-        // use a sliding cache - same as FullDataSet cache policy
-        _appCaches.RuntimeCache.GetCacheItem(CacheKey, GetAllTypesInternal, RepositoryCacheConstants.DefaultCacheDuration, true);
+    public Task<IEnumerable<IContentTypeComposition>?> GetAllTypesAsync()
+        => _appCaches.RuntimeCache.GetCacheItemAsync<IEnumerable<IContentTypeComposition>>(
+            CacheKey,
+            async () => await FetchAllTypesFromDatabaseAsync(),
+            RepositoryCacheConstants.DefaultCacheDuration,
+            isSliding: true);
 
     /// <inheritdoc />
     public void ClearCache() => _appCaches.RuntimeCache.Clear(CacheKey);
 
-    private IEnumerable<IContentTypeComposition> GetAllTypesInternal()
-    {
-        // Touch the scope on the synchronous caller context before entering the async flow, ensuring that
-        // async-local scope state (including bridge-scope enlistment) is captured on this execution context.
-        EnsureAmbientScopeOnCallerContext();
-        return GetAllTypesAsync().GetAwaiter().GetResult();
-    }
-
-    private void EnsureAmbientScopeOnCallerContext() => _ = AmbientScope;
-
-    private async Task<IEnumerable<IContentTypeComposition>> GetAllTypesAsync()
-    {
-        return await AmbientScope.ExecuteWithContextAsync<IEnumerable<IContentTypeComposition>>(async db =>
+    private async Task<IEnumerable<IContentTypeComposition>> FetchAllTypesFromDatabaseAsync() =>
+        await AmbientScope.ExecuteWithContextAsync<IEnumerable<IContentTypeComposition>>(async db =>
         {
             // Query 1: content types with their nodes, ordered so pointer-walking below works
             List<ContentTypeDto> contentTypeDtos = await db.ContentTypes
@@ -172,7 +164,6 @@ internal sealed class ContentTypeCommonRepository : IContentTypeCommonRepository
 
             return contentTypes.Values;
         });
-    }
 
     private static void MapHistoryCleanup(
         Dictionary<int, IContentTypeComposition> contentTypes,

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EFCore/AsyncContentTypeRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/EFCore/AsyncContentTypeRepositoryBase.cs
@@ -114,8 +114,8 @@ internal abstract class AsyncContentTypeRepositoryBase<TEntity> : AsyncEntityRep
         => Task.FromResult(GetAllCached().FirstOrDefault(x => x.Key == key));
 
     /// <inheritdoc />
-    protected override Task<IEnumerable<TEntity>?> PerformGetAllAsync()
-        => Task.FromResult(CommonRepository.GetAllTypes()?.OfType<TEntity>());
+    protected override async Task<IEnumerable<TEntity>?> PerformGetAllAsync()
+        => (await CommonRepository.GetAllTypesAsync())?.OfType<TEntity>();
 
     /// <inheritdoc />
     protected override Task<IEnumerable<TEntity>?> PerformGetManyAsync(Guid[]? keys)

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MediaTypeRepository.cs
@@ -74,7 +74,7 @@ internal sealed class MediaTypeRepository : ContentTypeRepositoryBase<IMediaType
         => GetMany().FirstOrDefault(x => x.Id == id);
 
     protected override IEnumerable<IMediaType>? GetAllWithFullCachePolicy() =>
-        CommonRepository.GetAllTypes()?.OfType<IMediaType>();
+        CommonRepository.GetAllTypesAsync().GetAwaiter().GetResult()?.OfType<IMediaType>();
 
     protected override IEnumerable<IMediaType> PerformGetByQuery(IQuery<IMediaType> query)
     {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/MemberTypeRepository.cs
@@ -79,7 +79,7 @@ internal sealed class MemberTypeRepository : ContentTypeRepositoryBase<IMemberTy
         => GetMany().FirstOrDefault(x => x.Id == id);
 
     protected override IEnumerable<IMemberType>? GetAllWithFullCachePolicy() =>
-        CommonRepository.GetAllTypes()?.OfType<IMemberType>();
+        CommonRepository.GetAllTypesAsync().GetAwaiter().GetResult()?.OfType<IMemberType>();
 
     protected override IEnumerable<IMemberType> PerformGetByQuery(IQuery<IMemberType> query)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ContentTypeRepositoryTest.cs
@@ -228,8 +228,9 @@ internal sealed class ContentTypeRepositoryTest : UmbracoIntegrationTest
     {
         appCaches ??= AppCaches;
 
+        var efCoreScopeAccessor = GetRequiredService<IEFCoreScopeAccessor<UmbracoDbContext>>();
         var commonRepository =
-            new ContentTypeCommonRepository(scopeAccessor, TemplateRepository, appCaches, ShortStringHelper);
+            new ContentTypeCommonRepository(efCoreScopeAccessor, TemplateRepository, appCaches, ShortStringHelper);
 
         return new ContentTypeRepository(
             appCaches,
@@ -239,7 +240,7 @@ internal sealed class ContentTypeRepositoryTest : UmbracoIntegrationTest
             Mock.Of<IRepositoryCacheVersionService>(),
             IdKeyMap,
             Mock.Of<ICacheSyncService>(),
-            GetRequiredService<IEFCoreScopeAccessor<UmbracoDbContext>>());
+            efCoreScopeAccessor);
     }
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/DocumentRepositoryTest.cs
@@ -131,9 +131,9 @@ internal sealed class DocumentRepositoryTest : UmbracoIntegrationTest
 
         templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), LoggerFactory, FileSystems, ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object,  Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
-        var commonRepository =
-            new ContentTypeCommonRepository(scopeAccessor, templateRepository, appCaches, ShortStringHelper);
         var efCoreScopeAccessor = GetRequiredService<IEFCoreScopeAccessor<UmbracoDbContext>>();
+        var commonRepository =
+            new ContentTypeCommonRepository(efCoreScopeAccessor, templateRepository, appCaches, ShortStringHelper);
         var languageRepository =
             new LanguageRepository(efCoreScopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         contentTypeRepository = new ContentTypeRepository(appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>(), efCoreScopeAccessor);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ElementRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/ElementRepositoryTest.cs
@@ -77,9 +77,9 @@ public class ElementRepositoryTest : UmbracoIntegrationTest
 
         var templateRepository = new TemplateRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TemplateRepository>(), LoggerFactory, GetRequiredService<FileSystems>(), ShortStringHelper, Mock.Of<IViewHelper>(), runtimeSettingsMock.Object,  Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         var tagRepository = new TagRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
-        var commonRepository =
-            new ContentTypeCommonRepository(scopeAccessor, templateRepository, appCaches, ShortStringHelper);
         var efCoreScopeAccessor = GetRequiredService<IEFCoreScopeAccessor<UmbracoDbContext>>();
+        var commonRepository =
+            new ContentTypeCommonRepository(efCoreScopeAccessor, templateRepository, appCaches, ShortStringHelper);
         var languageRepository =
             new LanguageRepository(efCoreScopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         contentTypeRepository = new ContentTypeRepository(appCaches, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>(), efCoreScopeAccessor);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/MediaRepositoryTest.cs
@@ -53,9 +53,9 @@ internal sealed class MediaRepositoryTest : UmbracoIntegrationTest
     {
         appCaches ??= AppCaches.NoCache;
         var scopeAccessor = (IScopeAccessor)provider;
-        var commonRepository =
-            new ContentTypeCommonRepository(scopeAccessor, TemplateRepository, appCaches, ShortStringHelper);
         var efCoreScopeAccessor = GetRequiredService<IEFCoreScopeAccessor<UmbracoDbContext>>();
+        var commonRepository =
+            new ContentTypeCommonRepository(efCoreScopeAccessor, TemplateRepository, appCaches, ShortStringHelper);
         var languageRepository =
             new LanguageRepository(efCoreScopeAccessor, appCaches, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
         mediaTypeRepository = new MediaTypeRepository(scopeAccessor, appCaches, LoggerFactory.CreateLogger<MediaTypeRepository>(), commonRepository, languageRepository, ShortStringHelper, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>());

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -519,7 +519,7 @@ internal sealed class TemplateRepositoryTest : UmbracoIntegrationTest
             var serializer = new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory());
             var tagRepository = new TagRepository(scopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<TagRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
             var commonRepository =
-                new ContentTypeCommonRepository(scopeAccessor, templateRepository, AppCaches, ShortStringHelper);
+                new ContentTypeCommonRepository(newScopeAccessor, templateRepository, AppCaches, ShortStringHelper);
             var languageRepository = new LanguageRepository(newScopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<LanguageRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());
             var contentTypeRepository = new ContentTypeRepository(AppCaches.Disabled, LoggerFactory.CreateLogger<ContentTypeRepository>(), commonRepository, languageRepository, Mock.Of<IRepositoryCacheVersionService>(), IdKeyMap, Mock.Of<ICacheSyncService>(), newScopeAccessor);
             var relationTypeRepository = new RelationTypeRepository(newScopeAccessor, AppCaches.Disabled, LoggerFactory.CreateLogger<RelationTypeRepository>(), Mock.Of<IRepositoryCacheVersionService>(), Mock.Of<ICacheSyncService>());


### PR DESCRIPTION
# Notes 
- Migrates the `ICommonContentTypeRepository` to EFCore
- ⚠️ I have left the TODO in the interface, about renaming this to `ContentTypeRepository` to make it less breaking. I feel like it doesn't have enough value to rename this.
