### PR TITLE
Collection Views: Accumulate table selection across pages (closes #23403)

### DIFF
--- a/src/Umbraco.Web.UI.Client/docs/testing.md
+++ b/src/Umbraco.Web.UI.Client/docs/testing.md
@@ -108,6 +108,16 @@ it('should do something', async () => {
 });
 ```
 
+**Assertion style**: for length/count checks, prefer Chai's `lengthOf` matcher over asserting on `.length` directly — it works on any value with a numeric `length` (arrays, strings, etc.) and gives a clearer failure message that reports the actual length:
+
+```typescript
+// ✅ Reports "expected [ '1', '2' ] to have a length of 3 but got 2"
+expect(element.selection).to.have.lengthOf(3);
+
+// ❌ Reports only "expected 2 to equal 3" — loses the collection context
+expect(element.selection.length).to.equal(3);
+```
+
 ### Unit Test Guidelines
 
 **What to Test**:

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.test.ts
@@ -57,7 +57,7 @@ describe('UmbTableElement', () => {
 			await toggleSelectAll(true);
 
 			expect(element.selection).to.have.members(['1', '2', '3']);
-			expect(element.selection.length).to.equal(3);
+			expect(element.selection).to.have.lengthOf(3);
 		});
 
 		it('excludes non-selectable rows from the current page', async () => {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.test.ts
@@ -1,0 +1,147 @@
+import { UmbTableElement, type UmbTableConfig, type UmbTableItem } from './table.element.js';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+
+function item(id: string, overrides: Partial<UmbTableItem> = {}): UmbTableItem {
+	return { id, data: [], ...overrides };
+}
+
+function items(ids: Array<string>): Array<UmbTableItem> {
+	return ids.map((id) => item(id));
+}
+
+describe('UmbTableElement', () => {
+	let element: UmbTableElement;
+
+	const config: UmbTableConfig = { allowSelection: true, allowSelectAll: true };
+
+	beforeEach(async () => {
+		element = await fixture(html`<umb-table></umb-table>`);
+		element.config = config;
+	});
+
+	function getHeaderCheckbox(): HTMLInputElement {
+		return element.shadowRoot!.querySelector('uui-table-head uui-checkbox') as unknown as HTMLInputElement;
+	}
+
+	async function toggleSelectAll(checked: boolean) {
+		const checkbox = getHeaderCheckbox();
+		checkbox.checked = checked;
+		checkbox.dispatchEvent(new Event('change'));
+		await element.updateComplete;
+	}
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbTableElement);
+	});
+
+	describe('select all across pages', () => {
+		it('accumulates the current page into the existing selection instead of replacing it', async () => {
+			// Page 1
+			element.items = items(['1', '2', '3', '4']);
+			await element.updateComplete;
+			await toggleSelectAll(true);
+			expect(element.selection).to.have.members(['1', '2', '3', '4']);
+
+			// Navigate to page 2 — the selection persists across the page change
+			element.items = items(['5', '6', '7', '8']);
+			await element.updateComplete;
+			await toggleSelectAll(true);
+
+			expect(element.selection).to.have.members(['1', '2', '3', '4', '5', '6', '7', '8']);
+		});
+
+		it('does not duplicate ids already present in the selection', async () => {
+			element.items = items(['1', '2', '3']);
+			element.selection = ['1'];
+			await element.updateComplete;
+			await toggleSelectAll(true);
+
+			expect(element.selection).to.have.members(['1', '2', '3']);
+			expect(element.selection.length).to.equal(3);
+		});
+
+		it('excludes non-selectable rows from the current page', async () => {
+			element.items = [item('1'), item('2', { selectable: false }), item('3')];
+			await element.updateComplete;
+			await toggleSelectAll(true);
+
+			expect(element.selection).to.have.members(['1', '3']);
+		});
+
+		it('emits a selected event', async () => {
+			element.items = items(['1', '2']);
+			await element.updateComplete;
+
+			const listener = oneEvent(element, 'selected');
+			await toggleSelectAll(true);
+			const event = await listener;
+
+			expect(event).to.exist;
+		});
+	});
+
+	describe('deselect all across pages', () => {
+		it('removes only the current page, leaving other pages selected', async () => {
+			element.items = items(['1', '2', '3', '4']);
+			element.selection = ['1', '2', '3', '4', '5', '6', '7', '8'];
+			await element.updateComplete;
+			await toggleSelectAll(false);
+
+			expect(element.selection).to.have.members(['5', '6', '7', '8']);
+		});
+
+		it('emits a deselected event', async () => {
+			element.items = items(['1', '2']);
+			element.selection = ['1', '2'];
+			await element.updateComplete;
+
+			const listener = oneEvent(element, 'deselected');
+			await toggleSelectAll(false);
+			const event = await listener;
+
+			expect(event).to.exist;
+		});
+	});
+
+	describe('header checkbox state', () => {
+		it('is checked when every selectable row on the current page is selected', async () => {
+			element.items = items(['1', '2', '3', '4']);
+			element.selection = ['1', '2', '3', '4', '5'];
+			await element.updateComplete;
+
+			const checkbox = getHeaderCheckbox();
+			expect(checkbox.checked).to.be.true;
+			expect(checkbox.indeterminate).to.be.false;
+		});
+
+		it('is unchecked when no row on the current page is selected, even if other pages are', async () => {
+			element.items = items(['5', '6', '7', '8']);
+			element.selection = ['1', '2', '3', '4'];
+			await element.updateComplete;
+
+			const checkbox = getHeaderCheckbox();
+			expect(checkbox.checked).to.be.false;
+			expect(checkbox.indeterminate).to.be.false;
+		});
+
+		it('is indeterminate when only some rows on the current page are selected', async () => {
+			element.items = items(['1', '2', '3', '4']);
+			element.selection = ['1', '2'];
+			await element.updateComplete;
+
+			const checkbox = getHeaderCheckbox();
+			expect(checkbox.checked).to.be.false;
+			expect(checkbox.indeterminate).to.be.true;
+		});
+
+		it('is unchecked when the current page has no selectable rows', async () => {
+			element.items = items(['1', '2']).map((i) => ({ ...i, selectable: false }));
+			element.selection = [];
+			await element.updateComplete;
+
+			const checkbox = getHeaderCheckbox();
+			expect(checkbox.checked).to.be.false;
+			expect(checkbox.indeterminate).to.be.false;
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -402,7 +402,8 @@ export class UmbTableElement extends UmbLitElement {
 		// Compute the header state against the current page only — the selection can span multiple
 		// pages, so comparing its total length against the page size gives the wrong state.
 		const selectableIds = this.items.filter((item) => this.#isSelectableItem(item)).map((item) => item.id);
-		const allSelected = selectableIds.length > 0 && selectableIds.every((id) => this.selection.includes(id));
+		const selectionSet = new Set(this.selection);
+		const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selectionSet.has(id));
 		return html`
 			<uui-table-head-cell style="--uui-table-cell-padding: 0; text-align: center;">
 				${when(

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -404,6 +404,7 @@ export class UmbTableElement extends UmbLitElement {
 		const selectableIds = this.items.filter((item) => this.#isSelectableItem(item)).map((item) => item.id);
 		const selectionSet = new Set(this.selection);
 		const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selectionSet.has(id));
+		const indeterminate = !allSelected && selectableIds.some((id) => selectionSet.has(id));
 		return html`
 			<uui-table-head-cell style="--uui-table-cell-padding: 0; text-align: center;">
 				${when(
@@ -413,7 +414,8 @@ export class UmbTableElement extends UmbLitElement {
 							aria-label=${this.localize.term('general_selectAll')}
 							style="padding: var(--uui-size-4) var(--uui-size-5);"
 							@change="${this._handleAllRowsCheckboxChange}"
-							?checked=${allSelected}></uui-checkbox>
+							?checked=${allSelected}
+							.indeterminate=${indeterminate}></uui-checkbox>
 					`,
 				)}
 			</uui-table-head-cell>

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/table/table.element.ts
@@ -309,7 +309,10 @@ export class UmbTableElement extends UmbLitElement {
 			throw new Error('Select all is not allowed in the current table configuration.');
 		}
 
-		this.selection = this.items.filter((item) => this.#isSelectableItem(item)).map((item) => item.id);
+		// Merge the current page's selectable rows into the existing selection so selections
+		// accumulate across pages rather than replacing the previous page's selection.
+		const currentPageIds = this.items.filter((item) => this.#isSelectableItem(item)).map((item) => item.id);
+		this.selection = [...new Set([...this.selection, ...currentPageIds])];
 		this._selectionMode = true;
 		this.dispatchEvent(new UmbTableSelectedEvent());
 	}
@@ -319,8 +322,10 @@ export class UmbTableElement extends UmbLitElement {
 			throw new Error('Select all is not allowed in the current table configuration.');
 		}
 
-		this.selection = [];
-		this._selectionMode = false;
+		// Only remove the current page's rows, leaving any selection from other pages intact.
+		const currentPageIds = new Set(this.items.map((item) => item.id));
+		this.selection = this.selection.filter((id) => !currentPageIds.has(id));
+		this._selectionMode = this.selection.length > 0;
 		this.dispatchEvent(new UmbTableDeselectedEvent());
 	}
 
@@ -394,6 +399,10 @@ export class UmbTableElement extends UmbLitElement {
 
 	private _renderHeaderCheckboxCell() {
 		if (this.config.hideIcon && !this.config.allowSelection) return;
+		// Compute the header state against the current page only — the selection can span multiple
+		// pages, so comparing its total length against the page size gives the wrong state.
+		const selectableIds = this.items.filter((item) => this.#isSelectableItem(item)).map((item) => item.id);
+		const allSelected = selectableIds.length > 0 && selectableIds.every((id) => this.selection.includes(id));
 		return html`
 			<uui-table-head-cell style="--uui-table-cell-padding: 0; text-align: center;">
 				${when(
@@ -403,7 +412,7 @@ export class UmbTableElement extends UmbLitElement {
 							aria-label=${this.localize.term('general_selectAll')}
 							style="padding: var(--uui-size-4) var(--uui-size-5);"
 							@change="${this._handleAllRowsCheckboxChange}"
-							?checked=${this.selection.length === this.items.length}></uui-checkbox>
+							?checked=${allSelected}></uui-checkbox>
 					`,
 				)}
 			</uui-table-head-cell>


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes #23403

### Description

In any paginated table collection view, the header **"select all"** checkbox replaced the current selection with only the visible page's rows instead of accumulating across pages. Selecting all on page 1, moving to page 2, and selecting all again dropped page 1's selection — making it impossible to bulk-select items across multiple pages. Selecting rows individually already accumulated correctly, so select-all was inconsistent with per-row selection. (In Umbraco 13 select-all accumulated.)

Originally reported against Umbraco Forms ([Umbraco.Forms.Issues#1754](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1754)), but Forms holds no selection state of its own — it delegates entirely to the CMS collection stack (`UmbDefaultCollectionContext` → `UmbCollectionSelectionManager`, `UmbPaginationManager`, `umb-table`), so the defect is in the shared CMS `umb-table` component and reproduces in other paginated lists throughout the backoffice.

#### Root cause

In `umb-table`, per-row select **appended** to the selection but select-all **overwrote** it with only the currently-rendered page's rows:

- `_selectRow` → `this.selection = [...this.selection, item.id]` (append ✅)
- `_selectAllRows` → `this.selection = this.items.filter(...).map(...)` (replace with current page only ❌)
- `_deselectAllRows` → `this.selection = []` (cleared every page ❌)

`this.items` holds only the current page, while `this.selection` is the cross-page total, so select-all discarded the other pages. The header checkbox had a related display bug: `?checked=${this.selection.length === this.items.length}` compared a cross-page total against a single page's size, so it could show checked on a page whose rows were not selected.

Pagination itself was **not** the cause — the collection context preserves the selection across page changes; the loss happened entirely in the select-all path.

#### Changes

Single file — `packages/core/components/table/table.element.ts`:

- `_selectAllRows` merges the current page's selectable rows into the existing selection instead of replacing it.
- `_deselectAllRows` removes only the current page's rows, leaving other pages' selections intact.
- The header "select all" checkbox `?checked` state is now computed against the current page only.

No changes were needed in the collection view or selection manager: the `selected`/`deselected` events already carry the full `table.selection`, so the corrected value flows through the existing plumbing to every consumer.

### How to test

1. Open a paginated table collection with more than one page (e.g. a Content collection with paging, or Forms → Entries).
2. Tick the header "select all" checkbox to select every row on page 1.
3. Go to page 2 and tick "select all" again.
4. **Expected:** page 1's selection is preserved and page 2 is added (e.g. 20/100 → 40/100). Navigating back to page 1 shows its rows still selected.
5. On page 2, untick "select all" → only page 2's rows are removed; page 1 stays selected.
6. With one page fully selected and the next page unselected, the header checkbox on the unselected page reads unchecked.
