### PR TITLE
Normalize culture code casing in SetCultureInfo and SetPublishInfo

### DIFF
--- a/src/Umbraco.Core/Extensions/StringExtensions.Culture.cs
+++ b/src/Umbraco.Core/Extensions/StringExtensions.Culture.cs
@@ -184,9 +184,7 @@ public static partial class StringExtensions
             return culture;
         }
 
-        // Create as CultureInfo instance from provided name so we can ensure consistent casing of culture code when persisting.
-        // This will accept mixed case but once created have a `Name` property that is consistently and correctly cased.
-        // Will throw if an invalid culture code is provided.
-        return new CultureInfo(culture).Name;
+        // GetCultureInfo returns a cached instance and exposes a correctly cased Name; throws for invalid codes.
+        return CultureInfo.GetCultureInfo(culture).Name;
     }
 }

--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.PropertyEditors;
 
@@ -17,6 +18,7 @@ public static class ContentRepositoryExtensions
     /// <param name="date">The date to associate with this culture information.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="name" /> or <paramref name="culture" /> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name" /> or <paramref name="culture" /> is empty or whitespace.</exception>
+    /// <exception cref="CultureNotFoundException">Thrown when <paramref name="culture" /> is not a valid culture code.</exception>
     public static void SetCultureInfo(this IContentBase content, string? culture, string? name, DateTime date)
     {
         if (name == null)
@@ -261,6 +263,7 @@ public static class ContentRepositoryExtensions
     /// <param name="date">The publish date to associate with this culture.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="name" /> or <paramref name="culture" /> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="name" /> or <paramref name="culture" /> is empty or whitespace.</exception>
+    /// <exception cref="CultureNotFoundException">Thrown when <paramref name="culture" /> is not a valid culture code.</exception>
     public static void SetPublishInfo(this IContent content, string? culture, string? name, DateTime date)
     {
         if (name == null)

--- a/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
+++ b/src/Umbraco.Core/Models/ContentRepositoryExtensions.cs
@@ -43,7 +43,7 @@ public static class ContentRepositoryExtensions
                 nameof(culture));
         }
 
-        content.CultureInfos?.AddOrUpdate(culture, name, date);
+        content.CultureInfos?.AddOrUpdate(culture.EnsureCultureCode()!, name, date);
     }
 
     /// <summary>
@@ -287,7 +287,7 @@ public static class ContentRepositoryExtensions
                 nameof(culture));
         }
 
-        content.PublishCultureInfos?.AddOrUpdate(culture, name, date);
+        content.PublishCultureInfos?.AddOrUpdate(culture.EnsureCultureCode()!, name, date);
     }
 
     /// <summary>

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
@@ -136,7 +136,7 @@ internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
         await LanguageService.CreateAsync(new Language("en-GB", "English (UK)"), Constants.Security.SuperUserKey);
 
         IContent content = ContentService.Create("Test Item", Constants.System.Root, contentType);
-        content.SetCultureInfo("en-gb", "Test item", DateTime.Now);
+        content.SetCultureInfo("en-gb", "Test item", DateTime.UtcNow);
         content.SetValue("title", "Title", "en-gb");
         ContentService.Save(content);
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentServiceVariantTests.cs
@@ -22,6 +22,8 @@ internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
 
     private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
 
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
     /// <summary>
     /// Provides both happy path with correctly cased cultures, and originally failing test cases for
     /// https://github.com/umbraco/Umbraco-CMS/issues/19287, where the culture codes are provided with inconsistent casing.
@@ -117,6 +119,35 @@ internal sealed class ContentServiceVariantTests : UmbracoIntegrationTest
             Assert.IsTrue(child.Published);
             Assert.AreEqual(1, child.PublishedCultures.Count());
             Assert.AreEqual("en-US", child.PublishedCultures.FirstOrDefault());
