### PR TITLE
Media: Assign deterministic keys to SVG Width/Height migration (closes #23337)

### DIFF
--- a/src/Umbraco.Core/Constants-Conventions.cs
+++ b/src/Umbraco.Core/Constants-Conventions.cs
@@ -169,6 +169,25 @@ public static partial class Constants
             ///     Suffix added to media files when moved to the recycle bin when recycle bin media protection is enabled.
             /// </summary>
             public const string TrashedMediaSuffix = ".deleted";
+
+            /// <summary>
+            ///     Constants for the keys of built-in Umbraco media property types.
+            /// </summary>
+            public static class PropertyTypeKeys
+            {
+                // Must stay in sync between the clean install (DatabaseDataCreator) and the AddDimensionsToSvg
+                // upgrade migration so upgraded and clean-installed sites end up identical.
+
+                /// <summary>
+                ///     Key of the Width property type on the built-in Vector Graphics media type.
+                /// </summary>
+                public const string VectorGraphicsWidth = "5BC7E468-C53E-41A6-A522-2723F3B94514";
+
+                /// <summary>
+                ///     Key of the Height property type on the built-in Vector Graphics media type.
+                /// </summary>
+                public const string VectorGraphicsHeight = "9E4C2B59-6BC6-4648-BB71-B0F45DDBC274";
+            }
         }
 
         /// <summary>

--- a/src/Umbraco.Infrastructure/CLAUDE.md
+++ b/src/Umbraco.Infrastructure/CLAUDE.md
@@ -538,6 +538,17 @@ using (var outer = ScopeProvider.CreateCoreScope())
 - Large data migrations (> 100k rows) should be chunked
 - Use `AsyncMigrationBase` for long-running operations
 
+**Schema-seeding migrations MUST assign the same fixed keys as a clean install**:
+- A migration that adds built-in schema entities (media/content/member types, property types,
+  property groups, data types, etc.) must set each entity's `Key` explicitly to the **same Guid**
+  used for that entity in `Migrations/Install/DatabaseDataCreator.cs`.
+- If you don't set `Key`, `EntityBase.Key` lazily generates a **random `Guid.NewGuid()`** — so every
+  upgraded site (and every environment) ends up with a **different** key, none of which match a clean
+  install. Umbraco Deploy / uSync key their schema artifacts by `Key`, so this shows up as spurious
+  "the key changed" schema diffs across environments (see issue #23337).
+- Keep the Guids in **one place** (a shared `Constants` value referenced by both `DatabaseDataCreator`
+  and the migration) so they cannot drift.
+
 ### Repository Edge Cases
 
 **Cache Invalidation**:

--- a/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Install/DatabaseDataCreator.cs
@@ -1954,7 +1954,7 @@ internal sealed class DatabaseDataCreator
                 new PropertyTypeDto
                 {
                     Id = 53,
-                    UniqueId = new Guid("5BC7E468-C53E-41A6-A522-2723F3B94514"),
+                    UniqueId = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsWidth),
                     DataTypeId = Constants.DataTypes.LabelPixels,
                     ContentTypeId = 1037,
                     PropertyTypeGroupId = 55,
@@ -1973,7 +1973,7 @@ internal sealed class DatabaseDataCreator
                 new PropertyTypeDto
                 {
                     Id = 54,
-                    UniqueId = new Guid("9E4C2B59-6BC6-4648-BB71-B0F45DDBC274"),
+                    UniqueId = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsHeight),
                     DataTypeId = Constants.DataTypes.LabelPixels,
                     ContentTypeId = 1037,
                     PropertyTypeGroupId = 55,

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvg.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvg.cs
@@ -71,35 +71,26 @@ public class AddDimensionsToSvg : AsyncMigrationBase
             ? vectorGraphicsMediaType.PropertyTypes.Max(x => x.SortOrder)
             : 0;
 
-        var updated = false;
-
         // The keys are set explicitly to match the clean install (DatabaseDataCreator) so that upgraded
         // and clean-installed sites end up identical - otherwise the keys would be randomly generated.
-        if (vectorGraphicsMediaType.PropertyTypes.Any(x => x.Alias == Constants.Conventions.Media.Width) is false)
-        {
-            vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Width)
-            {
-                Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsWidth),
-                Name = "Width",
-                SortOrder = highestSort + 1,
-                PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),
-            });
-            updated = true;
-        }
+        var addedWidth = AddMissingPropertyType(
+            vectorGraphicsMediaType,
+            labelPixelDataType,
+            propertyGroup,
+            Constants.Conventions.Media.Width,
+            "Width",
+            Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsWidth,
+            highestSort + 1);
+        var addedHeight = AddMissingPropertyType(
+            vectorGraphicsMediaType,
+            labelPixelDataType,
+            propertyGroup,
+            Constants.Conventions.Media.Height,
+            "Height",
+            Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsHeight,
+            highestSort + 2);
 
