### PR TITLE
Code Quality: Resolved warnings relating to hidden inherited member

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PartialViewRepository.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/PartialViewRepository.cs
@@ -124,35 +124,6 @@ internal sealed class PartialViewRepository : FileRepository<string, IPartialVie
     }
 
     /// <summary>
-    /// Returns a stream for reading the content of the file at the specified <paramref name="filepath"/>.
-    /// </summary>
-    /// <param name="filepath">The path of the file to read from the file system.</param>
-    /// <returns>A <see cref="Stream"/> containing the file's content, or <see cref="Stream.Null"/> if the file does not exist or cannot be opened.</returns>
-    public Stream GetFileContentStream(string filepath)
-    {
-        if (FileSystem?.FileExists(filepath) == false)
-        {
-            return Stream.Null;
-        }
-
-        try
-        {
-            return FileSystem?.OpenFile(filepath) ?? Stream.Null;
-        }
-        catch
-        {
-            return Stream.Null; // deal with race conds
-        }
-    }
-
-    /// <summary>
-    /// Sets the content of the specified file by writing the provided stream to the given file path, overwriting any existing content.
-    /// </summary>
-    /// <param name="filepath">The path of the file to which the content will be written.</param>
-    /// <param name="content">A stream containing the content to write to the file.</param>
-    public void SetFileContent(string filepath, Stream content) => FileSystem?.AddFile(filepath, content, true);
-
-    /// <summary>
     ///     Persists a new partial view item, but only when not in production runtime mode.
     /// </summary>
     /// <param name="entity">The partial view entity to persist.</param>

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Culture/AllCultureControllerTests.cs
@@ -14,7 +14,7 @@ public class AllCultureControllerTests : ManagementApiUserGroupTestBase<AllCultu
     private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var langDa = new LanguageBuilder()
             .WithCultureInfo("da-DK")

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/BatchDataTypesControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/BatchDataTypesControllerTests.cs
@@ -18,7 +18,7 @@ public class BatchDataTypesControllerTests : ManagementApiUserGroupTestBase<Batc
     private Guid _key2;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataType1 = new DataTypeBuilder()
             .WithId(0)

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/ByKeyDataTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/ByKeyDataTypeControllerTests.cs
@@ -17,7 +17,7 @@ public class ByKeyDataTypeControllerTests : ManagementApiUserGroupTestBase<ByKey
     private Guid _dataTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataType = new DataTypeBuilder()
             .WithId(0)

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/CopyDataTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/CopyDataTypeControllerTests.cs
@@ -23,7 +23,7 @@ public class CopyDataTypeControllerTests : ManagementApiUserGroupTestBase<CopyDa
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Folder
         var responseFolder = await DataTypeContainerService.CreateAsync(Guid.NewGuid(), "TestFolder", Constants.System.RootKey, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/DeleteDataTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/DeleteDataTypeControllerTests.cs
@@ -17,7 +17,7 @@ public class DeleteDataTypeControllerTests : ManagementApiUserGroupTestBase<Dele
     private Guid _dataTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataType = new DataTypeBuilder()
             .WithId(0)

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/ByKeyDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/ByKeyDataTypeFolderControllerTests.cs
@@ -14,7 +14,7 @@ public class ByKeyDataTypeFolderControllerTests : ManagementApiUserGroupTestBase
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var response = await DataTypeContainerService.CreateAsync(Guid.NewGuid(), "TestFolder", Constants.System.RootKey, Constants.Security.SuperUserKey);
         _folderKey = response.Result.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/DeleteDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/DeleteDataTypeFolderControllerTests.cs
@@ -14,7 +14,7 @@ public class DeleteDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var response = await DataTypeContainerService.CreateAsync(Guid.NewGuid(), "TestFolder", Constants.System.RootKey, Constants.Security.SuperUserKey);
         _folderKey = response.Result.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/UpdateDataTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Folder/UpdateDataTypeFolderControllerTests.cs
@@ -16,7 +16,7 @@ public class UpdateDataTypeFolderControllerTests : ManagementApiUserGroupTestBas
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var response = await DataTypeContainerService.CreateAsync(Guid.NewGuid(), "TestFolder", Constants.System.RootKey, Constants.Security.SuperUserKey);
         _folderKey = response.Result.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/IsUsedDataTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/IsUsedDataTypeControllerTests.cs
@@ -17,7 +17,7 @@ public class IsUsedDataTypeControllerTests : ManagementApiUserGroupTestBase<IsUs
     private Guid _dataTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataType = new DataTypeBuilder()
             .WithId(0)

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Item/AncestorsDataTypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Item/AncestorsDataTypeItemControllerTests.cs
@@ -17,7 +17,7 @@ public class AncestorsDataTypeItemControllerTests : ManagementApiUserGroupTestBa
     private Guid _dataTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataType = new DataTypeBuilder()
             .WithId(0)

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Item/ItemDatatypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Item/ItemDatatypeItemControllerTests.cs
@@ -17,7 +17,7 @@ public class ItemDatatypeItemControllerTests : ManagementApiUserGroupTestBase<It
     private Guid _dataTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataType = new DataTypeBuilder()
             .WithId(0)

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/MoveDataTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/MoveDataTypeControllerTests.cs
@@ -23,7 +23,7 @@ public class MoveDataTypeControllerTests : ManagementApiUserGroupTestBase<MoveDa
     private Guid _folderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var responseFolder = await DataTypeContainerService.CreateAsync(Guid.NewGuid(), "TestFolder", Constants.System.RootKey, Constants.Security.SuperUserKey);
         _folderKey = responseFolder.Result.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Tree/ChildrenDataTypeTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/Tree/ChildrenDataTypeTreeControllerTests.cs
@@ -19,7 +19,7 @@ public class ChildrenDataTypeTreeControllerTests : ManagementApiUserGroupTestBas
     private Guid _dataTypeFolderKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Folder
         _dataTypeFolderKey = Guid.NewGuid();

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DataType/UpdateDataTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DataType/UpdateDataTypeControllerTests.cs
@@ -19,7 +19,7 @@ public class UpdateDataTypeControllerTests : ManagementApiUserGroupTestBase<Upda
     private Guid _dataTypeId;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataType = new DataTypeBuilder()
             .WithId(0)

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/AllDictionaryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/AllDictionaryControllerTests.cs
@@ -13,7 +13,7 @@ public class AllDictionaryControllerTests : ManagementApiUserGroupTestBase<AllDi
     private IDictionaryItemService DictionaryItemService => GetRequiredService<IDictionaryItemService>();
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());
         await DictionaryItemService.CreateAsync(dictionaryItem, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/ByKeyDictionaryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/ByKeyDictionaryControllerTests.cs
@@ -15,7 +15,7 @@ public class ByKeyDictionaryControllerTests : ManagementApiUserGroupTestBase<ByK
     private Guid _dictionaryKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());
         _dictionaryKey = dictionaryItem.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/DeleteDictionaryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/DeleteDictionaryControllerTests.cs
