### PR TITLE
File Uploads: Add extensibility seam for storage paths (closes #21652)

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/IFileUploadPathResolver.cs
+++ b/src/Umbraco.Core/PropertyEditors/IFileUploadPathResolver.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+/// Resolves the storage path for a file managed by the file upload property editor (or an editor derived from it).
+/// </summary>
+/// <remarks>
+/// This is distinct from <see cref="IO.IMediaPathScheme"/>: the path scheme is the low-level, system-wide layout of
+/// media files, whereas this resolver is a configuration-aware strategy scoped to the file upload editor. Replace the
+/// registered implementation (via <c>AddUnique</c>) to control where uploaded and copied files are stored — for example
+/// to prepend a prefix read from a custom data type configuration.
+/// </remarks>
+public interface IFileUploadPathResolver
+{
+    /// <summary>
+    /// Resolves the filesystem-relative path at which a file should be stored.
+    /// </summary>
+    /// <param name="fileName">The name of the file being stored.</param>
+    /// <param name="dataTypeConfiguration">
+    /// The configuration of the data type owning the property, or <c>null</c> if unavailable. A custom
+    /// implementation can cast this to its own configuration type to vary the path per data type.
+    /// </param>
+    /// <param name="contentKey">The key of the content item owning the file.</param>
+    /// <param name="propertyTypeKey">The key of the property type owning the file.</param>
+    /// <returns>The filesystem-relative path to store the file at.</returns>
+    string ResolvePath(string fileName, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey);
+}

--- a/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.FileSystems.cs
+++ b/src/Umbraco.Infrastructure/DependencyInjection/UmbracoBuilder.FileSystems.cs
@@ -6,6 +6,8 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.IO.MediaPathSchemes;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Infrastructure.PropertyEditors;
 using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.DependencyInjection;
@@ -38,6 +40,9 @@ public static partial class UmbracoBuilderExtensions
 
         // register the scheme for media paths
         builder.Services.AddUnique<IMediaPathScheme, UniqueMediaPathScheme>();
+
+        // register the resolver that determines where file upload editor files are stored
+        builder.Services.AddUnique<IFileUploadPathResolver, FileUploadPathResolver>();
 
         builder.Services.AddUnique<IViewHelper, ViewHelper>();
         builder.Services.AddUnique<IDefaultViewContentProvider, DefaultViewContentProvider>();

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPathResolver.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPathResolver.cs
@@ -17,6 +17,7 @@ internal sealed class FileUploadPathResolver : IFileUploadPathResolver
     /// <summary>
     /// Initializes a new instance of the <see cref="FileUploadPathResolver"/> class.
     /// </summary>
+    /// <param name="mediaFileManager">Manages media file storage and computes the standard media path.</param>
     public FileUploadPathResolver(MediaFileManager mediaFileManager)
         => _mediaFileManager = mediaFileManager;
 

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPathResolver.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPathResolver.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.PropertyEditors;
+
+namespace Umbraco.Cms.Infrastructure.PropertyEditors;
+
+/// <summary>
+/// Default <see cref="IFileUploadPathResolver"/> that stores files using the standard media path scheme,
+/// ignoring the data type configuration.
+/// </summary>
+internal sealed class FileUploadPathResolver : IFileUploadPathResolver
+{
+    private readonly MediaFileManager _mediaFileManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileUploadPathResolver"/> class.
+    /// </summary>
+    public FileUploadPathResolver(MediaFileManager mediaFileManager)
+        => _mediaFileManager = mediaFileManager;
+
+    /// <inheritdoc/>
+    public string ResolvePath(string fileName, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
+        => _mediaFileManager.GetMediaPath(fileName, contentKey, propertyTypeKey);
+}

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
@@ -223,8 +223,8 @@ internal sealed class FileUploadPropertyValueEditor : DataValueEditor, IDisposab
             return null;
         }
 
-        // get the filepath
-        string filepath = GetMediaPath(file, dataTypeConfiguration, contentKey, propertyTypeKey);
+        // resolve the storage path; IFileUploadPathResolver is the point of extensibility for where files are stored
+        string filepath = _fileUploadPathResolver.ResolvePath(file.FileName, dataTypeConfiguration, contentKey, propertyTypeKey);
 
         using (Stream filestream = file.OpenReadStream())
         {
@@ -240,13 +240,6 @@ internal sealed class FileUploadPropertyValueEditor : DataValueEditor, IDisposab
 
         return filepath;
     }
-
-    /// <summary>
-    /// Provides media path.
-    /// </summary>
-    /// <returns>File system relative path</returns>
-    private string GetMediaPath(TemporaryFileModel file, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
-        => _fileUploadPathResolver.ResolvePath(file.FileName, dataTypeConfiguration, contentKey, propertyTypeKey);
 
     /// <summary>
     /// Releases the managed resources used by the <see cref="FileUploadPropertyValueEditor"/>, including any active subscriptions.

--- a/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/FileUploadPropertyValueEditor.cs
@@ -34,6 +34,7 @@ internal sealed class FileUploadPropertyValueEditor : DataValueEditor, IDisposab
     private readonly ITemporaryFileService _temporaryFileService;
     private readonly IScopeProvider _scopeProvider;
     private readonly IFileStreamSecurityValidator _fileStreamSecurityValidator;
+    private readonly IFileUploadPathResolver _fileUploadPathResolver;
     private readonly FileUploadValueParser _valueParser;
 
     private ContentSettings _contentSettings;
@@ -52,6 +53,7 @@ internal sealed class FileUploadPropertyValueEditor : DataValueEditor, IDisposab
     /// <param name="temporaryFileService">Manages temporary files used during file upload processes.</param>
     /// <param name="scopeProvider">Provides database scope management for transactional operations.</param>
     /// <param name="fileStreamSecurityValidator">Validates file streams for security during upload and access.</param>
+    /// <param name="fileUploadPathResolver">Resolves the storage path for uploaded files.</param>
     public FileUploadPropertyValueEditor(
         DataEditorAttribute attribute,
         MediaFileManager mediaFileManager,
@@ -61,13 +63,15 @@ internal sealed class FileUploadPropertyValueEditor : DataValueEditor, IDisposab
         IIOHelper ioHelper,
         ITemporaryFileService temporaryFileService,
         IScopeProvider scopeProvider,
-        IFileStreamSecurityValidator fileStreamSecurityValidator)
+        IFileStreamSecurityValidator fileStreamSecurityValidator,
+        IFileUploadPathResolver fileUploadPathResolver)
         : base(shortStringHelper, jsonSerializer, ioHelper, attribute)
     {
         _mediaFileManager = mediaFileManager;
         _temporaryFileService = temporaryFileService;
         _scopeProvider = scopeProvider;
         _fileStreamSecurityValidator = fileStreamSecurityValidator;
+        _fileUploadPathResolver = fileUploadPathResolver;
         _valueParser = new FileUploadValueParser(jsonSerializer);
 
         _contentSettings = contentSettings.CurrentValue;
@@ -242,10 +246,7 @@ internal sealed class FileUploadPropertyValueEditor : DataValueEditor, IDisposab
     /// </summary>
     /// <returns>File system relative path</returns>
     private string GetMediaPath(TemporaryFileModel file, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
-    {
-        // in case we are using the old path scheme, try to re-use numbers (bah...)
-        return _mediaFileManager.GetMediaPath(file.FileName, contentKey, propertyTypeKey);
-    }
+        => _fileUploadPathResolver.ResolvePath(file.FileName, dataTypeConfiguration, contentKey, propertyTypeKey);
 
     /// <summary>
     /// Releases the managed resources used by the <see cref="FileUploadPropertyValueEditor"/>, including any active subscriptions.

--- a/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentCopiedOrScaffoldedNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentCopiedOrScaffoldedNotificationHandler.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Cache.PropertyEditors;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
@@ -10,6 +11,7 @@ using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.PropertyEditors.NotificationHandlers;
 
@@ -23,6 +25,8 @@ internal sealed class FileUploadContentCopiedOrScaffoldedNotificationHandler : F
     INotificationHandler<ContentSavedBlueprintNotification>
 {
     private readonly IContentService _contentService;
+    private readonly IFileUploadPathResolver _fileUploadPathResolver;
+    private readonly IDataTypeConfigurationCache _dataTypeConfigurationCache;
     private readonly BlockEditorValues<BlockListValue, BlockListLayoutItem> _blockListEditorValues;
     private readonly BlockEditorValues<BlockGridValue, BlockGridLayoutItem> _blockGridEditorValues;
 
@@ -34,12 +38,17 @@ internal sealed class FileUploadContentCopiedOrScaffoldedNotificationHandler : F
         MediaFileManager mediaFileManager,
         IBlockEditorElementTypeCache elementTypeCache,
         ILogger<FileUploadContentCopiedOrScaffoldedNotificationHandler> logger,
-        IContentService contentService)
-        : base(jsonSerializer, mediaFileManager, elementTypeCache)
+        IContentService contentService,
+        PropertyEditorCollection propertyEditors,
+        IFileUploadPathResolver fileUploadPathResolver,
+        IDataTypeConfigurationCache dataTypeConfigurationCache)
+        : base(jsonSerializer, mediaFileManager, elementTypeCache, propertyEditors)
     {
         _blockListEditorValues = new(new BlockListEditorDataConverter(jsonSerializer), elementTypeCache, logger);
         _blockGridEditorValues = new(new BlockGridEditorDataConverter(jsonSerializer), elementTypeCache, logger);
         _contentService = contentService;
+        _fileUploadPathResolver = fileUploadPathResolver;
+        _dataTypeConfigurationCache = dataTypeConfigurationCache;
     }
 
     /// <inheritdoc/>
@@ -323,7 +332,21 @@ internal sealed class FileUploadContentCopiedOrScaffoldedNotificationHandler : F
     private string CopyFile(string sourceUrl, IContent destinationContent, IPropertyType propertyType)
     {
         var sourcePath = MediaFileManager.FileSystem.GetRelativePath(sourceUrl);
-        var copyPath = MediaFileManager.CopyFile(destinationContent, propertyType, sourcePath);
+
+        // The destination path is resolved via IFileUploadPathResolver and the file copied at the file system
+        // level directly, rather than via MediaFileManager.CopyFile, because the latter computes the destination
+        // path itself and so cannot honour a custom resolver (e.g. one that applies a per-data-type prefix).
+        // When the source file does not exist the copy path is left null, so GetUrl returns the media root url.
+        string? copyPath = null;
+        if (MediaFileManager.FileSystem.FileExists(sourcePath))
+        {
+            var fileName = Path.GetFileName(sourcePath);
+            object? dataTypeConfiguration = _dataTypeConfigurationCache.GetConfiguration(propertyType.DataTypeKey);
+            copyPath = _fileUploadPathResolver.ResolvePath(fileName, dataTypeConfiguration, destinationContent.Key, propertyType.Key);
+
+            MediaFileManager.FileSystem.CopyFile(sourcePath, copyPath);
+        }
+
         return MediaFileManager.FileSystem.GetUrl(copyPath);
     }
 }

--- a/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentCopiedOrScaffoldedNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentCopiedOrScaffoldedNotificationHandler.cs
@@ -33,6 +33,14 @@ internal sealed class FileUploadContentCopiedOrScaffoldedNotificationHandler : F
     /// <summary>
     /// Initializes a new instance of the <see cref="FileUploadContentCopiedOrScaffoldedNotificationHandler"/> class.
     /// </summary>
+    /// <param name="jsonSerializer">Serializes and deserializes property values.</param>
+    /// <param name="mediaFileManager">Manages media file storage operations.</param>
+    /// <param name="elementTypeCache">Caches block editor element types.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="contentService">Used to re-save content once copied files have been processed.</param>
+    /// <param name="propertyEditors">The collection of registered property editors, used to recognise upload fields.</param>
+    /// <param name="fileUploadPathResolver">Resolves the storage path for the copied file.</param>
+    /// <param name="dataTypeConfigurationCache">Provides the data type configuration passed to the path resolver.</param>
     public FileUploadContentCopiedOrScaffoldedNotificationHandler(
         IJsonSerializer jsonSerializer,
         MediaFileManager mediaFileManager,

--- a/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentDeletedNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentDeletedNotificationHandler.cs
@@ -39,8 +39,9 @@ internal sealed class FileUploadContentDeletedNotificationHandler : FileUploadNo
         MediaFileManager mediaFileManager,
         IBlockEditorElementTypeCache elementTypeCache,
         ILogger<FileUploadContentDeletedNotificationHandler> logger,
-        IOptionsMonitor<ContentSettings> contentSettngs)
-        : base(jsonSerializer, mediaFileManager, elementTypeCache)
+        IOptionsMonitor<ContentSettings> contentSettngs,
+        PropertyEditorCollection propertyEditors)
+        : base(jsonSerializer, mediaFileManager, elementTypeCache, propertyEditors)
     {
         _blockListEditorValues = new(new BlockListEditorDataConverter(jsonSerializer), elementTypeCache, logger);
         _blockGridEditorValues = new(new BlockGridEditorDataConverter(jsonSerializer), elementTypeCache, logger);

--- a/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentDeletedNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadContentDeletedNotificationHandler.cs
@@ -34,6 +34,12 @@ internal sealed class FileUploadContentDeletedNotificationHandler : FileUploadNo
     /// <summary>
     /// Initializes a new instance of the <see cref="FileUploadContentDeletedNotificationHandler"/> class.
     /// </summary>
+    /// <param name="jsonSerializer">Serializes and deserializes property values.</param>
+    /// <param name="mediaFileManager">Manages media file storage operations.</param>
+    /// <param name="elementTypeCache">Caches block editor element types.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="contentSettngs">Provides access to content-related configuration settings.</param>
+    /// <param name="propertyEditors">The collection of registered property editors, used to recognise upload fields.</param>
     public FileUploadContentDeletedNotificationHandler(
         IJsonSerializer jsonSerializer,
         MediaFileManager mediaFileManager,

--- a/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadMediaSavingNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadMediaSavingNotificationHandler.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Media;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Extensions;
 
@@ -27,13 +28,15 @@ internal sealed class FileUploadMediaSavingNotificationHandler : FileUploadNotif
     /// <param name="elementTypeCache">Caches block editor element types for efficient access during media processing.</param>
     /// <param name="contentSettings">Provides access to content-related configuration settings.</param>
     /// <param name="uploadAutoFillProperties">Handles automatic population of media properties during file upload.</param>
+    /// <param name="propertyEditors">The collection of registered property editors.</param>
     public FileUploadMediaSavingNotificationHandler(
         IJsonSerializer jsonSerializer,
         MediaFileManager mediaFileManager,
         IBlockEditorElementTypeCache elementTypeCache,
         IOptionsMonitor<ContentSettings> contentSettings,
-        UploadAutoFillProperties uploadAutoFillProperties)
-        : base(jsonSerializer, mediaFileManager, elementTypeCache)
+        UploadAutoFillProperties uploadAutoFillProperties,
+        PropertyEditorCollection propertyEditors)
+        : base(jsonSerializer, mediaFileManager, elementTypeCache, propertyEditors)
     {
         _contentSettings = contentSettings;
         _uploadAutoFillProperties = uploadAutoFillProperties;

--- a/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadNotificationHandlerBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadNotificationHandlerBase.cs
@@ -19,6 +19,10 @@ internal abstract class FileUploadNotificationHandlerBase
     /// <summary>
     /// Initializes a new instance of the <see cref="FileUploadNotificationHandlerBase"/> class.
     /// </summary>
+    /// <param name="jsonSerializer">Serializes and deserializes property values.</param>
+    /// <param name="mediaFileManager">Manages media file storage operations.</param>
+    /// <param name="elementTypeCache">Caches block editor element types.</param>
+    /// <param name="propertyEditors">The collection of registered property editors, used to recognise upload fields.</param>
     protected FileUploadNotificationHandlerBase(
         IJsonSerializer jsonSerializer,
         MediaFileManager mediaFileManager,

--- a/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadNotificationHandlerBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadNotificationHandlerBase.cs
@@ -14,18 +14,28 @@ namespace Umbraco.Cms.Infrastructure.PropertyEditors.NotificationHandlers;
 /// </summary>
 internal abstract class FileUploadNotificationHandlerBase
 {
+    private readonly HashSet<string> _uploadFieldPropertyEditorAliases;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="FileUploadNotificationHandlerBase"/> class.
     /// </summary>
     protected FileUploadNotificationHandlerBase(
         IJsonSerializer jsonSerializer,
         MediaFileManager mediaFileManager,
-        IBlockEditorElementTypeCache elementTypeCache)
+        IBlockEditorElementTypeCache elementTypeCache,
+        PropertyEditorCollection propertyEditors)
     {
         JsonSerializer = jsonSerializer;
         MediaFileManager = mediaFileManager;
         ElementTypeCache = elementTypeCache;
         FileUploadValueParser = new FileUploadValueParser(jsonSerializer);
+
+        // Cache the aliases of the file upload editor and any editors derived from it, so that recognising an
+        // upload field is a set lookup rather than a scan of the property editor collection per property.
+        _uploadFieldPropertyEditorAliases = propertyEditors
+            .Where(propertyEditor => propertyEditor is FileUploadPropertyEditor)
+            .Select(propertyEditor => propertyEditor.Alias)
+            .ToHashSet();
     }
 
     /// <summary>
@@ -55,8 +65,12 @@ internal abstract class FileUploadNotificationHandlerBase
     /// <returns>
     ///     <c>true</c> if the specified property is an upload field; otherwise, <c>false</c>.
     /// </returns>
-    protected static bool IsUploadFieldPropertyType(IPropertyType propertyType)
-        => propertyType.PropertyEditorAlias == Constants.PropertyEditors.Aliases.UploadField;
+    /// <remarks>
+    ///     Recognises the built-in file upload editor and any editor derived from
+    ///     <see cref="FileUploadPropertyEditor"/>.
+    /// </remarks>
+    protected bool IsUploadFieldPropertyType(IPropertyType propertyType)
+        => _uploadFieldPropertyEditorAliases.Contains(propertyType.PropertyEditorAlias);
 
     /// <summary>
     ///     Gets a value indicating whether a property is an block list field.

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadNotificationHandlerTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.PropertyEditors.NotificationHandlers;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.PropertyEditors;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class FileUploadNotificationHandlerTests : UmbracoIntegrationTest
+{
+    private const string Prefix = "copied-prefix";
+
+    private MediaFileManager MediaFileManager => GetRequiredService<MediaFileManager>();
+
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    // Prefix every resolved path so we can assert that the copy handler routes its destination path through
+    // IFileUploadPathResolver (rather than computing it directly). The file upload notification handlers are
+    // registered by AddCoreNotifications() (in the web layer), which the integration harness does not call, so
+    // they are registered here explicitly.
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.Services.AddUnique<IFileUploadPathResolver>(sp =>
+            new PrefixAllResolver(sp.GetRequiredService<MediaFileManager>(), Prefix));
+
+        builder.AddNotificationHandler<ContentCopiedNotification, FileUploadContentCopiedOrScaffoldedNotificationHandler>();
+        builder.AddNotificationHandler<ContentDeletedNotification, FileUploadContentDeletedNotificationHandler>();
+    }
+
+    [Test]
+    public async Task Can_Copy_File_Upload_To_Resolved_Path()
+    {
+        (IContent content, var sourceRelativePath) = await CreateContentWithUploadedFileAsync();
+
+        IContent? copy = ContentService.Copy(content, Constants.System.Root, relateToOriginal: false);
+        Assert.IsNotNull(copy);
+
+        var copiedValue = ContentService.GetById(copy!.Key)!.GetValue<string>("file");
+        Assert.IsNotNull(copiedValue);
+
+        var copiedRelativePath = MediaFileManager.FileSystem.GetRelativePath(copiedValue!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(copiedRelativePath, Does.StartWith(Prefix + "/"), "Expected the copied file to be under the resolver's prefix.");
+            Assert.IsTrue(MediaFileManager.FileSystem.FileExists(copiedRelativePath), "Expected the copied file to physically exist.");
+            Assert.AreNotEqual(sourceRelativePath, copiedRelativePath, "Expected the copy to be a distinct file from the source.");
+        });
+    }
+
+    [Test]
+    public async Task Can_Delete_File_On_Content_Delete()
+    {
+        (IContent content, var sourceRelativePath) = await CreateContentWithUploadedFileAsync();
+        Assert.IsTrue(MediaFileManager.FileSystem.FileExists(sourceRelativePath));
+
+        ContentService.Delete(content);
+
+        Assert.IsFalse(
+            MediaFileManager.FileSystem.FileExists(sourceRelativePath),
+            "Expected the associated file to be removed when the content was deleted.");
+    }
+
+    private async Task<(IContent Content, string SourceRelativePath)> CreateContentWithUploadedFileAsync()
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("uploadPage")
+            .AddPropertyType()
+                .WithAlias("file")
+                .WithName("File")
+                .WithDataTypeId(Constants.DataTypes.Upload)
+                .WithDataTypeKey(Constants.DataTypes.Guids.UploadGuid)
+                .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.UploadField)
+                .WithValueStorageType(ValueStorageType.Nvarchar)
+                .Done()
+            .WithAllowAsRoot(true)
+            .Build();
+        await ContentTypeService.CreateAsync(contentType, Constants.Security.SuperUserKey);
+
+        var sourceRelativePath = MediaFileManager.GetMediaPath("test.txt", Guid.NewGuid(), Guid.NewGuid());
+        MediaFileManager.FileSystem.AddFile(sourceRelativePath, new MemoryStream("test"u8.ToArray()));
+
+        var content = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithName("Original")
+            .Build();
+        content.SetValue("file", MediaFileManager.FileSystem.GetUrl(sourceRelativePath));
+        ContentService.Save(content);
+
+        return (content, sourceRelativePath);
+    }
+
+    private sealed class PrefixAllResolver : IFileUploadPathResolver
+    {
+        private readonly MediaFileManager _mediaFileManager;
+        private readonly string _prefix;
+
+        public PrefixAllResolver(MediaFileManager mediaFileManager, string prefix)
+        {
+            _mediaFileManager = mediaFileManager;
+            _prefix = prefix;
+        }
+
+        public string ResolvePath(string fileName, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
+            => $"{_prefix}/{_mediaFileManager.GetMediaPath(fileName, contentKey, propertyTypeKey)}";
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadNotificationHandlerTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
@@ -39,13 +40,14 @@ internal sealed class FileUploadNotificationHandlerTests : UmbracoIntegrationTes
             new PrefixAllResolver(sp.GetRequiredService<MediaFileManager>(), Prefix));
 
         builder.AddNotificationHandler<ContentCopiedNotification, FileUploadContentCopiedOrScaffoldedNotificationHandler>();
+        builder.AddNotificationHandler<ContentScaffoldedNotification, FileUploadContentCopiedOrScaffoldedNotificationHandler>();
         builder.AddNotificationHandler<ContentDeletedNotification, FileUploadContentDeletedNotificationHandler>();
     }
 
     [Test]
     public async Task Can_Copy_File_Upload_To_Resolved_Path()
     {
-        (IContent content, var sourceRelativePath) = await CreateContentWithUploadedFileAsync();
+        (_, IContent content, var sourceRelativePath) = await CreateContentWithUploadedFileAsync();
 
         IContent? copy = ContentService.Copy(content, Constants.System.Root, relateToOriginal: false);
         Assert.IsNotNull(copy);
@@ -65,7 +67,7 @@ internal sealed class FileUploadNotificationHandlerTests : UmbracoIntegrationTes
     [Test]
     public async Task Can_Delete_File_On_Content_Delete()
     {
-        (IContent content, var sourceRelativePath) = await CreateContentWithUploadedFileAsync();
+        (_, IContent content, var sourceRelativePath) = await CreateContentWithUploadedFileAsync();
         Assert.IsTrue(MediaFileManager.FileSystem.FileExists(sourceRelativePath));
 
         ContentService.Delete(content);
@@ -75,7 +77,32 @@ internal sealed class FileUploadNotificationHandlerTests : UmbracoIntegrationTes
             "Expected the associated file to be removed when the content was deleted.");
     }
 
