### PR TITLE
Delivery API: Never treat Delivery API requests as client-side requests (Closes #20810)

### DIFF
--- a/src/Umbraco.Core/Constants-Web.cs
+++ b/src/Umbraco.Core/Constants-Web.cs
@@ -87,6 +87,11 @@ public static partial class Constants
         public const string ManagementApiPath = "/management/api/";
 
         /// <summary>
+        ///     The "base" path to the Delivery API
+        /// </summary>
+        public const string DeliveryApiPath = "/delivery/api/";
+
+        /// <summary>
         ///     The SignalR hub path for backoffice real-time communication.
         /// </summary>
         public const string BackofficeSignalRHub = "/backofficeHub";

--- a/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
@@ -161,13 +161,18 @@ public class UmbracoRequestPaths
     /// </summary>
     public bool IsClientSideRequest(string absPath)
     {
+        var ext = Path.GetExtension(absPath);
+        if (ext.IsNullOrWhiteSpace())
+        {
+            return false;
+        }
+
         if (_deliveryApiSettings.Value.Enabled && TrimAppPath(absPath).InvariantStartsWith(_deliveryApiPath))
         {
             return false;
         }
 
-        var ext = Path.GetExtension(absPath);
-        return !ext.IsNullOrWhiteSpace();
+        return true;
     }
 
     private string TrimAppPath(string absPath)

--- a/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
@@ -25,7 +25,7 @@ public class UmbracoRequestPaths
     private readonly IOptions<UmbracoRequestPathsOptions> _umbracoRequestPathsOptions;
     private readonly IOptions<DeliveryApiSettings> _deliveryApiSettings;
 
-    [Obsolete("PLease use the constructor that accepts all arguments. Scheduled for removal in Umbraco 19.")]
+    [Obsolete("Please use the constructor that accepts all arguments. Scheduled for removal in Umbraco 19.")]
     public UmbracoRequestPaths(IHostingEnvironment hostingEnvironment, IOptions<UmbracoRequestPathsOptions> umbracoRequestPathsOptions)
         : this(hostingEnvironment, umbracoRequestPathsOptions, StaticServiceProvider.Instance.GetRequiredService<IOptions<DeliveryApiSettings>>())
     {

--- a/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
+++ b/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Extensions;
 
@@ -19,16 +21,26 @@ public class UmbracoRequestPaths
     private readonly string _surfaceMvcPath;
     private readonly string _apiMvcPath;
     private readonly string _managementApiPath;
-    private readonly string _installPath;
+    private readonly string _deliveryApiPath;
     private readonly IOptions<UmbracoRequestPathsOptions> _umbracoRequestPathsOptions;
+    private readonly IOptions<DeliveryApiSettings> _deliveryApiSettings;
+
+    [Obsolete("PLease use the constructor that accepts all arguments. Scheduled for removal in Umbraco 19.")]
+    public UmbracoRequestPaths(IHostingEnvironment hostingEnvironment, IOptions<UmbracoRequestPathsOptions> umbracoRequestPathsOptions)
+        : this(hostingEnvironment, umbracoRequestPathsOptions, StaticServiceProvider.Instance.GetRequiredService<IOptions<DeliveryApiSettings>>())
+    {
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UmbracoRequestPaths" /> class.
     /// </summary>
-    public UmbracoRequestPaths(IHostingEnvironment hostingEnvironment, IOptions<UmbracoRequestPathsOptions> umbracoRequestPathsOptions)
+    public UmbracoRequestPaths(
+        IHostingEnvironment hostingEnvironment,
+        IOptions<UmbracoRequestPathsOptions> umbracoRequestPathsOptions,
+        IOptions<DeliveryApiSettings> deliveryApiSettings)
     {
         _appPath = hostingEnvironment.ApplicationVirtualPath;
-        _backOfficePath = hostingEnvironment.GetBackOfficePath().EnsureStartsWith('/').TrimStart(_appPath).EnsureStartsWith('/');
+        _backOfficePath = TrimAppPath(hostingEnvironment.GetBackOfficePath().EnsureStartsWith('/'));
 
         const string mvcArea = Constants.System.UmbracoPathSegment;
         _defaultUmbPath = "/" + mvcArea;
@@ -38,9 +50,10 @@ public class UmbracoRequestPaths
         _surfaceMvcPath = "/" + mvcArea + "/Surface/";
         _apiMvcPath = "/" + mvcArea + "/Api/";
         _managementApiPath = "/" + mvcArea + Constants.Web.ManagementApiPath;
-        _installPath = hostingEnvironment.ToAbsolute(Constants.SystemDirectories.Install);
+        _deliveryApiPath = "/" + mvcArea + Constants.Web.DeliveryApiPath;
 
         _umbracoRequestPathsOptions = umbracoRequestPathsOptions;
+        _deliveryApiSettings = deliveryApiSettings;
     }
 
     /// <summary>
@@ -71,7 +84,7 @@ public class UmbracoRequestPaths
     /// </remarks>
     public bool IsBackOfficeRequest(string absPath)
     {
-        string urlPath = absPath.TrimStart(_appPath).EnsureStartsWith('/');
+        string urlPath = TrimAppPath(absPath);
 
         // check if this is in the umbraco back office
         if (!urlPath.InvariantStartsWith(_backOfficePath))
@@ -148,7 +161,15 @@ public class UmbracoRequestPaths
     /// </summary>
     public bool IsClientSideRequest(string absPath)
     {
+        if (_deliveryApiSettings.Value.Enabled && TrimAppPath(absPath).InvariantStartsWith(_deliveryApiPath))
+        {
+            return false;
+        }
+
         var ext = Path.GetExtension(absPath);
         return !ext.IsNullOrWhiteSpace();
     }
+
+    private string TrimAppPath(string absPath)
+        => absPath.TrimStart(_appPath).EnsureStartsWith('/');
 }

--- a/tests/Umbraco.Tests.UnitTests/TestHelpers/Objects/TestUmbracoContextFactory.cs
+++ b/tests/Umbraco.Tests.UnitTests/TestHelpers/Objects/TestUmbracoContextFactory.cs
@@ -24,12 +24,14 @@ public class TestUmbracoContextFactory
         IUmbracoContextAccessor umbracoContextAccessor = null,
         IHttpContextAccessor httpContextAccessor = null,
         IPublishedUrlProvider publishedUrlProvider = null,
-        UmbracoRequestPathsOptions umbracoRequestPathsOptions = null)
+        UmbracoRequestPathsOptions umbracoRequestPathsOptions = null,
+        DeliveryApiSettings deliveryApiSettings = null)
     {
         umbracoContextAccessor ??= new TestUmbracoContextAccessor();
         httpContextAccessor ??= Mock.Of<IHttpContextAccessor>();
         publishedUrlProvider ??= Mock.Of<IPublishedUrlProvider>();
         umbracoRequestPathsOptions ??= new UmbracoRequestPathsOptions();
+        deliveryApiSettings ??= new DeliveryApiSettings();
 
         var contentCache = new Mock<IPublishedContentCache>();
         var mediaCache = new Mock<IPublishedMediaCache>();
@@ -41,7 +43,10 @@ public class TestUmbracoContextFactory
 
         var umbracoContextFactory = new UmbracoContextFactory(
             umbracoContextAccessor,
-            new UmbracoRequestPaths(hostingEnvironment, Options.Create(umbracoRequestPathsOptions)),
+            new UmbracoRequestPaths(
+                hostingEnvironment,
+                Options.Create(umbracoRequestPathsOptions),
+                Options.Create(deliveryApiSettings)),
             hostingEnvironment,
             new UriUtility(hostingEnvironment),
             new AspNetCoreCookieManager(httpContextAccessor),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddlewareTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Middleware/BackOfficeAuthorizationInitializationMiddlewareTests.cs
@@ -156,8 +156,9 @@ public class BackOfficeAuthorizationInitializationMiddlewareTests
         mockHostingEnvironment.Setup(x => x.ToAbsolute(It.IsAny<string>()))
             .Returns<string>(path => path.TrimStart('~'));
 
-        var options = Options.Create(new UmbracoRequestPathsOptions());
+        var umbracoRequestPathsOptions = Options.Create(new UmbracoRequestPathsOptions());
+        var deliveryApiSettings = Options.Create(new DeliveryApiSettings());
 
-        return new UmbracoRequestPaths(mockHostingEnvironment.Object, options);
+        return new UmbracoRequestPaths(mockHostingEnvironment.Object, umbracoRequestPathsOptions, deliveryApiSettings);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UmbracoRequestPathsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Routing/UmbracoRequestPathsTests.cs
@@ -14,12 +14,14 @@ public class UmbracoRequestPathsTests
 {
     private IWebHostEnvironment _hostEnvironment;
     private UmbracoRequestPathsOptions _umbracoRequestPathsOptions;
+    private DeliveryApiSettings _deliveryApiSettings;
 
     [OneTimeSetUp]
     public void Setup()
     {
         _hostEnvironment = Mock.Of<IWebHostEnvironment>();
         _umbracoRequestPathsOptions = new UmbracoRequestPathsOptions();
+        _deliveryApiSettings = new DeliveryApiSettings();
     }
 
     private IHostingEnvironment CreateHostingEnvironment(string virtualPath = "")
@@ -43,10 +45,14 @@ public class UmbracoRequestPathsTests
     [TestCase("/home.aspx", true)] // has ext, assume client side
     [TestCase("http://www.domain.com/Umbraco/test/test.aspx", true)] // has ext, assume client side
     [TestCase("http://www.domain.com/umbraco/test/test.js", true)]
+    [TestCase("http://www.domain.com/umbraco/delivery/api/v1.0/my/controller/some.file", true)]
     public void Is_Client_Side_Request(string url, bool assert)
     {
         var hostingEnvironment = CreateHostingEnvironment();
-        var umbracoRequestPaths = new UmbracoRequestPaths(hostingEnvironment, Options.Create(_umbracoRequestPathsOptions));
+        var umbracoRequestPaths = new UmbracoRequestPaths(
+            hostingEnvironment,
+            Options.Create(_umbracoRequestPathsOptions),
+            Options.Create(_deliveryApiSettings));
 
         var uri = new Uri("http://test.com" + url);
         var result = umbracoRequestPaths.IsClientSideRequest(uri.AbsolutePath);
@@ -57,7 +63,10 @@ public class UmbracoRequestPathsTests
     public void Is_Client_Side_Request_InvalidPath_ReturnFalse()
     {
         var hostingEnvironment = CreateHostingEnvironment();
-        var umbracoRequestPaths = new UmbracoRequestPaths(hostingEnvironment, Options.Create(_umbracoRequestPathsOptions));
+        var umbracoRequestPaths = new UmbracoRequestPaths(
+            hostingEnvironment,
+            Options.Create(_umbracoRequestPathsOptions),
+            Options.Create(_deliveryApiSettings));
 
         // This URL is invalid. Default to false when the extension cannot be determined
         var uri = new Uri("http://test.com/installing-modules+foobar+\"yipee\"");
@@ -89,7 +98,10 @@ public class UmbracoRequestPathsTests
     {
         var source = new Uri(input);
         var hostingEnvironment = CreateHostingEnvironment(virtualPath);
-        var umbracoRequestPaths = new UmbracoRequestPaths(hostingEnvironment, Options.Create(_umbracoRequestPathsOptions));
+        var umbracoRequestPaths = new UmbracoRequestPaths(
+            hostingEnvironment,
+            Options.Create(_umbracoRequestPathsOptions),
+            Options.Create(_deliveryApiSettings));
         Assert.AreEqual(expected, umbracoRequestPaths.IsBackOfficeRequest(source.AbsolutePath));
     }
 
@@ -105,7 +117,29 @@ public class UmbracoRequestPathsTests
         {
             IsBackOfficeRequest = _ => true
         };
-        var umbracoRequestPaths = new UmbracoRequestPaths(hostingEnvironment, Options.Create(umbracoRequestPathsOptions));
+        var umbracoRequestPaths = new UmbracoRequestPaths(
+            hostingEnvironment,
+            Options.Create(umbracoRequestPathsOptions),
+            Options.Create(_deliveryApiSettings));
         Assert.AreEqual(expected, umbracoRequestPaths.IsBackOfficeRequest(source.AbsolutePath));
+    }
+
+    [TestCase("/favicon.ico", true)]
+    [TestCase("/umbraco_client/Tree/treeIcons.css", true)]
+    [TestCase("/test/test.aspx", true)]
+    [TestCase("/test/test.js", true)]
+    [TestCase("/umbraco/delivery/api/v1.0/my/controller/some.file", false)]
+    [TestCase("/umbraco/delivery/api/v2/media/item/%2Froot%20folder%2Fchild%20folder%2Funicorn.png%2F", false)]
+    public void Is_Client_Side_Request_Delivery_Api_Enabled(string url, bool assert)
+    {
+        var hostingEnvironment = CreateHostingEnvironment();
+        var umbracoRequestPaths = new UmbracoRequestPaths(
+            hostingEnvironment,
+            Options.Create(_umbracoRequestPathsOptions),
+            Options.Create(new DeliveryApiSettings { Enabled = true }));
+
+        var uri = new Uri("http://test.com" + url);
+        var result = umbracoRequestPaths.IsClientSideRequest(uri.AbsolutePath);
+        Assert.AreEqual(assert, result);
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/UmbracoContext/UmbracoContextTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Web.Common/UmbracoContext/UmbracoContextTests.cs
@@ -128,7 +128,8 @@ public class UmbracoContextTests
         var httpContextAccessor = Mock.Of<IHttpContextAccessor>(x => x.HttpContext == httpContext);
         var umbracoRequestPaths = new UmbracoRequestPaths(
             hostingEnvironment,
-            Options.Create(new UmbracoRequestPathsOptions()));
+            Options.Create(new UmbracoRequestPathsOptions()),
+            Options.Create(new DeliveryApiSettings()));
         var uriUtility = new UriUtility(hostingEnvironment);
         var cacheManager = Mock.Of<ICacheManager>(x =>
             x.Content == Mock.Of<IPublishedContentCache>() &&


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #20810

### Description

See the linked issue for a description 😄 

The root cause is that `UmbracoRequestPaths` treats all request _with_ an extension as a client-side (asset) request ([here](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.Core/Routing/UmbracoRequestPaths.cs#L149)), which short-circuits the `UmbracoRequestMiddleware` ([here](https://github.com/umbraco/Umbraco-CMS/blob/v17/dev/src/Umbraco.Web.Common/Middleware/UmbracoRequestMiddleware.cs#L79)). If a Media item is created with an extension, this short-circuit is triggered for Media Delivery API "by-path" requests - e.g. `/umbraco/delivery/api/v2/media/item/%2Funicorn.jpg`.

The fix at its core is to `UmbracoRequestPaths.IsClientSideRequest(string absPath)`. However, to align with other methods, and to avoid further duplication of logic, the PR looks a bit more complex than it really is 😆 

### Testing this PR

_To test this PR, the Media Delivery API must be enabled - instructions [here](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/headless-and-apis/content-delivery-api/media-delivery-api)._

1. Create a Media item with an extension.
2. Request it using the "by-path" Media Delivery API endpoint.

Without this PR, the request yields a HTTP500 due to the lack of context - with this PR, the request yields the Media item as expected:

<img width="696" height="657" alt="image" src="https://github.com/user-attachments/assets/10ade1ca-aed8-4d29-96d0-890c0d1fec41" />
