### PR TITLE
Documents: Scope mandatory validation to selected variants when scheduling

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -164,7 +164,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		const variantIds = variants.map((x) => x.variantId);
 		const saveData = await this.#documentWorkspaceContext.constructSaveData(variantIds);
-		await this.#documentWorkspaceContext.runMandatoryValidationForSaveData(saveData);
+		await this.#documentWorkspaceContext.runMandatoryValidationForSaveData(saveData, variantIds);
 		await this.#documentWorkspaceContext.askServerToValidate(saveData, variantIds);
 
 		return this.#documentWorkspaceContext.validateVariantsAndSubmit(


### PR DESCRIPTION
Small tidy-up to the document publishing flow. When you schedule a document for publishing, the mandatory validation now only runs against the variants you actually picked — the same way Save & Publish and the other publish paths already work. The schedule path was the odd one out.

No behaviour change for the normal happy path — it just brings scheduling in line with its siblings.

> [!NOTE]
> There's no automated test coverage for this path yet (there wasn't any before this change either). We started looking at adding some, but the schedule workspace context is fiddly to drive in a test, so it's parked for now — we'll come back to test coverage in a follow-up.