### PR TITLE
Media: Narrow sibling name-uniqueness fetch so writes scale on large libraries (closes #23446)

### DIFF
--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1218,10 +1218,10 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         {
             // Fetch only the siblings whose name can collide with nodeName (i.e. share its base
             // text), instead of every sibling under the parent. This is critical for flat trees
-            // such as large media libraries, where "all siblings" is the entire library and the
-            // full fetch scales O(total items) on every write. GetUniqueName still applies the
-            // authoritative uniqueness filter, so narrowing the fetch to a superset of the names
-            // it cares about preserves behaviour.
+            // such as large media libraries, where "all siblings" could be the majority or all
+            // of the entire library and the full fetch scales O(total items) on every write.
+            // GetUniqueName still applies the authoritative uniqueness filter, so narrowing the
+            // fetch to a superset of the names it cares about preserves behaviour.
             var prefix = GetSafeLikePrefix(SimilarNodeName.GetBaseText(nodeName));
 
             Sql<ISqlContext> sql = Sql()

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ContentRepositoryBase.cs
@@ -1215,7 +1215,36 @@ namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement
         #region Utilities
 
         protected virtual string? EnsureUniqueNodeName(int parentId, string? nodeName, int id = 0)
-            => EnsureUniqueNodeName(parentId, nodeName, id, out _);
+        {
+            // Fetch only the siblings whose name can collide with nodeName (i.e. share its base
+            // text), instead of every sibling under the parent. This is critical for flat trees
+            // such as large media libraries, where "all siblings" is the entire library and the
+            // full fetch scales O(total items) on every write. GetUniqueName still applies the
+            // authoritative uniqueness filter, so narrowing the fetch to a superset of the names
+            // it cares about preserves behaviour.
+            var prefix = GetSafeLikePrefix(SimilarNodeName.GetBaseText(nodeName));
+
+            Sql<ISqlContext> sql = Sql()
+                .Select<NodeDto>(x => Alias(x.NodeId, "id"), x => Alias(x.Text!, "name"))
+                .From<NodeDto>()
+                .Where<NodeDto>(x => x.NodeObjectType == NodeObjectTypeId && x.ParentId == parentId)
+                .Where<NodeDto>(x => x.Text!.StartsWith(prefix));
+
+            List<SimilarNodeName> siblings = Database.Fetch<SimilarNodeName>(sql);
+
+            return SimilarNodeName.GetUniqueName(siblings, id, nodeName);
+        }
+
+        // '[' opens a character-class in a SQL Server LIKE pattern, which could cause the prefix
+        // to match fewer rows than the case-insensitive StartsWith the caller expects. Truncating
+        // at the first '[' keeps the prefix a superset (a shorter prefix only broadens the match)
+        // and avoids needing an ESCAPE clause. '%' and '_' only ever broaden the match, so they
+        // are safe to leave in place.
+        private static string GetSafeLikePrefix(string baseText)
+        {
+            var index = baseText.IndexOf('[');
+            return index < 0 ? baseText : baseText[..index];
+        }
 
         private protected string? EnsureUniqueNodeName(int parentId, string? nodeName, int id, out List<SimilarNodeName> siblings)
         {

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
@@ -34,6 +34,8 @@ internal sealed partial class SimilarNodeName
     /// matches the base text that <see cref="GetUniqueName(IEnumerable{string?}, string?)"/> compares
     /// siblings against, so it can be used to fetch only the siblings that could actually collide.
     /// </summary>
+    /// <param name="name">The name to extract the base text from.</param>
+    /// <returns>The name with any trailing " (n)" suffix removed.</returns>
     internal static string GetBaseText(string? name) => new StructuredName(name).Text;
 
     /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/ListExtensions.cs
@@ -30,6 +30,13 @@ internal sealed partial class SimilarNodeName
     public string? Name { get; set; }
 
     /// <summary>
+    /// Returns the base text of a name, i.e. the name with any trailing " (n)" suffix removed. This
+    /// matches the base text that <see cref="GetUniqueName(IEnumerable{string?}, string?)"/> compares
+    /// siblings against, so it can be used to fetch only the siblings that could actually collide.
+    /// </summary>
+    internal static string GetBaseText(string? name) => new StructuredName(name).Text;
+
+    /// <summary>
     /// Returns a unique node name by comparing the proposed name against a collection of similar node names, excluding the node with the specified ID.
     /// </summary>
     /// <param name="names">A collection of <see cref="SimilarNodeName"/> objects to check for name uniqueness.</param>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimilarNodeName.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimilarNodeName.cs
@@ -4,6 +4,10 @@ using Umbraco.Extensions;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
 
+/// <summary>
+/// Represents the name of a node that is similar to another, and provides the logic for resolving a
+/// unique name among a set of siblings by appending or incrementing a " (n)" suffix.
+/// </summary>
 internal sealed partial class SimilarNodeName
 {
     /// <summary>
@@ -55,113 +59,76 @@ internal sealed partial class SimilarNodeName
         var model = new StructuredName(name);
         IEnumerable<StructuredName> items = names
             .Where(x => x?.InvariantStartsWith(model.Text) ?? false) // ignore non-matching names
-            .Select(x => new StructuredName(x)).ToArray();
+            .Select(x => new StructuredName(x))
+            .ToArray();
 
-        // name is empty, and there are no other names with suffixes, so just return " (1)"
-        if (model.IsEmptyName() && !items.Any())
+        if (model.IsEmptyName())
         {
+            return ResolveEmptyName(model, items);
+        }
+
+        return model.Suffix.HasValue
+            ? ResolveSuffixedName(model, items)
+            : ResolveUnsuffixedName(model, items);
+    }
+
+    private static string ResolveEmptyName(StructuredName model, IEnumerable<StructuredName> items)
+    {
+        if (!items.Any())
+        {
+            // Nothing to clash with, so the first duplicate suffix (" (1)") is enough.
             model.Suffix = StructuredName.Initialsuffix;
-
-            return model.FullName;
+        }
+        else if (SuffixedNameExists(items))
+        {
+            model.Suffix = (uint?)GetSuffixNumber(items);
         }
 
-        // name is empty, and there are other names with suffixes
-        if (model.IsEmptyName() && SuffixedNameExists(items))
+        return model.FullName;
+    }
+
+    private static string ResolveUnsuffixedName(StructuredName model, IEnumerable<StructuredName> items)
+    {
+        if (!SimpleNameExists(items, model.Text))
         {
-            var emptyNameSuffix = GetSuffixNumber(items);
-
-            if (emptyNameSuffix > 0)
-            {
-                model.Suffix = (uint?)emptyNameSuffix;
-
-                return model.FullName;
-            }
-        }
-
-        // no suffix - name without suffix does NOT exist - we can just use the name without suffix.
-        if (!model.Suffix.HasValue && !SimpleNameExists(items, model.Text))
-        {
+            // The plain name is free.
             model.Suffix = StructuredName._nosuffix;
-
-            return model.FullName;
+        }
+        else
+        {
+            // The plain name is taken, so take the next free suffix (or the first, if none exist yet).
+            model.Suffix = (uint?)(SuffixedNameExists(items)
+                ? GetSuffixNumber(items)
+                : GetFirstSuffix(items));
         }
 
-        // suffix - name with suffix does NOT exist
-        // We can just return the full name as it is as there's no conflict.
-        if (model.Suffix.HasValue && !SimpleNameExists(items, model.FullName))
+        return model.FullName;
+    }
+
+    private static string ResolveSuffixedName(StructuredName model, IEnumerable<StructuredName> items)
+    {
+        // The suffixed name itself is free, so there is no conflict.
+        if (!SimpleNameExists(items, model.FullName))
         {
             return model.FullName;
         }
 
-        // no suffix - name without suffix does NOT exist, AND name with suffix does NOT exist
-        if (!model.Suffix.HasValue && !SimpleNameExists(items, model.Text) && !SuffixedNameExists(items))
+        // The base name (without the supplied suffix) also exists, so simply take the next suffix.
+        if (SimpleNameExists(items, model.Text))
         {
-            model.Suffix = StructuredName._nosuffix;
+            model.Suffix = (uint?)GetSuffixNumber(items);
 
             return model.FullName;
         }
 
-        // no suffix - name without suffix exists, however name with suffix does NOT exist
-        if (!model.Suffix.HasValue && SimpleNameExists(items, model.Text) && !SuffixedNameExists(items))
-        {
-            var firstSuffix = GetFirstSuffix(items);
-            model.Suffix = (uint?)firstSuffix;
+        // The user supplied a suffix that has no base name of its own, so treat the whole thing as
+        // the base name and add a secondary suffix.
+        model.Text = model.FullName;
+        model.Suffix = StructuredName._nosuffix;
+        items = items.Where(x => x.Text.InvariantStartsWith(model.FullName));
+        model.Suffix = (uint?)GetFirstSuffix(items);
 
-            return model.FullName;
-        }
-
-        // no suffix - name without suffix exists, AND name with suffix does exist
-        if (!model.Suffix.HasValue && SimpleNameExists(items, model.Text) && SuffixedNameExists(items))
-        {
-            var nextSuffix = GetSuffixNumber(items);
-            model.Suffix = (uint?)nextSuffix;
-
-            return model.FullName;
-        }
-
-        // no suffix - name without suffix does NOT exist, however name with suffix exists
-        if (!model.Suffix.HasValue && !SimpleNameExists(items, model.Text) && SuffixedNameExists(items))
-        {
-            var nextSuffix = GetSuffixNumber(items);
-            model.Suffix = (uint?)nextSuffix;
-
-            return model.FullName;
-        }
-
-        // has suffix - name without suffix exists
-        if (model.Suffix.HasValue && SimpleNameExists(items, model.Text))
-        {
-            var nextSuffix = GetSuffixNumber(items);
-            model.Suffix = (uint?)nextSuffix;
-
-            return model.FullName;
-        }
-
-        // has suffix - name without suffix does NOT exist
-        // a case where the user added the suffix, so add a secondary suffix
-        if (model.Suffix.HasValue && !SimpleNameExists(items, model.Text))
-        {
-            model.Text = model.FullName;
-            model.Suffix = StructuredName._nosuffix;
-
-            // filter items based on full name with suffix
-            items = items.Where(x => x.Text.InvariantStartsWith(model.FullName));
-            var secondarySuffix = GetFirstSuffix(items);
-            model.Suffix = (uint?)secondarySuffix;
-
-            return model.FullName;
-        }
-
-        // has suffix - name without suffix also exists, therefore we simply increment
-        if (model.Suffix.HasValue && SimpleNameExists(items, model.Text))
-        {
-            var nextSuffix = GetSuffixNumber(items);
-            model.Suffix = (uint?)nextSuffix;
-
-            return model.FullName;
-        }
-
-        return name;
+        return model.FullName;
     }
 
     private static bool SimpleNameExists(IEnumerable<StructuredName> items, string name) =>
@@ -203,6 +170,9 @@ internal sealed partial class SimilarNodeName
         return current;
     }
 
+    /// <summary>
+    /// Represents a name split into its base text and an optional trailing " (n)" numeric suffix.
+    /// </summary>
     internal sealed partial class StructuredName
     {
         /// <summary>

--- a/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimilarNodeName.cs
+++ b/src/Umbraco.Infrastructure/Persistence/Repositories/Implement/SimilarNodeName.cs
@@ -1,21 +1,8 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Umbraco.Extensions;
-using static Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement.SimilarNodeName;
 
 namespace Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
-
-internal static class ListExtensions
-{
-    internal static bool Contains(this IEnumerable<StructuredName> items, StructuredName model) =>
-        items.Any(x => x.FullName.InvariantEquals(model.FullName));
-
-    internal static bool SimpleNameExists(this IEnumerable<StructuredName> items, string name) =>
-        items.Any(x => x.FullName.InvariantEquals(name));
-
-    internal static bool SuffixedNameExists(this IEnumerable<StructuredName> items) =>
-        items.Any(x => x.Suffix.HasValue);
-}
 
 internal sealed partial class SimilarNodeName
 {
@@ -56,6 +43,13 @@ internal sealed partial class SimilarNodeName
         return uniqueName;
     }
 
+    /// <summary>
+    /// Returns a unique name by comparing the proposed name against a collection of existing names,
+    /// appending or incrementing a " (n)" suffix as required to avoid a collision.
+    /// </summary>
+    /// <param name="names">The existing names to compare against.</param>
+    /// <param name="name">The proposed name to make unique.</param>
+    /// <returns>A unique name derived from <paramref name="name"/>.</returns>
     public static string? GetUniqueName(IEnumerable<string?> names, string? name)
     {
         var model = new StructuredName(name);
@@ -72,7 +66,7 @@ internal sealed partial class SimilarNodeName
         }
 
         // name is empty, and there are other names with suffixes
-        if (model.IsEmptyName() && items.SuffixedNameExists())
+        if (model.IsEmptyName() && SuffixedNameExists(items))
         {
             var emptyNameSuffix = GetSuffixNumber(items);
 
@@ -85,7 +79,7 @@ internal sealed partial class SimilarNodeName
         }
 
         // no suffix - name without suffix does NOT exist - we can just use the name without suffix.
-        if (!model.Suffix.HasValue && !items.SimpleNameExists(model.Text))
+        if (!model.Suffix.HasValue && !SimpleNameExists(items, model.Text))
         {
             model.Suffix = StructuredName._nosuffix;
 
@@ -94,13 +88,13 @@ internal sealed partial class SimilarNodeName
 
         // suffix - name with suffix does NOT exist
         // We can just return the full name as it is as there's no conflict.
-        if (model.Suffix.HasValue && !items.SimpleNameExists(model.FullName))
+        if (model.Suffix.HasValue && !SimpleNameExists(items, model.FullName))
         {
             return model.FullName;
         }
 
         // no suffix - name without suffix does NOT exist, AND name with suffix does NOT exist
-        if (!model.Suffix.HasValue && !items.SimpleNameExists(model.Text) && !items.SuffixedNameExists())
+        if (!model.Suffix.HasValue && !SimpleNameExists(items, model.Text) && !SuffixedNameExists(items))
         {
             model.Suffix = StructuredName._nosuffix;
 
@@ -108,7 +102,7 @@ internal sealed partial class SimilarNodeName
         }
 
         // no suffix - name without suffix exists, however name with suffix does NOT exist
-        if (!model.Suffix.HasValue && items.SimpleNameExists(model.Text) && !items.SuffixedNameExists())
+        if (!model.Suffix.HasValue && SimpleNameExists(items, model.Text) && !SuffixedNameExists(items))
         {
             var firstSuffix = GetFirstSuffix(items);
             model.Suffix = (uint?)firstSuffix;
@@ -117,7 +111,7 @@ internal sealed partial class SimilarNodeName
         }
 
         // no suffix - name without suffix exists, AND name with suffix does exist
-        if (!model.Suffix.HasValue && items.SimpleNameExists(model.Text) && items.SuffixedNameExists())
+        if (!model.Suffix.HasValue && SimpleNameExists(items, model.Text) && SuffixedNameExists(items))
         {
             var nextSuffix = GetSuffixNumber(items);
             model.Suffix = (uint?)nextSuffix;
@@ -126,7 +120,7 @@ internal sealed partial class SimilarNodeName
         }
 
         // no suffix - name without suffix does NOT exist, however name with suffix exists
-        if (!model.Suffix.HasValue && !items.SimpleNameExists(model.Text) && items.SuffixedNameExists())
+        if (!model.Suffix.HasValue && !SimpleNameExists(items, model.Text) && SuffixedNameExists(items))
         {
             var nextSuffix = GetSuffixNumber(items);
             model.Suffix = (uint?)nextSuffix;
@@ -135,7 +129,7 @@ internal sealed partial class SimilarNodeName
         }
 
         // has suffix - name without suffix exists
-        if (model.Suffix.HasValue && items.SimpleNameExists(model.Text))
+        if (model.Suffix.HasValue && SimpleNameExists(items, model.Text))
         {
             var nextSuffix = GetSuffixNumber(items);
             model.Suffix = (uint?)nextSuffix;
@@ -145,7 +139,7 @@ internal sealed partial class SimilarNodeName
 
         // has suffix - name without suffix does NOT exist
         // a case where the user added the suffix, so add a secondary suffix
-        if (model.Suffix.HasValue && !items.SimpleNameExists(model.Text))
+        if (model.Suffix.HasValue && !SimpleNameExists(items, model.Text))
         {
             model.Text = model.FullName;
             model.Suffix = StructuredName._nosuffix;
@@ -159,7 +153,7 @@ internal sealed partial class SimilarNodeName
         }
 
         // has suffix - name without suffix also exists, therefore we simply increment
-        if (model.Suffix.HasValue && items.SimpleNameExists(model.Text))
+        if (model.Suffix.HasValue && SimpleNameExists(items, model.Text))
         {
             var nextSuffix = GetSuffixNumber(items);
             model.Suffix = (uint?)nextSuffix;
@@ -169,6 +163,12 @@ internal sealed partial class SimilarNodeName
 
         return name;
     }
+
+    private static bool SimpleNameExists(IEnumerable<StructuredName> items, string name) =>
+        items.Any(x => x.FullName.InvariantEquals(name));
+
+    private static bool SuffixedNameExists(IEnumerable<StructuredName> items) =>
+        items.Any(x => x.Suffix.HasValue);
 
     private static int GetFirstSuffix(IEnumerable<StructuredName> items)
     {
@@ -205,14 +205,26 @@ internal sealed partial class SimilarNodeName
 
     internal sealed partial class StructuredName
     {
+        /// <summary>
+        /// The suffix applied to the first duplicate of a name (i.e. the "1" in "Name (1)").
+        /// </summary>
         internal const uint Initialsuffix = 1;
+
         private const string Spacecharacter = " ";
 
         [GeneratedRegex(@"(.*) \(([1-9]\d*)\)$")]
         private static partial Regex SuffixedPatternRegex();
 
+        /// <summary>
+        /// Represents the absence of a numeric suffix.
+        /// </summary>
         internal static readonly uint? _nosuffix = default;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StructuredName"/> class, splitting
+        /// <paramref name="name"/> into its base text and any trailing " (n)" numeric suffix.
+        /// </summary>
+        /// <param name="name">The name to parse.</param>
         internal StructuredName(string? name)
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -252,10 +264,20 @@ internal sealed partial class SimilarNodeName
             }
         }
 
+        /// <summary>
+        /// Gets or sets the base text of the name, i.e. the name without its numeric suffix.
+        /// </summary>
         internal string Text { get; set; }
 
+        /// <summary>
+        /// Gets or sets the numeric suffix parsed from the name, or <c>null</c> when the name has none.
+        /// </summary>
         internal uint? Suffix { get; set; }
 
+        /// <summary>
+        /// Returns a value indicating whether the name has no meaningful base text.
+        /// </summary>
+        /// <returns><c>true</c> if the base text is null or whitespace; otherwise, <c>false</c>.</returns>
         internal bool IsEmptyName() => string.IsNullOrWhiteSpace(Text);
     }
 }

--- a/tests/Umbraco.Tests.Benchmarks/MediaUniqueNameBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/MediaUniqueNameBenchmarks.cs
@@ -1,0 +1,160 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using Microsoft.Data.Sqlite;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Persistence.Repositories.Implement;
+
+namespace Umbraco.Tests.Benchmarks;
+
+/// <summary>
+/// Measures the cost of resolving a unique node name on create (<c>EnsureUniqueNodeName</c>) against a
+/// flat tree, i.e. one parent with many direct children — the shape of a large media library.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Models the two fetch strategies against a real SQLite database seeded with <see cref="SiblingCount"/>
+/// siblings under a single parent, then feeds the result to the production
+/// <see cref="SimilarNodeName.GetUniqueName(System.Collections.Generic.IEnumerable{SimilarNodeName}, int, string?)"/>:
+/// <list type="bullet">
+///   <item><see cref="FetchAllSiblings"/> — the original query that materialises every sibling.</item>
+///   <item><see cref="FetchPrefixMatched"/> — the query narrowed to name-prefix matches (issue #23446).</item>
+/// </list>
+/// The prefix-matched query cost is expected to stay flat as <see cref="SiblingCount"/> grows, whereas the
+/// all-siblings query scales linearly (rows transferred + objects allocated + in-memory scan).
+/// </para>
+/// <para>
+/// Run with: <c>dotnet run -c Release --project tests/Umbraco.Tests.Benchmarks -- --filter "*MediaUniqueName*"</c>.
+/// Uses <see cref="InProcessEmitToolchain"/> to avoid the per-benchmark MSBuild compile.
+/// </para>
+/// </remarks>
+[Config(typeof(InProcessRunConfig))]
+public class MediaUniqueNameBenchmarks
+{
+    private const int ParentId = Constants.System.Root;
+
+    // A proposed name that does not collide with any seeded sibling — the overwhelmingly common case on
+    // upload / folder-create, and the one where the all-siblings fetch does the most wasted work.
+    private const string ProposedName = "a-brand-new-unique-name";
+
+    private static readonly string MediaObjectType = Constants.ObjectTypes.Media.ToString();
+
+    private SqliteConnection _connection = null!;
+
+    private sealed class InProcessRunConfig : ManualConfig
+    {
+        public InProcessRunConfig()
+        {
+            AddJob(Job.Default
+                .WithLaunchCount(1)
+                .WithWarmupCount(3)
+                .WithIterationCount(8)
+                .WithToolchain(InProcessEmitToolchain.Instance));
+            AddDiagnoser(MemoryDiagnoser.Default);
+        }
+    }
+
+    [Params(1_000, 10_000, 30_000)]
+    public int SiblingCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        using (SqliteCommand create = _connection.CreateCommand())
+        {
+            create.CommandText =
+                """
+                CREATE TABLE umbracoNode (
+                    id INTEGER PRIMARY KEY,
+                    parentId INTEGER NOT NULL,
+                    nodeObjectType TEXT NOT NULL,
+                    text TEXT NULL
+                );
+                CREATE INDEX IX_umbracoNode_parentId_nodeObjectType ON umbracoNode (parentId, nodeObjectType, text);
+                """;
+            create.ExecuteNonQuery();
+        }
+
+        using SqliteTransaction transaction = _connection.BeginTransaction();
+        using (SqliteCommand insert = _connection.CreateCommand())
+        {
+            insert.Transaction = transaction;
+            insert.CommandText =
+                "INSERT INTO umbracoNode (id, parentId, nodeObjectType, text) VALUES (@id, @parentId, @objectType, @text)";
+            SqliteParameter id = insert.Parameters.Add("@id", SqliteType.Integer);
+            insert.Parameters.AddWithValue("@parentId", ParentId);
+            insert.Parameters.AddWithValue("@objectType", MediaObjectType);
+            SqliteParameter text = insert.Parameters.Add("@text", SqliteType.Text);
+
+            for (var i = 0; i < SiblingCount; i++)
+            {
+                id.Value = i + 1;
+                text.Value = $"media-item-{i:D6}";
+                insert.ExecuteNonQuery();
+            }
+        }
+
+        transaction.Commit();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _connection.Dispose();
+        SqliteConnection.ClearAllPools();
+    }
+
+    [Benchmark(Baseline = true)]
+    public string? FetchAllSiblings()
+    {
+        using SqliteCommand command = _connection.CreateCommand();
+        command.CommandText =
+            "SELECT id, text FROM umbracoNode WHERE nodeObjectType = @objectType AND parentId = @parentId";
+        command.Parameters.AddWithValue("@objectType", MediaObjectType);
+        command.Parameters.AddWithValue("@parentId", ParentId);
+
+        return SimilarNodeName.GetUniqueName(Read(command), 0, ProposedName);
+    }
+
+    [Benchmark]
+    public string? FetchPrefixMatched()
+    {
+        var prefix = GetSafeLikePrefix(SimilarNodeName.GetBaseText(ProposedName));
+
+        using SqliteCommand command = _connection.CreateCommand();
+        command.CommandText =
+            "SELECT id, text FROM umbracoNode WHERE nodeObjectType = @objectType AND parentId = @parentId AND upper(text) LIKE upper(@prefix)";
+        command.Parameters.AddWithValue("@objectType", MediaObjectType);
+        command.Parameters.AddWithValue("@parentId", ParentId);
+        command.Parameters.AddWithValue("@prefix", prefix + "%");
+
+        return SimilarNodeName.GetUniqueName(Read(command), 0, ProposedName);
+    }
+
+    private static List<SimilarNodeName> Read(SqliteCommand command)
+    {
+        var siblings = new List<SimilarNodeName>();
+        using SqliteDataReader reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            siblings.Add(new SimilarNodeName
+            {
+                Id = reader.GetInt32(0),
+                Name = reader.IsDBNull(1) ? null : reader.GetString(1),
+            });
+        }
+
+        return siblings;
+    }
+
+    private static string GetSafeLikePrefix(string baseText)
+    {
+        var index = baseText.IndexOf('[');
+        return index < 0 ? baseText : baseText[..index];
+    }
+}

--- a/tests/Umbraco.Tests.Benchmarks/MediaUniqueNameBenchmarks.cs
+++ b/tests/Umbraco.Tests.Benchmarks/MediaUniqueNameBenchmarks.cs
@@ -152,6 +152,8 @@ public class MediaUniqueNameBenchmarks
         return siblings;
     }
 
