### PR TITLE
Scheduled Publishing: Schedule all selected languages at once

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/da.ts
@@ -281,6 +281,7 @@ export default {
 			'Klik <em>Udgiv med undersider</em> for at udgive <strong>de valgte sprog</strong> og de samme sprog for sider under og dermed gøre deres indhold offentligt tilgængelige.',
 		releaseDate: 'Udgivelsesdato',
 		unpublishDate: 'Afpubliceringsdato',
+		scheduleForAllLanguages: 'Planlæg for alle valgte sprog',
 		removeDate: 'Fjern dato',
 		setDate: 'Vælg dato',
 		sortDone: 'Sorteringsrækkefølgen er opdateret',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -293,6 +293,7 @@ export default {
 		unpublishDate: 'Unpublish at',
 		removeDate: 'Clear date',
 		scheduledPublishing: 'Scheduled publishing',
+		scheduleForAllLanguages: 'Schedule for all selected languages',
 		setDate: 'Set date',
 		sortDone: 'Sort order is updated',
 		sortHelp:

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/nb.ts
@@ -240,6 +240,7 @@ export default {
 		type: 'Type',
 		unpublish: 'Avpubliser',
 		unpublishDate: 'Dato for avpublisering',
+		scheduleForAllLanguages: 'Planlegg for alle valgte språk',
 		unpublished: 'Avpublisert',
 		updatedBy: 'Oppdatert av',
 		updateDate: 'Sist endret',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/pt.ts
@@ -279,6 +279,7 @@ export default {
 		noVariantsToProcess: 'Não há variantes disponíveis',
 		releaseDate: 'Publicar em',
 		unpublishDate: 'Despublicar em',
+		scheduleForAllLanguages: 'Agendar para todos os idiomas selecionados',
 		removeDate: 'Limpar data',
 		setDate: 'Definir data',
 		sortDone: 'A ordem foi atualizada',

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/vi.ts
@@ -282,6 +282,7 @@ export default {
 		noVariantsToProcess: 'Không có biến thể nào có sẵn',
 		releaseDate: 'Xuất bản vào',
 		unpublishDate: 'Hủy xuất bản vào',
+		scheduleForAllLanguages: 'Lên lịch cho tất cả ngôn ngữ đã chọn',
 		removeDate: 'Xóa ngày',
 		setDate: 'Đặt ngày',
 		sortDone: 'Thứ tự sắp xếp đã được cập nhật',

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/document-schedule-modal.element.ts
@@ -1,6 +1,7 @@
 import { UmbDocumentVariantState } from '../../../variant-state.js';
 import type { UmbDocumentVariantOptionModel } from '../../../types.js';
 import { isNotPublishedMandatory } from '../../utils.js';
+import { mirrorSchedule } from './mirror-schedules.function.js';
 import { UmbDocumentVariantLanguagePickerElement } from '../../../modals/index.js';
 import type {
 	UmbDocumentScheduleModalData,
@@ -33,6 +34,9 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 
 	@state()
 	private _isAllSelected = false;
+
+	@state()
+	private _scheduleForAll = false;
 
 	@state()
 	private _internalValues: Array<UmbDocumentScheduleSelectionModel> = [];
@@ -69,6 +73,16 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 					}
 				}
 				this._isAllSelected = this.#isAllSelected();
+
+				// "Schedule for all" requires the active (current) language selected; if it is deselected we
+				// leave the mode, otherwise every selected variant inherits the active language's dates.
+				if (this._scheduleForAll) {
+					if (this.#isActiveSelected()) {
+						this.#mirrorToSelection();
+					} else {
+						this._scheduleForAll = false;
+					}
+				}
 
 				//Getting not published mandatory options — the options that are mandatory and not currently published.
 				const missingMandatoryOptions = this._options.filter(isNotPublishedMandatory);
@@ -159,6 +173,36 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 		return this._selection.length !== 0 && this._selection.length === allowedUniques.length;
 	}
 
+	// The "schedule for all" source is the first active variant. `activeVariants` is ordered with the
+	// split-view active variants first, so [0] is the one the editor is currently on.
+	#activeUnique(): string | undefined {
+		return this.data?.activeVariants?.[0];
+	}
+
+	#isActiveSelected(): boolean {
+		const active = this.#activeUnique();
+		return !!active && this._selection.some((s) => s.unique === active);
+	}
+
+	#onScheduleForAllChange(event: Event) {
+		this._scheduleForAll = (event.target as UUIBooleanInputElement).checked;
+		if (this._scheduleForAll) {
+			this.#mirrorToSelection();
+			this.#validation.validate();
+		}
+		this.requestUpdate('_internalValues');
+	}
+
+	#mirrorToSelection() {
+		const active = this.#activeUnique();
+		if (!active) return;
+		mirrorSchedule(
+			this._internalValues,
+			this._selection.map((s) => s.unique),
+			active,
+		);
+	}
+
 	override render() {
 		return html`<uui-dialog-layout headline=${this.localize.term('general_scheduledPublishing')}>
 			${this.#renderOptions()}
@@ -181,10 +225,17 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 			${when(
 				this._options.length > 1,
 				() => html`
-					<uui-checkbox
-						@change=${this.#onSelectAllChange}
-						label=${this.localize.term('general_selectAll')}
-						.checked=${this._isAllSelected}></uui-checkbox>
+					<div class="options-header">
+						<uui-checkbox
+							@change=${this.#onSelectAllChange}
+							label=${this.localize.term('general_selectAll')}
+							.checked=${this._isAllSelected}></uui-checkbox>
+						<uui-checkbox
+							@change=${this.#onScheduleForAllChange}
+							label=${this.localize.term('content_scheduleForAllLanguages')}
+							?disabled=${!this.#isActiveSelected()}
+							.checked=${this._scheduleForAll}></uui-checkbox>
+					</div>
 				`,
 			)}
 			${repeat(
@@ -202,6 +253,9 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 		const isChanged =
 			fromDate !== option.variant?.scheduledPublishDate || toDate !== option.variant?.scheduledUnpublishDate;
 
+		// While "schedule for all" is on, every variant except the active language mirrors its dates and is not editable.
+		const mirrored = this._scheduleForAll && option.unique !== this.#activeUnique();
+
 		return html`
 			<uui-menu-item
 				?selectable=${pickable}
@@ -213,7 +267,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 				<uui-icon slot="icon" name="icon-globe"></uui-icon>
 				${UmbDocumentVariantLanguagePickerElement.renderLabel(option)}
 			</uui-menu-item>
-			${when(this.#isSelected(option.unique), () => this.#renderPublishDateInput(option, fromDate, toDate))}
+			${when(this.#isSelected(option.unique), () => this.#renderPublishDateInput(option, fromDate, toDate, mirrored))}
 			${when(
 				isChanged,
 				() =>
@@ -273,22 +327,28 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 		);
 	}
 
-	#renderPublishDateInput(option: UmbDocumentVariantOptionModel, fromDate: string | null, toDate: string | null) {
+	#renderPublishDateInput(
+		option: UmbDocumentVariantOptionModel,
+		fromDate: string | null,
+		toDate: string | null,
+		mirrored: boolean,
+	) {
 		return html`
 			<div class="publish-date">
 				<uui-form-layout-item>
 					<uui-label slot="label"><umb-localize key="content_releaseDate">Publish at</umb-localize></uui-label>
 					<div>
 						<umb-input-date
-							${ref((e) => this.#attachValidatorsToPublish(e as UmbInputDateElement))}
+							${ref((e) => (mirrored ? undefined : this.#attachValidatorsToPublish(e as UmbInputDateElement)))}
 							${umbBindToValidation(this)}
 							type="datetime-local"
+							?disabled=${mirrored}
 							.value=${this.#formatDate(fromDate)}
 							@change=${(e: Event) => this.#onFromDateChange(e, option.unique)}
 							label=${this.localize.term('general_publishDate')}>
 							<div slot="append">
 								${when(
-									fromDate,
+									fromDate && !mirrored,
 									() => html`
 										<uui-button
 											compact
@@ -308,15 +368,18 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 					<uui-label slot="label"><umb-localize key="content_unpublishDate">Unpublish at</umb-localize></uui-label>
 					<div>
 						<umb-input-date
-							${ref((e) => this.#attachValidatorsToUnpublish(e as UmbInputDateElement, option.unique))}
+							${ref((e) =>
+								mirrored ? undefined : this.#attachValidatorsToUnpublish(e as UmbInputDateElement, option.unique),
+							)}
 							${umbBindToValidation(this)}
 							type="datetime-local"
+							?disabled=${mirrored}
 							.value=${this.#formatDate(toDate)}
 							@change=${(e: Event) => this.#onToDateChange(e, option.unique)}
 							label=${this.localize.term('general_publishDate')}>
 							<div slot="append">
 								${when(
-									toDate,
+									toDate && !mirrored,
 									() => html`
 										<uui-button
 											compact
@@ -352,6 +415,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 			...variant.schedule,
 			publishTime: null,
 		};
+		if (this._scheduleForAll) this.#mirrorToSelection();
 		this.#validation.validate();
 		this.requestUpdate('_internalValues');
 	}
@@ -363,6 +427,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 			...variant.schedule,
 			unpublishTime: null,
 		};
+		if (this._scheduleForAll) this.#mirrorToSelection();
 		this.#validation.validate();
 		this.requestUpdate('_internalValues');
 	}
@@ -404,6 +469,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 			...variant.schedule,
 			publishTime: this.#getDateValue(e),
 		};
+		if (this._scheduleForAll) this.#mirrorToSelection();
 		this.#validation.validate();
 		this.requestUpdate('_internalValues');
 	}
@@ -415,6 +481,7 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 			...variant.schedule,
 			unpublishTime: this.#getDateValue(e),
 		};
+		if (this._scheduleForAll) this.#mirrorToSelection();
 		this.#validation.validate();
 		this.requestUpdate('_internalValues');
 	}
@@ -458,6 +525,14 @@ export class UmbDocumentScheduleModalElement extends UmbModalBaseElement<
 
 			.publish-date > uui-form-layout-item:first-child {
 				border-right: 1px dashed var(--uui-color-border);
+			}
+
+			.options-header {
+				display: flex;
+				flex-direction: row;
+				flex-wrap: wrap;
+				align-items: center;
+				gap: var(--uui-size-space-5);
 			}
 
 			uui-checkbox {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/mirror-schedules.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/mirror-schedules.function.test.ts
@@ -1,0 +1,77 @@
+import { mirrorSchedule } from './mirror-schedules.function.js';
+import type { UmbDocumentScheduleSelectionModel } from './document-schedule-modal.token.js';
+import { expect } from '@open-wc/testing';
+
+const PUBLISH = '2099-01-01T10:00:00.000Z';
+const UNPUBLISH = '2099-02-01T10:00:00.000Z';
+
+describe('mirrorSchedule', () => {
+	it('copies both dates onto a variant that has none', () => {
+		const values: Array<UmbDocumentScheduleSelectionModel> = [
+			{ unique: 'en-US', schedule: { publishTime: PUBLISH, unpublishTime: UNPUBLISH } },
+			{ unique: 'da-DK', schedule: null },
+		];
+
+		mirrorSchedule(values, ['en-US', 'da-DK'], 'en-US');
+
+		expect(values.find((v) => v.unique === 'da-DK')?.schedule).to.eql({
+			publishTime: PUBLISH,
+			unpublishTime: UNPUBLISH,
+		});
+	});
+
+	it('overwrites a variant that already has its own custom dates', () => {
+		const values: Array<UmbDocumentScheduleSelectionModel> = [
+			{ unique: 'en-US', schedule: { publishTime: PUBLISH, unpublishTime: UNPUBLISH } },
+			{ unique: 'da-DK', schedule: { publishTime: '2099-06-01T12:00:00.000Z', unpublishTime: null } },
+		];
+
+		mirrorSchedule(values, ['en-US', 'da-DK'], 'en-US');
+
+		expect(values.find((v) => v.unique === 'da-DK')?.schedule).to.eql({
+			publishTime: PUBLISH,
+			unpublishTime: UNPUBLISH,
+		});
+	});
+
+	it('leaves the source variant untouched', () => {
+		const values: Array<UmbDocumentScheduleSelectionModel> = [
+			{ unique: 'en-US', schedule: { publishTime: PUBLISH, unpublishTime: null } },
+			{ unique: 'da-DK', schedule: { publishTime: '2099-06-01T12:00:00.000Z', unpublishTime: null } },
+		];
+
+		mirrorSchedule(values, ['en-US', 'da-DK'], 'en-US');
+
+		expect(values.find((v) => v.unique === 'en-US')?.schedule).to.eql({
+			publishTime: PUBLISH,
+			unpublishTime: null,
+		});
+	});
+
+	it('adds an entry for a target that is not yet present', () => {
+		const values: Array<UmbDocumentScheduleSelectionModel> = [
+			{ unique: 'en-US', schedule: { publishTime: PUBLISH, unpublishTime: null } },
+		];
+
+		mirrorSchedule(values, ['en-US', 'de-DE'], 'en-US');
+
+		expect(values.find((v) => v.unique === 'de-DE')?.schedule).to.eql({
+			publishTime: PUBLISH,
+			unpublishTime: null,
+		});
+	});
+
+	it('mirrors empty dates when the source has none', () => {
+		const values: Array<UmbDocumentScheduleSelectionModel> = [
+			{ unique: 'en-US', schedule: null },
+			{ unique: 'da-DK', schedule: { publishTime: PUBLISH, unpublishTime: UNPUBLISH } },
+		];
+
+		mirrorSchedule(values, ['en-US', 'da-DK'], 'en-US');
+
+		expect(values.find((v) => v.unique === 'da-DK')?.schedule).to.eql({
+			publishTime: null,
+			unpublishTime: null,
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/mirror-schedules.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/schedule-publish/modal/mirror-schedules.function.ts
@@ -1,0 +1,31 @@
+import type { UmbDocumentScheduleSelectionModel } from './document-schedule-modal.token.js';
+
+/**
+ * Overwrites the schedule of every target variant with a copy of the source variant's publish and
+ * unpublish dates, so all targets share the source's schedule. The source variant itself is never
+ * modified. Mutates `values` in place, adding an entry for any target that is not yet present.
+ * @param {Array<UmbDocumentScheduleSelectionModel>} values - the current per-variant schedule selection.
+ * @param {Array<string>} targetUniques - the variant uniques to mirror the source onto.
+ * @param {string} sourceUnique - the variant to copy the dates from.
+ */
+export function mirrorSchedule(
+	values: Array<UmbDocumentScheduleSelectionModel>,
+	targetUniques: Array<string>,
+	sourceUnique: string,
+): void {
+	const source = values.find((v) => v.unique === sourceUnique);
+	const publishTime = source?.schedule?.publishTime ?? null;
+	const unpublishTime = source?.schedule?.unpublishTime ?? null;
+
+	for (const unique of targetUniques) {
+		if (unique === sourceUnique) continue;
+
+		let variant = values.find((v) => v.unique === unique);
+		if (!variant) {
+			variant = { unique, schedule: null };
+			values.push(variant);
+		}
+
+		variant.schedule = { publishTime, unpublishTime };
+	}
+}

--- a/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/lib/helpers/ContentUiHelper.ts
@@ -158,6 +158,7 @@ export class ContentUiHelper extends UiBaseLocators {
   private readonly inlineCreateBtn: Locator;
   private readonly removeAt: Locator;
   private readonly selectAllCheckbox: Locator;
+  private readonly scheduleForAllLanguagesCheckbox: Locator;
   private readonly confirmToPublishBtn: Locator;
   private readonly tiptapStatusbarWordCount: Locator;
   private readonly tiptapStatusbarElementPath: Locator;
@@ -375,6 +376,7 @@ export class ContentUiHelper extends UiBaseLocators {
     this.publishAt = this.generalItem.filter({hasText: 'Publish at'}).locator('umb-localize-date');
     this.removeAt = this.generalItem.filter({hasText: 'Remove at'}).locator('umb-localize-date');
     this.selectAllCheckbox = this.documentScheduleModal.locator('[label="Select all"]');
+    this.scheduleForAllLanguagesCheckbox = this.documentScheduleModal.locator('[label="Schedule for all selected languages"]');
     this.confirmToPublishBtn = page.locator('umb-content-publish-modal').getByLabel('Publish');
     // Publish with descendants
     this.documentPublishWithDescendantsModal = page.locator('umb-document-publish-with-descendants-modal');
@@ -1654,6 +1656,15 @@ export class ContentUiHelper extends UiBaseLocators {
 
   async clickSelectAllCheckbox() {
     await this.click(this.selectAllCheckbox);
+  }
+
+  async clickScheduleForAllLanguagesCheckbox() {
+    await this.click(this.scheduleForAllLanguagesCheckbox);
+  }
+
+  async doesPublishTimeHaveValue(time: string, index: number = 0) {
+    const publishAtInput = this.documentScheduleModal.locator('.publish-date').nth(index).locator('uui-form-layout-item').first().locator('#input');
+    await expect(publishAtInput).toHaveValue(time);
   }
 
   async doesSchedulePublishModalButtonContainDisabledTag(hasDisabledTag: boolean = false) {

--- a/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ScheduledPublishing.spec.ts
+++ b/tests/Umbraco.Tests.AcceptanceTest/tests/DefaultConfig/Content/ScheduledPublishing.spec.ts
@@ -281,6 +281,40 @@ test('can schedule the publishing of multiple culture variants content', async (
   await umbracoApi.language.ensureIsoCodeNotExists(secondCulture);
 });
 
+test('can schedule the publishing of all selected languages at once', async ({umbracoApi, umbracoUi}) => {
+  // Arrange
+  const firstCulture = 'en-US';
+  const secondCulture = 'da';
+  await umbracoApi.language.createDanishLanguage();
+  const documentTypeId = await umbracoApi.documentType.createVariantDocumentTypeWithInvariantPropertyEditor(documentTypeName, dataTypeName, dataTypeId);
+  await umbracoApi.document.createDocumentWithTwoCulturesAndTextContent(contentName, documentTypeId, contentText, dataTypeName, firstCulture, secondCulture);
+  await umbracoUi.goToBackOffice();
+  await umbracoUi.content.goToSection(ConstantHelper.sections.content);
+
+  // Act
+  await umbracoUi.content.goToContentWithName(contentName);
+  await umbracoUi.content.clickViewMoreOptionsButton();
+  await umbracoUi.content.clickSchedulePublishButton();
+  await umbracoUi.content.clickSelectAllCheckbox();
+  await umbracoUi.content.clickScheduleForAllLanguagesCheckbox();
+  const publishDateTime = await umbracoApi.getCurrentTimePlusMinute();
+  const publishedTime = await umbracoApi.convertDateFormat(publishDateTime);
+  // Enter the publish time on the active language only.
+  await umbracoUi.content.enterPublishTime(publishDateTime);
+
+  // Assert
+  // The other selected language mirrors the active language's date without it being entered manually.
+  await umbracoUi.content.doesPublishTimeHaveValue(publishDateTime, 1);
+  await umbracoUi.content.clickSchedulePublishModalButton();
+  await umbracoUi.content.doesSuccessNotificationHaveText(NotificationConstantHelper.success.schedulePublishingUpdated);
+  await umbracoUi.content.clickInfoTab();
+  await umbracoUi.content.doesDocumentStateHaveText('Unpublished');
+  await umbracoUi.content.doesPublishAtContainText(publishedTime);
+
+  // Clean
+  await umbracoApi.language.ensureIsoCodeNotExists(secondCulture);
+});
+
 test('cannot schedule publishing with a publish time in the past', async ({umbracoApi, umbracoUi}) => {
   // Arrange
   const warningMessage = 'The release date cannot be in the past';


### PR DESCRIPTION
## Description

Relates to discussion [#15296](https://github.com/umbraco/Umbraco-CMS/discussions/15296).

When scheduling publish/unpublish dates for culture-variant content, editors have had to enter the same date individually for every language in the "Schedule publishing" dialog — tedious and error-prone on sites with many languages (the discussion references a 24-language site).

This adds a **"Schedule for all selected languages"** option to the schedule dialog, shown next to the existing "Select all":

<img width="633" height="705" alt="image" src="https://github.com/user-attachments/assets/e9c24675-051e-4769-acf3-5a8d4b60f571" />

The behaviour is that:

- When enabled, every selected language other than the active being edited is greyed out and **mirrors the active language's publish/unpublish dates live** — set the dates once and they apply to all selected languages.
- It is a mode you can toggle off again to return to per-language editing; the mirrored dates remain in place so you can then tweak individual languages if needed.
- The option is only available while the active (current) language is selected, and automatically switches off if that language is deselected.

No server-side changes were required — the publish endpoint already accepts a per-culture schedule list, so this is purely a backoffice usability improvement.

Translations have been added for all language that already had a translation for "Select all", so we don't get a mix of English and selected language in the dialog.

## Testing

### Automated

- Unit test (`mirror-schedules.function.test.ts`) for the date-mirroring helper: copies dates onto languages with none, overwrites languages that had their own dates, leaves the source language untouched, adds an entry for a missing language, and mirrors empty dates when the source has none.
- End-to-end acceptance test (`ScheduledPublishing.spec.ts` → *"can schedule the publishing of all selected languages at once"*): creates a two-culture document, selects all languages, enables "Schedule for all selected languages", enters a date on the active language only, then asserts the second language mirrors that date before confirming and scheduling succeeds.

### Manual

1. Enable at least two languages and create a culture-variant document type; create a document with two or more language variants.
2. Open the document and choose **Schedule publish** from the main "Save and published button menu.
3. Click **Select all**, then tick **Schedule for all selected languages**.
4. Set a publish (and/or unpublish) date on the active language and confirm the other selected languages grey out and show the same date.
5. Click **Schedule publish** and confirm the schedule is saved (state shows *Unpublished* with the publish-at date on the Info tab).
6. Reopen the dialog, untick the option, and confirm the languages become individually editable again (retaining the mirrored dates).
7. Deselect the active language and confirm the option becomes disabled / switches off.
