### PR TITLE
Tags: Split pasted comma/newline lists into multiple tags while keeping typed commas literal

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.test.ts
@@ -1,0 +1,123 @@
+import { UmbTagsInputElement } from './tags-input.element.js';
+import { expect, fixture, html } from '@open-wc/testing';
+import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
+import { type UmbTestRunnerWindow, defaultA11yConfig } from '@umbraco-cms/internal/test-utils';
+
+describe('UmbTagsInputElement', () => {
+	let element: UmbTagsInputElement;
+
+	beforeEach(async () => {
+		element = await fixture(html`<umb-tags-input></umb-tags-input>`);
+	});
+
+	function getInput(): HTMLInputElement {
+		return element.shadowRoot!.querySelector('#tag-input') as HTMLInputElement;
+	}
+
+	function dispatchPaste(text: string): ClipboardEvent {
+		const clipboardData = new DataTransfer();
+		clipboardData.setData('text', text);
+		const event = new ClipboardEvent('paste', { clipboardData, bubbles: true, cancelable: true });
+		getInput().dispatchEvent(event);
+		return event;
+	}
+
+	function typeAndPressEnter(text: string) {
+		const input = getInput();
+		input.value = text;
+		input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+	}
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbTagsInputElement);
+	});
+
+	describe('paste handling', () => {
+		it('splits comma-separated pasted text into multiple tags', async () => {
+			dispatchPaste('one,two,three');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one', 'two', 'three']);
+		});
+
+		it('splits newline-separated pasted text into multiple tags', async () => {
+			dispatchPaste('one\ntwo\r\nthree');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one', 'two', 'three']);
+		});
+
+		it('trims whitespace and drops empty segments', async () => {
+			dispatchPaste(' one , , two ,');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one', 'two']);
+		});
+
+		it('appends pasted tags to existing ones and skips duplicates', async () => {
+			element.items = ['one'];
+			dispatchPaste('one,two');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one', 'two']);
+		});
+
+		it('dispatches a change event when tags are added', async () => {
+			let changeCount = 0;
+			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);
+			dispatchPaste('one,two');
+			await element.updateComplete;
+			expect(changeCount).to.equal(1);
+		});
+
+		it('does not split pasted text without a separator', async () => {
+			const event = dispatchPaste('single');
+			await element.updateComplete;
+			expect(element.items).to.have.lengthOf(0);
+			expect(event.defaultPrevented).to.be.false;
+		});
+	});
+
+	describe('typing', () => {
+		it('creates a tag when a value is typed and Enter is pressed', async () => {
+			typeAndPressEnter('hello');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['hello']);
+		});
+
+		it('keeps a typed comma as a literal part of a single tag', async () => {
+			typeAndPressEnter('one, two');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one, two']);
+		});
+
+		it('trims the typed value before creating the tag', async () => {
+			typeAndPressEnter('  hello  ');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['hello']);
+		});
+
+		it('does not create a tag from an empty or whitespace-only value', async () => {
+			typeAndPressEnter('   ');
+			await element.updateComplete;
+			expect(element.items).to.have.lengthOf(0);
+		});
+
+		it('does not add a duplicate of an existing tag', async () => {
+			element.items = ['hello'];
+			typeAndPressEnter('hello');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['hello']);
+		});
+
+		it('dispatches a change event when a tag is created', async () => {
+			let changeCount = 0;
+			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);
+			typeAndPressEnter('hello');
+			await element.updateComplete;
+			expect(changeCount).to.equal(1);
+		});
+	});
+
+	if ((window as UmbTestRunnerWindow).__UMBRACO_TEST_RUN_A11Y_TEST) {
+		it('passes the a11y audit', async () => {
+			await expect(element).shadowDom.to.be.accessible(defaultA11yConfig);
+		});
+	}
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.test.ts
@@ -58,6 +58,32 @@ describe('UmbTagsInputElement', () => {
 			expect(element.items).to.deep.equal(['one', 'two']);
 		});
 
+		it('de-duplicates repeated values within a single paste', async () => {
+			dispatchPaste('one,one,two');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one', 'two']);
+		});
+
+		it('does not update or fire a change event when every pasted value already exists', async () => {
+			element.items = ['one', 'two'];
+			let changeCount = 0;
+			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);
+			dispatchPaste('one,two');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one', 'two']);
+			expect(changeCount).to.equal(0);
+		});
+
+		it('clears the input after a paste that adds tags', async () => {
+			const input = getInput();
+			input.value = 'hello';
+			input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+			dispatchPaste('one,two');
+			await element.updateComplete;
+			expect(element.items).to.deep.equal(['one', 'two']);
+			expect(getInput().value).to.equal('');
+		});
+
 		it('dispatches a change event when tags are added', async () => {
 			let changeCount = 0;
 			element.addEventListener(UmbChangeEvent.TYPE, () => changeCount++);

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
@@ -188,6 +188,39 @@ export class UmbTagsInputElement extends UUIFormControlMixin(UmbLitElement, '') 
 		}
 	}
 
