### PR TITLE
Migrations: Migrate settings values for block editors when a block has no content values (closes #23392)

### DIFF
--- a/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
+++ b/src/Umbraco.Core/Models/Blocks/BlockEditorDataConverter.cs
@@ -74,10 +74,13 @@ public abstract class BlockEditorDataConverter<TValue, TLayout>
     {
         if (value is not null)
         {
-            var converted = ConvertOriginalBlockFormat(value.ContentData);
-            if (converted)
+            // Content and settings must be converted independently: a block can have no content
+            // property values to migrate (e.g. a structural element type) while its settings still
+            // carry legacy flat values that need relocating.
+            var contentConverted = ConvertOriginalBlockFormat(value.ContentData);
+            var settingsConverted = ConvertOriginalBlockFormat(value.SettingsData);
+            if (contentConverted || settingsConverted)
             {
-                ConvertOriginalBlockFormat(value.SettingsData);
                 AmendExpose(value);
             }
         }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/Blocks/BlockEditorDataConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/Blocks/BlockEditorDataConverterTests.cs
@@ -1,0 +1,355 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Infrastructure.Serialization;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Models.Blocks;
+
+[TestFixture]
+public class BlockEditorDataConverterTests
+{
+    private static readonly Guid _contentKey = new("1304e1dd-ac87-4396-84fe-8a399231cb3d");
+    private static readonly Guid _settingsKey = new("90859e4c-0000-4a05-b33f-9f06cb723da1");
+
+    // A legacy (v13) Block List value with one block referencing both a content and a settings element.
+    private const string LegacyJsonWithContentAndSettings = """
+    {
+        "layout": {
+            "Umbraco.BlockList": [
+                {
+                    "contentUdi": "umb://element/1304e1ddac87439684fe8a399231cb3d",
+                    "settingsUdi": "umb://element/90859e4c00004a05b33f9f06cb723da1"
+                }
+            ]
+        },
+        "contentData": [
+            {
+                "contentTypeKey": "a1d1123c-289b-4a05-b33f-9f06cb723da1",
+                "udi": "umb://element/1304e1ddac87439684fe8a399231cb3d",
+                "text": "Hello world"
+            }
+        ],
+        "settingsData": [
+            {
+                "contentTypeKey": "b2e2234d-390c-4b16-c44f-af17dc834eb2",
+                "udi": "umb://element/90859e4c00004a05b33f9f06cb723da1",
+                "cssClasses": "text-xl"
+            }
+        ]
+    }
+    """;
+
+    private static BlockListEditorDataConverter CreateConverter()
+        => new(new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory()));
+
+    private static BlockGridEditorDataConverter CreateGridConverter()
+        => new(new SystemTextJsonSerializer(new DefaultJsonSerializerEncoderFactory()));
+
+    /// <summary>
+    /// Regression test for https://github.com/umbraco/Umbraco-CMS/issues/23392.
+    /// Legacy (v13) settings values must be migrated into the new <see cref="BlockItemData.Values"/> array
+    /// even when the block's content element has no property values to migrate.
+    /// </summary>
+    [Test]
+    public void Can_Migrate_Settings_Values_When_Content_Has_No_Property_Values()
+    {
+        // Legacy Block List data where the content element has no property values (e.g. a structural
+        // element type), but the settings element carries flat cssClasses/customCSS values.
+        const string json = """
+        {
+            "layout": {
+                "Umbraco.BlockList": [
+                    {
+                        "contentUdi": "umb://element/1304e1ddac87439684fe8a399231cb3d",
+                        "settingsUdi": "umb://element/90859e4c00004a05b33f9f06cb723da1"
+                    }
+                ]
+            },
+            "contentData": [
+                {
+                    "contentTypeKey": "a1d1123c-289b-4a05-b33f-9f06cb723da1",
+                    "udi": "umb://element/1304e1ddac87439684fe8a399231cb3d"
+                }
+            ],
+            "settingsData": [
+                {
+                    "contentTypeKey": "b2e2234d-390c-4b16-c44f-af17dc834eb2",
+                    "udi": "umb://element/90859e4c00004a05b33f9f06cb723da1",
+                    "cssClasses": "text-xl",
+                    "customCSS": null
+                }
+            ]
+        }
+        """;
+
+        BlockListEditorDataConverter converter = CreateConverter();
+        BlockEditorData<BlockListValue, BlockListLayoutItem> result = converter.Deserialize(json);
+
+        Assert.AreEqual(1, result.BlockValue.SettingsData.Count);
+
+        BlockItemData settings = result.BlockValue.SettingsData[0];
+
+        // The flat legacy values must have been relocated into the Values array...
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(2, settings.Values.Count);
+
+            BlockPropertyValue? cssClasses = settings.Values.SingleOrDefault(v => v.Alias == "cssClasses");
+            Assert.IsNotNull(cssClasses);
+            Assert.AreEqual("text-xl", cssClasses!.Value?.ToString());
+
+            BlockPropertyValue? customCss = settings.Values.SingleOrDefault(v => v.Alias == "customCSS");
+            Assert.IsNotNull(customCss);
+            Assert.IsNull(customCss!.Value);
+
+            // ...and cleared from the raw property values so they are not written back to the DB.
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.IsEmpty(settings.RawPropertyValues);
+#pragma warning restore CS0618 // Type or member is obsolete
+        });
+    }
+
+    /// <summary>
+    /// The reported scenario in https://github.com/umbraco/Umbraco-CMS/issues/23392 is Block Grid.
+    /// The conversion logic is shared in the base <see cref="BlockEditorDataConverter{TValue, TLayout}"/>,
+    /// but this covers the Block Grid layout shape (nested areas) end-to-end.
+    /// </summary>
+    [Test]
+    public void Can_Migrate_Block_Grid_Settings_Values_When_Content_Has_No_Property_Values()
+    {
+        const string json = """
+        {
+            "layout": {
+                "Umbraco.BlockGrid": [
+                    {
+                        "contentUdi": "umb://element/1304e1ddac87439684fe8a399231cb3d",
+                        "settingsUdi": "umb://element/90859e4c00004a05b33f9f06cb723da1",
+                        "areas": [],
+                        "columnSpan": 12,
+                        "rowSpan": 1
+                    }
+                ]
+            },
+            "contentData": [
+                {
+                    "contentTypeKey": "a1d1123c-289b-4a05-b33f-9f06cb723da1",
+                    "udi": "umb://element/1304e1ddac87439684fe8a399231cb3d"
+                }
+            ],
+            "settingsData": [
+                {
+                    "contentTypeKey": "b2e2234d-390c-4b16-c44f-af17dc834eb2",
+                    "udi": "umb://element/90859e4c00004a05b33f9f06cb723da1",
+                    "cssClasses": "text-xl",
+                    "customCSS": null
+                }
+            ]
+        }
+        """;
+
+        BlockGridEditorDataConverter converter = CreateGridConverter();
+        BlockEditorData<BlockGridValue, BlockGridLayoutItem> result = converter.Deserialize(json);
+
+        Assert.AreEqual(1, result.BlockValue.SettingsData.Count);
+
+        BlockItemData settings = result.BlockValue.SettingsData[0];
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(2, settings.Values.Count);
+
+            BlockPropertyValue? cssClasses = settings.Values.SingleOrDefault(v => v.Alias == "cssClasses");
+            Assert.IsNotNull(cssClasses);
+            Assert.AreEqual("text-xl", cssClasses!.Value?.ToString());
+
+            BlockPropertyValue? customCss = settings.Values.SingleOrDefault(v => v.Alias == "customCSS");
+            Assert.IsNotNull(customCss);
+            Assert.IsNull(customCss!.Value);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.IsEmpty(settings.RawPropertyValues);
+#pragma warning restore CS0618 // Type or member is obsolete
+        });
+    }
+
+    [Test]
+    public void Can_Migrate_Content_Values_When_Only_Content_Has_Property_Values()
+    {
+        const string json = """
+        {
+            "layout": {
+                "Umbraco.BlockList": [
+                    {
+                        "contentUdi": "umb://element/1304e1ddac87439684fe8a399231cb3d"
+                    }
+                ]
+            },
+            "contentData": [
+                {
+                    "contentTypeKey": "a1d1123c-289b-4a05-b33f-9f06cb723da1",
+                    "udi": "umb://element/1304e1ddac87439684fe8a399231cb3d",
+                    "text": "Hello world"
+                }
+            ],
+            "settingsData": []
+        }
+        """;
+
+        BlockListEditorDataConverter converter = CreateConverter();
+        BlockEditorData<BlockListValue, BlockListLayoutItem> result = converter.Deserialize(json);
+
+        Assert.AreEqual(1, result.BlockValue.ContentData.Count);
+
+        BlockItemData content = result.BlockValue.ContentData[0];
+        Assert.Multiple(() =>
+        {
+            BlockPropertyValue? text = content.Values.SingleOrDefault(v => v.Alias == "text");
+            Assert.IsNotNull(text);
+            Assert.AreEqual("Hello world", text!.Value?.ToString());
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.IsEmpty(content.RawPropertyValues);
+#pragma warning restore CS0618 // Type or member is obsolete
+        });
+    }
+
+    [Test]
+    public void Can_Populate_References_From_Layout()
+    {
+        BlockListEditorDataConverter converter = CreateConverter();
+        BlockEditorData<BlockListValue, BlockListLayoutItem> result = converter.Deserialize(LegacyJsonWithContentAndSettings);
+
+        Assert.AreEqual(1, result.References.Count);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(_contentKey, result.References[0].ContentKey);
+            Assert.AreEqual(_settingsKey, result.References[0].SettingsKey);
+        });
+    }
+
+    [Test]
+    public void Can_Resolve_Keys_From_Legacy_Udi()
+    {
+        BlockListEditorDataConverter converter = CreateConverter();
+        BlockEditorData<BlockListValue, BlockListLayoutItem> result = converter.Deserialize(LegacyJsonWithContentAndSettings);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(_contentKey, result.BlockValue.ContentData[0].Key);
+            Assert.AreEqual(_settingsKey, result.BlockValue.SettingsData[0].Key);
+        });
+    }
+
+    [Test]
+    public void Can_Amend_Expose_When_Migrating_Legacy_Data()
+    {
+        BlockListEditorDataConverter converter = CreateConverter();
+        BlockEditorData<BlockListValue, BlockListLayoutItem> result = converter.Deserialize(LegacyJsonWithContentAndSettings);
+
+        // migrating legacy (pre-block-level-variance) data should expose every content block invariantly
+        Assert.AreEqual(1, result.BlockValue.Expose.Count);
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(_contentKey, result.BlockValue.Expose[0].ContentKey);
+            Assert.IsNull(result.BlockValue.Expose[0].Culture);
+            Assert.IsNull(result.BlockValue.Expose[0].Segment);
+        });
+    }
+
+    [Test]
+    public void Cannot_Reconvert_New_Format_Data()
+    {
+        // Data already in the new format: values are populated and expose is explicitly set (here with a
+        // culture, which AmendExpose would overwrite to null if it wrongly ran on already-migrated data).
+        var json = $$"""
+        {
+            "layout": {
+                "Umbraco.BlockList": [
+                    {
+                        "contentKey": "{{_contentKey}}",
+                        "settingsKey": "{{_settingsKey}}"
+                    }
+                ]
+            },
+            "contentData": [
+                {
+                    "key": "{{_contentKey}}",
+                    "contentTypeKey": "a1d1123c-289b-4a05-b33f-9f06cb723da1",
+                    "values": [ { "alias": "text", "value": "Hello world" } ]
+                }
+            ],
+            "settingsData": [
+                {
+                    "key": "{{_settingsKey}}",
+                    "contentTypeKey": "b2e2234d-390c-4b16-c44f-af17dc834eb2",
+                    "values": [ { "alias": "cssClasses", "value": "text-xl" } ]
+                }
+            ],
+            "expose": [ { "contentKey": "{{_contentKey}}", "culture": "en-US", "segment": null } ]
+        }
+        """;
+
+        BlockListEditorDataConverter converter = CreateConverter();
+        BlockEditorData<BlockListValue, BlockListLayoutItem> result = converter.Deserialize(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.AreEqual(1, result.BlockValue.ContentData[0].Values.Count);
+            Assert.AreEqual(1, result.BlockValue.SettingsData[0].Values.Count);
+
+            // expose must be left exactly as deserialized - not regenerated by AmendExpose
+            Assert.AreEqual(1, result.BlockValue.Expose.Count);
+            Assert.AreEqual("en-US", result.BlockValue.Expose[0].Culture);
+        });
+    }
+
+    [Test]
+    public void Cannot_Build_References_When_Layout_Is_Missing()
+    {
+        // Layout only contains a foreign block editor alias, so there's nothing for the Block List converter.
+        const string json = """
+        {
+            "layout": {
+                "Umbraco.BlockGrid": [
+                    { "contentUdi": "umb://element/1304e1ddac87439684fe8a399231cb3d" }
+                ]
+            },
+            "contentData": [
+                {
+                    "contentTypeKey": "a1d1123c-289b-4a05-b33f-9f06cb723da1",
+                    "udi": "umb://element/1304e1ddac87439684fe8a399231cb3d"
+                }
+            ],
+            "settingsData": []
+        }
+        """;
+
+        BlockListEditorDataConverter converter = CreateConverter();
+        BlockEditorData<BlockListValue, BlockListLayoutItem> result = converter.Deserialize(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsEmpty(result.References);
+            Assert.IsEmpty(result.BlockValue.ContentData);
+        });
+    }
+
+    [Test]
+    public void Can_TryDeserialize_Valid_Json()
+    {
+        BlockListEditorDataConverter converter = CreateConverter();
+
+        var success = converter.TryDeserialize(LegacyJsonWithContentAndSettings, out BlockEditorData<BlockListValue, BlockListLayoutItem>? result);
+
+        Assert.IsTrue(success);
+        Assert.IsNotNull(result);
+    }
+
+    [Test]
+    public void Cannot_TryDeserialize_Invalid_Json()
+    {
+        BlockListEditorDataConverter converter = CreateConverter();
+
+        var success = converter.TryDeserialize("this is not json", out BlockEditorData<BlockListValue, BlockListLayoutItem>? result);
+
+        Assert.IsFalse(success);
+        Assert.IsNull(result);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/Blocks/BlockEditorDataConverterTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/Blocks/BlockEditorDataConverterTests.cs
@@ -105,6 +105,10 @@ public class BlockEditorDataConverterTests
 #pragma warning disable CS0618 // Type or member is obsolete
             Assert.IsEmpty(settings.RawPropertyValues);
 #pragma warning restore CS0618 // Type or member is obsolete
+
+            // ...and the content block must still be exposed - AmendExpose is the other half of the migration.
+            Assert.AreEqual(1, result.BlockValue.Expose.Count);
+            Assert.AreEqual(_contentKey, result.BlockValue.Expose[0].ContentKey);
         });
     }
 
