### PR TITLE
Document Url Service: Always get published value (closes #23206)

### DIFF
--- a/src/Umbraco.Core/Persistence/Repositories/IDocumentUrlAliasRepository.cs
+++ b/src/Umbraco.Core/Persistence/Repositories/IDocumentUrlAliasRepository.cs
@@ -27,6 +27,13 @@ public interface IDocumentUrlAliasRepository
     void DeleteByDocumentKey(IEnumerable<Guid> documentKeys);
 
     /// <summary>
+    /// Deletes every persisted alias, i.e. for a full rebuild that repopulates the table from scratch.
+    /// </summary>
+    // TODO (V19): Remove the default implementation.
+    void DeleteAll()
+        => DeleteByDocumentKey(GetAll().Select(x => x.DocumentKey).Distinct());
+
+    /// <summary>
     /// Gets all document aliases.
     /// </summary>
     /// <returns>Raw alias data from documents with umbracoUrlAlias property.</returns>

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -33,7 +33,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     /// By doing this we can keep the same logic for rebuild on startup after a migration, provide a means of triggering
     /// a rebuild, and we have future-proofing in case the alias parsing logic changes in future versions.
     /// Bumped to "2" so that installs which persisted draft alias values (before aliases were restricted to the
-    /// published property value) rebuild once on startup and flush the stale entries.
+    /// published property value, see #23206) rebuild once on startup and flush the stale entries.
     /// </remarks>
     private const string CurrentRebuildValue = "2";
 
@@ -451,10 +451,8 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
 
         scope.WriteLock(Constants.Locks.DocumentUrlAliases);
 
-        // A rebuild is authoritative, so clear the whole table first and repopulate from scratch. Deleting only the
-        // keys still returned by the query above would orphan rows for documents whose published alias was removed,
-        // or that only had a draft alias persisted by an older version (before aliases were restricted to the
-        // published value), and InitAsync would reload those straight back into the routing cache.
+        // Clear the table first and repopulate from scratch in case the rebuild no longer includes document URL aliases
+        // that are currently stored.
         _documentUrlAliasRepository.DeleteAll();
 
         if (toSave.Count > 0)

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -32,8 +32,10 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
     /// Here, however, the alias parsing logic is internal and not customizable, so we simply use a constant value.
     /// By doing this we can keep the same logic for rebuild on startup after a migration, provide a means of triggering
     /// a rebuild, and we have future-proofing in case the alias parsing logic changes in future versions.
+    /// Bumped to "2" so that installs which persisted draft alias values (before aliases were restricted to the
+    /// published property value) rebuild once on startup and flush the stale entries.
     /// </remarks>
-    private const string CurrentRebuildValue = "1";
+    private const string CurrentRebuildValue = "2";
 
     private readonly ILogger<DocumentUrlAliasService> _logger;
     private readonly IDocumentUrlAliasRepository _documentUrlAliasRepository;

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -418,7 +418,6 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         // Use optimized SQL query to fetch only documents with aliases
         IEnumerable<DocumentUrlAliasRaw> rawAliases = _documentUrlAliasRepository.GetAllDocumentUrlAliases();
 
-        var documentKeys = rawAliases.Select(x => x.DocumentKey).Distinct().ToList();
         var toSave = new List<PublishedDocumentUrlAlias>();
 
         foreach (DocumentUrlAliasRaw raw in rawAliases)
@@ -450,9 +449,14 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
             }
         }
 
-        // Clear existing database records and save new
         scope.WriteLock(Constants.Locks.DocumentUrlAliases);