@@ -15,7 +15,7 @@ public class DeleteDictionaryControllerTests : ManagementApiUserGroupTestBase<De
     private Guid _dictionaryKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());
         _dictionaryKey = dictionaryItem.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/ExportDictionaryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/ExportDictionaryControllerTests.cs
@@ -15,7 +15,7 @@ public class ExportDictionaryControllerTests : ManagementApiUserGroupTestBase<Ex
     private Guid _dictionaryKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());
         _dictionaryKey = dictionaryItem.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/ImportDictionaryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/ImportDictionaryControllerTests.cs
@@ -30,7 +30,7 @@ public class ImportDictionaryControllerTests : ManagementApiUserGroupTestBase<Im
     }
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var createTempFileModel = new CreateTemporaryFileModel
         {

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/Item/ItemDictionaryItemControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/Item/ItemDictionaryItemControllerTests.cs
@@ -15,7 +15,7 @@ public class ItemDictionaryItemControllerTests : ManagementApiUserGroupTestBase<
     private Guid _dictionaryKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());
         _dictionaryKey = dictionaryItem.Key;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/MoveDictionaryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/MoveDictionaryControllerTests.cs
@@ -19,7 +19,7 @@ public class MoveDictionaryControllerTests : ManagementApiUserGroupTestBase<Move
     private Guid _targetId;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var originalDictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());
         var targetDictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/Tree/ChildrenDictionaryTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/Tree/ChildrenDictionaryTreeControllerTests.cs
@@ -15,7 +15,7 @@ public class ChildrenDictionaryTreeControllerTests : ManagementApiUserGroupTestB
     private Guid _parentDictionaryKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Parent dictionary
         var dictionaryParentItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/UpdateDictionaryControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Dictionary/UpdateDictionaryControllerTests.cs
@@ -17,7 +17,7 @@ public class UpdateDictionaryControllerTests : ManagementApiUserGroupTestBase<Up
     private Guid _dictionaryKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dictionaryItem = new DictionaryItem(Constants.System.RootKey, Guid.NewGuid().ToString());
 

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/ByKeyDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/ByKeyDocumentControllerTests.cs
@@ -20,7 +20,7 @@ public class ByKeyDocumentControllerTests : ManagementApiUserGroupTestBase<ByKey
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/CopyDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/CopyDocumentControllerTests.cs
@@ -25,7 +25,7 @@ public class CopyDocumentControllerTests : ManagementApiUserGroupTestBase<CopyDo
     private Guid _moveContentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/CreateAndPublishDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/CreateAndPublishDocumentControllerTests.cs
