### PR TITLE
Backoffice: Support running in insecure browser contexts (plain HTTP on IP addresses)

### DIFF
--- a/src/Umbraco.Core/Services/PreviewService.cs
+++ b/src/Umbraco.Core/Services/PreviewService.cs
@@ -37,29 +37,6 @@ public class PreviewService : IPreviewService
     /// <param name="previewTokenGenerator">The generator for creating and validating preview tokens.</param>
     /// <param name="serviceScopeFactory">The factory for creating service scopes.</param>
     /// <param name="requestCache">The request cache for caching preview state per request.</param>
-    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
-    public PreviewService(
-        ICookieManager cookieManager,
-        IPreviewTokenGenerator previewTokenGenerator,
-        IServiceScopeFactory serviceScopeFactory,
-        IRequestCache requestCache)
-        : this(
-            cookieManager,
-            previewTokenGenerator,
-            serviceScopeFactory,
-            requestCache,
-            StaticServiceProvider.Instance.GetRequiredService<IOptions<GlobalSettings>>(),
-            StaticServiceProvider.Instance.GetRequiredService<IRequestAccessor>())
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of the <see cref="PreviewService" /> class.
-    /// </summary>
-    /// <param name="cookieManager">The cookie manager for handling preview cookies.</param>
-    /// <param name="previewTokenGenerator">The generator for creating and validating preview tokens.</param>
-    /// <param name="serviceScopeFactory">The factory for creating service scopes.</param>
-    /// <param name="requestCache">The request cache for caching preview state per request.</param>
     /// <param name="globalSettings">The global settings.</param>
     /// <param name="requestAccessor">The request accessor for determining the current request scheme.</param>
     public PreviewService(
@@ -76,6 +53,29 @@ public class PreviewService : IPreviewService
         _requestCache = requestCache;
         _globalSettings = globalSettings.Value;
         _requestAccessor = requestAccessor;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="PreviewService" /> class.
+    /// </summary>
+    /// <param name="cookieManager">The cookie manager for handling preview cookies.</param>
+    /// <param name="previewTokenGenerator">The generator for creating and validating preview tokens.</param>
+    /// <param name="serviceScopeFactory">The factory for creating service scopes.</param>
+    /// <param name="requestCache">The request cache for caching preview state per request.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
+    public PreviewService(
+        ICookieManager cookieManager,
+        IPreviewTokenGenerator previewTokenGenerator,
+        IServiceScopeFactory serviceScopeFactory,
+        IRequestCache requestCache)
+        : this(
+            cookieManager,
+            previewTokenGenerator,
+            serviceScopeFactory,
+            requestCache,
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<GlobalSettings>>(),
+            StaticServiceProvider.Instance.GetRequiredService<IRequestAccessor>())
+    {
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Core/Services/PreviewService.cs
+++ b/src/Umbraco.Core/Services/PreviewService.cs
@@ -1,6 +1,9 @@
 using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Preview;
 using Umbraco.Cms.Core.Security;
@@ -15,7 +18,8 @@ namespace Umbraco.Cms.Core.Services;
 /// <remarks>
 ///     Preview mode allows backoffice users to view unpublished content changes
 ///     as they would appear on the front-end website. This implementation uses
-///     secure cookies with SameSite=None to support cross-site preview scenarios.
+///     secure cookies with SameSite=None to support cross-site preview scenarios,
+///     falling back to non-secure SameSite=Lax cookies for insecure (plain http) setups.
 /// </remarks>
 public class PreviewService : IPreviewService
 {
@@ -23,6 +27,8 @@ public class PreviewService : IPreviewService
     private readonly IPreviewTokenGenerator _previewTokenGenerator;
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IRequestCache _requestCache;
+    private readonly GlobalSettings _globalSettings;
+    private readonly IRequestAccessor _requestAccessor;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="PreviewService" /> class.
@@ -31,16 +37,45 @@ public class PreviewService : IPreviewService
     /// <param name="previewTokenGenerator">The generator for creating and validating preview tokens.</param>
     /// <param name="serviceScopeFactory">The factory for creating service scopes.</param>
     /// <param name="requestCache">The request cache for caching preview state per request.</param>
+    [Obsolete("Please use the constructor with all parameters. Scheduled for removal in Umbraco 19.")]
     public PreviewService(
         ICookieManager cookieManager,
         IPreviewTokenGenerator previewTokenGenerator,
         IServiceScopeFactory serviceScopeFactory,
         IRequestCache requestCache)
+        : this(
+            cookieManager,
+            previewTokenGenerator,
+            serviceScopeFactory,
+            requestCache,
+            StaticServiceProvider.Instance.GetRequiredService<IOptions<GlobalSettings>>(),
+            StaticServiceProvider.Instance.GetRequiredService<IRequestAccessor>())
+    {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="PreviewService" /> class.
+    /// </summary>
+    /// <param name="cookieManager">The cookie manager for handling preview cookies.</param>
+    /// <param name="previewTokenGenerator">The generator for creating and validating preview tokens.</param>
+    /// <param name="serviceScopeFactory">The factory for creating service scopes.</param>
+    /// <param name="requestCache">The request cache for caching preview state per request.</param>
+    /// <param name="globalSettings">The global settings.</param>
+    /// <param name="requestAccessor">The request accessor for determining the current request scheme.</param>
+    public PreviewService(
+        ICookieManager cookieManager,
+        IPreviewTokenGenerator previewTokenGenerator,
+        IServiceScopeFactory serviceScopeFactory,
+        IRequestCache requestCache,
+        IOptions<GlobalSettings> globalSettings,
+        IRequestAccessor requestAccessor)
     {
         _cookieManager = cookieManager;
         _previewTokenGenerator = previewTokenGenerator;
         _serviceScopeFactory = serviceScopeFactory;
         _requestCache = requestCache;
+        _globalSettings = globalSettings.Value;
+        _requestAccessor = requestAccessor;
     }
 
     /// <inheritdoc />
@@ -50,10 +85,18 @@ public class PreviewService : IPreviewService
 
         if (attempt.Success)
         {
-            // Preview cookies must use SameSite=None and Secure=true to support cross-site scenarios
+            // Preview cookies use SameSite=None and Secure=true to support cross-site scenarios
             // (e.g., when the backoffice is on a different domain/port than the frontend during development).
-            // SameSite=None requires Secure=true per browser specifications.
-            _cookieManager.SetCookieValue(Constants.Web.PreviewCookieName, attempt.Result!, httpOnly: true, secure: true, sameSiteMode: "None");
+            // SameSite=None requires Secure=true per browser specifications. However, browsers reject
+            // Secure cookies set over plain http on anything but localhost, so for insecure setups
+            // (e.g. http://<ip> development environments) fall back to a non-secure SameSite=Lax cookie.
+            var secure = _globalSettings.UseHttps || _requestAccessor.GetRequestUrl()?.Scheme == Uri.UriSchemeHttps;
+            _cookieManager.SetCookieValue(
+                Constants.Web.PreviewCookieName,
+                attempt.Result!,
+                httpOnly: true,
+                secure: secure,
+                sameSiteMode: secure ? "None" : "Lax");
         }
 
         return attempt.Success;
@@ -62,8 +105,8 @@ public class PreviewService : IPreviewService
     /// <inheritdoc />
     public Task EndPreviewAsync()
     {
-         _cookieManager.ExpireCookie(Constants.Web.PreviewCookieName);
-         return Task.CompletedTask;
+        _cookieManager.ExpireCookie(Constants.Web.PreviewCookieName);
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
+++ b/src/Umbraco.Web.UI.Client/src/assets/lang/en.ts
@@ -1620,6 +1620,7 @@ export default {
 			'There is no hostname configured for %0%, please contact an administrator, see log for more information',
 		copySuccessMessage: 'Your system information has successfully been copied to the clipboard',
 		cannotCopyInformation: 'Could not copy your system information to the clipboard',
+		cannotCopyToClipboard: 'Could not copy to the clipboard',
 		webhookSaved: 'Webhook saved',
 		editMultiContentPublishedText: '%0% documents published and are visible on the website',
 		editMultiContentUnpublishedText: '%0% documents unpublished and are no longer visible on the website',

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-local-storage.manager.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-local-storage.manager.test.ts
@@ -104,6 +104,32 @@ describe('UmbClipboardLocalStorageManager', () => {
 		});
 	});
 
+	describe('insecure contexts', () => {
+		it('stores and retrieves entries when crypto.subtle is unavailable', async () => {
+			// http://<ip> origins are insecure contexts where the browser removes crypto.subtle;
+			// simulate that by shadowing the globals for the duration of the test.
+			// isSecureContext is an own property of window, so its descriptor must be restored;
+			// crypto.subtle is a prototype getter, so deleting the shadowing own property suffices.
+			const originalIsSecureContext = Object.getOwnPropertyDescriptor(window, 'isSecureContext');
+			Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+			Object.defineProperty(window.crypto, 'subtle', { value: undefined, configurable: true });
+			try {
+				const insecureManager = new UmbClipboardLocalStorageManager(hostElement);
+				await insecureManager.setEntries(clipboardEntries);
+				const { entries, total } = await insecureManager.getEntries();
+				expect(entries).to.deep.equal(clipboardEntries);
+				expect(total).to.equal(clipboardEntries.length);
+			} finally {
+				if (originalIsSecureContext) {
+					Object.defineProperty(window, 'isSecureContext', originalIsSecureContext);
+				} else {
+					delete (window as { isSecureContext?: boolean }).isSecureContext;
+				}
+				delete (window.crypto as { subtle?: SubtleCrypto }).subtle;
+			}
+		});
+	});
+
 	describe('setEntries', () => {
 		it('sets entries in local storage', async () => {
 			const newEntry: UmbClipboardEntryDetailModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-local-storage.manager.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/clipboard/clipboard-local-storage.manager.ts
@@ -1,5 +1,4 @@
 import type { UmbClipboardEntryDetailModel } from './clipboard-entry/index.js';
-import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import { UMB_CURRENT_USER_CONTEXT } from '@umbraco-cms/backoffice/current-user';
 
@@ -15,15 +14,6 @@ interface UmbClipboardLocalStorageFilterModel {
 export class UmbClipboardLocalStorageManager extends UmbControllerBase {
 	#currentUserUnique?: string;
 	#fingerprint?: string;
-
-	constructor(host: UmbControllerHost) {
-		super(host);
-
-		// TODO: look into encrypting the data
-		if (!window.isSecureContext && window.crypto) {
-			throw new Error('Clipboard local storage manager can only be used in a secure context');
-		}
-	}
 
 	// Gets all entries from local storage
 	async getEntries(): Promise<{
@@ -44,6 +34,7 @@ export class UmbClipboardLocalStorageManager extends UmbControllerBase {
 	}
 
 	// Sets all entries in local storage
+	// TODO: look into encrypting the data
 	async setEntries(entries: Array<UmbClipboardEntryDetailModel>) {
 		const currentUserUnique = await this.#requestCurrentUserUnique();
 
@@ -102,6 +93,13 @@ export class UmbClipboardLocalStorageManager extends UmbControllerBase {
 	}
 
 	async #fingerPrint(text: string) {
+		// crypto.subtle only exists in secure contexts (https or localhost). The hash only shapes
+		// the per-user localStorage key — it is not a security boundary — and localStorage is
+		// per-origin, so a raw-text key on an insecure origin never collides with hashed keys.
+		if (!window.crypto?.subtle) {
+			return text;
+		}
+
 		const encoder = new TextEncoder();
 		const data = encoder.encode(text);
 		const hashBuffer = await window.crypto.subtle.digest('SHA-256', data);

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/umb-auth-client.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/umb-auth-client.test.ts
@@ -64,6 +64,32 @@ describe('UmbAuthClient', () => {
 		});
 	});
 
+	describe('PKCE generation in insecure contexts', () => {
+		it('derives the same S256 code challenge when crypto.subtle is unavailable', async () => {
+			// http://<ip> origins are insecure contexts where the browser removes crypto.subtle;
+			// simulate that by shadowing the prototype getter on the crypto instance.
+			const subtle = crypto.subtle;
+			let url: string;
+			Object.defineProperty(crypto, 'subtle', { value: undefined, configurable: true });
+			try {
+				expect(crypto.subtle, 'crypto.subtle should be shadowed for this test').to.be.undefined;
+				url = await client.buildAuthorizationUrl('Umbraco');
+			} finally {
+				// Deleting the own property restores the prototype getter.
+				delete (crypto as { subtle?: SubtleCrypto }).subtle;
+			}
+
+			const challenge = new URL(url).searchParams.get('code_challenge');
+			const expectedHash = await subtle.digest('SHA-256', new TextEncoder().encode(client.codeVerifier!));
+			const expectedChallenge = btoa(String.fromCharCode(...new Uint8Array(expectedHash)))
+				.replace(/\+/g, '-')
+				.replace(/\//g, '_')
+				.replace(/=/g, '');
+
+			expect(challenge).to.equal(expectedChallenge);
+		});
+	});
+
 	describe('clearPkceState', () => {
 		it('clears the stored PKCE state', async () => {
 			await client.buildAuthorizationUrl('Umbraco');

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/umb-auth-client.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/umb-auth-client.ts
@@ -26,8 +26,102 @@ function generateRandom(size: number): string {
 async function deriveChallenge(codeVerifier: string): Promise<string> {
 	const encoder = new TextEncoder();
 	const data = encoder.encode(codeVerifier);
-	const hash = await crypto.subtle.digest('SHA-256', data);
+	// crypto.subtle only exists in secure contexts (https or localhost). Fall back to a local
+	// SHA-256 implementation so login still works over plain http, e.g. http://<ip> dev setups.
+	const hash = crypto.subtle ? await crypto.subtle.digest('SHA-256', data) : sha256(data);
 	return urlSafeBase64(hash);
+}
+
+// SHA-256 (FIPS 180-4) round constants: first 32 bits of the fractional parts of the
+// cube roots of the first 64 primes.
+// prettier-ignore
+const SHA256_K = new Uint32Array([
+	0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+	0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+	0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+	0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+	0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+	0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+	0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+	0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+/**
+ * Rotates a 32-bit unsigned integer right by n bits.
+ * @param {number} x The value to rotate.
+ * @param {number} n The number of bits to rotate by.
+ * @returns {number} The rotated value as an unsigned 32-bit integer.
+ */
+function rotr(x: number, n: number): number {
+	return ((x >>> n) | (x << (32 - n))) >>> 0;
+}
+
+/**
+ * Plain-JavaScript SHA-256 (FIPS 180-4), used only when `crypto.subtle` is unavailable.
+ * Verified against `crypto.subtle.digest` in unit tests.
+ * @param {Uint8Array} data The bytes to hash.
+ * @returns {ArrayBuffer} The 32-byte digest.
+ */
+function sha256(data: Uint8Array): ArrayBuffer {
+	const state = new Uint32Array([
+		0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+	]);
+
+	// Pad the message: append 0x80, zero-fill, then the 64-bit big-endian bit length.
+	const byteLength = data.length;
+	const paddedLength = (((byteLength + 8) >> 6) + 1) << 6;
+	const padded = new Uint8Array(paddedLength);
+	padded.set(data);
+	padded[byteLength] = 0x80;
+	const view = new DataView(padded.buffer);
+	view.setUint32(paddedLength - 8, Math.floor(byteLength / 0x20000000));
+	view.setUint32(paddedLength - 4, (byteLength << 3) >>> 0);
+
+	const w = new Uint32Array(64);
+	for (let offset = 0; offset < paddedLength; offset += 64) {
+		for (let i = 0; i < 16; i++) {
+			w[i] = view.getUint32(offset + i * 4);
+		}
+		for (let i = 16; i < 64; i++) {
+			const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+			const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+			w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+		}
+
+		let [a, b, c, d, e, f, g, h] = state;
+		for (let i = 0; i < 64; i++) {
+			const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+			const ch = (e & f) ^ (~e & g);
+			const temp1 = (h + S1 + ch + SHA256_K[i] + w[i]) >>> 0;
+			const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+			const maj = (a & b) ^ (a & c) ^ (b & c);
+			const temp2 = (S0 + maj) >>> 0;
+			h = g;
+			g = f;
+			f = e;
+			e = (d + temp1) >>> 0;
+			d = c;
+			c = b;
+			b = a;
+			a = (temp1 + temp2) >>> 0;
+		}
+
+		state[0] = (state[0] + a) >>> 0;
+		state[1] = (state[1] + b) >>> 0;
+		state[2] = (state[2] + c) >>> 0;
+		state[3] = (state[3] + d) >>> 0;
+		state[4] = (state[4] + e) >>> 0;
+		state[5] = (state[5] + f) >>> 0;
+		state[6] = (state[6] + g) >>> 0;
+		state[7] = (state[7] + h) >>> 0;
+	}
+
+	const digest = new Uint8Array(32);
+	const digestView = new DataView(digest.buffer);
+	for (let i = 0; i < 8; i++) {
+		digestView.setUint32(i * 4, state[i]);
+	}
+	return digest.buffer;
 }
 
 export interface UmbAuthClientEndpoints {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/auth/umb-auth-client.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/auth/umb-auth-client.ts
@@ -57,8 +57,14 @@ function rotr(x: number, n: number): number {
 }
 
 /**
- * Plain-JavaScript SHA-256 (FIPS 180-4), used only when `crypto.subtle` is unavailable.
- * Verified against `crypto.subtle.digest` in unit tests.
+ * Plain-JavaScript SHA-256 (FIPS 180-4), used ONLY to derive the PKCE code challenge when
+ * `crypto.subtle` is unavailable (insecure contexts, e.g. http://<ip> dev setups).
+ * Verified byte-for-byte against `crypto.subtle.digest` in unit tests.
+ *
+ * An in-repo implementation is acceptable for this narrow case because a wrong digest fails
+ * closed: the server recomputes and compares the challenge at token exchange, so any deviation
+ * breaks login — it cannot weaken the flow. Do NOT reuse this for anything security-sensitive;
+ * use `crypto.subtle`. Removed together with the PKCE flow in V19.
  * @param {Uint8Array} data The bytes to hash.
  * @returns {ArrayBuffer} The 32-byte digest.
  */

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.element.ts
@@ -1,6 +1,8 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, customElement, html, property, state, when } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import type { UmbNotificationContext } from '@umbraco-cms/backoffice/notification';
+import { UMB_NOTIFICATION_CONTEXT } from '@umbraco-cms/backoffice/notification';
 
 //TODO consider adding a highlight prop to the code block, that could spin up/access monaco instance and highlight the code
 
@@ -19,15 +21,29 @@ export class UmbCodeBlockElement extends UmbLitElement {
 	@state()
 	private _copyState: 'idle' | 'success' = 'idle';
 
+	#notificationContext?: UmbNotificationContext;
+
+	constructor() {
+		super();
+		this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => (this.#notificationContext = instance));
+	}
 
 	async copyCode() {
 		const text = this.textContent;
-		if (text) {
+		if (!text) return;
+
+		try {
+			// navigator.clipboard only exists in secure contexts (https or localhost) and the
+			// write can also be denied by permissions policy, so failures must be surfaced.
 			await navigator.clipboard.writeText(text);
 			this._copyState = 'success';
 			setTimeout(() => {
 				this._copyState = 'idle';
 			}, 2000);
+		} catch {
+			this.#notificationContext?.peek('danger', {
+				data: { message: this.localize.term('speechBubbles_cannotCopyToClipboard') },
+			});
 		}
 	}
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/components/code-block/code-block.test.ts
@@ -1,0 +1,22 @@
+import { UmbCodeBlockElement } from './code-block.element.js';
+import { expect, fixture, html } from '@open-wc/testing';
+
+describe('UmbCodeBlockElement', () => {
+	describe('copyCode', () => {
+		it('does not throw when navigator.clipboard is unavailable', async () => {
+			const element = await fixture<UmbCodeBlockElement>(html`<umb-code-block copy>some code</umb-code-block>`);
+
+			// http://<ip> origins are insecure contexts where the browser removes navigator.clipboard;
+			// simulate that by shadowing the prototype getter on the navigator instance.
+			Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+			try {
+				await element.copyCode();
+			} finally {
+				// Deleting the own property restores the prototype getter.
+				delete (navigator as { clipboard?: Clipboard }).clipboard;
+			}
+
+			expect(element).to.exist;
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/entity-actions/create/modal/create-user-success-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/entity-actions/create/modal/create-user-success-modal.element.ts
@@ -64,13 +64,21 @@ export class UmbCreateUserSuccessModalElement extends UmbModalBaseElement<
 		}
 	}
 
-	#copyPassword() {
+	async #copyPassword() {
 		const passwordInput = this.shadowRoot?.querySelector('#password') as UUIInputPasswordElement;
 		if (!passwordInput || typeof passwordInput.value !== 'string') return;
 
-		navigator.clipboard.writeText(passwordInput.value);
-		const data: UmbNotificationDefaultData = { message: this.localize.term('user_passwordCopied') };
-		this.#notificationContext?.peek('positive', { data });
+		try {
+			// navigator.clipboard only exists in secure contexts (https or localhost) and the
+			// write can also be denied by permissions policy, so failures must be surfaced.
+			await navigator.clipboard.writeText(passwordInput.value);
+			const data: UmbNotificationDefaultData = { message: this.localize.term('user_passwordCopied') };
+			this.#notificationContext?.peek('positive', { data });
+		} catch {
+			this.#notificationContext?.peek('danger', {
+				data: { message: this.localize.term('speechBubbles_cannotCopyToClipboard') },
+			});
+		}
 	}
 
 	#onCloseModal = (event: Event) => {

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/PreviewServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/PreviewServiceTests.cs
@@ -56,7 +56,19 @@ public class PreviewServiceTests
         Assert.IsTrue(result);
     }
 
-    private static PreviewService CreatePreviewService(Mock<ICookieManager> cookieManagerMock, out IUser user, bool useHttps, string requestUrl)
+    [Test]
+    public async Task TryEnterPreviewAsync_Sets_NonSecure_SameSiteLax_Cookie_When_Request_Url_Is_Unavailable()
+    {
+        var cookieManagerMock = new Mock<ICookieManager>();
+        var previewService = CreatePreviewService(cookieManagerMock, out var user, useHttps: false, requestUrl: null);
+
+        var result = await previewService.TryEnterPreviewAsync(user);
+
+        VerifyCookie(cookieManagerMock, secure: false, sameSiteMode: SameSiteMode.Lax);
+        Assert.IsTrue(result);
+    }
+
+    private static PreviewService CreatePreviewService(Mock<ICookieManager> cookieManagerMock, out IUser user, bool useHttps, string? requestUrl)
     {
         var userKey = Guid.NewGuid();
 
@@ -68,7 +80,7 @@ public class PreviewServiceTests
         var requestAccessorMock = new Mock<IRequestAccessor>();
         requestAccessorMock
             .Setup(x => x.GetRequestUrl())
-            .Returns(new Uri(requestUrl));
+            .Returns(requestUrl is null ? null : new Uri(requestUrl));
 
         user = new UserBuilder()
             .WithKey(userKey)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/PreviewServiceTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Services/PreviewServiceTests.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Preview;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
@@ -15,39 +18,77 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Core.Services;
 [TestFixture]
 public class PreviewServiceTests
 {
+    private const string Token = "token";
+
     [Test]
-    public async Task TryEnterPreviewAsync_Sets_Expected_Cookie_On_Successful_Token_Generation()
+    public async Task TryEnterPreviewAsync_Sets_Secure_SameSiteNone_Cookie_On_Https_Request()
+    {
+        var cookieManagerMock = new Mock<ICookieManager>();
+        var previewService = CreatePreviewService(cookieManagerMock, out var user, useHttps: false, requestUrl: "https://localhost/umbraco");
+
+        var result = await previewService.TryEnterPreviewAsync(user);
+
+        VerifyCookie(cookieManagerMock, secure: true, sameSiteMode: SameSiteMode.None);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public async Task TryEnterPreviewAsync_Sets_NonSecure_SameSiteLax_Cookie_On_Http_Request()
+    {
+        var cookieManagerMock = new Mock<ICookieManager>();
+        var previewService = CreatePreviewService(cookieManagerMock, out var user, useHttps: false, requestUrl: "http://192.168.0.10:30645/umbraco");
+
+        var result = await previewService.TryEnterPreviewAsync(user);
+
+        VerifyCookie(cookieManagerMock, secure: false, sameSiteMode: SameSiteMode.Lax);
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public async Task TryEnterPreviewAsync_Sets_Secure_SameSiteNone_Cookie_When_UseHttps_Is_Configured()
+    {
+        var cookieManagerMock = new Mock<ICookieManager>();
+        var previewService = CreatePreviewService(cookieManagerMock, out var user, useHttps: true, requestUrl: "http://localhost/umbraco");
+
+        var result = await previewService.TryEnterPreviewAsync(user);
+
+        VerifyCookie(cookieManagerMock, secure: true, sameSiteMode: SameSiteMode.None);
+        Assert.IsTrue(result);
+    }
+
+    private static PreviewService CreatePreviewService(Mock<ICookieManager> cookieManagerMock, out IUser user, bool useHttps, string requestUrl)
     {
         var userKey = Guid.NewGuid();
-        const string Token = "token";
-
-        var cookieManagerMock = new Mock<ICookieManager>();
 
         var previewTokenGeneratorMock = new Mock<IPreviewTokenGenerator>();
         previewTokenGeneratorMock
             .Setup(x => x.GenerateTokenAsync(It.Is<Guid>(y => y == userKey)))
             .ReturnsAsync(Attempt<string?>.Succeed(Token));
 
-        var previewService = new PreviewService(
-            cookieManagerMock.Object,
-            previewTokenGeneratorMock.Object,
-            Mock.Of<IServiceScopeFactory>(),
-            Mock.Of<IRequestCache>());
+        var requestAccessorMock = new Mock<IRequestAccessor>();
+        requestAccessorMock
+            .Setup(x => x.GetRequestUrl())
+            .Returns(new Uri(requestUrl));
 
-        var user = new UserBuilder()
+        user = new UserBuilder()
             .WithKey(userKey)
             .Build();
 
-        var result = await previewService.TryEnterPreviewAsync(user);
+        return new PreviewService(
+            cookieManagerMock.Object,
+            previewTokenGeneratorMock.Object,
+            Mock.Of<IServiceScopeFactory>(),
+            Mock.Of<IRequestCache>(),
+            Options.Create(new GlobalSettings { UseHttps = useHttps }),
+            requestAccessorMock.Object);
+    }
 
-        cookieManagerMock
+    private static void VerifyCookie(Mock<ICookieManager> cookieManagerMock, bool secure, SameSiteMode sameSiteMode)
+        => cookieManagerMock
             .Verify(x => x.SetCookieValue(
                 It.Is<string>(y => y == Constants.Web.PreviewCookieName),
                 It.Is<string>(y => y == Token),
                 It.Is<bool>(y => y == true),
-                It.Is<bool>(y => y == true),
-                It.Is<string>(y => y == SameSiteMode.None.ToString())));
-
-        Assert.IsTrue(result);
-    }
+                It.Is<bool>(y => y == secure),
+                It.Is<string>(y => y == sameSiteMode.ToString())));
 }


### PR DESCRIPTION
## Summary

The backoffice breaks when hosted over plain HTTP on anything other than `localhost` — e.g. `http://192.168.x.x:port` for testing from another device on the network. Browsers treat such origins as **insecure contexts**: secure-context-only APIs (`crypto.subtle`, `navigator.locks`, `navigator.clipboard`) are removed, and `Secure` cookies are rejected. No appsettings combination can work around this, since it is browser policy tied to the origin.

Reported on the forum: https://forum.umbraco.com/t/authorization-issue-on-locally-hosted-dev-environment/8331 — the telltale symptom is the console warning `navigator.locks is not available` together with an infinite spinner on login.

## Fixes

- **Login (blocking)**: `UmbAuthClient` derives the PKCE code challenge via `crypto.subtle.digest`, which is `undefined` in insecure contexts, so the authorization URL could never be built and login hung on boot. Added a local FIPS 180-4 SHA-256 fallback used only when `crypto.subtle` is unavailable — the flow stays on `code_challenge_method=S256` (no downgrade to `plain`). Kept deliberately small as the PKCE flow is scheduled for removal in v19.
- **Preview (silent failure)**: `PreviewService` set the `UMB_PREVIEW` cookie with `Secure` + `SameSite=None` unconditionally; browsers reject that combination on insecure origins, so preview always showed published content. It now falls back to a non-`Secure` `SameSite=Lax` cookie when the request is plain http and `Umbraco:Global:UseHttps` is not set — the same rule `HideBackOfficeTokensHandler` already applies to the token cookies. The secure path (https or `UseHttps=true`) is unchanged.
- **Clipboard storage (blocking for clipboard features)**: `UmbClipboardLocalStorageManager` threw from its constructor in insecure contexts, and it is eagerly constructed by all three clipboard data sources. The SHA-256 it used only shapes a per-user localStorage key (not a security boundary, and localStorage is per-origin), so it now falls back to the unhashed key instead of throwing. Existing secure-context users keep their exact keys and stored entries.
- **Copy buttons (unhandled errors)**: the code-block copy button and the new-user password copy now try/catch `navigator.clipboard.writeText` and peek a danger notification on failure (mirroring the existing sysinfo pattern), instead of throwing an unhandled `TypeError`. New localisation key `speechBubbles_cannotCopyToClipboard`.

## Why an in-repo SHA-256 is acceptable here

A fair review question is whether we should own ~70 lines of hash code ourselves. The reasoning for doing so:

- **It fails closed.** The fallback only derives the PKCE `code_challenge` from a random verifier; the server recomputes and compares it at token exchange. Any deviation from the real algorithm breaks login outright — it cannot produce a weaker or bypassable flow. This makes the code correctness-critical, not confidentiality-critical: the verifier it hashes already lives in the same JavaScript memory.
- **It is verified against the platform.** A unit test asserts byte-for-byte equality with `crypto.subtle.digest` on the production input shape, so CI catches any deviation from the published algorithm.
- **It is contained.** Module-private, not exported from the package, documented as not-for-reuse, only reachable when `crypto.subtle` is absent, and removed together with the PKCE flow in v19.
- **The alternative was considered.** An audited dependency (e.g. `@noble/hashes`) avoids owning the code but adds a supply-chain dependency to the backoffice bundle for a fixed, published algorithm — arguably the larger attack surface of the two for this narrow, short-lived use.

## Breaking-change handling

`PreviewService` gained two constructor dependencies (`IOptions<GlobalSettings>`, `IRequestAccessor`); the old constructor is `[Obsolete]` and delegates via `StaticServiceProvider`, scheduled for removal in Umbraco 19.

## Testing

- Unit: PKCE fallback verified byte-for-byte against `crypto.subtle.digest` with the production input shape; preview cookie attributes pinned for http, https, and `UseHttps=true`; clipboard manager round-trips with `isSecureContext=false` and `crypto.subtle` removed; code-block copy no longer rejects.
- Browser e2e on this branch (built client + real backend bound to `http://0.0.0.0`): on `http://192.168.30.190` (verified `isSecureContext === false`), login completes end-to-end with a 200 token exchange and zero console errors, and preview provably serves draft content (cookie `secure:false, sameSite:Lax`; same URL returns the draft name with the cookie and the published name without it).

## Out of scope

UUI's `<uui-button-copy-text>` already fails soft internally and is not currently used by the CMS client; proactively disabling it in insecure contexts would be a Umbraco.UI improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
