### PR TITLE
Dependency Tracking: Swap `CycloneDX` for `Umbraco.Internal.Sbom` in SBOM pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,7 +388,7 @@ public interface IMyService
 
 When editing those steps:
 
-- **Output filenames** (`bom-dotnet.xml`, `bom-login.xml`, `bom-backoffice.xml`, `bom-e2e.xml`) are mapped by `templates/dependency-track.yml` — don't rename.
+- **Output filenames** (`bom-dotnet.xml`, `bom-login.xml`, `bom-backoffice.xml`, `bom-e2e.xml`) are mapped by `build/templates/dependency-track.yml` — don't rename.
 - **Usage**: `umbraco-sbom <path> --output-file <full-path> [policy flags]`. Only `--output-file` plus policy flags (`--allow-package`, `--allow-commercial`, `--allow-copyleft`, `--fail-on-unknown`, `--policy-allow-file`) exist.
 - **Commercial packages** need `--allow-package`, else **exit 50**. Backend uses `nuget:SixLabors.*` (covers both `SixLabors.ImageSharp` and `.ImageSharp.Web`).
 - **Exit 10** = success-with-warnings (unresolved licenses; SBOM still written). Each step tolerates it: `if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }; exit 0`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,18 @@ public interface IMyService
 - `.editorconfig` - Code style rules
 - `.globalconfig` - Roslyn analyzer rules
 
+### SBOM Generation & License Policy (Azure Pipelines)
+
+`build/azure-pipelines.yml` generates a CycloneDX SBOM per project (Backend/NuGet, Login UI, Backoffice, E2E) via **`umbraco-sbom`** (the `Umbraco.Internal.Sbom` .NET 10 global tool), not plain `dotnet CycloneDX` / `@cyclonedx/cyclonedx-npm`. It adds license-policy enforcement over CycloneDX. Repo (private): https://github.com/umbraco/Umbraco.Internal.Sbom — README has the full flag/exit-code/policy reference.
+
+When editing those steps:
+
+- **Output filenames** (`bom-dotnet.xml`, `bom-login.xml`, `bom-backoffice.xml`, `bom-e2e.xml`) are mapped by `templates/dependency-track.yml` — don't rename.
+- **Usage**: `umbraco-sbom <path> --output-file <full-path> [policy flags]`. Only `--output-file` plus policy flags (`--allow-package`, `--allow-commercial`, `--allow-copyleft`, `--fail-on-unknown`, `--policy-allow-file`) exist.
+- **Commercial packages** need `--allow-package`, else **exit 50**. Backend uses `nuget:SixLabors.*` (covers both `SixLabors.ImageSharp` and `.ImageSharp.Web`).
+- **Exit 10** = success-with-warnings (unresolved licenses; SBOM still written). Each step tolerates it: `if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }; exit 0`.
+- **Frontend jobs** need a `UseDotNet@2` (`useGlobalJson: true`) step before the tool install (the .NET 10 tool needs the SDK; those jobs are otherwise Node-only).
+
 ### Persistence Layer - NPoco and EF Core
 
 The repository contains BOTH (actively supported):

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -128,7 +128,7 @@ stages:
             displayName: 'Generate Backend BOM'
           - powershell: |
               dotnet tool install --global Umbraco.Internal.Sbom
-              umbraco-sbom $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Login --output-file $(Build.ArtifactStagingDirectory)/bom/bom-login.xml
+              umbraco-sbom $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Login --output-file $(Build.ArtifactStagingDirectory)/bom-login/bom-login.xml
               if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }
               exit 0
             displayName: Generate Login UI BOM
@@ -147,6 +147,11 @@ stages:
             inputs:
               targetPath: $(Build.ArtifactStagingDirectory)/bom
               artifactName: bom-backend
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Login BOM
+            inputs:
+              targetPath: $(Build.ArtifactStagingDirectory)/bom-login
+              artifactName: bom-login
 
       - job: B
         displayName: Build Bellissima Package
@@ -802,7 +807,7 @@ stages:
               artifact: "bom-backend"
               bomFilePath: "bom-dotnet.xml"
             - name: "Login"
-              artifact: "bom-backend"
+              artifact: "bom-login"
               bomFilePath: "bom-login.xml"
             - name: "Backoffice"
               artifact: "bom-frontend"

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -117,6 +117,11 @@ stages:
               artifactName: csharp-docs-dlls
           - powershell: |
               dotnet tool install --global Umbraco.Internal.Sbom
+              # umbraco-sbom scans every project in the solution and requires each to be restored.
+              # These two are excluded from the Release build config, so the solution restore/build
+              # skips them; restore them explicitly to avoid a failure.
+              dotnet restore $(Build.SourcesDirectory)/tests/Umbraco.Tests.AcceptanceTest.UmbracoProject/Umbraco.Tests.AcceptanceTest.UmbracoProject.csproj
+              dotnet restore $(Build.SourcesDirectory)/tools/Umbraco.JsonSchema/Umbraco.JsonSchema.csproj
               umbraco-sbom $(solution) --output-file $(Build.ArtifactStagingDirectory)/bom/bom-dotnet.xml --allow-package nuget:SixLabors.*
               if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }
               exit 0

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -116,14 +116,17 @@ stages:
               targetPath: $(Build.SourcesDirectory)/src/Umbraco.Cms/bin/Release
               artifactName: csharp-docs-dlls
           - powershell: |
