### PR TITLE
Logging: Prevent session-id log enricher recursion / stack overflow (closes #16744)

### DIFF
--- a/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/HttpSessionIdEnricher.cs
+++ b/src/Umbraco.Infrastructure/Logging/Serilog/Enrichers/HttpSessionIdEnricher.cs
@@ -17,6 +17,13 @@ public class HttpSessionIdEnricher : ILogEventEnricher
     /// </summary>
     public const string HttpSessionIdPropertyName = "HttpSessionId";
 
+    // Guards against re-entrancy: resolving the session id can force a session-store load, and a failing
+    // load logs before its own load-guard is set. That log event is enriched by this same (LogContext-pushed)
+    // enricher, which reads the session id again, re-triggering the load and recursing until the stack
+    // overflows (#16744).
+    // Use AsyncLocal (not [ThreadStatic]) so the flag tracks the logical flow even if session resolution hops threads.
+    private static readonly AsyncLocal<bool> _enriching = new();
+
     private readonly ISessionIdResolver _sessionIdResolver;
 
     /// <summary>
@@ -37,13 +44,27 @@ public class HttpSessionIdEnricher : ILogEventEnricher
             throw new ArgumentNullException(nameof(logEvent));
         }
 
-        var sessionId = _sessionIdResolver.SessionId;
-        if (sessionId is null)
+        // A nested log event was raised while we were resolving the session id - do not resolve it again.
+        if (_enriching.Value)
         {
             return;
         }
 
-        var sessionIdProperty = new LogEventProperty(HttpSessionIdPropertyName, new ScalarValue(sessionId));
-        logEvent.AddPropertyIfAbsent(sessionIdProperty);
+        _enriching.Value = true;
+        try
+        {
+            var sessionId = _sessionIdResolver.SessionId;
+            if (sessionId is null)
+            {
+                return;
+            }
+
+            var sessionIdProperty = new LogEventProperty(HttpSessionIdPropertyName, new ScalarValue(sessionId));
+            logEvent.AddPropertyIfAbsent(sessionIdProperty);
+        }
+        finally
+        {
+            _enriching.Value = false;
+        }
     }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/Serilog/Enrichers/HttpSessionIdEnricherTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/Serilog/Enrichers/HttpSessionIdEnricherTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+using Umbraco.Cms.Core.Logging.Serilog.Enrichers;
