### PR TITLE
Block Editors: Preserve published state of property-less blocks on upgrade (closes #23379)

### DIFF
--- a/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
@@ -42,6 +42,8 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
             throw new JsonException($"Could not create an instance of {nameof(BlockValue)} from type: {typeToConvert.FullName}.");
         }
 
+        var exposeSeen = false;
+
         while (reader.Read())
         {
             if (reader.TokenType is JsonTokenType.EndObject)
@@ -70,9 +72,21 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
                         break;
                     case nameof(BlockValue.Expose):
                         blockValue.Expose = DeserializeBlockVariation(ref reader, options, typeToConvert, nameof(BlockValue.Expose));
+                        exposeSeen = true;
                         break;
                 }
             }
+        }
+
+        // Legacy (pre-variant) block values had no "expose" property. The current format always
+        // serializes one (see Write), so its absence marks legacy data whose blocks must be exposed
+        // to preserve their published state on upgrade (#23379). Property-less blocks are the case
+        // the downstream converted-flag heuristic in BlockEditorDataConverter misses.
+        if (exposeSeen is false && blockValue.ContentData.Count > 0)
+        {
+            blockValue.Expose = blockValue.ContentData
+                .Select(cd => new BlockItemVariation(cd.Key, null, null))
+                .ToList();
         }
 
         return blockValue;

--- a/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonBlockValueConverter.cs
@@ -27,20 +27,7 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
             throw new JsonException("Expected start object");
         }
 
-        BlockValue? blockValue;
-        try
-        {
-            blockValue = (BlockValue?)Activator.CreateInstance(typeToConvert);
-        }
-        catch (Exception ex)
-        {
-            throw new JsonException($"Unable to create an instance of {nameof(BlockValue)} from type: {typeToConvert.FullName}. Please make sure the type has an default (parameterless) constructor. See the inner exception for more details.", ex);
-        }
-
-        if (blockValue is null)
-        {
-            throw new JsonException($"Could not create an instance of {nameof(BlockValue)} from type: {typeToConvert.FullName}.");
-        }
+        BlockValue? blockValue = GetBlockValue(typeToConvert);
 
         var exposeSeen = false;
 
@@ -87,6 +74,26 @@ public class JsonBlockValueConverter : JsonConverter<BlockValue>
             blockValue.Expose = blockValue.ContentData
                 .Select(cd => new BlockItemVariation(cd.Key, null, null))
                 .ToList();
+        }
+
+        return blockValue;
+    }
+
+    private static BlockValue GetBlockValue(Type typeToConvert)
+    {
+        BlockValue? blockValue;
+        try
+        {
+            blockValue = (BlockValue?)Activator.CreateInstance(typeToConvert);
+        }
+        catch (Exception ex)
+        {
+            throw new JsonException($"Unable to create an instance of {nameof(BlockValue)} from type: {typeToConvert.FullName}. Please make sure the type has an default (parameterless) constructor. See the inner exception for more details.", ex);
+        }
+
+        if (blockValue is null)
+        {
+            throw new JsonException($"Could not create an instance of {nameof(BlockValue)} from type: {typeToConvert.FullName}.");
         }
 
         return blockValue;

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockEditorBackwardsCompatibilityTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/PropertyEditors/BlockEditorBackwardsCompatibilityTests.cs
@@ -277,6 +277,60 @@ internal sealed class BlockEditorBackwardsCompatibilityTests : UmbracoIntegratio
         });
     }
 
