### PR TITLE
Dependencies: Pin SQLitePCLRaw.lib.e_sqlite3 to a non-vulnerable version (closes #23325)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,5 +101,12 @@
       until the referencing packages raise their floor.
     -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
+    <!--
+      Microsoft.Data.Sqlite and Microsoft.EntityFrameworkCore.Sqlite (via SQLitePCLRaw.bundle_e_sqlite3)
+      otherwise resolve the native SQLitePCLRaw.lib.e_sqlite3 down to a vulnerable 2.1.11
+      (GHSA-2m69-gcr7-jv3q). Pin forward to the patched 2.1.12 until the referencing packages raise
+      their floor.
+    -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

`SQLitePCLRaw.lib.e_sqlite3` was resolving to the vulnerable `2.1.11` (GHSA-2m69-gcr7-jv3q, high severity). It is a purely transitive dependency, reached via `Microsoft.Data.Sqlite` (used by `Umbraco.Cms.Persistence.Sqlite`) and `Microsoft.EntityFrameworkCore.Sqlite` (used by the EF Core persistence projects), both of which pull it in through `SQLitePCLRaw.bundle_e_sqlite3`.

`SQLitePCLRaw.lib.e_sqlite3` has been patched in `2.1.12` and we've run all Umbraco integration tests on this version, which pass (as CI on this PR should confirm).

I was waiting a few days for our direct dependencies to pin their versions on 2.1.12.  However as yet they haven't.  The latest available versions of those direct dependencies (`Microsoft.Data.Sqlite` / `Microsoft.EntityFrameworkCore.Sqlite` 10.0.10), released two days ago, still reference `bundle_e_sqlite3 2.1.11`, so there is no upstream floor bump to adopt yet.

As such, I think we'll need to pin Umbraco instead so we ship referencing a non-vulnerable version and avioid the build warnings.

This pins the transitive `SQLitePCLRaw.lib.e_sqlite3` forward to the patched `2.1.12` in `Directory.Packages.props`, following the existing convention for transitive pinned versions. Only the native `lib.e_sqlite3` package is flagged, so it is the sole package pinned.

Fixes #23325.

## Testing

Solution should build and CI checks pass.
