### PR TITLE
Documents/Media: Configuration contexts use repository

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/configuration/configuration.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/configuration/configuration.server.data-source.ts
@@ -18,6 +18,8 @@ export class UmbDocumentConfigurationServerDataSource extends UmbControllerBase 
 				disableDeleteWhenReferenced: data.disableDeleteWhenReferenced,
 				disableUnpublishWhenReferenced: data.disableUnpublishWhenReferenced,
 				allowEditInvariantFromNonDefault: data.allowEditInvariantFromNonDefault,
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
+				allowNonExistingSegmentsCreation: data.allowNonExistingSegmentsCreation,
 			};
 
 			return { data: mappedData };

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/configuration/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/configuration/types.ts
@@ -2,4 +2,8 @@ export interface UmbDocumentConfigurationModel {
 	disableDeleteWhenReferenced: boolean;
 	disableUnpublishWhenReferenced: boolean;
 	allowEditInvariantFromNonDefault: boolean;
+	/**
+	 * @deprecated Will be removed in Umbraco 19. [NL]
+	 */
+	allowNonExistingSegmentsCreation: boolean;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/global-contexts/document-configuration.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/global-contexts/document-configuration.context.ts
@@ -4,6 +4,7 @@ import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 /**
  * A context for fetching and caching the document configuration.
@@ -24,6 +25,20 @@ export class UmbDocumentConfigurationContext extends UmbContextBase implements U
 		const { data } = await this.#repository.requestConfiguration();
 
 		return data ?? null;
+	}
+
+	/**
+	 * @deprecated Deprecated since v17. Use `getDocumentConfiguration()` instead. Will be removed in v19.
+	 * @returns {Promise<UmbDocumentConfigurationModel | null>} A promise that resolves to the document configuration, or null if the configuration could not be fetched.
+	 */
+	fetchDocumentConfiguration(): Promise<UmbDocumentConfigurationModel | null> {
+		new UmbDeprecation({
+			deprecated: 'UmbDocumentConfigurationContext.fetchDocumentConfiguration()',
+			removeInVersion: '19.0.0',
+			solution: 'Use getDocumentConfiguration() instead.',
+		}).warn();
+
+		return this.getDocumentConfiguration();
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/global-contexts/document-configuration.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/global-contexts/document-configuration.context.ts
@@ -1,20 +1,16 @@
+import { UmbDocumentConfigurationRepository } from '../configuration/index.js';
+import type { UmbDocumentConfigurationModel } from '../configuration/types.js';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
-import { DocumentService, type DocumentConfigurationResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { tryExecute } from '@umbraco-cms/backoffice/resources';
 
-// TODO: Turn this into a Repository with a Store that holds the cache [NL]
 /**
  * A context for fetching and caching the document configuration.
  * @internal
  */
 export class UmbDocumentConfigurationContext extends UmbContextBase implements UmbApi {
-	/**
-	 * The cached document configuration.
-	 */
-	static #documentConfiguration: Promise<DocumentConfigurationResponseModel | null>;
+	readonly #repository = new UmbDocumentConfigurationRepository(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_DOCUMENT_CONFIGURATION_CONTEXT);
@@ -22,18 +18,10 @@ export class UmbDocumentConfigurationContext extends UmbContextBase implements U
 
 	/**
 	 * Get the document configuration from the server, or return the cached configuration if it has already been fetched.
-	 * @returns A promise that resolves to the document configuration, or null if the configuration could not be fetched.
+	 * @returns {Promise<UmbDocumentConfigurationModel | null>} A promise that resolves to the document configuration, or null if the configuration could not be fetched.
 	 */
-	getDocumentConfiguration(): Promise<DocumentConfigurationResponseModel | null> {
-		return (UmbDocumentConfigurationContext.#documentConfiguration ??= this.fetchDocumentConfiguration());
-	}
-
-	/**
-	 * Fetch the document configuration from the server.
-	 * @returns A promise that resolves to the document configuration, or null if the configuration could not be fetched.
-	 */
-	async fetchDocumentConfiguration() {
-		const { data } = await tryExecute(this, DocumentService.getDocumentConfiguration());
+	async getDocumentConfiguration(): Promise<UmbDocumentConfigurationModel | null> {
+		const { data } = await this.#repository.requestConfiguration();
 
 		return data ?? null;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.repository.test.ts
@@ -1,6 +1,6 @@
 import { useMockHandlers, resetMockHandlers } from '../../../../../mocks/index.js';
-import { UmbDocumentConfigurationRepository, resetUmbDocumentConfigurationCache } from './configuration.repository.js';
-import type { UmbDocumentConfigurationModel } from './types.js';
+import { UmbMediaConfigurationRepository, resetUmbMediaConfigurationCache } from './configuration.repository.js';
+import type { UmbMediaConfigurationModel } from './types.js';
 import { expect } from '@open-wc/testing';
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
@@ -8,29 +8,26 @@ import { umbracoPath } from '@umbraco-cms/backoffice/utils';
 
 const { http, HttpResponse } = window.MockServiceWorker;
 
-const UMB_SLUG = '/document';
+const UMB_SLUG = '/media';
 
-const configuration: UmbDocumentConfigurationModel = {
+const configuration: UmbMediaConfigurationModel = {
 	disableDeleteWhenReferenced: true,
-	disableUnpublishWhenReferenced: true,
-	allowEditInvariantFromNonDefault: false,
-	allowNonExistingSegmentsCreation: false,
 };
 
-@customElement('umb-test-document-configuration-repository-host')
-class UmbTestDocumentConfigurationRepositoryHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+@customElement('umb-test-media-configuration-repository-host')
+class UmbTestMediaConfigurationRepositoryHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
 
-describe('UmbDocumentConfigurationRepository', () => {
-	let host: UmbTestDocumentConfigurationRepositoryHostElement;
-	let repository: UmbDocumentConfigurationRepository;
+describe('UmbMediaConfigurationRepository', () => {
+	let host: UmbTestMediaConfigurationRepositoryHostElement;
+	let repository: UmbMediaConfigurationRepository;
 	let requestCount: number;
 
 	beforeEach(() => {
 		requestCount = 0;
-		resetUmbDocumentConfigurationCache();
-		host = new UmbTestDocumentConfigurationRepositoryHostElement();
+		resetUmbMediaConfigurationCache();
+		host = new UmbTestMediaConfigurationRepositoryHostElement();
 		document.body.appendChild(host);
-		repository = new UmbDocumentConfigurationRepository(host);
+		repository = new UmbMediaConfigurationRepository(host);
 	});
 
 	afterEach(() => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.repository.test.ts
@@ -12,6 +12,7 @@ const UMB_SLUG = '/media';
 
 const configuration: UmbMediaConfigurationModel = {
 	disableDeleteWhenReferenced: true,
+	disableUnpublishWhenReferenced: true,
 };
 
 @customElement('umb-test-media-configuration-repository-host')

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.repository.ts
@@ -1,0 +1,42 @@
+import { UmbMediaConfigurationServerDataSource } from './configuration.server.data-source.js';
+import type { UmbMediaConfigurationModel } from './types.js';
+import { UmbRepositoryBase, type UmbRepositoryResponse } from '@umbraco-cms/backoffice/repository';
+
+/**
+ * The cached media configuration, shared across all repository instances.
+ */
+let configurationPromise: Promise<UmbRepositoryResponse<UmbMediaConfigurationModel>> | undefined;
+
+/**
+ * @description - Repository for Media configuration.
+ * @exports
+ * @class UmbMediaConfigurationRepository
+ * @augments UmbRepositoryBase
+ */
+export class UmbMediaConfigurationRepository extends UmbRepositoryBase {
+	readonly #serverDataSource = new UmbMediaConfigurationServerDataSource(this);
+
+	/**
+	 * Requests the Media configuration from the server, or returns the cached configuration if it has already been fetched. Error responses are not cached.
+	 * @returns {Promise<UmbRepositoryResponse<UmbMediaConfigurationModel>>} - The media configuration.
+	 * @memberof UmbMediaConfigurationRepository
+	 */
+	async requestConfiguration(): Promise<UmbRepositoryResponse<UmbMediaConfigurationModel>> {
+		configurationPromise ??= this.#serverDataSource.getConfiguration();
+		const response = await configurationPromise;
+		if (response.error) {
+			configurationPromise = undefined;
+		}
+		return response;
+	}
+}
+
+export { UmbMediaConfigurationRepository as api };
+
+/**
+ * Test-only.
+ * @internal
+ */
+export function resetUmbMediaConfigurationCache(): void {
+	configurationPromise = undefined;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.server.data-source.ts
@@ -16,6 +16,8 @@ export class UmbMediaConfigurationServerDataSource extends UmbControllerBase {
 		if (data) {
 			const mappedData: UmbMediaConfigurationModel = {
 				disableDeleteWhenReferenced: data.disableDeleteWhenReferenced,
+				// eslint-disable-next-line @typescript-eslint/no-deprecated
+				disableUnpublishWhenReferenced: data.disableUnpublishWhenReferenced,
 			};
 
 			return { data: mappedData };

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/configuration.server.data-source.ts
@@ -1,0 +1,26 @@
+import type { UmbMediaConfigurationModel } from './types.js';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import { MediaService } from '@umbraco-cms/backoffice/external/backend-api';
+import type { UmbDataSourceResponse } from '@umbraco-cms/backoffice/repository';
+import { tryExecute } from '@umbraco-cms/backoffice/resources';
+
+export class UmbMediaConfigurationServerDataSource extends UmbControllerBase {
+	/**
+	 * Gets the media configuration from the server.
+	 * @returns {Promise<UmbDataSourceResponse<UmbMediaConfigurationModel>>} - The media configuration.
+	 * @memberof UmbMediaConfigurationServerDataSource
+	 */
+	async getConfiguration(): Promise<UmbDataSourceResponse<UmbMediaConfigurationModel>> {
+		const { data, error } = await tryExecute(this, MediaService.getMediaConfiguration());
+
+		if (data) {
+			const mappedData: UmbMediaConfigurationModel = {
+				disableDeleteWhenReferenced: data.disableDeleteWhenReferenced,
+			};
+
+			return { data: mappedData };
+		}
+
+		return { error };
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/constants.ts
@@ -1,0 +1,1 @@
+export const UMB_MEDIA_CONFIGURATION_REPOSITORY_ALIAS = 'Umb.Repository.Media.Configuration';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/index.ts
@@ -1,0 +1,4 @@
+export { UmbMediaConfigurationRepository } from './configuration.repository.js';
+export * from './constants.js';
+
+export type * from './types.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/manifests.ts
@@ -1,0 +1,10 @@
+import { UMB_MEDIA_CONFIGURATION_REPOSITORY_ALIAS } from './constants.js';
+
+export const manifests: Array<UmbExtensionManifest> = [
+	{
+		type: 'repository',
+		alias: UMB_MEDIA_CONFIGURATION_REPOSITORY_ALIAS,
+		name: 'Media Configuration Repository',
+		api: () => import('./configuration.repository.js'),
+	},
+];

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/types.ts
@@ -1,3 +1,7 @@
 export interface UmbMediaConfigurationModel {
 	disableDeleteWhenReferenced: boolean;
+	/**
+	 * @deprecated Media does not support unpublishing, so this field is not used. [NL]
+	 */
+	disableUnpublishWhenReferenced: boolean;
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/types.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/configuration/types.ts
@@ -1,0 +1,3 @@
+export interface UmbMediaConfigurationModel {
+	disableDeleteWhenReferenced: boolean;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/constants.ts
@@ -1,4 +1,5 @@
 export * from './collection/constants.js';
+export * from './configuration/constants.js';
 export * from './entity-actions/constants.js';
 export * from './entity-bulk-actions/constants.js';
 export * from './menu/constants.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/global-contexts/media-configuration.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/global-contexts/media-configuration.context.ts
@@ -1,19 +1,16 @@
+import { UmbMediaConfigurationRepository } from '../configuration/index.js';
+import type { UmbMediaConfigurationModel } from '../configuration/types.js';
 import { UmbContextBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
-import { MediaService, type MediaConfigurationResponseModel } from '@umbraco-cms/backoffice/external/backend-api';
-import { tryExecute } from '@umbraco-cms/backoffice/resources';
 
 /**
  * A context for fetching and caching the media configuration.
  * @internal
  */
 export class UmbMediaConfigurationContext extends UmbContextBase implements UmbApi {
-	/**
-	 * The cached media configuration.
-	 */
-	static #mediaConfiguration: Promise<MediaConfigurationResponseModel | null>;
+	readonly #repository = new UmbMediaConfigurationRepository(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_MEDIA_CONFIGURATION_CONTEXT);
@@ -21,18 +18,10 @@ export class UmbMediaConfigurationContext extends UmbContextBase implements UmbA
 
 	/**
 	 * Get the media configuration from the server, or return the cached configuration if it has already been fetched.
-	 * @returns A promise that resolves to the media configuration, or null if the configuration could not be fetched.
+	 * @returns {Promise<UmbMediaConfigurationModel | null>} A promise that resolves to the media configuration, or null if the configuration could not be fetched.
 	 */
-	getMediaConfiguration(): Promise<MediaConfigurationResponseModel | null> {
-		return (UmbMediaConfigurationContext.#mediaConfiguration ??= this.#fetchMediaConfiguration());
-	}
-
-	/**
-	 * Fetch the media configuration from the server.
-	 * @returns A promise that resolves to the media configuration, or null if the configuration could not be fetched.
-	 */
-	async #fetchMediaConfiguration() {
-		const { data } = await tryExecute(this, MediaService.getMediaConfiguration());
+	async getMediaConfiguration(): Promise<UmbMediaConfigurationModel | null> {
+		const { data } = await this.#repository.requestConfiguration();
 
 		return data ?? null;
 	}

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/manifests.ts
@@ -1,6 +1,7 @@
 import { manifests as startNodeManifests } from './user-start-node/manifests.js';
 import { manifests as auditLogManifests } from './audit-log/manifests.js';
 import { manifests as collectionManifests } from './collection/manifests.js';
+import { manifests as configurationManifests } from './configuration/manifests.js';
 import { manifests as entityActionsManifests } from './entity-actions/manifests.js';
 import { manifests as entityBulkActionsManifests } from './entity-bulk-actions/manifests.js';
 import { manifests as fileUploadPreviewManifests } from './components/input-upload-field/manifests.js';
@@ -23,6 +24,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 	...startNodeManifests,
 	...auditLogManifests,
 	...collectionManifests,
+	...configurationManifests,
 	...entityActionsManifests,
 	...entityBulkActionsManifests,
 	...fileUploadPreviewManifests,


### PR DESCRIPTION
> [!NOTE]
> Question: @iOvergaard @nielslyngsoe
> I wonder whether we need these to be a Global Context?
> The internal usages could use the repository directly - when required - rather than have the global context always available. _(I'm happy to refactor and deprecate the global contexts)._ Otherwise, let's proceed with this PR as is.

## Description

Small tidy-up: the document and media configuration contexts were each fetching from the backend and caching the result themselves. Documents already had a proper configuration repository sitting unused nearby, so this hooks the context up to it instead of duplicating the fetch/cache logic. Media didn't have a repository at all, so it gets a matching one, built the same way as the document one.

No behaviour changes for consumers — same data, same fields, just one cache instead of two. As a nice side effect, a failed config request can now be retried instead of getting stuck cached as empty forever.

### Test plan

- [ ] Trash a document/media item that has incoming references and confirm the "are you sure" relation warning still shows correctly
- [ ] Unpublish a referenced document and confirm the unpublish confirmation still behaves as before
- [ ] `npm run compile`, `npm test`, and `npm run lint` all pass in `src/Umbraco.Web.UI.Client`