-              dotnet tool install --global CycloneDX
-              dotnet-CycloneDX $(solution) --spec-version 1.5 --output $(Build.ArtifactStagingDirectory)/bom --filename bom-dotnet.xml
+              dotnet tool install --global Umbraco.Internal.Sbom
+              umbraco-sbom $(solution) --output-file $(Build.ArtifactStagingDirectory)/bom/bom-dotnet.xml --allow-package nuget:SixLabors.*
+              if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }
+              exit 0
             displayName: 'Generate Backend BOM'
           - powershell: |
-              npm install --global @cyclonedx/cyclonedx-npm
-              cyclonedx-npm -o $(Build.ArtifactStagingDirectory)\bom\bom-login.xml --ignore-npm-errors --verbose
+              dotnet tool install --global Umbraco.Internal.Sbom
+              umbraco-sbom $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Login --output-file $(Build.ArtifactStagingDirectory)/bom/bom-login.xml
+              if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }
+              exit 0
             displayName: Generate Login UI BOM
-            workingDirectory: src/Umbraco.Web.UI.Login
           - task: PublishPipelineArtifact@1
             displayName: Publish nupkg
             inputs:
@@ -150,11 +153,16 @@ stages:
             lfs: false,
             fetchDepth: 500
           - template: templates/backoffice-install.yml
+          - task: UseDotNet@2
+            displayName: Use .NET SDK from global.json
+            inputs:
+              useGlobalJson: true
           - powershell: |
-              npm install --global @cyclonedx/cyclonedx-npm
-              cyclonedx-npm -o $(Build.ArtifactStagingDirectory)/bom/bom-backoffice.xml --ignore-npm-errors --verbose
+              dotnet tool install --global Umbraco.Internal.Sbom
+              umbraco-sbom $(Build.SourcesDirectory)/src/Umbraco.Web.UI.Client --output-file $(Build.ArtifactStagingDirectory)/bom/bom-backoffice.xml
+              if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }
+              exit 0
             displayName: Generate Backoffice UI BOM
-            workingDirectory: src/Umbraco.Web.UI.Client
           - script: npm run build:for:npm
             displayName: Run build:for:npm
             workingDirectory: src/Umbraco.Web.UI.Client
@@ -220,11 +228,16 @@ stages:
           parameters:
             nodeVersion: ${{ variables.nodeVersion }}
             npm_config_cache: ${{ variables.npm_config_cache }}
+        - task: UseDotNet@2
+          displayName: Use .NET SDK from global.json
+          inputs:
+            useGlobalJson: true
         - powershell: |
-            npm install --global @cyclonedx/cyclonedx-npm
-            cyclonedx-npm -o $(Build.ArtifactStagingDirectory)/bom/bom-e2e.xml --ignore-npm-errors --verbose
+            dotnet tool install --global Umbraco.Internal.Sbom
+            umbraco-sbom $(Build.SourcesDirectory)/tests/Umbraco.Tests.AcceptanceTest --output-file $(Build.ArtifactStagingDirectory)/bom/bom-e2e.xml
+            if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 10) { exit $LASTEXITCODE }
+            exit 0
           displayName: Generate E2E Tests BOM
-          workingDirectory: tests/Umbraco.Tests.AcceptanceTest
         - publish: $(Build.ArtifactStagingDirectory)/bom
           artifact: bom-e2e
           displayName: 'Publish E2E BOM'


### PR DESCRIPTION
## Description

Swaps the raw `dotnet CycloneDX` / `@cyclonedx/cyclonedx-npm` calls in `build/azure-pipelines.yml` for Umbraco's own **`umbraco-sbom`** tool (`Umbraco.Internal.Sbom`), which wraps CycloneDX and adds license-policy enforcement plus a centrally-maintained SPDX override list. Output format is unchanged (CycloneDX XML), so the Dependency-Track upload and everything downstream keep working.

All four BOM steps are migrated:

| Step | Ecosystem | Path |
|------|-----------|------|
| Backend | NuGet | `umbraco.sln` |
| Login UI | npm | `src/Umbraco.Web.UI.Login` |
| Backoffice | npm | `src/Umbraco.Web.UI.Client` |
| E2E | npm | `tests/Umbraco.Tests.AcceptanceTest` |

Key points, verified by installing and running the tool locally against each project (as well as running on the pipeline):

- **Flags** — `umbraco-sbom` takes `--output-file` plus policy flags only; the legacy `--spec-version`/`--output`/`--filename` are dropped.
- **SixLabors** — the solution pulls in both `SixLabors.ImageSharp` and `SixLabors.ImageSharp.Web` (as accepted licenses), so the backend scopes the exception with `--allow-package nuget:SixLabors.*`.
- **Exit 10** — unresolved licenses return exit 10 (success-with-warnings; SBOM still written). Azure DevOps fails a step on any non-zero code, so each step tolerates 0/10 while still failing on real errors and policy violations (exit 50).
- **.NET 10** — the backoffice and E2E jobs are otherwise Node-only, so a `UseDotNet@2` (`useGlobalJson: true`) step is added before the tool install.
- Output filenames are preserved so `templates/dependency-track.yml` keeps mapping them.

Also documents the above in the root `CLAUDE.md`.

## Testing

Solution should build and CI checks pass.  I've verified this for each of the BOM creation jobs and run the PR branch to upload to Dependency Track — all jobs succeed.