### PR TITLE
Chore: Fixed up minor issues on `v17/dev`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/media/imaging/components/media-thumbnail.stories.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/imaging/components/media-thumbnail.stories.ts
@@ -12,7 +12,7 @@ const SAMPLE_IMAGE =
 // imaging backend, so this story-only helper sets the resolved URL directly to demonstrate rendering.
 // The stable callback identity ensures the ref only runs on mount, not on every update.
 const withSampleImage = (el?: Element) => {
-	const thumbnail = el as (UmbMediaThumbnailElement & { _thumbnailUrl: string }) | undefined;
+	const thumbnail = el as unknown as { _thumbnailUrl: string; requestUpdate: () => void } | undefined;
 	if (thumbnail && thumbnail._thumbnailUrl !== SAMPLE_IMAGE) {
 		thumbnail._thumbnailUrl = SAMPLE_IMAGE;
 		thumbnail.requestUpdate();

--- a/src/Umbraco.Web.UI.Login/package-lock.json
+++ b/src/Umbraco.Web.UI.Login/package-lock.json
@@ -1031,7 +1031,6 @@
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1895,7 +1894,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2217,7 +2215,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2263,7 +2260,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
### Description

Fixed up a couple of snags in the `v17/dev` branch.

- Login: Whenever I'd `npm install`, the `package-lock.json` would have modifications
- `media-thumbnail.stories.ts` kept flagging TypeScript errors (when running `npx tsc`)