-        _documentUrlAliasRepository.DeleteByDocumentKey(documentKeys);
+
+        // A rebuild is authoritative, so clear the whole table first and repopulate from scratch. Deleting only the
+        // keys still returned by the query above would orphan rows for documents whose published alias was removed,
+        // or that only had a draft alias persisted by an older version (before aliases were restricted to the
+        // published value), and InitAsync would reload those straight back into the routing cache.
+        _documentUrlAliasRepository.DeleteAll();
+
         if (toSave.Count > 0)
         {
             _documentUrlAliasRepository.Save(toSave);

--- a/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
+++ b/src/Umbraco.Core/Services/DocumentUrlAliasService.cs
@@ -485,7 +485,9 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         // Store alias for ALL languages (like DocumentUrlService).
         if (document.ContentType.VariesByCulture() is false || aliasPropertyVariesByCulture is false)
         {
-            var aliasValue = document.GetValue<string>(Constants.Conventions.Content.UrlAlias);
+            // Aliases are routing data for the published site, so only the published property value counts -
+            // GetValue(published: true) returns null until the document is actually published.
+            var aliasValue = document.GetValue<string>(Constants.Conventions.Content.UrlAlias, published: true);
 
             if (!string.IsNullOrWhiteSpace(aliasValue))
             {
@@ -507,7 +509,7 @@ public class DocumentUrlAliasService : IDocumentUrlAliasService
         IEnumerable<ILanguage> languages = await _languageService.GetAllAsync();
         foreach (ILanguage language in languages)
         {
-            var aliasValue = document.GetValue<string>(Constants.Conventions.Content.UrlAlias, language.IsoCode);
+            var aliasValue = document.GetValue<string>(Constants.Conventions.Content.UrlAlias, language.IsoCode, published: true);
 
             if (string.IsNullOrWhiteSpace(aliasValue))
             {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentUrlAliasRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentUrlAliasRepository.cs
@@ -105,6 +105,10 @@ internal class DocumentUrlAliasRepository : IDocumentUrlAliasRepository
     }
 
     /// <inheritdoc/>
+    public void DeleteAll()
+        => Database.Execute(Database.SqlContext.Sql().Delete<DocumentUrlAliasDto>());
+
+    /// <inheritdoc/>
     /// <remarks>
     /// This gets all document aliases directly from property data (using an optimized SQL query).
     /// This is more efficient than loading all IContent objects.

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentUrlAliasRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/DocumentUrlAliasRepository.cs
@@ -108,6 +108,9 @@ internal class DocumentUrlAliasRepository : IDocumentUrlAliasRepository
     /// <remarks>
     /// This gets all document aliases directly from property data (using an optimized SQL query).
     /// This is more efficient than loading all IContent objects.
+    /// Aliases are routing data for the published site, so this reads the published version's property
+    /// data (joined via <see cref="DocumentVersionDto"/>) rather than the current/draft version - a draft
+    /// edit to an alias must not affect routing until the document is actually published.
     /// </remarks>
     public IEnumerable<DocumentUrlAliasRaw> GetAllDocumentUrlAliases()
     {
@@ -117,9 +120,10 @@ internal class DocumentUrlAliasRepository : IDocumentUrlAliasRepository
             .From<PropertyDataDto>("pd")
             .InnerJoin<PropertyTypeDto>("pt").On<PropertyDataDto, PropertyTypeDto>((pd, pt) => pd.PropertyTypeId == pt.Id, "pd", "pt")
             .InnerJoin<ContentVersionDto>("cv").On<PropertyDataDto, ContentVersionDto>((pd, cv) => pd.VersionId == cv.Id, "pd", "cv")
+            .InnerJoin<DocumentVersionDto>("dv").On<ContentVersionDto, DocumentVersionDto>((cv, dv) => cv.Id == dv.Id, "cv", "dv")
             .InnerJoin<NodeDto>("n").On<ContentVersionDto, NodeDto>((cv, n) => cv.NodeId == n.NodeId, "cv", "n")
             .Where<PropertyTypeDto>(pt => pt.Alias == Constants.Conventions.Content.UrlAlias, "pt")
-            .Where<ContentVersionDto>(cv => cv.Current == true, "cv")
+            .Where<DocumentVersionDto>(dv => dv.Published == true, "dv")
             .Where<NodeDto>(n => n.Trashed == false, "n")
             .Where<NodeDto>(n => n.NodeObjectType == Constants.ObjectTypes.Document, "n") // Exclude blueprints
             .Append($"AND (pd.{QuotedColName("textValue")} IS NOT NULL OR pd.{QuotedColName("varcharValue")} IS NOT NULL)");

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -877,6 +877,51 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public async Task RebuildAllAliasesAsync_Ignores_Alias_For_Unpublished_Culture()
+    {
+        // Arrange - a second language and a culture-variant content type with a culture-varied alias.
+        var secondLanguage = new LanguageBuilder()
+            .WithCultureInfo("fr-FR")
+            .WithIsDefault(false)
+            .Build();
+        await LanguageService.CreateAsync(secondLanguage, Constants.Security.SuperUserKey);
+
+        var defaultIsoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+
+        var template = TemplateBuilder.CreateTextPageTemplate("unpublishCultureTemplate");
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        var variantContentType = CreateCultureVariantContentTypeWithUrlAlias(template.Id, "pageWithAliasUnpublishCulture");
+        await ContentTypeService.CreateAsync(variantContentType, Constants.Security.SuperUserKey);
+
+        var content = new ContentBuilder()
+            .WithContentType(variantContentType)
+            .WithCultureName(defaultIsoCode, "Multi Culture Page")
+            .WithCultureName("fr-FR", "Page Multi Culture")
+            .Build();
+        content.ParentId = RootPage.Id;
+        content.SetValue(Constants.Conventions.Content.UrlAlias, "default-culture-alias", defaultIsoCode);
+        content.SetValue(Constants.Conventions.Content.UrlAlias, "french-culture-alias", "fr-FR");
+        ContentService.Save(content, -1);
+        ContentService.Publish(content, [defaultIsoCode, "fr-FR"]);
+
+        await DocumentUrlAliasService.CreateOrUpdateAliasesAsync(content.Key);
+
+        // Sanity check - both aliases resolve while both cultures are published.
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("default-culture-alias", defaultIsoCode), Does.Contain(content.Key));
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("french-culture-alias", "fr-FR"), Does.Contain(content.Key));
+
+        // Act - unpublish only the French culture (the document stays published via the default culture),
+        // then rebuild the whole table from scratch.
+        ContentService.Unpublish(content, "fr-FR");
+        await DocumentUrlAliasService.RebuildAllAliasesAsync();
+
+        // Assert - the still-published culture's alias resolves; the unpublished culture's alias does not.
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("default-culture-alias", defaultIsoCode), Does.Contain(content.Key));
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("french-culture-alias", "fr-FR"), Is.Empty);
+    }
+
+    [Test]
     public async Task RebuildAllAliasesAsync_Handles_Empty_Database()
     {
         // Arrange - clear all aliases from documents

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -821,6 +821,26 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public async Task RebuildAllAliasesAsync_Ignores_Draft_Alias_Edit_On_Published_Document()
+    {
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+        var documentKey = new Guid(PageWithSingleAliasKey);
+
+        // The page is published (from setup) with alias "my-single-alias". Edit the alias as a draft only.
+        var content = ContentService.GetById(documentKey)!;
+        content.SetValue(Constants.Conventions.Content.UrlAlias, "my-single-alias-draft-edit");
+        ContentService.Save(content, -1);
+
+        // Act - a full rebuild (as happens on startup after the rebuild key changes) must read the
+        // published property value, not the current draft one.
+        await DocumentUrlAliasService.RebuildAllAliasesAsync();
+
+        // Assert - the published alias should still resolve; the unpublished draft alias should not.
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("my-single-alias", isoCode), Does.Contain(documentKey));
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("my-single-alias-draft-edit", isoCode), Is.Empty);
+    }
+
+    [Test]
     public async Task RebuildAllAliasesAsync_Handles_Empty_Database()
     {
         // Arrange - clear all aliases from documents

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -1272,5 +1272,44 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
         Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("my-single-alias-draft-edit", isoCode), Is.Empty);
     }
 
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_Ignores_Draft_Alias_Edit_On_Published_Variant_Culture()
+    {
+        // Arrange - create a culture-variant content type with a CULTURE-VARIED umbracoUrlAlias property,
+        // publish one culture with an alias, then edit that culture's alias as a draft without re-publishing.
+        var template = TemplateBuilder.CreateTextPageTemplate("variantDraftEditTemplate");
+        await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);
+
+        var variantContentType = CreateCultureVariantContentTypeWithUrlAlias(template.Id, "pageWithVariantAliasDraftEdit");
+        await ContentTypeService.CreateAsync(variantContentType, Constants.Security.SuperUserKey);
+
+        var defaultLanguage = (await LanguageService.GetDefaultLanguageAsync())!;
+
+        var content = new ContentBuilder()
+            .WithContentType(variantContentType)
+            .WithCultureName(defaultLanguage.IsoCode, "Page With Variant Alias Draft Edit")
+            .Build();
+        content.SetValue(Constants.Conventions.Content.UrlAlias, "variant-published-alias", defaultLanguage.IsoCode);
+        content.ParentId = RootPage.Id;
+        ContentService.Save(content, -1);
+        ContentService.Publish(content, [defaultLanguage.IsoCode]);
+
+        await DocumentUrlAliasService.CreateOrUpdateAliasesAsync(content.Key);
+
+        // Sanity check - the published alias resolves before the draft edit.
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("variant-published-alias", defaultLanguage.IsoCode), Does.Contain(content.Key));
+
+        // Act - edit the alias for the published culture and save without re-publishing.
+        var draftContent = ContentService.GetById(content.Key)!;
+        draftContent.SetValue(Constants.Conventions.Content.UrlAlias, "variant-draft-alias", defaultLanguage.IsoCode);
+        ContentService.Save(draftContent, -1);
+
+        await DocumentUrlAliasService.CreateOrUpdateAliasesAsync(draftContent.Key);
+
+        // Assert - the published alias should still resolve; the unpublished draft alias should not.
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("variant-published-alias", defaultLanguage.IsoCode), Does.Contain(content.Key));
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("variant-draft-alias", defaultLanguage.IsoCode), Is.Empty);
+    }
+
     #endregion
 }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -841,6 +841,42 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
     }
 
     [Test]
