### PR TITLE
Content Types: Fix stale published cache when property variance changes without content type variance changing

### DIFF
--- a/src/Umbraco.Core/Models/ContentTypeBase.cs
+++ b/src/Umbraco.Core/Models/ContentTypeBase.cs
@@ -455,37 +455,40 @@ public abstract class ContentTypeBase : TreeEntityBase, IContentTypeBase
     }
 
     /// <summary>
-    ///     Resets dirty properties by clearing the dictionary used to track changes.
+    ///     Resets dirty properties, cascading into property groups and property types.
     /// </summary>
+    /// <param name="rememberDirty">
+    ///     If <c>true</c>, the properties that were dirty are remembered so <see cref="IRememberBeingDirty.WasPropertyDirty"/>
+    ///     can still report them after the reset; if <c>false</c>, both the current and remembered dirty state are cleared.
+    /// </param>
     /// <remarks>
     ///     Please note that resetting the dirty properties could potentially
     ///     obstruct the saving of a new or updated entity.
     /// </remarks>
-    public override void ResetDirtyProperties()
+    public override void ResetDirtyProperties(bool rememberDirty)
     {
-        base.ResetDirtyProperties();
+        base.ResetDirtyProperties(rememberDirty);
 
-        // loop through each property group to reset the property types
         var propertiesReset = new List<int>();
 
         foreach (PropertyGroup propertyGroup in PropertyGroups)
         {
-            propertyGroup.ResetDirtyProperties();
-            if (propertyGroup.PropertyTypes is not null)
+            propertyGroup.ResetDirtyProperties(rememberDirty);
+            if (propertyGroup.PropertyTypes is null)
             {
-                foreach (IPropertyType propertyType in propertyGroup.PropertyTypes)
-                {
-                    propertyType.ResetDirtyProperties();
-                    propertiesReset.Add(propertyType.Id);
-                }
+                continue;
+            }
+
+            foreach (IPropertyType propertyType in propertyGroup.PropertyTypes)
+            {
+                propertyType.ResetDirtyProperties(rememberDirty);
+                propertiesReset.Add(propertyType.Id);
             }
         }
 
-        // then loop through our property type collection since some might not exist on a property group
-        // but don't re-reset ones we've already done.
         foreach (IPropertyType propertyType in PropertyTypes.Where(x => propertiesReset.Contains(x.Id) == false))
         {
-            propertyType.ResetDirtyProperties();
+            propertyType.ResetDirtyProperties(rememberDirty);
         }
     }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVarianceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVarianceTests.cs
