### PR TITLE
Performance: Batch the content cache delete on structural content type changes

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/NuCacheSettings.cs
@@ -27,6 +27,12 @@ public class NuCacheSettings
     internal const bool StaticUsePagedSqlQuery = true;
 
     /// <summary>
+    ///     The default number of content items whose stale NuCache rows are deleted per batch during a
+    ///     content type rebuild. Matches the SQL parameter limit ceiling the delete is capped to.
+    /// </summary>
+    internal const int StaticContentTypeRebuildDeleteBatchSize = 2000;
+
+    /// <summary>
     ///     The serializer type that nucache uses to persist documents in the database.
     /// </summary>
     [DefaultValue(StaticNuCacheSerializerType)]
@@ -43,4 +49,20 @@ public class NuCacheSettings
     /// </summary>
     [DefaultValue(StaticUsePagedSqlQuery)]
     public bool UsePagedSqlQuery { get; set; } = true;
+
+    /// <summary>
+    ///     Gets or sets the number of content items whose stale NuCache rows are deleted per batch during a
+    ///     content type structural rebuild.
+    /// </summary>
+    /// <remarks>
+    ///     Deleting in batches avoids a single unbounded DELETE that can escalate to a table lock, bloat the
+    ///     transaction log, or exceed the command timeout on sites with a lot of content. The matching node ids
+    ///     are read from the source tables once, then their rows are deleted in batches of this size, so the
+    ///     value only bounds the per-statement (and, for a deferred rebuild, per-transaction) footprint — it
+    ///     does not cause repeated scans. The effective size is capped at the SQL parameter limit
+    ///     (<see cref="Constants.Sql.MaxParameterCount" />); lower it if brief lock escalation on
+    ///     <c>cmsContentNu</c> during a rebuild is a concern.
+    /// </remarks>
+    [DefaultValue(StaticContentTypeRebuildDeleteBatchSize)]
+    public int ContentTypeRebuildDeleteBatchSize { get; set; } = StaticContentTypeRebuildDeleteBatchSize;
 }

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -445,43 +445,25 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
 
         Guid contentObjectType = Constants.ObjectTypes.Document;
 
-        long total = 0;
         Dictionary<int, byte>? contentTypeVariations = null;
         Dictionary<short, string>? languageMap = null;
         Dictionary<int, List<PropertyTypeInfo>>? propertyInfoByContentType = null;
 
-        // Delete and pre-fetch in one step, then release locks before the paging loop.
-        executeStep(() =>
-        {
-            RemoveByObjectType(contentObjectType, contentTypeIds);
-
-            Sql<ISqlContext> countSql = Sql()
-                .SelectCount()
-                .From<NodeDto>()
-                .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
-                .Where<NodeDto>(x => x.NodeObjectType == contentObjectType);
-
-            if (contentTypeIds.Count > 0)
-            {
-                countSql = countSql.WhereIn<ContentDto>(x => x.ContentTypeId, contentTypeIds);
-            }
-
-            total = Database.ExecuteScalar<long>(countSql);
-
-            if (total == 0)
-            {
-                return;
-            }
-
-            contentTypeVariations = GetContentTypeVariations(contentTypeIds);
-            languageMap = GetLanguageMap();
-            propertyInfoByContentType = GetPropertyInfoByContentType(contentTypeIds);
-        });
+        // Delete stale rows in batches (each its own step); the returned count of affected nodes is the
+        // number to repopulate, so no separate count query is needed.
+        long total = RemoveByObjectTypeInBatches(contentObjectType, contentTypeIds, executeStep);
 
         if (total == 0)
         {
             return;
         }
+
+        executeStep(() =>
+        {
+            contentTypeVariations = GetContentTypeVariations(contentTypeIds);
+            languageMap = GetLanguageMap();
+            propertyInfoByContentType = GetPropertyInfoByContentType(contentTypeIds);
+        });
 
         long processed = 0;
         long pageIndex = 0;
@@ -1023,38 +1005,21 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
 
         Guid mediaObjectType = Constants.ObjectTypes.Media;
 
-        long total = 0;
         Dictionary<int, List<string>>? propertyAliasesByContentType = null;
 
