### PR TITLE
Maindom: Broadcast cache instructions without maindom (closes #23219)

### DIFF
--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -305,7 +305,7 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
 
         if (registered == false)
         {
-            Logger.LogWarning(
+            Logger.LogError(
                 "Could not register with MainDom; this instance will not process distributed cache instructions and its published cache may become stale until the application is restarted.");
             return null;
         }

--- a/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
+++ b/src/Umbraco.Infrastructure/Sync/DatabaseServerMessenger.cs
@@ -237,7 +237,17 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
     // we don't care if there are servers listed or not,
     // if distributed call is enabled we will make the call
     protected override bool RequiresDistributed(ICacheRefresher refresher, MessageType dispatchType)
-        => EnsureInitialized() && DistributedEnabled;
+    {
+        // Attempt initialization so the sync boot state is established as early as possible, but do not
+        // gate the instruction write on its success. Writing cache instructions requires no exclusivity,
+        // and a process that could not register with MainDom (e.g. it lost it to an overlapping worker
+        // during an app pool recycle or deployment slot swap) must still broadcast its local cache changes,
+        // otherwise other servers silently never refresh (#23219). Only processing instructions (Sync)
+        // remains gated on MainDom.
+        EnsureInitialized();
+
+        return DistributedEnabled;
+    }
 
     protected override void DeliverRemote(
         ICacheRefresher refresher,
@@ -295,7 +305,8 @@ public abstract class DatabaseServerMessenger : ServerMessengerBase, IDisposable
 
         if (registered == false)
         {
-            // return null if we cannot initialize
+            Logger.LogWarning(
+                "Could not register with MainDom; this instance will not process distributed cache instructions and its published cache may become stale until the application is restarted.");
             return null;
         }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Sync/DatabaseServerMessengerMainDomTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Sync/DatabaseServerMessengerMainDomTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Runtime;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.Sync;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Extensions;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Sync;
+
+/// <summary>
+/// Reproduces https://github.com/umbraco/Umbraco-CMS/issues/23219: an instance whose MainDom registration
+/// failed (e.g. MainDom was released to an overlapping worker during an app pool recycle or deployment slot
+/// swap before the messenger first initialized) must still write cache instructions when content is published,
+/// otherwise subscriber servers silently never refresh.
+/// </summary>
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class DatabaseServerMessengerMainDomTests : UmbracoIntegrationTest
+{
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private ICacheInstructionService CacheInstructionService => GetRequiredService<ICacheInstructionService>();
+
+    private IFileService FileService => GetRequiredService<IFileService>();
+
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.Services.AddUnique<IMainDom, NeverRegisteredMainDom>();
+        builder.Services.AddUnique<IServerMessenger, BatchedDatabaseServerMessenger>();
+        builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
+    }
+
+    [Test]
+    public void Publish_WhenMainDomRegistrationFails_StillWritesCacheInstructions()
+    {
+        var maxInstructionIdBeforePublish = CacheInstructionService.GetMaxInstructionId();
+
+        var template = TemplateBuilder.CreateTextPageTemplate("testPageTemplate");
+        FileService.SaveTemplate(template);
+
+        var contentType = ContentTypeBuilder.CreateSimpleContentType("testPage", "Test Page", defaultTemplateId: template.Id);
+        ContentTypeService.Save(contentType);
+        var content = ContentBuilder.CreateSimpleContent(contentType, "Test Content");
+        ContentService.Save(content);
+
+        var publishResult = ContentService.Publish(content, Array.Empty<string>());
+        Assert.That(publishResult.Success, Is.True);
+
+        var maxInstructionIdAfterPublish = CacheInstructionService.GetMaxInstructionId();
+        Assert.That(
+            maxInstructionIdAfterPublish,
+            Is.GreaterThan(maxInstructionIdBeforePublish),
+            "Publishing did not write any cache instructions, so subscriber servers would never refresh.");
+    }
+
+    /// <summary>
+    /// Simulates an instance that lost the MainDom race: still running and serving traffic, but every
+    /// <see cref="IMainDom.Register" /> call fails, as happens after MainDom has been released to another
+    /// overlapping application instance.
+    /// </summary>
+    private sealed class NeverRegisteredMainDom : IMainDom
+    {
+        public bool IsMainDom => false;
+
+        public bool Acquire(IApplicationShutdownRegistry hostingEnvironment) => true;
+
+        public bool Register(Action? install = null, Action? release = null, int weight = 100) => false;
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Sync/DatabaseServerMessengerMainDomTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Sync/DatabaseServerMessengerMainDomTests.cs
@@ -3,7 +3,6 @@
 
 using NUnit.Framework;
 using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Runtime;
@@ -13,7 +12,6 @@ using Umbraco.Cms.Infrastructure.Sync;
 using Umbraco.Cms.Tests.Common.Builders;
 using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
-using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Sync;
 
@@ -33,7 +31,7 @@ internal sealed class DatabaseServerMessengerMainDomTests : UmbracoIntegrationTe
 
     private ICacheInstructionService CacheInstructionService => GetRequiredService<ICacheInstructionService>();
 
-    private IFileService FileService => GetRequiredService<IFileService>();
+    private ITemplateService TemplateService => GetRequiredService<ITemplateService>();
 
     protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
@@ -43,15 +41,15 @@ internal sealed class DatabaseServerMessengerMainDomTests : UmbracoIntegrationTe
     }
 
     [Test]
-    public void Publish_WhenMainDomRegistrationFails_StillWritesCacheInstructions()
+    public async Task Publish_WhenMainDomRegistrationFails_StillWritesCacheInstructions()
     {
         var maxInstructionIdBeforePublish = CacheInstructionService.GetMaxInstructionId();
 
         var template = TemplateBuilder.CreateTextPageTemplate("testPageTemplate");
-        FileService.SaveTemplate(template);
+        await TemplateService.CreateAsync(template, Cms.Core.Constants.Security.SuperUserKey);
 
         var contentType = ContentTypeBuilder.CreateSimpleContentType("testPage", "Test Page", defaultTemplateId: template.Id);
-        ContentTypeService.Save(contentType);
+        await ContentTypeService.CreateAsync(contentType, Cms.Core.Constants.Security.SuperUserKey);
         var content = ContentBuilder.CreateSimpleContent(contentType, "Test Content");
         ContentService.Save(content);
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessengerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessengerTests.cs
@@ -60,7 +60,7 @@ public class BatchedDatabaseServerMessengerTests
     }
 
     [Test]
-    public void QueueRefresh_WhenMainDomRegistrationFails_LogsWarning()
+    public void QueueRefresh_WhenMainDomRegistrationFails_LogsError()
     {
         BatchedDatabaseServerMessenger sut = CreateMessenger(mainDomRegistered: false);
 
@@ -68,7 +68,7 @@ public class BatchedDatabaseServerMessengerTests
 
         _loggerMock.Verify(
             x => x.Log(
-                LogLevel.Warning,
+                LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.IsAny<It.IsAnyType>(),
                 It.IsAny<Exception?>(),

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessengerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Sync/BatchedDatabaseServerMessengerTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Factories;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Runtime;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Infrastructure.Sync;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Sync;
+
+[TestFixture]
+public class BatchedDatabaseServerMessengerTests
+{
+    private Mock<IMainDom> _mainDomMock = null!;
+    private Mock<ICacheInstructionService> _cacheInstructionServiceMock = null!;
+    private Mock<ILogger<BatchedDatabaseServerMessenger>> _loggerMock = null!;
+    private Mock<ICacheRefresher> _cacheRefresherMock = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mainDomMock = new Mock<IMainDom>();
+        _cacheInstructionServiceMock = new Mock<ICacheInstructionService>();
+        _loggerMock = new Mock<ILogger<BatchedDatabaseServerMessenger>>();
+        _cacheRefresherMock = new Mock<ICacheRefresher>();
+        _cacheRefresherMock.SetupGet(x => x.RefresherUniqueId).Returns(Guid.NewGuid());
+    }
+
+    [Test]
+    public void QueueRefresh_WhenMainDomIsRegistered_DeliversRemoteInstructions()
+    {
+        BatchedDatabaseServerMessenger sut = CreateMessenger(mainDomRegistered: true);
+
+        sut.QueueRefresh(_cacheRefresherMock.Object, 1234);
+
+        _cacheInstructionServiceMock.Verify(
+            x => x.DeliverInstructionsInBatches(It.IsAny<IEnumerable<RefreshInstruction>>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Test]
+    public void QueueRefresh_WhenMainDomRegistrationFails_StillDeliversRemoteInstructions()
+    {
+        BatchedDatabaseServerMessenger sut = CreateMessenger(mainDomRegistered: false);
+
+        sut.QueueRefresh(_cacheRefresherMock.Object, 1234);
+
+        _cacheInstructionServiceMock.Verify(
+            x => x.DeliverInstructionsInBatches(It.IsAny<IEnumerable<RefreshInstruction>>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Test]
+    public void QueueRefresh_WhenMainDomRegistrationFails_LogsWarning()
+    {
+        BatchedDatabaseServerMessenger sut = CreateMessenger(mainDomRegistered: false);
+
+        sut.QueueRefresh(_cacheRefresherMock.Object, 1234);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    private BatchedDatabaseServerMessenger CreateMessenger(bool mainDomRegistered)
+    {
+        _mainDomMock
+            .Setup(x => x.Register(It.IsAny<Action?>(), It.IsAny<Action?>(), It.IsAny<int>()))
+            .Returns(mainDomRegistered);
+
+        var syncBootStateAccessorMock = new Mock<ISyncBootStateAccessor>();
+        syncBootStateAccessorMock.Setup(x => x.GetSyncBootState()).Returns(SyncBootState.WarmBoot);
+
+        var globalSettingsMock = new Mock<IOptionsMonitor<GlobalSettings>>();
+        globalSettingsMock.SetupGet(x => x.CurrentValue).Returns(new GlobalSettings());
+
+        var machineInfoFactoryMock = new Mock<IMachineInfoFactory>();
+        machineInfoFactoryMock.Setup(x => x.GetLocalIdentity()).Returns("test-identity");
+
+        // No available request cache, so remote deliveries are written immediately instead of batched.
+        var requestCacheMock = new Mock<IRequestCache>();
+        requestCacheMock.SetupGet(x => x.IsAvailable).Returns(false);
+
+        return new BatchedDatabaseServerMessenger(
+            _mainDomMock.Object,
+            new CacheRefresherCollection(() => new[] { _cacheRefresherMock.Object }),
+            _loggerMock.Object,
+            syncBootStateAccessorMock.Object,
+            Mock.Of<IHostingEnvironment>(),
+            _cacheInstructionServiceMock.Object,
+            Mock.Of<IJsonSerializer>(),
+            requestCacheMock.Object,
+            Mock.Of<ILastSyncedManager>(),
+            globalSettingsMock.Object,
+            machineInfoFactoryMock.Object);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/umbraco/Umbraco-CMS/issues/23219

# Notes
- I had a hard time producing this locally, but was able to setup scenarios via integration tests, so this is more of a defensive change.
- Now instead return `DistributedEnabled` no matter what, in order to not gate the cache instruction writes, this way if we fail to register the maindom but still run, we will still write cache instructions
- Also adds and error to the log, when this situation happens

# How to test
- Verify the integration & unit test passes