@@ -1,0 +1,242 @@
+// Copyright (c) Umbraco.
+// See LICENSE for more details.
+
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Sync;
+using Umbraco.Cms.Tests.Common.Builders;
+using Umbraco.Cms.Tests.Common.Builders.Extensions;
+using Umbraco.Cms.Tests.Common.Testing;
+using Umbraco.Cms.Tests.Integration.Testing;
+using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
+
+[TestFixture]
+[UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
+internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
+{
+    protected override void CustomTestSetup(IUmbracoBuilder builder)
+    {
+        builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
+        builder.AddNotificationHandler<ContentTypeChangedNotification, ContentTypeChangedDistributedCacheNotificationHandler>();
+        builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
+    }
+
+    private IContentTypeService ContentTypeService => GetRequiredService<IContentTypeService>();
+
+    private IContentService ContentService => GetRequiredService<IContentService>();
+
+    private IPublishedContentCache PublishedContentCache => GetRequiredService<IPublishedContentCache>();
+
+    private ILanguageService LanguageService => GetRequiredService<ILanguageService>();
+
+    private IVariationContextAccessor VariationContextAccessor => GetRequiredService<IVariationContextAccessor>();
+
+    [Test]
+    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Invariant_To_Variant()
+    {
+        var documentType = await CreateDocumentType(ContentVariation.Nothing);
+
+        await CreateAdditionalLanguage("da-DK");
+        var defaultCulture = await LanguageService.GetDefaultIsoCodeAsync();
+
+        var content = new ContentBuilder()
+            .WithContentType(documentType)
+            .WithName("Variance Render Test")
+            .Build();
+        content.SetValue("title", "invariant title");
+        ContentService.Save(content);
+        ContentService.Publish(content, ["*"]);
+
+        // Routing sets this before rendering; simulate it so a culture-less read resolves like a real request.
+        VariationContextAccessor.VariationContext = new VariationContext(defaultCulture);
+
+        var beforeChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(beforeChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(beforeChange!.Value<string>("title"), Is.EqualTo("invariant title"));
+            Assert.That(beforeChange!.Value<string>("title", defaultCulture), Is.EqualTo("invariant title"));
+            Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.EqualTo("invariant title"));
+        });
+
+        documentType.Variations = ContentVariation.Culture;
+        var titleProperty = documentType.PropertyTypes.Single(p => p.Alias == "title");
+        titleProperty.Variations = ContentVariation.Culture;
+        await ContentTypeService.UpdateAsync(documentType, Constants.Security.SuperUserKey);
+
+        var afterChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(afterChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterChange!.Value<string>("title"), Is.EqualTo("invariant title"));
+            Assert.That(afterChange!.Value<string>("title", defaultCulture), Is.EqualTo("invariant title"));
+            Assert.That(afterChange!.Value<string>("title", "da-DK"), Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Variant_To_Invariant()
+    {
+        var documentType = await CreateDocumentType(ContentVariation.Culture);
+
+        await CreateAdditionalLanguage("da-DK");
+        var defaultCulture = await LanguageService.GetDefaultIsoCodeAsync();
+
+        var content = new ContentBuilder()
+            .WithContentType(documentType)
+            .WithCultureName(defaultCulture, "Variance Render Test")
+            .Build();
+        content.SetValue("title", "variant title", defaultCulture);
+        ContentService.Save(content);
+        ContentService.Publish(content, ["*"]);
+
+        // Routing sets this before rendering; simulate it so a culture-less read resolves like a real request.
+        VariationContextAccessor.VariationContext = new VariationContext(defaultCulture);
+
+        var beforeChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(beforeChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(beforeChange!.Value<string>("title"), Is.EqualTo("variant title"));
+            Assert.That(beforeChange!.Value<string>("title", defaultCulture), Is.EqualTo("variant title"));
+            Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.Empty);
+        });
+
+        documentType = await ContentTypeService.GetAsync(documentType.Key);
+        documentType!.Variations = ContentVariation.Nothing;
+        var titleProperty = documentType.PropertyTypes.Single(p => p.Alias == "title");
+        titleProperty.Variations = ContentVariation.Nothing;
+        await ContentTypeService.UpdateAsync(documentType, Constants.Security.SuperUserKey);
+
+        var afterChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(afterChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterChange!.Value<string>("title"), Is.EqualTo("variant title"));
+            Assert.That(afterChange!.Value<string>("title", defaultCulture), Is.EqualTo("variant title"));
+
+            // Invariant properties ignore the requested culture and always resolve to the same value.
+            Assert.That(afterChange!.Value<string>("title", "da-DK"), Is.EqualTo("variant title"));
+        });
+    }
+
+    [Test]
+    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Invariant_To_Variant_When_Type_Stays_Variant()
+    {
+        var documentType = await CreateDocumentType(ContentVariation.Culture, ContentVariation.Nothing);
+
+        await CreateAdditionalLanguage("da-DK");
+        var defaultCulture = await LanguageService.GetDefaultIsoCodeAsync();
+
+        var content = new ContentBuilder()
+            .WithContentType(documentType)
+            .WithCultureName(defaultCulture, "Variance Render Test")
+            .Build();
+        content.SetValue("title", "invariant title");
+        ContentService.Save(content);
+        ContentService.Publish(content, ["*"]);
+
+        // Routing sets this before rendering; simulate it so a culture-less read resolves like a real request.
+        VariationContextAccessor.VariationContext = new VariationContext(defaultCulture);
+
+        var beforeChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(beforeChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(beforeChange!.Value<string>("title"), Is.EqualTo("invariant title"));
+            Assert.That(beforeChange!.Value<string>("title", defaultCulture), Is.EqualTo("invariant title"));
+            Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.EqualTo("invariant title"));
+        });
+
+        documentType = await ContentTypeService.GetAsync(documentType.Key);
+        var titleProperty = documentType!.PropertyTypes.Single(p => p.Alias == "title");
+        titleProperty.Variations = ContentVariation.Culture;
+        await ContentTypeService.UpdateAsync(documentType, Constants.Security.SuperUserKey);
+
+        var afterChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(afterChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterChange!.Value<string>("title"), Is.EqualTo("invariant title"));
+            Assert.That(afterChange!.Value<string>("title", defaultCulture), Is.EqualTo("invariant title"));
+            Assert.That(afterChange!.Value<string>("title", "da-DK"), Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Variant_To_Invariant_When_Type_Stays_Variant()
+    {
+        var documentType = await CreateDocumentType(ContentVariation.Culture, ContentVariation.Culture);
+
+        await CreateAdditionalLanguage("da-DK");
+        var defaultCulture = await LanguageService.GetDefaultIsoCodeAsync();
+
+        var content = new ContentBuilder()
+            .WithContentType(documentType)
+            .WithCultureName(defaultCulture, "Variance Render Test")
+            .Build();
+        content.SetValue("title", "variant title", defaultCulture);
+        ContentService.Save(content);
+        ContentService.Publish(content, ["*"]);
+
+        // Routing sets this before rendering; simulate it so a culture-less read resolves like a real request.
+        VariationContextAccessor.VariationContext = new VariationContext(defaultCulture);
+
+        var beforeChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(beforeChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(beforeChange!.Value<string>("title", defaultCulture), Is.EqualTo("variant title"));
+            Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.Empty);
+        });
+
+        documentType = await ContentTypeService.GetAsync(documentType.Key);
+        var titleProperty = documentType!.PropertyTypes.Single(p => p.Alias == "title");
+        titleProperty.Variations = ContentVariation.Nothing;
+        await ContentTypeService.UpdateAsync(documentType, Constants.Security.SuperUserKey);
+
+        var afterChange = await PublishedContentCache.GetByIdAsync(content.Key, preview: false);
+        Assert.That(afterChange, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(afterChange!.Value<string>("title"), Is.EqualTo("variant title"));
+            Assert.That(afterChange!.Value<string>("title", defaultCulture), Is.EqualTo("variant title"));
+
+            // Invariant properties ignore the requested culture and always resolve to the same value.
+            Assert.That(afterChange!.Value<string>("title", "da-DK"), Is.EqualTo("variant title"));
+        });
+    }
+
+    private async Task<IContentType> CreateDocumentType(ContentVariation typeVariation, ContentVariation? propertyVariation = null)
+    {
+        var documentType = new ContentTypeBuilder()
+            .WithAlias("varianceRenderTest" + Guid.NewGuid().ToString("N"))
+            .WithName("Variance Render Test")
+            .WithAllowAsRoot(true)
+            .WithContentVariation(typeVariation)
+            .AddPropertyType()
+            .WithAlias("title")
+            .WithName("Title")
+            .WithVariations(propertyVariation ?? typeVariation)
+            .Done()
+            .Build();
+        await ContentTypeService.CreateAsync(documentType, Constants.Security.SuperUserKey);
+        return documentType;
+    }
+
+    private async Task CreateAdditionalLanguage(string culture)
+    {
+        var additionalLanguage = new LanguageBuilder().WithCultureInfo(culture).Build();
+        var attempt = await LanguageService.CreateAsync(additionalLanguage, Constants.Security.SuperUserKey);
+        Assert.That(attempt.Status, Is.EqualTo(LanguageOperationStatus.Success), $"Failed to create additional language '{culture}': {attempt.Exception?.Message}");
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVarianceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheVarianceTests.cs
@@ -19,12 +19,28 @@ using Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
 
 namespace Umbraco.Cms.Tests.Integration.Umbraco.PublishedCache.HybridCache;
 
-[TestFixture]
+// Parameterized over NoCache (the harness default) and a real DeepCloneAppCache (matching
+// production), since a previous regression here was only reproducible with caching disabled.
+// Both are run so a future fix must hold under real caching too, not just NoCache.
+[TestFixture(true)]
+[TestFixture(false)]
 [UmbracoTest(Database = UmbracoTestOptions.Database.NewSchemaPerTest)]
 internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
 {
+    private readonly bool _useRealCache;
+
+    public DocumentHybridCacheVarianceTests(bool useRealCache) => _useRealCache = useRealCache;
+
     protected override void CustomTestSetup(IUmbracoBuilder builder)
     {
+        if (_useRealCache)
+        {
+            builder.Services.AddUnique(_ => new AppCaches(
+                new DeepCloneAppCache(new ObjectCacheAppCache()),
+                NoAppCache.Instance,
+                new IsolatedCaches(_ => new DeepCloneAppCache(new ObjectCacheAppCache()))));
+        }
+
         builder.AddNotificationHandler<ContentTreeChangeNotification, ContentTreeChangeDistributedCacheNotificationHandler>();
         builder.AddNotificationHandler<ContentTypeChangedNotification, ContentTypeChangedDistributedCacheNotificationHandler>();
         builder.Services.AddUnique<IServerMessenger, ContentEventsTests.LocalServerMessenger>();
@@ -41,7 +57,7 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
     private IVariationContextAccessor VariationContextAccessor => GetRequiredService<IVariationContextAccessor>();
 
     [Test]
-    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Invariant_To_Variant()
+    public async Task Can_Serve_Correct_Value_After_Property_Variance_Changes_Invariant_To_Variant()
     {
         var documentType = await CreateDocumentType(ContentVariation.Nothing);
 
@@ -68,6 +84,7 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
             Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.EqualTo("invariant title"));
         });
 
+        documentType = await RefetchDocumentType(documentType.Key);
         documentType.Variations = ContentVariation.Culture;
         var titleProperty = documentType.PropertyTypes.Single(p => p.Alias == "title");
         titleProperty.Variations = ContentVariation.Culture;
@@ -84,7 +101,7 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Variant_To_Invariant()
+    public async Task Can_Serve_Correct_Value_After_Property_Variance_Changes_Variant_To_Invariant()
     {
         var documentType = await CreateDocumentType(ContentVariation.Culture);
 
@@ -111,8 +128,8 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
             Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.Empty);
         });
 