+	#onPaste(e: ClipboardEvent) {
+		const pastedText = e.clipboardData?.getData('text') ?? '';
+
+		// A typed comma is a literal part of a single tag; only a pasted separator splits into multiple tags.
+		if (!/[,\r\n]/.test(pastedText)) return;
+
+		e.preventDefault();
+
+		const candidates = pastedText
+			.split(/[,\r\n]+/)
+			.map((tag) => tag.trim())
+			.filter((tag) => tag !== '');
+
+		this.#addTags(candidates);
+	}
+
+	#addTags(candidates: string[]) {
+		const existing = new Set(this.items);
+		const newTags: string[] = [];
+		for (const candidate of candidates) {
+			if (existing.has(candidate)) continue;
+			existing.add(candidate);
+			newTags.push(candidate);
+		}
+
+		if (!newTags.length) return;
+
+		this.#inputError(false);
+		this.items = [...this.items, ...newTags];
+		this._matches = [];
+		this.dispatchEvent(new UmbChangeEvent());
+	}
+
 	protected override updated(): void {
 		// #main-tag is not rendered in readonly mode, and the queries can resolve to null
 		// during transient re-renders, so guard before touching the elements.
@@ -387,6 +420,7 @@ export class UmbTagsInputElement extends UUIFormControlMixin(UmbLitElement, '') 
 					.value="${this._currentInput ?? undefined}"
 					@keydown="${this.#onInputKeydown}"
 					@input="${this.#onInput}"
+					@paste="${this.#onPaste}"
 					@blur="${this.#onBlur}" />
 				<uui-icon id="icon-add" name="icon-add"></uui-icon>
 				${this.#renderTagOptions()}

--- a/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/tags/components/tags-input/tags-input.element.ts
@@ -217,6 +217,8 @@ export class UmbTagsInputElement extends UUIFormControlMixin(UmbLitElement, '') 
 
 		this.#inputError(false);
 		this.items = [...this.items, ...newTags];
+		this._tagInput.value = '';
+		this._currentInput = '';
 		this._matches = [];
 		this.dispatchEvent(new UmbChangeEvent());
 	}


### PR DESCRIPTION
## Description

This improves how the Tags property editor handles **pasting** a list of values, without reintroducing the bug that comma-in-tag support originally fixed.

### Background

- **#22413** reported that tags containing a comma could not be created with JSON storage — the editor always split on the comma — even though JSON storage is documented to support them.
- **#22432** fixed that: for JSON storage the property editor now reads the tag array directly (`tagsInput.items`) instead of round-tripping through a comma-joined string, so a typed comma stays a literal part of a single tag.
- **#23147** then tried to serve a different use case — an editor pasting a comma-separated list and expecting it to split into several tags — by adding a `preserveCommas` configuration toggle on the data type.

That toggle approach had a few downsides:

- **It regressed #22432 by default.** The new flag defaulted to "split", so JSON storage went back to breaking commas-in-tags unless the editor explicitly opted out — silently undoing the fix for the original bug.
- **It added configuration where behaviour should be intuitive.** The option only did anything when storage type was set a particular way, increasing the surface area and the "which combination do I need?" confusion.
- **It mixed two concerns.** The suggested follow-up (folding the behaviour into the storage-type dropdown, e.g. *"Json (preserving commas)"*) conflates *how a value is persisted* (storage type) with *how the editor parses input* (an editing behaviour). Those are different axes and shouldn't be coupled.

### This approach

Distinguish **typing** from **pasting**, with no new configuration and no change to storage type:

- **Typing** a comma keeps it as a literal character, so it remains part of a single tag (preserves #22413 / #22432).
- **Pasting** text that contains a separator (comma, or a newline) splits it into multiple tags. Segments are trimmed, empties are dropped, and values already present are skipped.

This serves both audiences — a comma inside a single tag, and pasting a ready-made list — while keeping the editor free of extra options and leaving storage type to mean only what it says. Newline handling means pasting a multi-line list works too. Pasting a value with no separator falls through to the browser's normal paste, so nothing changes for that case.

The change lives entirely in the shared `umb-tags-input` component; the property editor needs no change because its JSON path already reads the tag array.

## Testing

### Automated

A new `tags-input.element.test.ts` covers both paths:

- **Paste** — comma-separated and newline-separated (incl. `\r\n`) input split into multiple tags; whitespace trimmed and empty segments dropped; pasted tags appended to existing ones with duplicates skipped; a single change event dispatched; and pasted text with no separator is left to the default paste (not split).
- **Typing** — a typed value creates a tag; a **typed comma stays literal within a single tag**; the value is trimmed; empty/whitespace-only input creates nothing; a duplicate of an existing tag is not added; and a change event is dispatched per created tag.

The paste tests were confirmed to fail if the new handler is removed, so they genuinely exercise the behaviour.

### Manual testing

1. Create a document type with a Tags property (JSON storage) and add it to a document.
2. **Type** a tag containing a comma, e.g. `Smith, John`, and press Enter — it should be stored as **one** tag. Save and reload; it should remain one tag.
3. **Paste** a comma-separated list, e.g. `red, green, blue`, into the tag input — it should become **three** separate tags.
4. **Paste** a multi-line list (one value per line) — each line should become its own tag.
5. Paste a list containing a value that already exists — the duplicate should be skipped.
6. Confirm the CSV storage type continues to behave as before.
