### PR TITLE
Block: Restrict block thumbnail picker to image files (cherry-pick #21848)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/workspace/views/block-grid-type-workspace-view-advanced.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-grid/workspace/views/block-grid-type-workspace-view-advanced.element.ts
@@ -45,7 +45,7 @@ export class UmbBlockGridTypeWorkspaceViewAdvancedElement extends UmbLitElement 
 				<umb-property
 					label=${this.localize.term('blockEditor_thumbnail')}
 					alias="thumbnail"
-					property-editor-ui-alias="Umb.PropertyEditorUi.StaticFilePicker"
+					property-editor-ui-alias="Umb.PropertyEditorUi.StaticImageFilePicker"
 					.config=${[
 						{
 							alias: 'singleItemMode',

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-list/workspace/views/block-list-type-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-list/workspace/views/block-list-type-workspace-view.element.ts
@@ -62,7 +62,7 @@ export class UmbBlockListTypeWorkspaceViewSettingsElement extends UmbLitElement 
 				<umb-property
 					label=${this.localize.term('blockEditor_thumbnail')}
 					alias="thumbnail"
-					property-editor-ui-alias="Umb.PropertyEditorUi.StaticFilePicker"
+					property-editor-ui-alias="Umb.PropertyEditorUi.StaticImageFilePicker"
 					.config=${[
 						{
 							alias: 'singleItemMode',

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/workspace/views/block-rte-type-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-rte/workspace/views/block-rte-type-workspace-view.element.ts
@@ -67,7 +67,7 @@ export class UmbBlockRteTypeWorkspaceViewSettingsElement extends UmbLitElement i
 				<umb-property
 					label="Thumbnail"
 					alias="thumbnail"
-					property-editor-ui-alias="Umb.PropertyEditorUi.StaticFilePicker"
+					property-editor-ui-alias="Umb.PropertyEditorUi.StaticImageFilePicker"
 					.config=${[
 						{
 							alias: 'singleItemMode',

--- a/src/Umbraco.Web.UI.Client/src/packages/block/block-single/workspace/views/block-single-type-workspace-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block-single/workspace/views/block-single-type-workspace-view.element.ts
@@ -62,7 +62,7 @@ export class UmbBlockSingleTypeWorkspaceViewSettingsElement extends UmbLitElemen
 				<umb-property
 					label=${this.localize.term('blockEditor_thumbnail')}
 					alias="thumbnail"
-					property-editor-ui-alias="Umb.PropertyEditorUi.StaticFilePicker"
+					property-editor-ui-alias="Umb.PropertyEditorUi.StaticImageFilePicker"
 					.config=${[
 						{
 							alias: 'singleItemMode',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -6,6 +6,11 @@ import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { Observable } from '@umbraco-cms/backoffice/observable-api';
+import { map } from '@umbraco-cms/backoffice/external/rxjs';
+
+// SVG is rendered natively by browsers but can never appear in the server's imageFileTypes,
+// because the imaging pipeline cannot process it (#20574).
+const ADDITIONAL_DISPLAYABLE_IMAGE_FILE_TYPES = ['svg'];
 
 export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implements UmbApi {
 	/**
@@ -72,6 +77,25 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 		}
 
 		return this.#dataStore.part(part);
+	}
+
+	/**
+	 * Subscribe to the image file types that can be displayed directly by the browser.
+	 * This is the configured `imageFileTypes` plus formats browsers render natively but the server's
+	 * imaging pipeline cannot process (e.g. svg), so it is suited for display-only consumers such as
+	 * image pickers and previews — not for upload or cropping contexts, where the server-configured
+	 * `imageFileTypes` applies as-is.
+	 * @returns {Observable<Array<string>>} The file extensions, lowercased and without leading dots.
+	 */
+	displayableImageFileTypes(): Observable<Array<string>> {
+		return this.part('imageFileTypes').pipe(
+			map((fileTypes) => [
+				...new Set([
+					...(fileTypes ?? []).map((type) => type.toLowerCase()),
+					...ADDITIONAL_DISPLAYABLE_IMAGE_FILE_TYPES,
+				]),
+			]),
+		);
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/manifests.ts
@@ -1,3 +1,4 @@
 import { manifest as staticFilePickerManifest } from './static-file-picker/manifests.js';
+import { manifest as staticImageFilePickerManifest } from './static-image-file-picker/manifests.js';
 
-export const manifests: Array<UmbExtensionManifest> = [staticFilePickerManifest];
+export const manifests: Array<UmbExtensionManifest> = [staticFilePickerManifest, staticImageFilePickerManifest];

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-file-picker/property-editor-ui-static-file-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-file-picker/property-editor-ui-static-file-picker.element.ts
@@ -1,3 +1,4 @@
+import type { UmbStaticFileItemModel } from '../../repository/item/types.js';
 import type { UmbInputStaticFileElement } from '../../components/index.js';
 import type {
 	UmbPropertyEditorUiElement,
@@ -52,6 +53,8 @@ export class UmbPropertyEditorUIStaticFilePickerElement extends UmbLitElement im
 	@state()
 	private _limitMax: number = Infinity;
 
+	protected pickableFilter?: (item: UmbStaticFileItemModel) => boolean;
+
 	private _onChange(event: CustomEvent) {
 		if (this.#singleItemMode) {
 			this._value = (event.target as UmbInputStaticFileElement).selection[0];
@@ -65,6 +68,7 @@ export class UmbPropertyEditorUIStaticFilePickerElement extends UmbLitElement im
 	override render() {
 		return html`
 			<umb-input-static-file
+				.pickableFilter=${this.pickableFilter}
 				.selection=${this._value ? (Array.isArray(this._value) ? this._value : [this._value]) : []}
 				.min=${this._limitMin ?? 0}
 				.max=${this._limitMax ?? Infinity}

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/manifests.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/manifests.ts
@@ -1,0 +1,13 @@
+import type { ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/property-editor';
+
+export const manifest: ManifestPropertyEditorUi = {
+	type: 'propertyEditorUi',
+	alias: 'Umb.PropertyEditorUi.StaticImageFilePicker',
+	name: 'Static Image File Picker Property Editor UI',
+	element: () => import('./property-editor-ui-static-image-file-picker.element.js'),
+	meta: {
+		label: 'Static Image File Picker',
+		icon: 'icon-picture',
+		group: '#propertyEditorUIGroups_common',
+	},
+};

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.element.ts
@@ -1,0 +1,64 @@
+import { UmbPropertyEditorUIStaticFilePickerElement } from '../static-file-picker/property-editor-ui-static-file-picker.element.js';
+import { customElement, state } from '@umbraco-cms/backoffice/external/lit';
+import { UmbTemporaryFileConfigRepository } from '@umbraco-cms/backoffice/temporary-file';
+import { UmbServerFilePathUniqueSerializer } from '@umbraco-cms/backoffice/server-file-system';
+import { getFileExtension } from '@umbraco-cms/backoffice/utils';
+
+/**
+ * Decides whether a static file can be picked as an image.
+ * @param {string} path The server file path of the item.
+ * @param {boolean} isFolder Whether the item is a folder.
+ * @param {Array<string> | undefined} imageFileTypes The allowed image file extensions (without leading dots). When undefined or empty, any file is allowed.
+ * @returns {boolean} True if the item can be picked.
+ */
+export function isPickableImageFile(
+	path: string,
+	isFolder: boolean,
+	imageFileTypes: Array<string> | undefined,
+): boolean {
+	if (isFolder) return false;
+	if (!imageFileTypes || imageFileTypes.length === 0) return true;
+	const extension = getFileExtension(path)?.toLowerCase();
+	if (!extension) return false;
+	return imageFileTypes.includes(extension);
+}
+
+@customElement('umb-property-editor-ui-static-image-file-picker')
+export class UmbPropertyEditorUIStaticImageFilePickerElement extends UmbPropertyEditorUIStaticFilePickerElement {
+	#serializer = new UmbServerFilePathUniqueSerializer();
+	#temporaryFileConfigRepository = new UmbTemporaryFileConfigRepository(this);
+
+	@state()
+	private _imageFileTypes?: Array<string>;
+
+	constructor() {
+		super();
+
+		this.pickableFilter = (item) =>
+			isPickableImageFile(this.#serializer.toServerPath(item.unique) ?? '', item.isFolder, this._imageFileTypes);
+
+		this.#observeImageFileTypes();
+	}
+
+	async #observeImageFileTypes() {
+		await this.#temporaryFileConfigRepository.initialized;
+		if (!this.isConnected) return;
+		this.observe(
+			this.#temporaryFileConfigRepository.displayableImageFileTypes(),
+			(fileTypes) => {
+				this._imageFileTypes = fileTypes;
+			},
+			'_observeImageFileTypes',
+		);
+	}
+}
+
+export { UmbPropertyEditorUIStaticImageFilePickerElement as element };
+
+export default UmbPropertyEditorUIStaticImageFilePickerElement;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'umb-property-editor-ui-static-image-file-picker': UmbPropertyEditorUIStaticImageFilePickerElement;
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.stories.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.stories.ts
@@ -1,0 +1,14 @@
+import type { UmbPropertyEditorUIStaticImageFilePickerElement } from './property-editor-ui-static-image-file-picker.element.js';
+import type { Meta, StoryFn } from '@storybook/web-components-vite';
+import { html } from '@umbraco-cms/backoffice/external/lit';
+
+import './property-editor-ui-static-image-file-picker.element.js';
+
+export default {
+	title: 'Extension Type/Property Editor UI/Static Image File Picker',
+	component: 'umb-property-editor-ui-static-image-file-picker',
+	id: 'umb-property-editor-ui-static-image-file-picker',
+} as Meta;
+
+export const Docs: StoryFn<UmbPropertyEditorUIStaticImageFilePickerElement> = () =>
+	html` <umb-property-editor-ui-static-image-file-picker></umb-property-editor-ui-static-image-file-picker>`;

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.test.ts
@@ -1,0 +1,58 @@
+import {
+	UmbPropertyEditorUIStaticImageFilePickerElement,
+	isPickableImageFile,
+} from './property-editor-ui-static-image-file-picker.element.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+
+describe('UmbPropertyEditorUIStaticImageFilePickerElement', () => {
+	let element: UmbPropertyEditorUIStaticImageFilePickerElement;
+
+	beforeEach(async () => {
+		element = await fixture(
+			html` <umb-property-editor-ui-static-image-file-picker></umb-property-editor-ui-static-image-file-picker> `,
+		);
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbPropertyEditorUIStaticImageFilePickerElement);
+	});
+
+	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {
+		it('passes the a11y audit', async () => {
+			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
+		});
+	}
+
+	describe('isPickableImageFile', () => {
+		const imageFileTypes = ['jpg', 'jpeg', 'png', 'webp', 'svg'];
+
+		it('never allows folders to be picked', () => {
+			expect(isPickableImageFile('/wwwroot/images', true, imageFileTypes)).to.be.false;
+			expect(isPickableImageFile('/wwwroot/images', true, undefined)).to.be.false;
+		});
+
+		it('allows files with an allowed image extension', () => {
+			expect(isPickableImageFile('/wwwroot/images/logo.png', false, imageFileTypes)).to.be.true;
+			expect(isPickableImageFile('/wwwroot/images/icon.svg', false, imageFileTypes)).to.be.true;
+		});
+
+		it('matches extensions case-insensitively', () => {
+			expect(isPickableImageFile('/wwwroot/images/LOGO.PNG', false, imageFileTypes)).to.be.true;
+		});
+
+		it('rejects files with a non-image extension', () => {
+			expect(isPickableImageFile('/wwwroot/css/site.css', false, imageFileTypes)).to.be.false;
+			expect(isPickableImageFile('/wwwroot/js/app.js', false, imageFileTypes)).to.be.false;
+		});
+
+		it('rejects files without an extension', () => {
+			expect(isPickableImageFile('/wwwroot/README', false, imageFileTypes)).to.be.false;
+		});
+
+		it('allows any file while the configuration has not loaded yet', () => {
+			expect(isPickableImageFile('/wwwroot/css/site.css', false, undefined)).to.be.true;
+			expect(isPickableImageFile('/wwwroot/css/site.css', false, [])).to.be.true;
+		});
+	});
+});


### PR DESCRIPTION
### Description

Cherry-pick of #21848 (merged to `main` as ab73294988b) onto `v17/dev`, so the fix ships in the v17 line as well. Original contribution by @TechPdo, reworked per review to use the `imageFileTypes` configuration.

Summary of the change:

- New `Umb.PropertyEditorUi.StaticImageFilePicker` property editor UI that restricts picking to image files. Allowed formats come from the server's `imageFileTypes` configuration via `UmbTemporaryFileConfigRepository`, plus `svg` (browsers render it natively, but it can never appear in the imaging configuration).
- The allowed-formats logic is exposed centrally as `UmbTemporaryFileConfigRepository.displayableImageFileTypes()` for display-only consumers.
- The generic static file picker gains only a `protected pickableFilter` hook — no config API changes.
- The four block workspace views (list, grid, RTE, single) point the thumbnail property at the new UI. Folders remain navigable but can no longer be picked.

The cherry-pick applied clean (all touched files were identical between the two branches) and was re-verified on the v17 toolchain: static-file package tests, `tsc`, and lint all pass.

Fixed issue: #20574 (already closed by the `main` merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)