-        executeStep(() =>
-        {
-            RemoveByObjectType(mediaObjectType, contentTypeIds);
-
-            Sql<ISqlContext> countSql = Sql()
-                .SelectCount()
-                .From<NodeDto>()
-                .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
-                .Where<NodeDto>(x => x.NodeObjectType == mediaObjectType);
-
-            if (contentTypeIds.Count > 0)
-            {
-                countSql = countSql.WhereIn<ContentDto>(x => x.ContentTypeId, contentTypeIds);
-            }
-
-            total = Database.ExecuteScalar<long>(countSql);
-
-            if (total == 0)
-            {
-                return;
-            }
-
-            propertyAliasesByContentType = GetPropertyAliasesByContentType(contentTypeIds);
-        });
+        // Delete stale rows in batches (each its own step); the returned count of affected nodes is the
+        // number to repopulate, so no separate count query is needed.
+        long total = RemoveByObjectTypeInBatches(mediaObjectType, contentTypeIds, executeStep);
 
         if (total == 0)
         {
             return;
         }
+
+        executeStep(() =>
+        {
+            propertyAliasesByContentType = GetPropertyAliasesByContentType(contentTypeIds);
+        });
 
         long processed = 0;
         long pageIndex = 0;
@@ -1344,37 +1309,21 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
 
         Guid memberObjectType = Constants.ObjectTypes.Member;
 
-        long total = 0;
         Dictionary<int, List<string>>? propertyAliasesByContentType = null;
 
-        executeStep(() =>
-        {
-            RemoveByObjectType(memberObjectType, contentTypeIds);
-
-            Sql<ISqlContext> countSql = Sql()
-                .SelectCount()
-                .From<NodeDto>()
-                .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
-                .Where<NodeDto>(x => x.NodeObjectType == memberObjectType);
-
-            if (contentTypeIds.Count > 0)
-            {
-                countSql = countSql.WhereIn<ContentDto>(x => x.ContentTypeId, contentTypeIds);
-            }
-
-            total = Database.ExecuteScalar<long>(countSql);
-            if (total == 0)
-            {
-                return;
-            }
-
-            propertyAliasesByContentType = GetPropertyAliasesByContentType(contentTypeIds);
-        });
+        // Delete stale rows in batches (each its own step); the returned count of affected nodes is the
+        // number to repopulate, so no separate count query is needed.
+        long total = RemoveByObjectTypeInBatches(memberObjectType, contentTypeIds, executeStep);
 
         if (total == 0)
         {
             return;
         }
+
+        executeStep(() =>
+        {
+            propertyAliasesByContentType = GetPropertyAliasesByContentType(contentTypeIds);
+        });
 
         long processed = 0;
         long pageIndex = 0;
@@ -1413,6 +1362,112 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
 
             pageIndex++;
         }
