### PR TITLE
Config Repositories: Defer store-backed config observables via a shared base so consumers need not await initialized

### DIFF
--- a/src/Umbraco.Web.UI.Client/mocks/db/user.db.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/user.db.ts
@@ -71,18 +71,20 @@ class UmbUserMockDB extends UmbEntityMockDbBase<UmbMockUserModel> {
 		return [];
 	}
 
+	#passwordConfiguration = {
+		minimumPasswordLength: 8,
+		requireDigit: true,
+		requireLowercase: true,
+		requireUppercase: true,
+		requireNonLetterOrDigit: true,
+	};
+
 	getConfiguration(): UserConfigurationResponseModel {
 		return {
 			allowChangePassword: true,
 			allowTwoFactor: true,
 			canInviteUsers: true,
-			passwordConfiguration: {
-				minimumPasswordLength: 8,
-				requireDigit: true,
-				requireLowercase: true,
-				requireUppercase: true,
-				requireNonLetterOrDigit: true,
-			},
+			passwordConfiguration: this.#passwordConfiguration,
 			usernameIsEmail: true,
 		};
 	}
@@ -92,13 +94,7 @@ class UmbUserMockDB extends UmbEntityMockDbBase<UmbMockUserModel> {
 			allowChangePassword: true,
 			allowTwoFactor: true,
 			keepUserLoggedIn: true,
-			passwordConfiguration: {
-				minimumPasswordLength: 8,
-				requireDigit: true,
-				requireLowercase: true,
-				requireUppercase: true,
-				requireNonLetterOrDigit: true,
-			},
+			passwordConfiguration: this.#passwordConfiguration,
 		};
 	}
 

--- a/src/Umbraco.Web.UI.Client/mocks/db/user.db.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/db/user.db.ts
@@ -9,6 +9,7 @@ import { UmbId } from '@umbraco-cms/backoffice/id';
 import type {
 	CalculatedUserStartNodesResponseModel,
 	CreateUserRequestModel,
+	CurrentUserConfigurationResponseModel,
 	CurrentUserResponseModel,
 	InviteUserRequestModel,
 	PagedUserResponseModel,
@@ -83,6 +84,21 @@ class UmbUserMockDB extends UmbEntityMockDbBase<UmbMockUserModel> {
 				requireNonLetterOrDigit: true,
 			},
 			usernameIsEmail: true,
+		};
+	}
+
+	getCurrentConfiguration(): CurrentUserConfigurationResponseModel {
+		return {
+			allowChangePassword: true,
+			allowTwoFactor: true,
+			keepUserLoggedIn: true,
+			passwordConfiguration: {
+				minimumPasswordLength: 8,
+				requireDigit: true,
+				requireLowercase: true,
+				requireUppercase: true,
+				requireNonLetterOrDigit: true,
+			},
 		};
 	}
 

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/user/detail.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/user/detail.handlers.ts
@@ -24,6 +24,10 @@ export const detailHandlers = [
 		return HttpResponse.json(umbUserMockDb.getConfiguration());
 	}),
 