@@ -21,7 +21,7 @@ public class CreateAndPublishDocumentControllerTests : ManagementApiUserGroupTes
     private Guid _contentTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/CreateDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/CreateDocumentControllerTests.cs
@@ -21,7 +21,7 @@ public class CreateDocumentControllerTests : ManagementApiUserGroupTestBase<Crea
     private Guid _contentTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/CreatePublicAccessDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/CreatePublicAccessDocumentControllerTests.cs
@@ -30,7 +30,7 @@ public class
     private Guid _contentErrorPageKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/DeletePublicAccessDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/DeletePublicAccessDocumentControllerTests.cs
@@ -29,7 +29,7 @@ public class DeletePublicAccessDocumentControllerTests : ManagementApiUserGroupT
     private Guid _contentErrorPageKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/DomainsControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/DomainsControllerTests.cs
@@ -27,7 +27,7 @@ public class DomainsControllerTests : ManagementApiUserGroupTestBase<DomainsCont
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/GetPublicAccessDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/GetPublicAccessDocumentControllerTests.cs
@@ -29,7 +29,7 @@ public class GetPublicAccessDocumentControllerTests : ManagementApiUserGroupTest
     private Guid _contentErrorPageKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/Item/AncestorsDocumentItemControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/Item/AncestorsDocumentItemControllerTests.cs
@@ -20,7 +20,7 @@ public class AncestorsDocumentItemControllerTests : ManagementApiUserGroupTestBa
     private Guid _contentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());
         await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/Item/ItemDocumentItemControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/Item/ItemDocumentItemControllerTests.cs
@@ -20,7 +20,7 @@ public class ItemDocumentItemControllerTests : ManagementApiUserGroupTestBase<It
     private Guid _contentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/MoveDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/MoveDocumentControllerTests.cs
@@ -25,7 +25,7 @@ public class MoveDocumentControllerTests : ManagementApiUserGroupTestBase<MoveDo
     private Guid _moveContentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/MoveToRecycleBinDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/MoveToRecycleBinDocumentControllerTests.cs
@@ -20,7 +20,7 @@ public class MoveToRecycleBinDocumentControllerTests : ManagementApiUserGroupTes
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/NotificationsControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/NotificationsControllerTests.cs
@@ -24,7 +24,7 @@ public class NotificationsControllerTests : ManagementApiUserGroupTestBase<Notif
     private Guid _contentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/PatchDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/PatchDocumentControllerTests.cs
@@ -37,7 +37,7 @@ public class PatchDocumentControllerTests : ManagementApiUserGroupTestBase<Patch
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/RecycleBin/ChildrenDocumentRecycleBinControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/RecycleBin/ChildrenDocumentRecycleBinControllerTests.cs
@@ -21,7 +21,7 @@ public class ChildrenDocumentRecycleBinControllerTests : ManagementApiUserGroupT
     private Guid _parentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/RecycleBin/RootDocumentRecycleBinControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/RecycleBin/RootDocumentRecycleBinControllerTests.cs
