### PR TITLE
Backoffice: Tidy up leftover `elementName` constants

### DIFF
--- a/src/Umbraco.Web.UI.Client/.claude/skills/general-add-value-summary/SKILL.md
+++ b/src/Umbraco.Web.UI.Client/.claude/skills/general-add-value-summary/SKILL.md
@@ -63,7 +63,7 @@ export { Umb{Feature}ValueSummaryElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-{feature}-value-summary']: Umb{Feature}ValueSummaryElement;
+		'umb-{feature}-value-summary': Umb{Feature}ValueSummaryElement;
 	}
 }
 ```

--- a/src/Umbraco.Web.UI.Client/docs/package-development.md
+++ b/src/Umbraco.Web.UI.Client/docs/package-development.md
@@ -57,7 +57,7 @@ export class UmbFeatureElement extends UmbLitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    ['umb-feature']: UmbFeatureElement;
+    'umb-feature': UmbFeatureElement;
   }
 }
 ```

--- a/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/code-editor/property-editor/property-editor-ui-code-editor.element.ts
@@ -11,9 +11,7 @@ import type {
 import '../components/code-editor.element.js';
 import { UMB_VALIDATION_EMPTY_LOCALIZATION_KEY, UmbFormControlMixin } from '@umbraco-cms/backoffice/validation';
 
-const elementName = 'umb-property-editor-ui-code-editor';
-
-@customElement(elementName)
+@customElement('umb-property-editor-ui-code-editor')
 export class UmbPropertyEditorUICodeEditorElement
 	extends UmbFormControlMixin<string, typeof UmbLitElement, undefined>(UmbLitElement)
 	implements UmbPropertyEditorUiElement
@@ -96,6 +94,6 @@ export { UmbPropertyEditorUICodeEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbPropertyEditorUICodeEditorElement;
+		'umb-property-editor-ui-code-editor': UmbPropertyEditorUICodeEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/entity-bulk-action/entity-bulk-action.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/entity-bulk-action/entity-bulk-action.element.ts
@@ -8,9 +8,7 @@ import type {
 	MetaEntityBulkActionDefaultKind,
 } from '@umbraco-cms/backoffice/extension-registry';
 
-const elementName = 'umb-entity-bulk-action';
-
-@customElement(elementName)
+@customElement('umb-entity-bulk-action')
 export class UmbEntityBulkActionDefaultElement<
 		MetaType extends MetaEntityBulkActionDefaultKind = MetaEntityBulkActionDefaultKind,
 		ApiType extends UmbEntityBulkAction<MetaType> = UmbEntityBulkAction<MetaType>,
@@ -44,6 +42,6 @@ export default UmbEntityBulkActionDefaultElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbEntityBulkActionDefaultElement;
+		'umb-entity-bulk-action': UmbEntityBulkActionDefaultElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item/link/link-menu-item.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/menu/components/menu-item/link/link-menu-item.element.ts
@@ -3,8 +3,7 @@ import type { ManifestMenuItemLinkKind } from './types.js';
 import { customElement, html, property } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 
-const elementName = 'umb-link-menu-item';
-@customElement(elementName)
+@customElement('umb-link-menu-item')
 export class UmbLinkMenuItemElement extends UmbLitElement implements UmbMenuItemElement {
 	@property({ type: Object, attribute: false })
 	manifest?: ManifestMenuItemLinkKind;
@@ -35,6 +34,6 @@ export { UmbLinkMenuItemElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbLinkMenuItemElement;
+		'umb-link-menu-item': UmbLinkMenuItemElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/recycle-bin/entity-action/restore-from-recycle-bin/modal/restore-from-recycle-bin-modal.element.ts
@@ -202,6 +202,6 @@ export default UmbRestoreFromRecycleBinModalElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-restore-from-recycle-bin-modal']: UmbRestoreFromRecycleBinModalElement;
+		'umb-restore-from-recycle-bin-modal': UmbRestoreFromRecycleBinModalElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/entity-actions/duplicate-to/modal/duplicate-to-modal.element.ts
@@ -6,12 +6,10 @@ import { UmbModalBaseElement } from '@umbraco-cms/backoffice/modal';
 import { UmbDeprecation } from '@umbraco-cms/backoffice/utils';
 import type { UmbSelectionChangeEvent } from '@umbraco-cms/backoffice/event';
 
-const elementName = 'umb-duplicate-to-modal';
-
 /**
  * @deprecated Deprecated since v17. The "Duplicate to" entity action now uses the shared `UMB_TREE_PICKER_MODAL`. Scheduled for removal in Umbraco 19.
  */
-@customElement(elementName)
+@customElement('umb-duplicate-to-modal')
 export class UmbDuplicateToModalElement extends UmbModalBaseElement<UmbDuplicateToModalData, UmbDuplicateToModalValue> {
 	@state()
 	private _destinationUnique?: string | null;
@@ -80,6 +78,6 @@ export { UmbDuplicateToModalElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbDuplicateToModalElement;
+		'umb-duplicate-to-modal': UmbDuplicateToModalElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/core/tree/folder/workspace/folder-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/tree/folder/workspace/folder-workspace-editor.element.ts
@@ -25,6 +25,6 @@ export class UmbFolderWorkspaceEditorElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-folder-workspace-editor']: UmbFolderWorkspaceEditorElement;
+		'umb-folder-workspace-editor': UmbFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/workspace/data-type-folder-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/folder/workspace/data-type-folder-editor.element.ts
@@ -12,6 +12,6 @@ export { UmbDataTypeFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-data-type-folder-workspace-editor']: UmbDataTypeFolderWorkspaceEditorElement;
+		'umb-data-type-folder-workspace-editor': UmbDataTypeFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/tree-item-children/collection/views/data-type-tree-item-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/data-type/tree/tree-item-children/collection/views/data-type-tree-item-table-collection-view.element.ts
@@ -123,6 +123,6 @@ export { UmbDataTypeTreeItemTableCollectionViewElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-data-type-tree-item-table-collection-view']: UmbDataTypeTreeItemTableCollectionViewElement;
+		'umb-data-type-tree-item-table-collection-view': UmbDataTypeTreeItemTableCollectionViewElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/document-blueprint-folder-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-blueprints/tree/folder/workspace/document-blueprint-folder-editor.element.ts
@@ -12,6 +12,6 @@ export { UmbDocumentBlueprintFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-document-blueprint-folder-workspace-editor']: UmbDocumentBlueprintFolderWorkspaceEditorElement;
+		'umb-document-blueprint-folder-workspace-editor': UmbDocumentBlueprintFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/workspace/document-type-folder-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/folder/workspace/document-type-folder-editor.element.ts
@@ -12,6 +12,6 @@ export { UmbDocumentTypeFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-document-type-folder-workspace-editor']: UmbDocumentTypeFolderWorkspaceEditorElement;
+		'umb-document-type-folder-workspace-editor': UmbDocumentTypeFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/views/document-type-tree-item-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/document-types/tree/tree-item-children/collection/views/document-type-tree-item-table-collection-view.element.ts
@@ -10,12 +10,10 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbModalRouteRegistrationController, type UmbModalRouteBuilder } from '@umbraco-cms/backoffice/router';
 import { UMB_WORKSPACE_MODAL } from '@umbraco-cms/backoffice/workspace';
 
-const elementName = 'umb-document-type-tree-item-table-collection-view';
-
 /**
  * @deprecated Deprecated since v18. Scheduled for removal in Umbraco 20.
  */
-@customElement(elementName)
+@customElement('umb-document-type-tree-item-table-collection-view')
 export class UmbDocumentTypeTreeItemTableCollectionViewElement extends UmbLitElement {
 	@state()
 	private _tableConfig: UmbTableConfig = {
@@ -136,6 +134,6 @@ export { UmbDocumentTypeTreeItemTableCollectionViewElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbDocumentTypeTreeItemTableCollectionViewElement;
+		'umb-document-type-tree-item-table-collection-view': UmbDocumentTypeTreeItemTableCollectionViewElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/entity-actions/duplicate/modal/duplicate-document-modal.element.ts
@@ -10,9 +10,7 @@ import type { UmbTreeSelectionConfiguration } from '@umbraco-cms/backoffice/tree
 import type { UUIBooleanInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbDocumentTreeItemModel } from '../../../types.js';
 
-const elementName = 'umb-document-duplicate-to-modal';
-
-@customElement(elementName)
+@customElement('umb-document-duplicate-to-modal')
 export class UmbDocumentDuplicateToModalElement extends UmbModalBaseElement<
 	UmbDuplicateDocumentModalData,
 	UmbDuplicateDocumentModalValue
@@ -170,6 +168,6 @@ export { UmbDocumentDuplicateToModalElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbDocumentDuplicateToModalElement;
+		'umb-document-duplicate-to-modal': UmbDocumentDuplicateToModalElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/tree-item-children/collection/views/document-recycle-bin-tree-item-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/documents/documents/recycle-bin/tree/tree-item-children/collection/views/document-recycle-bin-tree-item-table-collection-view.element.ts
@@ -96,6 +96,6 @@ export { UmbDocumentRecycleBinTreeItemTableCollectionViewElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-document-recycle-bin-tree-item-table-collection-view']: UmbDocumentRecycleBinTreeItemTableCollectionViewElement;
+		'umb-document-recycle-bin-tree-item-table-collection-view': UmbDocumentRecycleBinTreeItemTableCollectionViewElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/workspace/media-type-folder-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media-types/tree/folder/workspace/media-type-folder-editor.element.ts
@@ -12,6 +12,6 @@ export { UmbMediaTypeFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-media-type-folder-workspace-editor']: UmbMediaTypeFolderWorkspaceEditorElement;
+		'umb-media-type-folder-workspace-editor': UmbMediaTypeFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/components/input-media/input-media.element.ts
@@ -24,8 +24,7 @@ import type { UmbTreeStartNode } from '@umbraco-cms/backoffice/tree';
 
 import '@umbraco-cms/backoffice/imaging';
 
-const elementName = 'umb-input-media';
-@customElement(elementName)
+@customElement('umb-input-media')
 export class UmbInputMediaElement extends UmbFormControlMixin<string | undefined, typeof UmbLitElement>(UmbLitElement) {
 	#sorter = new UmbSorterController<string>(this, {
 		getUniqueOfElement: (element) => {
@@ -346,6 +345,6 @@ export { UmbInputMediaElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbInputMediaElement;
+		'umb-input-media': UmbInputMediaElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/property-editors/media-picker/property-editor-ui-media-picker.element.ts
@@ -161,6 +161,6 @@ export { UmbPropertyEditorUIMediaPickerElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-property-editor-ui-media-picker']: UmbPropertyEditorUIMediaPickerElement;
+		'umb-property-editor-ui-media-picker': UmbPropertyEditorUIMediaPickerElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/tree-item-children/collection/views/media-recycle-bin-tree-item-table-collection-view.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/recycle-bin/tree/tree-item-children/collection/views/media-recycle-bin-tree-item-table-collection-view.element.ts
@@ -96,6 +96,6 @@ export { UmbMediaRecycleBinTreeItemTableCollectionViewElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-media-recycle-bin-tree-item-table-collection-view']: UmbMediaRecycleBinTreeItemTableCollectionViewElement;
+		'umb-media-recycle-bin-tree-item-table-collection-view': UmbMediaRecycleBinTreeItemTableCollectionViewElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/media/media/tree/media-tree.element.ts
@@ -1,14 +1,13 @@
 import { customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbDefaultTreeElement } from '@umbraco-cms/backoffice/tree';
 
-const elementName = 'umb-media-tree';
-@customElement(elementName)
+@customElement('umb-media-tree')
 export class UmbMediaTreeElement extends UmbDefaultTreeElement {}
 
 export { UmbMediaTreeElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbMediaTreeElement;
+		'umb-media-tree': UmbMediaTreeElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/workspace/member-type-folder-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/members/member-type/tree/folder/workspace/member-type-folder-editor.element.ts
@@ -12,6 +12,6 @@ export { UmbMemberTypeFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-member-type-folder-workspace-editor']: UmbMemberTypeFolderWorkspaceEditorElement;
+		'umb-member-type-folder-workspace-editor': UmbMemberTypeFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/dynamic-root/components/input-content-picker-document-root.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/property-editors/content-picker/dynamic-root/components/input-content-picker-document-root.element.ts
@@ -19,8 +19,7 @@ import type { UmbDocumentItemModel } from '@umbraco-cms/backoffice/document';
 import type { UmbDocumentTypeItemModel } from '@umbraco-cms/backoffice/document-type';
 import type { UmbModalContext } from '@umbraco-cms/backoffice/modal';
 
-const elementName = 'umb-input-content-picker-document-root';
-@customElement(elementName)
+@customElement('umb-input-content-picker-document-root')
 export class UmbInputContentPickerDocumentRootElement extends UmbFormControlMixin<
 	string | undefined,
 	typeof UmbLitElement
@@ -321,6 +320,6 @@ export { UmbInputContentPickerDocumentRootElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbInputContentPickerDocumentRootElement;
+		'umb-input-content-picker-document-root': UmbInputContentPickerDocumentRootElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/workspace/partial-view-folder-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/partial-views/tree/folder/workspace/partial-view-folder-workspace-editor.element.ts
@@ -25,6 +25,6 @@ export { UmbPartialViewFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-partial-view-folder-workspace-editor']: UmbPartialViewFolderWorkspaceEditorElement;
+		'umb-partial-view-folder-workspace-editor': UmbPartialViewFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/workspace/script-folder-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/scripts/tree/folder/workspace/script-folder-workspace-editor.element.ts
@@ -25,6 +25,6 @@ export { UmbScriptFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-script-folder-workspace-editor']: UmbScriptFolderWorkspaceEditorElement;
+		'umb-script-folder-workspace-editor': UmbScriptFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/workspace/stylesheet-folder-workspace-editor.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/templating/stylesheets/tree/folder/workspace/stylesheet-folder-workspace-editor.element.ts
@@ -25,6 +25,6 @@ export { UmbStylesheetFolderWorkspaceEditorElement as element };
 
 declare global {
 	interface HTMLElementTagNameMap {
-		['umb-stylesheet-folder-workspace-editor']: UmbStylesheetFolderWorkspaceEditorElement;
+		'umb-stylesheet-folder-workspace-editor': UmbStylesheetFolderWorkspaceEditorElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-access/user-workspace-access.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-access/user-workspace-access.element.ts
@@ -6,8 +6,7 @@ import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 
 import '../user-workspace-assign-access/user-workspace-assign-access.element.js';
 
-const elementName = 'umb-user-workspace-access';
-@customElement(elementName)
+@customElement('umb-user-workspace-access')
 export class UmbUserWorkspaceAccessElement extends UmbLitElement {
 	@state()
 	private _calculatedStartNodes?: UmbUserStartNodesModel;
@@ -81,6 +80,6 @@ export default UmbUserWorkspaceAccessElement;
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbUserWorkspaceAccessElement;
+		'umb-user-workspace-access': UmbUserWorkspaceAccessElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-assign-access/user-workspace-assign-access.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-assign-access/user-workspace-assign-access.element.ts
@@ -7,8 +7,7 @@ import type { UmbUserGroupInputElement } from '@umbraco-cms/backoffice/user-grou
 import type { UUIBooleanInputEvent } from '@umbraco-cms/backoffice/external/uui';
 import type { UmbReferenceByUnique } from '@umbraco-cms/backoffice/models';
 
-const elementName = 'umb-user-workspace-assign-access';
-@customElement(elementName)
+@customElement('umb-user-workspace-assign-access')
 export class UmbUserWorkspaceAssignAccessElement extends UmbLitElement {
 	@state()
 	private _userGroupUniques: UmbUserDetailModel['userGroupUniques'] = [];
@@ -204,6 +203,6 @@ export class UmbUserWorkspaceAssignAccessElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbUserWorkspaceAssignAccessElement;
+		'umb-user-workspace-assign-access': UmbUserWorkspaceAssignAccessElement;
 	}
 }

--- a/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-client-credentials/user-workspace-client-credentials.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/user/user/workspace/user/components/user-workspace-client-credentials/user-workspace-client-credentials.element.ts
@@ -11,8 +11,7 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { UMB_MODAL_MANAGER_CONTEXT, umbConfirmModal } from '@umbraco-cms/backoffice/modal';
 
-const elementName = 'umb-user-workspace-client-credentials';
-@customElement(elementName)
+@customElement('umb-user-workspace-client-credentials')
 export class UmbUserWorkspaceClientCredentialsElement extends UmbLitElement {
 	@state()
 	private _userUnique?: string;
@@ -161,6 +160,6 @@ export class UmbUserWorkspaceClientCredentialsElement extends UmbLitElement {
 
 declare global {
 	interface HTMLElementTagNameMap {
-		[elementName]: UmbUserWorkspaceClientCredentialsElement;
+		'umb-user-workspace-client-credentials': UmbUserWorkspaceClientCredentialsElement;
 	}
 }


### PR DESCRIPTION
## Summary
Small tidy-up in the backoffice client — a few files still had a leftover `elementName` constant pattern from an old experiment that we moved away from a while back. Cleaned those up and tidied a handful of similarly-styled files along the way so they're all consistent now.

No behaviour changes, just cleanup.

## Test plan
- [ ] `npm run compile` passes
- [ ] Backoffice loads and behaves as normal (tags/elements register the same as before)