+	http.get(umbracoPath(`${UMB_SLUG}/current/configuration`), () => {
+		return HttpResponse.json(umbUserMockDb.getCurrentConfiguration());
+	}),
+
 	http.get(umbracoPath(`${UMB_SLUG}/:id/calculate-start-nodes`), ({ params }) => {
 		const id = params.id as string;
 		if (!id) return new HttpResponse(null, { status: 400 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.test.ts
@@ -1,0 +1,93 @@
+import { expect } from '@open-wc/testing';
+import { UmbConfigRepositoryBase } from './config-repository-base.js';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbStoreObjectBase } from '@umbraco-cms/backoffice/store';
+import { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+
+interface TestConfigModel {
+	foo: string;
+}
+
+class TestConfigStore extends UmbStoreObjectBase<TestConfigModel> {
+	constructor(host: UmbControllerHost) {
+		super(host, TEST_CONFIG_STORE_CONTEXT);
+	}
+}
+
+const TEST_CONFIG_STORE_CONTEXT = new UmbContextToken<TestConfigStore>('UmbTestConfigStore');
+
+class TestConfigRepository extends UmbConfigRepositoryBase<TestConfigModel> {
+	constructor(host: UmbControllerHost) {
+		super(host, TEST_CONFIG_STORE_CONTEXT);
+	}
+
+	protected override async _requestConfig(): Promise<TestConfigModel | undefined> {
+		return { foo: 'bar' };
+	}
+}
+
+@customElement('test-config-repository-base-host')
+class UmbTestConfigRepositoryBaseHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new TestConfigStore(this);
+	}
+}
+
+describe('UmbConfigRepositoryBase', () => {
+	let hostElement: UmbTestConfigRepositoryBaseHostElement;
+	let repository: TestConfigRepository;
+
+	beforeEach(() => {
+		// The host is intentionally NOT connected here. While disconnected, the store context is
+		// unresolved and the internal data store is undefined — the state a naive implementation throws in.
+		hostElement = new UmbTestConfigRepositoryBaseHostElement();
+		repository = new TestConfigRepository(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('part() subscribed before the store resolves does not throw and still delivers', async () => {
+		let observable!: ReturnType<typeof repository.part<'foo'>>;
+		expect(() => (observable = repository.part('foo'))).to.not.throw();
+
+		const value = firstValueFrom(observable);
+		document.body.appendChild(hostElement);
+
+		expect(await value).to.equal('bar');
+	});
+
+	it('all() subscribed before the store resolves does not throw and still delivers', async () => {
+		let observable!: ReturnType<typeof repository.all>;
+		expect(() => (observable = repository.all())).to.not.throw();
+
+		const value = firstValueFrom(observable);
+		document.body.appendChild(hostElement);
+
+		expect(await value).to.deep.equal({ foo: 'bar' });
+	});
+
+	it('deprecated initialized warns and still resolves', async () => {
+		document.body.appendChild(hostElement);
+
+		const originalWarn = console.warn;
+		let warned = '';
+		console.warn = (...args: Array<unknown>) => {
+			warned += args.map(String).join(' ');
+		};
+		try {
+			await repository.initialized;
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		expect(warned).to.contain('deprecated');
+		expect(warned).to.contain('initialized');
+		expect(await firstValueFrom(repository.part('foo'))).to.equal('bar');
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.ts
@@ -1,0 +1,84 @@
+import { UmbRepositoryBase } from './repository-base.js';
+import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import type { UmbContextToken } from '@umbraco-cms/backoffice/context-api';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type { UmbStoreObjectBase } from '@umbraco-cms/backoffice/store';
+import { type Observable, from, switchMap } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
+
+/**
+ * Base class for a repository exposing a single configuration object backed by an {@link UmbStoreObjectBase}.
+ * The configuration is fetched once per store context on initialization; `all()` and `part()` defer internally
+ * until it is ready, so consumers can subscribe immediately without awaiting.
+ */
+export abstract class UmbConfigRepositoryBase<ConfigModel> extends UmbRepositoryBase implements UmbApi {
+	#initialized: Promise<void>;
+	#dataStore?: UmbStoreObjectBase<ConfigModel>;
+
+	/**
+	 * Promise that resolves when the repository has been initialized, i.e. when the configuration has been fetched from the server.
+	 * @deprecated Deprecated since v17. Awaiting this is no longer necessary — all() and part() defer internally
+	 * until the configuration is ready, so you can subscribe directly. Scheduled for removal in Umbraco 19.
+	 * @returns {Promise<void>} A promise that resolves once the configuration has been fetched.
+	 */
+	get initialized(): Promise<void> {
+		new UmbDeprecation({
+			deprecated: 'The "initialized" property on config repositories is deprecated.',
+			removeInVersion: '19.0.0',
+			solution:
+				'Awaiting initialized is no longer necessary — all() and part() defer internally until the configuration is ready. Subscribe directly.',
+		}).warn();
+		return this.#initialized;
+	}
+
+	constructor(
+		host: UmbControllerHost,
+		storeContext: UmbContextToken<UmbStoreObjectBase<ConfigModel>>,
+		repositoryAlias?: string,
+	) {
+		super(host, repositoryAlias);
+		this.#initialized = new Promise<void>((resolve) => {
+			this.consumeContext(storeContext, async (store) => {
+				if (store) {
+					this.#dataStore = store;
+					await this.#init();
+					resolve();
+				}
+			});
+		});
+	}
+
+	/**
+	 * Fetches the configuration from the server. Implemented by the concrete repository using its own data source.
+	 * @returns {Promise<ConfigModel | undefined>} The configuration, or undefined if it could not be fetched.
+	 */
+	protected abstract _requestConfig(): Promise<ConfigModel | undefined>;
+
+	async #init() {
+		// Configuration is immutable per session — only fetch once per store context.
+		if (this.#dataStore?.getState()) {
+			return;
+		}
+		const config = await this._requestConfig();
+		if (config) {
+			this.#dataStore?.update(config);
+		}
+	}
+
+	/**
+	 * Subscribe to the entire configuration.
+	 * @returns {Observable<ConfigModel | null>} An observable of the configuration.
+	 */
+	all(): Observable<ConfigModel | null> {
+		return from(this.#initialized).pipe(switchMap(() => this.#dataStore!.all()));
+	}
+
+	/**
+	 * Subscribe to a part of the configuration.
+	 * @param {Part} part The configuration key to subscribe to.
+	 * @returns {Observable<ConfigModel[Part]>} An observable of that part.
+	 */
+	part<Part extends keyof ConfigModel>(part: Part): Observable<ConfigModel[Part]> {
+		return from(this.#initialized).pipe(switchMap(() => this.#dataStore!.part(part)));
+	}
+}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.ts
@@ -37,15 +37,15 @@ export abstract class UmbConfigRepositoryBase<ConfigModel> extends UmbRepository
 		repositoryAlias?: string,
 	) {
 		super(host, repositoryAlias);
-		this.#initialized = new Promise<void>((resolve) => {
-			this.consumeContext(storeContext, async (store) => {
-				if (store) {
-					this.#dataStore = store;
-					await this.#init();
-					resolve();
-				}
-			});
-		});
+		this.#initialized = this.consumeContext(storeContext, (store) => {
+			if (store) {
+				this.#dataStore = store;
+			}
+		})
+			.asPromise({ preventTimeout: true })
+			.then(() => this.#init())
+			// Ignore the error; a failed asPromise means the flow was stopped, not that consumption failed.
+			.catch(() => undefined);
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/config-repository-base.ts
@@ -12,7 +12,7 @@ import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
  * until it is ready, so consumers can subscribe immediately without awaiting.
  */
 export abstract class UmbConfigRepositoryBase<ConfigModel> extends UmbRepositoryBase implements UmbApi {
-	#initialized: Promise<void>;
+	readonly #initialized: Promise<void>;
 	#dataStore?: UmbStoreObjectBase<ConfigModel>;
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/repository/index.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/repository/index.ts
@@ -1,3 +1,4 @@
+export * from './config-repository-base.js';
 export * from './constants.js';
 export * from './data-mapper/index.js';
 export * from './detail/index.js';

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
@@ -58,29 +58,4 @@ describe('UmbTemporaryFileConfigRepository', () => {
 		const types = await firstValueFrom(repository.displayableImageFileTypes());
 		expect(types).to.deep.equal(['jpg', 'png', 'gif', 'jpeg', 'svg']);
 	});
-
-	it('deprecated initialized still resolves and warns, keeping the legacy await-then-subscribe pattern working', async () => {
-		document.body.appendChild(hostElement);
-
-		const originalWarn = console.warn;
-		let warned = '';
-		console.warn = (...args: Array<unknown>) => {
-			warned += args.map(String).join(' ');
-		};
-		try {
-			await repository.initialized;
-		} finally {
-			console.warn = originalWarn;
-		}
-
-		expect(warned).to.contain('deprecated');
-		expect(warned).to.contain('initialized');
-		expect(await firstValueFrom(repository.part('imageFileTypes'))).to.deep.equal([
-			'jpg',
-			'png',
-			'gif',
-			'jpeg',
-			'svg',
-		]);
-	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
@@ -30,6 +30,9 @@ describe('UmbTemporaryFileConfigRepository', () => {
 		document.body.innerHTML = '';
 	});
 
+	// The shared MSW mock returns imageFileTypes ['jpg','png','gif','jpeg','svg']. Production never
+	// includes svg there (the imaging pipeline cannot process it, #20574) — the mock includes it so the
+	// displayableImageFileTypes() de-duplication path is exercised below without svg appearing twice.
 	it('part() subscribed before the store resolves does not throw and still delivers', async () => {
 		let observable!: ReturnType<typeof repository.part<'imageFileTypes'>>;
 		expect(() => (observable = repository.part('imageFileTypes'))).to.not.throw();

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
@@ -59,8 +59,15 @@ describe('UmbTemporaryFileConfigRepository', () => {
 		expect(types).to.deep.equal(['jpg', 'png', 'gif', 'jpeg', 'svg']);
 	});
 
-	it('still resolves the initialized promise (backward compatible)', async () => {
+	it('still supports the legacy await-initialized-then-subscribe pattern (backward compatible)', async () => {
 		document.body.appendChild(hostElement);
 		await repository.initialized;
+		expect(await firstValueFrom(repository.part('imageFileTypes'))).to.deep.equal([
+			'jpg',
+			'png',
+			'gif',
+			'jpeg',
+			'svg',
+		]);
 	});
 });

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
@@ -59,9 +59,21 @@ describe('UmbTemporaryFileConfigRepository', () => {
 		expect(types).to.deep.equal(['jpg', 'png', 'gif', 'jpeg', 'svg']);
 	});
 
-	it('still supports the legacy await-initialized-then-subscribe pattern (backward compatible)', async () => {
+	it('deprecated initialized still resolves and warns, keeping the legacy await-then-subscribe pattern working', async () => {
 		document.body.appendChild(hostElement);
-		await repository.initialized;
+
+		const originalWarn = console.warn;
+		let warned = '';
+		console.warn = (...args: Array<unknown>) => {
+			warned += args.map(String).join(' ');
+		};
+		try {
+			await repository.initialized;
+		} finally {
+			console.warn = originalWarn;
+		}
+
+		expect(warned).to.contain('initialized is deprecated');
 		expect(await firstValueFrom(repository.part('imageFileTypes'))).to.deep.equal([
 			'jpg',
 			'png',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
@@ -1,0 +1,63 @@
+import { expect } from '@open-wc/testing';
+import { UmbTemporaryFileConfigRepository } from './config.repository.js';
+import { UmbTemporaryFileConfigStore } from './config.store.js';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+
+@customElement('test-temporary-file-config-host')
+class UmbTestTemporaryFileConfigHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new UmbTemporaryFileConfigStore(this);
+		new UmbNotificationContext(this);
+	}
+}
+
+describe('UmbTemporaryFileConfigRepository', () => {
+	let hostElement: UmbTestTemporaryFileConfigHostElement;
+	let repository: UmbTemporaryFileConfigRepository;
+
+	beforeEach(() => {
+		// The host is intentionally NOT connected here. While disconnected, the store context is
+		// unresolved and #dataStore is undefined — the exact state the old code threw in.
+		hostElement = new UmbTestTemporaryFileConfigHostElement();
+		repository = new UmbTemporaryFileConfigRepository(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('part() subscribed before the store resolves does not throw and still delivers', async () => {
+		let observable!: ReturnType<typeof repository.part<'imageFileTypes'>>;
+		expect(() => (observable = repository.part('imageFileTypes'))).to.not.throw();
+
+		const value = firstValueFrom(observable);
+		document.body.appendChild(hostElement);
+
+		expect(await value).to.deep.equal(['jpg', 'png', 'gif', 'jpeg', 'svg']);
+	});
+
+	it('all() subscribed before the store resolves does not throw and still delivers', async () => {
+		let observable!: ReturnType<typeof repository.all>;
+		expect(() => (observable = repository.all())).to.not.throw();
+
+		const value = firstValueFrom(observable);
+		document.body.appendChild(hostElement);
+
+		expect((await value)?.imageFileTypes).to.deep.equal(['jpg', 'png', 'gif', 'jpeg', 'svg']);
+	});
+
+	it('displayableImageFileTypes() includes svg once, all-lowercase', async () => {
+		document.body.appendChild(hostElement);
+		const types = await firstValueFrom(repository.displayableImageFileTypes());
+		expect(types).to.deep.equal(['jpg', 'png', 'gif', 'jpeg', 'svg']);
+	});
+
+	it('still resolves the initialized promise (backward compatible)', async () => {
+		document.body.appendChild(hostElement);
+		await repository.initialized;
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.test.ts
@@ -73,7 +73,8 @@ describe('UmbTemporaryFileConfigRepository', () => {
 			console.warn = originalWarn;
 		}
 
-		expect(warned).to.contain('initialized is deprecated');
+		expect(warned).to.contain('deprecated');
+		expect(warned).to.contain('initialized');
 		expect(await firstValueFrom(repository.part('imageFileTypes'))).to.deep.equal([
 			'jpg',
 			'png',

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -17,7 +17,7 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 	 * Promise that resolves when the repository has been initialized, i.e. when the configuration has been fetched from the server.
 	 * Awaiting this is no longer required before calling all(), part() or displayableImageFileTypes() — they defer internally.
 	 */
-	initialized;
+	initialized: Promise<void>;
 
 	#dataStore?: typeof UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT.TYPE;
 	#dataSource = new UmbTemporaryFileConfigServerDataSource(this);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -7,24 +7,38 @@ import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { Observable } from '@umbraco-cms/backoffice/observable-api';
 import { from, map, switchMap } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 
 // SVG is rendered natively by browsers but can never appear in the server's imageFileTypes,
 // because the imaging pipeline cannot process it (#20574).
 const ADDITIONAL_DISPLAYABLE_IMAGE_FILE_TYPES = ['svg'];
 
 export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implements UmbApi {
+	#initialized: Promise<void>;
+
 	/**
 	 * Promise that resolves when the repository has been initialized, i.e. when the configuration has been fetched from the server.
-	 * Awaiting this is no longer required before calling all(), part() or displayableImageFileTypes() — they defer internally.
+	 * @deprecated Deprecated since v17. Awaiting this is no longer necessary — all(), part() and
+	 * displayableImageFileTypes() defer internally until the configuration is ready, so you can subscribe
+	 * directly. Scheduled for removal in Umbraco 19.
+	 * @returns {Promise<void>} A promise that resolves once the configuration has been fetched.
 	 */
-	initialized: Promise<void>;
+	get initialized(): Promise<void> {
+		new UmbDeprecation({
+			deprecated: 'UmbTemporaryFileConfigRepository.initialized is deprecated.',
+			removeInVersion: '19.0.0',
+			solution:
+				'Awaiting initialized is no longer necessary — all(), part() and displayableImageFileTypes() defer internally until the configuration is ready. Subscribe directly.',
+		}).warn();
+		return this.#initialized;
+	}
 
 	#dataStore?: typeof UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT.TYPE;
 	#dataSource = new UmbTemporaryFileConfigServerDataSource(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_TEMPORARY_FILE_REPOSITORY_ALIAS.toString());
-		this.initialized = new Promise<void>((resolve) => {
+		this.#initialized = new Promise<void>((resolve) => {
 			this.consumeContext(UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT, async (store) => {
 				if (store) {
 					this.#dataStore = store;
@@ -58,7 +72,7 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 	 * @returns {Observable<UmbTemporaryFileConfigurationModel>}
 	 */
 	all() {
-		return from(this.initialized).pipe(switchMap(() => this.#dataStore!.all()));
+		return from(this.#initialized).pipe(switchMap(() => this.#dataStore!.all()));
 	}
 
 	/**
@@ -69,7 +83,7 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 	part<Part extends keyof UmbTemporaryFileConfigurationModel>(
 		part: Part,
 	): Observable<UmbTemporaryFileConfigurationModel[Part]> {
-		return from(this.initialized).pipe(switchMap(() => this.#dataStore!.part(part)));
+		return from(this.#initialized).pipe(switchMap(() => this.#dataStore!.part(part)));
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -11,7 +11,7 @@ import { type Observable, map } from '@umbraco-cms/backoffice/external/rxjs';
 const ADDITIONAL_DISPLAYABLE_IMAGE_FILE_TYPES = ['svg'];
 
 export class UmbTemporaryFileConfigRepository extends UmbConfigRepositoryBase<UmbTemporaryFileConfigurationModel> {
-	#dataSource = new UmbTemporaryFileConfigServerDataSource(this);
+	readonly #dataSource = new UmbTemporaryFileConfigServerDataSource(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT, UMB_TEMPORARY_FILE_REPOSITORY_ALIAS.toString());

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -2,88 +2,28 @@ import type { UmbTemporaryFileConfigurationModel } from '../types.js';
 import { UmbTemporaryFileConfigServerDataSource } from './config.server.data-source.js';
 import { UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT } from './config.store.token.js';
 import { UMB_TEMPORARY_FILE_REPOSITORY_ALIAS } from './constants.js';
-import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
-import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbConfigRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import type { Observable } from '@umbraco-cms/backoffice/observable-api';
-import { from, map, switchMap } from '@umbraco-cms/backoffice/external/rxjs';
-import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
+import { type Observable, map } from '@umbraco-cms/backoffice/external/rxjs';
 
 // SVG is rendered natively by browsers but can never appear in the server's imageFileTypes,
 // because the imaging pipeline cannot process it (#20574).
 const ADDITIONAL_DISPLAYABLE_IMAGE_FILE_TYPES = ['svg'];
 
-export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implements UmbApi {
-	#initialized: Promise<void>;
-
-	/**
-	 * Promise that resolves when the repository has been initialized, i.e. when the configuration has been fetched from the server.
-	 * @deprecated Deprecated since v17. Awaiting this is no longer necessary — all(), part() and
-	 * displayableImageFileTypes() defer internally until the configuration is ready, so you can subscribe
-	 * directly. Scheduled for removal in Umbraco 19.
-	 * @returns {Promise<void>} A promise that resolves once the configuration has been fetched.
-	 */
-	get initialized(): Promise<void> {
-		new UmbDeprecation({
-			deprecated: 'UmbTemporaryFileConfigRepository.initialized is deprecated.',
-			removeInVersion: '19.0.0',
-			solution:
-				'Awaiting initialized is no longer necessary — all(), part() and displayableImageFileTypes() defer internally until the configuration is ready. Subscribe directly.',
-		}).warn();
-		return this.#initialized;
-	}
-
-	#dataStore?: typeof UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT.TYPE;
+export class UmbTemporaryFileConfigRepository extends UmbConfigRepositoryBase<UmbTemporaryFileConfigurationModel> {
 	#dataSource = new UmbTemporaryFileConfigServerDataSource(this);
 
 	constructor(host: UmbControllerHost) {
-		super(host, UMB_TEMPORARY_FILE_REPOSITORY_ALIAS.toString());
-		this.#initialized = new Promise<void>((resolve) => {
-			this.consumeContext(UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT, async (store) => {
-				if (store) {
-					this.#dataStore = store;
-					await this.#init();
-					resolve();
-				}
-			});
-		});
+		super(host, UMB_TEMPORARY_FILE_CONFIG_STORE_CONTEXT, UMB_TEMPORARY_FILE_REPOSITORY_ALIAS.toString());
 	}
 
-	async #init() {
-		// Check if the store already has data
-		if (this.#dataStore?.getState()) {
-			return;
-		}
-
-		const temporaryFileConfig = await this.requestTemporaryFileConfiguration();
-
-		if (temporaryFileConfig) {
-			this.#dataStore?.update(temporaryFileConfig);
-		}
+	protected override _requestConfig() {
+		return this.requestTemporaryFileConfiguration();
 	}
 
 	async requestTemporaryFileConfiguration() {
 		const { data } = await this.#dataSource.getConfig();
 		return data;
-	}
-
-	/**
-	 * Subscribe to the entire configuration.
-	 * @returns {Observable<UmbTemporaryFileConfigurationModel>}
-	 */
-	all() {
-		return from(this.#initialized).pipe(switchMap(() => this.#dataStore!.all()));
-	}
-
-	/**
-	 * Subscribe to a part of the configuration.
-	 * @param part
-	 * @returns {Observable<UmbTemporaryFileConfigurationModel[Part]>}
-	 */
-	part<Part extends keyof UmbTemporaryFileConfigurationModel>(
-		part: Part,
-	): Observable<UmbTemporaryFileConfigurationModel[Part]> {
-		return from(this.#initialized).pipe(switchMap(() => this.#dataStore!.part(part)));
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/config/config.repository.ts
@@ -6,7 +6,7 @@ import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import type { Observable } from '@umbraco-cms/backoffice/observable-api';
-import { map } from '@umbraco-cms/backoffice/external/rxjs';
+import { from, map, switchMap } from '@umbraco-cms/backoffice/external/rxjs';
 
 // SVG is rendered natively by browsers but can never appear in the server's imageFileTypes,
 // because the imaging pipeline cannot process it (#20574).
@@ -15,6 +15,7 @@ const ADDITIONAL_DISPLAYABLE_IMAGE_FILE_TYPES = ['svg'];
 export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implements UmbApi {
 	/**
 	 * Promise that resolves when the repository has been initialized, i.e. when the configuration has been fetched from the server.
+	 * Awaiting this is no longer required before calling all(), part() or displayableImageFileTypes() — they defer internally.
 	 */
 	initialized;
 
@@ -57,11 +58,7 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 	 * @returns {Observable<UmbTemporaryFileConfigurationModel>}
 	 */
 	all() {
-		if (!this.#dataStore) {
-			throw new Error('Data store not initialized');
-		}
-
-		return this.#dataStore.all();
+		return from(this.initialized).pipe(switchMap(() => this.#dataStore!.all()));
 	}
 
 	/**
@@ -72,11 +69,7 @@ export class UmbTemporaryFileConfigRepository extends UmbRepositoryBase implemen
 	part<Part extends keyof UmbTemporaryFileConfigurationModel>(
 		part: Part,
 	): Observable<UmbTemporaryFileConfigurationModel[Part]> {
-		if (!this.#dataStore) {
-			throw new Error('Data store not initialized');
-		}
-
-		return this.#dataStore.part(part);
+		return from(this.initialized).pipe(switchMap(() => this.#dataStore!.part(part)));
 	}
 
 	/**

--- a/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/temporary-file/temporary-file-manager.class.ts
@@ -38,7 +38,6 @@ export class UmbTemporaryFileManager<
 	 * @returns {Promise<UmbTemporaryFileConfigRepository>} The temporary file configuration.
 	 */
 	async getConfiguration(): Promise<UmbTemporaryFileConfigRepository> {
-		await this.#temporaryFileConfigRepository.initialized;
 		return this.#temporaryFileConfigRepository;
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-image-cropper/input-image-cropper.element.ts
@@ -75,8 +75,7 @@ export class UmbInputImageCropperElement extends UmbFormControlMixin<
 		this.#observeAcceptedFileTypes();
 	}
 
-	async #observeAcceptedFileTypes() {
-		await this.#config.initialized;
+	#observeAcceptedFileTypes() {
 		this.observe(
 			this.#config.part('imageFileTypes'),
 			(imageFileTypes) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/image-cropper-editor/image-cropper-editor-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/modals/image-cropper-editor/image-cropper-editor-modal.element.ts
@@ -85,8 +85,7 @@ export class UmbImageCropperEditorModalElement extends UmbModalBaseElement<
 		this.#getSrc();
 	}
 
-	async #observeAcceptedFileTypes() {
-		await this.#config.initialized;
+	#observeAcceptedFileTypes() {
 		this.observe(
 			this.#config.part('imageFileTypes'),
 			(imageFileTypes) => (this.#imageFileTypes = imageFileTypes),

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/property-editor-ui-accepted-upload-types.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/accepted-types/property-editor-ui-accepted-upload-types.element.ts
@@ -14,10 +14,9 @@ export class UmbPropertyEditorUIAcceptedUploadTypesElement
 {
 	#temporaryFileConfigRepository = new UmbTemporaryFileConfigRepository(this);
 
-	override async connectedCallback() {
+	override connectedCallback() {
 		super.connectedCallback();
 
-		await this.#temporaryFileConfigRepository.initialized;
 		this.observe(this.#temporaryFileConfigRepository.all(), (config) => {
 			if (!config) return;
 

--- a/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/static-file/property-editors/static-image-file-picker/property-editor-ui-static-image-file-picker.element.ts
@@ -40,9 +40,7 @@ export class UmbPropertyEditorUIStaticImageFilePickerElement extends UmbProperty
 		this.#observeImageFileTypes();
 	}
 
-	async #observeImageFileTypes() {
-		await this.#temporaryFileConfigRepository.initialized;
-		if (!this.isConnected) return;
+	#observeImageFileTypes() {
 		this.observe(
 			this.#temporaryFileConfigRepository.displayableImageFileTypes(),
 			(fileTypes) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/change-password/modal/change-password-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/change-password/modal/change-password-modal.element.ts
@@ -80,9 +80,7 @@ export class UmbChangePasswordModalElement extends UmbModalBaseElement<
 		this.#loadPasswordConfiguration();
 	}
 
-	async #loadPasswordConfiguration() {
-		await this.#userConfigRepository.initialized;
-		if (!this.isConnected) return;
+	#loadPasswordConfiguration() {
 		this.observe(this.#userConfigRepository.part('passwordConfiguration'), (passwordConfig) => {
 			this._passwordConfiguration = passwordConfig;
 		});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/conditions/allow-mfa/current-user-allow-mfa-action.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/conditions/allow-mfa/current-user-allow-mfa-action.condition.ts
@@ -12,8 +12,7 @@ export class UmbCurrentUserAllowMfaActionCondition extends UmbConditionBase<neve
 		this.#init();
 	}
 
-	async #init() {
-		await this.#configRepository.initialized;
+	#init() {
 		this.observe(
 			observeMultiple([
 				this.#configRepository.part('allowTwoFactor'),

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user-config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user-config.repository.test.ts
@@ -1,0 +1,50 @@
+import { expect } from '@open-wc/testing';
+import { UmbCurrentUserConfigRepository } from './current-user-config.repository.js';
+import { UmbCurrentUserConfigStore } from './current-user-config.store.js';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+
+@customElement('test-current-user-config-host')
+class UmbTestCurrentUserConfigHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new UmbCurrentUserConfigStore(this);
+		new UmbNotificationContext(this);
+	}
+}
+
+describe('UmbCurrentUserConfigRepository', () => {
+	let hostElement: UmbTestCurrentUserConfigHostElement;
+	let repository: UmbCurrentUserConfigRepository;
+
+	beforeEach(() => {
+		// The host is intentionally NOT connected here, so the store context is unresolved when we subscribe.
+		hostElement = new UmbTestCurrentUserConfigHostElement();
+		repository = new UmbCurrentUserConfigRepository(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('part() subscribed before the store resolves does not throw and still delivers', async () => {
+		let observable!: ReturnType<typeof repository.part<'keepUserLoggedIn'>>;
+		expect(() => (observable = repository.part('keepUserLoggedIn'))).to.not.throw();
+
+		const value = firstValueFrom(observable);
+		document.body.appendChild(hostElement);
+
+		expect(await value).to.equal(true);
+	});
+
+	it('all() subscribed before the store resolves delivers the mocked configuration', async () => {
+		const value = firstValueFrom(repository.all());
+		document.body.appendChild(hostElement);
+
+		const config = await value;
+		expect(config?.allowChangePassword).to.equal(true);
+		expect(config?.allowTwoFactor).to.equal(true);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user-config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user-config.repository.ts
@@ -1,70 +1,19 @@
 import type { UmbCurrentUserConfigurationModel } from '../../user/types.js';
 import { UmbCurrentUserConfigServerDataSource } from './current-user-config.server.data-source.js';
 import { UMB_CURRENT_USER_CONFIG_STORE_CONTEXT } from './current-user-config.store.token.js';
-import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
-import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbConfigRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import type { Observable } from '@umbraco-cms/backoffice/observable-api';
 
-export class UmbCurrentUserConfigRepository extends UmbRepositoryBase implements UmbApi {
-	/**
-	 * Promise that resolves when the repository has been initialized, i.e. when the user configuration has been fetched from the server.
-	 * @memberof UmbCurrentUserConfigRepository
-	 */
-	initialized: Promise<void>;
-
-	#dataStore?: typeof UMB_CURRENT_USER_CONFIG_STORE_CONTEXT.TYPE;
+export class UmbCurrentUserConfigRepository extends UmbConfigRepositoryBase<UmbCurrentUserConfigurationModel> {
 	#dataSource = new UmbCurrentUserConfigServerDataSource(this);
 
 	constructor(host: UmbControllerHost) {
-		super(host);
-		this.initialized = new Promise<void>((resolve) => {
-			this.consumeContext(UMB_CURRENT_USER_CONFIG_STORE_CONTEXT, async (store) => {
-				if (store) {
-					this.#dataStore = store;
-					await this.#init();
-					resolve();
-				}
-			});
-		});
+		super(host, UMB_CURRENT_USER_CONFIG_STORE_CONTEXT);
 	}
 
-	async #init() {
-		// Check if the store already has data
-		if (this.#dataStore?.getState()) {
-			return;
-		}
-
+	protected override async _requestConfig() {
 		const { data } = await this.#dataSource.getCurrentUserConfig();
-
-		if (data) {
-			this.#dataStore?.update(data);
-		}
-	}
-
-	/**
-	 * Subscribe to the entire user configuration.
-	 */
-	all() {
-		if (!this.#dataStore) {
-			throw new Error('Data store not initialized');
-		}
-
-		return this.#dataStore.all();
-	}
-
-	/**
-	 * Subscribe to a part of the user configuration.
-	 * @param part
-	 */
-	part<Part extends keyof UmbCurrentUserConfigurationModel>(
-		part: Part,
-	): Observable<UmbCurrentUserConfigurationModel[Part]> {
-		if (!this.#dataStore) {
-			throw new Error('Data store not initialized');
-		}
-
-		return this.#dataStore.part(part);
+		return data;
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user-config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/repository/current-user-config.repository.ts
@@ -5,7 +5,7 @@ import { UmbConfigRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbCurrentUserConfigRepository extends UmbConfigRepositoryBase<UmbCurrentUserConfigurationModel> {
-	#dataSource = new UmbCurrentUserConfigServerDataSource(this);
+	readonly #dataSource = new UmbCurrentUserConfigServerDataSource(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_CURRENT_USER_CONFIG_STORE_CONTEXT);

--- a/src/Umbraco.Web.UI.Client/src/packages/user/current-user/workspace/current-user-workspace-avatar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/current-user/workspace/current-user-workspace-avatar.element.ts
@@ -63,9 +63,7 @@ export class UmbCurrentUserWorkspaceAvatarElement extends UmbLitElement {
 		this.#observeAllowedFileTypes();
 	}
 
-	async #observeAllowedFileTypes() {
-		await this.#temporaryFileConfigRepository.initialized;
-		if (!this.isConnected) return;
+	#observeAllowedFileTypes() {
 		this.observe(
 			this.#temporaryFileConfigRepository.part('imageFileTypes'),
 			(fileTypes) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/conditions/allow-change-password/current-user-allow-change-password-action.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/conditions/allow-change-password/current-user-allow-change-password-action.condition.ts
@@ -12,8 +12,7 @@ export class UmbCurrentUserAllowChangePasswordActionCondition extends UmbConditi
 		this.#init();
 	}
 
-	async #init() {
-		await this.#configRepository.initialized;
+	#init() {
 		this.observe(
 			this.#configRepository.part('allowChangePassword'),
 			(isAllowed) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/conditions/allow-change-password/user-allow-change-password-action.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/conditions/allow-change-password/user-allow-change-password-action.condition.ts
@@ -12,8 +12,7 @@ export class UmbUserAllowChangePasswordActionCondition extends UmbConditionBase<
 		this.#init();
 	}
 
-	async #init() {
-		await this.#configRepository.initialized;
+	#init() {
 		this.observe(
 			this.#configRepository.part('allowChangePassword'),
 			(isAllowed) => {

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/conditions/allow-mfa/user-allow-mfa-action.condition.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/conditions/allow-mfa/user-allow-mfa-action.condition.ts
@@ -12,8 +12,7 @@ export class UmbUserAllowMfaActionCondition extends UmbConditionBase<never> {
 		this.#init();
 	}
 
-	async #init() {
-		await this.#configRepository.initialized;
+	#init() {
 		this.observe(
 			observeMultiple([
 				this.#configRepository.part('allowTwoFactor'),

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.test.ts
@@ -1,0 +1,50 @@
+import { expect } from '@open-wc/testing';
+import { UmbUserConfigRepository } from './user-config.repository.js';
+import { UmbUserConfigStore } from './user-config.store.js';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { firstValueFrom } from '@umbraco-cms/backoffice/external/rxjs';
+import { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+
+@customElement('test-user-config-host')
+class UmbTestUserConfigHostElement extends UmbControllerHostElementMixin(HTMLElement) {
+	constructor() {
+		super();
+		new UmbUserConfigStore(this);
+		new UmbNotificationContext(this);
+	}
+}
+
+describe('UmbUserConfigRepository', () => {
+	let hostElement: UmbTestUserConfigHostElement;
+	let repository: UmbUserConfigRepository;
+
+	beforeEach(() => {
+		// The host is intentionally NOT connected here, so the store context is unresolved when we subscribe.
+		hostElement = new UmbTestUserConfigHostElement();
+		repository = new UmbUserConfigRepository(hostElement);
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('part() subscribed before the store resolves does not throw and still delivers', async () => {
+		let observable!: ReturnType<typeof repository.part<'usernameIsEmail'>>;
+		expect(() => (observable = repository.part('usernameIsEmail'))).to.not.throw();
+
+		const value = firstValueFrom(observable);
+		document.body.appendChild(hostElement);
+
+		expect(await value).to.equal(true);
+	});
+
+	it('all() subscribed before the store resolves delivers the mocked configuration', async () => {
+		const value = firstValueFrom(repository.all());
+		document.body.appendChild(hostElement);
+
+		const config = await value;
+		expect(config?.allowChangePassword).to.equal(true);
+		expect(config?.canInviteUsers).to.equal(true);
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.ts
@@ -5,7 +5,7 @@ import { UmbConfigRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export class UmbUserConfigRepository extends UmbConfigRepositoryBase<UmbUserConfigurationModel> {
-	#dataSource = new UmbUserConfigServerDataSource(this);
+	readonly #dataSource = new UmbUserConfigServerDataSource(this);
 
 	constructor(host: UmbControllerHost) {
 		super(host, UMB_USER_CONFIG_STORE_CONTEXT);

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/repository/config/user-config.repository.ts
@@ -1,68 +1,19 @@
 import type { UmbUserConfigurationModel } from '../../types.js';
 import { UmbUserConfigServerDataSource } from './user-config.server.data-source.js';
 import { UMB_USER_CONFIG_STORE_CONTEXT } from './user-config.store.token.js';
-import { UmbRepositoryBase } from '@umbraco-cms/backoffice/repository';
-import type { UmbApi } from '@umbraco-cms/backoffice/extension-api';
+import { UmbConfigRepositoryBase } from '@umbraco-cms/backoffice/repository';
 import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
-import type { Observable } from '@umbraco-cms/backoffice/observable-api';
 
-export class UmbUserConfigRepository extends UmbRepositoryBase implements UmbApi {
-	/**
-	 * Promise that resolves when the repository has been initialized, i.e. when the user configuration has been fetched from the server.
-	 * @memberof UmbUserConfigRepository
-	 */
-	initialized: Promise<void>;
-
-	#dataStore?: typeof UMB_USER_CONFIG_STORE_CONTEXT.TYPE;
+export class UmbUserConfigRepository extends UmbConfigRepositoryBase<UmbUserConfigurationModel> {
 	#dataSource = new UmbUserConfigServerDataSource(this);
 
 	constructor(host: UmbControllerHost) {
-		super(host);
-		this.initialized = new Promise<void>((resolve) => {
-			this.consumeContext(UMB_USER_CONFIG_STORE_CONTEXT, async (store) => {
-				if (store) {
-					this.#dataStore = store;
-					await this.#init();
-					resolve();
-				}
-			});
-		});
+		super(host, UMB_USER_CONFIG_STORE_CONTEXT);
 	}
 
-	async #init() {
-		// Check if the store already has data
-		if (this.#dataStore?.getState()) {
-			return;
-		}
-
+	protected override async _requestConfig() {
 		const { data } = await this.#dataSource.getUserConfig();
-
-		if (data) {
-			this.#dataStore?.update(data);
-		}
-	}
-
-	/**
-	 * Subscribe to the entire user configuration.
-	 */
-	all() {
-		if (!this.#dataStore) {
-			throw new Error('Data store not initialized');
-		}
-
-		return this.#dataStore.all();
-	}
-
-	/**
-	 * Subscribe to a part of the user configuration.
-	 * @param part
-	 */
-	part<Part extends keyof UmbUserConfigurationModel>(part: Part): Observable<UmbUserConfigurationModel[Part]> {
-		if (!this.#dataStore) {
-			throw new Error('Data store not initialized');
-		}
-
-		return this.#dataStore.part(part);
+		return data;
 	}
 }
 

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-avatar/user-workspace-avatar.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-avatar/user-workspace-avatar.element.ts
@@ -38,8 +38,7 @@ export class UmbUserWorkspaceAvatarElement extends UmbLitElement {
 		return this._selectElement;
 	}
 
-	async #observeAllowedFileTypes() {
-		await this.#temporaryFileConfigRepository.initialized;
+	#observeAllowedFileTypes() {
 		this.observe(
 			this.#temporaryFileConfigRepository.part('imageFileTypes'),
 			(fileTypes) => {


### PR DESCRIPTION
## Why

Store-backed config repositories exposed an `all()`/`part()` API that **threw `"Data store not initialized"`** until the store context resolved, forcing every consumer to `await repo.initialized` before subscribing — an easy-to-miss footgun (flagged in review on #23414). The same fragile shape was **copy-pasted across three repositories** (`UmbTemporaryFileConfigRepository`, `UmbCurrentUserConfigRepository`, `UmbUserConfigRepository`).

## What

**1. A shared base class** — `UmbConfigRepositoryBase<ConfigModel>` in `core/repository`. It owns the whole pattern: consume the store context, fetch the config once on init, and expose `all()`/`part()` that **defer internally** (`from(this.#initialized).pipe(switchMap(() => this.#dataStore!.…()))`) so callers subscribe immediately and values arrive once the store is ready. Concrete repos declare only their store token, data source, and a one-line `_requestConfig()`.

**2. All three config repositories migrated onto it** — each collapses to a constructor + `_requestConfig()`. `UmbTemporaryFileConfigRepository` keeps its public `requestTemporaryFileConfiguration()` (used by sysinfo) and `displayableImageFileTypes()` (which composes on `part()` and inherits the deferral for free).

**3. `initialized` is deprecated on the base** (inherited by all three): `@deprecated` JSDoc + `UmbDeprecation` runtime warning (`removeInVersion: '19.0.0'`, per the v17→v19 rule). It still resolves, so the legacy `await`-then-subscribe pattern keeps working — consumers just get nudged to subscribe directly. **No breaking changes** (return types unchanged; `initialized` remains public and awaitable).

**4. Consumers updated to drop the now-unneeded `await …initialized`** across the temporary-file, current-user and user config consumers (and two orphaned `if (!this.isConnected) return` guards that only covered the removed async gap).

Net effect: the pattern lives in one place, the throw-until-ready footgun is gone from all three repos, and the next config repository inherits emit-when-ready instead of copy-pasting the throw. Diff is a **net reduction** (−61 lines) despite adding the base class and tests.

## Tests

- New `config-repository-base.test.ts` — endpoint-independent proof of the base mechanism: subscribe-before-ready delivers, `part()`/`all()` don't throw pre-connect, and the deprecated `initialized` warns. TDD (verified RED against a throwing impl).
- Per-repo subscribe-before-ready tests for all three (`config.repository.test.ts` for temporary-file; new tests for user and current-user). Added a `user/current/configuration` MSW handler for the current-user case.

## Verification

- `npm test` for all four config test suites → all pass
- `npx tsc --noEmit` → clean
- `npm run check:circular` → no circular dependencies (`core/repository` → `core/store` with no back-edge)

> Note: `npm run lint:fix` crashes locally on an unrelated file due to a pre-existing ESLint 10.2.0 / `eslint-plugin-import` incompatibility (`getTokenOrCommentBefore` removed in ESLint 10); the changed files lint clean in isolation. Not caused by this change, but it will affect the CI lint step for any PR in this environment.
