### PR TITLE
Markdown Editor: Tweak toolbar background color for UI consistency

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/components/input-markdown-editor/input-markdown.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/markdown-editor/components/input-markdown-editor/input-markdown.element.ts
@@ -617,7 +617,7 @@ export class UmbInputMarkdownElement extends UmbFormControlMixin<string, typeof 
 					0 2px 2px -2px rgba(34, 47, 62, 0.1),
 					0 8px 8px -4px rgba(34, 47, 62, 0.07);
 
-				background-color: var(--uui-color-surface-alt);
+				background-color: var(--uui-color-surface);
 				color: var(--color-text);
 
 				position: sticky;


### PR DESCRIPTION
## Description

Small tweak to the Markdown Editor toolbar background color to match the surface colour for UI consistency.

### How to test?

Open a markdown editor property in the backoffice and eyeball the toolbar in light/dark theme