### PR TITLE
Table: make header buttons align left

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -616,7 +616,7 @@ export class UmbTableElement extends UmbLitElement {
 				align-items: center;
 				justify-content: space-between;
 				width: 100%;
-				text-align: left;
+				text-align: inherit;
 			}
 
 			uui-table-head-cell button > span {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -616,6 +616,7 @@ export class UmbTableElement extends UmbLitElement {
 				align-items: center;
 				justify-content: space-between;
 				width: 100%;
+				text-align: left;
 			}
 
 			uui-table-head-cell button > span {


### PR DESCRIPTION
Make table header buttons align left:

<img width="613" height="184" alt="image" src="https://github.com/user-attachments/assets/f352768e-8da2-4b1a-8a61-b2cd7c244e50" />

Previously:

<img width="445" height="188" alt="image" src="https://github.com/user-attachments/assets/f6314e20-b60f-4ab0-b827-26fc22bffbc7" />