-        if (vectorGraphicsMediaType.PropertyTypes.Any(x => x.Alias == Constants.Conventions.Media.Height) is false)
-        {
-            vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Height)
-            {
-                Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsHeight),
-                Name = "Height",
-                SortOrder = highestSort + 2,
-                PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),
-            });
-            updated = true;
-        }
-
-        if (updated is false)
+        if (addedWidth is false && addedHeight is false)
         {
             _logger.LogInformation("Vector Graphics Media Type already has width/height properties, skipping update.");
             return;
@@ -108,14 +99,37 @@ public class AddDimensionsToSvg : AsyncMigrationBase
         Attempt<ContentTypeOperationStatus> attempt = await _mediaTypeService.UpdateAsync(vectorGraphicsMediaType, Constants.Security.SuperUserKey);
         if (attempt.Success is false)
         {
-            if (attempt.Exception is not null)
-            {
-                _logger.LogError(attempt.Exception, "Failed to update media type '{Alias}' during migration.", vectorGraphicsMediaType.Alias);
-            }
-            else
-            {
-                _logger.LogWarning("Failed to update media type '{Alias}' during migration. Status: {ResultStatus}", vectorGraphicsMediaType.Alias, attempt.Result);
-            }
+            LogFailedUpdate(vectorGraphicsMediaType, attempt);
+        }
+    }
+
+    private bool AddMissingPropertyType(IMediaType mediaType, IDataType dataType, PropertyGroup propertyGroup, string alias, string name, string key, int sortOrder)
+    {
+        if (mediaType.PropertyTypes.Any(x => x.Alias == alias))
+        {
+            return false;
+        }
+
+        mediaType.AddPropertyType(new PropertyType(_shortStringHelper, dataType, alias)
+        {
+            Key = new Guid(key),
+            Name = name,
+            SortOrder = sortOrder,
+            PropertyGroupId = new Lazy<int>(() => propertyGroup.Id),
+        });
+
+        return true;
+    }
+
+    private void LogFailedUpdate(IMediaType mediaType, Attempt<ContentTypeOperationStatus> attempt)
+    {
+        if (attempt.Exception is not null)
+        {
+            _logger.LogError(attempt.Exception, "Failed to update media type '{Alias}' during migration.", mediaType.Alias);
+        }
+        else
+        {
+            _logger.LogWarning("Failed to update media type '{Alias}' during migration. Status: {ResultStatus}", mediaType.Alias, attempt.Result);
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvg.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvg.cs
@@ -72,14 +72,18 @@ public class AddDimensionsToSvg : AsyncMigrationBase
             : 0;
 
         // Add new properties (AddPropertyType handles duplicates, so the migration is idempotent).
+        // The keys are set explicitly to match the clean install (DatabaseDataCreator) so that upgraded
+        // and clean-installed sites end up identical - otherwise the keys would be randomly generated.
         vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Width)
         {
+            Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsWidth),
             Name = "Width",
             SortOrder = highestSort + 1,
             PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),
         });
         vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Height)
         {
+            Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsHeight),
             Name = "Height",
             SortOrder = highestSort + 2,
             PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvg.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvg.cs
@@ -71,23 +71,39 @@ public class AddDimensionsToSvg : AsyncMigrationBase
             ? vectorGraphicsMediaType.PropertyTypes.Max(x => x.SortOrder)
             : 0;
 
-        // Add new properties (AddPropertyType handles duplicates, so the migration is idempotent).
+        var updated = false;
+
         // The keys are set explicitly to match the clean install (DatabaseDataCreator) so that upgraded
         // and clean-installed sites end up identical - otherwise the keys would be randomly generated.
-        vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Width)
+        if (vectorGraphicsMediaType.PropertyTypes.Any(x => x.Alias == Constants.Conventions.Media.Width) is false)
         {
-            Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsWidth),
-            Name = "Width",
-            SortOrder = highestSort + 1,
-            PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),
-        });
-        vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Height)
+            vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Width)
+            {
+                Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsWidth),
+                Name = "Width",
+                SortOrder = highestSort + 1,
+                PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),
+            });
+            updated = true;
+        }
+
+        if (vectorGraphicsMediaType.PropertyTypes.Any(x => x.Alias == Constants.Conventions.Media.Height) is false)
         {
-            Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsHeight),
-            Name = "Height",
-            SortOrder = highestSort + 2,
-            PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),
-        });
+            vectorGraphicsMediaType.AddPropertyType(new PropertyType(_shortStringHelper, labelPixelDataType, Constants.Conventions.Media.Height)
+            {
+                Key = new Guid(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsHeight),
+                Name = "Height",
+                SortOrder = highestSort + 2,
+                PropertyGroupId = new Lazy<int>(()=> propertyGroup.Id),
+            });
+            updated = true;
+        }
+
+        if (updated is false)
+        {
+            _logger.LogInformation("Vector Graphics Media Type already has width/height properties, skipping update.");
+            return;
+        }
 
         Attempt<ContentTypeOperationStatus> attempt = await _mediaTypeService.UpdateAsync(vectorGraphicsMediaType, Constants.Security.SuperUserKey);
         if (attempt.Success is false)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvgTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvgTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade.V_17_4_0;