+    }
+
+    /// <summary>
+    ///     Deletes the <c>cmsContentNu</c> rows for the given object type in batches, running each batch through
+    ///     the supplied <paramref name="executeStep" /> delegate.
+    /// </summary>
+    /// <remarks>
+    ///     Batching avoids a single unbounded DELETE that can escalate to a table lock, bloat the transaction
+    ///     log, and (for a content type backing a lot of content) exceed the command timeout. When the caller's
+    ///     <paramref name="executeStep" /> opens a fresh scope per step (the deferred rebuild path), each batch
+    ///     commits in its own transaction, so the locks and log space it uses are released between batches
+    ///     instead of accumulating across the whole delete. When it runs inline (the immediate path) the batches
+    ///     share the ambient transaction, but each DELETE statement is still individually bounded.
+    /// </remarks>
+    /// <returns>The number of content nodes affected, i.e. the number that will need repopulating.</returns>
+    private long RemoveByObjectTypeInBatches(Guid objectType, IReadOnlyCollection<int> contentTypeIds, Action<Action> executeStep)
+    {
+        // A full clear (no content type filter) is only used by full rebuilds, where the table has typically
+        // already been truncated, so keep it as a single statement.
+        if (contentTypeIds.Count == 0)
+        {
+            long allCount = 0;
+            executeStep(() =>
+            {
+                RemoveByObjectType(objectType, contentTypeIds);
+                allCount = CountByObjectType(objectType, contentTypeIds);
+            });
+            return allCount;
+        }
+
+        // The node ids come from the (stable) source tables, not cmsContentNu, so fetching them once up front
+        // is safe: concurrent foreground saves during a deferred rebuild only add/remove rows we either
+        // correctly skip (new rows are preserved) or harmlessly no-op on (already-removed rows).
+        List<int> nodeIds = [];
+        executeStep(() => nodeIds = GetNodeIdsByContentTypes(objectType, contentTypeIds));
+
+        var batchSize = Math.Clamp(_nucacheSettings.Value.ContentTypeRebuildDeleteBatchSize, 1, Constants.Sql.MaxParameterCount);
+        var totalBatches = (int)Math.Ceiling(nodeIds.Count / (double)batchSize);
+
+        _logger.LogDebug(
+            "Rebuild: deleting cmsContentNu rows for object type {ObjectType} — {NodeCount} node(s) in {BatchCount} batch(es) of up to {BatchSize}.",
+            objectType,
+            nodeIds.Count,
+            totalBatches,
+            batchSize);
+
+        var batchNumber = 0;
+        foreach (IEnumerable<int> batch in nodeIds.InGroupsOf(batchSize))
+        {
+            var nodeIdBatch = batch.ToArray();
+            var currentBatchNumber = ++batchNumber;
+            executeStep(() =>
+            {
+                DeleteContentNuByNodeIds(nodeIdBatch);
+                _logger.LogDebug(
+                    "Rebuild: deleted cmsContentNu batch {BatchNumber}/{BatchCount} ({NodeCount} node(s)) for object type {ObjectType}.",
+                    currentBatchNumber,
+                    totalBatches,
+                    nodeIdBatch.Length,
+                    objectType);
+            });
+        }
+
+        return nodeIds.Count;
+    }
+
+    private List<int> GetNodeIdsByContentTypes(Guid objectType, IReadOnlyCollection<int> contentTypeIds)
+    {
+        Sql<ISqlContext> sql = Sql()
+            .Select<NodeDto>(x => x.NodeId)
+            .From<NodeDto>()
+            .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
+            .Where<NodeDto>(x => x.NodeObjectType == objectType)
+            .WhereIn<ContentDto>(x => x.ContentTypeId, contentTypeIds);
+
+        return Database.Fetch<int>(sql);
+    }
+
+    private long CountByObjectType(Guid objectType, IReadOnlyCollection<int> contentTypeIds)
+    {
+        Sql<ISqlContext> sql = Sql()
+            .SelectCount()
+            .From<NodeDto>()
+            .InnerJoin<ContentDto>().On<NodeDto, ContentDto>((n, c) => n.NodeId == c.NodeId)
+            .Where<NodeDto>(x => x.NodeObjectType == objectType);
+
+        if (contentTypeIds.Count > 0)
+        {
+            sql = sql.WhereIn<ContentDto>(x => x.ContentTypeId, contentTypeIds);
+        }
+
+        return Database.ExecuteScalar<long>(sql);
+    }
+
+    private void DeleteContentNuByNodeIds(IReadOnlyCollection<int> nodeIds)
+    {
+        if (nodeIds.Count == 0)
+        {
+            return;
+        }
+
+        Sql<ISqlContext> sql = Sql()
+            .Delete<ContentNuDto>()
+            .WhereIn<ContentNuDto>(x => x.NodeId, nodeIds);
+
+        Database.Execute(sql);
     }
 
     private void RemoveByObjectType(Guid objectType, IReadOnlyCollection<int> contentTypeIds)

--- a/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
+++ b/src/Umbraco.PublishedCache.HybridCache/Persistence/DatabaseCacheRepository.cs
@@ -508,10 +508,16 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
                 pageComplete = true;
             });
 
+            // The break IS reachable: the executeStep delegate's early return (a page yielding no nodes — e.g.
+            // content removed concurrently, leaving the total row count stale) leaves pageComplete false, which
+            // guards against looping indefinitely. SonarLint cannot see through the delegate, so it incorrectly
+            // reports the condition as always false.
+#pragma warning disable S2583 // Conditionally executed code should be reachable
             if (!pageComplete)
             {
                 break;
             }
