### PR TITLE
Content: Respect server-reassigned key after create (closes #23344)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -1101,6 +1101,12 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			? await overwriteCreate(saveData, variantIds, parent)
 			: await this.#defaultCreatePersistence(saveData, parent.unique);
 
+		// The server may have assigned a different unique than the one this workspace scaffolded with
+		// (e.g. a Saving notification handler assigning its own key), so re-sync before anything reads it.
+		if (persisted?.unique) {
+			this.setUnique(persisted.unique);
+		}
+
 		// Set persisted AND current before flipping isNew: the flip triggers the new->edit redirect,
 		// whose navigation guard compares the two states with an order-sensitive comparison.
 		await this.#applyPersistedData(persisted, variantIds);

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/repository/document-publishing.server.data-source.ts
@@ -47,7 +47,7 @@ export class UmbDocumentPublishingServerDataSource {
 		model: UmbDocumentDetailModel,
 		variantIds: Array<UmbVariantId>,
 		parentUnique: string | null = null,
-	) {
+	): Promise<UmbDataSourceResponse<string>> {
 		if (!model) throw new Error('Document is missing');
 		if (!model.unique) throw new Error('Document unique is missing');
 
@@ -59,7 +59,11 @@ export class UmbDocumentPublishingServerDataSource {
 		// 201 Created returns only the key (no document body). The workspace reloads after this to refresh
 		// its state, so we deliberately do NOT re-read the full document here — that would be a redundant
 		// round-trip on top of the reload.
-		return tryExecute(this.#host, DocumentService.postDocumentCreateAndPublish({ body }));
+		const { data, error } = await tryExecute(this.#host, DocumentService.postDocumentCreateAndPublish({ body }));
+
+		// The generated response type is `unknown` (Swagger has no schema for the empty 201 body), but the
+		// Umb-Generated-Resource interceptor rewrites it to the created document's key at runtime.
+		return { data: data as string | undefined, error };
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -440,9 +440,25 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		await this.#documentWorkspaceContext.performCreateOrUpdate(variantIds, saveData, {
 			create: async (data, ids, parent) => {
-				const { error } = await this.#publishingRepository.createAndPublish(data, ids, parent.unique);
+				const { data: createdUnique, error } = await this.#publishingRepository.createAndPublish(
+					data,
+					ids,
+					parent.unique,
+				);
 				if (error) throw new Error('Error creating and publishing document', { cause: error });
-				return loadAfterPublish();
+
+				// The server may have assigned a different unique than the one this workspace scaffolded with
+				// (e.g. a Saving notification handler assigning its own key). The reload below reads by the
+				// workspace's current unique, so it must be updated to the actual persisted one first.
+				if (createdUnique) {
+					this.#documentWorkspaceContext!.setUnique(createdUnique);
+				}
+
+				const result = await loadAfterPublish();
+
+				// If the reload above failed, loadAfterPublish falls back to the pre-save `saveData`, which
+				// still carries the pre-save unique. That must not clobber the server-assigned unique set above.
+				return createdUnique ? { ...result, unique: createdUnique } : result;
 			},
 			update: async (data, ids) => {
 				const { error } = await this.#publishingRepository.updateAndPublish(data, ids);
@@ -467,7 +483,10 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 
 		await this.#loadAndProcessLastPublished();
 
-		const event = new UmbRequestReloadStructureForEntityEvent({ unique, entityType });
+		// Re-read the unique: for a new document, the server may have assigned a different one than the
+		// workspace scaffolded with, and `performCreateOrUpdate` above will have re-synced it if so.
+		const persistedUnique = this.#documentWorkspaceContext.getUnique() ?? unique;
+		const event = new UmbRequestReloadStructureForEntityEvent({ unique: persistedUnique, entityType });
 		this.#eventContext?.dispatchEvent(event);
 	}
 


### PR DESCRIPTION
## Description

#23344 reposts that when a `ContentSavingNotification` (or `MediaSavingNotification`/`DataTypeSavingNotification`) handler reassigns `Key` for a new entity the backoffice lost track of the entity after save: the breadcrumb didn't render the full path, the URL showed the wrong (original, client-generated) key, and refreshing or copying that URL to another tab produced a 404.

**Root cause**: `UmbContentDetailWorkspaceContextBase#create()` (shared by the Document, Media, Member, and Document Blueprint workspaces) never re-synced its workspace `unique` from the server's persisted create response. The generic `UmbEntityDetailWorkspaceContextBase._create()` already does this correctly, but the content-specific override didn't.

Documents have a second, document-only create path for "save and publish", which calls the combined create-and-publish endpoint directly. That path discarded the server-returned key entirely and reloaded the document by the stale one — producing the same routing bug, plus a "Document published, but the editor could not be refreshed" toast (the reload 404'd against the wrong key).

Fixes #23344.

Note: for 18, we have tightened up changing keys on already persisted entities in https://github.com/umbraco/Umbraco-CMS/pull/21374. That doesn't preclude doing what is being looked for in this issue report, as this is changing key for an entity that's not yet persisted.

## Testing

This can only be reproduced with a server-side extension that reassigns `Key` during the `Saving` notification — verified manually using the handlers below, temporarily added to a local `Umbraco.Web.UI` instance (not part of this PR):

```csharp
using Umbraco.Cms.Core.Composing;
using Umbraco.Cms.Core.Events;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Notifications;

namespace Umbraco.Cms.Web.UI.Custom.Content;

public class AssignNewKeyOnContentSavingHandler : INotificationHandler<ContentSavingNotification>
{
    public void Handle(ContentSavingNotification notification)
    {
        foreach (IContent entity in notification.SavedEntities)
        {
            if (!entity.HasIdentity)
            {
                entity.Key = Guid.NewGuid();
            }
        }
    }
}

public class AssignNewKeyOnMediaSavingHandler : INotificationHandler<MediaSavingNotification>
{
    public void Handle(MediaSavingNotification notification)
    {
        foreach (IMedia entity in notification.SavedEntities)
        {
            if (!entity.HasIdentity)
            {
                entity.Key = Guid.NewGuid();
            }
        }
    }
}

public class AssignNewKeyOnDataTypeSavingHandler : INotificationHandler<DataTypeSavingNotification>
{
    public void Handle(DataTypeSavingNotification notification)
    {
        foreach (IDataType entity in notification.SavedEntities)
        {
            if (!entity.HasIdentity)
            {
                entity.Key = Guid.NewGuid();
            }
        }
    }
}

public class AssignNewKeyOnSavingComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.AddNotificationHandler<ContentSavingNotification, AssignNewKeyOnContentSavingHandler>();
        builder.AddNotificationHandler<MediaSavingNotification, AssignNewKeyOnMediaSavingHandler>();
        builder.AddNotificationHandler<DataTypeSavingNotification, AssignNewKeyOnDataTypeSavingHandler>();
    }
}
```

Steps:
1. Add the handlers above under e.g. `Custom/Content/` in `Umbraco.Web.UI` so the composer is auto-discovered.
2. Create a new document, Save. Confirm the breadcrumb renders the full path, the URL shows the reassigned key, and refreshing / copying the URL to a new tab loads the same document (no 404).
3. Repeat using Save and publish. Confirm there's no "could not be refreshed" toast and the editor reloads with the correct data.
4. Repeat for a new media item, Save.
5. Repeat for a new data type, Save.

Before this fix, documents and media showed the stale-key symptoms (data types didn't have the problem); after, the workspace correctly follows the server-assigned key in every case.