+using Umbraco.Cms.Infrastructure.Persistence;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Migrations.Upgrade.V17_4_0;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class AddDimensionsToSvgTests : UmbracoIntegrationTest
+{
+    private static readonly Guid _expectedWidthKey = new(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsWidth);
+    private static readonly Guid _expectedHeightKey = new(Constants.Conventions.Media.PropertyTypeKeys.VectorGraphicsHeight);
+
+    private IMediaTypeService MediaTypeService => GetRequiredService<IMediaTypeService>();
+
+    private IMigrationBuilder MigrationBuilder => GetRequiredService<IMigrationBuilder>();
+
+    private IUmbracoDatabaseFactory UmbracoDatabaseFactory => GetRequiredService<IUmbracoDatabaseFactory>();
+
+    private IServiceScopeFactory ServiceScopeFactory => GetRequiredService<IServiceScopeFactory>();
+
+    private DistributedCache DistributedCache => GetRequiredService<DistributedCache>();
+
+    private IDatabaseCacheRebuilder DatabaseCacheRebuilder => GetRequiredService<IDatabaseCacheRebuilder>();
+
+    private IPublishedContentTypeFactory PublishedContentTypeFactory => GetRequiredService<IPublishedContentTypeFactory>();
+
+    private IMigrationPlanExecutor MigrationPlanExecutor => new MigrationPlanExecutor(
+        ScopeProvider,
+        ScopeAccessor,
+        LoggerFactory,
+        MigrationBuilder,
+        UmbracoDatabaseFactory,
+        DatabaseCacheRebuilder,
+        DistributedCache,
+        Mock.Of<IKeyValueService>(),
+        ServiceScopeFactory,
+        AppCaches.NoCache,
+        PublishedContentTypeFactory);
+
+    [Test]
+    public async Task Adds_Width_And_Height_With_Canonical_Keys()
+    {
+        await RemoveDimensionPropertiesToSimulatePreMigrationState();
+
+        await ExecuteMigration();
+
+        IMediaType mediaType = MediaTypeService.Get(Constants.Conventions.MediaTypes.VectorGraphicsAlias)!;
+        IPropertyType? width = mediaType.PropertyTypes.SingleOrDefault(x => x.Alias == Constants.Conventions.Media.Width);
+        IPropertyType? height = mediaType.PropertyTypes.SingleOrDefault(x => x.Alias == Constants.Conventions.Media.Height);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(width, Is.Not.Null, "Width property was not added by the migration.");
+            Assert.That(height, Is.Not.Null, "Height property was not added by the migration.");
+
+            // The migration must assign the same keys as a clean install (DatabaseDataCreator), otherwise
+            // upgraded and clean-installed sites diverge and Umbraco Deploy reports schema differences.
+            Assert.That(width!.Key, Is.EqualTo(_expectedWidthKey));
+            Assert.That(height!.Key, Is.EqualTo(_expectedHeightKey));
+        });
+    }
+
+    private async Task RemoveDimensionPropertiesToSimulatePreMigrationState()
+    {
+        IMediaType mediaType = MediaTypeService.Get(Constants.Conventions.MediaTypes.VectorGraphicsAlias)!;
+        mediaType.RemovePropertyType(Constants.Conventions.Media.Width);
+        mediaType.RemovePropertyType(Constants.Conventions.Media.Height);
+        await MediaTypeService.UpdateAsync(mediaType, Constants.Security.SuperUserKey);
+
+        IMediaType reloaded = MediaTypeService.Get(Constants.Conventions.MediaTypes.VectorGraphicsAlias)!;
+        Assert.That(
+            reloaded.PropertyTypes.Any(x =>
+                x.Alias == Constants.Conventions.Media.Width || x.Alias == Constants.Conventions.Media.Height),
+            Is.False,
+            "Arrange failed: dimension properties were not removed.");
+    }
+
+    private async Task ExecuteMigration()
+    {
+        var upgrader = new Upgrader(
+            new MigrationPlan("AddDimensionsToSvgTest")
+                .From(string.Empty)
+                .To<AddDimensionsToSvg>("done"));
+
+        await upgrader.ExecuteAsync(MigrationPlanExecutor, ScopeProvider, Mock.Of<IKeyValueService>());
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvgTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Migrations/Upgrade/V_17_4_0/AddDimensionsToSvgTests.cs
@@ -77,6 +77,26 @@ internal sealed class AddDimensionsToSvgTests : UmbracoIntegrationTest
         });
     }
 
