### PR TITLE
Member Types: Fixed issue with missing icon for workspace design view

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/workspace/manifests.ts
@@ -20,7 +20,7 @@ export const manifests: Array<UmbExtensionManifest> = [
 		meta: {
 			label: '#general_design',
 			pathname: 'design',
-			icon: 'icon-member-dashed-line',
+			icon: 'icon-document-dashed-line',
 			compositionRepositoryAlias: UMB_MEMBER_TYPE_COMPOSITION_REPOSITORY_ALIAS,
 		},
 		conditions: [


### PR DESCRIPTION
An icon with the alias `icon-member-dashed-line` doesn't exist. The corresponding workspace views for document and media both use `icon-document-dashed-line`, so we might as well do the same here instead of introducing `icon-member-dashed-line`.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

By default, we don't see the tab for **Design** workspace view as it's not shown if there aren't any other workspace view. But if you do add another workspace view, you can see that the icon for **Design** isn't shown.

<img width="1363" height="134" alt="image" src="https://github.com/user-attachments/assets/c2522ed0-dc06-4083-8ae2-99f4daf6c1f4" />

The issue is that the **Design** workspace view extension specifies that the icon should be `icon-member-dashed-line`, but this doesn't exist. Using `icon-document-dashed-line` fixes the issue.