### PR TITLE
Date Time Picker: Honour min/max config on the time-zone-aware editors (closes #23372)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/property-editor-ui-date-time-picker-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/property-editor-ui-date-time-picker-base.ts
@@ -55,6 +55,12 @@ export abstract class UmbPropertyEditorUiDateTimePickerElementBase
 	private _dateInputStep: number = 1;
 
 	@state()
+	private _min?: string;
+
+	@state()
+	private _max?: string;
+
+	@state()
 	private _selectedDate?: DateTime;
 
 	@state()
@@ -117,6 +123,8 @@ export abstract class UmbPropertyEditorUiDateTimePickerElementBase
 		if (!config) return;
 
 		const timeFormat = config.getValueByAlias<string>('timeFormat');
+		this._min = this.#formatMinMaxValue(config.getValueByAlias<string>('min'), 'min');
+		this._max = this.#formatMinMaxValue(config.getValueByAlias<string>('max'), 'max');
 		let timeZonePickerConfig: UmbTimeZonePickerValue | undefined = undefined;
 
 		if (this._displayTimeZone) {
@@ -253,6 +261,34 @@ export abstract class UmbPropertyEditorUiDateTimePickerElementBase
 		if (this._selectedDate) {
 			this._selectedDate = this._selectedDate.setZone(firstOption);
 			this._datePickerValue = this._selectedDate.toFormat(this._dateInputFormat);
+		}
+	}
+
+	// A native date/datetime-local/time input ignores min/max unless they match the input's own
+	// value format, so normalise the configured bound to the active input type (e.g. a date-only
+	// bound like "2026-07-01" must gain a time component to constrain a datetime-local input).
+	#formatMinMaxValue(value: string | undefined, bound: 'min' | 'max'): string | undefined {
+		if (!value) return undefined;
+
+		let dateTime = DateTime.fromISO(value);
+		if (!dateTime.isValid) {
+			dateTime = DateTime.fromSQL(value);
+		}
+		if (!dateTime.isValid) return value;
+
+		switch (this._dateInputType) {
+			case 'date':
+				return dateTime.toFormat('yyyy-MM-dd');
+			case 'time':
+				return dateTime.toFormat('HH:mm:ss');
+			default: {
+				// A date-only bound should cover the whole day on a datetime-local field, mirroring
+				// how a date field treats it: the lower bound starts the day, the upper bound ends it.
+				if (/^\d{4}-\d{2}-\d{2}$/.test(value.trim())) {
+					dateTime = bound === 'max' ? dateTime.endOf('day') : dateTime.startOf('day');
+				}
+				return dateTime.toFormat("yyyy-MM-dd'T'HH:mm:ss");
+			}
 		}
 	}
 
@@ -396,6 +432,8 @@ export abstract class UmbPropertyEditorUiDateTimePickerElementBase
 				<umb-input-date
 					label=${this.localize.term('placeholders_enterdate')}
 					.value=${this._datePickerValue}