+    [Test]
+    public async Task Migration_Is_Idempotent_When_Dimensions_Already_Present()
+    {
+        // The clean install already has Width/Height with the canonical keys. Running the migration
+        // against that state must not duplicate the properties or change their keys.
+        await ExecuteMigration();
+
+        IMediaType mediaType = MediaTypeService.Get(Constants.Conventions.MediaTypes.VectorGraphicsAlias)!;
+        IPropertyType[] widths = mediaType.PropertyTypes.Where(x => x.Alias == Constants.Conventions.Media.Width).ToArray();
+        IPropertyType[] heights = mediaType.PropertyTypes.Where(x => x.Alias == Constants.Conventions.Media.Height).ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(widths, Has.Length.EqualTo(1), "Width property was duplicated by the migration.");
+            Assert.That(heights, Has.Length.EqualTo(1), "Height property was duplicated by the migration.");
+            Assert.That(widths[0].Key, Is.EqualTo(_expectedWidthKey));
+            Assert.That(heights[0].Key, Is.EqualTo(_expectedHeightKey));
+        });
+    }
+
     private async Task RemoveDimensionPropertiesToSimulatePreMigrationState()
     {
         IMediaType mediaType = MediaTypeService.Get(Constants.Conventions.MediaTypes.VectorGraphicsAlias)!;


### PR DESCRIPTION
## Description

After an upgrade, Umbraco Deploy reports the built-in `umbracoMediaVectorGraphics` media type's `umbracoWidth` / `umbracoHeight` **property keys** as changed.

**Root cause:** the `AddDimensionsToSvg` upgrade migration (`V_17_4_0`, shipped in 17.4.0 and introduced in https://github.com/umbraco/Umbraco-CMS/pull/22244) constructed the two `PropertyType` objects without setting `Key`. `EntityBase.Key` lazily generates a random `Guid.NewGuid()` when no key is assigned, so the migration persisted **random, per-environment** keys. A clean install (`DatabaseDataCreator`) assigns **fixed** keys. Upgraded sites therefore never match a clean install, and can diverge between environments.

Note: `AddPropertyType` is alias-guarded, so the migration never overwrites a property a customer already added — the divergence is purely the randomly-generated keys on the freshly-added properties.

## Changes

- Extracted the canonical Guids into `Constants.Conventions.Media.PropertyTypeKeys.VectorGraphics{Width,Height}` as a single source of truth.
- `DatabaseDataCreator` (clean install) now references those constants.
- `AddDimensionsToSvg` now sets `Key` on both property types to the canonical values, so upgraded and clean-installed sites end up identical.
- Added a note to `src/Umbraco.Infrastructure/CLAUDE.md` to try to avoid a similar situation in future: schema-seeding migrations must assign the same fixed keys as a clean install.

## Testing

### Automated

- New integration test `AddDimensionsToSvgTests` (`tests/Umbraco.Tests.Integration/.../Upgrade/V_17_4_0/`):
  - Removes `umbracoWidth`/`umbracoHeight` from the Vector Graphics media type to simulate a pre-17.4.0 site.
  - Runs the real `AddDimensionsToSvg` via `Upgrader` + `MigrationPlanExecutor`.
  - Asserts the re-added properties have the canonical keys (`5BC7E468-…` / `9E4C2B59-…`).
- Confirmed the test **fails before the fix** (random keys) and passes after.

### Manual (re-running the migration on a test site)

The migration only assigns keys when it actually adds the properties (the alias guard skips existing ones), so first remove them, then replay the migration:

1. On the Vector Graphics media type, remove the **Width** and **Height** properties and save.
2. Reset the migration state so the upgrader replays from just before `AddDimensionsToSvg`:
   ```sql
   UPDATE umbracoKeyValue
   SET value = '{6748CB56-CC16-49F0-BA91-B8ECE31BF456}'
   WHERE [key] = 'Umbraco.Core.Upgrader.State+Umbraco.Core';
   ```
3. Restart the site so the upgrader runs the pending migration.

#### Verification SQL

```sql
SELECT pt.Alias, pt.Name, pt.UniqueId AS [Key]
FROM cmsPropertyType pt
INNER JOIN cmsContentType ct ON pt.contentTypeId = ct.nodeId
WHERE ct.alias = 'umbracoMediaVectorGraphics'
  AND pt.Alias IN ('umbracoWidth', 'umbracoHeight')
ORDER BY pt.Alias;
```

Expected after the fix (matching a clean install):

| Alias | Key |
|---|---|
| `umbracoHeight` | `9E4C2B59-6BC6-4648-BB71-B0F45DDBC274` |
| `umbracoWidth`  | `5BC7E468-C53E-41A6-A522-2723F3B94514` |