### PR TITLE
Backoffice: Fix workspace view icon/label not updating on late-arriving overrides (closes #23311)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.test.ts
@@ -1,0 +1,104 @@
+import type { ManifestWorkspaceView } from '../../types.js';
+import { UmbWorkspaceEditorContext } from './workspace-editor.context.js';
+import { expect } from '@open-wc/testing';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { filter, firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
+import type { Observable } from '@umbraco-cms/backoffice/external/rxjs';
+
+@customElement('test-workspace-editor-controller-host')
+class UmbTestControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+const VIEW_1_ALIAS = 'UmbTest.WorkspaceEditor.View.1';
+const VIEW_2_ALIAS = 'UmbTest.WorkspaceEditor.View.2';
+
+const OVERRIDDEN_LABEL = 'Overridden label';
+const OVERRIDDEN_ICON = 'icon-checkbox';
+
+const manifests: Array<ManifestWorkspaceView> = [
+	{
+		type: 'workspaceView',
+		alias: VIEW_1_ALIAS,
+		name: 'Test Workspace View 1',
+		weight: 200,
+		meta: { label: 'View 1', icon: 'icon-document', pathname: 'view-1' },
+	},
+	{
+		type: 'workspaceView',
+		alias: VIEW_2_ALIAS,
+		name: 'Test Workspace View 2',
+		weight: 100,
+		meta: { label: 'View 2', icon: 'icon-document', pathname: 'view-2' },
+	},
+];
+
+/**
+ * Resolves once the observable emits *after* the initial (replayed) value that
+ * subscribing synchronously delivers, or `false` if nothing new arrives within
+ * `timeoutMs`.
+ */
+function waitForNextEmission(observable: Observable<unknown>, timeoutMs: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		let sawBaseline = false;
+		let settled = false;
+		const settle = (result: boolean) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			subscription.unsubscribe();
+			resolve(result);
+		};
+		const subscription = observable.subscribe(() => {
+			if (!sawBaseline) {
+				sawBaseline = true;
+				return;
+			}
+			settle(true);
+		});
+		const timer = setTimeout(() => settle(false), timeoutMs);
+	});
+}
+
+describe('UmbWorkspaceEditorContext', () => {
+	let hostElement: UmbTestControllerHostElement;
+	let context: UmbWorkspaceEditorContext;
+
+	before(() => {
+		umbExtensionsRegistry.registerMany(manifests);
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregisterMany(manifests.map((m) => m.alias));
+	});
+
+	beforeEach(() => {
+		hostElement = new UmbTestControllerHostElement();
+		context = new UmbWorkspaceEditorContext(hostElement);
+	});
+
+	afterEach(() => {
+		hostElement.destroy();
+	});
+
+	// Regression for #23311: a late-arriving override that changes a view's manifest
+	// (icon/label) must re-emit `views`. The bug was that the merged value kept the
+	// same array reference, so `distinctUntilChanged` suppressed the update and the
+	// workspace view header never refreshed.
+	it('re-emits views when an override changes a view manifest', async () => {
+		// Wait for the async extension initializer to surface the registered views.
+		await firstValueFrom(context.views.pipe(filter((views) => views.length === manifests.length)));
+
+		// Arm the waiter before mutating overrides so the baseline replay is consumed first.
+		const emittedAgain = waitForNextEmission(context.views, 250);
+
+		context.setOverrides([{ alias: VIEW_1_ALIAS, meta: { label: OVERRIDDEN_LABEL, icon: OVERRIDDEN_ICON } }]);
+
+		expect(await emittedAgain, 'views did not re-emit after the override changed').to.be.true;
+
+		const views = await firstValueFrom(context.views);
+		const overriddenView = views.find((view) => view.manifest.alias === VIEW_1_ALIAS);
+		expect(overriddenView?.manifest.meta.label).to.equal(OVERRIDDEN_LABEL);
+		expect(overriddenView?.manifest.meta.icon).to.equal(OVERRIDDEN_ICON);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
@@ -75,7 +75,7 @@ export class UmbWorkspaceEditorContext extends UmbContextBase {
 		(previousValue: Array<UmbWorkspaceViewContext>, currentValue: Array<UmbWorkspaceViewContext>): boolean => {
 			return (
 				previousValue === currentValue &&
-				currentValue.some(
+				currentValue.every(
 					(x) => x.manifest === previousValue.find((y) => y.manifest.alias === x.manifest.alias)?.manifest,
 				)
 			);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/components/workspace-editor/workspace-editor.context.ts
@@ -49,6 +49,7 @@ export class UmbWorkspaceEditorContext extends UmbContextBase {
 			}
 
 			// Apply overrides:
+			let hasOverrideChange = false;
 			contexts.forEach((context) => {
 				const override = overrides.find((x) => x.alias === context.manifest.alias);
 				if (override) {
@@ -61,6 +62,7 @@ export class UmbWorkspaceEditorContext extends UmbContextBase {
 							...(override as ManifestWorkspaceView),
 							meta: { ...context.manifest.meta, ...override.meta },
 						};
+						hasOverrideChange = true;
 					}
 				}
 			});
@@ -69,7 +71,8 @@ export class UmbWorkspaceEditorContext extends UmbContextBase {
 			contexts.sort((a, b): number => (b.manifest.weight || 0) - (a.manifest.weight || 0));
 
 			this.#contexts = contexts;
-			return contexts;
+			// Return a new array reference when overrides changed, so distinctUntilChanged can detect it:
+			return hasOverrideChange || hasDiff ? [...contexts] : contexts;
 		},
 		// Custom memoize method, to check context instance and manifest instance:
 		(previousValue: Array<UmbWorkspaceViewContext>, currentValue: Array<UmbWorkspaceViewContext>): boolean => {


### PR DESCRIPTION
Closes #23311

## Summary

Workspace view tabs show default icon/name on initial page load when collection configuration (providing icon/label overrides) arrives after the views have already rendered. Navigating away and back or clicking the tab triggers a re-render that shows the correct icon.

## Root cause

Two issues in the `mergeObservables` memoization in `UmbWorkspaceEditorContext.views`:

1. **Incorrect memoize logic**: The custom memoize used `.some()` to check if views should be re-emitted. `.some()` returns `true` (suppress re-emit) if *any single* manifest reference is unchanged — it should use `.every()` which only suppresses when *all* manifest references are unchanged.

2. **Same array reference**: When only overrides change (no views added/removed), the merge function returned the same `this.#contexts` array reference. Since `distinctUntilChanged` compares by reference, `previousValue === currentValue` is always `true` for the same array — meaning it looks up manifests through the same reference and always sees them as equal, regardless of whether overrides were applied.

## What was changed

```diff
- currentValue.some(
+ currentValue.every(
    (x) => x.manifest === previousValue.find((y) => y.manifest.alias === x.manifest.alias)?.manifest,
  )
```

```diff
+ let hasOverrideChange = false;
  // ... (existing override application logic)
+   hasOverrideChange = true;

- return contexts;
+ return hasOverrideChange || hasDiff ? [...contexts] : contexts;
```

Both changes in `workspace-editor.context.ts`.

## Why this is safe

- `.every()` is strictly more correct for equality memoization
- Returning a new array reference only when overrides actually changed avoids unnecessary re-renders in the normal case
- No behavioral change when overrides arrive before the initial render (the common path)

## Testing

This is a timing-dependent race condition (per @nielslyngsoe's analysis). To reproduce:

1. Configure a Document Type with a Collection using a custom icon/label
2. Create content with child nodes using that type
3. Do a full page reload while on the collection workspace view

**Before fix**: Default "Child items" label/icon remains stuck until clicking the tab
**After fix**: Custom icon/label renders correctly on initial load

### Before

<img width="1900" height="944" alt="Reproducing_icon_and_label_issue_on_latest17" src="https://github.com/user-attachments/assets/5e1cbcab-ef1a-4644-a735-57adaf0ec86b" />


### After

<img width="1899" height="944" alt="After_adding_fix-for_icon_and_label_issue_on_latest17" src="https://github.com/user-attachments/assets/1d9b3bc9-70bd-420c-b562-ef964e8a3b2f" />


## Regression check

- Navigate between content nodes with workspace views — tabs render correctly
- Icons and labels display properly throughout
