### PR TITLE
Migrations: Fix errors upgrading v13 databases with block editors to v17

### DIFF
--- a/src/Umbraco.Core/PropertyEditors/CacheReferencedEntitiesSuppression.cs
+++ b/src/Umbraco.Core/PropertyEditors/CacheReferencedEntitiesSuppression.cs
@@ -19,6 +19,10 @@ namespace Umbraco.Cms.Core.PropertyEditors;
 /// removed alongside it once referenced entities are loaded via lazy read locks.
 /// </para>
 /// </remarks>
+[Obsolete("The ICacheReferencedEntities interface is available for support of request caching retrieved entities in property value editors that implement it. " +
+          "The intention is to supersede this with lazy loaded read locks, which will make this unnecessary. " +
+          "When the interface is removed, these extension methods will also be removed. " +
+          "Scheduled for removal in Umbraco 19.")]
 public static class CacheReferencedEntitiesSuppression
 {
     private static readonly AsyncLocal<bool> _suppressedState = new();

--- a/src/Umbraco.Core/PropertyEditors/CacheReferencedEntitiesSuppression.cs
+++ b/src/Umbraco.Core/PropertyEditors/CacheReferencedEntitiesSuppression.cs
@@ -1,0 +1,49 @@
+namespace Umbraco.Cms.Core.PropertyEditors;
+
+/// <summary>
+/// Provides an ambient, opt-in mechanism to suppress the eager caching of referenced entities performed
+/// by <see cref="ICacheReferencedEntities" /> implementations while re-running a value editor's
+/// <c>FromEditor</c> pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Upgrade migrations re-run <c>FromEditor</c> purely to re-serialize stored property values. The
+/// referenced-entity caching that pipeline performs only benefits the reference tracking of a live save
+/// - which migrations do not perform - so during a migration it is wasted work that issues a
+/// content/media lookup per processed property. Those lookups run in their own scopes (and, for the
+/// parallelized migrations, on separate connections), contending with the migration's own scope.
+/// Wrapping the <c>FromEditor</c> call in <see cref="Suppress" /> skips them.
+/// </para>
+/// <para>
+/// This is a companion to the obsolete <see cref="ICacheReferencedEntities" /> and is expected to be
+/// removed alongside it once referenced entities are loaded via lazy read locks.
+/// </para>
+/// </remarks>
+public static class CacheReferencedEntitiesSuppression
+{
+    private static readonly AsyncLocal<bool> _suppressedState = new();
+
+    /// <summary>
+    /// Gets a value indicating whether referenced-entity caching is currently suppressed on the executing context.
+    /// </summary>
+    public static bool IsSuppressed => _suppressedState.Value;
+
+    /// <summary>
+    /// Suppresses referenced-entity caching until the returned <see cref="IDisposable" /> is disposed.
+    /// </summary>
+    /// <returns>A disposable that restores the previous suppression state when disposed.</returns>
+    public static IDisposable Suppress() => new SuppressionScope();
+
+    private sealed class SuppressionScope : IDisposable
+    {
+        private readonly bool _previous;
+
+        public SuppressionScope()
+        {
+            _previous = _suppressedState.Value;
+            _suppressedState.Value = true;
+        }
+
+        public void Dispose() => _suppressedState.Value = _previous;
+    }
+}

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
@@ -5,6 +5,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Blocks;
 using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
@@ -249,7 +250,16 @@ public abstract class ConvertBlockEditorPropertiesBase : MigrationBase
                             toEditorValue = UpdateEditorValue(toEditorValue);
 
                             var editorValue = _jsonSerializer.Serialize(toEditorValue);
-                            var dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+
+                            // Re-running FromEditor here is only to re-serialize the converted value; the
+                            // referenced-entity caching it would otherwise trigger is wasted work during a
+                            // migration and issues per-property reads that contend with the migration's scope.
+                            object? dbValue;
+                            using (CacheReferencedEntitiesSuppression.Suppress())
+                            {
+                                dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+                            }
+
                             if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
                             {
                                 _logger.LogError(

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertBlockEditorPropertiesBase.cs
@@ -255,10 +255,12 @@ public abstract class ConvertBlockEditorPropertiesBase : MigrationBase
                             // referenced-entity caching it would otherwise trigger is wasted work during a
                             // migration and issues per-property reads that contend with the migration's scope.
                             object? dbValue;
+#pragma warning disable CS0618 // Type or member is obsolete
                             using (CacheReferencedEntitiesSuppression.Suppress())
                             {
                                 dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
                             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
                             if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
                             {

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertLocalLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertLocalLinks.cs
@@ -369,10 +369,12 @@ public class ConvertLocalLinks : MigrationBase
         // caching it would otherwise trigger is wasted work that issues per-property content/media reads
         // in separate scopes, contending with this migration's own scope. Suppress it.
         object? dbValue;
+#pragma warning disable CS0618 // Type or member is obsolete
         using (CacheReferencedEntitiesSuppression.Suppress())
         {
             dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
         {

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertLocalLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_0_0/ConvertLocalLinks.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
@@ -363,7 +364,16 @@ public class ConvertLocalLinks : MigrationBase
         }
 
         var editorValue = _jsonSerializer.Serialize(toEditorValue);
-        var dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+
+        // Re-running FromEditor here is only to re-serialize the converted value; the referenced-entity
+        // caching it would otherwise trigger is wasted work that issues per-property content/media reads
+        // in separate scopes, contending with this migration's own scope. Suppress it.
+        object? dbValue;
+        using (CacheReferencedEntitiesSuppression.Suppress())
+        {
+            dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+        }
+
         if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
         {
             _logger.LogWarning(

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
@@ -4,6 +4,7 @@ using NPoco;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Editors;
+using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Scoping;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
@@ -283,7 +284,16 @@ public class FixConvertLocalLinks : MigrationBase
         }
 
         var editorValue = _jsonSerializer.Serialize(toEditorValue);
-        var dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+
+        // Re-running FromEditor here is only to re-serialize the converted value; the referenced-entity
+        // caching it would otherwise trigger is wasted work that issues per-property content/media reads
+        // in separate scopes, contending with this migration's own scope. Suppress it.
+        object? dbValue;
+        using (CacheReferencedEntitiesSuppression.Suppress())
+        {
+            dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+        }
+
         if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
         {
             _logger.LogWarning(

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_15_1_0/FixConvertLocalLinks.cs
@@ -289,10 +289,12 @@ public class FixConvertLocalLinks : MigrationBase
         // caching it would otherwise trigger is wasted work that issues per-property content/media reads
         // in separate scopes, contending with this migration's own scope. Suppress it.
         object? dbValue;
+#pragma warning disable CS0618 // Type or member is obsolete
         using (CacheReferencedEntitiesSuppression.Suppress())
         {
             dbValue = valueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
         {

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -394,9 +394,18 @@ WHERE nodeId IN (@0)";
     private bool FinalizeUpdateItem(UpdateItem updateItem, IDataValueEditor updatedValueEditor)
     {
         var editorValue = _jsonSerializer.Serialize(updateItem.UpdatedValue);
-        var dbValue = updateItem.UpdatedValue is SingleBlockValue
-            ? _dummySingleBlockValueEditor.FromEditor(new ContentPropertyData(editorValue, null), null)
-            : updatedValueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+
+        // Re-running FromEditor here is only to re-serialize the converted value; the referenced-entity
+        // caching it would otherwise trigger is wasted work that issues per-property content/media reads
+        // in separate scopes, contending with this migration's own scope. Suppress it.
+        object? dbValue;
+        using (CacheReferencedEntitiesSuppression.Suppress())
+        {
+            dbValue = updateItem.UpdatedValue is SingleBlockValue
+                ? _dummySingleBlockValueEditor.FromEditor(new ContentPropertyData(editorValue, null), null)
+                : updatedValueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
+        }
+
         if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
         {
             _logger.LogWarning(

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/V_18_0_0/MigrateSingleBlockList.cs
@@ -399,12 +399,14 @@ WHERE nodeId IN (@0)";
         // caching it would otherwise trigger is wasted work that issues per-property content/media reads
         // in separate scopes, contending with this migration's own scope. Suppress it.
         object? dbValue;
+#pragma warning disable CS0618 // Type or member is obsolete
         using (CacheReferencedEntitiesSuppression.Suppress())
         {
             dbValue = updateItem.UpdatedValue is SingleBlockValue
                 ? _dummySingleBlockValueEditor.FromEditor(new ContentPropertyData(editorValue, null), null)
                 : updatedValueEditor.FromEditor(new ContentPropertyData(editorValue, null), null);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (dbValue is not string stringValue || stringValue.DetectIsJson() is false)
         {

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockValuePropertyValueEditorBase.cs
@@ -60,6 +60,11 @@ public abstract class BlockValuePropertyValueEditorBase<TValue, TLayout> : DataV
               "Scheduled for removal in Umbraco 19.")]
     protected void CacheReferencedEntities(BlockEditorData<TValue, TLayout>? blockEditorData)
     {
+        if (CacheReferencedEntitiesSuppression.IsSuppressed)
+        {
+            return;
+        }
+
         // Group property values by their associated data editor alias.
         IEnumerable<IGrouping<string, BlockPropertyValue>> valuesByDataEditors = (blockEditorData?.BlockValue.ContentData ?? []).Union(blockEditorData?.BlockValue.SettingsData ?? [])
             .SelectMany(x => x.Values)

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -256,10 +256,12 @@ public class MediaPicker3PropertyEditor : DataEditor, IValueSchemaProvider
         /// <inheritdoc/>
         public void CacheReferencedEntities(IEnumerable<object> values)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (CacheReferencedEntitiesSuppression.IsSuppressed)
             {
                 return;
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var mediaKeys = values
                 .SelectMany(value => Deserialize(_jsonSerializer, value))

--- a/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MediaPicker3PropertyEditor.cs
@@ -256,6 +256,11 @@ public class MediaPicker3PropertyEditor : DataEditor, IValueSchemaProvider
         /// <inheritdoc/>
         public void CacheReferencedEntities(IEnumerable<object> values)
         {
+            if (CacheReferencedEntitiesSuppression.IsSuppressed)
+            {
+                return;
+            }
+
             var mediaKeys = values
                 .SelectMany(value => Deserialize(_jsonSerializer, value))
                 .Select(dto => dto.MediaKey)

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -113,6 +113,11 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference, I
     /// <inheritdoc/>
     public void CacheReferencedEntities(IEnumerable<object> values)
     {
+        if (CacheReferencedEntitiesSuppression.IsSuppressed)
+        {
+            return;
+        }
+
         var dtos = values
             .Select(value =>
             {

--- a/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/MultiUrlPickerValueEditor.cs
@@ -113,10 +113,12 @@ public class MultiUrlPickerValueEditor : DataValueEditor, IDataValueReference, I
     /// <inheritdoc/>
     public void CacheReferencedEntities(IEnumerable<object> values)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         if (CacheReferencedEntitiesSuppression.IsSuppressed)
         {
             return;
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var dtos = values
             .Select(value =>

--- a/src/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactory.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactory.cs
@@ -52,15 +52,75 @@ public sealed class JsonTolerantNumberConverterFactory : JsonConverterFactory
                         ? parsed
                         : T.Zero;
                 case JsonTokenType.Number:
-                    return reader.TryGetDecimal(out decimal decimalValue)
-                        ? T.CreateTruncating(decimalValue)
-                        : T.CreateTruncating(reader.GetDouble());
+                    return ReadNumber(ref reader);
                 default:
                     throw new JsonException($"Unexpected token '{reader.TokenType}' when parsing a number.");
             }
         }
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
-            => writer.WriteRawValue(value.ToString(null, CultureInfo.InvariantCulture) ?? "0");
+        {
+            // Use the typed numeric writers rather than WriteRawValue, which can emit invalid JSON for
+            // floating-point edge cases.
+            if (typeof(T) == typeof(int))
+            {
+                writer.WriteNumberValue((int)(object)value);
+            }
+            else if (typeof(T) == typeof(long))
+            {
+                writer.WriteNumberValue((long)(object)value);
+            }
+            else if (typeof(T) == typeof(short))
+            {
+                writer.WriteNumberValue((int)(short)(object)value);
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                writer.WriteNumberValue((double)(object)value);
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                writer.WriteNumberValue((float)(object)value);
+            }
+            else
+            {
+                writer.WriteNumberValue((decimal)(object)value);
+            }
+        }
+
+        // Read a JSON number token using the typed reader for the target type, so a value that cannot be
+        // represented (e.g. a fractional number for an integer type, or an out-of-range value) resolves to
+        // the default rather than being silently truncated.
+        private static T ReadNumber(ref Utf8JsonReader reader)
+        {
+            if (typeof(T) == typeof(int))
+            {
+                return reader.TryGetInt32(out var intValue) ? (T)(object)intValue : T.Zero;
+            }
+
+            if (typeof(T) == typeof(long))
+            {
+                return reader.TryGetInt64(out var longValue) ? (T)(object)longValue : T.Zero;
+            }
+
+            if (typeof(T) == typeof(short))
+            {
+                return reader.TryGetInt32(out var intValue) && intValue is >= short.MinValue and <= short.MaxValue
+                    ? (T)(object)(short)intValue
+                    : T.Zero;
+            }
+
+            if (typeof(T) == typeof(double))
+            {
+                return reader.TryGetDouble(out var doubleValue) ? (T)(object)doubleValue : T.Zero;
+            }
+
+            if (typeof(T) == typeof(float))
+            {
+                return reader.TryGetSingle(out var floatValue) ? (T)(object)floatValue : T.Zero;
+            }
+
+            return reader.TryGetDecimal(out var decimalValue) ? (T)(object)decimalValue : T.Zero;
+        }
     }
 }

--- a/src/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactory.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactory.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Umbraco.Cms.Infrastructure.Serialization;
+
+/// <summary>
+/// A tolerant JSON converter factory for the numeric value types used in data type configurations.
+/// </summary>
+/// <remarks>
+/// Legacy Umbraco databases (pre-v14) frequently stored numeric configuration values - for example the
+/// <c>minNumber</c>/<c>maxNumber</c> of the pickers, or the <c>minVal</c>/<c>step</c> of the slider - as
+/// empty strings. The Newtonsoft-based serialization used at the time coerced these to the default value;
+/// <see cref="System.Text.Json"/> throws instead. This converter coerces an empty, whitespace or otherwise
+/// unparseable string to the type's default (zero), so configurations can still be loaded - and upgrades
+/// from such databases run - without a manual data fix.
+/// </remarks>
+public sealed class JsonTolerantNumberConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert)
+        => typeToConvert == typeof(int)
+           || typeToConvert == typeof(long)
+           || typeToConvert == typeof(short)
+           || typeToConvert == typeof(double)
+           || typeToConvert == typeof(float)
+           || typeToConvert == typeof(decimal);
+
+    /// <inheritdoc />
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        => (JsonConverter)Activator.CreateInstance(
+            typeof(TolerantNumberConverter<>).MakeGenericType(typeToConvert))!;
+
+    private sealed class TolerantNumberConverter<T> : JsonConverter<T>
+        where T : struct, INumber<T>
+    {
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Null:
+                    return T.Zero;
+                case JsonTokenType.String:
+                    var value = reader.GetString();
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        return T.Zero;
+                    }
+
+                    return T.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out T parsed)
+                        ? parsed
+                        : T.Zero;
+                case JsonTokenType.Number:
+                    return reader.TryGetDecimal(out decimal decimalValue)
+                        ? T.CreateTruncating(decimalValue)
+                        : T.CreateTruncating(reader.GetDouble());
+                default:
+                    throw new JsonException($"Unexpected token '{reader.TokenType}' when parsing a number.");
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+            => writer.WriteRawValue(value.ToString(null, CultureInfo.InvariantCulture) ?? "0");
+    }
+}

--- a/src/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactory.cs
+++ b/src/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactory.cs
@@ -58,27 +58,75 @@ public sealed class JsonTolerantNumberConverterFactory : JsonConverterFactory
             }
         }
 
+        // Read a JSON number token using the typed reader for the target type, so a value that cannot be
+        // represented (e.g. a fractional number for an integer type, or an out-of-range value) resolves to
+        // the default rather than being silently truncated.
+        private static T ReadNumber(ref Utf8JsonReader reader)
+        {
+            if (IsInt())
+            {
+                return reader.TryGetInt32(out var intValue) ? (T)(object)intValue : T.Zero;
+            }
+
+            if (IsLong())
+            {
+                return reader.TryGetInt64(out var longValue) ? (T)(object)longValue : T.Zero;
+            }
+
+            if (IsShort())
+            {
+                return reader.TryGetInt16(out var shortValue) ? (T)(object)shortValue : T.Zero;
+            }
+
+            return ReadFloatingPointNumber(ref reader);
+        }
+
+        private static T ReadFloatingPointNumber(ref Utf8JsonReader reader)
+        {
+            if (IsDouble())
+            {
+                return reader.TryGetDouble(out var doubleValue) ? (T)(object)doubleValue : T.Zero;
+            }
+
+            if (IsFloat())
+            {
+                return reader.TryGetSingle(out var floatValue) ? (T)(object)floatValue : T.Zero;
+            }
+
+            return reader.TryGetDecimal(out var decimalValue) ? (T)(object)decimalValue : T.Zero;
+        }
+
+        private static bool IsInt() => typeof(T) == typeof(int);
+
+        private static bool IsLong() => typeof(T) == typeof(long);
+
+        private static bool IsShort() => typeof(T) == typeof(short);
+
+        private static bool IsDouble() => typeof(T) == typeof(double);
+
+        private static bool IsFloat() => typeof(T) == typeof(float);
+
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
             // Use the typed numeric writers rather than WriteRawValue, which can emit invalid JSON for
             // floating-point edge cases.
-            if (typeof(T) == typeof(int))
+            if (IsInt())
             {
                 writer.WriteNumberValue((int)(object)value);
             }
-            else if (typeof(T) == typeof(long))
+            else if (IsLong())
             {
                 writer.WriteNumberValue((long)(object)value);
             }
-            else if (typeof(T) == typeof(short))
+            else if (IsShort())
             {
                 writer.WriteNumberValue((int)(short)(object)value);
             }
-            else if (typeof(T) == typeof(double))
+            else if (IsDouble())
             {
                 writer.WriteNumberValue((double)(object)value);
             }
-            else if (typeof(T) == typeof(float))
+            else if (IsFloat())
             {
                 writer.WriteNumberValue((float)(object)value);
             }
@@ -86,41 +134,6 @@ public sealed class JsonTolerantNumberConverterFactory : JsonConverterFactory
             {
                 writer.WriteNumberValue((decimal)(object)value);
             }
-        }
-
-        // Read a JSON number token using the typed reader for the target type, so a value that cannot be
-        // represented (e.g. a fractional number for an integer type, or an out-of-range value) resolves to
-        // the default rather than being silently truncated.
-        private static T ReadNumber(ref Utf8JsonReader reader)
-        {
-            if (typeof(T) == typeof(int))
-            {
-                return reader.TryGetInt32(out var intValue) ? (T)(object)intValue : T.Zero;
-            }
-
-            if (typeof(T) == typeof(long))
-            {
-                return reader.TryGetInt64(out var longValue) ? (T)(object)longValue : T.Zero;
-            }
-
-            if (typeof(T) == typeof(short))
-            {
-                return reader.TryGetInt32(out var intValue) && intValue is >= short.MinValue and <= short.MaxValue
-                    ? (T)(object)(short)intValue
-                    : T.Zero;
-            }
-
-            if (typeof(T) == typeof(double))
-            {
-                return reader.TryGetDouble(out var doubleValue) ? (T)(object)doubleValue : T.Zero;
-            }
-
-            if (typeof(T) == typeof(float))
-            {
-                return reader.TryGetSingle(out var floatValue) ? (T)(object)floatValue : T.Zero;
-            }
-
-            return reader.TryGetDecimal(out var decimalValue) ? (T)(object)decimalValue : T.Zero;
         }
     }
 }

--- a/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
+++ b/src/Umbraco.Infrastructure/Serialization/SystemTextConfigurationEditorJsonSerializer.cs
@@ -46,6 +46,7 @@ public sealed class SystemTextConfigurationEditorJsonSerializer : SystemTextJson
                 new JsonUdiConverter(),
                 new JsonUdiRangeConverter(),
                 new JsonBooleanConverter(),
+                new JsonTolerantNumberConverterFactory(),
             },
 
             // Properties of data type configuration objects are annotated with [ConfigurationField] attributes

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
@@ -1,0 +1,106 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Infrastructure.Serialization;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Serialization;
+
+[TestFixture]
+public class JsonTolerantNumberConverterFactoryTests
+{
+    private readonly IConfigurationEditorJsonSerializer _serializer =
+        new SystemTextConfigurationEditorJsonSerializer(new DefaultJsonSerializerEncoderFactory());
+
+    [TestCase("\"\"")]
+    [TestCase("\" \"")]
+    [TestCase("null")]
+    public void Can_Deserialize_Empty_Int_Configuration_As_Zero(string minMaxValue)
+    {
+        // Legacy (pre-v14) databases stored the picker min/max as empty strings; deserialization must not throw.
+        var json = $"{{\"ignoreUserStartNodes\":false,\"minNumber\":{minMaxValue},\"maxNumber\":{minMaxValue}}}";
+
+        MultiUrlPickerConfiguration? configuration =
+            _serializer.Deserialize<MultiUrlPickerConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0, configuration.MinNumber);
+            Assert.AreEqual(0, configuration.MaxNumber);
+        });
+    }
+
+    [Test]
+    public void Can_Deserialize_Empty_Int_Configuration_On_MultiNodePicker_As_Zero()
+    {
+        var json = "{\"minNumber\":\"\",\"maxNumber\":\"\",\"filter\":\"\"}";
+
+        MultiNodePickerConfiguration? configuration =
+            _serializer.Deserialize<MultiNodePickerConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0, configuration.MinNumber);
+            Assert.AreEqual(0, configuration.MaxNumber);
+        });
+    }
+
+    [Test]
+    public void Can_Deserialize_Empty_Decimal_Configuration_As_Zero()
+    {
+        var json = "{\"minVal\":\"\",\"maxVal\":\"\",\"step\":\"\",\"minimumRange\":\"\"}";
+
+        SliderConfiguration? configuration = _serializer.Deserialize<SliderConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0m, configuration.MinimumValue);
+            Assert.AreEqual(0m, configuration.MaximumValue);
+            Assert.AreEqual(0m, configuration.Step);
+        });
+    }
+
+    [Test]
+    public void Can_Deserialize_Empty_Nullable_Int_Configuration_As_Zero()
+    {
+        var json = "{\"maxChars\":\"\"}";
+
+        TextAreaConfiguration? configuration = _serializer.Deserialize<TextAreaConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.AreEqual(0, configuration.MaxChars);
+    }
+
+    [TestCase("\"5\"", 5)]
+    [TestCase("5", 5)]
+    public void Can_Deserialize_Valid_Number(string minNumberValue, int expected)
+    {
+        var json = $"{{\"minNumber\":{minNumberValue},\"maxNumber\":10}}";
+
+        MultiUrlPickerConfiguration? configuration =
+            _serializer.Deserialize<MultiUrlPickerConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(expected, configuration.MinNumber);
+            Assert.AreEqual(10, configuration.MaxNumber);
+        });
+    }
+
+    [Test]
+    public void Can_Serialize_Number_As_Numeric_Value()
+    {
+        var configuration = new MultiUrlPickerConfiguration { MinNumber = 2, MaxNumber = 5 };
+
+        var serialized = _serializer.Serialize(configuration);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(serialized.Contains("\"minNumber\":2"), serialized);
+            Assert.IsTrue(serialized.Contains("\"maxNumber\":5"), serialized);
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using Umbraco.Cms.Core.PropertyEditors;
-using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Infrastructure.Serialization;
 
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Serialization;
@@ -8,8 +7,8 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Serialization;
 [TestFixture]
 public class JsonTolerantNumberConverterFactoryTests
 {
-    private readonly IConfigurationEditorJsonSerializer _serializer =
-        new SystemTextConfigurationEditorJsonSerializer(new DefaultJsonSerializerEncoderFactory());
+    private readonly SystemTextConfigurationEditorJsonSerializer _serializer =
+        new(new DefaultJsonSerializerEncoderFactory());
 
     [TestCase("\"\"")]
     [TestCase("\" \"")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Serialization/JsonTolerantNumberConverterFactoryTests.cs
@@ -91,6 +91,36 @@ public class JsonTolerantNumberConverterFactoryTests
     }
 
     [Test]
+    public void Can_Deserialize_Fractional_Number_For_Integer_Field_As_Zero()
+    {
+        // A fractional JSON number cannot represent an int, so it must resolve to the default rather than
+        // being silently truncated (e.g. 1.5 -> 1).
+        var json = "{\"minNumber\":1.5,\"maxNumber\":10}";
+
+        MultiUrlPickerConfiguration? configuration =
+            _serializer.Deserialize<MultiUrlPickerConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(0, configuration.MinNumber);
+            Assert.AreEqual(10, configuration.MaxNumber);
+        });
+    }
+
+    [Test]
+    public void Can_Deserialize_Fractional_Number_For_Decimal_Field()
+    {
+        // Floating-point config must retain its fractional value.
+        var json = "{\"step\":0.5,\"minVal\":1,\"maxVal\":10}";
+
+        SliderConfiguration? configuration = _serializer.Deserialize<SliderConfiguration>(json);
+
+        Assert.IsNotNull(configuration);
+        Assert.AreEqual(0.5m, configuration.Step);
+    }
+
+    [Test]
     public void Can_Serialize_Number_As_Numeric_Value()
     {
         var configuration = new MultiUrlPickerConfiguration { MinNumber = 2, MaxNumber = 5 };


### PR DESCRIPTION
## Description

Upgrading a customer's Umbraco 13 database to 17 failed in the V15 block-editor / local-link data migrations. Two independent problems were uncovered (each blocking the upgrade in turn), both stemming from the migration re-running the live value-editor pipeline over legacy data. This PR fixes both.

### 1. Invalid data type configuration aborts the migration

Legacy databases can store numeric data type configuration values as **empty strings** — e.g. `"minNumber":""` / `"maxNumber":""` on the pickers (`Umbraco.MultiUrlPicker`, `Umbraco.MultiNodeTreePicker`), and similarly for the slider (`decimal`) and text area (`int?`). Under Newtonsoft (v13) these coerced to a default; `System.Text.Json` (v15+) throws `JsonException` deserializing them into the typed configuration, which surfaces as `The configuration for data type … is invalid` and aborts the migration when it loads a nested editor's configuration.

**Fix:** a tolerant numeric JSON converter (`JsonTolerantNumberConverterFactory`) registered on the configuration serializer. It coerces an empty / whitespace / `null` string to the type's default (`0`) for `int`, `long`, `short`, `double`, `float`, `decimal` (and their nullable variants), while still parsing valid numbers and quoted-number strings, and writing normal numeric JSON. It sits alongside the existing tolerant converters (`JsonBooleanConverter`) and mirrors the leniency Newtonsoft previously provided.

The change is **strictly additive** — any value that deserializes today is unchanged; only previously-throwing values now resolve to a default.

### 2. Local-link migration times out / self-blocks on large sites

`ConvertLocalLinks` (and the sibling block migrations) re-run the value editor's `FromEditor` purely to re-serialize the converted value. For block editors, `FromEditor` eagerly calls `CacheReferencedEntities`, which for `MultiUrlPicker` / `MediaPicker3` issues an `IContentService`/`IMediaService.GetByIds` **per processed property**. During the migration this cache-warming is wasted work (the migration only wants the serialized string), and — because the parallelised worker path runs each lookup in its **own scope/transaction** — it contends with the migration's own scope. On the customer's database this effectively blocked the migration against itself.

**Fix:** an ambient, opt-in `CacheReferencedEntitiesSuppression`. The affected migrations wrap their `FromEditor` call in it, and the block base editor plus the picker value editors honour it and skip the eager referenced-entity loads. `FromEditor`'s output is unchanged (the suppressed call only warms a request cache the migration never reads).

Migrations updated to suppress: `V_15_0_0.ConvertLocalLinks`, `V_15_0_0.ConvertBlockEditorPropertiesBase`, `V_15_1_0.FixConvertLocalLinks`, `V_18_0_0.MigrateSingleBlockList`.

## Testing

Reproduced both failures against a real customer Umbraco 13 database that exhibited them, and confirmed the v13→17 upgrade now completes end-to-end after the fixes. Unit tests added for the tolerant numeric converter (covering the picker/slider/text-area configs and valid-value round-trips).