### PR TITLE
Dependencies: Update MailKit dependency and resolve nullability breaking changes (for Umbraco 13)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="Examine.Core" Version="3.8.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.74" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-    <PackageVersion Include="MailKit" Version="4.8.0" />
+    <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
     <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -10,13 +10,13 @@ internal static class EmailMessageExtensions
     {
         var fromEmail = string.IsNullOrEmpty(mailMessage.From) ? configuredFromAddress : mailMessage.From;
 
-        if (!InternetAddress.TryParse(fromEmail, out InternetAddress fromAddress))
+        if (!InternetAddress.TryParse(fromEmail, out InternetAddress? fromAddress))
         {
             throw new ArgumentException(
                 $"Email could not be sent.  Could not parse from address {fromEmail} as a valid email address.");
         }
 
-        var messageToSend = new MimeMessage { From = { fromAddress }, Subject = mailMessage.Subject };
+        var messageToSend = new MimeMessage { From = { fromAddress }, Subject = mailMessage.Subject ?? string.Empty };
 
         AddAddresses(messageToSend, mailMessage.To, x => x.To, true);
         AddAddresses(messageToSend, mailMessage.Cc, x => x.Cc);
@@ -45,7 +45,7 @@ internal static class EmailMessageExtensions
         else
         {
             messageToSend.Body =
-                new TextPart(mailMessage.IsBodyHtml ? TextFormat.Html : TextFormat.Plain) { Text = mailMessage.Body };
+                new TextPart(mailMessage.IsBodyHtml ? TextFormat.Html : TextFormat.Plain) { Text = mailMessage.Body ?? string.Empty };
         }
 
         return messageToSend;
@@ -78,7 +78,7 @@ internal static class EmailMessageExtensions
         {
             foreach (var address in addresses)
             {
-                if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
+                if (InternetAddress.TryParse(address, out InternetAddress? internetAddress))
                 {
                     addressListGetter(message).Add(internetAddress);
                     foundValid = true;
@@ -94,11 +94,11 @@ internal static class EmailMessageExtensions
 
     private static NotificationEmailAddress? ToNotificationAddress(string? address)
     {
-        if (InternetAddress.TryParse(address, out InternetAddress internetAddress))
+        if (InternetAddress.TryParse(address, out InternetAddress? internetAddress))
         {
             if (internetAddress is MailboxAddress mailboxAddress)
             {
-                return new NotificationEmailAddress(mailboxAddress.Address, internetAddress.Name);
+                return new NotificationEmailAddress(mailboxAddress.Address, mailboxAddress.Name ?? string.Empty);
             }
         }
 

--- a/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
+++ b/src/Umbraco.Infrastructure/Extensions/EmailMessageExtensions.cs
@@ -16,7 +16,7 @@ internal static class EmailMessageExtensions
                 $"Email could not be sent.  Could not parse from address {fromEmail} as a valid email address.");
         }
 
-        var messageToSend = new MimeMessage { From = { fromAddress }, Subject = mailMessage.Subject ?? string.Empty };
+        var messageToSend = new MimeMessage { From = { fromAddress }, Subject = mailMessage.Subject! };
 
         AddAddresses(messageToSend, mailMessage.To, x => x.To, true);
         AddAddresses(messageToSend, mailMessage.Cc, x => x.Cc);
@@ -45,7 +45,7 @@ internal static class EmailMessageExtensions
         else
         {
             messageToSend.Body =
-                new TextPart(mailMessage.IsBodyHtml ? TextFormat.Html : TextFormat.Plain) { Text = mailMessage.Body ?? string.Empty };
+                new TextPart(mailMessage.IsBodyHtml ? TextFormat.Html : TextFormat.Plain) { Text = mailMessage.Body! };
         }
 
         return messageToSend;

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -154,7 +154,13 @@ public class EmailSender : IEmailSender
 
         if (string.IsNullOrWhiteSpace(_globalSettings.Smtp!.Host))
         {
-            throw new InvalidOperationException("Cannot send email over SMTP: no host is configured.");
+            // We only reach here without an SMTP host when the pickup-directory path above was skipped.
+            // The one way that happens is a pickup directory configured without the required 'From' address,
+            // so point the user at that rather than reporting a generic missing-host error.
+            throw new InvalidOperationException(
+                _globalSettings.IsPickupDirectoryLocationConfigured
+                    ? "Cannot send email: a pickup directory is configured but no 'From' address is set (Smtp.From), and no SMTP host is configured as a fallback. Set Smtp.From to use the pickup directory, or configure an SMTP host."
+                    : "Cannot send email over SMTP: no host is configured.");
         }
 
         using var client = new SmtpClient();

--- a/src/Umbraco.Infrastructure/Mail/EmailSender.cs
+++ b/src/Umbraco.Infrastructure/Mail/EmailSender.cs
@@ -152,10 +152,15 @@ public class EmailSender : IEmailSender
             while (true);
         }
 
+        if (string.IsNullOrWhiteSpace(_globalSettings.Smtp!.Host))
+        {
+            throw new InvalidOperationException("Cannot send email over SMTP: no host is configured.");
+        }
+
         using var client = new SmtpClient();
 
         await client.ConnectAsync(
-            _globalSettings.Smtp!.Host,
+            _globalSettings.Smtp.Host,
             _globalSettings.Smtp.Port,
             (SecureSocketOptions)(int)_globalSettings.Smtp.SecureSocketOptions);
 

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -670,10 +670,15 @@ public class UsersController : BackOfficeNotificationsController
             UmbracoUserExtensions.GetUserCulture(to?.Language, _localizedTextService, _globalSettings),
             new[] { name, from, WebUtility.HtmlEncode(message)!.ReplaceLineEndings("<br/>"), inviteUri.ToString(), senderEmail });
 
+        // An invite email cannot be sent without a recipient address, so fail fast with a clear
+        // message rather than constructing an invalid MailboxAddress from an empty string.
+        var toEmail = to?.Email ??
+            throw new InvalidOperationException("Cannot send user invite email: recipient email address is missing.");
+
         // This needs to be in the correct mailto format including the name, else
         // the name cannot be captured in the email sending notification.
         // i.e. "Some Person" <hello@example.com>
-        var toMailBoxAddress = new MailboxAddress(to?.Name, to?.Email ?? string.Empty);
+        var toMailBoxAddress = new MailboxAddress(to?.Name, toEmail);
 
         var mailMessage = new EmailMessage(senderEmail, toMailBoxAddress.ToString(), emailSubject, emailBody, true);
 

--- a/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
+++ b/src/Umbraco.Web.BackOffice/Controllers/UsersController.cs
@@ -673,7 +673,7 @@ public class UsersController : BackOfficeNotificationsController
         // This needs to be in the correct mailto format including the name, else
         // the name cannot be captured in the email sending notification.
         // i.e. "Some Person" <hello@example.com>
-        var toMailBoxAddress = new MailboxAddress(to?.Name, to?.Email);
+        var toMailBoxAddress = new MailboxAddress(to?.Name, to?.Email ?? string.Empty);
 
         var mailMessage = new EmailMessage(senderEmail, toMailBoxAddress.ToString(), emailSubject, emailBody, true);
 


### PR DESCRIPTION
## Description

Updates the `MailKit` dependency from **4.8.0 → 4.17.0** to remediate a known vulnerability in the previously referenced version. Although this is a minor version bump, it surfaced nullability-related compiler breaking changes, which are resolved here.

### Why a minor bump broke the build

This is **not** a runtime API change. Between 4.8.0 and 4.16.0, MailKit/MimeKit enabled `<Nullable>enable</Nullable>` in their own build, so the shipped assemblies now carry nullable reference type annotations. 4.8.0 was nullable-*oblivious* (consumers got no warnings); 4.17.0 exposes real nullability, producing warnings — errors, under warnings-as-errors — at our call sites. Every change below is resolving a newly *surfaced* annotation, not a behavioural change in the library.

### Changes

- **`Directory.Packages.props`** — MailKit `4.8.0` → `4.17.0`.
- **`EmailMessageExtensions.cs`**
  - `InternetAddress.TryParse` now declares `[NotNullWhen(true)] out InternetAddress?`, so the `out` locals become `InternetAddress?` (the `[NotNullWhen(true)]` keeps their use inside the success branch warning-free).
  - `MimeMessage.Subject` and `TextPart.Text` require non-null values. Since `EmailMessage`'s constructor already enforces a non-null/non-empty `Subject` and `Body`, these use the null-forgiving operator (`mailMessage.Subject!` / `mailMessage.Body!`) to make that invariant explicit. This keeps the original runtime behaviour and avoids masking an invalid `EmailMessage` — coalescing to `string.Empty` would silently hide such a violation.
  - Simplified the notification display name to `mailboxAddress.Name ?? string.Empty` (dropped a redundant null-conditional on an already-proven-non-null value; `InternetAddress.Name` is genuinely nullable, so the empty default is warranted here).
- **`EmailSender.cs`** — `SmtpClient.ConnectAsync(host, …)` requires a non-null host. Rather than silently pass an empty string (`Host` is *required* config, and empty is never valid), added a guard that throws a clear `InvalidOperationException` when no SMTP host is configured.
- **`UsersController.cs`** — `MailboxAddress(string? name, string address)` requires a non-null address. An invite email cannot be sent without a recipient, so rather than defaulting to `string.Empty` this now fails fast with a clear `InvalidOperationException` when the recipient has no email address.

### Testing

To verify the full send path end-to-end I used this throwaway debug controller you can drop into `src/Umbraco.Web.UI/Controllers/`.

Log in, configure SMTP (e.g. using smtp4dev or a `SpecifiedPickupDirectory` to write `.eml` files to disk without a real server), then hit `/umbraco/surface/debugemail/send?to=you@example.com`.

```csharp
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Cache;
using Umbraco.Cms.Core.Logging;
using Umbraco.Cms.Core.Mail;
using Umbraco.Cms.Core.Models.Email;
using Umbraco.Cms.Core.Routing;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Web;
using Umbraco.Cms.Infrastructure.Persistence;
using Umbraco.Cms.Web.Website.Controllers;

namespace Umbraco.Cms.Web.UI.Controllers;

public class DebugEmailController : SurfaceController
{
    private readonly IEmailSender _emailSender;

    public DebugEmailController(
        IUmbracoContextAccessor umbracoContextAccessor,
        IUmbracoDatabaseFactory databaseFactory,
        ServiceContext services,
        AppCaches appCaches,
        IProfilingLogger profilingLogger,
        IPublishedUrlProvider publishedUrlProvider,
        IEmailSender emailSender)
        : base(umbracoContextAccessor, databaseFactory, services, appCaches, profilingLogger, publishedUrlProvider)
        => _emailSender = emailSender;

    [HttpGet]
    public async Task<IActionResult> Send(string to = "recipient@example.com", string? from = null, bool html = false)
    {
        if (!_emailSender.CanSendRequiredEmail())
        {
            return StatusCode(
                StatusCodes.Status500InternalServerError,
                "Email is not configured: neither an SMTP server nor a pickup directory is set up.");
        }

        var message = new EmailMessage(
            from,
            to,
            "Umbraco MailKit upgrade test",
            html
                ? "<p>This is a <strong>test</strong> email sent from the debug controller.</p>"
                : "This is a test email sent from the debug controller.",
            html);

        try
        {
            await _emailSender.SendAsync(message, "Debug");
        }
        catch (Exception ex)
        {
            return StatusCode(StatusCodes.Status500InternalServerError, $"Failed to send email to '{to}':\n\n{ex}");
        }

        return Ok($"Email to '{to}' was handed off to the sender without error.");
    }
}
```

> ⚠️ **Security note** This snippet is deliberately unhardened for local convenience.  It's included here purely as a testing aid. 
