### PR TITLE
Property Context: Handle if destroy happens while executing `_observeProperty`

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
@@ -160,9 +160,14 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 
 	private async _observeProperty(): Promise<void> {
 		const alias = this.#alias.getValue();
+		const variantIdSource = alias ? await this.#datasetContext?.propertyVariantId?.(alias) : undefined;
+		const valueSource = alias ? await this.#datasetContext?.propertyValueByAlias<ValueType>(alias) : undefined;
+
+		// Guard: this context may have been destroyed while the awaits were in flight.
+		if (!this._host) return;
 
 		this.observe(
-			alias ? await this.#datasetContext?.propertyVariantId?.(alias) : undefined,
+			variantIdSource,
 			(variantId) => {
 				this.#variantId.setValue(variantId);
 			},
@@ -170,7 +175,7 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 		);
 
 		this.observe(
-			alias ? await this.#datasetContext?.propertyValueByAlias<ValueType>(alias) : undefined,
+			valueSource,
 			(value) => {
 				this.#value.setValue(value);
 			},

--- a/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/property/components/property/property.context.ts
@@ -160,10 +160,9 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 
 	private async _observeProperty(): Promise<void> {
 		const alias = this.#alias.getValue();
-		if (!this.#datasetContext || !alias) return;
 
 		this.observe(
-			await this.#datasetContext.propertyVariantId?.(alias),
+			alias ? await this.#datasetContext?.propertyVariantId?.(alias) : undefined,
 			(variantId) => {
 				this.#variantId.setValue(variantId);
 			},
@@ -171,14 +170,14 @@ export class UmbPropertyContext<ValueType = any> extends UmbContextBase {
 		);
 
 		this.observe(
-			await this.#datasetContext.propertyValueByAlias<ValueType>(alias),
+			alias ? await this.#datasetContext?.propertyValueByAlias<ValueType>(alias) : undefined,
 			(value) => {
 				this.#value.setValue(value);
 			},
 			'observeValue',
 		);
 
-		this.observe(this.#datasetContext.readOnly, (value) => {
+		this.observe(this.#datasetContext?.readOnly, (value) => {
 			const unique = 'UMB_DATASET';
 
 			if (value) {


### PR DESCRIPTION
Handle if a property context is destroyed while the _observeProperty is still executing.

Seen a few times while debugging.