+#pragma warning restore S2583
 
             pageIndex++;
         }
@@ -1051,10 +1057,16 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
                 pageComplete = true;
             });
 
+            // The break IS reachable: the executeStep delegate's early return (a page yielding no nodes — e.g.
+            // content removed concurrently, leaving the total row count stale) leaves pageComplete false, which
+            // guards against looping indefinitely. SonarLint cannot see through the delegate, so it incorrectly
+            // reports the condition as always false.
+#pragma warning disable S2583 // Conditionally executed code should be reachable
             if (!pageComplete)
             {
                 break;
             }
+#pragma warning restore S2583
 
             pageIndex++;
         }
@@ -1355,10 +1367,16 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
                 pageComplete = true;
             });
 
+            // The break IS reachable: the executeStep delegate's early return (a page yielding no nodes — e.g.
+            // content removed concurrently, leaving the total row count stale) leaves pageComplete false, which
+            // guards against looping indefinitely. SonarLint cannot see through the delegate, so it incorrectly
+            // reports the condition as always false.
+#pragma warning disable S2583 // Conditionally executed code should be reachable
             if (!pageComplete)
             {
                 break;
             }
+#pragma warning restore S2583
 
             pageIndex++;
         }
@@ -1401,12 +1419,15 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
         var batchSize = Math.Clamp(_nucacheSettings.Value.ContentTypeRebuildDeleteBatchSize, 1, Constants.Sql.MaxParameterCount);
         var totalBatches = (int)Math.Ceiling(nodeIds.Count / (double)batchSize);
 
-        _logger.LogDebug(
-            "Rebuild: deleting cmsContentNu rows for object type {ObjectType} — {NodeCount} node(s) in {BatchCount} batch(es) of up to {BatchSize}.",
-            objectType,
-            nodeIds.Count,
-            totalBatches,
-            batchSize);
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "Rebuild: deleting cmsContentNu rows for object type {ObjectType} — {NodeCount} node(s) in {BatchCount} batch(es) of up to {BatchSize}.",
+                objectType,
+                nodeIds.Count,
+                totalBatches,
+                batchSize);
+        }
 
         var batchNumber = 0;
         foreach (IEnumerable<int> batch in nodeIds.InGroupsOf(batchSize))
@@ -1416,12 +1437,15 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
             executeStep(() =>
             {
                 DeleteContentNuByNodeIds(nodeIdBatch);
-                _logger.LogDebug(
-                    "Rebuild: deleted cmsContentNu batch {BatchNumber}/{BatchCount} ({NodeCount} node(s)) for object type {ObjectType}.",
-                    currentBatchNumber,
-                    totalBatches,
-                    nodeIdBatch.Length,
-                    objectType);
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        "Rebuild: deleted cmsContentNu batch {BatchNumber}/{BatchCount} ({NodeCount} node(s)) for object type {ObjectType}.",
+                        currentBatchNumber,
+                        totalBatches,
+                        nodeIdBatch.Length,
+                        objectType);
+                }
             });
         }
 
@@ -1456,9 +1480,9 @@ internal sealed class DatabaseCacheRepository : RepositoryBase, IDatabaseCacheRe
         return Database.ExecuteScalar<long>(sql);
     }
 
-    private void DeleteContentNuByNodeIds(IReadOnlyCollection<int> nodeIds)
+    private void DeleteContentNuByNodeIds(int[] nodeIds)
     {
-        if (nodeIds.Count == 0)
+        if (nodeIds.Length == 0)
         {
             return;
         }

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DatabaseCacheRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DatabaseCacheRepositoryTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -15,6 +16,7 @@ using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Attributes;
 using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
@@ -29,10 +31,12 @@ internal sealed class DatabaseCacheRepositoryTests : UmbracoIntegrationTestWithC
         builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
         builder.AddNotificationHandler<MediaTreeChangeNotification, MediaTreeChangeDistributedCacheNotificationHandler>();
         builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
-
-        // Force several delete batches over the handful of fixture documents so the batched delete loop is exercised.
-        builder.Services.PostConfigure<NuCacheSettings>(options => options.ContentTypeRebuildDeleteBatchSize = 2);
     }
