### PR TITLE
Content Workspaces: Redirect stale variant workspace URLs when the content type variance changes

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-base.ts
@@ -249,7 +249,7 @@ export abstract class UmbContentDetailWorkspaceContextBase<
 			this.view.hints,
 		);
 
-		new UmbContentDetailWorkspaceTypeTransformController(this as any);
+		new UmbContentDetailWorkspaceTypeTransformController(this as any, this._data);
 
 		this.variantOptions = mergeObservables(
 			[this.variesByCulture, this.variesBySegment, this.variants, this.languages, this._segments.asObservable()],

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.test.ts
@@ -11,9 +11,12 @@ import type { UmbLanguageDetailModel } from '@umbraco-cms/backoffice/language';
 @customElement('umb-test-workspace-host')
 class UmbTestWorkspaceHostElement extends UmbControllerHostElementMixin(HTMLElement) {
 	#propertyTypesState = new UmbObjectState<Array<UmbPropertyTypeModel> | undefined>(undefined);
+	#ownerContentTypeState = new UmbObjectState<{ variesByCulture?: boolean } | undefined>(undefined);
 
 	structure = {
 		contentTypeProperties: this.#propertyTypesState.asObservable(),
+		ownerContentTypeObservablePart: <R>(fn: (contentType: { variesByCulture?: boolean } | undefined) => R) =>
+			this.#ownerContentTypeState.asObservablePart(fn),
 	};
 
 	#data: UmbContentDetailModel<UmbEntityVariantModel> | undefined;

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
@@ -14,6 +14,7 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 	#workspace: UmbContentDetailWorkspaceContextBase<DetailModelType, any, any, any>;
 	// Current property types, currently used to detect variation changes:
 	#propertyTypes?: Array<UmbPropertyTypeModel>;
+	#variesByCulture?: boolean;
 
 	constructor(host: UmbContentDetailWorkspaceContextBase<DetailModelType, any, any, any>) {
 		super(host);
@@ -30,6 +31,85 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 			},
 			null,
 		);
+
+		// Observe the owner content type's culture variance to migrate the variants collection alongside
+		// the values, so the active variant keeps its name, state and dates and the next save matches the type
+		this.observe(
+			host.structure.ownerContentTypeObservablePart((x) => x?.variesByCulture),
+			(variesByCulture: boolean | undefined) => {
+				const previousVariesByCulture = this.#variesByCulture;
+				this.#variesByCulture = variesByCulture;
+				if (
+					previousVariesByCulture === undefined ||
+					variesByCulture === undefined ||
+					previousVariesByCulture === variesByCulture
+				) {
+					return;
+				}
+				this.#handleContentTypeVarianceChange(variesByCulture);
+			},
+			null,
+		);
+	}
+
+	#handleContentTypeVarianceChange(variesByCulture: boolean): void {
+		const currentData = this.#workspace.getData();
+		if (!currentData) return;
+
+		const defaultLanguage = this.#getDefaultLanguage();
+		const variants = variesByCulture
+			? this.#transformVariantsToCultureVariant(currentData.variants, defaultLanguage)
+			: this.#transformVariantsToInvariant(currentData.variants, defaultLanguage);
+
+		this.#workspace.setData({ ...currentData, variants });
+	}
+
+	/**
+	 * Moves invariant variant entries to the default language, keeping existing culture entries as-is.
+	 */
+	#transformVariantsToCultureVariant(
+		variants: DetailModelType['variants'],
+		defaultLanguage: string,
+	): DetailModelType['variants'] {
+		const result: DetailModelType['variants'] = [];
+		for (const variant of variants) {
+			if (variant.culture !== null) {
+				result.push(variant);
+				continue;
+			}
+			const existingCultureVariant = variants.find(
+				(v) => v.culture === defaultLanguage && v.segment === variant.segment,
+			);
+			if (!existingCultureVariant) {
+				result.push({ ...variant, culture: defaultLanguage });
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Collapses culture variant entries to invariant, preferring the default language and discarding other cultures.
+	 */
+	#transformVariantsToInvariant(
+		variants: DetailModelType['variants'],
+		defaultLanguage: string,
+	): DetailModelType['variants'] {
+		const cultureToKeep = variants.some((v) => v.culture === defaultLanguage)
+			? defaultLanguage
+			: variants.find((v) => v.culture !== null)?.culture;
+
+		const result: DetailModelType['variants'] = [];
+		for (const variant of variants) {
+			if (variant.culture === null) {
+				result.push(variant);
+			} else if (variant.culture === cultureToKeep) {
+				const existingInvariantVariant = variants.find((v) => v.culture === null && v.segment === variant.segment);
+				if (!existingInvariantVariant) {
+					result.push({ ...variant, culture: null });
+				}
+			}
+		}
+		return result;
 	}
 
 	async #handlePropertyTypeVariationChanges(

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
@@ -4,6 +4,11 @@ import type { UmbPropertyTypeModel } from '@umbraco-cms/backoffice/content-type'
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import type { UmbEntityVariantModel } from '@umbraco-cms/backoffice/variant';
 
+interface UmbTypeTransformPersistedDataAccessor<DetailModelType> {
+	getPersisted(): DetailModelType | undefined;
+	setPersisted(data: DetailModelType | undefined): void;
+}
+
 /**
  * @class UmbContentDetailWorkspaceTypeTransformController
  * @description - Controller to handle content detail workspace type transformations, such as property variation changes.
@@ -12,14 +17,19 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 	DetailModelType extends UmbContentDetailModel<UmbEntityVariantModel>,
 > extends UmbControllerBase {
 	#workspace: UmbContentDetailWorkspaceContextBase<DetailModelType, any, any, any>;
+	#persistedData?: UmbTypeTransformPersistedDataAccessor<DetailModelType>;
 	// Current property types, currently used to detect variation changes:
 	#propertyTypes?: Array<UmbPropertyTypeModel>;
 	#variesByCulture?: boolean;
 
-	constructor(host: UmbContentDetailWorkspaceContextBase<DetailModelType, any, any, any>) {
+	constructor(
+		host: UmbContentDetailWorkspaceContextBase<DetailModelType, any, any, any>,
+		persistedData?: UmbTypeTransformPersistedDataAccessor<DetailModelType>,
+	) {
 		super(host);
 
 		this.#workspace = host;
+		this.#persistedData = persistedData;
 
 		// Observe property variation changes to trigger value migration when properties change
 		// from invariant to variant (or vice versa) via Infinite Editing
@@ -57,11 +67,19 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 		if (!currentData) return;
 
 		const defaultLanguage = this.#getDefaultLanguage();
-		const variants = variesByCulture
-			? this.#transformVariantsToCultureVariant(currentData.variants, defaultLanguage)
-			: this.#transformVariantsToInvariant(currentData.variants, defaultLanguage);
+		const transformVariants = (variants: DetailModelType['variants']) =>
+			variesByCulture
+				? this.#transformVariantsToCultureVariant(variants, defaultLanguage)
+				: this.#transformVariantsToInvariant(variants, defaultLanguage);
 
-		this.#workspace.setData({ ...currentData, variants });
+		this.#workspace.setData({ ...currentData, variants: transformVariants(currentData.variants) });
+
+		// The persisted data must be migrated too — the server migrated its copy when the content type
+		// was saved, and constructing save data merges the persisted variants back in:
+		const persisted = this.#persistedData?.getPersisted();
+		if (persisted) {
+			this.#persistedData?.setPersisted({ ...persisted, variants: transformVariants(persisted.variants) });
+		}
 	}
 
 	/**
@@ -77,10 +95,8 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 				result.push(variant);
 				continue;
 			}
-			const existingCultureVariant = variants.find(
-				(v) => v.culture === defaultLanguage && v.segment === variant.segment,
-			);
-			if (!existingCultureVariant) {
+			const hasCultureVariant = variants.some((v) => v.culture === defaultLanguage && v.segment === variant.segment);
+			if (!hasCultureVariant) {
 				result.push({ ...variant, culture: defaultLanguage });
 			}
 		}
@@ -103,8 +119,8 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 			if (variant.culture === null) {
 				result.push(variant);
 			} else if (variant.culture === cultureToKeep) {
-				const existingInvariantVariant = variants.find((v) => v.culture === null && v.segment === variant.segment);
-				if (!existingInvariantVariant) {
+				const hasInvariantVariant = variants.some((v) => v.culture === null && v.segment === variant.segment);
+				if (!hasInvariantVariant) {
 					result.push({ ...variant, culture: null });
 				}
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/content/content/workspace/content-detail-workspace-type-transform.controller.ts
@@ -17,7 +17,7 @@ export class UmbContentDetailWorkspaceTypeTransformController<
 	DetailModelType extends UmbContentDetailModel<UmbEntityVariantModel>,
 > extends UmbControllerBase {
 	#workspace: UmbContentDetailWorkspaceContextBase<DetailModelType, any, any, any>;
-	#persistedData?: UmbTypeTransformPersistedDataAccessor<DetailModelType>;
+	readonly #persistedData?: UmbTypeTransformPersistedDataAccessor<DetailModelType>;
 	// Current property types, currently used to detect variation changes:
 	#propertyTypes?: Array<UmbPropertyTypeModel>;
 	#variesByCulture?: boolean;

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/index.ts
@@ -1,6 +1,7 @@
 export * from './route/index.js';
 export * from './contexts/index.js';
 export * from './encode-folder-name.function.js';
+export * from './modal-registration/constants.js';
 export * from './modal-registration/modal-route-registration.controller.js';
 export * from './path-pattern.class.js';
 export * from './router-slot/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/modal-registration/constants.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/modal-registration/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * The path segment that prefixes modal routes in the URL.
+ */
+export const UMB_MODAL_ROUTE_PATH_SEGMENT = 'modal';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/modal-registration/modal-route-registration.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/modal-registration/modal-route-registration.controller.ts
@@ -2,6 +2,7 @@ import type { IRouterSlot, Params } from '../router-slot/index.js';
 import { UMB_ROUTE_PATH_ADDENDUM_CONTEXT } from '../contexts/route-path-addendum.context-token.js';
 import { UMB_ROUTE_CONTEXT } from '../route/route.context.js';
 import { encodeFolderName } from '../encode-folder-name.function.js';
+import { UMB_MODAL_ROUTE_PATH_SEGMENT } from './constants.js';
 import type { UmbModalRouteRegistration } from './modal-route-registration.interface.js';
 import type {
 	UmbModalConfig,
@@ -41,9 +42,9 @@ export type UmbModalRouteSetupReturn<UmbModalTokenData, UmbModalTokenValue> = Um
 				value: UmbModalTokenValue;
 			};
 export class UmbModalRouteRegistrationController<
-		UmbModalTokenData extends { [key: string]: any } = { [key: string]: any },
-		UmbModalTokenValue = unknown,
-	>
+	UmbModalTokenData extends { [key: string]: any } = { [key: string]: any },
+	UmbModalTokenValue = unknown,
+>
 	extends UmbControllerBase
 	implements UmbModalRouteRegistration<UmbModalTokenData, UmbModalTokenValue>
 {
@@ -258,7 +259,7 @@ export class UmbModalRouteRegistrationController<
 	}
 
 	public generateModalPath() {
-		return `modal/${encodeFolderName(this.alias.toString())}${this.path && this.path !== '' ? `/${this.path}` : ''}`;
+		return `${UMB_MODAL_ROUTE_PATH_SEGMENT}/${encodeFolderName(this.alias.toString())}${this.path && this.path !== '' ? `/${this.path}` : ''}`;
 	}
 
 	public get path() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/index.ts
@@ -3,3 +3,4 @@ export * from './resolve-stale-variant-route.function.js';
 export * from './workspace-is-new-redirect.controller.js';
 export * from './workspace-route-manager.controller.js';
 export * from './workspace-split-view-manager.controller.js';
+export * from './workspace-stale-variant-redirect.controller.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/index.ts
@@ -1,4 +1,5 @@
 export * from './constants.js';
+export * from './resolve-stale-variant-route.function.js';
 export * from './workspace-is-new-redirect.controller.js';
 export * from './workspace-route-manager.controller.js';
 export * from './workspace-split-view-manager.controller.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
@@ -77,6 +77,28 @@ describe('resolveStaleVariantRoute', () => {
 		).to.equal(`${WORKSPACE_ROUTE}/invariant`);
 	});
 
+	it('returns null while a modal is open on top of the workspace', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN, DA],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
+	it('returns null while a modal is open directly on the variant route', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN, DA],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
 	it('returns null when there are no variant options', () => {
 		expect(
 			resolveStaleVariantRoute({

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
@@ -22,23 +22,23 @@ function resolve(
 
 describe('resolveStaleVariantRoute', () => {
 	it('returns null when the variant in the URL exists', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US`, [EN, DA])).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US`, [EN, DA])).to.equal(null);
 	});
 
 	it('returns null when the variant is valid and a trailing path is present', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [EN, DA])).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [EN, DA])).to.equal(null);
 	});
 
 	it('returns null when the current path is outside the workspace route', () => {
-		expect(resolve('/section/media/workspace/media/edit/456/invariant', [EN])).to.be.null;
+		expect(resolve('/section/media/workspace/media/edit/456/invariant', [EN])).to.equal(null);
 	});
 
 	it('returns null when the current path equals the workspace route (default route case)', () => {
-		expect(resolve(WORKSPACE_ROUTE, [EN])).to.be.null;
+		expect(resolve(WORKSPACE_ROUTE, [EN])).to.equal(null);
 	});
 
 	it('returns null when the current path is the workspace route with a trailing slash', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/`, [EN])).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/`, [EN])).to.equal(null);
 	});
 
 	it('falls back to the pure invariant option even when a segment option is listed first', () => {
@@ -47,15 +47,17 @@ describe('resolveStaleVariantRoute', () => {
 	});
 
 	it('returns null while a modal is open on top of the workspace', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.equal(
+			null,
+		);
 	});
 
 	it('returns null while a modal is open directly on the variant route', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.equal(null);
 	});
 
 	it('returns null when there are no variant options', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant`, [])).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant`, [])).to.equal(null);
 	});
 
 	it('redirects invariant to the app culture when the type now varies by culture', () => {
@@ -93,6 +95,6 @@ describe('resolveStaleVariantRoute', () => {
 	});
 
 	it('returns null for a valid segment variant', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US_seg1`, [EN, EN_SEG])).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US_seg1`, [EN, EN_SEG])).to.equal(null);
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
@@ -54,6 +54,29 @@ describe('resolveStaleVariantRoute', () => {
 		).to.be.null;
 	});
 
