### PR TITLE
Scoping: Restore `LogIncompletedScopes` warning for uncompleted child scopes (closes #15243)

### DIFF
--- a/src/Umbraco.Core/Configuration/Models/CoreDebugSettings.cs
+++ b/src/Umbraco.Core/Configuration/Models/CoreDebugSettings.cs
@@ -6,9 +6,11 @@ using System.ComponentModel;
 namespace Umbraco.Cms.Core.Configuration.Models;
 
 /// <summary>
-///     Typed configuration options for core debug settings.
+///     Typed configuration options for debug settings.
 /// </summary>
-[UmbracoOptions(Constants.Configuration.ConfigCoreDebug)]
+// TODO (V19): Rename to DebugSettings to match the "Umbraco:CMS:Debug" section (the "Core" prefix
+// dates from the legacy "Umbraco:CMS:Core:Debug" section, which is deprecated).
+[UmbracoOptions(Constants.Configuration.ConfigDebug)]
 public class CoreDebugSettings
 {
     /// <summary>

--- a/src/Umbraco.Core/Constants-Configuration.cs
+++ b/src/Umbraco.Core/Constants-Configuration.cs
@@ -116,8 +116,17 @@ public static partial class Constants
         public const string ConfigDeliveryApi = ConfigPrefix + "DeliveryApi";
 
         /// <summary>
-        ///     The configuration key for core debug settings.
+        ///     The configuration key for debug settings.
         /// </summary>
+        public const string ConfigDebug = ConfigPrefix + "Debug";
+
+        /// <summary>
+        ///     The legacy configuration key for debug settings.
+        /// </summary>
+        /// <remarks>
+        ///     Retained so existing configuration under this section keeps working; new configuration should
+        ///     use <see cref="ConfigDebug" />. TODO (V19): remove once the legacy binding is dropped.
+        /// </remarks>
         public const string ConfigCoreDebug = ConfigCorePrefix + "Debug";
 
         /// <summary>

--- a/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
+++ b/src/Umbraco.Core/DependencyInjection/UmbracoBuilder.Configuration.cs
@@ -68,7 +68,14 @@ public static partial class UmbracoBuilderExtensions
             .AddUmbracoOptions<MarketplaceSettings>()
             .AddUmbracoOptions<ContentSettings>()
             .AddUmbracoOptions<DeliveryApiSettings>()
-            .AddUmbracoOptions<CoreDebugSettings>()
+
+            // Bound to the canonical "Umbraco:CMS:Debug" section (via the UmbracoOptions attribute), plus the
+            // legacy "Umbraco:CMS:Core:Debug" section for backwards compatibility. The legacy bind runs last so
+            // existing configuration under that section continues to take effect.
+            // TODO (V19): remove the legacy section bind.
+            .AddUmbracoOptions<CoreDebugSettings>(optionsBuilder => optionsBuilder.Bind(
+                builder.Config.GetSection(Constants.Configuration.ConfigCoreDebug)))
+
             .AddUmbracoOptions<DictionarySettings>()
             .AddUmbracoOptions<ExceptionFilterSettings>()
             .AddUmbracoOptions<GlobalSettings>(optionsBuilder => optionsBuilder.PostConfigure(options =>

--- a/src/Umbraco.Core/Scoping/CoreScope.cs
+++ b/src/Umbraco.Core/Scoping/CoreScope.cs
@@ -289,7 +289,7 @@ public class CoreScope : ICoreScope
     ///     Called when a child scope has completed, to update the parent's completion status.
     /// </summary>
     /// <param name="completed">A value indicating whether the child completed successfully.</param>
-    protected void ChildCompleted(bool? completed)
+    protected virtual void ChildCompleted(bool? completed)
     {
         // if child did not complete we cannot complete
         if (completed.HasValue == false || completed.Value == false)

--- a/src/Umbraco.Infrastructure/Scoping/Scope.cs
+++ b/src/Umbraco.Infrastructure/Scoping/Scope.cs
@@ -299,7 +299,6 @@ namespace Umbraco.Cms.Infrastructure.Scoping
             }
         }
 
-        // true if Umbraco.CoreDebugSettings.LogUncompletedScope appSetting is set to "true"
         private bool LogUncompletedScopes => _coreDebugSettings.LogIncompletedScopes;
 
         /// <summary>
@@ -484,6 +483,17 @@ namespace Umbraco.Cms.Infrastructure.Scoping
             }
 
             _disposed = true;
+        }
+
+        /// <inheritdoc />
+        protected override void ChildCompleted(bool? completed)
+        {
+            if (LogUncompletedScopes && completed is not true)
+            {
+                _logger.LogWarning("Uncompleted Child Scope at\r\n {StackTrace}", Environment.StackTrace);
+            }
+
+            base.ChildCompleted(completed);
         }
 
         /// <summary>

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/CoreDebugSettingsConfigurationTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Configuration/CoreDebugSettingsConfigurationTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Tests.UnitTests.TestHelpers;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Configuration;
+
+[TestFixture]
+public class CoreDebugSettingsConfigurationTests
+{
+    private static CoreDebugSettings GetSettings(IDictionary<string, string> configValues)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configValues)
+            .Build();
+
+        var services = new ServiceCollection();
+        var builder = new UmbracoBuilder(services, configuration, TestHelper.GetMockedTypeLoader());
+        builder.AddConfiguration();
+
+        return services.BuildServiceProvider().GetRequiredService<IOptions<CoreDebugSettings>>().Value;
+    }
+
+    [Test]
+    public void Can_Bind_From_Debug_Section()
+    {
+        CoreDebugSettings settings = GetSettings(new Dictionary<string, string>
+        {
+            ["Umbraco:CMS:Debug:LogIncompletedScopes"] = "true",
+        });
+
+        Assert.That(settings.LogIncompletedScopes, Is.True);
+    }
+
+    // TODO (V19): remove this test when the legacy "Umbraco:CMS:Core:Debug" section bind is dropped.
+    [Test]
+    public void Can_Bind_From_Legacy_Core_Debug_Section()
+    {
+        CoreDebugSettings settings = GetSettings(new Dictionary<string, string>
+        {
+            ["Umbraco:CMS:Core:Debug:LogIncompletedScopes"] = "true",
+        });
+
+        Assert.That(settings.LogIncompletedScopes, Is.True);
+    }
+}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -20,16 +19,18 @@ using Umbraco.Cms.Tests.Common;
 namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 {
     [TestFixture]
-    public class ScopeUnitTests
+    public class ScopeTests
     {
         /// <summary>
         /// Creates a ScopeProvider with mocked internals.
         /// </summary>
-        /// <param name="lockingMechanism"></param>
-        /// <returns></returns>
-        private ScopeProvider GetScopeProvider(out Mock<IDistributedLockingMechanism> lockingMechanism)
+        private ScopeProvider GetScopeProvider(
+            out Mock<IDistributedLockingMechanism> lockingMechanism,
+            CoreDebugSettings coreDebugSettings = null,
+            ILoggerFactory loggerFactory = null)
         {
-            var loggerFactory = NullLoggerFactory.Instance;
+            coreDebugSettings ??= new CoreDebugSettings();
+            loggerFactory ??= NullLoggerFactory.Instance;
             var fileSystems = new FileSystems(
                 loggerFactory,
                 Mock.Of<IIOHelper>(),
@@ -74,7 +75,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
                 lockingMechanismFactory.Object,
                 databaseFactory.Object,
                 fileSystems,
-                new TestOptionsMonitor<CoreDebugSettings>(new CoreDebugSettings()),
+                new TestOptionsMonitor<CoreDebugSettings>(coreDebugSettings),
                 mediaFileManager,
                 loggerFactory,
                 Mock.Of<IEventAggregator>());
@@ -111,6 +112,70 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
             outerScope.Complete();
 
             Assert.DoesNotThrow(() => outerScope.Dispose());
+        }
+
+        [Test]
+        public void Uncompleted_Child_Scope_Is_Logged_When_LogIncompletedScopes_Enabled()
+        {
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+
+            var scopeProvider = GetScopeProvider(
+                out _,
+                new CoreDebugSettings { LogIncompletedScopes = true },
+                loggerFactoryMock.Object);
+
+            using (var outerScope = (Scope)scopeProvider.CreateScope())
+            {
+                using (var childScope = (Scope)scopeProvider.CreateScope())
+                {
+                    // Deliberately not completed.
+                }
+
+                outerScope.Complete();
+            }
+
+            loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Uncompleted Child Scope")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void Uncompleted_Child_Scope_Is_Not_Logged_When_LogIncompletedScopes_Disabled()
+        {
+            var loggerMock = new Mock<ILogger>();
+            var loggerFactoryMock = new Mock<ILoggerFactory>();
+            loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+
+            var scopeProvider = GetScopeProvider(
+                out _,
+                new CoreDebugSettings { LogIncompletedScopes = false },
+                loggerFactoryMock.Object);
+
+            using (var outerScope = (Scope)scopeProvider.CreateScope())
+            {
+                using (var childScope = (Scope)scopeProvider.CreateScope())
+                {
+                    // Deliberately not completed.
+                }
+
+                outerScope.Complete();
+            }
+
+            loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Uncompleted Child Scope")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Never);
         }
 
         [Test]
@@ -522,8 +587,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
                 // Request a lock to create the ReadLocks dict.
                 scope.ReadLock(Constants.Locks.Domains);
 
-                var readDict = new Dictionary<int, int>();
-                readDict[Constants.Locks.Languages] = 1;
+                var readDict = new Dictionary<int, int>
+                {
+                    [Constants.Locks.Languages] = 1
+                };
                 scope.GetReadLocks()[Guid.NewGuid()] = readDict;
 
                 Assert.Throws<InvalidOperationException>(() => scope.Dispose());
@@ -547,8 +614,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
                 // Request a lock to create the WriteLocks dict.
                 scope.WriteLock(Constants.Locks.Domains);
 
-                var writeDict = new Dictionary<int, int>();
-                writeDict[Constants.Locks.Languages] = 1;
+                var writeDict = new Dictionary<int, int>
+                {
+                    [Constants.Locks.Languages] = 1
+                };
                 scope.GetWriteLocks()[Guid.NewGuid()] = writeDict;
 
                 Assert.Throws<InvalidOperationException>(() => scope.Dispose());

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
@@ -115,7 +115,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
         }
 
         [Test]
-        public void Uncompleted_Child_Scope_Is_Logged_When_LogIncompletedScopes_Enabled()
+        public void Can_Log_Uncompleted_Child_Scope_When_LogIncompletedScopes_Enabled()
         {
             var loggerMock = new Mock<ILogger>();
             var loggerFactoryMock = new Mock<ILoggerFactory>();
@@ -147,7 +147,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
         }
 
         [Test]
-        public void Uncompleted_Child_Scope_Is_Not_Logged_When_LogIncompletedScopes_Disabled()
+        public void Cannot_Log_Uncompleted_Child_Scope_When_LogIncompletedScopes_Disabled()
         {
             var loggerMock = new Mock<ILogger>();
             var loggerFactoryMock = new Mock<ILoggerFactory>();

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Scoping/ScopeTests.cs
@@ -24,7 +24,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
         /// <summary>
         /// Creates a ScopeProvider with mocked internals.
         /// </summary>
-        private ScopeProvider GetScopeProvider(
+        private static ScopeProvider GetScopeProvider(
             out Mock<IDistributedLockingMechanism> lockingMechanism,
             CoreDebugSettings coreDebugSettings = null,
             ILoggerFactory loggerFactory = null)
@@ -589,7 +589,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 
                 var readDict = new Dictionary<int, int>
                 {
-                    [Constants.Locks.Languages] = 1
+                    [Constants.Locks.Languages] = 1,
                 };
                 scope.GetReadLocks()[Guid.NewGuid()] = readDict;
 
@@ -616,7 +616,7 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 
                 var writeDict = new Dictionary<int, int>
                 {
-                    [Constants.Locks.Languages] = 1
+                    [Constants.Locks.Languages] = 1,
                 };
                 scope.GetWriteLocks()[Guid.NewGuid()] = writeDict;
 
@@ -661,10 +661,9 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Scoping
 
             using (var scope = scopeProvider.CreateScope())
             {
-                Assert.AreEqual(0,scope.Depth);
+                Assert.AreEqual(0, scope.Depth);
             }
         }
-
 
         [Test]
         public void Depth_WhenChildScope_ReturnsDepth()


### PR DESCRIPTION
## Description

Restores the "uncompleted scope" warning logging that the `Umbraco:CMS:Debug:LogIncompletedScopes` setting is meant to control.

Fixes #15243

### Background

`CoreDebugSettings.LogIncompletedScopes` is [still documented](https://docs.umbraco.com/umbraco-cms/develop-with-umbraco/configuration/debugsettings) and still exists in configuration, but setting it to `true` had no effect. When a child scope was disposed without being completed, Umbraco used to emit a warning with a stack trace — a useful diagnostic for tracking down "forgot to call `scope.Complete()`" bugs. That warning had silently stopped working.

The warning was inadvertently dropped in #14109 (EF Core support, commit `487e85cacd`). Before that refactor, `ChildCompleted` lived in `Umbraco.Infrastructure/Scoping/Scope.cs` and contained the guarded log:

```csharp
if (_coreDebugSettings.LogIncompletedScopes)
{
    _logger.LogWarning("Uncompleted Child Scope at\r\n {StackTrace}", Environment.StackTrace);
}
```

During #14109, `ChildCompleted` was pulled up into the new base class `Umbraco.Core/Scoping/CoreScope.cs`. `CoreScope` has neither an `ILogger` nor `CoreDebugSettings`, so the guarded log couldn't come with it and was simply removed. Telltale signs the feature was left half-wired: `Scope` still injected and stored both `_logger` and `_coreDebugSettings`, and still exposed a `LogUncompletedScopes` property — but that property had become dead code with no remaining callers.

### Fix 1 — add the missing implementation

"A child scope was disposed without being completed" is a *core scoping* concept — the completion state, the parent chain, and `ChildCompleted` itself all live in `CoreScope`, and the setting is `CoreDebugSettings`. So the natural home for the diagnostic is `ChildCompleted`, right where the "child didn't complete → parent can't complete" decision is made (which is also where the original code logged it).

The blocker is that `CoreScope` doesn't have the logger or the setting, and threading `CoreDebugSettings` into its `protected` constructors would be a breaking change to a public type — a lot of obsolete-constructor machinery for a debug log line.

So instead:

- `CoreScope.ChildCompleted` is made `protected virtual` (adding `virtual` to a protected member is source- and binary-compatible — not a breaking change).
- `Scope` (Infrastructure), which already has `_logger` and `_coreDebugSettings`, overrides it to emit the guarded warning and then calls `base.ChildCompleted(...)`.

This restores the original pre-#14109 structure, co-locates the log with the completion decision, reuses the previously-orphaned `LogUncompletedScopes` property, and — because the method is now virtual — also covers the `CoreScope.Dispose` path. EF Core scopes are intentionally left untouched: they never had this behaviour.

### Fix 2 — the config path was mis-bound

While verifying the fix, it turned out the documented config path never reached the setting either. The docs (and the shipped `appsettings-schema` that drives IntelliSense) both show:

```
Umbraco:CMS:Debug:LogIncompletedScopes
```

…but `CoreDebugSettings` was bound via `[UmbracoOptions(ConfigCoreDebug)]` to `Umbraco:CMS:`**`Core:`**`Debug`. So a value placed at the documented path was silently ignored — the options binder handed back a default-constructed settings object (`false`). This has been the case since the settings/JSON-schema refactor (`74e2b7aca2f`); nothing else lives under `Umbraco:CMS:Core:`, and the JSON-schema generator (`tools/Umbraco.JsonSchema/UmbracoCmsSchema.cs` → `UmbracoCmsDefinition.Debug`) has always placed this class at `Umbraco:CMS:Debug`, so the binding attribute was the outlier.

To resolve this, whilst maintaining backward compatibility for anyone that has these values configured under `Core:Debug` we have:

- `CoreDebugSettings` now bound to the `Umbraco:CMS:Debug` section (new `Constants.Configuration.ConfigDebug`). This matches the JSON schema and the docs.
- The legacy `Umbraco:CMS:Core:Debug` section is still bound (a second `.Bind()` in the `AddUmbracoOptions<CoreDebugSettings>` registration) so any existing configuration keeps working.
- `TODO (V19)` markers are in place to drop the legacy bind and rename `CoreDebugSettings` → `DebugSettings` (the `Core` prefix only existed because of the old section).

Together with the logging fix, this means a user following the docs (`Umbraco:CMS:Debug:LogIncompletedScopes: true`) now actually gets the warning. Restoring the code and correcting the binding makes the existing docs accurate again.

## Testing

### Automated

Solution should build and CI checks pass. Added unit tests:

- `ScopeTests` — the warning fires when the setting is enabled and does not when disabled (verified the positive test fails without the fix).
- `CoreDebugSettingsConfigurationTests` — `LogIncompletedScopes` binds from both the canonical `Umbraco:CMS:Debug` section and the legacy `Umbraco:CMS:Core:Debug` section (verified the legacy test fails if the back-compat bind is removed).

### Manual

The warning only fires for a **child** scope disposed without being completed — a lone top-level scope that is never completed goes down the "last scope" path and does not warn. _I've verified this against what we had before this logging was removed, and this aligns with that old behaviour._

So the repro needs a parent scope with a nested child.

**1. Enable the setting** in `appsettings.Development.json` (the legacy `Umbraco:CMS:Core:Debug` section works too):

```json
{
  "Umbraco": {
    "CMS": {
      "Debug": {
        "LogIncompletedScopes": true
      }
    }
  }
}
```

**2. Add a test controller** that creates a parent scope and a nested child scope, then disposes the child without completing it:

```csharp
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core.Scoping;

namespace Umbraco.Cms.Web.UI.Controllers;

public class DebugUncompletedScopeController : Controller
{
    private readonly ICoreScopeProvider _scopeProvider;

    public DebugUncompletedScopeController(ICoreScopeProvider scopeProvider)
        => _scopeProvider = scopeProvider;

    [HttpGet("/debug/uncompleted-scope")]
    public IActionResult CreateUncompletedScope([FromQuery] bool complete = false)
    {
        using ICoreScope parentScope = _scopeProvider.CreateCoreScope();

        using (ICoreScope childScope = _scopeProvider.CreateCoreScope())
        {
            if (complete)
            {
                childScope.Complete();
            }

            // When complete is false the child scope is disposed here (end of the using
            // block) without having been completed, triggering the warning on the parent.
        }

        parentScope.Complete();

        return Content(complete ? "Child completed — no warning expected." : "Child not completed — expect a warning.", "text/plain");
    }
}
```

**3. Run the site and hit `GET /debug/uncompleted-scope`.** A warning is logged (category `Umbraco.Cms.Infrastructure.Scoping.Scope`):

```
[WRN] Uncompleted Child Scope at
   at System.Environment.get_StackTrace()
   at Umbraco.Cms.Infrastructure.Scoping.Scope.ChildCompleted(Nullable`1 completed)
   at Umbraco.Cms.Infrastructure.Scoping.Scope.Dispose()
   at Umbraco.Cms.Web.UI.Controllers.DebugUncompletedScopeController.CreateUncompletedScope(Boolean complete)
   ...
```

**4. Confirm the negative paths are silent:**

- `GET /debug/uncompleted-scope?complete=true` (child completed) → no warning.
- Setting `false` or absent → no warning.
- Setting the value under the legacy `Umbraco:CMS:Core:Debug:LogIncompletedScopes` instead → still warns (back-compat).