-    private async Task<(IContent Content, string SourceRelativePath)> CreateContentWithUploadedFileAsync()
+    [Test]
+    public async Task Can_Scaffold_File_Upload_To_Resolved_Path_Without_Resave()
+    {
+        (IContentType contentType, IContent original, _) = await CreateContentWithUploadedFileAsync();
+
+        // A scaffold is an in-memory target that the handler updates but does not re-save (postUpdateAction is null).
+        IContent scaffold = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithName("Scaffold")
+            .Build();
+
+        GetRequiredService<IEventAggregator>().Publish(
+            new ContentScaffoldedNotification(original, scaffold, Constants.System.Root, new EventMessages()));
+
+        var scaffoldedValue = scaffold.GetValue<string>("file");
+        Assert.IsNotNull(scaffoldedValue, "Expected the scaffolded (in-memory) property value to be populated.");
+
+        var relativePath = MediaFileManager.FileSystem.GetRelativePath(scaffoldedValue!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(relativePath, Does.StartWith(Prefix + "/"), "Expected the scaffolded file to be under the resolver's prefix.");
+            Assert.IsTrue(MediaFileManager.FileSystem.FileExists(relativePath), "Expected the scaffolded file to physically exist.");
+        });
+    }
+
+    private async Task<(IContentType ContentType, IContent Content, string SourceRelativePath)> CreateContentWithUploadedFileAsync()
     {
         var contentType = new ContentTypeBuilder()
             .WithAlias("uploadPage")
@@ -101,7 +128,7 @@ internal sealed class FileUploadNotificationHandlerTests : UmbracoIntegrationTes
         content.SetValue("file", MediaFileManager.FileSystem.GetUrl(sourceRelativePath));
         ContentService.Save(content);
 
-        return (content, sourceRelativePath);
+        return (contentType, content, sourceRelativePath);
     }
 
     private sealed class PrefixAllResolver : IFileUploadPathResolver

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadNotificationHandlerTests.cs
@@ -83,7 +83,7 @@ internal sealed class FileUploadNotificationHandlerTests : UmbracoIntegrationTes
         (IContentType contentType, IContent original, _) = await CreateContentWithUploadedFileAsync();
 
         // A scaffold is an in-memory target that the handler updates but does not re-save (postUpdateAction is null).