-        documentType = await ContentTypeService.GetAsync(documentType.Key);
-        documentType!.Variations = ContentVariation.Nothing;
+        documentType = await RefetchDocumentType(documentType.Key);
+        documentType.Variations = ContentVariation.Nothing;
         var titleProperty = documentType.PropertyTypes.Single(p => p.Alias == "title");
         titleProperty.Variations = ContentVariation.Nothing;
         await ContentTypeService.UpdateAsync(documentType, Constants.Security.SuperUserKey);
@@ -130,7 +147,7 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Invariant_To_Variant_When_Type_Stays_Variant()
+    public async Task Can_Serve_Correct_Value_After_Property_Variance_Changes_Invariant_To_Variant_When_Type_Stays_Variant()
     {
         var documentType = await CreateDocumentType(ContentVariation.Culture, ContentVariation.Nothing);
 
@@ -157,8 +174,8 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
             Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.EqualTo("invariant title"));
         });
 
-        documentType = await ContentTypeService.GetAsync(documentType.Key);
-        var titleProperty = documentType!.PropertyTypes.Single(p => p.Alias == "title");
+        documentType = await RefetchDocumentType(documentType.Key);
+        var titleProperty = documentType.PropertyTypes.Single(p => p.Alias == "title");
         titleProperty.Variations = ContentVariation.Culture;
         await ContentTypeService.UpdateAsync(documentType, Constants.Security.SuperUserKey);
 
