### PR TITLE
Documents: Pre-select default template on document creation (closes #23293)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/repository/detail/document-detail.server.data-source.ts
@@ -39,11 +39,12 @@ export class UmbDocumentServerDataSource
 		const { data } = await new UmbDocumentTypeDetailServerDataSource(this).read(documentTypeUnique);
 		const documentTypeIcon = data?.icon ?? null;
 		const documentTypeCollection = data?.collection ?? null;
+		const defaultTemplate = data?.defaultTemplate ? { unique: data.defaultTemplate.id } : null;
 
 		const defaultData: UmbDocumentDetailModel = {
 			entityType: UMB_DOCUMENT_ENTITY_TYPE,
 			unique: UmbId.new(),
-			template: null,
+			template: defaultTemplate,
 			documentType: {
 				unique: documentTypeUnique,
 				collection: documentTypeCollection,


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

Fixes #23293

### Description

When creating a new content node, the Info tab showed no template selected until after the first save/publish. The document type's `defaultTemplate` was already being fetched during scaffold creation but was never used — `template` was hardcoded to `null`.

The fix seeds the scaffold with `defaultTemplate` from the document type, so new nodes immediately reflect the correct default in the Info tab.

#### Testing

Create a document type with at least one allowed template and a default template set. Create a new content node of that type and open the Info tab before saving — the default template should now be shown as selected.

---

> **Question for reviewers:** If a user opens the create workspace, removes the pre-selected template so the field is empty, then saves and publishes — the frontend sends `null` for the template in the create request. However, the subsequent GET returns the default template rather than `null`. This means it appears impossible to explicitly create a document with no template when the document type has a default template. I'm guessing this a bug and not intentional? Although changing it would be a behavioral change.