### PR TITLE
Localization Skill: naming convention

### DIFF
--- a/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
+++ b/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
@@ -40,28 +40,28 @@ export default {
 
 #### Choosing a group
 
-A group should cover a reasonable **scope of usage**, not just the one component you're currently editing. Before naming a group, ask: "where else in the backoffice does this same UX pattern show up?" If several features share the same UX, they should share the same group — otherwise the same kind of text ends up duplicated (and inconsistently worded) across `myFeatureA` and `myFeatureB`.
+A group covers a **shared UX area**, not just the one component you're editing. Ask: "where else does this same UX show up?" — features with matching UX should share a group, or the same kind of text ends up duplicated and inconsistently worded elsewhere.
 
 Examples already in this codebase:
 
-- `blockEditor` — shared by Block List, Block Grid, and Block RTE, because they share the same block-configuration and editing UX
-- `contentTypeEditor` — shared by Document Type, Media Type, and Member Type editing
-- `codeEditor` — shared by anything embedding the code editor
+- `blockEditor` — Block List, Block Grid, and Block RTE share the same block-configuration UX
+- `contentTypeEditor` — Document Type, Media Type, and Member Type share the same editing UX
+- `codeEditor` — anything embedding the code editor
 
-Check whether an existing group already covers the UX area before creating a new one. Only introduce a new group when the text belongs to a feature area with no existing overlap.
+Reuse an existing group when it covers the UX area. Only create a new one when there's no overlap.
 
 #### Choosing a term
 
-A term describes the **situation the text is used in** — not the wording of the text itself. Two situations that happen to use identical English wording today should still get two separate terms, since the copy for one may change independently of the other later.
+A term names the **situation**, not the wording — two situations with identical English text today should still get separate terms, since the copy can diverge later.
 
-Build the term from two parts:
+Build it from two parts:
 
-1. **How it's presented** — the UI role the text plays: `Title`, `Description`, `Action`, `Label`, `Notice`, `Message`, `ValidationMessage`, `Headline`, etc.
-2. **What it represents** — a short name for the subject or situation: `CreateBlock`, `ConfirmDelete`, `AddGroup`.
+1. **Presentation role**: `Title`, `Description`, `Action`, `Label`, `Notice`, `Message`, `ValidationMessage`, `Headline`, etc.
+2. **Subject**: `CreateBlock`, `ConfirmDelete`, `AddGroup`.
 
-Combined, in either order depending on what reads best: `createAction`, `confirmDeleteTitle`, `addGroupDescription`.
+Combined: `createAction`, `confirmDeleteTitle`, `addGroupDescription`.
 
-This matters most when several terms belong to the same moment in the UI. Take the `blockEditor` group's "delete a block group" confirmation:
+Example — three terms for one dialog in the `blockEditor` group, same subject (`confirmDeleteBlockGroup`) with different roles:
 
 ```typescript
 confirmDeleteBlockGroupTitle: 'Delete group?',
@@ -69,7 +69,7 @@ confirmDeleteBlockGroupMessage: 'Are you sure you want to delete group <strong>%
 confirmDeleteBlockGroupNotice: 'The content of these Blocks will still be present, editing of this content will no longer be available and will be shown as unsupported content.',
 ```
 
-Same subject (`confirmDeleteBlockGroup`), three presentation roles (`Title`, `Message`, `Notice`). Naming them this way keeps every piece of that one dialog grouped together, and makes it obvious they belong to the same situation even though the wording has nothing in common.
+Grouping by subject keeps every piece of the dialog together, even though the wording shares nothing.
 
 ### Value types
 

--- a/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
+++ b/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
@@ -60,10 +60,10 @@ A term names the **situation**, not the wording — two situations with identica
 
 Build it from two parts:
 
-1. **Presentation role**: `Title`, `Description`, `Action`, `Label`, `Notice`, `Message`, `ValidationMessage`, `Headline`, etc.
-2. **Subject**: `CreateBlock`, `ConfirmDelete`, `AddGroup`.
+1. **Subject**: `CreateBlock`, `ConfirmDelete`, `AddGroup`.
+2. **Presentation role**: `Title`, `Description`, `Action`, `Label`, `Notice`, `Message`, `ValidationMessage`, `Headline`, etc.
 
-Combined: `createAction`, `confirmDeleteTitle`, `addGroupDescription`.
+Combined (subject + role suffix): `createAction`, `confirmDeleteTitle`, `addGroupDescription`.
 
 Example — three terms for one dialog in the `blockEditor` group, same subject (`confirmDeleteBlockGroup`) with different roles:
 

--- a/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
+++ b/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
@@ -95,7 +95,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 @customElement('umb-my-element')
 export class UmbMyElement extends UmbLitElement {
 	override render() {
-		return html` <uui-button label=${this.localize.term('myFeature_myLabel')}></uui-button> `;
+		return html`<uui-button label=${this.localize.term('myFeature_myLabel')}></uui-button>`;
 	}
 }
 ```

--- a/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
+++ b/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
@@ -44,7 +44,7 @@ A group covers a **shared UX area**, not just the one component you're editing. 
 
 1. **If you already have a good idea of the scope** (from the surrounding code, the feature being worked on, etc.), propose it: "This looks like it belongs to the `{scope}` scope — should that be the localization group?"
 2. **If you don't**, ask directly: "What is the common group name for this localization?"
-3. **Either way, check for an existing match first.** Search the groups already in `en.ts` for one that already covers this UX area, and if you find one, ask whether it should be reused instead of creating a new group: "`{existingGroup}` already covers this — should I use that instead?"
+3. **Either way, check for an existing match first.** Search the groups already in `src/assets/lang/en.ts` for one that already covers this UX area, and if you find one, ask whether it should be reused instead of creating a new group: "`{existingGroup}` already covers this — should I use that instead?"
 
 Examples already in this codebase:
 

--- a/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
+++ b/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
@@ -40,7 +40,11 @@ export default {
 
 #### Choosing a group
 
-A group covers a **shared UX area**, not just the one component you're editing. Ask: "where else does this same UX show up?" — features with matching UX should share a group, or the same kind of text ends up duplicated and inconsistently worded elsewhere.
+A group covers a **shared UX area**, not just the one component you're editing. Don't pick a group unilaterally — confirm it with the user:
+
+1. **If you already have a good idea of the scope** (from the surrounding code, the feature being worked on, etc.), propose it: "This looks like it belongs to the `{scope}` scope — should that be the localization group?"
+2. **If you don't**, ask directly: "What is the common group name for this localization?"
+3. **Either way, check for an existing match first.** Search the groups already in `en.ts` for one that already covers this UX area, and if you find one, ask whether it should be reused instead of creating a new group: "`{existingGroup}` already covers this — should I use that instead?"
 
 Examples already in this codebase:
 
@@ -48,7 +52,7 @@ Examples already in this codebase:
 - `contentTypeEditor` — Document Type, Media Type, and Member Type share the same editing UX
 - `codeEditor` — anything embedding the code editor
 
-Reuse an existing group when it covers the UX area. Only create a new one when there's no overlap.
+Only create a new group once the user confirms no existing one fits.
 
 #### Choosing a term
 

--- a/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
+++ b/src/Umbraco.Web.UI.Client/.claude/skills/general-add-localization/SKILL.md
@@ -37,14 +37,45 @@ export default {
 - **Group**: camelCase feature name (e.g., `actions`, `general`, `content`, `media`, `user`)
 - **Term**: camelCase descriptive name (e.g., `assignDomain`, `auditTrail`, `browse`)
 - **Full key** used in code: `group_termName` (underscore separator)
-- Add to an **existing group** when the text belongs to that feature area
-- Create a **new group** only for new feature areas
+
+#### Choosing a group
+
+A group should cover a reasonable **scope of usage**, not just the one component you're currently editing. Before naming a group, ask: "where else in the backoffice does this same UX pattern show up?" If several features share the same UX, they should share the same group — otherwise the same kind of text ends up duplicated (and inconsistently worded) across `myFeatureA` and `myFeatureB`.
+
+Examples already in this codebase:
+
+- `blockEditor` — shared by Block List, Block Grid, and Block RTE, because they share the same block-configuration and editing UX
+- `contentTypeEditor` — shared by Document Type, Media Type, and Member Type editing
+- `codeEditor` — shared by anything embedding the code editor
+
+Check whether an existing group already covers the UX area before creating a new one. Only introduce a new group when the text belongs to a feature area with no existing overlap.
+
+#### Choosing a term
+
+A term describes the **situation the text is used in** — not the wording of the text itself. Two situations that happen to use identical English wording today should still get two separate terms, since the copy for one may change independently of the other later.
+
+Build the term from two parts:
+
+1. **How it's presented** — the UI role the text plays: `Title`, `Description`, `Action`, `Label`, `Notice`, `Message`, `ValidationMessage`, `Headline`, etc.
+2. **What it represents** — a short name for the subject or situation: `CreateBlock`, `ConfirmDelete`, `AddGroup`.
+
+Combined, in either order depending on what reads best: `createAction`, `confirmDeleteTitle`, `addGroupDescription`.
+
+This matters most when several terms belong to the same moment in the UI. Take the `blockEditor` group's "delete a block group" confirmation:
+
+```typescript
+confirmDeleteBlockGroupTitle: 'Delete group?',
+confirmDeleteBlockGroupMessage: 'Are you sure you want to delete group <strong>%0%</strong>?',
+confirmDeleteBlockGroupNotice: 'The content of these Blocks will still be present, editing of this content will no longer be available and will be shown as unsupported content.',
+```
+
+Same subject (`confirmDeleteBlockGroup`), three presentation roles (`Title`, `Message`, `Notice`). Naming them this way keeps every piece of that one dialog grouped together, and makes it obvious they belong to the same situation even though the wording has nothing in common.
 
 ### Value types
 
-| Type | Use when | Example |
-|------|----------|---------|
-| `string` | Static text | `myLabel: 'My Label'` |
+| Type               | Use when                 | Example                                           |
+| ------------------ | ------------------------ | ------------------------------------------------- |
+| `string`           | Static text              | `myLabel: 'My Label'`                             |
 | `(args) => string` | Text with dynamic values | `createFor: (name: string) => \`Create ${name}\`` |
 
 ## Step 2: Use the localized text
@@ -60,9 +91,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 @customElement('umb-my-element')
 export class UmbMyElement extends UmbLitElement {
 	override render() {
-		return html`
-			<uui-button label=${this.localize.term('myFeature_myLabel')}></uui-button>
-		`;
+		return html` <uui-button label=${this.localize.term('myFeature_myLabel')}></uui-button> `;
 	}
 }
 ```


### PR DESCRIPTION
Improving the localization skill regarding naming conventions for Localization Terms.
This will additionally improve the review skill as the information will be surfaced when adding new localizations.