+
+    // Applied via [ConfigureBuilder] to only the batched-delete test, so the tiny batch size doesn't change the
+    // number of SQL statements other tests in this fixture issue.
+    public static void ConfigureSmallDeleteBatchSize(IUmbracoBuilder builder) =>
+        builder.Services.PostConfigure<NuCacheSettings>(options => options.ContentTypeRebuildDeleteBatchSize = 2);
 
     private IDatabaseCacheRepository DatabaseCacheRepository => GetRequiredService<IDatabaseCacheRepository>();
 
@@ -119,8 +123,13 @@ internal sealed class DatabaseCacheRepositoryTests : UmbracoIntegrationTestWithC
     }
 
     [Test]
+    [ConfigureBuilder(ActionName = nameof(ConfigureSmallDeleteBatchSize))]
     public void Rebuild_Deletes_Stale_Rows_In_Batches_And_Repopulates()
     {
+        // Guard: the [ConfigureBuilder] override must be in effect, otherwise the default (large) batch size
+        // would delete every row in one statement and this test would no longer exercise the batching loop.
+        Assert.That(GetRequiredService<IOptions<NuCacheSettings>>().Value.ContentTypeRebuildDeleteBatchSize, Is.EqualTo(2));
+
         // Arrange — populate the cache for the document type, then mark every row for the type as stale.
         // If the batched delete failed to remove a row, the repopulation's insert-where-not-exists would
         // skip it and the stale marker would survive — so this proves the delete actually runs (with a

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DatabaseCacheRepositoryTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DatabaseCacheRepositoryTests.cs
@@ -1,6 +1,8 @@
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.PublishedCache;
@@ -8,6 +10,8 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HybridCache.Persistence;
 using Umbraco.Cms.Infrastructure.HybridCache.Serialization;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Infrastructure.Persistence.Dtos;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Builders.Extensions;
 using Umbraco.Cms.Tests.Common.Testing;
@@ -25,9 +29,16 @@ internal sealed class DatabaseCacheRepositoryTests : UmbracoIntegrationTestWithC
         builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
         builder.AddNotificationHandler<MediaTreeChangeNotification, MediaTreeChangeDistributedCacheNotificationHandler>();
         builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+
+        // Force several delete batches over the handful of fixture documents so the batched delete loop is exercised.
+        builder.Services.PostConfigure<NuCacheSettings>(options => options.ContentTypeRebuildDeleteBatchSize = 2);
     }
 
     private IDatabaseCacheRepository DatabaseCacheRepository => GetRequiredService<IDatabaseCacheRepository>();
+
+    private IDocumentCacheService DocumentCacheService => GetRequiredService<IDocumentCacheService>();
+
+    private ISqlContext SqlContext => GetRequiredService<ISqlContext>();
 
     private IContentPublishingService ContentPublishingService => GetRequiredService<IContentPublishingService>();
 
@@ -105,6 +116,54 @@ internal sealed class DatabaseCacheRepositoryTests : UmbracoIntegrationTestWithC
         var sources = await DatabaseCacheRepository.GetMediaSourcesAsync(Array.Empty<Guid>());
 
         Assert.That(sources, Is.Empty);
