### PR TITLE
Resolve agent disk space issue

### DIFF
--- a/build/templates/backoffice-install.yml
+++ b/build/templates/backoffice-install.yml
@@ -1,4 +1,14 @@
 steps:
+  # The Microsoft-hosted Linux agents can run low on disk space, which causes the cache
+  # save step below to fail while writing its archive. The pre-installed Android SDK is
+  # unused by any Umbraco job, so removing it reclaims the space.
+  - bash: |
+      df -h /
+      sudo rm -rf /usr/local/lib/android
+      df -h /
+    displayName: Free up disk space
+    condition: eq(variables['Agent.OS'], 'Linux')
+
   - task: NodeTool@0
     displayName: Use Node.js
     retryCountOnTaskFailure: 3


### PR DESCRIPTION
## Description

Today we've had all builds failing on `v17/dev` due to a failure in the front-end build step, where a clean-up job runs out of space.

```
Starting: Cache node_modules
==============================================================================
Task         : Cache
Description  : Cache files between runs
Version      : 2.274.0
Author       : Microsoft Corporation
Help         : https://aka.ms/pipeline-caching-docs
==============================================================================
Resolving key:
 - "npm_client"                                       [string]
 - "Linux"                                            [string]
 - /home/vsts/work/1/s/src/Umbraco.Web.UI.Client/p... [file] --> B07C2EA5392AD4EC2EA4FBC01CFDFDCFDCC4D16D9E79292F76208B4B2A8DCD77
Resolved to: "npm_client"|"Linux"|006a/gyeZilI2vIw4RWMn+TX8LgABgP91SwN/0ZFeyg=
Using default max parallelism.
Max dedup parallelism: 192
DomainId: 0
ApplicationInsightsTelemetrySender will correlate events with X-TFS-Session 40636ca2-c6b2-4196-9ae0-0d12566d3ef8
Hashtype: Dedup64K
Getting a pipeline cache artifact with one of the following fingerprints:
Fingerprint: `"npm_client"|"Linux"|006a/gyeZilI2vIw4RWMn+TX8LgABgP91SwN/0ZFeyg=`
There is a cache miss.
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
##[warning]Free disk space on / is lower than 5%; Currently used: 95.45%
tar: ffcde9d2b1884e9db52d0eb4063dcc79_archive.tar: Wrote only 4096 of 10240 bytes
tar: Error is not recoverable: exiting now
ApplicationInsightsTelemetrySender correlated 1 events with X-TFS-Session 40636ca2-c6b2-4196-9ae0-0d12566d3ef8
##[error]Process returned non-zero exit code: 2
Finishing: Cache node_modules
```

This PR reclaims some space by removing the mult-GB Android toolkit that we don't need to build Umbraco:

```
- bash: |
      df -h /
      sudo rm -rf /usr/local/lib/android   # ~14 GB, unused by any Umbraco job
      df -h /
    displayName: 'Free up disk space'
```

## Testing

I've verified this PR be noting that the build failed with the first empty commit (i.e. using code from `v17/dev`), but passes once the second commit was added that removes the Android toolkit.