+        });
+    }
+
+    /// <summary>
+    /// Reproduces https://github.com/umbraco/Umbraco-CMS/issues/19287 via the reported path: setting the culture
+    /// directly with non-canonical casing through <see cref="ContentRepositoryExtensions.SetCultureInfo" /> (rather
+    /// than <c>SetCultureName</c>, which already normalises) and then publishing.
+    /// </summary>
+    [Test]
+    public async Task Can_Publish_Content_With_Culture_Set_Directly_With_Inconsistent_Casing()
+    {
+        var contentType = await SetupVariantTest();
+
+        // en-GB is not installed by default; add it so the non-canonical "en-gb" can be published.
+        await LanguageService.CreateAsync(new Language("en-GB", "English (UK)"), Constants.Security.SuperUserKey);
+
+        IContent content = ContentService.Create("Test Item", Constants.System.Root, contentType);
+        content.SetCultureInfo("en-gb", "Test item", DateTime.Now);
+        content.SetValue("title", "Title", "en-gb");
+        ContentService.Save(content);
+
+        var publishResult = ContentService.Publish(content, ["en-gb"]);
+        Assert.IsTrue(publishResult.Success);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsTrue(content.Published);
+            Assert.AreEqual("en-GB", content.AvailableCultures.FirstOrDefault());
+            Assert.AreEqual("en-GB", content.PublishedCultures.FirstOrDefault());
         });
     }
 

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTests.cs
@@ -113,6 +113,46 @@ public class ContentTests
         Assert.IsTrue(content.IsPropertyDirty("PublishCultureInfos")); // it's true now since we've updated a name
     }
 
+    [TestCase("en-us", "en-US")]
+    [TestCase("en-GB", "en-GB")]
+    public void Can_Set_Culture_Info_With_Normalized_Culture_Code_Casing(string culture, string expectedCulture)
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("contentType")
+            .WithContentVariation(ContentVariation.Culture)
+            .Build();
+        var content = new ContentBuilder()
+            .WithId(1)
+            .WithVersionId(1)
+            .WithName("content")
+            .WithContentType(contentType)
+            .Build();
+
+        content.SetCultureInfo(culture, "name", DateTime.UtcNow);
+
+        Assert.AreEqual(expectedCulture, content.CultureInfos[culture].Culture);
+    }
+
+    [TestCase("en-us", "en-US")]
+    [TestCase("en-GB", "en-GB")]
+    public void Can_Set_Publish_Info_With_Normalized_Culture_Code_Casing(string culture, string expectedCulture)
+    {
+        var contentType = new ContentTypeBuilder()
+            .WithAlias("contentType")
+            .WithContentVariation(ContentVariation.Culture)
+            .Build();
+        var content = new ContentBuilder()
+            .WithId(1)
+            .WithVersionId(1)
+            .WithName("content")
+            .WithContentType(contentType)
+            .Build();
+
+        content.SetPublishInfo(culture, "name", DateTime.UtcNow);
+
+        Assert.AreEqual(expectedCulture, content.PublishCultureInfos[culture].Culture);
+    }
+
     [Test]
     public void Get_Non_Grouped_Properties()
     {


### PR DESCRIPTION
## Problem

Culture codes set on content via the low-level `SetCultureInfo` / `SetPublishInfo` extensions are stored with whatever casing the caller provides. Since #19290 (which resolved #19287) normalizes the casing in `SaveAndPublish` and `SetCultureName`, but not in these two setters, a programmatic caller (e.g. Umbraco Deploy importing older, lower-cased culture codes) can end up with the draft (`CultureInfos`) and published (`PublishCultureInfos`) collections holding the same culture with different casing.

`DocumentRepository.GetDocumentVariationDtos` then builds its rows from `AvailableCultures.Union(PublishedCultures)` using the default (ordinal, case-sensitive) comparer, so `{da-dk} ∪ {da-DK}` yields two entries that both resolve (case-insensitively) to the same language id, producing a duplicate row and a unique constraint violation on `umbracoDocumentCultureVariation (nodeId, languageId)`.

This is the root cause behind umbraco/Umbraco.Deploy.Issues#280 and umbraco/Umbraco.Deploy.Issues#271.

## Fix

Normalize the culture code at the input boundary by calling `EnsureCultureCode()` in `SetCultureInfo` and `SetPublishInfo`, completing the approach started in #19290. Both collections now always store canonical casing, so any consumer (including `GetDocumentVariationDtos`) is safe regardless of how the culture was originally cased.

Also switches `EnsureCultureCode` from `new CultureInfo(culture)` to the cached `CultureInfo.GetCultureInfo(culture)` to avoid an allocation per culture on hot paths such as content materialization (these setters are also used when reading content from the database). Behaviour is identical for all valid, hyphenated culture codes and for invalid codes (both throw `CultureNotFoundException`).

## Testing

Existing `StringExtensionsTests` for `EnsureCultureCode` continue to pass. The scenario can be reproduced by setting a culture with non-canonical casing (e.g. `content.SetCultureInfo("en-gb", ...)`) and publishing.