+using Umbraco.Cms.Core.Net;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Logging.Serilog.Enrichers;
+
+[TestFixture]
+public class HttpSessionIdEnricherTests
+{
+    [Test]
+    public void Cannot_Recurse_When_Resolving_Session_Id_Logs()
+    {
+        // Reproduces #16744: resolving the session id raises a nested log event (as a failing
+        // DistributedSession.Load() does), which is enriched by this same enricher. Without the
+        // re-entrancy guard the enricher resolves the id again and recurses until the stack overflows.
+        var resolver = new ReentrantSessionIdResolver();
+        var enricher = new HttpSessionIdEnricher(resolver);
+        resolver.Enricher = enricher;
+
+        enricher.Enrich(CreateLogEvent(), new PassthroughPropertyFactory());
+
+        Assert.AreEqual(
+            1,
+            resolver.SessionIdReadCount,
+            "The session id must be resolved once; a nested log event during resolution must not re-resolve it.");
+    }
+
+    [Test]
+    public void Can_Add_Session_Id_Property()
+    {
+        var enricher = new HttpSessionIdEnricher(new FixedSessionIdResolver("the-session-id"));
+        LogEvent logEvent = CreateLogEvent();
+
+        enricher.Enrich(logEvent, new PassthroughPropertyFactory());
+
+        Assert.IsTrue(logEvent.Properties.TryGetValue(HttpSessionIdEnricher.HttpSessionIdPropertyName, out LogEventPropertyValue? value));
+        Assert.AreEqual("the-session-id", ((ScalarValue)value!).Value);
+    }
+
+    [Test]
+    public void Cannot_Add_Property_When_Session_Id_Is_Null()
+    {
+        var enricher = new HttpSessionIdEnricher(new FixedSessionIdResolver(null));
+        LogEvent logEvent = CreateLogEvent();
+
+        enricher.Enrich(logEvent, new PassthroughPropertyFactory());
+
+        Assert.IsFalse(logEvent.Properties.ContainsKey(HttpSessionIdEnricher.HttpSessionIdPropertyName));
+    }
+
+    private static LogEvent CreateLogEvent() =>
+        new(
+            DateTimeOffset.UtcNow,
+            LogEventLevel.Information,
+            exception: null,
+            new MessageTemplateParser().Parse("test"),
+            Array.Empty<LogEventProperty>());
+
+    private sealed class FixedSessionIdResolver(string? sessionId) : ISessionIdResolver
+    {
+        public string? SessionId { get; } = sessionId;
+    }
+
+    private sealed class ReentrantSessionIdResolver : ISessionIdResolver
+    {
+        private int _depth;
+
+        public HttpSessionIdEnricher? Enricher { get; set; }
+
+        public int SessionIdReadCount { get; private set; }
+
+        public string? SessionId
+        {
+            get
+            {
+                SessionIdReadCount++;
+
+                // Simulate the log-during-load that triggers the recursion, but cap the depth so the
+                // unguarded code path terminates for the test rather than overflowing the stack.
+                if (_depth++ < 50)
+                {
+                    Enricher!.Enrich(CreateLogEvent(), new PassthroughPropertyFactory());
+                }
+
+                return "the-session-id";
+            }
+        }
+    }
+
+    private sealed class PassthroughPropertyFactory : ILogEventPropertyFactory
+    {
+        public LogEventProperty CreateProperty(string name, object? value, bool destructureObjects = false)
+            => new(name, new ScalarValue(value));
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/Serilog/Enrichers/HttpSessionIdEnricherTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Logging/Serilog/Enrichers/HttpSessionIdEnricherTests.cs
@@ -82,7 +82,10 @@ public class HttpSessionIdEnricherTests
                 SessionIdReadCount++;
 
                 // Simulate the log-during-load that triggers the recursion, but cap the depth so the
-                // unguarded code path terminates for the test rather than overflowing the stack.
+                // unguarded code path terminates cleanly for the test rather than overflowing the stack.
+                // 50 is well below the frame depth a StackOverflowException needs (~hundreds to low
+                // thousands), so it reliably distinguishes "guarded" (one read) from "unguarded" (many
+                // reads) without ever actually overflowing the test host.
                 if (_depth++ < 50)
                 {
                     Enricher!.Enrich(CreateLogEvent(), new PassthroughPropertyFactory());


### PR DESCRIPTION
## Description

On sites where members have sessions, a `StackOverflowException` inside Serilog's enrichment pipeline could crash the worker process.

The reported stack repeats this cycle hundreds of times before the stack is exhausted:

```
DistributedSession.Load()
  → Logger.Dispatch()
    → SafeAggregateEnricher.Enrich()
      → LogContext.Enrich()
        → HttpSessionIdEnricher.Enrich()   ← reads Session.Id → back into Load()
```

Fixed #16744.

### Root cause — a logging re-entrancy cycle

`HttpSessionIdEnricher` is pushed into Serilog's `LogContext` for every request by `UmbracoRequestLoggingMiddleware`, so it runs on **every** log event. Its `Enrich` reads `ISessionIdResolver.SessionId`, which reads `HttpContext.Session.Id` and forces ASP.NET Core's `DistributedSession.Load()`.

When the session can't be loaded — expired / gone from the distributed store after a redeploy, or a deserialize/timeout failure — `DistributedSession.Load()` **logs the failure**. That log event is enriched, the enricher reads `Session.Id` again, re-enters `Load()`, logs again… and recurses until the stack overflows.

### Fix - add re-entrancy guard

A guard inside `HttpSessionIdEnricher.Enrich`: if a log event is raised **while the enricher is already resolving the session id** (i.e. the nested log from `DistributedSession.Load()`), the nested `Enrich` returns immediately without touching the resolver. This breaks the enrich → log → enrich cycle regardless of session provider or config mode.

The flag is an `AsyncLocal<bool>`, not a plain field or `[ThreadStatic]`:
- The enricher is a **DI singleton** shared across all concurrent requests, so a plain field would let one request's in-progress resolution suppress enrichment on unrelated requests (and race).
- `[ThreadStatic]` would be correct only as long as session resolution never leaves the thread — but a distributed session store can hop threads, which would both defeat the guard and leave a stuck flag. `AsyncLocal<bool>` flows with the logical operation across any thread transitions.

## Testing

### Automated

New unit tests (`HttpSessionIdEnricherTests`) reproduce the re-entrant log-during-resolution and assert the session id is resolved exactly once (the test was confirmed to fail without the guard, without overflowing the host), plus happy-path coverage that normal enrichment is unaffected.

### Manual

I've not attempted to reproduce the issue manually, and from the issue conversation, seems that's not been proved easy to do in the past.