@@ -173,7 +190,7 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
     }
 
     [Test]
-    public async Task Published_Output_Reflects_Property_Variance_Change_Without_Republishing_Variant_To_Invariant_When_Type_Stays_Variant()
+    public async Task Can_Serve_Correct_Value_After_Property_Variance_Changes_Variant_To_Invariant_When_Type_Stays_Variant()
     {
         var documentType = await CreateDocumentType(ContentVariation.Culture, ContentVariation.Culture);
 
@@ -199,8 +216,8 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
             Assert.That(beforeChange!.Value<string>("title", "da-DK"), Is.Empty);
         });
 
-        documentType = await ContentTypeService.GetAsync(documentType.Key);
-        var titleProperty = documentType!.PropertyTypes.Single(p => p.Alias == "title");
+        documentType = await RefetchDocumentType(documentType.Key);
+        var titleProperty = documentType.PropertyTypes.Single(p => p.Alias == "title");
         titleProperty.Variations = ContentVariation.Nothing;
         await ContentTypeService.UpdateAsync(documentType, Constants.Security.SuperUserKey);
 
@@ -229,8 +246,16 @@ internal sealed class DocumentHybridCacheVarianceTests : UmbracoIntegrationTest
             .WithVariations(propertyVariation ?? typeVariation)
             .Done()
             .Build();
-        await ContentTypeService.CreateAsync(documentType, Constants.Security.SuperUserKey);
+        var attempt = await ContentTypeService.CreateAsync(documentType, Constants.Security.SuperUserKey);
+        Assert.That(attempt.Success, Is.True, $"Failed to create document type: {attempt.Exception?.Message}");
         return documentType;
+    }
+
+    private async Task<IContentType> RefetchDocumentType(Guid key)
+    {
+        var documentType = await ContentTypeService.GetAsync(key);
+        Assert.That(documentType, Is.Not.Null);
+        return documentType!;
     }
 
     private async Task CreateAdditionalLanguage(string culture)

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTypeTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Core/Models/ContentTypeTests.cs
@@ -189,6 +189,85 @@ public class ContentTypeTests
     }
 
     [Test]
