### PR TITLE
Extension API: Guard against a cleared manifest when an extension is unregistered mid-initialization (closes #23384)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extension-initializer.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/base-extension-initializer.controller.ts
@@ -292,6 +292,14 @@ export abstract class UmbBaseExtensionInitializer<
 					// Since this is a new call, then lets abort the pending call. [NL]
 					this.#abortPendingGoodCall();
 					await this._conditionsAreBad();
+
+					// The manifest can be cleared during the await (e.g. the extension is
+					// unregistered mid-navigation). _conditionsAreGood() asserts a non-null
+					// manifest, so bail out here if it is gone.
+					if (this.#manifest === undefined) {
+						return;
+					}
+
 					const abortController = new AbortController();
 					const promise = this._conditionsAreGood(abortController.signal);
 					entry = { manifest: this.#manifest, promise, abortController };

--- a/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extension-element-and-api-initializer.race.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/libs/extension-api/controller/extension-element-and-api-initializer.race.test.ts
@@ -457,4 +457,56 @@ describe('UmbExtensionElementAndApiInitializer — condition-flip race with a sl
 
 		controller.destroy();
 	});
+
+	// Regression test for #23384. The extension is unregistered while a good-call is being
+	// set up, clearing the manifest mid-flight:
+	//
+	//   1. `flipTo(true)` synchronously enters #onConditionsChangedCallback and suspends at
+	//      `await _conditionsAreBad()`, queuing the _conditionsAreGood() call as a microtask.
+	//   2. `unregister()` runs synchronously before that microtask resumes. The manifest
+	//      observer fires synchronously and sets the internal manifest to undefined.
+	//   3. The microtask resumes and (before the fix) called _conditionsAreGood() with an
+	//      undefined manifest. The subclass asserts `this.manifest!` and handed undefined to
+	//      createExtensionElementWithApi, which threw
+	//      "Cannot read properties of undefined (reading 'api')" — an uncaught rejection.
+	//
+	// The fix re-checks the manifest after the await and bails. After it, the controller
+	// simply settles unpermitted with no element/api and no throw.
+	it('does not crash when the extension is unregistered during the good-call setup', async () => {
+		// The crash surfaces as an unhandled rejection (the callback is fired from the
+		// condition's onChange with no awaiting caller), so capture those to assert on.
+		const rejections: unknown[] = [];
+		const onRejection = (event: PromiseRejectionEvent) => rejections.push(event.reason);
+		window.addEventListener('unhandledrejection', onRejection);
+
+		try {
+			const controller = new UmbExtensionElementAndApiInitializer<TestManifest>(
+				hostElement,
+				extensionRegistry,
+				baseManifest.alias,
+				[hostElement],
+				() => {},
+			);
+
+			await wait(0);
+			expect(lastManualCondition, 'condition must exist').to.exist;
+
+			lastManualCondition!.flipTo(true);
+			extensionRegistry.unregister(baseManifest.alias);
+
+			await wait(120);
+
+			expect(
+				rejections.map((r) => (r instanceof Error ? r.message : String(r))),
+				'unregistering during the good-call setup must not throw',
+			).to.be.empty;
+			expect(controller.permitted, 'not permitted after unregister').to.be.false;
+			expect(controller.component, 'no component after unregister').to.be.undefined;
+			expect(controller.api, 'no api after unregister').to.be.undefined;
+
+			controller.destroy();
+		} finally {
+			window.removeEventListener('unhandledrejection', onRejection);
+		}
+	});
 });


### PR DESCRIPTION
## Description

Fixes a `TypeError: Cannot read properties of undefined (reading 'api')` that appears in the browser console when navigating to certain content nodes on a clean install (reported on 17.5.3, no third-party packages).

### Root cause

The crash originates in `UmbBaseExtensionInitializer.#onConditionsChangedCallback`. When a condition flips positive, the callback checks that the manifest exists, then `await`s `this._conditionsAreBad()`. That await yields a microtask, and if the extension is unregistered during it (routine churn as the user navigates), the manifest observer synchronously clears the internal manifest. The callback then resumes and calls `_conditionsAreGood()`, which asserts a non-null manifest (`this.manifest!`) and hands `undefined` to `createExtensionElementWithApi` — where `manifest.api` throws.

This is the only invocation site of `_conditionsAreGood()`, and the `await` above it is the only window where the manifest can go stale.

### Fix

Re-check the manifest immediately after that `await` and bail out if it has been cleared. This upholds the non-null-manifest contract that every subclass initializer relies on, so no subclass changes are needed.

Fixes #23384

## Testing

### Automated

A regression test in `extension-element-and-api-initializer.race.test.ts` reproduces the exact scenario (unregister during the good-call setup) and captures the unhandled rejection; it fails before the fix and passes after.

### Manual

See [reproduction steps](https://github.com/umbraco/Umbraco-CMS/issues/23384#issuecomment-4984731822) added to the linked issue.