-        IContent scaffold = new ContentBuilder()
+        Content scaffold = new ContentBuilder()
             .WithContentType(contentType)
             .WithName("Scaffold")
             .Build();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadPathResolverTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/FileUploadPathResolverTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.Models.TemporaryFile;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.PropertyEditors;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Attributes;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.PropertyEditors;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class FileUploadPathResolverTests : UmbracoIntegrationTest
+{
+    private const string Prefix = "custom-prefix";
+
+    private MediaFileManager MediaFileManager => GetRequiredService<MediaFileManager>();
+
+    // Register a resolver that mirrors the sample: it prefixes only when the data type configuration is the
+    // prefixed subclass. This lets us prove the value editor routes through IFileUploadPathResolver while a
+    // standard configuration is left untouched.
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+        => builder.Services.AddUnique<IFileUploadPathResolver>(sp =>
+            new ConfigGatedPrefixingResolver(sp.GetRequiredService<MediaFileManager>()));
+
+    public static void ConfigureAllowedUploadedFileExtensions(IUmbracoBuilder builder)
+        => builder.Services.Configure<ContentSettings>(config =>
+            config.AllowedUploadedFileExtensions = new HashSet<string> { "txt" });
+
+    [Test]
+    public void Can_Get_Standard_Media_Path_From_Default_Resolver()
+    {
+        var contentKey = Guid.NewGuid();
+        var propertyTypeKey = Guid.NewGuid();
+        var sut = new FileUploadPathResolver(MediaFileManager);
+        var expected = MediaFileManager.GetMediaPath("file.txt", contentKey, propertyTypeKey);
+
+        // The default resolver ignores the data type configuration entirely.
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(expected, sut.ResolvePath("file.txt", dataTypeConfiguration: null, contentKey, propertyTypeKey));
+            Assert.AreEqual(expected, sut.ResolvePath("file.txt", new FileUploadConfiguration(), contentKey, propertyTypeKey));
+        });
+    }
+
+    [Test]
+    public void Cannot_Prefix_Standard_File_Upload_Configuration()
+    {
+        var contentKey = Guid.NewGuid();
+        var propertyTypeKey = Guid.NewGuid();
+        var sut = new ConfigGatedPrefixingResolver(MediaFileManager);
+        var expected = MediaFileManager.GetMediaPath("file.txt", contentKey, propertyTypeKey);
+
+        // A standard (non-prefixed) configuration resolves to the standard path, so the default file upload
+        // editor is unaffected when a prefixing resolver is installed for other data types.
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(expected, sut.ResolvePath("file.txt", new FileUploadConfiguration(), contentKey, propertyTypeKey));
+            Assert.AreEqual(expected, sut.ResolvePath("file.txt", dataTypeConfiguration: null, contentKey, propertyTypeKey));
+        });
+    }
+
+    [Test]
+    public void Can_Prefix_Custom_File_Upload_Configuration()
+    {
+        var contentKey = Guid.NewGuid();
+        var propertyTypeKey = Guid.NewGuid();
+        var sut = new ConfigGatedPrefixingResolver(MediaFileManager);
+        var expected = $"{Prefix}/{MediaFileManager.GetMediaPath("file.txt", contentKey, propertyTypeKey)}";
+
+        var path = sut.ResolvePath("file.txt", new TestPrefixedFileUploadConfiguration { Prefix = Prefix }, contentKey, propertyTypeKey);
+
+        Assert.AreEqual(expected, path);
+    }
+
+    [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureAllowedUploadedFileExtensions))]
+    public async Task Can_Store_Uploaded_File_At_Resolved_Path()
+    {
+        var temporaryFileId = Guid.NewGuid();
+        await GetRequiredService<ITemporaryFileService>().CreateAsync(new CreateTemporaryFileModel
+        {
+            Key = temporaryFileId,
+            FileName = "test.txt",
+            OpenReadStream = () => new MemoryStream("test"u8.ToArray()),
+        });
+
+        IJsonSerializer serializer = GetRequiredService<IJsonSerializer>();
+        PropertyEditorCollection propertyEditors = GetRequiredService<PropertyEditorCollection>();
+        IDataEditor editor = propertyEditors[Constants.PropertyEditors.Aliases.UploadField]!;
+
+        // Use the prefixed configuration subclass so the resolver applies the prefix, exercising the full
+        // configuration round-trip through the value editor.
+        var editorValue = new ContentPropertyData(
+            serializer.Serialize(new FileUploadValue { TemporaryFileId = temporaryFileId }),
+            new TestPrefixedFileUploadConfiguration { Prefix = Prefix })
+        {
+            ContentKey = Guid.NewGuid(),
+            PropertyTypeKey = Guid.NewGuid(),
+        };
+
+        var storedValue = editor.GetValueEditor().FromEditor(editorValue, null) as string;
+
+        Assert.IsNotNull(storedValue, "Expected the file upload to be processed and a path returned.");
+
+        var relativePath = MediaFileManager.FileSystem.GetRelativePath(storedValue!);
+        Assert.Multiple(() =>
+        {
+            Assert.That(relativePath, Does.StartWith(Prefix + "/"), "Expected the stored path to be under the resolver's prefix.");
+            Assert.IsTrue(
+                MediaFileManager.FileSystem.FileExists(relativePath),
+                "Expected the uploaded file to physically exist at the prefixed path.");
+        });
+    }
+
+    private sealed class TestPrefixedFileUploadConfiguration : FileUploadConfiguration
+    {
+        public string? Prefix { get; set; }
+    }
+
+    private sealed class ConfigGatedPrefixingResolver : IFileUploadPathResolver
+    {
+        private readonly MediaFileManager _mediaFileManager;
+
+        public ConfigGatedPrefixingResolver(MediaFileManager mediaFileManager) => _mediaFileManager = mediaFileManager;
+
+        public string ResolvePath(string fileName, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
+        {
+            var path = _mediaFileManager.GetMediaPath(fileName, contentKey, propertyTypeKey);
+            if (dataTypeConfiguration is TestPrefixedFileUploadConfiguration configuration
+                && string.IsNullOrWhiteSpace(configuration.Prefix) is false)
+            {
+                path = $"{configuration.Prefix.Trim('/')}/{path}";
+            }
+
+            return path;
+        }
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/FileUploadValueParserTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/FileUploadValueParserTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
+using Umbraco.Cms.Infrastructure.PropertyEditors;
+using Umbraco.Cms.Infrastructure.Serialization;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.PropertyEditors;
+
+[TestFixture]
+public class FileUploadValueParserTests
+{
+    private static SystemTextJsonSerializer CreateSerializer() => new(new DefaultJsonSerializerEncoderFactory());
+
+    private static FileUploadValueParser CreateParser() => new(CreateSerializer());
+
+    [Test]
+    public void Cannot_Parse_Null_Input()
+        => Assert.IsNull(CreateParser().Parse(null));
+
+    [Test]
+    public void Can_Parse_Plain_String_As_Src()
+    {
+        FileUploadValue? result = CreateParser().Parse("media/abc/image.jpg");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("media/abc/image.jpg", result!.Src);
+        Assert.IsNull(result.TemporaryFileId);
+    }
+
+    [Test]
+    public void Can_Parse_Json_Value()
+    {
+        var serializer = CreateSerializer();
+        var parser = new FileUploadValueParser(serializer);
+        var temporaryFileId = Guid.NewGuid();
+        var json = serializer.Serialize(new FileUploadValue { Src = "media/abc/image.jpg", TemporaryFileId = temporaryFileId });
+
+        FileUploadValue? result = parser.Parse(json);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("media/abc/image.jpg", result!.Src);
+        Assert.AreEqual(temporaryFileId, result.TemporaryFileId);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadNotificationHandlerBaseTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/PropertyEditors/NotificationHandlers/FileUploadNotificationHandlerBaseTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache.PropertyEditors;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Infrastructure.PropertyEditors.NotificationHandlers;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.PropertyEditors.NotificationHandlers;
+
+[TestFixture]
+public class FileUploadNotificationHandlerBaseTests
+{
+    [TestCase("Umbraco.UploadField", true, TestName = "Can_Recognise_Built_In_File_Upload_Editor")]
+    [TestCase("Test.PrefixedUpload", true, TestName = "Can_Recognise_File_Upload_Editor_Subclass")]
+    [TestCase("Test.NotUpload", false, TestName = "Cannot_Recognise_Unrelated_Editor")]
+    [TestCase("Does.Not.Exist", false, TestName = "Cannot_Recognise_Unknown_Alias")]
+    public void Can_Recognise_File_Upload_Editor_Property_Types(string alias, bool expected)
+    {
+        var factory = Mock.Of<IDataValueEditorFactory>();
+        var ioHelper = Mock.Of<IIOHelper>();
+        var dataEditors = new DataEditorCollection(() => new IDataEditor[]
+        {
+            new FileUploadPropertyEditor(factory, ioHelper),
+            new TestPrefixedFileUploadPropertyEditor(factory, ioHelper),
+            new TestNotUploadPropertyEditor(factory),
+        });
+        var propertyEditors = new PropertyEditorCollection(dataEditors);
+        var handler = new TestHandler(propertyEditors);
+
+        var propertyType = Mock.Of<IPropertyType>(x => x.PropertyEditorAlias == alias);
+
+        Assert.AreEqual(expected, handler.IsUploadField(propertyType));
+    }
+
+    [DataEditor("Test.PrefixedUpload", ValueEditorIsReusable = true)]
+    private sealed class TestPrefixedFileUploadPropertyEditor : FileUploadPropertyEditor
+    {
+        public TestPrefixedFileUploadPropertyEditor(IDataValueEditorFactory dataValueEditorFactory, IIOHelper ioHelper)
+            : base(dataValueEditorFactory, ioHelper)
+        {
+        }
+    }
+
+    [DataEditor("Test.NotUpload", ValueEditorIsReusable = true)]
+    private sealed class TestNotUploadPropertyEditor : DataEditor
+    {
+        public TestNotUploadPropertyEditor(IDataValueEditorFactory dataValueEditorFactory)
+            : base(dataValueEditorFactory)
+        {
+        }
+    }
+
+    private sealed class TestHandler : FileUploadNotificationHandlerBase
+    {
+        public TestHandler(PropertyEditorCollection propertyEditors)
+            : base(Mock.Of<IJsonSerializer>(), null!, Mock.Of<IBlockEditorElementTypeCache>(), propertyEditors)
+        {
+        }
+
+        public bool IsUploadField(IPropertyType propertyType) => IsUploadFieldPropertyType(propertyType);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a small, replaceable extensibility seam — `IFileUploadPathResolver` — that lets implementors control **where** files uploaded through the file upload property editor (or an editor derived from it) are stored, without exposing or subclassing Umbraco's internal file upload value editor and notification handlers.

This is an alternative approach to #21653, addressing the same underlying request.

Fixes #21652.

## Background

- Discussion: [#18335 — Provide an ability to extend FileUploadPropertyEditor](https://github.com/umbraco/Umbraco-CMS/discussions/18335)
- Issue: [#21652 — It is unable to extend FileUploadPropertyEditor](https://github.com/umbraco/Umbraco-CMS/issues/21652)
- Existing PR: [#21653 — Amend accessibility modifiers on file upload property editor components to support extension](https://github.com/umbraco/Umbraco-CMS/pull/21653)

The scenario (from #18335) is a private-cloud-storage setup where uploaded files need to be stored under a configurable path **prefix** (e.g. `{prefix}/{folder}/{file}`), with different upload data types storing to different locations (a "public" and a "private" variant). To achieve this the contributor extended `FileUploadPropertyEditor` and needed to override internals — including the then-`private static` `IsUploadField` — which weren't accessible.

#21653 achieves extensibility by widening access modifiers: it makes `FileUploadPropertyValueEditor`, `FileUploadValueParser`, `FileUploadNotificationHandlerBase` and the three concrete notification handlers `public`, and opens several members `virtual`, so they can be subclassed.

Whilst this should allow the required use case, I'm reluctant to take it as-is because **it's a large, permanent public surface.** Six types plus several members become part of the public contract, which constrains our ability to refactor the file upload internals in future without a breaking change. In general we prefer to keep code internal unless there's a clear reason not to.

The thing that genuinely needs to vary for this use case is narrow: *given a file, the owning content/property, and the data type configuration, decide the storage path.* That's a single well-defined seam rather than a reason to open up the whole editor.  So that's the alternative approach I've taken in this PR.

## Approach

Introduce one new public interface in `Umbraco.Core`:

```csharp
namespace Umbraco.Cms.Core.PropertyEditors;

public interface IFileUploadPathResolver
{
    string ResolvePath(string fileName, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey);
}
```

- The default implementation (`internal`) reproduces today's behaviour exactly — it delegates to `MediaFileManager.GetMediaPath(...)` — and is registered with `AddUnique`, so it can be replaced.
- The (still `internal`) `FileUploadPropertyValueEditor` and `FileUploadContentCopiedOrScaffoldedNotificationHandler` consume the resolver for the two places an upload path is produced (on upload, and when a file is duplicated on copy/scaffold).
- `FileUploadNotificationHandlerBase.IsUploadFieldPropertyType(...)` now recognises the built-in editor **and any editor derived from `FileUploadPropertyEditor`** (by type, via the property editor collection) instead of matching a single alias string, so copy/delete/media-fill handling automatically applies to derived editors.

This exposes just one interface and covers the full lifecycle (upload, copy/scaffold and delete) for derived editors because recognition is now by type. 

## Using the new abstraction

A consumer implements `IFileUploadPathResolver` and registers it with `AddUnique` to override where files go. Because the resolver receives the data type configuration, the prefix can be read from a custom configuration on a derived editor:

```csharp
// 1. A configuration that adds a prefix on top of the standard file upload configuration.
public class PrefixedFileUploadConfiguration : FileUploadConfiguration
{
    [ConfigurationField("prefix")]
    public string? Prefix { get; set; }
}

// 2. A configuration editor for it.
public class PrefixedFileUploadConfigurationEditor : ConfigurationEditor<PrefixedFileUploadConfiguration>
{
    public PrefixedFileUploadConfigurationEditor(IIOHelper ioHelper) : base(ioHelper) { }
}

// 3. A derived editor with its own alias and configuration. It inherits the standard value editor, so no
//    internal type is referenced, and is recognised for copy/delete automatically. HideFromTypeFinder keeps
//    it out of auto-discovery, so the composer below is the single registration point.
[HideFromTypeFinder]
[DataEditor("Sample.PrefixedFileUpload", ValueEditorIsReusable = true)]
public class PrefixedFileUploadPropertyEditor : FileUploadPropertyEditor
{
    private readonly IIOHelper _ioHelper;

    public PrefixedFileUploadPropertyEditor(IDataValueEditorFactory dataValueEditorFactory, IIOHelper ioHelper)
        : base(dataValueEditorFactory, ioHelper) => _ioHelper = ioHelper;

    protected override IConfigurationEditor CreateConfigurationEditor()
        => new PrefixedFileUploadConfigurationEditor(_ioHelper);
}

// 4. The resolver: prepend the prefix read from the data type configuration.
//    This is where a real implementation could prepend a tenant/bucket prefix, etc.
public class PrefixedFileUploadPathResolver : IFileUploadPathResolver
{
    private readonly MediaFileManager _mediaFileManager;

    public PrefixedFileUploadPathResolver(MediaFileManager mediaFileManager)
        => _mediaFileManager = mediaFileManager;

    public string ResolvePath(string fileName, object? dataTypeConfiguration, Guid contentKey, Guid propertyTypeKey)
    {
        var path = _mediaFileManager.GetMediaPath(fileName, contentKey, propertyTypeKey);
        if (dataTypeConfiguration is PrefixedFileUploadConfiguration configuration
            && string.IsNullOrWhiteSpace(configuration.Prefix) is false)
        {
            path = $"{configuration.Prefix.Trim('/')}/{path}";
        }

        return path;
    }
}

// 5. Registration.
public class PrefixedFileUploadComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.DataEditors().Add<PrefixedFileUploadPropertyEditor>();
        builder.MediaUrlGenerators().Add<PrefixedFileUploadPropertyEditor>();
        builder.Services.AddUnique<IFileUploadPathResolver, PrefixedFileUploadPathResolver>();
    }
}
```

> Note: registering the resolver via `AddUnique` replaces it globally, but standard File Upload data types (whose configuration is a plain `FileUploadConfiguration`) fall through to the standard media path — so the built-in file upload editor is unaffected.

To make the derived editor configurable in the backoffice, pair it with a client manifest whose `propertyEditorSchema` alias matches (`Sample.PrefixedFileUpload`) and reuse the built-in upload UI (`Umb.PropertyEditorUi.UploadField`) with a text field bound to the `prefix` configuration alias:

**prefixed-upload-field.element.js**

```javascript
import { html } from '@umbraco-cms/backoffice/external/lit';
import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';

// Importing the media package registers the <umb-input-upload-field> custom element we reuse below.
import '@umbraco-cms/backoffice/media';

/**
 * Content-side value editor for the prefixed file upload sample. It reuses the built-in
 * <umb-input-upload-field> so uploads behave exactly like the standard file upload; the prefixing
 * happens entirely server-side via IFileUploadPathResolver.
 */
export default class SamplePrefixedUploadFieldElement extends UmbLitElement {
	static properties = {
		value: {},
		_fileExtensions: { state: true },
	};

	#config;

	set config(config) {
		this.#config = config;
		const extensions = config?.getValueByAlias('fileExtensions');
		this._fileExtensions = extensions?.length
			? extensions.map((ext) => (ext.startsWith('.') || ext.includes('/') ? ext : `.${ext}`))
			: undefined;
	}

	get config() {
		return this.#config;
	}

	#onChange(event) {
		this.value = event.target.value;
		this.dispatchEvent(new UmbChangeEvent());
	}

	render() {
		return html`
			<umb-input-upload-field
				.allowedFileExtensions=${this._fileExtensions}
				.value=${this.value}
				@change=${this.#onChange}>
			</umb-input-upload-field>
		`;
	}
}

customElements.define('sample-prefixed-upload-field', SamplePrefixedUploadFieldElement);
```

**umbraco-package.json**

```json
{
  "$schema": "../../umbraco-package-schema.json",
  "name": "Sample Prefixed File Upload",
  "alias": "Sample.PrefixedFileUpload",
  "version": "1.0.0",
  "extensions": [
    {
      "type": "propertyEditorUi",
      "alias": "Sample.PropertyEditorUi.PrefixedFileUpload",
      "name": "Prefixed File Upload",
      "element": "/App_Plugins/Sample.PrefixedFileUpload/prefixed-upload-field.element.js",
      "meta": {
        "label": "Prefixed File Upload",
        "propertyEditorSchemaAlias": "Sample.PrefixedFileUpload",
        "icon": "icon-download-alt",
        "group": "media"
      }
    },
    {
      "type": "propertyEditorSchema",
      "name": "Prefixed File Upload",
      "alias": "Sample.PrefixedFileUpload",
      "meta": {
        "defaultPropertyEditorUiAlias": "Sample.PropertyEditorUi.PrefixedFileUpload",
        "settings": {
          "properties": [
            {
              "alias": "prefix",
              "label": "Storage path prefix",
              "description": "Sub-folder that uploaded files are stored under, e.g. `private`.",
              "propertyEditorUiAlias": "Umb.PropertyEditorUi.TextBox"
            },
            {
              "alias": "fileExtensions",
              "label": "Accepted file extensions",
              "description": "Insert one extension per line, for example `jpg`.",
              "propertyEditorUiAlias": "Umb.PropertyEditorUi.AcceptedUploadTypes"
            }
          ]
        }
      }
    }
  ]
}
```


## Testing

### Automated

New coverage (these are the first tests for this handler family):

- **Unit** — `FileUploadValueParserTests` (parser round-trip) and `FileUploadNotificationHandlerBaseTests` (upload-field recognition: built-in ✓, derived editor ✓, unrelated ✗, unknown alias ✗).
- **Integration — `FileUploadPathResolverTests`**: default resolver returns the standard path (incl. with a populated configuration); a config-gated resolver prefixes a custom configuration but leaves a standard `FileUploadConfiguration` untouched (proving the built-in editor is unaffected); and the value editor stores an uploaded file at the resolved (prefixed) path on disk.
- **Integration — `FileUploadNotificationHandlerTests`**: copying content routes the duplicated file through the resolver (lands under the prefix, is a distinct file); deleting content removes the associated file.

Each behavioural assertion was confirmed to fail before the change (e.g. reverting the value editor's delegation breaks the prefixed-path assertion).

### Manual (using the sample above)

1. Add the sample types + a backoffice manifest to a test site and run it.
2. **Settings → Data Types → Create → Prefixed File Upload**, set a prefix (e.g. `private`); optionally create a second with a different prefix (e.g. `public`), and a standard **File Upload** data type as a control.
3. Add properties using these data types to a document type; create content and upload a file to each; Save.
4. Confirm on disk (`wwwroot/media/`): prefixed uploads land under `media/<prefix>/<hash>/<file>`, and the standard upload stays at `media/<hash>/<file>`.
5. **Copy** the content node → the duplicated files keep their prefixes and are distinct files; **Delete** → the files are removed.

All of the above was exercised manually and behaves as expected, including file uploads nested within Block List / Block Grid / rich-text blocks.