+    public async Task RebuildAllAliasesAsync_Removes_Orphaned_Alias_For_Document_Without_Published_Alias()
+    {
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+        var documentKey = new Guid(PageWithNoAliasKey);
+
+        // Simulate a stale row persisted by an older (buggy) version: an alias row exists in the table for a
+        // published document whose published version has no umbracoUrlAlias value. The rebuild must clear it.
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            DocumentUrlAliasRepository.Save(new[]
+            {
+                new PublishedDocumentUrlAlias
+                {
+                    DocumentKey = documentKey,
+                    NullableLanguageId = null,
+                    Alias = "orphaned-alias",
+                },
+            });
+        }
+
+        // Act - rebuild.
+        await DocumentUrlAliasService.RebuildAllAliasesAsync();
+
+        // Assert - the orphaned alias is gone from the database (and so cannot be reloaded into the cache).
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("orphaned-alias", isoCode), Is.Empty);
+
+        List<PublishedDocumentUrlAlias> storedAliases;
+        using (CoreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            storedAliases = DocumentUrlAliasRepository.GetAll().Where(a => a.DocumentKey == documentKey).ToList();
+        }
+
+        Assert.That(storedAliases, Is.Empty);
+    }
+
+    [Test]
     public async Task RebuildAllAliasesAsync_Handles_Empty_Database()
     {
         // Arrange - clear all aliases from documents

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentUrlAliasServiceTests.cs
@@ -1230,4 +1230,47 @@ internal sealed class DocumentUrlAliasServiceTests : UmbracoIntegrationTest
     }
 
     #endregion