@@ -20,7 +20,7 @@ public class RootDocumentRecycleBinControllerTests : ManagementApiUserGroupTestB
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortChildrenDocumentControllerTests.cs
@@ -23,7 +23,7 @@ public class SortChildrenDocumentControllerTests : ManagementApiUserGroupTestBas
     private Guid _parentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());
         await TemplateService.CreateAsync(template, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/SortDocumentControllerTests.cs
@@ -23,7 +23,7 @@ public class SortDocumentControllerTests : ManagementApiUserGroupTestBase<SortDo
     private Guid _contentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/Tree/ChildrenDocumentTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/Tree/ChildrenDocumentTreeControllerTests.cs
@@ -21,7 +21,7 @@ public class ChildrenDocumentTreeControllerTests : ManagementApiUserGroupTestBas
     private Guid _parentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateAndPublishDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateAndPublishDocumentControllerTests.cs
@@ -23,7 +23,7 @@ public class UpdateAndPublishDocumentControllerTests : ManagementApiUserGroupTes
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateDocumentControllerTests.cs
@@ -23,7 +23,7 @@ public class UpdateDocumentControllerTests : ManagementApiUserGroupTestBase<Upda
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateDomainsControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateDomainsControllerTests.cs
@@ -29,7 +29,7 @@ public class UpdateDomainsControllerTests : ManagementApiUserGroupTestBase<Updat
     private Guid _documentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateNotificationsControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdateNotificationsControllerTests.cs
@@ -26,7 +26,7 @@ public class UpdateNotificationsControllerTests : ManagementApiUserGroupTestBase
     private Guid _contentKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdatePublicAccessDocumentControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Document/UpdatePublicAccessDocumentControllerTests.cs
@@ -33,7 +33,7 @@ public class UpdatePublicAccessDocumentControllerTests : ManagementApiUserGroupT
     private Guid _newContentErrorPageKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Item/ItemDocumentBlueprintControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentBlueprint/Item/ItemDocumentBlueprintControllerTests.cs
@@ -23,7 +23,7 @@ public class ItemDocumentBlueprintControllerTests : ManagementApiUserGroupTestBa
     private Guid _blueprintKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/AllowedParentsDocumentTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/AllowedParentsDocumentTypeControllerTests.cs
@@ -15,7 +15,7 @@ public class AllowedParentsDocumentTypeControllerTests : ManagementApiUserGroupT
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeEditingService.CreateAsync(new ContentTypeCreateModel { Key = _key, Name = Guid.NewGuid().ToString(), Alias = Guid.NewGuid().ToString() }, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/BatchDocumentTypesControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/BatchDocumentTypesControllerTests.cs
@@ -16,7 +16,7 @@ public class BatchDocumentTypesControllerTests : ManagementApiUserGroupTestBase<
     private Guid _key2;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key1 = Guid.NewGuid();
         _key2 = Guid.NewGuid();

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/ByKeyDocumentTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/ByKeyDocumentTypeControllerTests.cs
@@ -15,7 +15,7 @@ public class ByKeyDocumentTypeControllerTests : ManagementApiUserGroupTestBase<B
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeEditingService.CreateAsync(new ContentTypeCreateModel { Key = _key, Name = Guid.NewGuid().ToString(), Alias = Guid.NewGuid().ToString() }, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/DeleteDocumentTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/DeleteDocumentTypeControllerTests.cs
@@ -15,7 +15,7 @@ public class DeleteDocumentTypeControllerTests : ManagementApiUserGroupTestBase<
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeEditingService.CreateAsync(new ContentTypeCreateModel { Key = _key, Name = "Test", Alias = "test" }, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Folder/ByKeyDocumentTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Folder/ByKeyDocumentTypeFolderControllerTests.cs
@@ -14,7 +14,7 @@ public class ByKeyDocumentTypeFolderControllerTests : ManagementApiUserGroupTest
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeContainerService.CreateAsync(_key, "Test", Constants.System.RootKey, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Folder/DeleteDocumentTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Folder/DeleteDocumentTypeFolderControllerTests.cs
@@ -14,7 +14,7 @@ public class DeleteDocumentTypeFolderControllerTests : ManagementApiUserGroupTes
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeContainerService.CreateAsync(_key, "Test", null, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Folder/UpdateDocumentTypeFolderControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Folder/UpdateDocumentTypeFolderControllerTests.cs
@@ -16,7 +16,7 @@ public class UpdateDocumentTypeFolderControllerTests : ManagementApiUserGroupTes
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeContainerService.CreateAsync(_key, "Test", null, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Item/AncestorsDocumentTypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Item/AncestorsDocumentTypeItemControllerTests.cs
@@ -15,7 +15,7 @@ public class AncestorsDocumentTypeItemControllerTests : ManagementApiUserGroupTe
     private Guid _documentTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _documentTypeKey = Guid.NewGuid();
         await ContentTypeEditingService.CreateAsync(new ContentTypeCreateModel { Key = _documentTypeKey, Name = Guid.NewGuid().ToString(), Alias = Guid.NewGuid().ToString() }, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Item/ItemDocumentTypeItemControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Item/ItemDocumentTypeItemControllerTests.cs
@@ -15,7 +15,7 @@ public class ItemDocumentTypeItemControllerTests : ManagementApiUserGroupTestBas
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeEditingService.CreateAsync(new ContentTypeCreateModel { Key = _key, Name = Guid.NewGuid().ToString(), Alias = Guid.NewGuid().ToString() }, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Tree/ChildrenDocumentTypeTreeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/Tree/ChildrenDocumentTypeTreeControllerTests.cs
@@ -19,7 +19,7 @@ public class ChildrenDocumentTypeTreeControllerTests : ManagementApiUserGroupTes
     private Guid _contentTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _contentFolderKey = Guid.NewGuid();
         await ContentTypeContainerService.CreateAsync(_contentFolderKey,"Folder", null, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/UpdateDocumentTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/DocumentType/UpdateDocumentTypeControllerTests.cs
@@ -17,7 +17,7 @@ public class UpdateDocumentTypeControllerTests : ManagementApiUserGroupTestBase<
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await ContentTypeEditingService.CreateAsync(new ContentTypeCreateModel { Key = _key, Name = "Test", Alias = "test",  Icon = "icon-document" }, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/HealthCheck/ExecuteActionHealthCheckControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/HealthCheck/ExecuteActionHealthCheckControllerTests.cs
@@ -16,7 +16,7 @@ public class ExecuteActionHealthCheckControllerTests : ManagementApiUserGroupTes
     private HealthCheckCollection HealthChecks => GetRequiredService<HealthCheckCollection>();
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var dataIntegrityCheck = HealthChecks.FirstOrDefault(x => x.Name.Contains("Data Integrity", StringComparison.OrdinalIgnoreCase));
         _dataIntegrityHealthCheckId = dataIntegrityCheck.Id;

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/DeleteLanguageControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/DeleteLanguageControllerTests.cs
@@ -14,7 +14,7 @@ public class DeleteLanguageControllerTests : ManagementApiUserGroupTestBase<Dele
     private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var daLanguage = new LanguageBuilder()
             .WithCultureInfo("da-DK")

--- a/tests/Umbraco.Tests.Integration/ManagementApi/Language/UpdateLanguageControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/Language/UpdateLanguageControllerTests.cs
@@ -16,7 +16,7 @@ public class UpdateLanguageControllerTests : ManagementApiUserGroupTestBase<Upda
     private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         var daLanguage = new LanguageBuilder()
             .WithCultureInfo("da-DK")

--- a/tests/Umbraco.Tests.Integration/ManagementApi/LogViewer/SavedSearch/ByNameSavedSearchLogViewerControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/LogViewer/SavedSearch/ByNameSavedSearchLogViewerControllerTests.cs
@@ -11,7 +11,7 @@ public class ByNameSavedSearchLogViewerControllerTests : ManagementApiUserGroupT
     private ILogViewerService LogViewerService => GetRequiredService<ILogViewerService>();
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         await LogViewerService.AddSavedLogQueryAsync("Find All", "SELECT * FROM LogEntries");
     }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/LogViewer/SavedSearch/DeleteSavedSearchLogViewerControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/LogViewer/SavedSearch/DeleteSavedSearchLogViewerControllerTests.cs
@@ -11,7 +11,7 @@ public class DeleteSavedSearchLogViewerControllerTests : ManagementApiUserGroupT
     private ILogViewerService LogViewerService => GetRequiredService<ILogViewerService>();
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         await LogViewerService.AddSavedLogQueryAsync("Find All", "SELECT * FROM LogEntries");
     }

--- a/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/AllowedParentsMediaTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/AllowedParentsMediaTypeControllerTests.cs
@@ -15,7 +15,7 @@ public class AllowedParentsMediaTypeControllerTests : ManagementApiUserGroupTest
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await MediaTypeEditingService.CreateAsync(new MediaTypeCreateModel { Key = _key, Name = Guid.NewGuid().ToString(), Alias = Guid.NewGuid().ToString() }, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/BatchMediaTypesControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/BatchMediaTypesControllerTests.cs
@@ -16,7 +16,7 @@ public class BatchMediaTypesControllerTests : ManagementApiUserGroupTestBase<Bat
     private Guid _key2;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key1 = Guid.NewGuid();
         _key2 = Guid.NewGuid();

--- a/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/ByKeyMediaTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/ByKeyMediaTypeControllerTests.cs
@@ -15,7 +15,7 @@ public class ByKeyMediaTypeControllerTests : ManagementApiUserGroupTestBase<ByKe
     private Guid _mediaTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _mediaTypeKey = Guid.NewGuid();
         MediaTypeCreateModel mediaTypeCreateModel = new() { Name = Guid.NewGuid().ToString(), Alias = Guid.NewGuid().ToString(), Key = _mediaTypeKey };

--- a/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/DeleteMediaTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/DeleteMediaTypeControllerTests.cs
@@ -15,7 +15,7 @@ public class DeleteMediaTypeControllerTests : ManagementApiUserGroupTestBase<Del
     private Guid _mediaTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _mediaTypeKey = Guid.NewGuid();
         MediaTypeCreateModel mediaTypeCreateModel = new() { Name = "Test", Alias = "test", Key = _mediaTypeKey };

--- a/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/UpdateMediaTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/MediaType/UpdateMediaTypeControllerTests.cs
@@ -17,7 +17,7 @@ public class UpdateMediaTypeControllerTests : ManagementApiUserGroupTestBase<Upd
     private Guid _mediaTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _mediaTypeKey = Guid.NewGuid();
         MediaTypeCreateModel mediaTypeCreateModel = new() { Name = "Test", Alias = "test", Key = _mediaTypeKey };

--- a/tests/Umbraco.Tests.Integration/ManagementApi/MemberType/BatchMemberTypesControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/MemberType/BatchMemberTypesControllerTests.cs
@@ -16,7 +16,7 @@ public class BatchMemberTypesControllerTests : ManagementApiUserGroupTestBase<Ba
     private Guid _key2;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key1 = Guid.NewGuid();
         _key2 = Guid.NewGuid();

--- a/tests/Umbraco.Tests.Integration/ManagementApi/PropertyType/IsUsedPropertyTypeControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/PropertyType/IsUsedPropertyTypeControllerTests.cs
@@ -18,7 +18,7 @@ public class IsUsedPropertyTypeControllerTests : ManagementApiUserGroupTestBase<
     private Guid _contentTypeKey;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Template
         var template = TemplateBuilder.CreateTextPageTemplate(Guid.NewGuid().ToString());

--- a/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/ByKeyTemporaryFileControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/ByKeyTemporaryFileControllerTests.cs
@@ -14,7 +14,7 @@ public class ByKeyTemporaryFileControllerTests : ManagementApiUserGroupTestBase<
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await TemporaryFileService.CreateAsync(new CreateTemporaryFileModel { Key = _key, FileName = "File.png" });

--- a/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/DeleteTemporaryFileControllerTests.cs
+++ b/tests/Umbraco.Tests.Integration/ManagementApi/TemporaryFile/DeleteTemporaryFileControllerTests.cs
@@ -14,7 +14,7 @@ public class DeleteTemporaryFileControllerTests : ManagementApiUserGroupTestBase
     private Guid _key;
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         _key = Guid.NewGuid();
         await TemporaryFileService.CreateAsync(new CreateTemporaryFileModel { Key = _key, FileName = "File.png" });

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTestWithContent.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTestWithContent.cs
@@ -38,7 +38,7 @@ public abstract class UmbracoIntegrationTestWithContent : UmbracoIntegrationTest
     protected ContentType ContentType { get; private set; }
 
     [SetUp]
-    public virtual void Setup() => CreateTestData();
+    public new virtual void Setup() => CreateTestData();
 
     public virtual void CreateTestData()
     {

--- a/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTestWithContentEditing.cs
+++ b/tests/Umbraco.Tests.Integration/Testing/UmbracoIntegrationTestWithContentEditing.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Umbraco.
+// Copyright (c) Umbraco.
 // See LICENSE for more details.
 
 using NUnit.Framework;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentEditingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentEditingServiceTests.cs
@@ -19,7 +19,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 internal sealed class ContentEditingServiceTests : UmbracoIntegrationTestWithContent
 {
     [SetUp]
-    public void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
+    public new void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
 
     [TearDown]
     public void Teardown() => ContentRepositoryBase.ThrowOnWarning = false;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/ContentServiceTests.cs
@@ -41,15 +41,12 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 internal sealed class ContentServiceTests : UmbracoIntegrationTestWithContent
 {
     [SetUp]
-    public void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
+    public new void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
 
     [TearDown]
     public void Teardown() => ContentRepositoryBase.ThrowOnWarning = false;
     // TODO: Add test to verify there is only ONE newest document/content in {Constants.DatabaseSchema.Tables.Document} table after updating.
     // TODO: Add test to delete specific version (with and without deleting prior versions) and versions by date.
-
-
-    private IDataTypeService DataTypeService => GetRequiredService<IDataTypeService>();
 
     private ILocalizedTextService LocalizedTextService => GetRequiredService<ILocalizedTextService>();
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.cs
@@ -9,7 +9,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 internal sealed partial class DocumentNavigationServiceTests : DocumentNavigationServiceTestsBase
 {
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Root
         //    - Child 1

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/LogViewerServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/LogViewerServiceTests.cs
@@ -42,7 +42,7 @@ internal sealed class LogViewerServiceTests : UmbracoIntegrationTest
     private string _corruptLogfilePath;
 
     [OneTimeSetUp]
-    public void Setup()
+    public new void Setup()
     {
         var testRoot = TestContext.CurrentContext.TestDirectory.Split("bin")[0];
         var ioHelper = TestHelper.IOHelper;
@@ -66,7 +66,7 @@ internal sealed class LogViewerServiceTests : UmbracoIntegrationTest
     }
 
     [OneTimeTearDown]
-    public void TearDown()
+    public new void TearDown()
     {
         if (File.Exists(_sampleLogfilePath))
         {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/MediaEditingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/MediaEditingServiceTests.cs
@@ -23,7 +23,7 @@ internal sealed class MediaEditingServiceTests : UmbracoIntegrationTest
     private IMediaType ArticleMediaType { get; set; }
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         ImageMediaType = MediaTypeService.Get(Constants.Conventions.MediaTypes.Image);
         ArticleMediaType = MediaTypeService.Get(Constants.Conventions.MediaTypes.ArticleAlias);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/MediaNavigationServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/MediaNavigationServiceTests.cs
@@ -7,7 +7,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 internal sealed partial class MediaNavigationServiceTests : MediaNavigationServiceTestsBase
 {
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
     {
         // Album
         //    - Image 1

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/BackOfficeExamineSearcherTests.cs
@@ -27,7 +27,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Examine.Lucene.UmbracoExamine;
 internal sealed class BackOfficeExamineSearcherTests : ExamineBaseTest
 {
     [SetUp]
-    public void Setup()
+    public new void Setup()
     {
         TestHelper.DeleteDirectory(GetIndexPath(Constants.UmbracoIndexes.InternalIndexName));
         TestHelper.DeleteDirectory(GetIndexPath(Constants.UmbracoIndexes.ExternalIndexName));
@@ -39,7 +39,7 @@ internal sealed class BackOfficeExamineSearcherTests : ExamineBaseTest
                 }
 
     [TearDown]
-    public void TearDown()
+    public new void TearDown()
     {
         // When disposing examine, it does a final write, which ends up locking the file if the indexing is not done yet. So we have this wait to circumvent that.
         Thread.Sleep(1500);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineExternalIndexTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/ExamineExternalIndexTests.cs
@@ -30,7 +30,7 @@ internal sealed class ExamineExternalIndexTests : ExamineBaseTest
     private const string ContentName = "TestContent";
 
     [SetUp]
-    public void Setup()
+    public new void Setup()
     {
         TestHelper.DeleteDirectory(GetIndexPath(Constants.UmbracoIndexes.InternalIndexName));
         TestHelper.DeleteDirectory(GetIndexPath(Constants.UmbracoIndexes.ExternalIndexName));
@@ -42,7 +42,7 @@ internal sealed class ExamineExternalIndexTests : ExamineBaseTest
     }
 
     [TearDown]
-    public void TearDown()
+    public new void TearDown()
     {
         // When disposing examine, it does a final write, which ends up locking the file if the indexing is not done yet. So we have this wait to circumvent that.
         Thread.Sleep(1500);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/IndexTest.cs
@@ -22,7 +22,7 @@ internal sealed class IndexTest : ExamineBaseTest
     private IDocumentUrlService DocumentUrlService => GetRequiredService<IDocumentUrlService>();
 
     [SetUp]
-    public void Setup()
+    public new void Setup()
     {
         DocumentUrlService.InitAsync(false, CancellationToken.None).GetAwaiter().GetResult();
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/SearchTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Examine.Lucene/UmbracoExamine/SearchTests.cs
@@ -21,7 +21,7 @@ internal sealed class SearchTests : ExamineBaseTest
     private IDocumentUrlService DocumentUrlService => GetRequiredService<IDocumentUrlService>();
 
     [SetUp]
-    public void Setup()
+    public new void Setup()
     {
         DocumentUrlService.InitAsync(false, CancellationToken.None).GetAwaiter().GetResult();
     }

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/AdvancedMigrationTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/AdvancedMigrationTests.cs
@@ -32,8 +32,6 @@ internal sealed class AdvancedMigrationTests : UmbracoIntegrationTest
     private IUmbracoVersion UmbracoVersion => GetRequiredService<IUmbracoVersion>();
     private IEventAggregator EventAggregator => GetRequiredService<IEventAggregator>();
     private ICoreScopeProvider CoreScopeProvider => GetRequiredService<ICoreScopeProvider>();
-    private IScopeAccessor ScopeAccessor => GetRequiredService<IScopeAccessor>();
-    private ILoggerFactory LoggerFactory => GetRequiredService<ILoggerFactory>();
     private IMigrationBuilder MigrationBuilder => GetRequiredService<IMigrationBuilder>();
     private IUmbracoDatabaseFactory UmbracoDatabaseFactory => GetRequiredService<IUmbracoDatabaseFactory>();
     private IServiceScopeFactory ServiceScopeFactory => GetRequiredService<IServiceScopeFactory>();

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/CreatedPackageSchemaTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Packaging/CreatedPackageSchemaTests.cs
@@ -15,7 +15,7 @@ internal sealed class CreatedPackageSchemaTests : UmbracoIntegrationTest
     private ICreatedPackagesRepository CreatedPackageSchemaRepository =>
         GetRequiredService<ICreatedPackagesRepository>();
 
-    private ICoreScopeProvider ScopeProvider => GetRequiredService<ICoreScopeProvider>();
+    private new ICoreScopeProvider ScopeProvider => GetRequiredService<ICoreScopeProvider>();
 
     [Test]
     public void PackagesRepository_Can_Save_PackageDefinition()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Persistence/Repositories/TemplateRepositoryTest.cs
@@ -34,7 +34,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Persistence.Repos
 internal sealed class TemplateRepositoryTest : UmbracoIntegrationTest
 {
     [TearDown]
-    public void TearDown()
+    public new void TearDown()
     {
         var testHelper = new TestHelper();
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Runtime/FileSystemMainDomLockTests.cs
@@ -35,7 +35,7 @@ internal sealed class FileSystemMainDomLockTests : UmbracoIntegrationTest
     }
 
     [TearDown]
-    public void TearDown()
+    public new void TearDown()
     {
         CleanupTestFile(LockFilePath);
         CleanupTestFile(LockReleaseFilePath);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 public partial class ContentEditingServiceTests : ContentEditingServiceTestsBase
 {
     [SetUp]
-    public void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
+    public new void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
 
     public void Relate(IContent parent, IContent child, string relationTypeAlias = Constants.Conventions.RelationTypes.RelatedDocumentAlias)
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTagsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceTagsTests.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 internal sealed class ContentServiceTagsTests : UmbracoIntegrationTest
 {
     [SetUp]
-    public void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
+    public new void Setup() => ContentRepositoryBase.ThrowOnWarning = true;
 
     [TearDown]
     public void Teardown() => ContentRepositoryBase.ThrowOnWarning = false;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaListViewServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaListViewServiceTests.cs
@@ -27,7 +27,7 @@ internal sealed class MediaListViewServiceTests : ContentListViewServiceTestsBas
     private IUser SuperUser { get; set; }
 
     [SetUp]
-    public async Task Setup()
+    public new async Task Setup()
         => SuperUser = await GetSuperUser();
 
     [Test]

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackedReferencesServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/TrackedReferencesServiceTests.cs
@@ -38,7 +38,7 @@ internal class TrackedReferencesServiceTests : UmbracoIntegrationTest
     }
 
     [SetUp]
-    public void Setup() => CreateTestData();
+    public new void Setup() => CreateTestData();
 
     protected virtual void CreateTestData()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheAncestryVariantTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheAncestryVariantTests.cs
@@ -49,7 +49,7 @@ internal sealed class DocumentHybridCacheAncestryVariantTests : UmbracoIntegrati
     }
 
     [SetUp]
-    public async Task Setup() => await CreateTestData();
+    public new async Task Setup() => await CreateTestData();
 
     [Test]
     [TestCase(true)]

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheTemplateTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheTemplateTests.cs
@@ -25,8 +25,6 @@ internal sealed class DocumentHybridCacheTemplateTests : UmbracoIntegrationTestW
 
     private IPublishedContentCache PublishedContentHybridCache => GetRequiredService<IPublishedContentCache>();
 
-    private IContentEditingService ContentEditingService => GetRequiredService<IContentEditingService>();
-
     [Test]
     public async Task Can_Get_Document_After_Removing_Template()
     {

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVariantsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVariantsTests.cs
@@ -49,7 +49,7 @@ internal sealed class DocumentHybridCacheVariantsTests : UmbracoIntegrationTest
     }
 
     [SetUp]
-    public async Task Setup() => await CreateTestData();
+    public new async Task Setup() => await CreateTestData();
 
     [Test]
     public async Task Can_Set_Invariant_Title()

--- a/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Web.BackOffice/UrlAndDomains/DomainAndUrlsTests.cs
@@ -26,7 +26,7 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Web.BackOffice.UrlAndDomains;
 internal sealed class DomainAndUrlsTests : UmbracoIntegrationTest
 {
     [SetUp]
-    public void Setup()
+    public new void Setup()
     {
         var xml = PackageMigrationResource.GetEmbeddedPackageDataManifest(GetType());
         var packagingService = GetRequiredService<IPackagingService>();


### PR DESCRIPTION
Fixes both CS0114 and CS0108 warnings

Most were fixed by adding 'new'
A couple properties was deleted because they were identical to the property they were hiding.