+    public void Can_Reset_Dirty_Properties_Cascades_Into_Property_Types()
+    {
+        var contentType = BuildContentType();
+
+        // Add an un-grouped property type so both cascade paths are covered: property types held
+        // on a property group, and property types held directly on the content type (no group).
+        contentType.AddPropertyType(new PropertyTypeBuilder().WithAlias("noGroup").WithName("No Group").Build());
+
+        var groupedPropertyTypes = contentType.PropertyGroups
+            .Where(g => g.PropertyTypes is not null)
+            .SelectMany(g => g.PropertyTypes!)
+            .ToList();
+        var noGroupPropertyTypes = contentType.NoGroupPropertyTypes.ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(groupedPropertyTypes, Is.Not.Empty, "expected at least one grouped property type");
+            Assert.That(noGroupPropertyTypes, Is.Not.Empty, "expected at least one no-group property type");
+        });
+
+        var allPropertyTypes = groupedPropertyTypes.Concat(noGroupPropertyTypes).ToList();
+
+        // Establish a clean baseline on each property type directly, not via the content type,
+        // so the arrange step does not depend on the behaviour under test. Then dirty every one.
+        foreach (var propertyType in allPropertyTypes)
+        {
+            propertyType.ResetDirtyProperties(false);
+            propertyType.Variations = ContentVariation.Culture;
+            Assert.That(propertyType.IsDirty(), Is.True, $"'{propertyType.Alias}' should be dirty before the reset");
+        }
+
+        // The (bool) overload is the one the repository cache calls on every round-trip.
+        contentType.ResetDirtyProperties(false);
+
+        Assert.Multiple(() =>
+        {
+            foreach (var propertyType in allPropertyTypes)
+            {
+                Assert.That(propertyType.IsDirty(), Is.False, $"'{propertyType.Alias}' should not be dirty after the reset");
+            }
+        });
+    }
+
+    [Test]
+    public void Can_Reset_Dirty_Properties_Cascades_And_Remembers_When_Requested()
+    {
+        var contentType = BuildContentType();
+        var property = contentType.PropertyGroups.First().PropertyTypes!.First();
+
+        property.ResetDirtyProperties(false);
+        property.Variations = ContentVariation.Culture;
+        Assert.That(property.IsDirty(), Is.True);
+
+        contentType.ResetDirtyProperties(true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(property.IsDirty(), Is.False);
+            Assert.That(property.WasDirty(), Is.True);
+            Assert.That(property.WasPropertyDirty("Variations"), Is.True);
+        });
+    }
+
+    [Test]
+    public void Can_Reset_Dirty_Properties_Cascades_Via_Parameterless_Overload()
+    {
+        var contentType = BuildContentType();
+        var property = contentType.PropertyGroups.First().PropertyTypes!.First();
+
+        property.ResetDirtyProperties(false);
+        property.Variations = ContentVariation.Culture;
+        Assert.That(property.IsDirty(), Is.True);
+
+        // The parameterless overload delegates to ResetDirtyProperties(true) and must still cascade.
+        contentType.ResetDirtyProperties();
+
+        Assert.That(property.IsDirty(), Is.False);
+    }
+
+    [Test]
     public void Can_Deep_Clone_Media_Type()
     {
         // Arrange


### PR DESCRIPTION
## Summary

`ContentTypeBase` only overrode the parameterless `ResetDirtyProperties()`, not the `ResetDirtyProperties(bool rememberDirty)` overload the repository cache actually calls on every cache round-trip. That overload fell back to the non-cascading base implementation, so property types never had their dirty flags reset — permanently defeating `WasPropertyTypeVariationChanged()`'s new-property guard. The result: if only a property's variance changed (not the content type's own), the change was misclassified as non-structural and the published cache could keep serving the stale value.

Fix: add the missing `ResetDirtyProperties(bool rememberDirty)` override, cascading into `PropertyGroups`/`PropertyTypes` the same way the parameterless one did. Drop the now-redundant parameterless override, since `BeingDirtyBase.ResetDirtyProperties()` already delegates to `ResetDirtyProperties(true)`.

**Caveat found during review**: the new tests only catch this because the integration harness runs with `AppCaches.NoCache` by default. With real caching (`AppCaches` using `DeepCloneAppCache`, matching any actual deployment), the tests pass even without this fix — `DeepCloneAppCache` deep-clones and resets dirty state on every cache write, independently masking the missing cascade. We could not reproduce the staleness manually against a running instance either. So this is a real gap in the dirty-tracking contract and a correct fix, but its real-world reachability under normal caching is unconfirmed — flagging for you to judge whether that changes scope or priority.

## Test plan

`DocumentHybridCacheVarianceTests.cs` has 4 tests covering property-variance changes with the content type's own variance held constant. Run them against `v17/dev` (before this fix) — 2 of the 4 fail. Run them again with this branch — all 4 pass.