+
+    #region Draft Alias Should Not Affect Published Routing (Issue #23206)
+
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_Ignores_Draft_Alias_Colliding_With_Published_Alias_On_Another_Document()
+    {
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+
+        // Page A is already published (from setup) with alias "my-single-alias".
+        // Page B is saved as a draft only, reusing the same alias.
+        var pageB = ContentBuilder.CreateSimpleContent(ContentType, "Page B", RootPage.Id);
+        pageB.SetValue(Constants.Conventions.Content.UrlAlias, "my-single-alias");
+        ContentService.Save(pageB, -1);
+
+        await DocumentUrlAliasService.CreateOrUpdateAliasesAsync(pageB.Key);
+
+        // Only the published page (A) should resolve for the shared alias - the unpublished
+        // draft (B) must not evict or shadow it.
+        var result = (await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("my-single-alias", isoCode)).ToList();
+
+        Assert.That(result, Does.Contain(new Guid(PageWithSingleAliasKey)), "Published page should still resolve for the alias.");
+        Assert.That(result, Does.Not.Contain(pageB.Key), "Unpublished draft should not be resolvable via the alias.");
+    }
+
+    [Test]
+    public async Task CreateOrUpdateAliasesAsync_Ignores_Draft_Alias_Edit_On_Published_Document()
+    {
+        var isoCode = (await LanguageService.GetDefaultLanguageAsync()).IsoCode;
+        var documentKey = new Guid(PageWithSingleAliasKey);
+
+        // Re-fetch the published content and change its alias without publishing.
+        var content = ContentService.GetById(documentKey)!;
+        content.SetValue(Constants.Conventions.Content.UrlAlias, "my-single-alias-draft-edit");
+        ContentService.Save(content, -1);
+
+        await DocumentUrlAliasService.CreateOrUpdateAliasesAsync(content.Key);
+
+        // The still-published alias should keep resolving; the unpublished draft alias should not.
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("my-single-alias", isoCode), Does.Contain(documentKey));
+        Assert.That(await DocumentUrlAliasService.GetDocumentKeysByAliasAsync("my-single-alias-draft-edit", isoCode), Is.Empty);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/23206

# Notes
- Fixes the bug by always passing `published: true`, when we are getting the values, thanks to the detailed issue description, this was an easy fix 🙌 
- Also added tests to prove this works now 😁 

# How to test
- Follow steps in linked issue