@@ -167,6 +171,9 @@ public class BlockEditorDataConverterTests
 #pragma warning disable CS0618 // Type or member is obsolete
             Assert.IsEmpty(settings.RawPropertyValues);
 #pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual(1, result.BlockValue.Expose.Count);
+            Assert.AreEqual(_contentKey, result.BlockValue.Expose[0].ContentKey);
         });
     }
 


### PR DESCRIPTION
## Description

When upgrading from Umbraco 13 to 17, the block editor migration (`ConvertBlockListEditorProperties` / `ConvertBlockGridEditorProperties`, run as part of the V15 upgrade) relocates a block's legacy flat property values into the new strongly-typed `values` array. For **settings** elements carrying properties, when the content element has no properties, this relocation was silently skipped, leaving the values orphaned and the editor showing them as empty:

```jsonc
// Broken result after migration
"settingsData": [{
  "key": "90859e4c-...",
  "values": [],            // never populated
  "cssClasses": "text-xl", // orphaned legacy value, never moved
  "customCSS": null
}]
```

Fixes #23392

### Root cause

The conversion lives in the shared base `BlockEditorDataConverter<TValue, TLayout>.Convert` (used by Block List, Block Grid, RTE and Single block). Settings-data conversion was gated behind content-data conversion returning `true`:

```csharp
var converted = ConvertOriginalBlockFormat(value.ContentData);
if (converted)
{
    ConvertOriginalBlockFormat(value.SettingsData); // only ran if CONTENT converted
    AmendExpose(value);
}
```

`ConvertOriginalBlockFormat` only returns `true` when a block actually had raw property values to migrate. So when **no content element had migratable values** (e.g. a structural/property-less content element type, or blocks whose content properties were all empty) **but the settings element did**, the settings converstion — and `AmendExpose` — were skipped entirely for every block in the property.

### Fix

Run the content and settings conversions independently, amending `Expose` if **either** converted:

```csharp
var contentConverted = ConvertOriginalBlockFormat(value.ContentData);
var settingsConverted = ConvertOriginalBlockFormat(value.SettingsData);
if (contentConverted || settingsConverted)
{
    AmendExpose(value);
}
```

This is safe for the other paths:
- **Already-migrated (new-format) data** – both passes return `false`, so `AmendExpose` is not called and existing `Expose` is preserved. No behaviour change.
- **Old data with content values** – unchanged (content converts, settings still converts).

It also **self-heals already-upgraded broken sites**: the orphaned flat values are still physically present in the stored JSON, so on the next read/resave through this converter they are finally relocated into `values`.

## Testing

### Automated
Added `BlockEditorDataConverterTests` (10 tests). Two are regression tests (Block List and Block Grid) verified to **fail before the fix and pass after**; the remaining eight fill previously-missing coverage of the converter class.

### Manual
Verified end-to-end against a real 13 -> 17 upgrade:

1. **Build a v13 site**: a Block List with a block whose **content element type has no properties** and whose **settings element type has a couple of properties**. Add a block, populate the settings properties, save & publish. Take a backup copy of the database.
2. **Reproduce (pre-fix code)**: point a v17 app *without* this fix at a fresh copy of the v13 DB and boot. The migration runs; the block's settings show empty properties, and the stored JSON has `"values": []` with orphaned key/values for the properties.
3. **Verify clean migration (this fix)**: point the fixed app at another fresh copy of the v13 DB and boot. The block's settings now show their values, and the stored JSON has the value relocated into `values`.