+    // Mirrors ContentRepositoryBase.GetSafeLikePrefix so this benchmark builds the same prefix as
+    // production; keep the two in sync if the truncation logic changes.
     private static string GetSafeLikePrefix(string baseText)
     {
         var index = baseText.IndexOf('[');

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaServiceTests.cs
@@ -611,4 +611,92 @@ internal sealed class MediaServiceTests : UmbracoIntegrationTest
         Assert.IsTrue(result.Success);
         Assert.AreEqual(reversed, ChildIdsInSortOrder());
     }
+
+    [Test]
+    public async Task Can_Make_Duplicate_Sibling_Names_Unique()
+    {
+        var mediaType = await CreateMediaType();
+
+        var first = SaveMedia(mediaType, "image");
+        var second = SaveMedia(mediaType, "image");
+        var third = SaveMedia(mediaType, "image");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Name, Is.EqualTo("image"));
+            Assert.That(second.Name, Is.EqualTo("image (1)"));
+            Assert.That(third.Name, Is.EqualTo("image (2)"));
+        });
+    }
+
+    [Test]
+    public async Task Can_Make_Duplicate_Sibling_Names_Unique_Ignoring_Case()
+    {
+        var mediaType = await CreateMediaType();
+
+        var first = SaveMedia(mediaType, "Image");
+        var second = SaveMedia(mediaType, "image");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Name, Is.EqualTo("Image"));
+            Assert.That(second.Name, Is.EqualTo("image (1)"));
+        });
+    }
+
+    [Test]
+    public async Task Can_Make_Name_Unique_Without_Being_Confused_By_Similar_Prefixes()
+    {
+        var mediaType = await CreateMediaType();
+
+        // Decoys that share a prefix with "image" but are not the same name; these must not
+        // consume a suffix nor otherwise perturb the result.
+        SaveMedia(mediaType, "image");
+        SaveMedia(mediaType, "imagery");
+        SaveMedia(mediaType, "image detail");
+
+        var duplicate = SaveMedia(mediaType, "image");
+
+        Assert.That(duplicate.Name, Is.EqualTo("image (1)"));
+    }
+
+    [TestCase("50%")]
+    [TestCase("a_b")]
+    [TestCase("x[y")]
+    public async Task Can_Make_Name_With_Like_Metacharacters_Unique(string name)
+    {
+        var mediaType = await CreateMediaType();
+
+        var first = SaveMedia(mediaType, name);
+        var second = SaveMedia(mediaType, name);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Name, Is.EqualTo(name));
+            Assert.That(second.Name, Is.EqualTo($"{name} (1)"));
+        });
+    }
+
+    [Test]
+    public async Task Can_Reuse_Freed_Suffix_When_Making_Name_Unique()
+    {
+        var mediaType = await CreateMediaType();
+
+        SaveMedia(mediaType, "image");
+        var one = SaveMedia(mediaType, "image"); // image (1)
+        SaveMedia(mediaType, "image");           // image (2)
+
+        MediaService.Delete(one); // frees "image (1)"
+
+        var reused = SaveMedia(mediaType, "image");
+
+        Assert.That(reused.Name, Is.EqualTo("image (1)"));
+    }
+
+    private IMedia SaveMedia(IMediaType mediaType, string name)
+    {
+        IMedia media = MediaBuilder.CreateSimpleMedia(mediaType, name, Constants.System.Root);
+        MediaService.Save(media);
+        return media;
+    }
 }

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/SimilarNodeNameTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/SimilarNodeNameTests.cs
@@ -211,6 +211,46 @@ internal sealed class SimilarNodeNameTests
         Assert.AreEqual("Test", res);
     }
 