+    }
+
+    [Test]
+    public void Rebuild_Deletes_Stale_Rows_In_Batches_And_Repopulates()
+    {
+        // Arrange — populate the cache for the document type, then mark every row for the type as stale.
+        // If the batched delete failed to remove a row, the repopulation's insert-where-not-exists would
+        // skip it and the stale marker would survive — so this proves the delete actually runs (with a
+        // batch size of 2 forcing multiple batches over the fixture's documents).
+        DocumentCacheService.Rebuild([ContentType.Id]);
+
+        const string staleMarker = "STALE";
+        var contentTypeNodeIds = new[] { Textpage.Id, Subpage.Id, Subpage2.Id, Subpage3.Id };
+
+        using (var scope = ScopeProvider.CreateScope())
+        {
+            ScopeAccessor.AmbientScope!.Database.Execute(
+                SqlContext.Sql()
+                    .Update<ContentNuDto>(u => u.Set(x => x.Data, staleMarker))
+                    .WhereIn<ContentNuDto>(x => x.NodeId, contentTypeNodeIds));
+            scope.Complete();
+        }
+
+        // Act
+        DocumentCacheService.Rebuild([ContentType.Id]);
+
+        // Assert — every document of the type has a refreshed (non-stale) row, and none was left behind.
+        using (var scope = ScopeProvider.CreateScope(autoComplete: true))
+        {
+            var dtos = ScopeAccessor.AmbientScope!.Database.Fetch<ContentNuDto>(
+                SqlContext.Sql()
+                    .Select<ContentNuDto>()
+                    .From<ContentNuDto>()
+                    .WhereIn<ContentNuDto>(x => x.NodeId, contentTypeNodeIds));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(dtos, Is.Not.Empty, "Expected the cache to be repopulated for the content type.");
+                Assert.That(
+                    dtos.Select(x => x.NodeId).Distinct(),
+                    Is.EquivalentTo(contentTypeNodeIds),
+                    "Every document of the type should have a cache row after the rebuild.");
+                Assert.That(
+                    dtos.Any(x => x.Data == staleMarker),
+                    Is.False,
+                    "The batched delete should have removed the stale rows before repopulation.");
+            });
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Description

Follow-up to the investigation into SQL command timeouts when saving a structural change to a document type (e.g. removing a property) that backs a lot of content.

When a content type changes structurally, the published cache (`cmsContentNu`) is rebuilt for every affected document. The first step of that rebuild deleted **all** of the type's rows in a **single, unbounded `DELETE`**. On sites with a lot of content those rows carry large LOB columns (`data` NVARCHAR(MAX), `dataRaw` VARBINARY), so the one statement generates heavy transaction-log I/O, can escalate to a table lock, and — as seen on a customer install — can exceed even a raised `CommandTimeout`, rolling the whole save back.

This PR replaces that single delete with a **batched delete**:

- The affected node ids are read from the (stable) source tables **once**, then their `cmsContentNu` rows are deleted in batches by clustered primary key (`nodeId`). This deliberately avoids re-scanning the source per batch, so it stays predictable even without a `contentTypeId` index.
- Each batch runs through the existing `executeStep` delegate, so under `ContentTypeRebuildMode.Deferred` **each batch commits in its own transaction** — releasing its locks and log space between batches instead of accumulating across the whole delete. Under the immediate path the batches share the ambient transaction, but each `DELETE` statement is still individually bounded.
- The batch size is configurable via `NuCacheSettings.ContentTypeRebuildDeleteBatchSize` (default 2000, capped at the SQL parameter limit). It sits next to `SqlPageSize`, which governs the insert/repopulation paging of the same rebuild.
- The count of affected nodes is derived from the fetched id list, so the previously separate `SELECT COUNT(*)` step is removed.
- Debug-level logging reports each batch as it is deleted (visible by enabling `Debug` for `Umbraco.Cms.Infrastructure.HybridCache.Persistence.DatabaseCacheRepository`).

The full-clear path (a full cache rebuild, where the table has typically already been truncated) is unchanged and remains a single statement.

This is a self-contained improvement and pairs with the separately-submitted index on `umbracoContent(contentTypeId)` in https://github.com/umbraco/Umbraco-CMS/pull/23328.

## Testing

### Automated

An integration test covering multi-batch deletion has been added.

### Manual

With `ContentTypeRebuildMode: Deferred` and a small `ContentTypeRebuildDeleteBatchSize` (e.g. 5), make a structural change to a document type that has several content items and watch the debug log — the rebuild deletes the rows in batches, each committed independently, e.g.:

```
Rebuild: deleting cmsContentNu rows for object type ... — 42 node(s) in 9 batch(es) of up to 5.
Rebuild: deleted cmsContentNu batch 1/9 (5 node(s)) ...
...
Rebuild: deleted cmsContentNu batch 9/9 (2 node(s)) ...
```