### PR TITLE
Current User: Re-fetch the current user when authorization is regained after a session timeout

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/apps/app/app.element.ts
@@ -244,6 +244,9 @@ export class UmbAppElement extends UmbLitElement {
 					// TODO: Remove dependency on current user context from the app element in future [MR]
 					this.#loadCurrentUser();
 				} else {
+					// Authorization was lost (e.g. session timeout). Invalidate the loaded current user,
+					// as a subsequent sign-in may be for a different user.
+					this.#currentUser?.invalidate();
 					// TODO: Unregistering all extensions from v.18 [NL]
 					//void this.#unregisterExtensions();
 				}

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.test.ts
@@ -275,4 +275,44 @@ describe('UmbCurrentUserContext', () => {
 			});
 		});
 	});
+
+	describe('invalidate', () => {
+		beforeEach(async () => {
+			// Re-seed the mock data before loading, as earlier tests mutate the user group.
+			await useMockSet('kitchenSink');
+			await hostElement.init();
+		});
+
+		async function removeUsersSectionFromCurrentUserGroup() {
+			const userGroupRepo = new UmbUserGroupDetailRepository(hostElement);
+			const { data: userGroup } = await userGroupRepo.requestByUnique(CURRENT_USER_GROUP_UNIQUE);
+			expect(userGroup).to.exist;
+
+			await userGroupRepo.save({
+				...userGroup!,
+				sections: userGroup!.sections.filter((s) => s !== 'Umb.Section.Users'),
+			});
+		}
+
+		it('load() reuses the previous load and does not re-fetch', async () => {
+			expect(context.getAllowedSection()).to.include('Umb.Section.Users');
+
+			await removeUsersSectionFromCurrentUserGroup();
+
+			await context.load();
+
+			expect(context.getAllowedSection()).to.include('Umb.Section.Users');
+		});
+
+		it('load() re-fetches after invalidate()', async () => {
+			expect(context.getAllowedSection()).to.include('Umb.Section.Users');
+
+			await removeUsersSectionFromCurrentUserGroup();
+
+			context.invalidate();
+			await context.load();
+
+			expect(context.getAllowedSection()).to.not.include('Umb.Section.Users');
+		});
+	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
@@ -65,6 +65,15 @@ export class UmbCurrentUserContext extends UmbContextBase {
 		return this.#loadPromise;
 	}
 
+	/**
+	 * Invalidates the loaded current user, so that the next call to {@link load} fetches it from the server again.
+	 * Call this when the loaded user can no longer be trusted, e.g. when authorization is lost — a subsequent
+	 * sign-in may be for a different user.
+	 */
+	public invalidate(): void {
+		this.#loadPromise = undefined;
+	}
+
 	async #doLoad(): Promise<void> {
 		const { asObservable } = await this.#currentUserRepository.requestCurrentUser();
 
@@ -83,7 +92,7 @@ export class UmbCurrentUserContext extends UmbContextBase {
 	}
 
 	#loadDebounced = debounce(() => {
-		this.#loadPromise = undefined;
+		this.invalidate();
 		this.load();
 	}, 100);
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/current-user.context.ts
@@ -69,6 +69,12 @@ export class UmbCurrentUserContext extends UmbContextBase {
 	 * Invalidates the loaded current user, so that the next call to {@link load} fetches it from the server again.
 	 * Call this when the loaded user can no longer be trusted, e.g. when authorization is lost — a subsequent
 	 * sign-in may be for a different user.
+	 * @remarks The `#currentUser` state is deliberately NOT cleared here. The backoffice stays mounted behind
+	 * the login overlay during a session timeout, and several consumers observe the unfiltered observable
+	 * parts (e.g. recycle-bin conditions, sensitive-data property gating, language read-only checks) without
+	 * guarding against `undefined` — clearing would tear down or read-only-flip open workspaces mid-edit for
+	 * the common case of the same user signing back in. Consumers of the filtered {@link currentUser}
+	 * observable hold their last value until the fresh user has been fetched and then re-evaluate.
 	 */
 	public invalidate(): void {
 		this.#loadPromise = undefined;


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->

Related to the discussion on #19485 (deliberately kept out of scope of the `userAuthorizedEntryPoint` work — this is the underlying stale-cache bug).

### Description

`UmbCurrentUserContext.load()` dedupes concurrent callers via a persistent `#loadPromise` that was only ever reset by the debounced entity-updated reload. It was never reset when authorization changed. After a session timeout, a subsequent sign-in — potentially by a **different** user — hit the already-settled promise, so `load()` resolved without re-fetching and the backoffice kept showing the previous user's data and permissions until an unrelated user/user-group entity event forced a reload.

**Trace:** `auth.context.ts` `timeOut()` sets `isAuthorized` to `false` → the user signs in again and `isAuthorized` rises to `true` → the `isAuthorized` observer in `app.element.ts` calls `#loadCurrentUser()` → `load()` returns the stale settled promise; no fetch happens.

**Fix:**

- `UmbCurrentUserContext` gets a public `invalidate()` that resets the cached load so the next `load()` fetches from the server. The debounced entity-event reload now reuses it.
- `app.element.ts` calls `invalidate()` on the **falling** edge of `isAuthorized` (the else-branch it already owns), so the existing `#loadCurrentUser()` on the rising edge naturally re-fetches. Resetting on the falling edge — rather than forcing a reload on the rising edge — preserves the startup dedup where three call sites share a single request, and keeps `UmbCurrentUserContext` free of any `UMB_AUTH_CONTEXT` coupling.

Deliberately **not** done here: clearing the `#currentUser` state itself on deauth. The timeout flow keeps the backoffice mounted behind the login overlay, and several consumers observe the unfiltered `asObservablePart` observables without guarding against `undefined` (recycle-bin conditions, sensitive-data property gating, app-language/variant read-only checks). Clearing would tear down or read-only-flip open workspaces mid-edit for the common same-user re-login. The permission conditions all observe the filtered `currentUser` observable, which never emits a falsy value, so they correctly hold their last state until the fresh user arrives and then re-evaluate.

### Testing this contribution

Automated: two new tests in `current-user.context.test.ts` — one guarding the existing `load()` dedup, one verifying `load()` re-fetches after `invalidate()`. The latter was verified to fail against the unfixed code with the stale-data symptom (`expected [...] to not include 'Umb.Section.Users'`).

Manual:
1. Sign in to the backoffice and let the session time out (or revoke the session server-side).
2. When the login screen appears, sign in as a **different** user.
3. Before this fix, the backoffice keeps the previous user's name, avatar, allowed sections and permissions; with the fix, the new user's data is fetched immediately on sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZzphG9EZTxedTi9MScEBB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZzphG9EZTxedTi9MScEBB)_