### PR TITLE
Migrations: Preserve segment variation for invariant block list data during v18 upgrade (closes #23357)

### DIFF
--- a/src/Umbraco.Infrastructure/Migrations/PropertyDataCultureResolver.cs
+++ b/src/Umbraco.Infrastructure/Migrations/PropertyDataCultureResolver.cs
@@ -90,9 +90,10 @@ internal static class PropertyDataCultureResolver
     /// <remarks>
     /// When a property type varies by culture (e.g. inherited from a composition) but the data
     /// is invariant (null culture), <see cref="Property.SetValue"/> rejects the null culture.
-    /// This method handles that case by deep-cloning the property type and setting its
-    /// <see cref="IPropertyType.Variations"/> to <see cref="ContentVariation.Nothing"/>,
-    /// which is safe because the data genuinely is invariant.
+    /// This method handles that case by deep-cloning the property type and clearing only the
+    /// <see cref="ContentVariation.Culture"/> flag from its <see cref="IPropertyType.Variations"/>,
+    /// which is safe because the data genuinely is culture-invariant. The segment flag is
+    /// preserved so that invariant data still carrying a segment continues to validate.
     /// </remarks>
     internal static Property CreateMigrationProperty(
         IPropertyType propertyType,
@@ -107,7 +108,10 @@ internal static class PropertyDataCultureResolver
             // Invariant data on a culture-varying property type (composition scenario).
             // Clone to avoid mutating shared state — important for parallel migration execution.
             effectivePropertyType = (IPropertyType)propertyType.DeepClone();
-            effectivePropertyType.Variations = ContentVariation.Nothing;
+
+            // Drop only the culture flag; keep segment variation so invariant data that still
+            // carries a segment (e.g. Engage personalization) validates. (#23357)
+            effectivePropertyType.Variations = propertyType.Variations.SetFlag(ContentVariation.Culture, false);
         }
 
         var property = new Property(effectivePropertyType);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/PropertyDataCultureResolverTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Migrations/PropertyDataCultureResolverTests.cs
@@ -131,6 +131,20 @@ internal sealed class PropertyDataCultureResolverTests
     }
 
     [Test]
+    public void CreateMigrationProperty_CultureAndSegmentVaryingPropertyType_NullCulture_WithSegment_DoesNotThrow()
+    {
+        // #23357: invariant (null culture) data that still carries a segment on a
+        // culture+segment-varying property type must not throw.
+        var propertyType = CreateConcretePropertyType(ContentVariation.CultureAndSegment);
+
+        var property = PropertyDataCultureResolver.CreateMigrationProperty(
+            propertyType, "test value", culture: null, segment: "engage_personalization_1");
+
+        Assert.That(property, Is.Not.Null);
+        Assert.That(property.GetValue(null, "engage_personalization_1"), Is.EqualTo("test value"));
+    }
+
+    [Test]
     public void CreateMigrationProperty_DoesNotMutateOriginalPropertyType()
     {
         var propertyType = CreateConcretePropertyType(ContentVariation.Culture);


### PR DESCRIPTION
## Description

During an unattended v17 → v18 upgrade, the core migration `V_18_0_0.MigrateSingleBlockList` has been shown to throw for particular setups:

> Variation "\<null\>,\<segment\>" is not supported by the property type.

The resulting `BootFailedException` prevents the site from starting.

The shared migration helper `PropertyDataCultureResolver.CreateMigrationProperty` builds a throwaway `Property` to round-trip a stored value. When the property type **varies by culture** but the row is **invariant** (null `languageId` — the legitimate "culture-varying composition on invariant content" case), it deep-clones the property type and neutralised its variation to `ContentVariation.Nothing`, clearing **both** the Culture and Segment flags.

But the caller still passes a non-null `segment` whenever the property type varies by segment (`MigrateSingleBlockList` computes `propertyType.VariesBySegment() ? propertyDataDto.Segment : null`). So for a **CultureAndSegment** property type with invariant, segment-stamped data, `property.SetValue(value, null, segment)` then fails validation (`Property.SetValue` → `PropertyType.SupportsVariation` → `ContentVariationExtensions.ValidateVariation`), which rejects a non-null segment on a type that — post-neutralisation — no longer varies by segment.

The real-world trigger is **Umbraco Engage personalization**, which stamps invariant rows with segment identifiers (`engage_personalization_<id>`), but the bug hits any invariant + segment data on a culture+segment-varying Block List property.

## Fix

Neutralise **only** the culture dimension, preserving the segment flag:

```csharp
// Drop only the culture flag; keep segment variation so invariant data that still
// carries a segment.
effectivePropertyType.Variations = propertyType.Variations.SetFlag(ContentVariation.Culture, false);
```

Fixes #23357

## Testing

### Automated

Added a unit test `CreateMigrationProperty_CultureAndSegmentVaryingPropertyType_NullCulture_WithSegment_DoesNotThrow` and confirmed that it fails before the fix (throws `NotSupportedException` at `SetValue`) and passes after.

### Manual (full upgrade repro)

I reproduced the boot failure end-to-end and confirmed the fix resolves it.

**Setup on a fresh v17 install** (built via the backoffice):

1. Element type **Migration Test Block** with a `title` textstring property.
2. Data type **Single Block List (migration test)** — `Umbraco.BlockList` with `useSingleBlockMode: true` and `validationLimit.max: 1` (the config the migration keys on), referencing the element type.
3. Document type **Migration Test Page**, both the doc type and its `blockContent` property set to vary by **culture and segment** (property variation = `CultureAndSegment`), using the block list data type.
4. Document **Migration Test Doc** — published with a valid single block value on `en-US`.

**Inject the invariant + segment row** (simulates Engage personalization) via SQL:

```sql
-- Sanity check: property varies by culture+segment (expect variations = 3)
SELECT id, Alias, variations FROM cmsPropertyType WHERE Alias = 'blockContent';

-- Inspect current rows (expect languageId set, segment NULL, block JSON in textValue)
SELECT id, versionId, languageId, segment, substr(textValue, 1, 120) AS preview
FROM umbracoPropertyData
WHERE propertyTypeId = (SELECT id FROM cmsPropertyType WHERE Alias = 'blockContent');
-- (SQL Server: use LEFT(textValue, 120) instead of substr)

-- Make it invariant + segmented — this is what trips the migration
UPDATE umbracoPropertyData
SET languageId = NULL, segment = 'engage_personalization_1'
WHERE propertyTypeId = (SELECT id FROM cmsPropertyType WHERE Alias = 'blockContent');
```

**Upgrade test:**

1. Stop the v17 site and back up the database.
2. Boot with `main` → `MigrateSingleBlockList` calls `SetValue(value, null, "engage_personalization_1")` and throws `NotSupportedException: Variation "<null>,engage_personalization_1" is not supported by the property type`, wrapped in a `BootFailedException`. Site does not start. ✅ repro.
3. Restore the backup and boot with this branch → upgrade completes, site starts, and the row is converted to the single-block format with the segment preserved. ✅ fix.