+	it('returns null when the current path is the workspace route with a trailing slash', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
+	it('falls back to the pure invariant option even when a segment option is listed first', () => {
+		const INVARIANT_SEG = { culture: null, segment: 'seg1', unique: 'invariant_seg1' };
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [INVARIANT_SEG, INVARIANT],
+				appCulture: 'en-US',
+			}),
+		).to.equal(`${WORKSPACE_ROUTE}/invariant`);
+	});
+
 	it('returns null when there are no variant options', () => {
 		expect(
 			resolveStaleVariantRoute({

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
@@ -1,5 +1,8 @@
 import { expect } from '@open-wc/testing';
-import { resolveStaleVariantRoute } from './resolve-stale-variant-route.function.js';
+import {
+	resolveStaleVariantRoute,
+	type UmbStaleVariantRouteResolverVariant,
+} from './resolve-stale-variant-route.function.js';
 import { UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from './constants.js';
 
 const WORKSPACE_ROUTE = '/section/content/workspace/document/edit/123';
@@ -9,181 +12,87 @@ const DA = { culture: 'da', segment: null, unique: 'da' };
 const EN_SEG = { culture: 'en-US', segment: 'seg1', unique: 'en-US_seg1' };
 const INVARIANT = { culture: null, segment: null, unique: 'invariant' };
 
+function resolve(
+	currentPath: string,
+	variants: Array<UmbStaleVariantRouteResolverVariant>,
+	appCulture: string | undefined = 'en-US',
+) {
+	return resolveStaleVariantRoute({ currentPath, workspaceRoute: WORKSPACE_ROUTE, variants, appCulture });
+}
+
 describe('resolveStaleVariantRoute', () => {
 	it('returns null when the variant in the URL exists', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN, DA],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null when the variant is valid and a trailing path is present', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US/view/info`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN, DA],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null when the current path is outside the workspace route', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: '/section/media/workspace/media/edit/456/invariant',
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve('/section/media/workspace/media/edit/456/invariant', [EN])).to.be.null;
 	});
 
 	it('returns null when the current path equals the workspace route (default route case)', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: WORKSPACE_ROUTE,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(WORKSPACE_ROUTE, [EN])).to.be.null;
 	});
 
 	it('returns null when the current path is the workspace route with a trailing slash', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/`, [EN])).to.be.null;
 	});
 
 	it('falls back to the pure invariant option even when a segment option is listed first', () => {
 		const INVARIANT_SEG = { culture: null, segment: 'seg1', unique: 'invariant_seg1' };
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [INVARIANT_SEG, INVARIANT],
-				appCulture: 'en-US',
-			}),
-		).to.equal(`${WORKSPACE_ROUTE}/invariant`);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US`, [INVARIANT_SEG, INVARIANT])).to.equal(`${WORKSPACE_ROUTE}/invariant`);
 	});
 
 	it('returns null while a modal is open on top of the workspace', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN, DA],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null while a modal is open directly on the variant route', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN, DA],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null when there are no variant options', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/invariant`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant`, [])).to.be.null;
 	});
 
 	it('redirects invariant to the app culture when the type now varies by culture', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/invariant/tab/content`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN, DA],
-				appCulture: 'en-US',
-			}),
-		).to.equal(`${WORKSPACE_ROUTE}/en-US/tab/content`);
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant/tab/content`, [EN, DA])).to.equal(
+			`${WORKSPACE_ROUTE}/en-US/tab/content`,
+		);
 	});
 
 	it('falls back to the first option when the app culture is not available', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/invariant`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [DA],
-				appCulture: 'en-US',
-			}),
-		).to.equal(`${WORKSPACE_ROUTE}/da`);
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant`, [DA])).to.equal(`${WORKSPACE_ROUTE}/da`);
 	});
 
 	it('redirects a culture variant to invariant when the type no longer varies', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US/view/info`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [INVARIANT],
-				appCulture: 'en-US',
-			}),
-		).to.equal(`${WORKSPACE_ROUTE}/invariant/view/info`);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [INVARIANT])).to.equal(
+			`${WORKSPACE_ROUTE}/invariant/view/info`,
+		);
 	});
 
 	it('collapses a split view when both variants became invalid', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US${UMB_WORKSPACE_PATH_VARIANT_DELIMITER}da`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [INVARIANT],
-				appCulture: 'en-US',
-			}),
-		).to.equal(`${WORKSPACE_ROUTE}/invariant`);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US${UMB_WORKSPACE_PATH_VARIANT_DELIMITER}da`, [INVARIANT])).to.equal(
+			`${WORKSPACE_ROUTE}/invariant`,
+		);
 	});
 
 	it('collapses a split view when the invalid side resolves to the valid side', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US${UMB_WORKSPACE_PATH_VARIANT_DELIMITER}da`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN],
