### PR TITLE
Avoid some string allocations

### DIFF
--- a/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
+++ b/src/Umbraco.Cms.Api.Common/OpenApi/SubTypesSelector.cs
@@ -47,7 +47,7 @@ public class SubTypesSelector : ISubTypesSelector
         {
             // Split the path into segments
             var segments = _httpContextAccessor.HttpContext.Request.Path.Value![swaggerPath.Length..]
-                .TrimStart(Constants.CharArrays.ForwardSlash)
+                .TrimStart('/')
                 .Split(Constants.CharArrays.ForwardSlash);
 
             // Extract the document name from the path

--- a/src/Umbraco.Cms.Api.Common/Rendering/ElementOnlyOutputExpansionStrategy.cs
+++ b/src/Umbraco.Cms.Api.Common/Rendering/ElementOnlyOutputExpansionStrategy.cs
@@ -212,13 +212,14 @@ public class ElementOnlyOutputExpansionStrategy : IOutputExpansionStrategy
         public static Node Parse(string value)
         {
             // verify that there are as many start brackets as there are end brackets
-            if (value.CountOccurrences("[") != value.CountOccurrences("]"))
+            ReadOnlySpan<char> valueAsSpan = value.AsSpan();
+            if (valueAsSpan.Count('[') != valueAsSpan.Count(']'))
             {
                 throw new ArgumentException("Value did not contain an equal number of start and end brackets");
             }
 
             // verify that the value does not start with a start bracket
-            if (value.StartsWith("["))
+            if (value.StartsWith('['))
             {
                 throw new ArgumentException("Value cannot start with a bracket");
             }

--- a/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Controllers/Content/ByRouteContentApiController.cs
@@ -89,7 +89,7 @@ public class ByRouteContentApiController : ContentApiItemControllerBase
             return null;
         }
 
-        if (Guid.TryParse(path.AsSpan(PreviewContentRequestPathPrefix.Length).TrimEnd("/"), out Guid contentId) is false)
+        if (Guid.TryParse(path.AsSpan(PreviewContentRequestPathPrefix.Length).TrimEnd('/'), out Guid contentId) is false)
         {
             return null;
         }

--- a/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContainsFilterBase.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Querying/Filters/ContainsFilterBase.cs
@@ -42,7 +42,7 @@ public abstract class ContainsFilterBase : IFilterHandler
             return DefaultFilterOption();
         }
 
-        FilterOperation? filterOperation = ParseFilterOperation(operatorGroup.Value);
+        FilterOperation? filterOperation = ParseFilterOperation(operatorGroup.ValueSpan);
         if (filterOperation.HasValue is false)
         {
             return DefaultFilterOption();
@@ -64,7 +64,7 @@ public abstract class ContainsFilterBase : IFilterHandler
             };
     }
 
-    private FilterOperation? ParseFilterOperation(string filterOperation)
+    private static FilterOperation? ParseFilterOperation(ReadOnlySpan<char> filterOperation)
         => filterOperation switch
         {
             ":" => FilterOperation.Is,

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
@@ -100,7 +100,12 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             return null;
         }
 
-        ReadOnlySpan<char> childrenOf = fetch.AsSpan().TrimStart(childrenOfParameter);
+        ReadOnlySpan<char> childrenOf = fetch.AsSpan();
+        if (fetch.StartsWith(childrenOfParameter, StringComparison.InvariantCultureIgnoreCase))
+        {
+            childrenOf = childrenOf[childrenOfParameter.Length..];
+        }
+
         if (childrenOf.IsEmpty)
         {
             // this mirrors the current behavior of the Content Delivery API :-)
@@ -108,7 +113,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
         }
 
         IPublishedMediaCache mediaCache = GetRequiredPublishedMediaCache();
-        if (childrenOf.Trim(Constants.CharArrays.ForwardSlash).IsEmpty)
+        if (childrenOf.Trim('/').IsEmpty)
         {
             return GetRootContent(mediaCache);
         }

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
@@ -100,12 +100,8 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             return null;
         }
 
