### PR TITLE
Performance: Add index on `umbracoContent.contentTypeId`

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -186,6 +186,9 @@ public partial class UmbracoPlan : MigrationPlan
         To<V_17_4_0.AddExternalMemberTables>("{D7E8F9A0-B1C2-4D3E-A5F6-7890ABCDEF12}");
         To<V_17_4_0.FixLabelDataTypeDbTypeFromConfiguration>("{3F9B6A1C-7D84-4E2B-9C15-6A2E8F3D5B47}");
 
+        // To 17.6.0
+        To<V_17_6_0.AddContentTypeIdIndexForContent>("{3A1A8047-74AE-491A-B2C4-0BAE4A1289EC}");
+
         // To 18.0.0
         // TODO (V18): Enable on 18 branch
         //// To<V_18_0_0.MigrateSingleBlockList>("{74332C49-B279-4945-8943-F8F00B1F5949}");

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_6_0/AddContentTypeIdIndexForContent.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_6_0/AddContentTypeIdIndexForContent.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
+
+namespace Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_6_0;
+
+/// <summary>
+/// Adds an index on the contentTypeId column of the umbracoContent table to support efficient
+/// content-type-scoped queries (e.g. the content cache rebuild triggered by content type changes).
+/// </summary>
+public class AddContentTypeIdIndexForContent : AsyncMigrationBase
+{
+    private const string IndexName = "IX_" + ContentDto.TableName + "_" + ContentDto.ContentTypeIdColumnName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddContentTypeIdIndexForContent"/> class.
+    /// </summary>
+    /// <param name="context">The migration context.</param>
+    public AddContentTypeIdIndexForContent(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override Task MigrateAsync()
+    {
+        if (IndexExists(IndexName))
+        {
+            return Task.CompletedTask;
+        }
+
+        // Give scope for the migration to complete within the command timeout, which may be necessary on large datasets.
+        EnsureLongCommandTimeout(Database);
+
+        // Create the index from the definition on ContentDto, so it matches a fresh install exactly.
+        CreateIndex<ContentDto>(IndexName);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Umbraco.Infrastructure/Persistence/Dtos/ContentDto.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Dtos/ContentDto.cs
@@ -29,6 +29,7 @@ public class ContentDto
     /// </summary>
     [Column(ContentTypeIdColumnName)]
     [ForeignKey(typeof(ContentTypeDto), Column = ContentTypeDto.NodeIdColumnName)]
+    [Index(IndexTypes.NonClustered, Name = "IX_" + TableName + "_" + ContentTypeIdColumnName)]
     public int ContentTypeId { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## Description

Adds a non-clustered index on `umbracoContent(contentTypeId)`.

The column has a foreign key to `cmsContentType` but no supporting index. SQL Server does **not** automatically index foreign key columns, so any query that filters or joins on `umbracoContent.contentTypeId` has to scan the table.

That column is on the hot path for content-type-scoped operations — most notably the published cache (`cmsContentNu`) rebuild that runs when a document type changes structurally (e.g. a property is removed). That rebuild's delete, row count, and paged node-id selection all filter content by content type via this column:

```sql
DELETE FROM [cmsContentNu]
WHERE [nodeId] IN (
    SELECT [umbracoNode].[id]
    FROM [umbracoNode]
    INNER JOIN [umbracoContent] ON [umbracoNode].[id] = [umbracoContent].[nodeId]
    WHERE [umbracoNode].[nodeObjectType] = @0 AND [umbracoContent].[contentTypeId] IN (@1))
```

On sites with a large amount of content this scan is a measurable contributor to slow content-type saves (and, in the worst cases, to the SQL command timeouts some customers hit when editing a document type that backs a lot of content). The index lets these queries seek rather than scan.

### How it works

- **New installs** — the index is declared on `ContentDto.ContentTypeId` (`IX_umbracoContent_contentTypeId`), so the schema creator builds it from the DTO like every other index.
- **Upgrades** — a new migration (`V_17_6_0.AddContentTypeIdIndexForContent`) creates the same index. It uses the `CreateIndex<ContentDto>()` migration helper, so the index is generated from the exact same DTO definition — the migrated and freshly-installed schemas cannot drift. It is guarded by `IndexExists` (safe to re-run) and uses `EnsureLongCommandTimeout` since building the index can take a while on large tables.

## Testing

Solution builds and CI checks should pass. The existing `SchemaValidationTest` verifies the DTO-derived schema is internally consistent, which now includes the new index.

On starting up Umbraco and running either an attended or an unattended migration, the index should be created:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/b800a074-6c45-4c68-89b7-9544d4de15a6" />