-				appCulture: 'en-US',
-			}),
-		).to.equal(`${WORKSPACE_ROUTE}/en-US`);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US${UMB_WORKSPACE_PATH_VARIANT_DELIMITER}da`, [EN])).to.equal(
+			`${WORKSPACE_ROUTE}/en-US`,
+		);
 	});
 
 	it('drops the segment when the segment option no longer exists but the culture does', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US_seg1/view/info`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN, DA],
-				appCulture: 'da',
-			}),
-		).to.equal(`${WORKSPACE_ROUTE}/en-US/view/info`);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US_seg1/view/info`, [EN, DA], 'da')).to.equal(
+			`${WORKSPACE_ROUTE}/en-US/view/info`,
+		);
 	});
 
 	it('returns null for a valid segment variant', () => {
-		expect(
-			resolveStaleVariantRoute({
-				currentPath: `${WORKSPACE_ROUTE}/en-US_seg1`,
-				workspaceRoute: WORKSPACE_ROUTE,
-				variants: [EN, EN_SEG],
-				appCulture: 'en-US',
-			}),
-		).to.be.null;
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US_seg1`, [EN, EN_SEG])).to.be.null;
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
@@ -1,0 +1,144 @@
+import { expect } from '@open-wc/testing';
+import { resolveStaleVariantRoute } from './resolve-stale-variant-route.function.js';
+import { UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from './constants.js';
+
+const WORKSPACE_ROUTE = '/section/content/workspace/document/edit/123';
+
+const EN = { culture: 'en-US', segment: null, unique: 'en-US' };
+const DA = { culture: 'da', segment: null, unique: 'da' };
+const EN_SEG = { culture: 'en-US', segment: 'seg1', unique: 'en-US_seg1' };
+const INVARIANT = { culture: null, segment: null, unique: 'invariant' };
+
+describe('resolveStaleVariantRoute', () => {
+	it('returns null when the variant in the URL exists', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN, DA],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
+	it('returns null when the variant is valid and a trailing path is present', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US/view/info`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN, DA],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
+	it('returns null when the current path is outside the workspace route', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: '/section/media/workspace/media/edit/456/invariant',
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
+	it('returns null when the current path equals the workspace route (default route case)', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: WORKSPACE_ROUTE,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
+	it('returns null when there are no variant options', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/invariant`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+
+	it('redirects invariant to the app culture when the type now varies by culture', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/invariant/tab/content`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN, DA],
+				appCulture: 'en-US',
+			}),
+		).to.equal(`${WORKSPACE_ROUTE}/en-US/tab/content`);
+	});
+
+	it('falls back to the first option when the app culture is not available', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/invariant`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [DA],
+				appCulture: 'en-US',
+			}),
+		).to.equal(`${WORKSPACE_ROUTE}/da`);
+	});
+
+	it('redirects a culture variant to invariant when the type no longer varies', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US/view/info`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [INVARIANT],
+				appCulture: 'en-US',
+			}),
+		).to.equal(`${WORKSPACE_ROUTE}/invariant/view/info`);
+	});
+
+	it('collapses a split view when both variants became invalid', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US${UMB_WORKSPACE_PATH_VARIANT_DELIMITER}da`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [INVARIANT],
+				appCulture: 'en-US',
+			}),
+		).to.equal(`${WORKSPACE_ROUTE}/invariant`);
+	});
+
+	it('collapses a split view when the invalid side resolves to the valid side', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US${UMB_WORKSPACE_PATH_VARIANT_DELIMITER}da`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN],
+				appCulture: 'en-US',
+			}),
+		).to.equal(`${WORKSPACE_ROUTE}/en-US`);
+	});
+
+	it('drops the segment when the segment option no longer exists but the culture does', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US_seg1/view/info`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN, DA],
+				appCulture: 'da',
+			}),
+		).to.equal(`${WORKSPACE_ROUTE}/en-US/view/info`);
+	});
+
+	it('returns null for a valid segment variant', () => {
+		expect(
+			resolveStaleVariantRoute({
+				currentPath: `${WORKSPACE_ROUTE}/en-US_seg1`,
+				workspaceRoute: WORKSPACE_ROUTE,
+				variants: [EN, EN_SEG],
+				appCulture: 'en-US',
+			}),
+		).to.be.null;
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@open-wc/testing';
+import { assert, expect } from '@open-wc/testing';
 import {
 	resolveStaleVariantRoute,
 	type UmbStaleVariantRouteResolverVariant,
@@ -22,23 +22,23 @@ function resolve(
 
 describe('resolveStaleVariantRoute', () => {
 	it('returns null when the variant in the URL exists', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US`, [EN, DA])).to.be.null;
+		assert.isNull(resolve(`${WORKSPACE_ROUTE}/en-US`, [EN, DA]));
 	});
 
 	it('returns null when the variant is valid and a trailing path is present', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [EN, DA])).to.be.null;
+		assert.isNull(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [EN, DA]));
 	});
 
 	it('returns null when the current path is outside the workspace route', () => {
-		expect(resolve('/section/media/workspace/media/edit/456/invariant', [EN])).to.be.null;
+		assert.isNull(resolve('/section/media/workspace/media/edit/456/invariant', [EN]));
 	});
 
 	it('returns null when the current path equals the workspace route (default route case)', () => {
-		expect(resolve(WORKSPACE_ROUTE, [EN])).to.be.null;
+		assert.isNull(resolve(WORKSPACE_ROUTE, [EN]));
 	});
 
 	it('returns null when the current path is the workspace route with a trailing slash', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/`, [EN])).to.be.null;
+		assert.isNull(resolve(`${WORKSPACE_ROUTE}/`, [EN]));
 	});
 
 	it('falls back to the pure invariant option even when a segment option is listed first', () => {
@@ -47,15 +47,15 @@ describe('resolveStaleVariantRoute', () => {
 	});
 
 	it('returns null while a modal is open on top of the workspace', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
+		assert.isNull(resolve(`${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`, [EN, DA]));
 	});
 
 	it('returns null while a modal is open directly on the variant route', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
+		assert.isNull(resolve(`${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`, [EN, DA]));
 	});
 
 	it('returns null when there are no variant options', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant`, [])).to.be.null;
+		assert.isNull(resolve(`${WORKSPACE_ROUTE}/invariant`, []));
 	});
 
 	it('redirects invariant to the app culture when the type now varies by culture', () => {
@@ -93,6 +93,6 @@ describe('resolveStaleVariantRoute', () => {
 	});
 
 	it('returns null for a valid segment variant', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US_seg1`, [EN, EN_SEG])).to.be.null;
+		assert.isNull(resolve(`${WORKSPACE_ROUTE}/en-US_seg1`, [EN, EN_SEG]));
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.test.ts
@@ -22,23 +22,23 @@ function resolve(
 
 describe('resolveStaleVariantRoute', () => {
 	it('returns null when the variant in the URL exists', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US`, [EN, DA])).to.equal(null);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null when the variant is valid and a trailing path is present', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [EN, DA])).to.equal(null);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US/view/info`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null when the current path is outside the workspace route', () => {
-		expect(resolve('/section/media/workspace/media/edit/456/invariant', [EN])).to.equal(null);
+		expect(resolve('/section/media/workspace/media/edit/456/invariant', [EN])).to.be.null;
 	});
 
 	it('returns null when the current path equals the workspace route (default route case)', () => {
-		expect(resolve(WORKSPACE_ROUTE, [EN])).to.equal(null);
+		expect(resolve(WORKSPACE_ROUTE, [EN])).to.be.null;
 	});
 
 	it('returns null when the current path is the workspace route with a trailing slash', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/`, [EN])).to.equal(null);
+		expect(resolve(`${WORKSPACE_ROUTE}/`, [EN])).to.be.null;
 	});
 
 	it('falls back to the pure invariant option even when a segment option is listed first', () => {
@@ -47,17 +47,15 @@ describe('resolveStaleVariantRoute', () => {
 	});
 
 	it('returns null while a modal is open on top of the workspace', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.equal(
-			null,
-		);
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant/view/info/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null while a modal is open directly on the variant route', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.equal(null);
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant/modal/umb-modal-workspace/edit/456`, [EN, DA])).to.be.null;
 	});
 
 	it('returns null when there are no variant options', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/invariant`, [])).to.equal(null);
+		expect(resolve(`${WORKSPACE_ROUTE}/invariant`, [])).to.be.null;
 	});
 
 	it('redirects invariant to the app culture when the type now varies by culture', () => {
@@ -95,6 +93,6 @@ describe('resolveStaleVariantRoute', () => {
 	});
 
 	it('returns null for a valid segment variant', () => {
-		expect(resolve(`${WORKSPACE_ROUTE}/en-US_seg1`, [EN, EN_SEG])).to.equal(null);
+		expect(resolve(`${WORKSPACE_ROUTE}/en-US_seg1`, [EN, EN_SEG])).to.be.null;
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
@@ -57,19 +57,27 @@ export function resolveStaleVariantRoute(args: UmbStaleVariantRouteResolverArgs)
 
 	if (parts.every(isValid)) return null;
 
-	const resolvedParts = parts.map((part) => {
-		if (isValid(part)) return part;
-		const variantId = UmbVariantId.FromString(part);
-		// Prefer the same culture without a segment, then the app culture, then invariant, then the first option:
-		const fallback =
-			variants.find((v) => v.culture === variantId.culture && v.segment === null) ??
-			variants.find((v) => v.culture === appCulture && v.segment === null) ??
-			variants.find((v) => v.culture === null && v.segment === null) ??
-			variants[0];
-		return fallback.unique;
-	});
+	const resolvedParts = parts.map((part) =>
+		isValid(part) ? part : findFallbackVariant(variants, UmbVariantId.FromString(part), appCulture).unique,
+	);
 
 	const uniqueParts = [...new Set(resolvedParts)];
 
 	return `${workspaceRoute}/${uniqueParts.join(UMB_WORKSPACE_PATH_VARIANT_DELIMITER)}${pathSuffix}`;
+}
+
+/**
+ * Prefers the same culture without a segment, then the app culture, then invariant, then the first option.
+ */
+function findFallbackVariant(
+	variants: Array<UmbStaleVariantRouteResolverVariant>,
+	variantId: UmbVariantId,
+	appCulture?: string,
+): UmbStaleVariantRouteResolverVariant {
+	return (
+		variants.find((v) => v.culture === variantId.culture && v.segment === null) ??
+		variants.find((v) => v.culture === appCulture && v.segment === null) ??
+		variants.find((v) => v.culture === null && v.segment === null) ??
+		variants[0]
+	);
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
@@ -43,16 +43,9 @@ export function resolveStaleVariantRoute(args: UmbStaleVariantRouteResolverArgs)
 	const { currentPath, workspaceRoute, variants, appCulture } = args;
 	if (variants.length === 0) return null;
 
-	const routePrefix = workspaceRoute + '/';
-	if (!currentPath.startsWith(routePrefix)) return null;
-
-	const remainingPath = currentPath.substring(routePrefix.length);
-	if (remainingPath.length === 0) return null;
-
-	// Separate the variant part from any trailing path (e.g. /view/info):
-	const slashIndex = remainingPath.indexOf('/');
-	const variantPart = slashIndex === -1 ? remainingPath : remainingPath.substring(0, slashIndex);
-	const pathSuffix = slashIndex === -1 ? '' : remainingPath.substring(slashIndex);
+	const parsed = parseVariantPath(currentPath, workspaceRoute);
+	if (!parsed) return null;
+	const { variantPart, pathSuffix } = parsed;
 
 	// Skip while a modal is layered on top — closing it restores the pre-modal URL and dispatches
 	// a changestate event, at which point the correction can run against the settled URL:
@@ -70,6 +63,26 @@ export function resolveStaleVariantRoute(args: UmbStaleVariantRouteResolverArgs)
 	const uniqueParts = [...new Set(resolvedParts)];
 
 	return `${workspaceRoute}/${uniqueParts.join(UMB_WORKSPACE_PATH_VARIANT_DELIMITER)}${pathSuffix}`;
+}
+
+/**
+ * Separates the variant part of a workspace path from any trailing path (e.g. /view/info).
+ */
+function parseVariantPath(
+	currentPath: string,
+	workspaceRoute: string,
+): { variantPart: string; pathSuffix: string } | null {
+	const routePrefix = workspaceRoute + '/';
+	if (!currentPath.startsWith(routePrefix)) return null;
+
+	const remainingPath = currentPath.substring(routePrefix.length);
+	if (remainingPath.length === 0) return null;
+
+	const slashIndex = remainingPath.indexOf('/');
+	if (slashIndex === -1) {
+		return { variantPart: remainingPath, pathSuffix: '' };
+	}
+	return { variantPart: remainingPath.substring(0, slashIndex), pathSuffix: remainingPath.substring(slashIndex) };
 }
 
 /**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
@@ -60,7 +60,7 @@ export function resolveStaleVariantRoute(args: UmbStaleVariantRouteResolverArgs)
 		const fallback =
 			variants.find((v) => v.culture === variantId.culture && v.segment === null) ??
 			variants.find((v) => v.culture === appCulture && v.segment === null) ??
-			variants.find((v) => v.culture === null) ??
+			variants.find((v) => v.culture === null && v.segment === null) ??
 			variants[0];
 		return fallback.unique;
 	});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
@@ -1,0 +1,71 @@
+import { UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from './constants.js';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
+
+export interface UmbStaleVariantRouteResolverVariant {
+	culture: string | null;
+	segment: string | null;
+	unique: string;
+}
+
+export interface UmbStaleVariantRouteResolverArgs {
+	/**
+	 * The current location pathname, e.g. window.location.pathname.
+	 */
+	currentPath: string;
+	/**
+	 * The absolute router path of the workspace, without a trailing slash.
+	 */
+	workspaceRoute: string;
+	/**
+	 * The available variant options.
+	 */
+	variants: Array<UmbStaleVariantRouteResolverVariant>;
+	/**
+	 * The culture currently selected in the app language switcher.
+	 */
+	appCulture?: string;
+}
+
+/**
+ * Checks whether the variant part of a workspace URL refers to variant options that no longer exist —
+ * e.g. after the content type's Vary by Culture setting changed — and resolves a corrected path.
+ * Split-view parts are resolved individually and deduplicated.
+ * @param {UmbStaleVariantRouteResolverArgs} args - The current path, workspace route, variant options and app culture.
+ * @returns {string | null} The corrected path without the query string, or null when the URL is valid or not applicable.
+ */
+export function resolveStaleVariantRoute(args: UmbStaleVariantRouteResolverArgs): string | null {
+	const { currentPath, workspaceRoute, variants, appCulture } = args;
+	if (variants.length === 0) return null;
+
+	const routePrefix = workspaceRoute + '/';
+	if (!currentPath.startsWith(routePrefix)) return null;
+
+	const remainingPath = currentPath.substring(routePrefix.length);
+	if (remainingPath.length === 0) return null;
+
+	// Separate the variant part from any trailing path (e.g. /view/info):
+	const slashIndex = remainingPath.indexOf('/');
+	const variantPart = slashIndex === -1 ? remainingPath : remainingPath.substring(0, slashIndex);
+	const pathSuffix = slashIndex === -1 ? '' : remainingPath.substring(slashIndex);
+
+	const parts = variantPart.split(UMB_WORKSPACE_PATH_VARIANT_DELIMITER);
+	const isValid = (part: string) => variants.some((v) => v.unique === part);
+
+	if (parts.every(isValid)) return null;
+
+	const resolvedParts = parts.map((part) => {
+		if (isValid(part)) return part;
+		const variantId = UmbVariantId.FromString(part);
+		// Prefer the same culture without a segment, then the app culture, then invariant, then the first option:
+		const fallback =
+			variants.find((v) => v.culture === variantId.culture && v.segment === null) ??
+			variants.find((v) => v.culture === appCulture && v.segment === null) ??
+			variants.find((v) => v.culture === null) ??
+			variants[0];
+		return fallback.unique;
+	});
+
+	const uniqueParts = [...new Set(resolvedParts)];
+
+	return `${workspaceRoute}/${uniqueParts.join(UMB_WORKSPACE_PATH_VARIANT_DELIMITER)}${pathSuffix}`;
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
@@ -1,4 +1,5 @@
 import { UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from './constants.js';
+import { UMB_MODAL_ROUTE_PATH_SEGMENT } from '@umbraco-cms/backoffice/router';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
 /**
@@ -49,7 +50,7 @@ export function resolveStaleVariantRoute(args: UmbStaleVariantRouteResolverArgs)
 
 	// Skip while a modal is layered on top — closing it restores the pre-modal URL and dispatches
 	// a changestate event, at which point the correction can run against the settled URL:
-	if (pathSuffix.split('/').includes('modal')) return null;
+	if (pathSuffix.split('/').includes(UMB_MODAL_ROUTE_PATH_SEGMENT)) return null;
 
 	const parts = variantPart.split(UMB_WORKSPACE_PATH_VARIANT_DELIMITER);
 	const isValid = (part: string) => variants.some((v) => v.unique === part);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
@@ -48,6 +48,10 @@ export function resolveStaleVariantRoute(args: UmbStaleVariantRouteResolverArgs)
 	const variantPart = slashIndex === -1 ? remainingPath : remainingPath.substring(0, slashIndex);
 	const pathSuffix = slashIndex === -1 ? '' : remainingPath.substring(slashIndex);
 
+	// Skip while a modal is layered on top — closing it restores the pre-modal URL and dispatches
+	// a changestate event, at which point the correction can run against the settled URL:
+	if (pathSuffix.split('/').includes('modal')) return null;
+
 	const parts = variantPart.split(UMB_WORKSPACE_PATH_VARIANT_DELIMITER);
 	const isValid = (part: string) => variants.some((v) => v.unique === part);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/resolve-stale-variant-route.function.ts
@@ -1,12 +1,18 @@
 import { UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from './constants.js';
 import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 
+/**
+ * A minimal variant option descriptor consumed by {@link resolveStaleVariantRoute}.
+ */
 export interface UmbStaleVariantRouteResolverVariant {
 	culture: string | null;
 	segment: string | null;
 	unique: string;
 }
 
+/**
+ * The arguments for {@link resolveStaleVariantRoute}.
+ */
 export interface UmbStaleVariantRouteResolverArgs {
 	/**
 	 * The current location pathname, e.g. window.location.pathname.

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/workspace-stale-variant-redirect.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/workspace-stale-variant-redirect.controller.ts
@@ -18,14 +18,14 @@ export interface UmbWorkspaceStaleVariantRedirectControllerArgs {
  * navigation, as closing a modal restores the pre-modal URL, which may hold a stale variant.
  */
 export class UmbWorkspaceStaleVariantRedirectController extends UmbControllerBase {
-	#args: UmbWorkspaceStaleVariantRedirectControllerArgs;
+	readonly #args: UmbWorkspaceStaleVariantRedirectControllerArgs;
 
 	constructor(host: UmbControllerHost, args: UmbWorkspaceStaleVariantRedirectControllerArgs) {
 		super(host);
 		this.#args = args;
 	}
 
-	#onChangeState = () => this.redirect();
+	readonly #onChangeState = () => this.redirect();
 
 	override hostConnected(): void {
 		super.hostConnected();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/workspace-stale-variant-redirect.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/workspace/controllers/workspace-stale-variant-redirect.controller.ts
@@ -1,0 +1,62 @@
+import { resolveStaleVariantRoute } from './resolve-stale-variant-route.function.js';
+import type { UmbStaleVariantRouteResolverVariant } from './resolve-stale-variant-route.function.js';
+import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+
+/**
+ * The accessors providing the current workspace state to {@link UmbWorkspaceStaleVariantRedirectController}.
+ */
+export interface UmbWorkspaceStaleVariantRedirectControllerArgs {
+	getWorkspaceRoute: () => string | undefined;
+	getVariants: () => Array<UmbStaleVariantRouteResolverVariant> | undefined;
+	getAppCulture: () => string | undefined;
+}
+
+/**
+ * Redirects the workspace URL to the best matching variant when its variant part no longer maps to an
+ * existing variant option — e.g. after the content type's variance changed. Re-validates on every
+ * navigation, as closing a modal restores the pre-modal URL, which may hold a stale variant.
+ */
+export class UmbWorkspaceStaleVariantRedirectController extends UmbControllerBase {
+	#args: UmbWorkspaceStaleVariantRedirectControllerArgs;
+
+	constructor(host: UmbControllerHost, args: UmbWorkspaceStaleVariantRedirectControllerArgs) {
+		super(host);
+		this.#args = args;
+	}
+
+	#onChangeState = () => this.redirect();
+
+	override hostConnected(): void {
+		super.hostConnected();
+		window.addEventListener('changestate', this.#onChangeState);
+	}
+
+	override hostDisconnected(): void {
+		super.hostDisconnected();
+		window.removeEventListener('changestate', this.#onChangeState);
+	}
+
+	/**
+	 * Applies the corrected variant URL via history.replaceState when the current URL is stale.
+	 */
+	public redirect(): void {
+		const workspaceRoute = this.#args.getWorkspaceRoute();
+		const variants = this.#args.getVariants();
+		if (!workspaceRoute || !variants?.length) return;
+		const newPath = resolveStaleVariantRoute({
+			currentPath: window.location.pathname,
+			workspaceRoute,
+			variants,
+			appCulture: this.#args.getAppCulture(),
+		});
+		if (newPath) {
+			history.replaceState(null, '', newPath + window.location.search);
+		}
+	}
+
+	public override destroy(): void {
+		window.removeEventListener('changestate', this.#onChangeState);
+		super.destroy();
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
@@ -55,7 +55,7 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
-	#staleVariantRedirect = new UmbWorkspaceStaleVariantRedirectController(this, {
+	readonly #staleVariantRedirect = new UmbWorkspaceStaleVariantRedirectController(this, {
 		getWorkspaceRoute: () => this.#workspaceRoute,
 		getVariants: () => this.#variants,
 		getAppCulture: () => this.#appCulture,

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
@@ -5,7 +5,10 @@ import { customElement, state, css, html } from '@umbraco-cms/backoffice/externa
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbRoute, UmbRouterSlotInitEvent } from '@umbraco-cms/backoffice/router';
-import { resolveStaleVariantRoute, UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from '@umbraco-cms/backoffice/workspace';
+import {
+	UmbWorkspaceStaleVariantRedirectController,
+	UMB_WORKSPACE_PATH_VARIANT_DELIMITER,
+} from '@umbraco-cms/backoffice/workspace';
 import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 
 // TODO: Refactor across all four content workspace editors (document, document blueprint, media, member) to use a base component. [NL]
@@ -52,19 +55,11 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
-	// Re-validate on every navigation — closing a modal restores the pre-modal URL, which may
-	// hold a variant that no longer exists after the content type changed while the modal was open:
-	#onChangeState = () => this.#redirectStaleVariantUrl();
-
-	override connectedCallback(): void {
-		super.connectedCallback();
-		window.addEventListener('changestate', this.#onChangeState);
-	}
-
-	override disconnectedCallback(): void {
-		super.disconnectedCallback();
-		window.removeEventListener('changestate', this.#onChangeState);
-	}
+	#staleVariantRedirect = new UmbWorkspaceStaleVariantRedirectController(this, {
+		getWorkspaceRoute: () => this.#workspaceRoute,
+		getVariants: () => this.#variants,
+		getAppCulture: () => this.#appCulture,
+	});
 
 	#observeVariants() {
 		if (!this.#workspaceContext) return;
@@ -73,7 +68,7 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 			(variants) => {
 				this.#variants = variants;
 				this.#generateRoutes();
-				this.#redirectStaleVariantUrl();
+				this.#staleVariantRedirect.redirect();
 			},
 			'_observeVariants',
 		);
@@ -120,19 +115,6 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 			'',
 			`${this.#workspaceRoute}/${newVariant.unique}${pathSuffix}${window.location.search}`,
 		);
-	}
-
-	#redirectStaleVariantUrl() {
-		if (!this.#workspaceRoute || !this.#variants?.length) return;
-		const newPath = resolveStaleVariantRoute({
-			currentPath: window.location.pathname,
-			workspaceRoute: this.#workspaceRoute,
-			variants: this.#variants,
-			appCulture: this.#appCulture,
-		});
-		if (newPath) {
-			history.replaceState(null, '', newPath + window.location.search);
-		}
 	}
 
 	async #generateRoutes() {
@@ -216,7 +198,7 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 	private _gotWorkspaceRoute = (e: UmbRouterSlotInitEvent) => {
 		this.#workspaceRoute = e.target.absoluteRouterPath;
 		this.#workspaceContext?.splitView.setWorkspaceRoute(this.#workspaceRoute);
-		this.#redirectStaleVariantUrl();
+		this.#staleVariantRedirect.redirect();
 	};
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
@@ -52,6 +52,20 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
+	// Re-validate on every navigation — closing a modal restores the pre-modal URL, which may
+	// hold a variant that no longer exists after the content type changed while the modal was open:
+	#onChangeState = () => this.#redirectStaleVariantUrl();
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		window.addEventListener('changestate', this.#onChangeState);
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		window.removeEventListener('changestate', this.#onChangeState);
+	}
+
 	#observeVariants() {
 		if (!this.#workspaceContext) return;
 		this.observe(

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/workspace/document-blueprint-workspace-editor.element.ts
@@ -5,7 +5,7 @@ import { customElement, state, css, html } from '@umbraco-cms/backoffice/externa
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import type { UmbRoute, UmbRouterSlotInitEvent } from '@umbraco-cms/backoffice/router';
-import { UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from '@umbraco-cms/backoffice/workspace';
+import { resolveStaleVariantRoute, UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from '@umbraco-cms/backoffice/workspace';
 import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 
 // TODO: Refactor across all four content workspace editors (document, document blueprint, media, member) to use a base component. [NL]
@@ -59,6 +59,7 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 			(variants) => {
 				this.#variants = variants;
 				this.#generateRoutes();
+				this.#redirectStaleVariantUrl();
 			},
 			'_observeVariants',
 		);
@@ -105,6 +106,19 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 			'',
 			`${this.#workspaceRoute}/${newVariant.unique}${pathSuffix}${window.location.search}`,
 		);
+	}
+
+	#redirectStaleVariantUrl() {
+		if (!this.#workspaceRoute || !this.#variants?.length) return;
+		const newPath = resolveStaleVariantRoute({
+			currentPath: window.location.pathname,
+			workspaceRoute: this.#workspaceRoute,
+			variants: this.#variants,
+			appCulture: this.#appCulture,
+		});
+		if (newPath) {
+			history.replaceState(null, '', newPath + window.location.search);
+		}
 	}
 
 	async #generateRoutes() {
@@ -188,6 +202,7 @@ export class UmbDocumentBlueprintWorkspaceEditorElement extends UmbLitElement {
 	private _gotWorkspaceRoute = (e: UmbRouterSlotInitEvent) => {
 		this.#workspaceRoute = e.target.absoluteRouterPath;
 		this.#workspaceContext?.splitView.setWorkspaceRoute(this.#workspaceRoute);
+		this.#redirectStaleVariantUrl();
 	};
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/publishing/workspace-context/document-publishing.workspace-context.ts
@@ -48,6 +48,7 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 	#publishedDocumentData?: UmbDocumentDetailModel;
 	#loadingPublishedData = false;
 	#currentUnique?: UmbEntityUnique;
+	#variesByCulture?: boolean;
 	#notificationContext?: typeof UMB_NOTIFICATION_CONTEXT.TYPE;
 	readonly #localize = new UmbLocalizationController(this);
 
@@ -568,6 +569,26 @@ export class UmbDocumentPublishingWorkspaceContext extends UmbContextBase implem
 				}
 			},
 			'umbPersistedDataObserver',
+		);
+
+		this.observe(
+			this.#documentWorkspaceContext.variesByCulture,
+			(variesByCulture) => {
+				const previousVariesByCulture = this.#variesByCulture;
+				this.#variesByCulture = variesByCulture;
+				if (
+					previousVariesByCulture === undefined ||
+					variesByCulture === undefined ||
+					previousVariesByCulture === variesByCulture
+				) {
+					return;
+				}
+				// The server migrates the published version when the content type's variance changes,
+				// so the cached copy no longer compares correctly against the persisted data:
+				this.#publishedDocumentData = undefined;
+				this.#loadAndProcessLastPublished().catch(() => undefined);
+			},
+			'umbVariesByCultureObserver',
 		);
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/context/document-workspace-variance-transform.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/context/document-workspace-variance-transform.context.test.ts
@@ -1,0 +1,99 @@
+import { assert, aTimeout, expect } from '@open-wc/testing';
+import { umbExtensionsRegistry } from '@umbraco-cms/backoffice/extension-registry';
+import { useMockSet } from '@umbraco-cms/internal/mock-manager';
+import { UmbDocumentWorkspaceContext } from './document-workspace.context.js';
+import { TEST_MANIFESTS, UmbTestDocumentWorkspaceHostElement } from './document-workspace-context.test-utils.js';
+import { umbDocumentTypeMockDb } from '../../../../../../mocks/db/document-type.db.js';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UmbEntityUpdatedEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '@umbraco-cms/backoffice/document-type';
+
+const INVARIANT_DOCUMENT_ID = 'variant-documents-invariant-document-id';
+const VARIANT_DOCUMENT_ID = 'variant-documents-variant-document-id';
+
+describe('UmbDocumentWorkspaceContext content type variance transform', () => {
+	let hostElement: UmbTestDocumentWorkspaceHostElement;
+	let context: UmbDocumentWorkspaceContext;
+
+	before(() => {
+		umbExtensionsRegistry.registerMany(TEST_MANIFESTS);
+	});
+
+	after(() => {
+		umbExtensionsRegistry.unregisterMany(TEST_MANIFESTS.map((m) => m.alias));
+	});
+
+	beforeEach(async () => {
+		await useMockSet('documents');
+		hostElement = new UmbTestDocumentWorkspaceHostElement();
+		document.body.appendChild(hostElement);
+		await hostElement.init();
+		context = new UmbDocumentWorkspaceContext(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	// Mimics saving the document type from infinite editing: the mock backend is updated and the
+	// entity-updated event makes the structure manager re-request the type.
+	async function setContentTypeVariesByCulture(variesByCulture: boolean) {
+		const documentTypeUnique = context.getData()!.documentType.unique;
+		umbDocumentTypeMockDb.detail.update(documentTypeUnique, { variesByCulture });
+
+		const eventContext = await context.getContext(UMB_ACTION_EVENT_CONTEXT);
+		eventContext!.dispatchEvent(
+			new UmbEntityUpdatedEvent({
+				unique: documentTypeUnique,
+				entityType: UMB_DOCUMENT_TYPE_ENTITY_TYPE,
+				eventUnique: 'variance-transform-test',
+			}),
+		);
+		await aTimeout(100);
+	}
+
+	it('moves the invariant variant to the default culture when the type becomes culture variant', async () => {
+		await context.load(INVARIANT_DOCUMENT_ID);
+		assert.isNull(context.getData()!.variants[0].culture);
+
+		await setContentTypeVariesByCulture(true);
+
+		const variants = context.getData()!.variants;
+		expect(variants).to.have.length(1);
+		expect(variants[0].culture).to.equal('en-US');
+		expect(variants[0].name).to.equal('Invariant Document');
+	});
+
+	it('preserves the variant state and dates when moving to the default culture', async () => {
+		await context.load(INVARIANT_DOCUMENT_ID);
+		const before = context.getData()!.variants[0];
+
+		await setContentTypeVariesByCulture(true);
+
+		const after = context.getData()!.variants[0];
+		expect(after.state).to.equal(before.state);
+		expect(after.createDate).to.equal(before.createDate);
+		expect(after.updateDate).to.equal(before.updateDate);
+	});
+
+	it('collapses culture variants to a single invariant variant when the type becomes invariant', async () => {
+		await context.load(VARIANT_DOCUMENT_ID);
+		expect(context.getData()!.variants).to.have.length(2);
+
+		await setContentTypeVariesByCulture(false);
+
+		const variants = context.getData()!.variants;
+		expect(variants).to.have.length(1);
+		assert.isNull(variants[0].culture);
+		expect(variants[0].name).to.equal('Variant Document');
+	});
+
+	it('does not change the variants when the type variance is unchanged', async () => {
+		await context.load(VARIANT_DOCUMENT_ID);
+		const before = context.getData()!.variants;
+
+		await setContentTypeVariesByCulture(true);
+
+		expect(context.getData()!.variants).to.deep.equal(before);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/context/document-workspace-variance-transform.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/context/document-workspace-variance-transform.context.test.ts
@@ -4,6 +4,7 @@ import { useMockSet } from '@umbraco-cms/internal/mock-manager';
 import { UmbDocumentWorkspaceContext } from './document-workspace.context.js';
 import { TEST_MANIFESTS, UmbTestDocumentWorkspaceHostElement } from './document-workspace-context.test-utils.js';
 import { umbDocumentTypeMockDb } from '../../../../../../mocks/db/document-type.db.js';
+import { UmbVariantId } from '@umbraco-cms/backoffice/variant';
 import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
 import { UmbEntityUpdatedEvent } from '@umbraco-cms/backoffice/entity-action';
 import { UMB_DOCUMENT_TYPE_ENTITY_TYPE } from '@umbraco-cms/backoffice/document-type';
@@ -86,6 +87,26 @@ describe('UmbDocumentWorkspaceContext content type variance transform', () => {
 		expect(variants).to.have.length(1);
 		assert.isNull(variants[0].culture);
 		expect(variants[0].name).to.equal('Variant Document');
+	});
+
+	it('does not include the stale invariant variant in the save data after the type becomes culture variant', async () => {
+		await context.load(INVARIANT_DOCUMENT_ID);
+		await setContentTypeVariesByCulture(true);
+
+		const saveData = await context.constructSaveData([UmbVariantId.Create({ culture: 'en-US', segment: null })]);
+
+		expect(saveData.variants.filter((v) => v.culture === null)).to.have.length(0);
+		expect(saveData.variants.some((v) => v.culture === 'en-US')).to.equal(true);
+	});
+
+	it('does not include stale culture variants in the save data after the type becomes invariant', async () => {
+		await context.load(VARIANT_DOCUMENT_ID);
+		await setContentTypeVariesByCulture(false);
+
+		const saveData = await context.constructSaveData([UmbVariantId.CreateInvariant()]);
+
+		expect(saveData.variants.filter((v) => v.culture !== null)).to.have.length(0);
+		expect(saveData.variants.some((v) => v.culture === null)).to.equal(true);
 	});
 
 	it('does not change the variants when the type variance is unchanged', async () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -7,7 +7,7 @@ import type { UmbRoute, UmbRouterSlotInitEvent } from '@umbraco-cms/backoffice/r
 import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 import { createObservablePart } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbDocumentVariantOptionModel } from '../types.js';
-import { UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from '@umbraco-cms/backoffice/workspace';
+import { resolveStaleVariantRoute, UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from '@umbraco-cms/backoffice/workspace';
 
 // TODO: Refactor across all four content workspace editors (document, document blueprint, media, member) to use a base component. [NL]
 // TODO: This seem fully identical with Media Workspace Editor, so we can refactor this to a generic component. [NL]
@@ -67,6 +67,7 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 			(variants) => {
 				this.#variants = variants;
 				this.#generateRoutes();
+				this.#redirectStaleVariantUrl();
 			},
 			'_observeVariants',
 		);
@@ -113,6 +114,19 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 			'',
 			`${this.#workspaceRoute}/${newVariant.unique}${pathSuffix}${window.location.search}`,
 		);
+	}
+
+	#redirectStaleVariantUrl() {
+		if (!this.#workspaceRoute || !this.#variants?.length) return;
+		const newPath = resolveStaleVariantRoute({
+			currentPath: window.location.pathname,
+			workspaceRoute: this.#workspaceRoute,
+			variants: this.#variants,
+			appCulture: this.#appCulture,
+		});
+		if (newPath) {
+			history.replaceState(null, '', newPath + window.location.search);
+		}
 	}
 
 	#generateRoutes() {
@@ -197,6 +211,7 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 	private _gotWorkspaceRoute = (e: UmbRouterSlotInitEvent) => {
 		this.#workspaceRoute = e.target.absoluteRouterPath;
 		this.#workspaceContext?.splitView.setWorkspaceRoute(this.#workspaceRoute);
+		this.#redirectStaleVariantUrl();
 	};
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -53,6 +53,20 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
+	// Re-validate on every navigation — closing a modal restores the pre-modal URL, which may
+	// hold a variant that no longer exists after the content type changed while the modal was open:
+	#onChangeState = () => this.#redirectStaleVariantUrl();
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		window.addEventListener('changestate', this.#onChangeState);
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		window.removeEventListener('changestate', this.#onChangeState);
+	}
+
 	#observeVariants() {
 		this.observe(
 			this.#workspaceContext

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -7,7 +7,10 @@ import type { UmbRoute, UmbRouterSlotInitEvent } from '@umbraco-cms/backoffice/r
 import { UMB_APP_LANGUAGE_CONTEXT } from '@umbraco-cms/backoffice/language';
 import { createObservablePart } from '@umbraco-cms/backoffice/observable-api';
 import type { UmbDocumentVariantOptionModel } from '../types.js';
-import { resolveStaleVariantRoute, UMB_WORKSPACE_PATH_VARIANT_DELIMITER } from '@umbraco-cms/backoffice/workspace';
+import {
+	UmbWorkspaceStaleVariantRedirectController,
+	UMB_WORKSPACE_PATH_VARIANT_DELIMITER,
+} from '@umbraco-cms/backoffice/workspace';
 
 // TODO: Refactor across all four content workspace editors (document, document blueprint, media, member) to use a base component. [NL]
 // TODO: This seem fully identical with Media Workspace Editor, so we can refactor this to a generic component. [NL]
@@ -53,19 +56,11 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
-	// Re-validate on every navigation — closing a modal restores the pre-modal URL, which may
-	// hold a variant that no longer exists after the content type changed while the modal was open:
-	#onChangeState = () => this.#redirectStaleVariantUrl();
-
-	override connectedCallback(): void {
-		super.connectedCallback();
-		window.addEventListener('changestate', this.#onChangeState);
-	}
-
-	override disconnectedCallback(): void {
-		super.disconnectedCallback();
-		window.removeEventListener('changestate', this.#onChangeState);
-	}
+	#staleVariantRedirect = new UmbWorkspaceStaleVariantRedirectController(this, {
+		getWorkspaceRoute: () => this.#workspaceRoute,
+		getVariants: () => this.#variants,
+		getAppCulture: () => this.#appCulture,
+	});
 
 	#observeVariants() {
 		this.observe(
@@ -81,7 +76,7 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 			(variants) => {
 				this.#variants = variants;
 				this.#generateRoutes();
-				this.#redirectStaleVariantUrl();
+				this.#staleVariantRedirect.redirect();
 			},
 			'_observeVariants',
 		);
@@ -128,19 +123,6 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 			'',
 			`${this.#workspaceRoute}/${newVariant.unique}${pathSuffix}${window.location.search}`,
 		);
-	}
-
-	#redirectStaleVariantUrl() {
-		if (!this.#workspaceRoute || !this.#variants?.length) return;
-		const newPath = resolveStaleVariantRoute({
-			currentPath: window.location.pathname,
-			workspaceRoute: this.#workspaceRoute,
-			variants: this.#variants,
-			appCulture: this.#appCulture,
-		});
-		if (newPath) {
-			history.replaceState(null, '', newPath + window.location.search);
-		}
 	}
 
 	#generateRoutes() {
@@ -225,7 +207,7 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 	private _gotWorkspaceRoute = (e: UmbRouterSlotInitEvent) => {
 		this.#workspaceRoute = e.target.absoluteRouterPath;
 		this.#workspaceContext?.splitView.setWorkspaceRoute(this.#workspaceRoute);
-		this.#redirectStaleVariantUrl();
+		this.#staleVariantRedirect.redirect();
 	};
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/workspace/document-workspace-editor.element.ts
@@ -56,7 +56,7 @@ export class UmbDocumentWorkspaceEditorElement extends UmbLitElement {
 		});
 	}
 
-	#staleVariantRedirect = new UmbWorkspaceStaleVariantRedirectController(this, {
+	readonly #staleVariantRedirect = new UmbWorkspaceStaleVariantRedirectController(this, {
 		getWorkspaceRoute: () => this.#workspaceRoute,
 		getVariants: () => this.#variants,
 		getAppCulture: () => this.#appCulture,


### PR DESCRIPTION
## Description

When a document type's **Vary by Culture** setting is changed from infinite editing while a content workspace is open underneath, the workspace URL keeps the now-invalid variant slug (e.g. `/invariant/` after enabling culture variance). Since #23342 the workspace detects the mismatch and shows a "Not found" screen — but that leaves the user on a dead end mid-editing-session: the URL never corrects itself, Save silently does nothing, and the only way out is a hard reload, which discards unsaved edits. The same dead end appears when deep-linking to a URL whose variant slug no longer exists.

This PR makes the workspace redirect to the best-matching variant instead:

- A new pure function `resolveStaleVariantRoute()` (core workspace module, 16 unit tests) parses the variant part of the URL — including split-view parts — validates it against the current variant options, and computes a corrected path. Fallback order per invalid part: same culture without segment → app culture → invariant → first option; collapsed split-view parts are deduplicated and any trailing path (`/view/info`, `/tab/...`) plus query string are preserved.
- The document and document-blueprint workspace editors apply the correction via `history.replaceState` whenever variant options emit, on router init, and on every `changestate` navigation event. The last one matters: closing an infinite-editing modal restores the captured pre-modal URL (still stale), so the correction must re-run at that moment. While a modal is layered on top, correction is deferred to avoid fighting the modal's router.
- The "Not found" guard from #23342 remains as fallback for truly unresolvable states.

Media and member types cannot vary by culture, so those editors are intentionally left to the existing "unify the content workspace editors" refactoring TODO.

**Merge-up note (v18):** apply the same redirect wiring to the *elements* workspace, which also supports variants on v18 (thanks @AndyButland).

## Testing

- 16 unit tests on the resolver (mutation-verified: guards and fallback ordering each have a test that fails without them).
- Browser-verified on a clean install (both toggle directions, stale deep links with/without trailing paths, garbage slugs, split-view collapse) plus regression checks: normal variant switching, split view open/close, app-language URL sync, and unsaved-edit preservation across the redirect (previously lost, now retained).

## Known follow-ups found during QA (out of scope — navigation only)

1. ~~After a live invariant→vary toggle, the first Save returns `400 ContentTypeCultureVarianceMismatch` until the page is reloaded.~~ Fixed in this PR: the type-transform controller now migrates the variants collection (current AND persisted snapshot) alongside the values when the content type's variance changes — this also fixes the empty name field and "Not created" state observed in review. Covered by unit tests on the migration and the constructed save data, and browser-verified in both toggle directions including save-without-reload.
2. ~~A transient `TypeError: Cannot read properties of undefined (reading 'api')` from extension-api condition evaluation fires once during the route transition.~~ Fixed independently by #23395 (now merged into this branch); the QA build that observed the error predated that guard.

AB#64268

🤖 Generated with [Claude Code](https://claude.com/claude-code)

