### PR TITLE
Collection Views: UI consistency for Columns and Layouts configuration editors

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/index.ts
@@ -1,0 +1,2 @@
+export * from './sortable-list.element.js';
+export * from './sortable-list-item.element.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list-item.element.ts
@@ -1,0 +1,102 @@
+import { css, customElement, html, nothing, property } from '@umbraco-cms/backoffice/external/lit';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+
+/**
+ * @element umb-sortable-list-item
+ * @slot - The content of the item.
+ * @slot actions - Actions to render for the item, e.g. a remove button.
+ */
+@customElement('umb-sortable-list-item')
+export class UmbSortableListItemElement extends UmbLitElement {
+	/**
+	 * The item's unique identifier, used by the parent `umb-sortable-list` to track it while sorting.
+	 * @type {string}
+	 */
+	@property({ attribute: 'data-sort-entry-id', reflect: true })
+	public unique?: string;
+
+	/**
+	 * Disables the item, hiding the drag handle and actions.
+	 * @type {boolean}
+	 * @attr
+	 */
+	@property({ type: Boolean, reflect: true })
+	disabled = false;
+
+	/**
+	 * Hides the drag handle.
+	 * @type {boolean}
+	 * @attr hide-handle
+	 */
+	@property({ type: Boolean, attribute: 'hide-handle' })
+	hideHandle = false;
+
+	/**
+	 * Hides the actions slot.
+	 * @type {boolean}
+	 * @attr hide-actions
+	 */
+	@property({ type: Boolean, attribute: 'hide-actions' })
+	hideActions = false;
+
+	override render() {
+		return html`
+			${this.#renderHandle()}
+			<slot></slot>
+			${this.#renderActions()}
+		`;
+	}
+
+	#renderHandle() {
+		if (this.hideHandle || this.disabled) return nothing;
+		return html`<uui-icon name="icon-grip" class="handle"></uui-icon>`;
+	}
+
+	#renderActions() {
+		if (this.hideActions || this.disabled) return nothing;
+		return html`<div class="actions"><slot name="actions"></slot></div>`;
+	}
+
+	static override readonly styles = [
+		css`
+			:host {
+				display: flex;
+				align-items: center;
+				gap: var(--uui-size-6);
+				padding: var(--uui-size-3) 0;
+				background-color: var(--uui-color-surface);
+			}
+
+			:host([drag-placeholder]) {
+				opacity: 0.5;
+			}
+
+			.handle {
+				flex: 0 0 var(--uui-size-6);
+				cursor: grab;
+
+				&:active {
+					cursor: grabbing;
+				}
+			}
+
+			::slotted(*) {
+				flex: 1;
+			}
+
+			.actions {
+				flex: 0 0 auto;
+				display: flex;
+				justify-content: flex-end;
+			}
+		`,
+	];
+}
+
+export default UmbSortableListItemElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-sortable-list-item': UmbSortableListItemElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list-item.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list-item.test.ts
@@ -1,0 +1,46 @@
+import { UmbSortableListItemElement } from './sortable-list-item.element.js';
+import { expect, fixture, html } from '@open-wc/testing';
+
+describe('UmbSortableListItemElement', () => {
+	let element: UmbSortableListItemElement;
+
+	beforeEach(async () => {
+		element = await fixture(html`<umb-sortable-list-item></umb-sortable-list-item>`);
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbSortableListItemElement);
+	});
+
+	it('renders the drag handle and actions by default', () => {
+		expect(element.shadowRoot!.querySelector('.handle')).to.exist;
+		expect(element.shadowRoot!.querySelector('.actions')).to.exist;
+	});
+
+	it('hides the drag handle when hide-handle is set', async () => {
+		element.hideHandle = true;
+		await element.updateComplete;
+		expect(element.shadowRoot!.querySelector('.handle')).to.not.exist;
+		expect(element.shadowRoot!.querySelector('.actions')).to.exist;
+	});
+
+	it('hides the actions when hide-actions is set', async () => {
+		element.hideActions = true;
+		await element.updateComplete;
+		expect(element.shadowRoot!.querySelector('.actions')).to.not.exist;
+		expect(element.shadowRoot!.querySelector('.handle')).to.exist;
+	});
+
+	it('hides both the drag handle and actions when disabled', async () => {
+		element.disabled = true;
+		await element.updateComplete;
+		expect(element.shadowRoot!.querySelector('.handle')).to.not.exist;
+		expect(element.shadowRoot!.querySelector('.actions')).to.not.exist;
+	});
+
+	it('reflects the unique property to the data-sort-entry-id attribute', async () => {
+		element.unique = 'my-unique-id';
+		await element.updateComplete;
+		expect(element.getAttribute('data-sort-entry-id')).to.equal('my-unique-id');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.element.ts
@@ -1,0 +1,154 @@
+import { UmbSorterController } from '../sorter.controller.js';
+import type { UmbSorterConfig } from '../sorter.controller.js';
+import type { TemplateResult } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, nothing, property, repeat } from '@umbraco-cms/backoffice/external/lit';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UUIBlinkAnimationValue, UUIBlinkKeyframes } from '@umbraco-cms/backoffice/external/uui';
+
+/**
+ * @element umb-sortable-list
+ * @fires UmbChangeEvent when the order of items has changed
+ * @example
+ * ```html
+ * <umb-sortable-list
+ *     .items=${this.items}
+ *     .getUnique=${(item) => item.alias}
+ *     .renderMethod=${(item) => html`
+ *         <umb-sortable-list-item .unique=${item.alias}>
+ *             <uui-input .value=${item.name}></uui-input>
+ *             <uui-button slot="actions" label="Remove"></uui-button>
+ *         </umb-sortable-list-item>
+ *     `}
+ *     @change=${this.#onSort}>
+ * </umb-sortable-list>
+ * ```
+ */
+@customElement('umb-sortable-list')
+export class UmbSortableListElement<T = unknown> extends UmbLitElement {
+	readonly #sorterConfig: UmbSorterConfig<T> = {
+		getUniqueOfElement: (element) => element.dataset.sortEntryId,
+		getUniqueOfModel: (model) => this.getUnique(model),
+		itemSelector: 'umb-sortable-list-item',
+		handleSelector: '.handle',
+		onChange: ({ model }) => {
+			this.items = model;
+			this.dispatchEvent(new UmbChangeEvent());
+		},
+	};
+
+	readonly #sorter = new UmbSorterController<T>(this, this.#sorterConfig);
+
+	/**
+	 * The selector used to find the items to sort within this element's shadow root.
+	 * @type {string}
+	 * @attr item-selector
+	 */
+	@property({ attribute: 'item-selector' })
+	public get itemSelector(): string {
+		return this.#sorterConfig.itemSelector;
+	}
+	public set itemSelector(value: string) {
+		this.#sorterConfig.itemSelector = value || 'umb-sortable-list-item';
+	}
+
+	/**
+	 * The selector used to find the drag handle within an item. If not found, the whole item is draggable.
+	 * @type {string}
+	 * @attr handle-selector
+	 */
+	@property({ attribute: 'handle-selector' })
+	public get handleSelector(): string {
+		return this.#sorterConfig.handleSelector ?? '';
+	}
+	public set handleSelector(value: string) {
+		this.#sorterConfig.handleSelector = value || '.handle';
+	}
+
+	/**
+	 * The items to render and sort.
+	 * @type {Array<T>}
+	 */
+	@property({ type: Array })
+	public get items(): Array<T> {
+		return this.#items;
+	}
+	public set items(items: Array<T> | undefined) {
+		this.#items = items ?? [];
+		this.#sorter.setModel(this.#items);
+	}
+	#items: Array<T> = [];
+
+	/**
+	 * Resolves the unique identifier of an item, used to keep track of items while sorting.
+	 * @type {(item: T) => string}
+	 */
+	@property({ attribute: false })
+	public getUnique: (item: T) => string = () => '';
+
+	/**
+	 * Renders the markup for an item. The returned template must be rooted at an element carrying
+	 * the item's unique identifier via a `data-sort-entry-id` attribute, e.g. `umb-sortable-list-item`'s `unique` property.
+	 * @type {(item: T, index: number) => TemplateResult}
+	 */
+	@property({ attribute: false })
+	public renderMethod: (item: T, index: number) => TemplateResult = () => html``;
+
+	/**
+	 * Disables sorting.
+	 * @type {boolean}
+	 * @attr
+	 */
+	@property({ type: Boolean, reflect: true })
+	public set disabled(value: boolean) {
+		this.#disabled = value;
+		this.#updateSorterState();
+	}
+	public get disabled(): boolean {
+		return this.#disabled;
+	}
+	#disabled = false;
+
+	#updateSorterState() {
+		if (this.#disabled) {
+			this.#sorter.disable();
+		} else {
+			this.#sorter.enable();
+		}
+	}
+
+	override render() {
+		if (!this.items.length) return nothing;
+		return repeat(
+			this.items,
+			(item) => this.getUnique(item),
+			(item, index) => this.renderMethod(item, index),
+		);
+	}
+
+	static override readonly styles = [
+		UUIBlinkKeyframes,
+		css`
+			:host {
+				display: flex;
+				flex-direction: column;
+				gap: 1px;
+			}
+
+			[drag-placeholder] {
+				animation: ${UUIBlinkAnimationValue};
+				background-color: color-mix(in srgb, var(--uui-color-interactive-emphasis) 15%, transparent) !important;
+				border-radius: var(--uui-border-radius);
+				border: 2px solid var(--uui-color-interactive-emphasis);
+			}
+		`,
+	];
+}
+
+export default UmbSortableListElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-sortable-list': UmbSortableListElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.element.ts
@@ -40,6 +40,20 @@ export class UmbSortableListElement<T = unknown> extends UmbLitElement {
 	readonly #sorter = new UmbSorterController<T>(this, this.#sorterConfig);
 
 	/**
+	 * An identifier shared between sortable lists, allowing items to be dragged from one list to another that shares the same identifier.
+	 * @type {string}
+	 * @attr
+	 */
+	@property()
+	public get identifier(): string | undefined {
+		// UmbSorterController assigns a Symbol default when none is set, so only surface an explicit string identifier.
+		return typeof this.#sorterConfig.identifier === 'string' ? this.#sorterConfig.identifier : undefined;
+	}
+	public set identifier(value: string | undefined) {
+		this.#sorterConfig.identifier = value || undefined;
+	}
+
+	/**
 	 * The selector used to find the items to sort within this element's shadow root.
 	 * @type {string}
 	 * @attr item-selector

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.element.ts
@@ -84,7 +84,7 @@ export class UmbSortableListElement<T = unknown> extends UmbLitElement {
 	 * @type {(item: T) => string}
 	 */
 	@property({ attribute: false })
-	public getUnique: (item: T) => string = () => '';
+	public getUnique: (item: T) => string = (): string => '';
 
 	/**
 	 * Renders the markup for an item. The returned template must be rooted at an element carrying
@@ -92,7 +92,7 @@ export class UmbSortableListElement<T = unknown> extends UmbLitElement {
 	 * @type {(item: T, index: number) => TemplateResult}
 	 */
 	@property({ attribute: false })
-	public renderMethod: (item: T, index: number) => TemplateResult = () => html``;
+	public renderMethod: (item: T, index: number) => TemplateResult = (): TemplateResult => html``;
 
 	/**
 	 * Disables sorting.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.stories.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.stories.ts
@@ -1,0 +1,42 @@
+import type { UmbSortableListElement } from './sortable-list.element.js';
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { html } from '@umbraco-cms/backoffice/external/lit';
+
+import './sortable-list.element.js';
+import './sortable-list-item.element.js';
+
+const items = ['Item 1', 'Item 2', 'Item 3'];
+
+const meta: Meta<UmbSortableListElement<string>> = {
+	title: 'Generic Components/Sortable List',
+	component: 'umb-sortable-list',
+	args: {
+		disabled: false,
+	},
+	render: (args) => html`
+		<umb-sortable-list
+			.items=${items}
+			.getUnique=${(item: string) => item}
+			.renderMethod=${(item: string) => html`
+				<umb-sortable-list-item .unique=${item} ?disabled=${args.disabled}>
+					<uui-input .value=${item} ?disabled=${args.disabled}></uui-input>
+					<uui-button slot="actions" label="Remove" look="secondary" compact>
+						<uui-icon name="icon-trash"></uui-icon>
+					</uui-button>
+				</umb-sortable-list-item>
+			`}
+			?disabled=${args.disabled}>
+		</umb-sortable-list>
+	`,
+};
+
+export default meta;
+type Story = StoryObj<UmbSortableListElement<string>>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+	args: {
+		disabled: true,
+	},
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.stories.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.stories.ts
@@ -20,9 +20,9 @@ const meta: Meta<UmbSortableListElement<string>> = {
 			.renderMethod=${(item: string) => html`
 				<umb-sortable-list-item .unique=${item} ?disabled=${args.disabled}>
 					<uui-input .value=${item} ?disabled=${args.disabled}></uui-input>
-					<uui-button slot="actions" label="Remove" look="secondary" compact>
-						<uui-icon name="icon-trash"></uui-icon>
-					</uui-button>
+					<uui-action-bar slot="actions">
+						<uui-button label="Remove"><uui-icon name="icon-trash"></uui-icon></uui-button>
+					</uui-action-bar>
 				</umb-sortable-list-item>
 			`}
 			?disabled=${args.disabled}>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.test.ts
@@ -1,0 +1,81 @@
+import { UmbSortableListElement } from './sortable-list.element.js';
+import './sortable-list-item.element.js';
+import { expect, fixture, html } from '@open-wc/testing';
+
+describe('UmbSortableListElement', () => {
+	let element: UmbSortableListElement<string>;
+
+	const getUnique = (item: string) => item;
+	const renderMethod = (item: string) =>
+		html`<umb-sortable-list-item .unique=${item}>${item}</umb-sortable-list-item>`;
+
+	beforeEach(async () => {
+		element = await fixture(html`<umb-sortable-list></umb-sortable-list>`);
+		element.getUnique = getUnique;
+		element.renderMethod = renderMethod;
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbSortableListElement);
+	});
+
+	it('renders nothing when there are no items', async () => {
+		element.items = [];
+		await element.updateComplete;
+		const items = element.shadowRoot!.querySelectorAll('umb-sortable-list-item');
+		expect(items.length).to.equal(0);
+	});
+
+	it('renders an item per entry, in order', async () => {
+		element.items = ['a', 'b', 'c'];
+		await element.updateComplete;
+
+		const items = element.shadowRoot!.querySelectorAll('umb-sortable-list-item');
+		expect(items.length).to.equal(3);
+		expect(Array.from(items).map((item) => item.textContent?.trim())).to.deep.equal(['a', 'b', 'c']);
+	});
+
+	it('stamps the unique identifier as the data-sort-entry-id attribute', async () => {
+		element.items = ['a', 'b', 'c'];
+		await element.updateComplete;
+
+		const items = element.shadowRoot!.querySelectorAll('umb-sortable-list-item');
+		expect(Array.from(items).map((item) => item.getAttribute('data-sort-entry-id'))).to.deep.equal(['a', 'b', 'c']);
+	});
+
+	it('re-renders when items are replaced', async () => {
+		element.items = ['a', 'b'];
+		await element.updateComplete;
+		element.items = ['b', 'c'];
+		await element.updateComplete;
+
+		const items = element.shadowRoot!.querySelectorAll('umb-sortable-list-item');
+		expect(Array.from(items).map((item) => item.textContent?.trim())).to.deep.equal(['b', 'c']);
+	});
+
+	it('reflects the disabled property to an attribute', async () => {
+		element.disabled = true;
+		await element.updateComplete;
+		expect(element.hasAttribute('disabled')).to.be.true;
+	});
+
+	it('defaults the item and handle selectors', () => {
+		expect(element.itemSelector).to.equal('umb-sortable-list-item');
+		expect(element.handleSelector).to.equal('.handle');
+	});
+
+	it('accepts custom item-selector and handle-selector attributes', async () => {
+		const custom = await fixture<UmbSortableListElement<string>>(
+			html`<umb-sortable-list item-selector=".my-item" handle-selector=".my-handle"></umb-sortable-list>`,
+		);
+		expect(custom.itemSelector).to.equal('.my-item');
+		expect(custom.handleSelector).to.equal('.my-handle');
+	});
+
+	it('falls back to the default selectors when set to an empty string', () => {
+		element.itemSelector = '';
+		element.handleSelector = '';
+		expect(element.itemSelector).to.equal('umb-sortable-list-item');
+		expect(element.handleSelector).to.equal('.handle');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.test.ts
@@ -23,7 +23,7 @@ describe('UmbSortableListElement', () => {
 		element.items = [];
 		await element.updateComplete;
 		const items = element.shadowRoot!.querySelectorAll('umb-sortable-list-item');
-		expect(items.length).to.equal(0);
+		expect(items).to.have.lengthOf(0);
 	});
 
 	it('renders an item per entry, in order', async () => {
@@ -31,7 +31,7 @@ describe('UmbSortableListElement', () => {
 		await element.updateComplete;
 
 		const items = element.shadowRoot!.querySelectorAll('umb-sortable-list-item');
-		expect(items.length).to.equal(3);
+		expect(items).to.have.lengthOf(3);
 		expect(Array.from(items).map((item) => item.textContent?.trim())).to.deep.equal(['a', 'b', 'c']);
 	});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/components/sortable-list.test.ts
@@ -78,4 +78,15 @@ describe('UmbSortableListElement', () => {
 		expect(element.itemSelector).to.equal('umb-sortable-list-item');
 		expect(element.handleSelector).to.equal('.handle');
 	});
+
+	it('has no identifier by default', () => {
+		expect(element.identifier).to.be.undefined;
+	});
+
+	it('accepts a custom identifier attribute', async () => {
+		const custom = await fixture<UmbSortableListElement<string>>(
+			html`<umb-sortable-list identifier="Umb.SorterIdentifier.Test"></umb-sortable-list>`,
+		);
+		expect(custom.identifier).to.equal('Umb.SorterIdentifier.Test');
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/sorter/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/sorter/index.ts
@@ -1,2 +1,3 @@
 export * from './sorter.controller.js';
 export * from './replacement-resolver-as-grid.function.js';
+export * from './components/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
@@ -1,19 +1,19 @@
 import type { UmbInputCollectionContentTypePropertyElement } from './components/index.js';
-import type { UmbCollectionColumnConfiguration } from '@umbraco-cms/backoffice/collection';
 import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
+import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbSortableListElement } from '@umbraco-cms/backoffice/sorter';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import type { UmbCollectionColumnConfiguration } from '@umbraco-cms/backoffice/collection';
 import type {
 	UmbPropertyEditorConfigCollection,
 	UmbPropertyEditorUiElement,
 } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbSortableListElement } from '@umbraco-cms/backoffice/sorter';
 import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 
 // import of local components
 import './components/index.js';
 import '@umbraco-cms/backoffice/sorter';
-import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 /**
  * @element umb-property-editor-ui-collection-column-configuration
@@ -84,14 +84,18 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
-	#onRemove(unique: string) {
-		const newValue: Array<UmbCollectionColumnConfiguration> = [];
-
-		this.value?.forEach((config) => {
-			if (config.alias !== unique) newValue.push(config);
+	async #onRemove(column: UmbCollectionColumnConfiguration, index: number) {
+		await umbConfirmModal(this, {
+			color: 'danger',
+			headline: `#actions_remove?`,
+			content: `#defaultdialogs_confirmremove ${column.header}?`,
+			confirmLabel: '#actions_remove',
 		});
 
-		this.value = newValue;
+		const values = [...(this.value ?? [])];
+		values.splice(index, 1);
+		this.value = values;
+
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
@@ -105,8 +109,9 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 			<umb-sortable-list
 				.items=${this.value}
 				.getUnique=${(column: UmbCollectionColumnConfiguration) => column.alias}
-				.renderMethod=${(column: UmbCollectionColumnConfiguration) => this.#renderColumn(column)}
-				@change=${this.#onSort}></umb-sortable-list>
+				.renderMethod=${(column: UmbCollectionColumnConfiguration, index: number) => this.#renderColumn(column, index)}
+				@change=${this.#onSort}>
+			</umb-sortable-list>
 			${this.#renderInput()}
 		`;
 	}
@@ -120,7 +125,7 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 		`;
 	}
 
-	#renderColumn(column: UmbCollectionColumnConfiguration) {
+	#renderColumn(column: UmbCollectionColumnConfiguration, index: number) {
 		return html`
 			<umb-sortable-list-item .unique=${column.alias}>
 				<div style="display:flex;align-items:center;gap:var(--uui-size-6);">
@@ -144,7 +149,7 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 					</uui-input>
 				</div>
 				<uui-action-bar slot="actions">
-					<uui-button label=${this.localize.term('general_remove')} @click=${() => this.#onRemove(column.alias)}>
+					<uui-button label=${this.localize.term('general_remove')} @click=${() => this.#onRemove(column, index)}>
 						<uui-icon name="icon-trash"></uui-icon>
 					</uui-button>
 				</uui-action-bar>
@@ -153,7 +158,6 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 	}
 
 	static override readonly styles = [
-		UmbTextStyles,
 		css`
 			umb-sortable-list {
 				display: block;

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
@@ -1,8 +1,8 @@
 import type { UmbInputCollectionContentTypePropertyElement } from './components/index.js';
 import type { UmbCollectionColumnConfiguration } from '@umbraco-cms/backoffice/collection';
-import { css, customElement, html, nothing, property, repeat, state } from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, property, state } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
+import type { UmbSortableListElement } from '@umbraco-cms/backoffice/sorter';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type {
 	UmbPropertyEditorConfigCollection,
@@ -12,6 +12,7 @@ import type { UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 
 // import of local components
 import './components/index.js';
+import '@umbraco-cms/backoffice/sorter';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 
 /**
@@ -22,21 +23,9 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 	extends UmbLitElement
 	implements UmbPropertyEditorUiElement
 {
-	#sorter = new UmbSorterController<UmbCollectionColumnConfiguration>(this, {
-		getUniqueOfElement: (element) => element.id,
-		getUniqueOfModel: (modelEntry) => modelEntry.alias,
-		itemSelector: '.layout-item',
-		containerSelector: '#layout-wrapper',
-		onChange: ({ model }) => {
-			this.value = model;
-			this.dispatchEvent(new UmbChangeEvent());
-		},
-	});
-
 	@property({ type: Array })
 	public set value(value: Array<UmbCollectionColumnConfiguration> | undefined) {
 		this.#value = value ?? [];
-		this.#sorter.setModel(this.#value);
 	}
 	public get value(): Array<UmbCollectionColumnConfiguration> {
 		return this.#value;
@@ -76,6 +65,7 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 	}
 
 	#onChangeLabel(e: UUIInputEvent, configuration: UmbCollectionColumnConfiguration) {
+		e.stopPropagation();
 		this.value = this.value?.map(
 			(config): UmbCollectionColumnConfiguration =>
 				config.alias === configuration.alias ? { ...config, header: e.target.value as string } : config,
@@ -85,6 +75,7 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 	}
 
 	#onChangeNameTemplate(e: UUIInputEvent, configuration: UmbCollectionColumnConfiguration) {
+		e.stopPropagation();
 		this.value = this.value?.map(
 			(config): UmbCollectionColumnConfiguration =>
 				config.alias === configuration.alias ? { ...config, nameTemplate: e.target.value as string } : config,
@@ -104,9 +95,18 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
+	#onSort(e: Event) {
+		this.value = (e.target as UmbSortableListElement<UmbCollectionColumnConfiguration>).items;
+		this.dispatchEvent(new UmbChangeEvent());
+	}
+
 	override render() {
 		return html`
-			<div id="layout-wrapper">${this.#renderColumns()}</div>
+			<umb-sortable-list
+				.items=${this.value}
+				.getUnique=${(column: UmbCollectionColumnConfiguration) => column.alias}
+				.renderMethod=${(column: UmbCollectionColumnConfiguration) => this.#renderColumn(column)}
+				@change=${this.#onSort}></umb-sortable-list>
 			${this.#renderInput()}
 		`;
 	}
@@ -120,86 +120,44 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 		`;
 	}
 
-	#renderColumns() {
-		if (!this.value) return nothing;
-		return repeat(
-			this.value,
-			(column) => column.alias,
-			(column) => this.#renderColumn(column),
-		);
-	}
-
 	#renderColumn(column: UmbCollectionColumnConfiguration) {
 		return html`
-			<div class="layout-item" id=${column.alias}>
-				<uui-icon class="drag-handle" name="icon-grip"></uui-icon>
-
-				<uui-input
-					required
-					label="label"
-					placeholder="Enter a label..."
-					.value=${column.header ?? ''}
-					@change=${(e: UUIInputEvent) => this.#onChangeLabel(e, column)}></uui-input>
-
-				<div class="alias">
-					<code>${column.alias}</code>
+			<umb-sortable-list-item .unique=${column.alias}>
+				<div style="display:flex;align-items:center;gap:var(--uui-size-6);">
+					<uui-input
+						required
+						label="label"
+						placeholder="Enter a label..."
+						style="flex:1;"
+						.value=${column.header ?? ''}
+						@change=${(e: UUIInputEvent) => this.#onChangeLabel(e, column)}>
+					</uui-input>
+					<div class="alias" style="flex:1;word-break:break-all;">
+						<code>${column.alias}</code>
+					</div>
+					<uui-input
+						label="template"
+						placeholder="Enter a label template..."
+						style="flex:1;"
+						.value=${column.nameTemplate ?? ''}
+						@change=${(e: UUIInputEvent) => this.#onChangeNameTemplate(e, column)}>
+					</uui-input>
 				</div>
-
-				<uui-input
-					label="template"
-					placeholder="Enter a label template..."
-					.value=${column.nameTemplate ?? ''}
-					@change=${(e: UUIInputEvent) => this.#onChangeNameTemplate(e, column)}></uui-input>
-
-				<div class="actions">
-					<uui-button
-						label=${this.localize.term('general_remove')}
-						look="secondary"
-						@click=${() => this.#onRemove(column.alias)}></uui-button>
-				</div>
-			</div>
+				<uui-action-bar slot="actions">
+					<uui-button label=${this.localize.term('general_remove')} @click=${() => this.#onRemove(column.alias)}>
+						<uui-icon name="icon-trash"></uui-icon>
+					</uui-button>
+				</uui-action-bar>
+			</umb-sortable-list-item>
 		`;
 	}
 
-	static override styles = [
+	static override readonly styles = [
 		UmbTextStyles,
 		css`
-			#layout-wrapper {
-				display: flex;
-				flex-direction: column;
-				gap: 1px;
+			umb-sortable-list {
+				display: block;
 				margin-bottom: var(--uui-size-1);
-			}
-
-			.layout-item {
-				background-color: var(--uui-color-surface-alt);
-				display: flex;
-				align-items: center;
-				gap: var(--uui-size-6);
-				padding: var(--uui-size-3) var(--uui-size-6);
-			}
-
-			.layout-item > uui-icon {
-				flex: 0 0 var(--uui-size-6);
-			}
-
-			.layout-item > uui-input,
-			.layout-item > .alias {
-				flex: 1;
-			}
-
-			.layout-item > .actions {
-				flex: 0 0 auto;
-				display: flex;
-				justify-content: flex-end;
-			}
-
-			.drag-handle {
-				cursor: grab;
-			}
-
-			.drag-handle:active {
-				cursor: grabbing;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/column/column-configuration.element.ts
@@ -88,7 +88,7 @@ export class UmbPropertyEditorUICollectionColumnConfigurationElement
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: `#defaultdialogs_confirmremove ${column.header}?`,
+			content: `#defaultdialogs_confirmremove ${column.header ?? ''}?`,
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
@@ -1,17 +1,9 @@
-import {
-	css,
-	customElement,
-	html,
-	ifDefined,
-	nothing,
-	property,
-	repeat,
-	when,
-} from '@umbraco-cms/backoffice/external/lit';
+import { css, customElement, html, ifDefined, property, when } from '@umbraco-cms/backoffice/external/lit';
 import { extractUmbColorVariable } from '@umbraco-cms/backoffice/resources';
 import { simpleHashCode } from '@umbraco-cms/backoffice/observable-api';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import { UmbSorterController } from '@umbraco-cms/backoffice/sorter';
+import type { UmbSortableListElement } from '@umbraco-cms/backoffice/sorter';
+import '@umbraco-cms/backoffice/sorter';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbInputManifestElement } from '@umbraco-cms/backoffice/components';
@@ -38,25 +30,9 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 	extends UmbLitElement
 	implements UmbPropertyEditorUiElement
 {
-	#sorter = new UmbSorterController<UmbCollectionLayoutConfiguration>(this, {
-		getUniqueOfElement: (element) => {
-			return element.id;
-		},
-		getUniqueOfModel: (modelEntry) => {
-			return this.#getUnique(modelEntry);
-		},
-		itemSelector: '.layout-item',
-		containerSelector: '#layout-wrapper',
-		onChange: ({ model }) => {
-			this.value = model;
-			this.dispatchEvent(new UmbChangeEvent());
-		},
-	});
-
 	@property({ type: Array })
 	public set value(value: Array<UmbCollectionLayoutConfiguration> | undefined) {
 		this.#value = value ?? [];
-		this.#sorter.setModel(this.#value);
 	}
 	public get value(): Array<UmbCollectionLayoutConfiguration> {
 		return this.#value;
@@ -68,8 +44,12 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 
 	async #focusNewItem() {
 		await this.updateComplete;
-		const input = this.shadowRoot?.querySelector('.layout-item:last-of-type > uui-input') as UUIInputElement;
-		input.focus();
+		const list = this.shadowRoot?.querySelector('umb-sortable-list');
+		await list?.updateComplete;
+		const input = list?.shadowRoot?.querySelector('umb-sortable-list-item:last-of-type > uui-input') as
+			| UUIInputElement
+			| undefined;
+		input?.focus();
 	}
 
 	#onAdd(event: { target: UmbInputManifestElement }) {
@@ -98,6 +78,7 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 	}
 
 	#onChangeLabel(e: UUIInputEvent, index: number) {
+		e.stopPropagation();
 		const values = [...(this.value ?? [])];
 		values[index] = { ...values[index], name: e.target.value as string };
 		this.value = values;
@@ -132,9 +113,18 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 		return 'x' + simpleHashCode('' + layout.collectionView + layout.name + layout.icon).toString(16);
 	}
 
+	#onSort(e: Event) {
+		this.value = (e.target as UmbSortableListElement<UmbCollectionLayoutConfiguration>).items;
+		this.dispatchEvent(new UmbChangeEvent());
+	}
+
 	override render() {
 		return html`
-			<div id="layout-wrapper">${this.#renderLayouts()}</div>
+			<umb-sortable-list
+				.items=${this.value}
+				.getUnique=${(layout: UmbCollectionLayoutConfiguration) => this.#getUnique(layout)}
+				.renderMethod=${(layout: UmbCollectionLayoutConfiguration, index: number) => this.#renderLayout(layout, index)}
+				@change=${this.#onSort}></umb-sortable-list>
 			${this.#renderInput()}
 		`;
 	}
@@ -143,93 +133,49 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 		return html`<umb-input-manifest extension-type="collectionView" @change=${this.#onAdd}></umb-input-manifest>`;
 	}
 
-	#renderLayouts() {
-		if (!this.value) return nothing;
-		return repeat(
-			this.value,
-			(layout) => this.#getUnique(layout),
-			(layout, index) => this.#renderLayout(layout, index),
-		);
-	}
-
 	#renderLayout(layout: UmbCollectionLayoutConfiguration, index: number) {
 		const icon = this.#parseIcon(layout.icon);
 		const varName = icon.color ? extractUmbColorVariable(icon.color) : undefined;
 		return html`
-			<div class="layout-item" id=${this.#getUnique(layout)}>
-				<uui-icon class="drag-handle" name="icon-grip"></uui-icon>
-
-				<uui-button compact look="outline" label="pick icon" @click=${() => this.#onIconChange(icon, index)}>
-					${when(
-						icon.color,
-						() => html`<uui-icon name=${ifDefined(icon.icon)} style="color:var(${varName})"></uui-icon>`,
-						() => html`<uui-icon name=${ifDefined(icon.icon)}></uui-icon>`,
-					)}
-				</uui-button>
-
-				<uui-input
-					label="name"
-					value=${ifDefined(layout.name)}
-					placeholder="Enter a label..."
-					@change=${(e: UUIInputEvent) => this.#onChangeLabel(e, index)}></uui-input>
-
-				<div class="alias">
-					<code>${layout.collectionView}</code>
-				</div>
-
-				<div class="actions">
+			<umb-sortable-list-item .unique=${this.#getUnique(layout)}>
+				<div style="display:flex;align-items:center;gap:var(--uui-size-6);">
 					<uui-button
-						label=${this.localize.term('general_remove')}
-						look="secondary"
-						@click=${() => this.#onRemove(index)}></uui-button>
+						compact
+						look="outline"
+						label="pick icon"
+						style="min-width:var(--uui-size-11);"
+						@click=${() => this.#onIconChange(icon, index)}>
+						${when(
+							icon.color,
+							() => html`<uui-icon name=${ifDefined(icon.icon)} style="color:var(${varName})"></uui-icon>`,
+							() => html`<uui-icon name=${ifDefined(icon.icon)}></uui-icon>`,
+						)}
+					</uui-button>
+					<uui-input
+						label="name"
+						value=${ifDefined(layout.name)}
+						placeholder="Enter a label..."
+						style="flex:1;"
+						@change=${(e: UUIInputEvent) => this.#onChangeLabel(e, index)}>
+					</uui-input>
+					<div class="alias" style="flex:1;word-break:break-all;">
+						<code>${layout.collectionView}</code>
+					</div>
 				</div>
-			</div>
+				<uui-action-bar slot="actions">
+					<uui-button label=${this.localize.term('general_remove')} @click=${() => this.#onRemove(index)}>
+						<uui-icon name="icon-trash"></uui-icon> </uui-button
+				></uui-action-bar>
+			</umb-sortable-list-item>
 		`;
 	}
 
-	static override styles = [
+	static override readonly styles = [
 		UmbTextStyles,
 		css`
-			#layout-wrapper {
-				display: flex;
-				flex-direction: column;
-				gap: 1px;
+			umb-sortable-list {
+				display: block;
 				margin-bottom: var(--uui-size-1);
-			}
-
-			.layout-item {
-				background-color: var(--uui-color-surface-alt);
-				display: flex;
-				align-items: center;
-				gap: var(--uui-size-6);
-				padding: var(--uui-size-3) var(--uui-size-6);
-			}
-
-			.layout-item > uui-icon {
-				flex: 0 0 var(--uui-size-6);
-			}
-
-			.layout-item > uui-button {
-				min-width: var(--uui-size-11);
-			}
-
-			.layout-item > uui-input,
-			.layout-item > .alias {
-				flex: 1;
-			}
-
-			.layout-item > .actions {
-				flex: 0 0 auto;
-				display: flex;
-				justify-content: flex-end;
-			}
-
-			.drag-handle {
-				cursor: grab;
-			}
-
-			.drag-handle:active {
-				cursor: grabbing;
 			}
 		`,
 	];

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
@@ -90,7 +90,7 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 		await umbConfirmModal(this, {
 			color: 'danger',
 			headline: `#actions_remove?`,
-			content: `#defaultdialogs_confirmremove ${layout.name}?`,
+			content: `#defaultdialogs_confirmremove ${layout.name ?? ''}?`,
 			confirmLabel: '#actions_remove',
 		});
 

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
@@ -10,7 +10,7 @@ import type {
 	UmbPropertyEditorConfigCollection,
 	UmbPropertyEditorUiElement,
 } from '@umbraco-cms/backoffice/property-editor';
-import type { UmbSortableListElement } from '@umbraco-cms/backoffice/sorter';
+import type { UmbSortableListElement, UmbSortableListItemElement } from '@umbraco-cms/backoffice/sorter';
 import type { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
 
 import '@umbraco-cms/backoffice/sorter';
@@ -45,15 +45,22 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 
 	async #focusNewItem() {
 		await this.updateComplete;
+
 		const list = this.shadowRoot?.querySelector('umb-sortable-list');
 		await list?.updateComplete;
-		const input = list?.shadowRoot?.querySelector('umb-sortable-list-item:last-of-type > uui-input') as
-			| UUIInputElement
+
+		const item = list?.shadowRoot?.querySelector('umb-sortable-list-item:last-of-type') as
+			| UmbSortableListItemElement
 			| undefined;
+
+		// The item's <slot> only exists in its shadow root once its own first update completes, so its
+		// slotted uui-input isn't part of the rendered tree (and therefore not focusable) until then.
+		await item?.updateComplete;
+		const input = item?.querySelector('uui-input') as UUIInputElement | undefined;
 		input?.focus();
 	}
 
-	#onAdd(event: { target: UmbInputManifestElement }) {
+	async #onAdd(event: { target: UmbInputManifestElement }) {
 		const manifest = event.target.value;
 
 		const duplicate = this.value?.find((config) => manifest?.value === config.collectionView);
@@ -75,7 +82,7 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 
 		this.dispatchEvent(new UmbChangeEvent());
 
-		this.#focusNewItem();
+		await this.#focusNewItem();
 	}
 
 	#onChangeLabel(e: UUIInputEvent, index: number) {

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/collection/config/layout/layout-configuration.element.ts
@@ -1,18 +1,19 @@
 import { css, customElement, html, ifDefined, property, when } from '@umbraco-cms/backoffice/external/lit';
 import { extractUmbColorVariable } from '@umbraco-cms/backoffice/resources';
 import { simpleHashCode } from '@umbraco-cms/backoffice/observable-api';
-import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
-import type { UmbSortableListElement } from '@umbraco-cms/backoffice/sorter';
-import '@umbraco-cms/backoffice/sorter';
+import { umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
-import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/icon';
 import type { UmbInputManifestElement } from '@umbraco-cms/backoffice/components';
 import type {
 	UmbPropertyEditorConfigCollection,
 	UmbPropertyEditorUiElement,
 } from '@umbraco-cms/backoffice/property-editor';
+import type { UmbSortableListElement } from '@umbraco-cms/backoffice/sorter';
 import type { UUIInputElement, UUIInputEvent } from '@umbraco-cms/backoffice/external/uui';
-import { UMB_ICON_PICKER_MODAL } from '@umbraco-cms/backoffice/icon';
+
+import '@umbraco-cms/backoffice/sorter';
 
 interface UmbCollectionLayoutConfiguration {
 	icon?: string;
@@ -85,10 +86,18 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
-	#onRemove(unique: number) {
+	async #onRemove(layout: UmbCollectionLayoutConfiguration, index: number) {
+		await umbConfirmModal(this, {
+			color: 'danger',
+			headline: `#actions_remove?`,
+			content: `#defaultdialogs_confirmremove ${layout.name}?`,
+			confirmLabel: '#actions_remove',
+		});
+
 		const values = [...(this.value ?? [])];
-		values.splice(unique, 1);
+		values.splice(index, 1);
 		this.value = values;
+
 		this.dispatchEvent(new UmbChangeEvent());
 	}
 
@@ -163,7 +172,7 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 					</div>
 				</div>
 				<uui-action-bar slot="actions">
-					<uui-button label=${this.localize.term('general_remove')} @click=${() => this.#onRemove(index)}>
+					<uui-button label=${this.localize.term('general_remove')} @click=${() => this.#onRemove(layout, index)}>
 						<uui-icon name="icon-trash"></uui-icon> </uui-button
 				></uui-action-bar>
 			</umb-sortable-list-item>
@@ -171,7 +180,6 @@ export class UmbPropertyEditorUICollectionLayoutConfigurationElement
 	}
 
 	static override readonly styles = [
-		UmbTextStyles,
 		css`
 			umb-sortable-list {
 				display: block;


### PR DESCRIPTION
### Description

Tidies up the drag-and-drop reordering in the Collection view's **Columns** and **Layouts** config screens so they look and behave the same way as each other, with a proper grip handle, smoother drag placeholder, and a confirmation prompt before removing a row.

Under the hood this introduces a couple of small, reusable building blocks for sortable lists, (e.g. `<umb-sortable-list>`), so future property editors with reorderable rows can pick up the same look and feel without reinventing it each time.

Before

<img width="854" height="299" alt="Screenshot 2026-07-14 174148" src="https://github.com/user-attachments/assets/df1923d4-92fb-407e-a1e3-0e4ecb7a981a" />

After

<img width="854" height="295" alt="Screenshot 2026-07-14 174115" src="https://github.com/user-attachments/assets/137d655d-20e3-432c-879e-c0435a10a796" />


### How to test?

- Open a Collection data type, and go to the **Columns** and **Layouts** config tabs.
- Add a few rows, drag them by the grip handle to reorder, and confirm the order saves.
- Try removing a row, you should get a confirmation prompt.