-        ReadOnlySpan<char> childrenOf = fetch.AsSpan();
-        if (fetch.StartsWith(childrenOfParameter, StringComparison.InvariantCultureIgnoreCase))
-        {
-            childrenOf = childrenOf[childrenOfParameter.Length..];
-        }
-
+        // The guard above guarantees fetch starts with the prefix, so we can strip it unconditionally.
+        ReadOnlySpan<char> childrenOf = fetch.AsSpan(childrenOfParameter.Length);
         if (childrenOf.IsEmpty)
         {
             // this mirrors the current behavior of the Content Delivery API :-)

--- a/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryService.cs
@@ -63,14 +63,21 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
     private IPublishedMediaCache GetRequiredPublishedMediaCache()
         => _publishedMediaCache;
 
-    private IPublishedContent? TryGetByPath(string path, IPublishedMediaCache mediaCache)
+    private IPublishedContent? TryGetByPath(ReadOnlySpan<char> path, IPublishedMediaCache mediaCache)
     {
-        var segments = path.Split(Constants.CharArrays.ForwardSlash, StringSplitOptions.RemoveEmptyEntries);
+        MemoryExtensions.SpanSplitEnumerator<char> segments = path.Split(Constants.CharArrays.ForwardSlash);
         IEnumerable<IPublishedContent> currentChildren = GetRootContent(mediaCache);
         IPublishedContent? resolvedMedia = null;
 
-        foreach (var segment in segments)
+        foreach (Range segmentRange in segments)
         {
+            ReadOnlySpan<char> segmentSpan = path[segmentRange];
+            if (segmentSpan.IsEmpty)
+            {
+                continue;
+            }
+
+            string segment = new string(segmentSpan);
             resolvedMedia = currentChildren.FirstOrDefault(c => segment.InvariantEquals(c.Name));
             if (resolvedMedia is null)
             {
@@ -93,15 +100,15 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             return null;
         }
 
-        var childrenOf = fetch.TrimStart(childrenOfParameter);
-        if (childrenOf.IsNullOrWhiteSpace())
+        ReadOnlySpan<char> childrenOf = fetch.AsSpan().TrimStart(childrenOfParameter);
+        if (childrenOf.IsEmpty)
         {
             // this mirrors the current behavior of the Content Delivery API :-)
-            return Array.Empty<IPublishedContent>();
+            return [];
         }
 
         IPublishedMediaCache mediaCache = GetRequiredPublishedMediaCache();
-        if (childrenOf.Trim(Constants.CharArrays.ForwardSlash).Length == 0)
+        if (childrenOf.Trim(Constants.CharArrays.ForwardSlash).IsEmpty)
         {
             return GetRootContent(mediaCache);
         }
@@ -110,28 +117,31 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             ? mediaCache.GetById(parentKey)
             : TryGetByPath(childrenOf, mediaCache);
 
-        return parent?.Children(_mediaNavigationQueryService, _publishedMediaStatusFilteringService) ?? Array.Empty<IPublishedContent>();
+        return parent?.Children(_mediaNavigationQueryService, _publishedMediaStatusFilteringService) ?? [];
     }
 
     private IEnumerable<IPublishedContent>? ApplyFilters(IEnumerable<IPublishedContent> source, IEnumerable<string> filters)
     {
+        Span<Range> partRanges = stackalloc Range[3];
         foreach (var filter in filters)
         {
-            var parts = filter.Split(':');
-            if (parts.Length != 2)
+            ReadOnlySpan<char> filterAsSpan = filter.AsSpan();
+            int partsFound = filterAsSpan.Split(partRanges, ':');
+            if (partsFound != 2)
             {
                 // invalid filter
                 _logger.LogInformation("An invalid filter option was encountered. Please ensure that supplied filter options are two-part, separated by ':'.");
                 return null;
             }
 
-            switch (parts[0])
+            string secondPart = new string(filterAsSpan[partRanges[1]]);
+            switch (filterAsSpan[partRanges[0]])
             {
                 case "mediaType":
-                    source = source.Where(c => c.ContentType.Alias == parts[1]);
+                    source = source.Where(c => c.ContentType.Alias == secondPart);
                     break;
                 case "name":
-                    source = source.Where(c => c.Name.InvariantContains(parts[1]));
+                    source = source.Where(c => c.Name.InvariantContains(secondPart));
                     break;
                 default:
                     // unknown filter
@@ -145,10 +155,12 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
 
     private IEnumerable<IPublishedContent>? ApplySorts(IEnumerable<IPublishedContent> source, IEnumerable<string> sorts)
     {
+        Span<Range> partRanges = stackalloc Range[3];
         foreach (var sort in sorts)
         {
-            var parts = sort.Split(':');
-            if (parts.Length != 2)
+            ReadOnlySpan<char> sortAsSpan = sort.AsSpan();
+            int partsFound = sortAsSpan.Split(partRanges, ':');
+            if (partsFound != 2)
             {
                 // invalid sort
                 _logger.LogInformation("An invalid sort option was encountered. Please ensure that the supplied sort options are two-part, separated by ':'.");
@@ -156,7 +168,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
             }
 
             Func<IPublishedContent, object> keySelector;
-            switch (parts[0])
+            switch (sortAsSpan[partRanges[0]])
             {
                 case "createDate":
                     keySelector = content => content.CreateDate;
@@ -176,7 +188,7 @@ internal sealed class ApiMediaQueryService : IApiMediaQueryService
                     return null;
             }
 
-            source = parts[1].StartsWith("asc")
+            source = sortAsSpan[partRanges[1]].StartsWith("asc")
                 ? source.OrderBy(keySelector)
                 : source.OrderByDescending(keySelector);
         }

--- a/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
+++ b/src/Umbraco.Cms.Api.Delivery/Services/RequestStartItemProvider.cs
@@ -41,7 +41,7 @@ internal sealed class RequestStartItemProvider : RequestHeaderHandler, IRequestS
             return _requestedStartContent;
         }
 
-        var headerValue = RequestedStartItem()?.Trim(Constants.CharArrays.ForwardSlash);
+        var headerValue = RequestedStartItem()?.Trim('/');
         if (headerValue.IsNullOrWhiteSpace())
         {
             return null;

--- a/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
+++ b/src/Umbraco.Cms.Api.Management/Security/BackOfficeApplicationManager.cs
@@ -324,5 +324,5 @@ public class BackOfficeApplicationManager : OpenIdDictApplicationManagerBase, IB
         return descriptor;
     }
 
-    private static Uri CallbackUrlFor(Uri url, string relativePath) => new Uri($"{url.GetLeftPart(UriPartial.Authority)}/{relativePath.TrimStart(Constants.CharArrays.ForwardSlash)}");
+    private static Uri CallbackUrlFor(Uri url, string relativePath) => new Uri($"{url.GetLeftPart(UriPartial.Authority)}/{relativePath.AsSpan().TrimStart('/')}");
 }

--- a/src/Umbraco.Cms.Persistence.SqlServer/FaultHandling/Strategies/ThrottlingCondition.cs
+++ b/src/Umbraco.Cms.Persistence.SqlServer/FaultHandling/Strategies/ThrottlingCondition.cs
@@ -258,7 +258,7 @@ public class ThrottlingCondition
         {
             Match match = _sqlErrorCodeRegEx.Match(error.Message);
 
-            if (match.Success && int.TryParse(match.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int reasonCode))
+            if (match.Success && int.TryParse(match.Groups[1].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out int reasonCode))
             {
                 return FromReasonCode(reasonCode);
             }

--- a/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
+++ b/src/Umbraco.Cms.Persistence.Sqlite/Services/SqliteSyntaxProvider.cs
@@ -320,7 +320,7 @@ public class SqliteSyntaxProvider : SqlSyntaxProviderBase<SqliteSyntaxProvider>
         var sb = new StringBuilder();
         foreach (ColumnDefinition column in columns)
         {
-            sb.AppendLine(", " + Format(column));
+            sb.Append(", ").AppendLine(Format(column));
         }
 
         return sb.ToString().TrimStart(',');

--- a/src/Umbraco.Core/DeliveryApi/ApiDocumentUrlService.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiDocumentUrlService.cs
@@ -26,7 +26,7 @@ public sealed class ApiDocumentUrlService : IApiDocumentUrlService
         {
             var index = route.IndexOf('/');
 
-            if (index > -1 && int.TryParse(route.Substring(0, index), out var nodeId))
+            if (index > -1 && int.TryParse(route.AsSpan(0, index), out var nodeId))
             {
                 documentStartNodeId = nodeId;
                 route = route.Substring(index);

--- a/src/Umbraco.Core/DeliveryApi/ApiPublishedContentCache.cs
+++ b/src/Umbraco.Core/DeliveryApi/ApiPublishedContentCache.cs
@@ -71,7 +71,7 @@ public sealed class ApiPublishedContentCache : IApiPublishedContentCache
         // e.g. "1234/second-root-url-segment". in V15+, IDocumentUrlService won't resolve this anymore; it will
         // however resolve "1234/" correctly, so to remain backwards compatible, we need to perform this extra step.
         var verifyUrlSegment = false;
-        if (documentKey is null && route.TrimEnd('/').CountOccurrences("/") is 1)
+        if (documentKey is null && route.AsSpan().TrimEnd('/').Count('/') is 1)
         {
             documentKey = _apiDocumentUrlService.GetDocumentKeyByRoute(
                 route[..(route.IndexOf('/') + 1)],

--- a/src/Umbraco.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Umbraco.Core/Extensions/DictionaryExtensions.cs
@@ -268,18 +268,27 @@ public static class DictionaryExtensions
         }
 
         var builder = new StringBuilder();
+        bool first = true;
         foreach (KeyValuePair<string, object?> i in d)
         {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                builder.Append('&');
+            }
+
             builder.Append(WebUtility.UrlEncode(i.Key));
             builder.Append('=');
             if (i.Value != null)
             {
                 builder.Append(WebUtility.UrlEncode(i.Value.ToString()));
             }
-            builder.Append('&');
         }
 
-        return builder.ToString().TrimEnd(Constants.CharArrays.Ampersand);
+        return builder.ToString();
     }
 
     /// <summary>The get entry ignore case.</summary>

--- a/src/Umbraco.Core/Extensions/DocumentUrlAliasServiceExtensions.cs
+++ b/src/Umbraco.Core/Extensions/DocumentUrlAliasServiceExtensions.cs
@@ -16,7 +16,6 @@ internal static class DocumentUrlAliasServiceExtensions
     public static string NormalizeAlias(this IDocumentUrlAliasService service, string alias) =>
         alias
             .Trim()
-            .TrimStart('/')
-            .TrimEnd('/')
+            .Trim('/')
             .ToLowerInvariant();
 }

--- a/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Manipulation.cs
@@ -194,7 +194,7 @@ public static partial class StringExtensions
         for (var i = 0; i < queryStrings.Length; i++)
         {
             queryStrings[i] = queryStrings[i].TrimStart(Constants.CharArrays.QuestionMarkAmpersand)
-                .TrimEnd(Constants.CharArrays.Ampersand);
+                .TrimEnd('&');
         }
 
         var nonEmpty = queryStrings.Where(x => !x.IsNullOrWhiteSpace()).ToArray();

--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -406,7 +406,7 @@ public static class UdiGetterExtensions
     /// </returns>
     private static StringUdi GetUdiFromPath(string entityType, string path)
     {
-        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace("\\", "/");
+        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace('\\', '/');
 
         return new StringUdi(entityType, id).EnsureClosed();
     }

--- a/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UdiGetterExtensions.cs
@@ -406,7 +406,7 @@ public static class UdiGetterExtensions
     /// </returns>
     private static StringUdi GetUdiFromPath(string entityType, string path)
     {
-        string id = path.TrimStart(Constants.CharArrays.ForwardSlash).Replace('\\', '/');
+        string id = path.TrimStart('/').Replace('\\', '/');
 
         return new StringUdi(entityType, id).EnsureClosed();
     }

--- a/src/Umbraco.Core/Extensions/UriExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UriExtensions.cs
@@ -21,7 +21,7 @@ public static class UriExtensions
     /// <remarks>Everything else remains unchanged, except for the fragment which is removed.</remarks>
     public static Uri Rewrite(this Uri uri, string path)
     {
-        if (path.StartsWith("/", StringComparison.Ordinal) == false)
+        if (path.StartsWith('/') == false)
         {
             throw new ArgumentException("Path must start with a slash.", "path");
         }
@@ -41,12 +41,12 @@ public static class UriExtensions
     /// <remarks>Everything else remains unchanged, except for the fragment which is removed.</remarks>
     public static Uri Rewrite(this Uri uri, string path, string query)
     {
-        if (path.StartsWith("/", StringComparison.Ordinal) == false)
+        if (path.StartsWith('/') == false)
         {
             throw new ArgumentException("Path must start with a slash.", "path");
         }
 
-        if (query.Length > 0 && query.StartsWith("?", StringComparison.Ordinal) == false)
+        if (query.Length > 0 && query.StartsWith('?') == false)
         {
             throw new ArgumentException("Query must start with a question mark.", "query");
         }
@@ -142,7 +142,7 @@ public static class UriExtensions
             if (path != "/")
             {
                 uri = new Uri(
-                    $"{uri.GetLeftPart(UriPartial.Authority)}{path.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{uri.Query}"
+                    $"{uri.GetLeftPart(UriPartial.Authority)}{path.AsSpan().TrimEnd('/')}{uri.Query}"
                 );
             }
         }
@@ -150,7 +150,7 @@ public static class UriExtensions
         {
             if (path != "/")
             {
-                uri = new Uri($"{path.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{uri.Query}", UriKind.Relative);
+                uri = new Uri($"{path.AsSpan().TrimEnd('/')}{uri.Query}", UriKind.Relative);
             }
         }
 

--- a/src/Umbraco.Core/Extensions/UriExtensions.cs
+++ b/src/Umbraco.Core/Extensions/UriExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Umbraco.
 // See LICENSE for more details.
 
-using System;
 using System.Net;
 using System.Web;
 using Umbraco.Cms.Core;
@@ -113,7 +112,7 @@ public static class UriExtensions
         var path = uri.GetSafeAbsolutePath();
         if (uri.IsAbsoluteUri)
         {
-            if (path != "/" && path.EndsWith("/") == false)
+            if (path != "/" && path.EndsWith('/') == false)
             {
                 uri = new Uri(uri.GetLeftPart(UriPartial.Authority) + path + "/" + uri.Query);
             }
@@ -121,7 +120,7 @@ public static class UriExtensions
             return uri;
         }
 
-        if (path != "/" && path.EndsWith("/") == false)
+        if (path != "/" && path.EndsWith('/') == false)
         {
             uri = new Uri(path + "/" + uri.Query, UriKind.Relative);
         }
@@ -142,15 +141,16 @@ public static class UriExtensions
         {
             if (path != "/")
             {
-                uri = new Uri(uri.GetLeftPart(UriPartial.Authority) + path.TrimEnd(Constants.CharArrays.ForwardSlash) +
-                              uri.Query);
+                uri = new Uri(
+                    $"{uri.GetLeftPart(UriPartial.Authority)}{path.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{uri.Query}"
+                );
             }
         }
         else
         {
             if (path != "/")
             {
-                uri = new Uri(path.TrimEnd(Constants.CharArrays.ForwardSlash) + uri.Query, UriKind.Relative);
+                uri = new Uri($"{path.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{uri.Query}", UriKind.Relative);
             }
         }
 

--- a/src/Umbraco.Core/GuidUdi.cs
+++ b/src/Umbraco.Core/GuidUdi.cs
@@ -25,7 +25,7 @@ public class GuidUdi : Udi
     public GuidUdi(Uri uriValue)
         : base(uriValue)
     {
-        if (Guid.TryParse(uriValue.AbsolutePath.TrimStart(Constants.CharArrays.ForwardSlash), out Guid guid) == false)
+        if (Guid.TryParse(uriValue.AbsolutePath.AsSpan().TrimStart('/'), out Guid guid) == false)
         {
             throw new FormatException("URI \"" + uriValue + "\" is not a GUID entity ID.");
         }

--- a/src/Umbraco.Core/IO/IOHelper.cs
+++ b/src/Umbraco.Core/IO/IOHelper.cs
@@ -29,15 +29,14 @@ public abstract class IOHelper : IIOHelper
     {
         var retval = virtualPath;
 
-        if (virtualPath.StartsWith("~"))
+        if (virtualPath.StartsWith('~'))
         {
             retval = virtualPath.Replace("~", _hostingEnvironment.ApplicationVirtualPath);
         }
 
-        if (virtualPath.StartsWith("/") && !PathStartsWith(virtualPath, _hostingEnvironment.ApplicationVirtualPath))
+        if (virtualPath.StartsWith('/') && !PathStartsWith(virtualPath, _hostingEnvironment.ApplicationVirtualPath))
         {
-            retval = _hostingEnvironment.ApplicationVirtualPath + "/" +
-                     virtualPath.TrimStart(Constants.CharArrays.ForwardSlash);
+            retval = $"{_hostingEnvironment.ApplicationVirtualPath}/{virtualPath.AsSpan().TrimStart('/')}";
         }
 
         return retval;
@@ -71,9 +70,9 @@ public abstract class IOHelper : IIOHelper
         if (_hostingEnvironment.IsHosted)
         {
             var result = !string.IsNullOrEmpty(path) &&
-                         (path.StartsWith("~") || PathStartsWith(path, _hostingEnvironment.ApplicationVirtualPath))
+                         (path.StartsWith('~') || PathStartsWith(path, _hostingEnvironment.ApplicationVirtualPath))
                 ? _hostingEnvironment.MapPathWebRoot(path)
-                : _hostingEnvironment.MapPathWebRoot("~/" + path.TrimStart(Constants.CharArrays.ForwardSlash));
+                : _hostingEnvironment.MapPathWebRoot($"~/{path.AsSpan().TrimStart('/')}");
 
             if (result != null)
             {
@@ -149,7 +148,7 @@ public abstract class IOHelper : IIOHelper
     public bool VerifyFileExtension(string filePath, IEnumerable<string> validFileExtensions)
     {
         var ext = Path.GetExtension(filePath);
-        return ext != null && validFileExtensions.Contains(ext.TrimStart(Constants.CharArrays.Period));
+        return ext != null && validFileExtensions.Contains(ext.TrimStart('.'));
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/IO/PhysicalFileSystem.cs
+++ b/src/Umbraco.Core/IO/PhysicalFileSystem.cs
@@ -77,7 +77,7 @@ public class PhysicalFileSystem : IPhysicalFileSystem, IFileProviderFactory
 
         _rootPath = EnsureDirectorySeparatorChar(rootPath).TrimEnd(Path.DirectorySeparatorChar);
         _rootPathFwd = EnsureUrlSeparatorChar(_rootPath);
-        _rootUrl = EnsureUrlSeparatorChar(rootUrl).TrimEnd(Constants.CharArrays.ForwardSlash);
+        _rootUrl = EnsureUrlSeparatorChar(rootUrl).TrimEnd('/');
     }
 
     /// <summary>
@@ -300,18 +300,18 @@ public class PhysicalFileSystem : IPhysicalFileSystem, IFileProviderFactory
         // or on unix systems "/var/wwwroot/test/Meia/1234/img.jpg"
         if (_ioHelper.PathStartsWith(path, _rootPathFwd, '/'))
         {
-            return path.Substring(_rootPathFwd.Length).TrimStart(Constants.CharArrays.ForwardSlash);
+            return path.Substring(_rootPathFwd.Length).TrimStart('/');
         }
 
         // if it starts with the root URL, strip it and trim the starting slash to make it relative
         // eg "/Media/1234/img.jpg" => "1234/img.jpg"
         if (_ioHelper.PathStartsWith(path, _rootUrl, '/'))
         {
-            return path.Substring(_rootUrl.Length).TrimStart(Constants.CharArrays.ForwardSlash);
+            return path.Substring(_rootUrl.Length).TrimStart('/');
         }
 
         // unchanged - what else?
-        return path.TrimStart(Constants.CharArrays.ForwardSlash);
+        return path.TrimStart('/');
     }
 
     /// <summary>
@@ -370,7 +370,7 @@ public class PhysicalFileSystem : IPhysicalFileSystem, IFileProviderFactory
     /// <remarks>All separators are forward-slashes.</remarks>
     public string GetUrl(string? path)
     {
-        path = EnsureUrlSeparatorChar(path ?? string.Empty).Trim(Constants.CharArrays.ForwardSlash);
+        path = EnsureUrlSeparatorChar(path ?? string.Empty).Trim('/');
         return _rootUrl + "/" + path;
     }
 

--- a/src/Umbraco.Core/Media/UploadAutoFillProperties.cs
+++ b/src/Umbraco.Core/Media/UploadAutoFillProperties.cs
@@ -130,7 +130,7 @@ public class UploadAutoFillProperties
 
     private void SetProperties(IContentBase content, ImagingAutoFillUploadField autoFillConfig, string filepath, Stream filestream, string? culture, string? segment)
     {
-        var extension = (Path.GetExtension(filepath) ?? string.Empty).TrimStart(Constants.CharArrays.Period);
+        var extension = (Path.GetExtension(filepath) ?? string.Empty).TrimStart('.');
 
         Size? size = _imageDimensionExtractor.IsSupportedImageFormat(extension)
             ? _imageDimensionExtractor.GetDimensions(filestream) ?? new Size(Constants.Conventions.Media.DefaultSize, Constants.Conventions.Media.DefaultSize)

--- a/src/Umbraco.Core/Routing/AliasUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/AliasUrlProvider.cs
@@ -184,9 +184,9 @@ public class AliasUrlProvider : IUrlProvider
 
     #region Utilities
 
-    private string CombinePaths(string path1, string path2)
+    private static string CombinePaths(string path1, string path2)
     {
-        var path = path1.TrimEnd(Constants.CharArrays.ForwardSlash) + path2;
+        var path = $"{path1.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{path2}";
         return path == "/" ? path : path.TrimEnd(Constants.CharArrays.ForwardSlash);
     }
 

--- a/src/Umbraco.Core/Routing/AliasUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/AliasUrlProvider.cs
@@ -186,8 +186,8 @@ public class AliasUrlProvider : IUrlProvider
 
     private static string CombinePaths(string path1, string path2)
     {
-        var path = $"{path1.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{path2}";
-        return path == "/" ? path : path.TrimEnd(Constants.CharArrays.ForwardSlash);
+        var path = $"{path1.AsSpan().TrimEnd('/')}{path2}";
+        return path == "/" ? path : path.TrimEnd('/');
     }
 
     #endregion

--- a/src/Umbraco.Core/Routing/ContentFinderByKeyPath.cs
+++ b/src/Umbraco.Core/Routing/ContentFinderByKeyPath.cs
@@ -65,7 +65,7 @@ public class ContentFinderByKeyPath : ContentFinderByIdentifierPathBase, IConten
             return LogAndReturnFailure();
         }
 
-        var noSlashPath = path.Substring(1);
+        ReadOnlySpan<char> noSlashPath = path.AsSpan(1);
 
         if (Guid.TryParse(noSlashPath, out var nodeKey) == false)
         {

--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -224,7 +224,7 @@ public class DefaultUrlProvider : IUrlProvider
             : DomainUtilities.DomainForNode(
                 umbracoContext.Domains,
                 _siteDomainMapper,
-                int.Parse(route[..pos], CultureInfo.InvariantCulture),
+                int.Parse(route.AsSpan(0, pos), CultureInfo.InvariantCulture),
                 current,
                 culture);
 
@@ -313,9 +313,9 @@ public class DefaultUrlProvider : IUrlProvider
         return _uriUtility.UriFromUmbraco(uri, _requestSettings);
     }
 
-    private string CombinePaths(string path1, string path2)
+    private static string CombinePaths(string path1, string path2)
     {
-        var path = path1.TrimEnd(Constants.CharArrays.ForwardSlash) + path2;
+        var path = $"{path1.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{path2}";
         return path == "/" ? path : path.TrimEnd(Constants.CharArrays.ForwardSlash);
     }
 

--- a/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/DefaultUrlProvider.cs
@@ -315,8 +315,8 @@ public class DefaultUrlProvider : IUrlProvider
 
     private static string CombinePaths(string path1, string path2)
     {
-        var path = $"{path1.AsSpan().TrimEnd(Constants.CharArrays.ForwardSlash)}{path2}";
-        return path == "/" ? path : path.TrimEnd(Constants.CharArrays.ForwardSlash);
+        var path = $"{path1.AsSpan().TrimEnd('/')}{path2}";
+        return path == "/" ? path : path.TrimEnd('/');
     }
 
     #endregion

--- a/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
@@ -315,7 +315,7 @@ public class NewDefaultUrlProvider : IUrlProvider
 
     private string CombinePaths(string path1, string path2)
     {
-        var path = path1.TrimEnd(Constants.CharArrays.ForwardSlash) + path2;
-        return path == "/" ? path : path.TrimEnd(Constants.CharArrays.ForwardSlash);
+        var path = $"{path1.AsSpan().TrimEnd('/')}{path2}";
+        return path == "/" ? path : path.TrimEnd('/');
     }
 }

--- a/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
+++ b/src/Umbraco.Core/Routing/NewDefaultUrlProvider.cs
@@ -313,7 +313,7 @@ public class NewDefaultUrlProvider : IUrlProvider
         return _uriUtility.UriFromUmbraco(uri, _requestSettings);
     }
 
-    private string CombinePaths(string path1, string path2)
+    private static string CombinePaths(string path1, string path2)
     {
         var path = $"{path1.AsSpan().TrimEnd('/')}{path2}";
         return path == "/" ? path : path.TrimEnd('/');

--- a/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
+++ b/src/Umbraco.Core/Routing/PublishedUrlInfoProvider.cs
@@ -177,7 +177,7 @@ public class PublishedUrlInfoProvider : IPublishedUrlInfoProvider
 
     private async Task<Attempt<UrlInfo?>> VerifyCollisionAsync(IContent content, string url, string culture)
     {
-        var uri = new Uri(url.TrimEnd(Constants.CharArrays.ForwardSlash), UriKind.RelativeOrAbsolute);
+        var uri = new Uri(url.TrimEnd('/'), UriKind.RelativeOrAbsolute);
         if (uri.IsAbsoluteUri is false)
         {
             uri = uri.MakeAbsolute(_umbracoContextAccessor.GetRequiredUmbracoContext().CleanedUmbracoUrl);

--- a/src/Umbraco.Core/Routing/UriUtility.cs
+++ b/src/Umbraco.Core/Routing/UriUtility.cs
@@ -143,7 +143,7 @@ public sealed class UriUtility
 
         if (path != "/")
         {
-            path = path.TrimEnd(Constants.CharArrays.ForwardSlash);
+            path = path.TrimEnd('/');
 
             // perform fallback to root if the path was all slashes (i.e. https://some.where//////)
             if (path == string.Empty)

--- a/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
+++ b/src/Umbraco.Core/Routing/UrlProviderExtensions.cs
@@ -226,7 +226,7 @@ public static class UrlProviderExtensions
         IPublishedContentStatusFilteringService publishedContentStatusFilteringService)
     {
         // test for collisions on the 'main' URL
-        var uri = new Uri(url.TrimEnd(Constants.CharArrays.ForwardSlash), UriKind.RelativeOrAbsolute);
+        var uri = new Uri(url.TrimEnd('/'), UriKind.RelativeOrAbsolute);
         if (uri.IsAbsoluteUri == false)
         {
             uri = uri.MakeAbsolute(umbracoContext.CleanedUmbracoUrl);

--- a/src/Umbraco.Core/Semver/SemVersion.cs
+++ b/src/Umbraco.Core/Semver/SemVersion.cs
@@ -122,7 +122,7 @@ namespace Umbraco.Cms.Core.Semver
 #if NETSTANDARD
             var major = int.Parse(match.Groups["major"].Value);
 #else
-            var major = int.Parse(match.Groups["major"].Value, CultureInfo.InvariantCulture);
+            var major = int.Parse(match.Groups["major"].ValueSpan, CultureInfo.InvariantCulture);
 #endif
 
             Group minorMatch = match.Groups["minor"];
@@ -132,7 +132,7 @@ namespace Umbraco.Cms.Core.Semver
 #if NETSTANDARD
                 minor = int.Parse(minorMatch.Value);
 #else
-                minor = int.Parse(minorMatch.Value, CultureInfo.InvariantCulture);
+                minor = int.Parse(minorMatch.ValueSpan, CultureInfo.InvariantCulture);
 #endif
             }
             else if (strict)
@@ -147,7 +147,7 @@ namespace Umbraco.Cms.Core.Semver
 #if NETSTANDARD
                 patch = int.Parse(patchMatch.Value);
 #else
-                patch = int.Parse(patchMatch.Value, CultureInfo.InvariantCulture);
+                patch = int.Parse(patchMatch.ValueSpan, CultureInfo.InvariantCulture);
 #endif
             }
             else if (strict)

--- a/src/Umbraco.Core/Services/ContentTypeEditing/MediaTypeEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentTypeEditing/MediaTypeEditingService.cs
@@ -111,7 +111,7 @@ internal sealed class MediaTypeEditingService : ContentTypeEditingServiceBase<IM
     /// <inheritdoc />
     public async Task<PagedModel<MediaTypeFileExtensionMatchResult>> GetMediaTypesForFileExtensionWithMatchInfoAsync(string fileExtension, int skip, int take)
     {
-        fileExtension = fileExtension.TrimStart(Constants.CharArrays.Period).ToLowerInvariant();
+        fileExtension = fileExtension.TrimStart('.').ToLowerInvariant();
 
         IMediaType[] candidateMediaTypes = _mediaTypeService.GetAll().Where(mt => mt.CompositionPropertyTypes.Any(pt => pt.Alias == Constants.Conventions.Media.File)).ToArray();
         var results = new List<MediaTypeFileExtensionMatchResult>();

--- a/src/Umbraco.Core/StringUdi.cs
+++ b/src/Umbraco.Core/StringUdi.cs
@@ -23,7 +23,7 @@ public class StringUdi : Udi
     /// <param name="uriValue">The uri value of the udi.</param>
     public StringUdi(Uri uriValue)
         : base(uriValue) =>
-        Id = Uri.UnescapeDataString(uriValue.AbsolutePath.AsSpan().TrimStart(Constants.CharArrays.ForwardSlash));
+        Id = Uri.UnescapeDataString(uriValue.AbsolutePath.AsSpan().TrimStart('/'));
 
     /// <summary>
     ///     The string part of the identifier.

--- a/src/Umbraco.Core/StringUdi.cs
+++ b/src/Umbraco.Core/StringUdi.cs
@@ -23,7 +23,7 @@ public class StringUdi : Udi
     /// <param name="uriValue">The uri value of the udi.</param>
     public StringUdi(Uri uriValue)
         : base(uriValue) =>
-        Id = Uri.UnescapeDataString(uriValue.AbsolutePath.TrimStart(Constants.CharArrays.ForwardSlash));
+        Id = Uri.UnescapeDataString(uriValue.AbsolutePath.AsSpan().TrimStart(Constants.CharArrays.ForwardSlash));
 
     /// <summary>
     ///     The string part of the identifier.

--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -148,10 +148,10 @@ public sealed partial class HtmlLocalLinkParser
         {
             return _linkPattern.Replace(text, match =>
             {
-                if (match.Groups["culture"].Value.Equals(culture, StringComparison.OrdinalIgnoreCase)
+                if (match.Groups["culture"].ValueSpan.Equals(culture, StringComparison.OrdinalIgnoreCase)
                     && match.Groups["href"].Value == tagHref)
                 {
-                    return match.Groups[1].Value + newLink + match.Groups["closequote"].Value;
+                    return $"{match.Groups[1].ValueSpan}{newLink}{match.Groups["closequote"].ValueSpan}";
                 }
                 return match.Value;
             });
@@ -171,7 +171,7 @@ public sealed partial class HtmlLocalLinkParser
         MatchCollection localLinkTagMatches = _localLinkTagPattern.Matches(text);
         foreach (Match linkTag in localLinkTagMatches)
         {
-            if (Guid.TryParse(linkTag.Groups["guid"].Value, out Guid guid) is false)
+            if (Guid.TryParse(linkTag.Groups["guid"].ValueSpan, out Guid guid) is false)
             {
                 continue;
             }

--- a/src/Umbraco.Core/UdiParser.cs
+++ b/src/Umbraco.Core/UdiParser.cs
@@ -170,11 +170,11 @@ public sealed class UdiParser
             throw new FormatException($"Unknown entity type \"{entityType}\".");
         }
 
-        var path = uri.AbsolutePath.TrimStart('/');
+        ReadOnlySpan<char> path = uri.AbsolutePath.AsSpan().TrimStart('/');
 
         if (udiType == UdiType.GuidUdi)
         {
-            if (path == string.Empty)
+            if (path.IsEmpty)
             {
                 udi = GetRootUdi(uri.Host);
                 return true;
@@ -196,7 +196,7 @@ public sealed class UdiParser
 
         if (udiType == UdiType.StringUdi)
         {
-            udi = path == string.Empty ? GetRootUdi(uri.Host) : new StringUdi(uri.Host, Uri.UnescapeDataString(path));
+            udi = path.IsEmpty ? GetRootUdi(uri.Host) : new StringUdi(uri.Host, Uri.UnescapeDataString(path));
             return true;
         }
 

--- a/src/Umbraco.Core/UdiRange.cs
+++ b/src/Umbraco.Core/UdiRange.cs
@@ -111,7 +111,7 @@ public class UdiRange
         // Only specify selector if query string is not empty
         return string.IsNullOrEmpty(uri.Query)
             ? new UdiRange(udi)
-            : new UdiRange(udi, uri.Query.TrimStart(Constants.CharArrays.QuestionMark));
+            : new UdiRange(udi, uri.Query.TrimStart('?'));
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/UriUtilityCore.cs
+++ b/src/Umbraco.Core/UriUtilityCore.cs
@@ -62,7 +62,7 @@ public static class UriUtilityCore
         var pos = IndexOfPathEnd(uriSpan);
 
         ReadOnlySpan<char> path = pos > 0 ? uriSpan[..pos] : uriSpan;
-        path = path.TrimEnd(Constants.CharArrays.ForwardSlash);
+        path = path.TrimEnd('/');
 
         if (pos > 0)
         {

--- a/src/Umbraco.Core/UriUtilityCore.cs
+++ b/src/Umbraco.Core/UriUtilityCore.cs
@@ -61,7 +61,7 @@ public static class UriUtilityCore
         ReadOnlySpan<char> uriSpan = uri.AsSpan();
         var pos = IndexOfPathEnd(uriSpan);
 
-        var path = (pos > 0 ? uriSpan[..pos] : uriSpan).ToString();
+        ReadOnlySpan<char> path = pos > 0 ? uriSpan[..pos] : uriSpan;
         path = path.TrimEnd(Constants.CharArrays.ForwardSlash);
 
         if (pos > 0)
@@ -69,7 +69,7 @@ public static class UriUtilityCore
             return string.Concat(path, uriSpan[pos..]);
         }
 
-        return path;
+        return new string(path);
     }
 
     private static int IndexOfPathEnd(ReadOnlySpan<char> uri)

--- a/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
+++ b/src/Umbraco.Infrastructure/DeliveryApi/ApiRichTextParserBase.cs
@@ -43,7 +43,7 @@ internal abstract partial class ApiRichTextParserBase
             return ReplaceStatus.NoMatch;
         }
 
-        if (Guid.TryParse(match.Groups["guid"].Value, out Guid guid) is false)
+        if (Guid.TryParse(match.Groups["guid"].ValueSpan, out Guid guid) is false)
         {
             return ReplaceStatus.NoMatch;
         }

--- a/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
+++ b/src/Umbraco.Infrastructure/Migrations/Upgrade/UmbracoPlan.cs
@@ -224,9 +224,9 @@ public partial class UmbracoPlan : MigrationPlan
             if (match.Success)
             {
                 trackedVersion = new SemVersion(
-                    int.Parse(match.Groups[1].Value),
-                    int.Parse(match.Groups[2].Value),
-                    int.Parse(match.Groups[3].Value));
+                    int.Parse(match.Groups[1].ValueSpan),
+                    int.Parse(match.Groups[2].ValueSpan),
+                    int.Parse(match.Groups[3].ValueSpan));
             }
 
             if (string.Equals(transition.TargetState, state, StringComparison.OrdinalIgnoreCase))

--- a/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
+++ b/src/Umbraco.Infrastructure/ModelsBuilder/Building/TextBuilder.cs
@@ -75,7 +75,7 @@ public class TextBuilder : Builder
             sb.AppendFormat("using {0};\n", t);
         }
 
-        sb.Append("\n");
+        sb.Append('\n');
         sb.AppendFormat("namespace {0}\n", GetModelsNamespace());
         sb.Append("{\n");
 
@@ -135,7 +135,7 @@ public class TextBuilder : Builder
         {
             var p = s.IndexOf('`');
             WriteNonGenericClrType(sb, s[..p]);
-            sb.Append("<");
+            sb.Append('<');
             Type[] args = type.GetGenericArguments();
             for (var i = 0; i < args.Length; i++)
             {
@@ -242,7 +242,7 @@ public class TextBuilder : Builder
             {
                 if (more)
                 {
-                    sb.Append("\n");
+                    sb.Append('\n');
                 }
 
                 more = true;
@@ -369,7 +369,7 @@ public class TextBuilder : Builder
 
     private void WriteMixinProperty(StringBuilder sb, PropertyModel property, string mixinClrName)
     {
-        sb.Append("\n");
+        sb.Append('\n');
 
         // Adds xml summary to each property containing
         // property name and property description
@@ -421,7 +421,7 @@ public class TextBuilder : Builder
     {
         var mixinStatic = mixinClrName != null;
 
-        sb.Append("\n");
+        sb.Append('\n');
 
         if (property.Errors != null)
         {
@@ -444,12 +444,12 @@ public class TextBuilder : Builder
                 {
                     sb.Append("\t\t * ");
                     sb.Append(s);
-                    sb.Append("\n");
+                    sb.Append('\n');
                 }
             }
 
             sb.Append("\t\t *\n");
-            sb.Append("\n");
+            sb.Append('\n');
         }
 
         // Adds xml summary to each property containing
@@ -507,9 +507,9 @@ public class TextBuilder : Builder
                 property.ClrName);
             if (property.ModelClrType != typeof(object))
             {
-                sb.Append("<");
+                sb.Append('<');
                 WriteClrType(sb, property.ClrTypeName);
-                sb.Append(">");
+                sb.Append('>');
             }
 
             sb.AppendFormat(
@@ -519,7 +519,7 @@ public class TextBuilder : Builder
 
         if (property.Errors != null)
         {
-            sb.Append("\n");
+            sb.Append('\n');
             sb.Append("\t\t *\n");
             sb.Append("\t\t */\n");
         }
@@ -532,7 +532,7 @@ public class TextBuilder : Builder
         var mixinStaticGetterName = MixinStaticGetterName(property.ClrName);
 
         // if (type.StaticMixinMethods.Contains(mixinStaticGetterName)) return;
-        sb.Append("\n");
+        sb.Append('\n');
 
         if (!string.IsNullOrWhiteSpace(property.Name))
         {
@@ -553,9 +553,9 @@ public class TextBuilder : Builder
             mixinClrName);
         if (property.ModelClrType != typeof(object))
         {
-            sb.Append("<");
+            sb.Append('<');
             WriteClrType(sb, property.ClrTypeName);
-            sb.Append(">");
+            sb.Append('>');
         }
 
         sb.AppendFormat(
@@ -586,12 +586,12 @@ public class TextBuilder : Builder
                 {
                     sb.Append("\t\t * ");
                     sb.Append(s);
-                    sb.Append("\n");
+                    sb.Append('\n');
                 }
             }
 
             sb.Append("\t\t *\n");
-            sb.Append("\n");
+            sb.Append('\n');
         }
 
         if (!string.IsNullOrWhiteSpace(property.Name))
@@ -613,7 +613,7 @@ public class TextBuilder : Builder
 
         if (property.Errors != null)
         {
-            sb.Append("\n");
+            sb.Append('\n');
             sb.Append("\t\t *\n");
             sb.Append("\t\t */\n");
         }
@@ -631,7 +631,7 @@ public class TextBuilder : Builder
         if (p >= 0)
         {
             WriteNonGenericClrType(sb, type[..p]);
-            sb.Append("<");
+            sb.Append('<');
 
             var argsString = type[(p + 1)..^1]; // Extract content between '<' and the final '>'
             IReadOnlyList<string> args = SplitGenericArguments(argsString);
@@ -646,7 +646,7 @@ public class TextBuilder : Builder
                 WriteClrType(sb, args[i]);
             }
 
-            sb.Append(">");
+            sb.Append('>');
         }
         else
         {
@@ -720,7 +720,7 @@ public class TextBuilder : Builder
     private void WriteNonGenericClrType(StringBuilder sb, string s)
     {
         // map model types
-        s = Regex.Replace(s, @"\{(.*)\}\[\*\]", m => ModelsMap[m.Groups[1].Value + "[]"]);
+        s = Regex.Replace(s, @"\{(.*)\}\[\*\]", m => ModelsMap[$"{m.Groups[1].ValueSpan}[]"]);
 
         // takes care eg of "System.Int32" vs. "int"
         if (_typesMap.TryGetValue(s, out var typeName))

--- a/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/NPocoSqlExtensions.cs
@@ -1641,7 +1641,7 @@ namespace Umbraco.Extensions
             // then GetAliased for "[umbracoNode].[nodeId]" returns "[umbracoNode__nodeId]"
 
             MatchCollection matches = sql.SqlContext.SqlSyntax.AliasRegex.Matches(sql.SQL);
-            Match? match = matches.Cast<Match>().FirstOrDefault(m => m.Groups[1].Value.InvariantEquals(field));
+            Match? match = matches.FirstOrDefault(m => m.Groups[1].ValueSpan.Equals(field, StringComparison.InvariantCultureIgnoreCase));
             return match == null ? field : match.Groups[2].Value;
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1100,7 +1100,7 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
             // so... if query contains "[umbracoNode].[nodeId] AS [umbracoNode__nodeId]"
             // then GetAliased for "[umbracoNode].[nodeId]" returns "[umbracoNode__nodeId]"
             MatchCollection matches = SqlContext.SqlSyntax.AliasRegex.Matches(sql.SQL);
-            Match? match = matches.Cast<Match>().FirstOrDefault(m => m.Groups[1].Value.InvariantEquals(field));
+            Match? match = matches.FirstOrDefault(m => m.Groups[1].ValueSpan.Equals(field, StringComparison.InvariantCultureIgnoreCase));
             return match == null ? field : match.Groups[2].Value;
         }
 

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
@@ -218,7 +218,7 @@ internal sealed partial class SimilarNodeName
             {
                 Match match = matches[0];
                 Text = match.Groups[1].Value;
-                int number = int.TryParse(match.Groups[2].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out number)
+                int number = int.TryParse(match.Groups[2].ValueSpan, NumberStyles.Integer, CultureInfo.InvariantCulture, out number)
                     ? number
                     : 0;
                 Suffix = (uint?)number;

--- a/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/SqlSyntax/SqlSyntaxProviderBase.cs
@@ -644,12 +644,22 @@ public abstract class SqlSyntaxProviderBase<TSyntax> : ISqlSyntaxProvider
     public virtual string Format(IEnumerable<ColumnDefinition> columns)
     {
         var sb = new StringBuilder();
+        bool first = true;
         foreach (ColumnDefinition column in columns)
         {
-            sb.Append(Format(column) + ",\n");
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                sb.Append(",\n");
+            }
+
+            sb.Append(Format(column));
         }
 
-        return sb.ToString().TrimEnd(",\n");
+        return sb.ToString();
     }
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyNotificationHandlerBase.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/BlockEditorPropertyNotificationHandlerBase.cs
@@ -64,7 +64,7 @@ public abstract class BlockEditorPropertyNotificationHandlerBase<TBlockLayoutIte
                     return match.Value;
                 }
 
-                var oldKey = Guid.Parse(match.Value);
+                var oldKey = Guid.Parse(match.ValueSpan);
                 if (oldToNewKeys.ContainsKey(oldKey) == false)
                 {
                     oldToNewKeys[oldKey] = createGuid(oldKey);

--- a/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
+++ b/src/Umbraco.Infrastructure/PropertyEditors/ValueConverters/RteBlockRenderingValueConverter.cs
@@ -342,7 +342,7 @@ public class RteBlockRenderingValueConverter : SimpleRichTextValueConverter, IDe
         var blocksByKey = richTextBlockModel.ToDictionary(block => block.ContentKey);
 
         string RenderBlock(Match match) =>
-            Guid.TryParse(match.Groups["key"].Value, out Guid key) && blocksByKey.TryGetValue(key, out RichTextBlockItem? richTextBlockItem)
+            Guid.TryParse(match.Groups["key"].ValueSpan, out Guid key) && blocksByKey.TryGetValue(key, out RichTextBlockItem? richTextBlockItem)
                 ? _partialViewBlockEngine.ExecuteAsync(richTextBlockItem).GetAwaiter().GetResult()
                 : string.Empty;
 

--- a/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
+++ b/src/Umbraco.Infrastructure/Routing/RedirectTracker.cs
@@ -114,7 +114,7 @@ internal sealed class RedirectTracker : IRedirectTracker
             {
                 try
                 {
-                    var route = _publishedUrlProvider.GetUrl(publishedContent.Key, UrlMode.Relative, culture).TrimEnd(Constants.CharArrays.ForwardSlash);
+                    var route = _publishedUrlProvider.GetUrl(publishedContent.Key, UrlMode.Relative, culture).TrimEnd('/');
                     if (IsValidRoute(route) && HasPublishedUrlSegment(publishedContent.Key, culture))
                     {
                         StoreRoute(oldRoutes, publishedContent, culture, route, domainRootId.Value);
@@ -227,7 +227,7 @@ internal sealed class RedirectTracker : IRedirectTracker
             .FirstOrDefault(x => _domainCache.HasAssigned(x, includeWildcards: true));
 
     private string GetUrl(Guid contentKey, string languageIsoCode) =>
-        _publishedUrlProvider.GetUrl(contentKey, UrlMode.Relative, languageIsoCode).TrimEnd(Constants.CharArrays.ForwardSlash);
+        _publishedUrlProvider.GetUrl(contentKey, UrlMode.Relative, languageIsoCode).TrimEnd('/');
 
     /// <summary>
     /// Strips the domain's path prefix from a relative URL so that the route stored for redirect

--- a/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
+++ b/src/Umbraco.Web.Common/AspNetCore/AspNetCoreHostingEnvironment.cs
@@ -165,7 +165,7 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
     /// <inheritdoc />
     public string ToAbsolute(string virtualPath)
     {
-        if (!virtualPath.StartsWith("~/") && !virtualPath.StartsWith("/") && _urlProviderMode != UrlMode.Absolute)
+        if (!virtualPath.StartsWith("~/") && !virtualPath.StartsWith('/') && _urlProviderMode != UrlMode.Absolute)
         {
             throw new InvalidOperationException(
                 $"The value {virtualPath} for parameter {nameof(virtualPath)} must start with ~/ or /");
@@ -177,8 +177,7 @@ public class AspNetCoreHostingEnvironment : IHostingEnvironment
             return virtualPath;
         }
 
-        var fullPath = ApplicationVirtualPath.EnsureEndsWith('/') +
-                       virtualPath.TrimStart(Core.Constants.CharArrays.TildeForwardSlash);
+        var fullPath = $"{ApplicationVirtualPath.EnsureEndsWith('/')}{virtualPath.AsSpan().TrimStart(Core.Constants.CharArrays.TildeForwardSlash)}";
 
         return fullPath;
     }

--- a/src/Umbraco.Web.Common/Extensions/FormCollectionExtensions.cs
+++ b/src/Umbraco.Web.Common/Extensions/FormCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class FormCollectionExtensions
             builder.Append($"{key}={value}&");
         }
 
-        return builder.ToString().TrimEnd(Constants.CharArrays.Ampersand);
+        return builder.ToString().TrimEnd('&');
     }
 
     /// <summary>

--- a/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
+++ b/src/Umbraco.Web.Common/Filters/ModelBindingExceptionAttribute.cs
@@ -92,7 +92,7 @@ public sealed class ModelBindingExceptionAttribute : TypeFilterAttribute
 
             if (matches.Count >= 2)
             {
-                return string.Equals(matches[0].Value, matches[1].Value, StringComparison.InvariantCulture);
+                return matches[0].ValueSpan.Equals(matches[1].ValueSpan, StringComparison.InvariantCulture);
             }
 
             return false;

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Delivery/Services/ApiMediaQueryServiceTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Api.Delivery.Services;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services.Navigation;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Cms.Api.Delivery.Services;
+
+[TestFixture]
+public class ApiMediaQueryServiceTests
+{
+    private Mock<IPublishedMediaCache> _mediaCache = null!;
+    private Mock<IMediaNavigationQueryService> _navigationQueryService = null!;
+    private Mock<IPublishedMediaStatusFilteringService> _statusFilteringService = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mediaCache = new Mock<IPublishedMediaCache>();
+        _navigationQueryService = new Mock<IMediaNavigationQueryService>();
+        _statusFilteringService = new Mock<IPublishedMediaStatusFilteringService>();
+    }
+
+    private ApiMediaQueryService CreateSut() => new(
+        _mediaCache.Object,
+        NullLogger<ApiMediaQueryService>.Instance,
+        _navigationQueryService.Object,
+        _statusFilteringService.Object);
+
+    private IPublishedContent SetUpParentWithSingleChild(Guid parentKey, Guid childKey)
+    {
+        var child = new Mock<IPublishedContent>();
+        child.Setup(x => x.Key).Returns(childKey);
+
+        IEnumerable<Guid> childKeys = new[] { childKey };
+        _navigationQueryService.Setup(x => x.TryGetChildrenKeys(parentKey, out childKeys)).Returns(true);
+        _statusFilteringService
+            .Setup(x => x.FilterAvailable(It.IsAny<IEnumerable<Guid>>(), It.IsAny<string?>()))
+            .Returns(new[] { child.Object });
+
+        var parent = new Mock<IPublishedContent>();
+        parent.Setup(x => x.Key).Returns(parentKey);
+        return parent.Object;
+    }
+
+    // Only the "children:" prefix may be removed from the selector. The media key here deliberately begins
+    // with 'e' — a character that also appears in "children:" — so the test fails if prefix removal ever
+    // regresses into character-set trimming that eats into the key itself.
+    [Test]
+    public void Can_Resolve_ChildrenOf_By_Key_When_Key_Starts_With_A_Prefix_Character()
+    {
+        var parentKey = new Guid("eeeeeeee-1111-1111-1111-111111111111");
+        var childKey = new Guid("aaaaaaaa-2222-2222-2222-222222222222");
+
+        IPublishedContent parent = SetUpParentWithSingleChild(parentKey, childKey);
+        _mediaCache.Setup(x => x.GetById(parentKey)).Returns(parent);
+
+        var attempt = CreateSut().ExecuteQuery(
+            $"children:{parentKey}",
+            [],
+            [],
+            skip: 0,
+            take: 100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(attempt.Success, Is.True);
+            Assert.That(attempt.Result.Total, Is.EqualTo(1));
+            Assert.That(attempt.Result.Items, Is.EqualTo(new[] { childKey }));
+        });
+    }
+
+    // Same invariant for path-based resolution: the leading path segment "news" begins with characters that
+    // also appear in the "children:" prefix. Removing the prefix must leave the segment intact ("news"), so
+    // the node stays resolvable by path — a character-set trim would reduce it to "ws" and lose the node.
+    [Test]
+    public void Can_Resolve_ChildrenOf_By_Path_When_Segment_Starts_With_A_Prefix_Character()
+    {
+        var newsKey = new Guid("cccccccc-1111-1111-1111-111111111111");
+        var childKey = new Guid("aaaaaaaa-2222-2222-2222-222222222222");
+
+        var newsNode = new Mock<IPublishedContent>();
+        newsNode.Setup(x => x.Key).Returns(newsKey);
+        newsNode.Setup(x => x.Name).Returns("news");
+
+        IEnumerable<Guid> rootKeys = new[] { newsKey };
+        _navigationQueryService.Setup(x => x.TryGetRootKeys(out rootKeys)).Returns(true);
+        _mediaCache.Setup(x => x.GetById(false, newsKey)).Returns(newsNode.Object);
+
+        IEnumerable<Guid> childKeys = new[] { childKey };
+        _navigationQueryService.Setup(x => x.TryGetChildrenKeys(newsKey, out childKeys)).Returns(true);
+
+        var child = new Mock<IPublishedContent>();
+        child.Setup(x => x.Key).Returns(childKey);
+        _statusFilteringService
+            .Setup(x => x.FilterAvailable(It.IsAny<IEnumerable<Guid>>(), It.IsAny<string?>()))
+            .Returns(new[] { child.Object });
+
+        var attempt = CreateSut().ExecuteQuery(
+            "children:news",
+            [],
+            [],
+            skip: 0,
+            take: 100);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(attempt.Success, Is.True);
+            Assert.That(attempt.Result.Total, Is.EqualTo(1));
+            Assert.That(attempt.Result.Items, Is.EqualTo(new[] { childKey }));
+        });
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/DictionaryExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/DictionaryExtensionsTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
+
+[TestFixture]
+public class DictionaryExtensionsTests
+{
+    [Test]
+    public void ToQueryString_Empty_Dictionary_Returns_Empty_String()
+    {
+        var dictionary = new Dictionary<string, object?>();
+
+        Assert.AreEqual(string.Empty, dictionary.ToQueryString());
+    }
+
+    [Test]
+    public void ToQueryString_Single_Entry_Has_No_Separator()
+    {
+        var dictionary = new Dictionary<string, object?> { ["firstname"] = "shannon" };
+
+        Assert.AreEqual("firstname=shannon", dictionary.ToQueryString());
+    }
+
+    [Test]
+    public void ToQueryString_Multiple_Entries_Are_Ampersand_Separated_Without_Trailing_Ampersand()
+    {
+        var dictionary = new Dictionary<string, object?>
+        {
+            ["firstname"] = "shannon",
+            ["lastname"] = "deminick",
+        };
+
+        var result = dictionary.ToQueryString();
+
+        Assert.Multiple(() =>
+        {
+            // Dictionary enumeration order is not contractually guaranteed, so assert on the set of pairs.
+            Assert.That(result.Split('&'), Is.EquivalentTo(new[] { "firstname=shannon", "lastname=deminick" }));
+            Assert.That(result, Does.Not.StartWith("&"));
+            Assert.That(result, Does.Not.EndWith("&"));
+        });
+    }
+
+    [Test]
+    public void ToQueryString_Null_Value_Renders_Key_With_Empty_Value()
+    {
+        var dictionary = new Dictionary<string, object?> { ["key"] = null };
+
+        Assert.AreEqual("key=", dictionary.ToQueryString());
+    }
+
+    [Test]
+    public void ToQueryString_Encodes_Ampersand_In_Value_And_Does_Not_Trim_It()
+    {
+        var dictionary = new Dictionary<string, object?> { ["key"] = "a&b" };
+
+        // The '&' inside the value must be URL-encoded (never treated as a separator or trimmed).
+        Assert.AreEqual("key=a%26b", dictionary.ToQueryString());
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/DocumentUrlAliasServiceExtensionsTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Extensions/DocumentUrlAliasServiceExtensionsTests.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Extensions;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Extensions;
+
+[TestFixture]
+public class DocumentUrlAliasServiceExtensionsTests
+{
+    private static readonly IDocumentUrlAliasService _service = Mock.Of<IDocumentUrlAliasService>();
+
+    [TestCase("some-alias", "some-alias")]
+    [TestCase("  some-alias  ", "some-alias")]
+    [TestCase("/some-alias/", "some-alias")]
+    [TestCase("//some-alias//", "some-alias")]
+    [TestCase("Some-Mixed-Case", "some-mixed-case")]
+    [TestCase("  /Some/Nested-Alias/  ", "some/nested-alias")]
+    public void NormalizeAlias_Trims_Whitespace_And_Slashes_And_Lowercases(string alias, string expected)
+        => Assert.AreEqual(expected, _service.NormalizeAlias(alias));
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

Avoid allocating strings when spans can be used when:
- Parsing
- Concatenating values
- Splitting (here is also heap allocated an array to contain the strings)

This is archived by using spans from regex matches, trimming on spans & spans instead of sub-strings.

There is also
- count single chars with spans instead of 2 string replace operations, that allocates strings.
- removed some unneeded trim operations, that allocates a string, if trimming happens.

@AndyButland v17 version of #23399