+    [Test]
+    public void Free_Name_Is_Used_Even_When_Suffixed_Names_Exist()
+    {
+        // The plain "Foxtrot" is free, so it must be returned as-is rather than jumping to a suffix
+        // just because numbered variants happen to exist.
+        SimilarNodeName[] names =
+        [
+            new() { Id = 1, Name = "Foxtrot (1)" },
+            new() { Id = 2, Name = "Foxtrot (2)" },
+        ];
+
+        var res = SimilarNodeName.GetUniqueName(names, 0, "Foxtrot");
+
+        Assert.AreEqual("Foxtrot", res);
+    }
+
+    [Test]
+    public void Empty_Name_With_Suffixed_Siblings_Is_Numbered()
+    {
+        // A sibling beginning with a space (" (1)") parses to an empty base name with suffix 1, so
+        // resolving an empty name against it must continue the numbering.
+        SimilarNodeName[] names = [new() { Id = 1, Name = " (1)" }];
+
+        var res = SimilarNodeName.GetUniqueName(names, 0, string.Empty);
+
+        Assert.AreEqual(" (2)", res);
+    }
+
+    [Test]
+    public void Empty_Name_With_No_Suffixed_Siblings_Is_Empty()
+    {
+        // Empty name, and the only sibling (though it starts with a space) carries no suffix, so
+        // there is nothing to number against and the empty name is returned.
+        SimilarNodeName[] names = [new() { Id = 1, Name = " leading-space" }];
+
+        var res = SimilarNodeName.GetUniqueName(names, 0, string.Empty);
+
+        Assert.AreEqual(string.Empty, res);
+    }
+
     [TestCase("Echo", "Echo")]
     [TestCase("Echo (2)", "Echo")]
     [TestCase("Echo (1) (2)", "Echo (1)")]

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/SimilarNodeNameTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Persistence/Repositories/SimilarNodeNameTests.cs
@@ -9,9 +9,10 @@ namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Persistence.Reposit
 [TestFixture]
 internal sealed class SimilarNodeNameTests
 {
+    [Test]
     public void Name_Is_Suffixed()
     {
-        SimilarNodeName[] names = { new SimilarNodeName { Id = 1, Name = "Zulu" } };
+        SimilarNodeName[] names = [new() { Id = 1, Name = "Zulu" }];
 
         var res = SimilarNodeName.GetUniqueName(names, 0, "Zulu");
         Assert.AreEqual("Zulu (1)", res);
@@ -21,10 +22,11 @@ internal sealed class SimilarNodeNameTests
     public void Suffixed_Name_Is_Incremented()
     {
         SimilarNodeName[] names =
-        {
-            new SimilarNodeName {Id = 1, Name = "Zulu"}, new SimilarNodeName {Id = 2, Name = "Kilo (1)"},
-            new SimilarNodeName {Id = 3, Name = "Kilo"}
-        };
+        [
+            new() { Id = 1, Name = "Zulu" },
+            new() { Id = 2, Name = "Kilo (1)" },
+            new() { Id = 3, Name = "Kilo" },
+        ];
 
         var res = SimilarNodeName.GetUniqueName(names, 0, "Kilo (1)");
         Assert.AreEqual("Kilo (2)", res);
@@ -34,9 +36,10 @@ internal sealed class SimilarNodeNameTests
     public void Lower_Number_Suffix_Is_Inserted()
     {
         SimilarNodeName[] names =
-        {
-            new SimilarNodeName {Id = 1, Name = "Golf"}, new SimilarNodeName {Id = 2, Name = "Golf (2)"}
-        };
+        [
+            new() { Id = 1, Name = "Golf" },
+            new() { Id = 2, Name = "Golf (2)" },
+        ];
 
         var res = SimilarNodeName.GetUniqueName(names, 0, "Golf");
         Assert.AreEqual("Golf (1)", res);
@@ -48,10 +51,11 @@ internal sealed class SimilarNodeNameTests
     public void Case_Is_Ignored(int nodeId, string nodeName, string expected)
     {
         SimilarNodeName[] names =
-        {
-            new SimilarNodeName {Id = 1, Name = "Alpha"}, new SimilarNodeName {Id = 2, Name = "Alpha (1)"},
-            new SimilarNodeName {Id = 3, Name = "Alpha (2)"}
-        };
+        [
+            new() { Id = 1, Name = "Alpha" },
+            new() { Id = 2, Name = "Alpha (1)" },
+            new() { Id = 3, Name = "Alpha (2)" },
+        ];
         var res = SimilarNodeName.GetUniqueName(names, nodeId, nodeName);
 
         Assert.AreEqual(expected, res);
@@ -72,7 +76,7 @@ internal sealed class SimilarNodeNameTests
     [TestCase(0, null, " (1)")]
     public void Empty_Name_Is_Suffixed(int nodeId, string nodeName, string expected)
     {
-        var names = new SimilarNodeName[] { };
+        var names = Array.Empty<SimilarNodeName>();
 
         var res = SimilarNodeName.GetUniqueName(names, nodeId, nodeName);
 
@@ -83,10 +87,11 @@ internal sealed class SimilarNodeNameTests
     public void Matching_NoedId_Causes_No_Change()
     {
         SimilarNodeName[] names =
-        {
-            new SimilarNodeName {Id = 1, Name = "Kilo (1)"}, new SimilarNodeName {Id = 2, Name = "Yankee"},
-            new SimilarNodeName {Id = 3, Name = "Kilo"}
-        };
+        [
+            new() { Id = 1, Name = "Kilo (1)" },
+            new() { Id = 2, Name = "Yankee" },
+            new() { Id = 3, Name = "Kilo" },
+        ];
 
         var res = SimilarNodeName.GetUniqueName(names, 1, "Kilo (1)");
 
@@ -96,14 +101,16 @@ internal sealed class SimilarNodeNameTests
     [Test]
     public void Extra_MultiSuffixed_Name_Is_Ignored()
     {
-        // Sequesnce is: Test, Test (1), Test (2)
+        // Sequence is: Test, Test (1), Test (2)
         // Ignore: Test (1) (1)
         SimilarNodeName[] names =
-        {
-            new SimilarNodeName {Id = 1, Name = "Alpha (2)"}, new SimilarNodeName {Id = 2, Name = "Test"},
-            new SimilarNodeName {Id = 3, Name = "Test (1)"}, new SimilarNodeName {Id = 4, Name = "Test (2)"},
-            new SimilarNodeName {Id = 5, Name = "Test (1) (1)"}
-        };
+        [
+            new() { Id = 1, Name = "Alpha (2)" },
+            new() { Id = 2, Name = "Test" },
+            new() { Id = 3, Name = "Test (1)" },
+            new() { Id = 4, Name = "Test (2)" },
+            new() { Id = 5, Name = "Test (1) (1)" },
+        ];
 
         var res = SimilarNodeName.GetUniqueName(names, 0, "Test");
 
@@ -113,7 +120,7 @@ internal sealed class SimilarNodeNameTests
     [Test]
     public void Matched_Name_Is_Suffixed()
     {
-        SimilarNodeName[] names = { new SimilarNodeName { Id = 1, Name = "Test" } };
+        SimilarNodeName[] names = [new() { Id = 1, Name = "Test" }];
 
         var res = SimilarNodeName.GetUniqueName(names, 0, "Test");
 
@@ -127,9 +134,9 @@ internal sealed class SimilarNodeNameTests
         // "Test (1) (1)" is the suffixed result of a copy, and therefore is incremented
         // Hence this test result should be the same as Suffixed_Name_Is_Incremented
         SimilarNodeName[] names =
-        {
-            new SimilarNodeName {Id = 1, Name = "Test (1)"}, new SimilarNodeName {Id = 2, Name = "Test (1) (1)"}
-        };
+        [
+            new() { Id = 1, Name = "Test (1)" }, new() { Id = 2, Name = "Test (1) (1)" }
+        ];
 
         var res = SimilarNodeName.GetUniqueName(names, 0, "Test (1) (1)");
 
@@ -139,7 +146,7 @@ internal sealed class SimilarNodeNameTests
     [Test]
     public void Suffixed_Name_Causes_Secondary_Suffix()
     {
-        SimilarNodeName[] names = { new SimilarNodeName { Id = 6, Name = "Alpha (1)" } };
+        SimilarNodeName[] names = [new() { Id = 6, Name = "Alpha (1)" }];
         var res = SimilarNodeName.GetUniqueName(names, 0, "Alpha (1)");
 
         Assert.AreEqual("Alpha (1) (1)", res);
@@ -150,7 +157,7 @@ internal sealed class SimilarNodeNameTests
     [TestCase("Test (1) (-1)", "Test (1) (-1) (1)")]
     public void NonPositive_Suffix_Is_Ignored(string suffix, string expected)
     {
-        SimilarNodeName[] names = { new SimilarNodeName { Id = 6, Name = suffix } };
+        SimilarNodeName[] names = [new() { Id = 6, Name = suffix }];
         var res = SimilarNodeName.GetUniqueName(names, 0, suffix);
 
         Assert.AreEqual(expected, res);
@@ -160,15 +167,64 @@ internal sealed class SimilarNodeNameTests
     public void Handles_Many_Similar_Names()
     {
         SimilarNodeName[] names =
-        {
-            new SimilarNodeName {Id = 1, Name = "Alpha (2)"},
-            new SimilarNodeName {Id = 2, Name = "Test"},
-            new SimilarNodeName {Id = 3, Name = "Test (1)"},
-            new SimilarNodeName {Id = 4, Name = "Test (2)"},
-            new SimilarNodeName {Id = 22, Name = "Test (1) (1)"}
-        };
+        [
+            new() { Id = 1, Name = "Alpha (2)" },
+            new() { Id = 2, Name = "Test" },
+            new() { Id = 3, Name = "Test (1)" },
+            new() { Id = 4, Name = "Test (2)" },
+            new() { Id = 22, Name = "Test (1) (1)" },
+        ];
 
         var uniqueName = SimilarNodeName.GetUniqueName(names, 0, "Test");
         Assert.AreEqual("Test (3)", uniqueName);
     }
+
+    [Test]
+    public void Missing_Suffix_In_Sequence_Is_Filled()
+    {
+        // Suffixes 1 and 3 exist, so the gap at 2 should be used rather than appending 4.
+        SimilarNodeName[] names =
+        [
+            new() { Id = 1, Name = "Delta" },
+            new() { Id = 2, Name = "Delta (1)" },
+            new() { Id = 3, Name = "Delta (3)" },
+        ];
+
+        var res = SimilarNodeName.GetUniqueName(names, 0, "Delta");
+
+        Assert.AreEqual("Delta (2)", res);
+    }
+
+    [Test]
+    public void Name_With_Longer_Text_Does_Not_Cause_A_Suffix()
+    {
+        // "Testing" and "Test Case" share a prefix with "Test" but are different names,
+        // so "Test" itself is still available and must be returned unchanged.
+        SimilarNodeName[] names =
+        [
+            new() { Id = 1, Name = "Testing" },
+            new() { Id = 2, Name = "Test Case" },
+        ];
+
+        var res = SimilarNodeName.GetUniqueName(names, 0, "Test");
+
+        Assert.AreEqual("Test", res);
+    }
+
+    [TestCase("Echo", "Echo")]
+    [TestCase("Echo (2)", "Echo")]
+    [TestCase("Echo (1) (2)", "Echo (1)")]
+    [TestCase("Echo (0)", "Echo (0)")]
+    [TestCase("50%", "50%")]
+    public void GetBaseText_Removes_Trailing_Suffix(string name, string expected)
+        => Assert.AreEqual(expected, SimilarNodeName.GetBaseText(name));
+
+    [TestCase("")]
+    [TestCase(null)]
+    [TestCase("   ")]
+    public void GetBaseText_Returns_Space_For_Empty_Name(string? name) =>
+
+        // An empty name has no base text; it is represented as a single space so that a unique
+        // name can still be produced (e.g. " (1)").
+        Assert.AreEqual(" ", SimilarNodeName.GetBaseText(name));
 }


### PR DESCRIPTION
## Description

Reported in #23446: every write operation in the Media Library (uploading a file, creating a folder) becomes very slow once the library holds a large number of items — >15s each at ~36,000 items. The slowdown scales with the **total** number of media items, is independent of file size, and does **not** affect the Content section even with 10,000+ items.

### Root cause

Still be be validated with the reporter, but the likely issue is that on every create/save, the repository resolves a unique node name via `ContentRepositoryBase.EnsureUniqueNodeName`, which fetches **all siblings under the parent** and runs a multi-pass in-memory algorithm (regex per name + repeated `.Any(...)`/`.OrderBy(...)`) over them — all while holding the global `MediaTree` write lock.

Content and Media share this code, so the real differentiator is **tree shape**: content is typically nested (few children per parent), whereas a media library can me much **flater** — e.g. with many items under the media root — so "siblings" could be a large proportion of or even all the library and the fetch scales O(total items).

### Fix

Narrow the fetch to only the siblings whose name could actually collide — those sharing the proposed name's base text — using a case-insensitive prefix (`upper(text) LIKE upper(@p)`, the framework's existing collation-independent translation of `StartsWith`). `SimilarNodeName.GetUniqueName` is unchanged and remains the authority; it already filters its input by `InvariantStartsWith(baseText)`, so restricting the DB fetch to a superset of the names `GetUniqueName` would keep is behaviour-preserving. In the common (non-colliding) case the query now returns a handful of rows instead of tens of thousands.

Scope is deliberately tight:
- Only the public `EnsureUniqueNodeName` overload (used by `MediaRepository`) is changed.
- The `out siblings` overload is left untouched — `DocumentRepository` reuses the full sibling list for URL-segment uniqueness, and documents as are typically more nested the full fetch stays cheap there.

Fixes #23446.

### Additional Refactoring

I took the opportunity to clean up `SimilarNodeName.cs` that I was in any case modifying, and which was previously held in a file called `ListExtension.cs`.  I've moved it into it's own file, removed the unnecessary extensions, added more tests, resolved warnings and refactored to reduce cognitive complexity.  All code is internal, so no concern around breaking changes.

## Testing

### Automated

New integration tests in `MediaServiceTests` exercise the narrowed fetch against a database — duplicate siblings, case-insensitive collisions, similar-prefix decoys, `LIKE` metacharacters (`50%`, `a_b`, `x[y`) and suffix-gap reuse. These are behaviour-preserving guards (they pass before and after) rather than fail-before-fix tests, since the change is a pure performance fix with identical semantics. Existing `SimilarNodeNameTests` and `MediaServiceTests` remain green.

### Benchmark

`MediaUniqueNameBenchmarks` (BenchmarkDotNet) models create-time unique-name resolution against a flat tree seeded with 1k/10k/30k siblings, comparing the old all-siblings fetch against the new prefix-matched fetch, to demonstrate the new path stays flat as the sibling count grows.

Results (resolving a non-colliding name; SQLite in-memory*):

| Siblings | Old alloc | New alloc | Old time | New time |
|---|---|---|---|---|
| 1,000 | 104 KB | 2.2 KB | 601 µs | 288 µs |
| 10,000 | 1,118 KB | 2.2 KB | 6,350 µs | 2,736 µs |
| 30,000 | 3,093 KB | 2.2 KB | 19,133 µs | 9,013 µs |

Allocations are the key result: the old path scales linearly (~104 KB → ~3 MB, with Gen2 GC pressure), while the new path stays flat at ~2.2 KB regardless of sibling count. Time roughly halves here and understates the real-world gain — both variants still pay the in-DB index range scan, so the benchmark isolates the app-side cost (row transfer + allocation + in-memory scan) that dominated on the reporter's remote database under the `MediaTree` write lock.

\* Times are slightly more pronounced using a local SQLite database, but not by much, likely as the whole dataset fits in SQLite's page cache after warmup, so it's not much different to an in-memory database.  The effect is expected to be much more pronounced with a SQL Server database remote from the web server.

### Manual

Verify that media creation behaviour in unchanged:
- Media without a name clash in the current folder or root should be created as per provided name.
- Media with a name clash should be created with the usual suffix logic (i.e. with suffix of `" (1)"`, then `" (2)"`, etc.)