+					.min=${this._min}
+					.max=${this._max}
 					.step=${this._dateInputStep}
 					type=${this._dateInputType}
 					@change=${this.#onValueChange}

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/property-editor-ui-date-time-picker.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/property-editor-ui-date-time-picker.test.ts
@@ -18,6 +18,54 @@ describe('UmbPropertyEditorUIDateTimePickerElement', () => {
 		expect(element).to.be.instanceOf(UmbPropertyEditorUIDateTimePickerElement);
 	});
 
+	it('expands a date-only bound to span the whole day on a datetime-local field', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([
+			{ alias: 'min', value: '2026-07-01' },
+			{ alias: 'max', value: '2026-07-30' },
+		]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('2026-07-01T00:00:00');
+		expect(inputElement.max).to.equal('2026-07-30T23:59:59');
+	});
+
+	it('preserves an explicit time on a datetime-local bound', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([
+			{ alias: 'min', value: '2026-07-01T09:30' },
+			{ alias: 'max', value: '2026-07-30T17:45' },
+		]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('2026-07-01T09:30:00');
+		expect(inputElement.max).to.equal('2026-07-30T17:45:00');
+	});
+
+	it('parses a stored SQL-style datetime bound', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([
+			{ alias: 'min', value: '2026-07-01 08:15:00' },
+			{ alias: 'max', value: '2026-07-30 17:45:00' },
+		]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('2026-07-01T08:15:00');
+		expect(inputElement.max).to.equal('2026-07-30T17:45:00');
+	});
+
+	it('passes an unparseable bound through unchanged', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([{ alias: 'min', value: 'not-a-date' }]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('not-a-date');
+	});
+
+	it('leaves a bound unset when its config value is absent', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([{ alias: 'min', value: '2026-07-01' }]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('2026-07-01T00:00:00');
+		expect(inputElement.max).to.be.undefined;
+	});
+
 	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {
 		it('passes the a11y audit', async () => {
 			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
@@ -66,6 +114,17 @@ describe('UmbPropertyEditorUIDateOnlyPickerElement', () => {
 		expect(element).to.be.instanceOf(UmbPropertyEditorUIDateOnlyPickerElement);
 	});
 
+	it('applies min/max config to the date input as date-only values', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([
+			{ alias: 'min', value: '2026-07-01' },
+			{ alias: 'max', value: '2026-07-30' },
+		]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('2026-07-01');
+		expect(inputElement.max).to.equal('2026-07-30');
+	});
+
 	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {
 		it('passes the a11y audit', async () => {
 			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
@@ -82,6 +141,17 @@ describe('UmbPropertyEditorUITimeOnlyPickerElement', () => {
 
 	it('is defined with its own instance', () => {
 		expect(element).to.be.instanceOf(UmbPropertyEditorUITimeOnlyPickerElement);
+	});
+
+	it('applies min/max config to the date input as time values', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([
+			{ alias: 'min', value: '09:00:00' },
+			{ alias: 'max', value: '17:30:00' },
+		]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('09:00:00');
+		expect(inputElement.max).to.equal('17:30:00');
 	});
 
 	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/property-editor-ui-date-time-picker.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/date-time/property-editor-ui-date-time-picker.test.ts
@@ -1,5 +1,7 @@
+import type { UmbInputDateElement } from '@umbraco-cms/backoffice/components';
 import { expect, fixture, html } from '@open-wc/testing';
 import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+import { UmbPropertyEditorConfigCollection } from '@umbraco-cms/backoffice/property-editor';
 import UmbPropertyEditorUIDateTimePickerElement from './date-time-picker/property-editor-ui-date-time-picker.element.js';
 import UmbPropertyEditorUIDateOnlyPickerElement from './date-only-picker/property-editor-ui-date-only-picker.element.js';
 import UmbPropertyEditorUITimeOnlyPickerElement from './time-only-picker/property-editor-ui-time-only-picker.element.js';
@@ -32,6 +34,17 @@ describe('UmbPropertyEditorUIDateTimeWithTimeZonePickerElement', () => {
 
 	it('is defined with its own instance', () => {
 		expect(element).to.be.instanceOf(UmbPropertyEditorUIDateTimeWithTimeZonePickerElement);
+	});
+
+	it('applies min/max config to the date input, normalised for a datetime-local field', async () => {
+		element.config = new UmbPropertyEditorConfigCollection([
+			{ alias: 'min', value: '2026-07-01' },
+			{ alias: 'max', value: '2026-07-30' },
+		]);
+		await element.updateComplete;
+		const inputElement = element.shadowRoot!.querySelector('umb-input-date') as UmbInputDateElement;
+		expect(inputElement.min).to.equal('2026-07-01T00:00:00');
+		expect(inputElement.max).to.equal('2026-07-30T23:59:59');
 	});
 
 	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {


### PR DESCRIPTION
## Description

`DateTimeWithTimeZonePicker` (and its sibling editors that share `UmbPropertyEditorUiDateTimePickerElementBase` — date-only, time-only, date-time) ignored `min`/`max` date constraints supplied via config, while the classic `DatePicker` (`Umbraco.DateTime`) respected them. All of these ultimately render `umb-input-date`, which forwards `min`/`max`/`step` to the native input — but the shared base element never read those values from config nor bound them.

This wires `min`/`max` through the base element, matching the DatePicker. It also **normalises each bound to the active input type**, which is necessary for the constraint to take effect: a native `datetime-local` input silently ignores a date-only bound like `2026-07-01`, so date-only bounds are expanded to span the whole day — lower bound to the start of the day, upper bound to the end — mirroring how a `date` field treats them.

No new data-type configuration UI is introduced: as with the DatePicker, `min`/`max` are read from the property editor's config collection.  So this is a developer-focussed update rather than an editor one (matching the behaviour the reporter asked for — parity with the date picker input).

Fixes #23372

## Testing

See reproduction steps in the linked issue.  Adding these two properties to the property data set example should now show both date picker editors respecting the mix/max configuration.