+    [TestCase]
+    public async Task RichTextWithPropertyLessBlocksIsBackwardsCompatible()
+    {
+        var elementType = await CreatePropertyLessElementType();
+        var richTextDataType = await CreateRichTextDataType(elementType);
+        var contentType = await CreateContentType(richTextDataType);
+
+        var json = $$"""
+                     {
+                         "markup": "<p><umb-rte-block data-content-udi=\"umb://element/1304e1ddac87439684fe8a399231cb3d\"></umb-rte-block></p>",
+                         "blocks": {
+                             "layout": {
+                                 "{{Constants.PropertyEditors.Aliases.RichText}}": [
+                                     {
+                                         "contentUdi": "umb://element/1304e1ddac87439684fe8a399231cb3d"
+                                     }
+                                 ]
+                             },
+                             "contentData": [
+                                 {
+                                     "contentTypeKey": "{{elementType.Key}}",
+                                     "udi": "umb://element/1304e1ddac87439684fe8a399231cb3d"
+                                 }
+                             ],
+                             "settingsData": []
+                         }
+                     }
+                     """;
+
+        var contentBuilder = new ContentBuilder()
+            .WithContentType(contentType)
+            .WithName("Home");
+
+        var content = contentBuilder.Build();
+        content.Properties["blocks"]!.SetValue(json);
+        ContentService.Save(content);
+
+        var toEditor = richTextDataType.Editor!.GetValueEditor().ToEditor(content.Properties["blocks"]!) as RichTextEditorValue;
+        Assert.IsNotNull(toEditor);
+        Assert.IsNotNull(toEditor.Blocks);
+
+        Assert.AreEqual(1, toEditor.Blocks.ContentData.Count);
+        Assert.AreEqual("1304e1ddac87439684fe8a399231cb3d", toEditor.Blocks.ContentData[0].Key.ToString("N"));
+        Assert.IsEmpty(toEditor.Blocks.ContentData[0].Values);
+
+        // The block has no properties, so historically it was never exposed on upgrade and rendered
+        // as unpublished (#23379). It must now be exposed to preserve its published state.
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, toEditor.Blocks.Expose.Count);
+            Assert.AreEqual("1304e1ddac87439684fe8a399231cb3d", toEditor.Blocks.Expose[0].ContentKey.ToString("N"));
+        });
+    }
+
     private static void AssertValueEquals(BlockItemData blockItemData, string propertyAlias, string expectedValue)
     {
         var blockPropertyValue = blockItemData.Values.FirstOrDefault(v => v.Alias == propertyAlias);
@@ -304,6 +358,18 @@ internal sealed class BlockEditorBackwardsCompatibilityTests : UmbracoIntegratio
             .WithPropertyEditorAlias(Constants.PropertyEditors.Aliases.TextBox)
             .WithValueStorageType(ValueStorageType.Nvarchar)
             .Done()
+            .Build();
+
+        await ContentTypeService.CreateAsync(elementType, Constants.Security.SuperUserKey);
+        return elementType;
+    }
+
+    private async Task<IContentType> CreatePropertyLessElementType()
+    {
+        var elementType = new ContentTypeBuilder()
+            .WithAlias("myPropertyLessElementType")
+            .WithName("My Property-less Element Type")
+            .WithIsElement(true)
             .Build();
 
         await ContentTypeService.CreateAsync(elementType, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonBlockValueConverterTests.cs
@@ -508,4 +508,76 @@ public class JsonBlockValueConverterTests
         Assert.AreEqual("Text", deserialized.ContentData[0].RawPropertyValues["text"]);
         Assert.AreEqual("Values", deserialized.ContentData[0].RawPropertyValues["values"]);
     }
+
+    /// <summary>
+    /// Test case that verifies the fix for https://github.com/umbraco/Umbraco-CMS/issues/23379.
+    /// </summary>
+    [Test]
+    public void Can_Populate_Expose_For_Legacy_Property_Less_Blocks()
+    {
+        // Legacy (pre-variant) block value with a content block that has no property values and no
+        // "expose" property. On upgrade the block must still be exposed to keep its published state.
+        var serialized = @"{
+   ""layout"":{
+      ""Umbraco.RichText"":[
+         {
+            ""contentUdi"":""umb://element/6ad18441631140d48515ea0fc5b00425""
+         }
+      ]
+   },
+   ""contentData"":[
+      {
+         ""contentTypeKey"":""a1d1123c-289b-4a05-b33f-9f06cb723da1"",
+         ""udi"":""umb://element/6ad18441631140d48515ea0fc5b00425""
+      }
+   ],
+   ""settingsData"":[
+   ]
+}";
+
+        var serializer = new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory());
+        var deserialized = serializer.Deserialize<RichTextBlockValue>(serialized);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(1, deserialized.ContentData.Count);
+        Assert.IsEmpty(deserialized.ContentData[0].Values);
+
+        Assert.AreEqual(1, deserialized.Expose.Count);
+        Assert.AreEqual(Guid.Parse("6ad18441631140d48515ea0fc5b00425"), deserialized.Expose[0].ContentKey);
+        Assert.IsNull(deserialized.Expose[0].Culture);
+        Assert.IsNull(deserialized.Expose[0].Segment);
+    }
+
+    [Test]
+    public void Does_Not_Populate_Expose_When_Expose_Present()
+    {
+        // Current-format block value that explicitly carries an empty "expose" array alongside content.
+        // This is a healthy (non-legacy) state and must be left untouched.
+        var serialized = @"{
+   ""layout"":{
+      ""Umbraco.RichText"":[
+         {
+            ""contentKey"":""6ad18441-6311-40d4-8515-ea0fc5b00425""
+         }
+      ]
+   },
+   ""contentData"":[
+      {
+         ""contentTypeKey"":""a1d1123c-289b-4a05-b33f-9f06cb723da1"",
+         ""key"":""6ad18441-6311-40d4-8515-ea0fc5b00425""
+      }
+   ],
+   ""settingsData"":[
+   ],
+   ""expose"":[
+   ]
+}";
+
+        var serializer = new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory());
+        var deserialized = serializer.Deserialize<RichTextBlockValue>(serialized);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(1, deserialized.ContentData.Count);
+        Assert.IsEmpty(deserialized.Expose);
+    }
 }


### PR DESCRIPTION
## Description

When upgrading from V13 to V17, Rich Text Editor blocks that have **no properties** come out of the migration **un-exposed** — the backoffice shows them greyed out.

### Root cause

A block's published state is tracked by the `Expose` array on `BlockValue` — one entry per exposed content block. The legacy (pre-variant) block format had no `expose` property; the current format always has one.

During migration, `Expose` is back-filled by `AmendExpose` in `BlockEditorDataConverter.Convert`, but only when a per-value `converted` flag flips to true. That flag only flips when a block has legacy property values to migrate **or** an empty key needing UDI resolution.

A property-less block has neither — no property values, and for RTE its key is already resolved from the legacy `udi` field during deserialization. So when a property value's block content is *entirely* property-less blocks, `converted` stays `false`, `AmendExpose` never runs, `Expose` stays empty, and every block renders as unpublished. Blocks *with* properties avoided the bug because they flip the flag, which then exposes all sibling blocks in the same value — which is why this particular variation had not surfaced before.

### Resolution

The absence of an `expose` property in the stored JSON is a signal of legacy data, because the serializer always writes `expose` for the current format (even when empty). In `JsonBlockValueConverter.Read` we now detect that the `expose` property was not present and, when there is content data, populate `Expose` from the content block keys:

```csharp
if (exposeSeen is false && blockValue.ContentData.Count > 0)
{
    blockValue.Expose = blockValue.ContentData
        .Select(cd => new BlockItemVariation(cd.Key, null, null))
        .ToList();
}
```

This is deliberately conservative: it changes behaviour **only** for genuinely legacy data and never touches current-format data (which always carries an `expose` key, even if empty). Because every block editor deserializes through this one converter, the fix covers Rich Text, Block List, Block Grid and Single Block.

**Known limitation:** this preserves published state for upgrades performed from this version onward. It does **not** retroactively fix sites that have *already* been migrated, because their stored JSON now legitimately contains `"expose": []` — which is indistinguishable from a block the editor deliberately left unexposed.

Fixes #23379.

## Testing

### Automated

Added tests, verified to fail before the change and pass after (red/green confirmed):

- **Unit** — `JsonBlockValueConverterTests`:
  - `Can_Populate_Expose_For_Legacy_Property_Less_Blocks` — deserializes legacy JSON (no `expose`) with a property-less content block and asserts `Expose` is populated. Reproduces the issue directly.
  - `Does_Not_Populate_Expose_When_Expose_Present` — current-format JSON with an explicit empty `expose` and content is left untouched, proving healthy data is never re-exposed.
- **Integration** — `BlockEditorBackwardsCompatibilityTests.RichTextWithPropertyLessBlocksIsBackwardsCompatible` — exercises the full value-editor `ToEditor` path (the path the migration uses) with a property-less element type, asserting the block is exposed. Also confirmed to fail without the fix, ruling out any other path populating expose.


### Manual

I've carried out the following to reproduce the issue and then repeated to verify the fix verification.

1. On Umbraco V13, create an element type with **no properties**, and an RTE data type configured to allow it as a block.
2. On a document, add that block into an RTE property and **publish** the page.
3. Upgrade the site to V17.
4. **Before this fix:** open the document — the property-less block(s) in the RTE show as unpublished (un-exposed/greyed out). **With this fix:** the block(s) remain "published", matching their pre-upgrade state.