### PR TITLE
Recycle bin: Support restoring a document or media item without its descendants at the service level (closes #23417)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/RestoreDocumentRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Document/RecycleBin/RestoreDocumentRecycleBinController.cs
@@ -84,7 +84,8 @@ public class RestoreDocumentRecycleBinController : DocumentRecycleBinControllerB
         Attempt<IContent?, ContentEditingOperationStatus> result = await _contentEditingService.RestoreAsync(
             id,
             moveDocumentRequestModel.Target?.Id,
-            CurrentUserKey(_backOfficeSecurityAccessor));
+            CurrentUserKey(_backOfficeSecurityAccessor),
+            includeDescendants: true);
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/RestoreMediaRecycleBinController.cs
+++ b/src/Umbraco.Cms.Api.Management/Controllers/Media/RecycleBin/RestoreMediaRecycleBinController.cs
@@ -79,7 +79,8 @@ public class RestoreMediaRecycleBinController : MediaRecycleBinControllerBase
         Attempt<IMedia?, ContentEditingOperationStatus> result = await _mediaEditingService.RestoreAsync(
             id,
             moveDocumentRequestModel.Target?.Id,
-            CurrentUserKey(_backOfficeSecurityAccessor));
+            CurrentUserKey(_backOfficeSecurityAccessor),
+            includeDescendants: true);
 
         return result.Success
             ? Ok()

--- a/src/Umbraco.Core/Services/ContentBlueprintEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentBlueprintEditingService.cs
@@ -270,7 +270,7 @@ internal sealed class ContentBlueprintEditingService
     /// Some methods from ContentEditingServiceBase are needed, so we need to inherit from it
     /// but there are others that are not required to be implemented in the case of blueprints.
     /// </remarks>
-    protected override OperationResult? Move(IContent content, int newParentId, int userId) => throw new NotImplementedException();
+    protected override OperationResult? Move(IContent content, int newParentId, bool includeDescendants, int userId) => throw new NotImplementedException();
 
     /// <summary>
     /// Copies the specified content to a new parent. Not supported for blueprints.

--- a/src/Umbraco.Core/Services/ContentBlueprintEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentBlueprintEditingService.cs
@@ -263,6 +263,7 @@ internal sealed class ContentBlueprintEditingService
     /// </summary>
     /// <param name="content">The content to move.</param>
     /// <param name="newParentId">The ID of the new parent.</param>
+    /// <param name="includeDescendants">Whether to move the descendants along with the content. Not supported for blueprints.</param>
     /// <param name="userId">The ID of the user performing the operation.</param>
     /// <returns>Not supported for blueprints.</returns>
     /// <exception cref="NotImplementedException">Always thrown as this operation is not supported for blueprints.</exception>

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -344,8 +344,13 @@ internal sealed class ContentEditingService
         => await HandleMoveAsync(key, parentKey, userKey);
 
     /// <inheritdoc />
+    [Obsolete("Use the overload that takes an includeDescendants parameter instead. Scheduled for removal in Umbraco 19.")]
     public async Task<Attempt<IContent?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey)
-        => await HandleMoveAsync(key, parentKey, userKey, true);
+        => await RestoreAsync(key, parentKey, userKey, true);
+
+    /// <inheritdoc />
+    public async Task<Attempt<IContent?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey, bool includeDescendants)
+        => await HandleMoveAsync(key, parentKey, userKey, true, includeDescendants);
 
     /// <inheritdoc />
     public async Task<Attempt<IContent?, ContentEditingOperationStatus>> CopyAsync(Guid key, Guid? parentKey, bool relateToOriginal, bool includeDescendants, Guid userKey)
@@ -407,6 +412,10 @@ internal sealed class ContentEditingService
     /// <inheritdoc />
     protected override OperationResult? Move(IContent content, int newParentId, int userId)
         => ContentService.Move(content, newParentId, userId);
+
+    /// <inheritdoc />
+    protected override OperationResult? Move(IContent content, int newParentId, bool includeDescendants, int userId)
+        => ContentService.Move(content, newParentId, includeDescendants, userId);
 
     /// <inheritdoc />
     protected override IContent? Copy(IContent content, int newParentId, bool relateToOriginal, bool includeDescendants, int userId)

--- a/src/Umbraco.Core/Services/ContentEditingService.cs
+++ b/src/Umbraco.Core/Services/ContentEditingService.cs
@@ -410,10 +410,6 @@ internal sealed class ContentEditingService
         => new Content(name, parentId, contentType);
 
     /// <inheritdoc />
-    protected override OperationResult? Move(IContent content, int newParentId, int userId)
-        => ContentService.Move(content, newParentId, userId);
-
-    /// <inheritdoc />
     protected override OperationResult? Move(IContent content, int newParentId, bool includeDescendants, int userId)
         => ContentService.Move(content, newParentId, includeDescendants, userId);
 

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -98,6 +98,20 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
     protected abstract OperationResult? Move(TContent content, int newParentId, int userId);
 
     /// <summary>
+    /// Moves content to a new parent, optionally leaving its descendants behind.
+    /// </summary>
+    /// <param name="content">The content to move.</param>
+    /// <param name="newParentId">The new parent identifier.</param>
+    /// <param name="includeDescendants">
+    /// Whether to move the descendants along with the content. When restoring content out of the recycle bin this can
+    /// be set to <c>false</c> to restore only the content item itself, leaving its descendants in the recycle bin.
+    /// </param>
+    /// <param name="userId">The user performing the operation.</param>
+    /// <returns>The operation result.</returns>
+    protected virtual OperationResult? Move(TContent content, int newParentId, bool includeDescendants, int userId)
+        => Move(content, newParentId, userId);
+
+    /// <summary>
     /// Copies content to a new parent.
     /// </summary>
     /// <param name="content">The content to copy.</param>
@@ -354,8 +368,12 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
     /// <param name="parentKey">The new parent key, or null for root.</param>
     /// <param name="userKey">The user key performing the operation.</param>
     /// <param name="mustBeInRecycleBin">Whether the content must be in the recycle bin (for restore operations).</param>
+    /// <param name="includeDescendants">
+    /// Whether to move the descendants along with the content. When restoring out of the recycle bin this can be set to
+    /// <c>false</c> to restore only the content item itself, leaving its descendants in the recycle bin.
+    /// </param>
     /// <returns>An attempt containing the content and operation status.</returns>
-    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleMoveAsync(Guid key, Guid? parentKey, Guid userKey, bool mustBeInRecycleBin = false)
+    protected async Task<Attempt<TContent?, ContentEditingOperationStatus>> HandleMoveAsync(Guid key, Guid? parentKey, Guid userKey, bool mustBeInRecycleBin = false, bool includeDescendants = true)
     {
         using ICoreScope scope = CoreScopeProvider.CreateCoreScope();
         TContent? content = ContentService.GetById(key);
@@ -396,7 +414,7 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
         }
 
         var userId = await GetUserIdAsync(userKey);
-        OperationResult? moveResult = Move(content, parent.ParentId ?? Constants.System.Root, userId);
+        OperationResult? moveResult = Move(content, parent.ParentId ?? Constants.System.Root, includeDescendants, userId);
 
         scope.Complete();
 

--- a/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
+++ b/src/Umbraco.Core/Services/ContentEditingServiceBase.cs
@@ -95,7 +95,8 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
     /// <param name="newParentId">The new parent identifier.</param>
     /// <param name="userId">The user performing the operation.</param>
     /// <returns>The operation result.</returns>
-    protected abstract OperationResult? Move(TContent content, int newParentId, int userId);
+    protected OperationResult? Move(TContent content, int newParentId, int userId)
+        => Move(content, newParentId, includeDescendants: true, userId);
 
     /// <summary>
     /// Moves content to a new parent, optionally leaving its descendants behind.
@@ -108,8 +109,7 @@ internal abstract class ContentEditingServiceBase<TContent, TContentType, TConte
     /// </param>
     /// <param name="userId">The user performing the operation.</param>
     /// <returns>The operation result.</returns>
-    protected virtual OperationResult? Move(TContent content, int newParentId, bool includeDescendants, int userId)
-        => Move(content, newParentId, userId);
+    protected abstract OperationResult? Move(TContent content, int newParentId, bool includeDescendants, int userId);
 
     /// <summary>
     /// Copies content to a new parent.

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2842,6 +2842,25 @@ public class ContentService : RepositoryService, IContentService
     /// <param name="parentId">Id of the Content's new Parent</param>
     /// <param name="userId">Optional Id of the User moving the Content</param>
     public OperationResult Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId)
+        => Move(content, parentId, true, userId);
+
+    /// <summary>
+    ///     Moves an <see cref="IContent" /> object to a new location by changing its parent id.
+    /// </summary>
+    /// <remarks>
+    ///     If the <see cref="IContent" /> object is already published it will be
+    ///     published after being moved to its new location. Otherwise it'll just
+    ///     be saved with a new parent id.
+    /// </remarks>
+    /// <param name="content">The <see cref="IContent" /> to move</param>
+    /// <param name="parentId">Id of the Content's new Parent</param>
+    /// <param name="includeDescendants">
+    ///     Whether to move the descendants of the content along with it. When restoring an item out of the recycle bin
+    ///     this can be set to <c>false</c> to restore only the item itself, leaving its descendants in the recycle bin
+    ///     as top-level bin items.
+    /// </param>
+    /// <param name="userId">Optional Id of the User moving the Content</param>
+    public OperationResult Move(IContent content, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
     {
         EventMessages eventMessages = EventMessagesFactory.Get();
 
@@ -2883,6 +2902,10 @@ public class ContentService : RepositoryService, IContentService
             // leave it unchanged
             var trashed = content.Trashed ? false : (bool?)null;
 
+            // when restoring a single item out of the recycle bin without its descendants, those descendants stay
+            // trashed and are re-homed under the recycle bin root - see PerformMoveLocked
+            var leaveDescendantsInRecycleBin = includeDescendants is false && content.Trashed && parentId != Constants.System.RecycleBinContent;
+
             // if the content was trashed under another content, and so has a published version,
             // it cannot move back as published but has to be unpublished first - that's for the
             // root content, everything underneath will retain its published status
@@ -2893,10 +2916,25 @@ public class ContentService : RepositoryService, IContentService
                 content.PublishedState = PublishedState.Unpublishing;
             }
 
-            PerformMoveLocked(content, parentId, parent, userId, moves, trashed);
+            PerformMoveLocked(content, parentId, parent, userId, moves, trashed, includeDescendants);
 
-            scope.Notifications.Publish(
-                new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshBranch, eventMessages));
+            if (leaveDescendantsInRecycleBin)
+            {
+                // The single RefreshBranch above cannot reconcile the descendants left in the bin (they are no longer
+                // descendants of the restored item), so also refresh the re-homed direct children. The navigation
+                // reconciler then moves them - and their sub-trees - back under the recycle bin root.
+                IContent[] rehomedChildren = moves
+                    .Select(x => x.Item1)
+                    .Where(x => x.ParentId == Constants.System.RecycleBinContent)
+                    .ToArray();
+                scope.Notifications.Publish(
+                    new ContentTreeChangeNotification(content.Yield().Concat(rehomedChildren), TreeChangeTypes.RefreshBranch, eventMessages));
+            }
+            else
+            {
+                scope.Notifications.Publish(
+                    new ContentTreeChangeNotification(content, TreeChangeTypes.RefreshBranch, eventMessages));
+            }
 
             // changes
             MoveEventInfo<IContent>[] moveInfo = moves
@@ -2919,7 +2957,7 @@ public class ContentService : RepositoryService, IContentService
 
     // MUST be called from within WriteLock
     // trash indicates whether we are trashing, un-trashing, or not changing anything
-    private void PerformMoveLocked(IContent content, int parentId, IContent? parent, int userId, ICollection<(IContent, string)> moves, bool? trash)
+    private void PerformMoveLocked(IContent content, int parentId, IContent? parent, int userId, ICollection<(IContent, string)> moves, bool? trash, bool includeDescendants = true)
     {
         content.WriterId = userId;
         content.ParentId = parentId;
@@ -2927,6 +2965,7 @@ public class ContentService : RepositoryService, IContentService
         // get the level delta (old pos to new pos)
         // note that recycle bin (id:-20) level is 0!
         var levelDelta = 1 - content.Level + (parent?.Level ?? 0);
+        var originalLevel = content.Level;
 
         var paths = new Dictionary<int, string>();
 
@@ -2949,6 +2988,13 @@ public class ContentService : RepositoryService, IContentService
                 ? parentId == Constants.System.RecycleBinContent ? "-1,-20" : Constants.System.RootString
                 : parent.Path) + "," + content.Id;
 
+        // When restoring a single item out of the recycle bin without its descendants, the descendants must stay
+        // trashed: the item's direct children are re-homed to the recycle bin root (and the rest of the subtree keeps
+        // its relative structure), so nothing is orphaned and it can still be restored on its own later.
+        var leaveDescendantsInRecycleBin = includeDescendants is false
+            && parentId != Constants.System.RecycleBinContent
+            && originalPath.Contains(Constants.System.RecycleBinContentString);
+
         const int pageSize = 500;
         IQuery<IContent>? query = GetPagedDescendantQuery(originalPath);
         long total;
@@ -2962,10 +3008,30 @@ public class ContentService : RepositoryService, IContentService
             {
                 moves.Add((descendant, descendant.Path)); // capture original path
 
-                // update path and level since we do not update parentId
-                descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
-                descendant.Level += levelDelta;
-                PerformMoveContentLocked(descendant, userId, trash);
+                if (leaveDescendantsInRecycleBin)
+                {
+                    // the restored item's direct children become top-level recycle bin items; deeper descendants keep
+                    // their relative structure below their (now re-homed) ancestor
+                    var isDirectChild = descendant.ParentId == content.Id;
+                    descendant.Path = paths[descendant.Id] = isDirectChild
+                        ? Constants.System.RecycleBinContentPathPrefix + descendant.Id
+                        : paths[descendant.ParentId] + "," + descendant.Id;
+                    descendant.Level -= originalLevel;
+                    if (isDirectChild)
+                    {
+                        descendant.ParentId = Constants.System.RecycleBinContent;
+                    }
+
+                    // leave the trashed state untouched - these items remain in the recycle bin
+                    PerformMoveContentLocked(descendant, userId, null);
+                }
+                else
+                {
+                    // update path and level since we do not update parentId
+                    descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
+                    descendant.Level += levelDelta;
+                    PerformMoveContentLocked(descendant, userId, trash);
+                }
             }
         }
         while (total > pageSize);

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2852,15 +2852,18 @@ public class ContentService : RepositoryService, IContentService
     ///     published after being moved to its new location. Otherwise it'll just
     ///     be saved with a new parent id.
     /// </remarks>
-    /// <param name="content">The <see cref="IContent" /> to move</param>
-    /// <param name="parentId">Id of the Content's new Parent</param>
+    /// <param name="content">The <see cref="IContent" /> to move.</param>
+    /// <param name="parentId">Id of the Content's new Parent.</param>
     /// <param name="includeDescendants">
     ///     Whether to move the descendants of the content along with it. When restoring an item out of the recycle bin
     ///     this can be set to <c>false</c> to restore only the item itself, leaving its descendants in the recycle bin
     ///     as top-level bin items.
     /// </param>
-    /// <param name="userId">Optional Id of the User moving the Content</param>
+    /// <param name="userId">Optional Id of the User moving the Content.</param>
+    /// <returns>The operation result.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete - the int-userId overloads still default to SuperUserId; there is no non-obsolete int equivalent until it is removed in v18
     public OperationResult Move(IContent content, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         EventMessages eventMessages = EventMessagesFactory.Get();
 
@@ -2957,7 +2960,7 @@ public class ContentService : RepositoryService, IContentService
 
     // MUST be called from within WriteLock
     // trash indicates whether we are trashing, un-trashing, or not changing anything
-    private void PerformMoveLocked(IContent content, int parentId, IContent? parent, int userId, ICollection<(IContent, string)> moves, bool? trash, bool includeDescendants = true)
+    private void PerformMoveLocked(IContent content, int parentId, IContent? parent, int userId, List<(IContent Content, string OriginalPath)> moves, bool? trash, bool includeDescendants = true)
     {
         content.WriterId = userId;
         content.ParentId = parentId;
@@ -3010,31 +3013,41 @@ public class ContentService : RepositoryService, IContentService
 
                 if (leaveDescendantsInRecycleBin)
                 {
-                    // the restored item's direct children become top-level recycle bin items; deeper descendants keep
-                    // their relative structure below their (now re-homed) ancestor
-                    var isDirectChild = descendant.ParentId == content.Id;
-                    descendant.Path = paths[descendant.Id] = isDirectChild
-                        ? Constants.System.RecycleBinContentPathPrefix + descendant.Id
-                        : paths[descendant.ParentId] + "," + descendant.Id;
-                    descendant.Level -= originalLevel;
-                    if (isDirectChild)
-                    {
-                        descendant.ParentId = Constants.System.RecycleBinContent;
-                    }
-
-                    // leave the trashed state untouched - these items remain in the recycle bin
-                    PerformMoveContentLocked(descendant, userId, null);
+                    LeaveDescendantInRecycleBinLocked(descendant, content.Id, originalLevel, userId, paths);
                 }
                 else
                 {
-                    // update path and level since we do not update parentId
-                    descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
-                    descendant.Level += levelDelta;
-                    PerformMoveContentLocked(descendant, userId, trash);
+                    PerformMoveDescendantLocked(descendant, levelDelta, userId, trash, paths);
                 }
             }
         }
         while (total > pageSize);
+    }
+
+    // Re-homes a descendant of a restored item within the recycle bin: the restored item's direct children become
+    // top-level recycle bin items, while deeper descendants keep their relative structure below their (now re-homed)
+    // ancestor. The trashed state is left untouched so these items remain in the recycle bin.
+    private void LeaveDescendantInRecycleBinLocked(IContent descendant, int restoredItemId, int originalLevel, int userId, Dictionary<int, string> paths)
+    {
+        var isDirectChild = descendant.ParentId == restoredItemId;
+        descendant.Path = paths[descendant.Id] = isDirectChild
+            ? Constants.System.RecycleBinContentPathPrefix + descendant.Id
+            : paths[descendant.ParentId] + "," + descendant.Id;
+        descendant.Level -= originalLevel;
+        if (isDirectChild)
+        {
+            descendant.ParentId = Constants.System.RecycleBinContent;
+        }
+
+        PerformMoveContentLocked(descendant, userId, null);
+    }
+
+    // Moves a descendant along with the item being moved, updating its path and level (parentId is unchanged).
+    private void PerformMoveDescendantLocked(IContent descendant, int levelDelta, int userId, bool? trash, Dictionary<int, string> paths)
+    {
+        descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
+        descendant.Level += levelDelta;
+        PerformMoveContentLocked(descendant, userId, trash);
     }
 
     private void PerformMoveContentLocked(IContent content, int userId, bool? trash)

--- a/src/Umbraco.Core/Services/ContentService.cs
+++ b/src/Umbraco.Core/Services/ContentService.cs
@@ -2841,7 +2841,9 @@ public class ContentService : RepositoryService, IContentService
     /// <param name="content">The <see cref="IContent" /> to move</param>
     /// <param name="parentId">Id of the Content's new Parent</param>
     /// <param name="userId">Optional Id of the User moving the Content</param>
+#pragma warning disable CS0618 // Type or member is obsolete - the int-userId overloads still default to SuperUserId; there is no non-obsolete int equivalent until it is removed in v18
     public OperationResult Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId)
+#pragma warning restore CS0618 // Type or member is obsolete
         => Move(content, parentId, true, userId);
 
     /// <summary>

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -145,5 +145,24 @@ public interface IContentEditingService
     /// <param name="parentKey">The unique identifier of the parent to restore to, or <c>null</c> for the original location.</param>
     /// <param name="userKey">The unique identifier of the user performing the action.</param>
     /// <returns>An attempt containing the restored content item or an error status.</returns>
+    [Obsolete("Use the overload that takes an includeDescendants parameter instead. Scheduled for removal in Umbraco 19.")]
     Task<Attempt<IContent?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey);
+
+    /// <summary>
+    ///     Restores a content item from the recycle bin, optionally leaving its descendants behind.
+    /// </summary>
+    /// <param name="key">The unique identifier of the content item to restore.</param>
+    /// <param name="parentKey">The unique identifier of the parent to restore to, or <c>null</c> for the original location.</param>
+    /// <param name="userKey">The unique identifier of the user performing the action.</param>
+    /// <param name="includeDescendants">
+    ///     Whether to restore the descendants of the content item along with it. When <c>false</c>, only the content
+    ///     item itself is restored and its descendants remain in the recycle bin as top-level bin items, ready to be
+    ///     restored later.
+    /// </param>
+    /// <returns>An attempt containing the restored content item or an error status.</returns>
+    // TODO (V19): Remove the default implementation when the obsolete overload without includeDescendants is removed.
+    Task<Attempt<IContent?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey, bool includeDescendants)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => RestoreAsync(key, parentKey, userKey);
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Umbraco.Core/Services/IContentEditingService.cs
+++ b/src/Umbraco.Core/Services/IContentEditingService.cs
@@ -162,7 +162,17 @@ public interface IContentEditingService
     /// <returns>An attempt containing the restored content item or an error status.</returns>
     // TODO (V19): Remove the default implementation when the obsolete overload without includeDescendants is removed.
     Task<Attempt<IContent?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey, bool includeDescendants)
+    {
+        // Only the whole-tree restore can be satisfied by delegating to the existing method; there is no way to honour
+        // includeDescendants: false without the concrete implementation, so fail fast rather than silently restore
+        // the descendants after all.
+        if (includeDescendants is false)
+        {
+            throw new NotImplementedException("This IContentEditingService implementation does not support restoring without descendants. Override the RestoreAsync overload that takes an includeDescendants parameter to support it.");
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
-        => RestoreAsync(key, parentKey, userKey);
+        return RestoreAsync(key, parentKey, userKey);
 #pragma warning restore CS0618 // Type or member is obsolete
+    }
 }

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -490,7 +490,9 @@ public interface IContentService : IContentServiceBase<IContent>
     /// </param>
     /// <param name="userId">The identifier of the user performing the action.</param>
     /// <returns>The operation result.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete - the int-userId overloads still default to SuperUserId; there is no non-obsolete int equivalent until it is removed in v18
     OperationResult Move(IContent content, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         // Only the whole-tree move can be satisfied by delegating to the existing method; there is no way to honour
         // includeDescendants: false without the concrete implementation, so fail fast rather than silently move

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -479,6 +479,21 @@ public interface IContentService : IContentServiceBase<IContent>
     OperationResult Move(IContent content, int parentId, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
+    ///     Moves a document under a new parent, optionally leaving its descendants behind.
+    /// </summary>
+    /// <param name="content">The document to move.</param>
+    /// <param name="parentId">The identifier of the new parent.</param>
+    /// <param name="includeDescendants">
+    ///     Whether to move the descendants of the document along with it. When restoring a document out of the recycle
+    ///     bin this can be set to <c>false</c> to restore only the document itself, leaving its descendants in the
+    ///     recycle bin as top-level bin items.
+    /// </param>
+    /// <param name="userId">The identifier of the user performing the action.</param>
+    /// <returns>The operation result.</returns>
+    OperationResult Move(IContent content, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
+        => Move(content, parentId, userId);
+
+    /// <summary>
     ///     Copies a document.
     /// </summary>
     /// <param name="content">The document to copy.</param>

--- a/src/Umbraco.Core/Services/IContentService.cs
+++ b/src/Umbraco.Core/Services/IContentService.cs
@@ -491,7 +491,17 @@ public interface IContentService : IContentServiceBase<IContent>
     /// <param name="userId">The identifier of the user performing the action.</param>
     /// <returns>The operation result.</returns>
     OperationResult Move(IContent content, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
-        => Move(content, parentId, userId);
+    {
+        // Only the whole-tree move can be satisfied by delegating to the existing method; there is no way to honour
+        // includeDescendants: false without the concrete implementation, so fail fast rather than silently move
+        // the descendants after all.
+        if (includeDescendants is false)
+        {
+            throw new NotImplementedException("This IContentService implementation does not support moving without descendants. Override the Move overload that takes an includeDescendants parameter to support it.");
+        }
+
+        return Move(content, parentId, userId);
+    }
 
     /// <summary>
     ///     Copies a document.

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -153,5 +153,29 @@ public interface IMediaEditingService
     ///     <see cref="Attempt{TResult,TStatus}"/> with the restored <see cref="IMedia"/> item (if successful)
     ///     and <see cref="ContentEditingOperationStatus"/> indicating the operation outcome.
     /// </returns>
+    [Obsolete("Use the overload that takes an includeDescendants parameter instead. Scheduled for removal in Umbraco 19.")]
     Task<Attempt<IMedia?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey);
+
+    /// <summary>
+    ///     Restores a media item from the recycle bin to a specified parent location, optionally leaving its
+    ///     descendants behind.
+    /// </summary>
+    /// <param name="key">The unique identifier of the media item to restore.</param>
+    /// <param name="parentKey">The unique identifier of the parent to restore to, or <c>null</c> to restore to the root.</param>
+    /// <param name="userKey">The unique identifier of the user performing the operation.</param>
+    /// <param name="includeDescendants">
+    ///     Whether to restore the descendants of the media item along with it. When <c>false</c>, only the media item
+    ///     itself is restored and its descendants remain in the recycle bin as top-level bin items, ready to be
+    ///     restored later.
+    /// </param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation. The task result contains an
+    ///     <see cref="Attempt{TResult,TStatus}"/> with the restored <see cref="IMedia"/> item (if successful)
+    ///     and <see cref="ContentEditingOperationStatus"/> indicating the operation outcome.
+    /// </returns>
+    // TODO (V19): Remove the default implementation when the obsolete overload without includeDescendants is removed.
+    Task<Attempt<IMedia?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey, bool includeDescendants)
+#pragma warning disable CS0618 // Type or member is obsolete
+        => RestoreAsync(key, parentKey, userKey);
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/Umbraco.Core/Services/IMediaEditingService.cs
+++ b/src/Umbraco.Core/Services/IMediaEditingService.cs
@@ -175,7 +175,17 @@ public interface IMediaEditingService
     /// </returns>
     // TODO (V19): Remove the default implementation when the obsolete overload without includeDescendants is removed.
     Task<Attempt<IMedia?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey, bool includeDescendants)
+    {
+        // Only the whole-tree restore can be satisfied by delegating to the existing method; there is no way to honour
+        // includeDescendants: false without the concrete implementation, so fail fast rather than silently restore
+        // the descendants after all.
+        if (includeDescendants is false)
+        {
+            throw new NotImplementedException("This IMediaEditingService implementation does not support restoring without descendants. Override the RestoreAsync overload that takes an includeDescendants parameter to support it.");
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
-        => RestoreAsync(key, parentKey, userKey);
+        return RestoreAsync(key, parentKey, userKey);
 #pragma warning restore CS0618 // Type or member is obsolete
+    }
 }

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -194,6 +194,21 @@ public interface IMediaService : IContentServiceBase<IMedia>
     Attempt<OperationResult?> Move(IMedia media, int parentId, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
+    ///     Moves an <see cref="IMedia" /> object to a new location, optionally leaving its descendants behind
+    /// </summary>
+    /// <param name="media">The <see cref="IMedia" /> to move</param>
+    /// <param name="parentId">Id of the Media's new Parent</param>
+    /// <param name="includeDescendants">
+    ///     Whether to move the descendants of the media along with it. When restoring media out of the recycle bin
+    ///     this can be set to <c>false</c> to restore only the media item itself, leaving its descendants in the
+    ///     recycle bin as top-level bin items.
+    /// </param>
+    /// <param name="userId">Id of the User moving the Media</param>
+    /// <returns>True if moving succeeded, otherwise False</returns>
+    Attempt<OperationResult?> Move(IMedia media, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
+        => Move(media, parentId, userId);
+
+    /// <summary>
     ///     Deletes an <see cref="IMedia" /> object by moving it to the Recycle Bin
     /// </summary>
     /// <param name="media">The <see cref="IMedia" /> to delete</param>

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -194,18 +194,20 @@ public interface IMediaService : IContentServiceBase<IMedia>
     Attempt<OperationResult?> Move(IMedia media, int parentId, int userId = Constants.Security.SuperUserId);
 
     /// <summary>
-    ///     Moves an <see cref="IMedia" /> object to a new location, optionally leaving its descendants behind
+    ///     Moves an <see cref="IMedia" /> object to a new location, optionally leaving its descendants behind.
     /// </summary>
-    /// <param name="media">The <see cref="IMedia" /> to move</param>
-    /// <param name="parentId">Id of the Media's new Parent</param>
+    /// <param name="media">The <see cref="IMedia" /> to move.</param>
+    /// <param name="parentId">Id of the Media's new Parent.</param>
     /// <param name="includeDescendants">
     ///     Whether to move the descendants of the media along with it. When restoring media out of the recycle bin
     ///     this can be set to <c>false</c> to restore only the media item itself, leaving its descendants in the
     ///     recycle bin as top-level bin items.
     /// </param>
-    /// <param name="userId">Id of the User moving the Media</param>
-    /// <returns>True if moving succeeded, otherwise False</returns>
+    /// <param name="userId">Id of the User moving the Media.</param>
+    /// <returns>True if moving succeeded, otherwise False.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete - the int-userId overloads still default to SuperUserId; there is no non-obsolete int equivalent until it is removed in v18
     Attempt<OperationResult?> Move(IMedia media, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         // Only the whole-tree move can be satisfied by delegating to the existing method; there is no way to honour
         // includeDescendants: false without the concrete implementation, so fail fast rather than silently move

--- a/src/Umbraco.Core/Services/IMediaService.cs
+++ b/src/Umbraco.Core/Services/IMediaService.cs
@@ -206,7 +206,17 @@ public interface IMediaService : IContentServiceBase<IMedia>
     /// <param name="userId">Id of the User moving the Media</param>
     /// <returns>True if moving succeeded, otherwise False</returns>
     Attempt<OperationResult?> Move(IMedia media, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
-        => Move(media, parentId, userId);
+    {
+        // Only the whole-tree move can be satisfied by delegating to the existing method; there is no way to honour
+        // includeDescendants: false without the concrete implementation, so fail fast rather than silently move
+        // the descendants after all.
+        if (includeDescendants is false)
+        {
+            throw new NotImplementedException("This IMediaService implementation does not support moving without descendants. Override the Move overload that takes an includeDescendants parameter to support it.");
+        }
+
+        return Move(media, parentId, userId);
+    }
 
     /// <summary>
     ///     Deletes an <see cref="IMedia" /> object by moving it to the Recycle Bin

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -166,8 +166,13 @@ internal sealed class MediaEditingService
         => await HandleMoveAsync(key, parentKey, userKey);
 
     /// <inheritdoc />
+    [Obsolete("Use the overload that takes an includeDescendants parameter instead. Scheduled for removal in Umbraco 19.")]
     public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey)
-        => await HandleMoveAsync(key, parentKey, userKey, true);
+        => await RestoreAsync(key, parentKey, userKey, true);
+
+    /// <inheritdoc />
+    public async Task<Attempt<IMedia?, ContentEditingOperationStatus>> RestoreAsync(Guid key, Guid? parentKey, Guid userKey, bool includeDescendants)
+        => await HandleMoveAsync(key, parentKey, userKey, true, includeDescendants);
 
     /// <inheritdoc />
     public async Task<ContentEditingOperationStatus> SortAsync(Guid? parentKey, IEnumerable<SortingModel> sortingModels, Guid userKey)
@@ -186,6 +191,10 @@ internal sealed class MediaEditingService
     /// <inheritdoc />
     protected override OperationResult? Move(IMedia media, int newParentId, int userId)
         => ContentService.Move(media, newParentId, userId).Result;
+
+    /// <inheritdoc />
+    protected override OperationResult? Move(IMedia media, int newParentId, bool includeDescendants, int userId)
+        => ContentService.Move(media, newParentId, includeDescendants, userId).Result;
 
     /// <inheritdoc />
     /// <exception cref="NotSupportedException">Copy is not supported for media items.</exception>

--- a/src/Umbraco.Core/Services/MediaEditingService.cs
+++ b/src/Umbraco.Core/Services/MediaEditingService.cs
@@ -189,10 +189,6 @@ internal sealed class MediaEditingService
         => new Models.Media(name, parentId, mediaType);
 
     /// <inheritdoc />
-    protected override OperationResult? Move(IMedia media, int newParentId, int userId)
-        => ContentService.Move(media, newParentId, userId).Result;
-
-    /// <inheritdoc />
     protected override OperationResult? Move(IMedia media, int newParentId, bool includeDescendants, int userId)
         => ContentService.Move(media, newParentId, includeDescendants, userId).Result;
 

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1193,6 +1193,20 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="parentId">Id of the Media's new Parent</param>
         /// <param name="userId">Id of the User moving the Media</param>
         public Attempt<OperationResult?> Move(IMedia media, int parentId, int userId = Constants.Security.SuperUserId)
+            => Move(media, parentId, true, userId);
+
+        /// <summary>
+        /// Moves an <see cref="IMedia"/> object to a new location
+        /// </summary>
+        /// <param name="media">The <see cref="IMedia"/> to move</param>
+        /// <param name="parentId">Id of the Media's new Parent</param>
+        /// <param name="includeDescendants">
+        ///     Whether to move the descendants of the media along with it. When restoring an item out of the recycle bin
+        ///     this can be set to <c>false</c> to restore only the item itself, leaving its descendants in the recycle bin
+        ///     as top-level bin items.
+        /// </param>
+        /// <param name="userId">Id of the User moving the Media</param>
+        public Attempt<OperationResult?> Move(IMedia media, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
         {
             EventMessages messages = EventMessagesFactory.Get();
 
@@ -1229,8 +1243,27 @@ namespace Umbraco.Cms.Core.Services
                 // leave it unchanged
                 var trashed = media.Trashed ? false : (bool?)null;
 
-                PerformMoveLocked(media, parentId, parent, userId, moves, trashed);
-                scope.Notifications.Publish(new MediaTreeChangeNotification(media, TreeChangeTypes.RefreshBranch, messages));
+                // when restoring a single item out of the recycle bin without its descendants, those descendants stay
+                // trashed and are re-homed under the recycle bin root - see PerformMoveLocked
+                var leaveDescendantsInRecycleBin = includeDescendants is false && media.Trashed && parentId != Constants.System.RecycleBinMedia;
+
+                PerformMoveLocked(media, parentId, parent, userId, moves, trashed, includeDescendants);
+
+                if (leaveDescendantsInRecycleBin)
+                {
+                    // The single RefreshBranch above cannot reconcile the descendants left in the bin (they are no longer
+                    // descendants of the restored item), so also refresh the re-homed direct children. The navigation
+                    // reconciler then moves them - and their sub-trees - back under the recycle bin root.
+                    IMedia[] rehomedChildren = moves
+                        .Select(x => x.Item1)
+                        .Where(x => x.ParentId == Constants.System.RecycleBinMedia)
+                        .ToArray();
+                    scope.Notifications.Publish(new MediaTreeChangeNotification(media.Yield().Concat(rehomedChildren), TreeChangeTypes.RefreshBranch, messages));
+                }
+                else
+                {
+                    scope.Notifications.Publish(new MediaTreeChangeNotification(media, TreeChangeTypes.RefreshBranch, messages));
+                }
 
                 MoveEventInfo<IMedia>[] moveInfo = moves //changes
                     // FIXME: Use MoveEventInfo that also takes a parent key when implementing move with parentKey.
@@ -1255,11 +1288,15 @@ namespace Umbraco.Cms.Core.Services
         ///     If <c>true</c>, marks items as trashed; if <c>false</c>, marks items as not trashed;
         ///     if <c>null</c>, leaves the trashed status unchanged.
         /// </param>
+        /// <param name="includeDescendants">
+        ///     Whether to move the descendants along with the media. When <c>false</c> during a restore out of the recycle
+        ///     bin, the descendants are left trashed - the item's direct children are re-homed to the recycle bin root.
+        /// </param>
         /// <remarks>
         ///     MUST be called from within WriteLock.
         ///     The trash parameter indicates whether we are trashing, un-trashing, or not changing anything.
         /// </remarks>
-        private void PerformMoveLocked(IMedia media, int parentId, IMedia? parent, int userId, ICollection<(IMedia, string)> moves, bool? trash)
+        private void PerformMoveLocked(IMedia media, int parentId, IMedia? parent, int userId, ICollection<(IMedia, string)> moves, bool? trash, bool includeDescendants = true)
         {
             // Needed to update the in-memory navigation structure
             var cameFromRecycleBin = media.ParentId == Constants.System.RecycleBinMedia;
@@ -1268,6 +1305,7 @@ namespace Umbraco.Cms.Core.Services
             // get the level delta (old pos to new pos)
             // note that recycle bin (id:-20) level is 0!
             var levelDelta = 1 - media.Level + (parent?.Level ?? 0);
+            var originalLevel = media.Level;
 
             var paths = new Dictionary<int, string>();
 
@@ -1287,6 +1325,13 @@ namespace Umbraco.Cms.Core.Services
             //paths[media.Id] = media.Path;
             paths[media.Id] = (parent == null ? parentId == Constants.System.RecycleBinMedia ? "-1,-21" : Constants.System.RootString : parent.Path) + "," + media.Id;
 
+            // When restoring a single item out of the recycle bin without its descendants, the descendants must stay
+            // trashed: the item's direct children are re-homed to the recycle bin root (and the rest of the subtree keeps
+            // its relative structure), so nothing is orphaned and it can still be restored on its own later.
+            var leaveDescendantsInRecycleBin = includeDescendants is false
+                && parentId != Constants.System.RecycleBinMedia
+                && originalPath.Contains(Constants.System.RecycleBinMediaString);
+
             const int pageSize = 500;
             IQuery<IMedia>? query = GetPagedDescendantQuery(originalPath);
             long total;
@@ -1299,10 +1344,30 @@ namespace Umbraco.Cms.Core.Services
                 {
                     moves.Add((descendant, descendant.Path)); // capture original path
 
-                    // update path and level since we do not update parentId
-                    descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
-                    descendant.Level += levelDelta;
-                    PerformMoveMediaLocked(descendant, userId, trash);
+                    if (leaveDescendantsInRecycleBin)
+                    {
+                        // the restored item's direct children become top-level recycle bin items; deeper descendants keep
+                        // their relative structure below their (now re-homed) ancestor
+                        var isDirectChild = descendant.ParentId == media.Id;
+                        descendant.Path = paths[descendant.Id] = isDirectChild
+                            ? Constants.System.RecycleBinMediaPathPrefix + descendant.Id
+                            : paths[descendant.ParentId] + "," + descendant.Id;
+                        descendant.Level -= originalLevel;
+                        if (isDirectChild)
+                        {
+                            descendant.ParentId = Constants.System.RecycleBinMedia;
+                        }
+
+                        // leave the trashed state untouched - these items remain in the recycle bin
+                        PerformMoveMediaLocked(descendant, userId, null);
+                    }
+                    else
+                    {
+                        // update path and level since we do not update parentId
+                        descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
+                        descendant.Level += levelDelta;
+                        PerformMoveMediaLocked(descendant, userId, trash);
+                    }
                 }
 
             }

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1196,17 +1196,20 @@ namespace Umbraco.Cms.Core.Services
             => Move(media, parentId, true, userId);
 
         /// <summary>
-        /// Moves an <see cref="IMedia"/> object to a new location
+        /// Moves an <see cref="IMedia"/> object to a new location.
         /// </summary>
-        /// <param name="media">The <see cref="IMedia"/> to move</param>
-        /// <param name="parentId">Id of the Media's new Parent</param>
+        /// <param name="media">The <see cref="IMedia"/> to move.</param>
+        /// <param name="parentId">Id of the Media's new Parent.</param>
         /// <param name="includeDescendants">
         ///     Whether to move the descendants of the media along with it. When restoring an item out of the recycle bin
         ///     this can be set to <c>false</c> to restore only the item itself, leaving its descendants in the recycle bin
         ///     as top-level bin items.
         /// </param>
-        /// <param name="userId">Id of the User moving the Media</param>
+        /// <param name="userId">Id of the User moving the Media.</param>
+        /// <returns>The operation result.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete - the int-userId overloads still default to SuperUserId; there is no non-obsolete int equivalent until it is removed in v18
         public Attempt<OperationResult?> Move(IMedia media, int parentId, bool includeDescendants, int userId = Constants.Security.SuperUserId)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             EventMessages messages = EventMessagesFactory.Get();
 
@@ -1296,7 +1299,7 @@ namespace Umbraco.Cms.Core.Services
         ///     MUST be called from within WriteLock.
         ///     The trash parameter indicates whether we are trashing, un-trashing, or not changing anything.
         /// </remarks>
-        private void PerformMoveLocked(IMedia media, int parentId, IMedia? parent, int userId, ICollection<(IMedia, string)> moves, bool? trash, bool includeDescendants = true)
+        private void PerformMoveLocked(IMedia media, int parentId, IMedia? parent, int userId, List<(IMedia Media, string OriginalPath)> moves, bool? trash, bool includeDescendants = true)
         {
             // Needed to update the in-memory navigation structure
             var cameFromRecycleBin = media.ParentId == Constants.System.RecycleBinMedia;
@@ -1346,32 +1349,42 @@ namespace Umbraco.Cms.Core.Services
 
                     if (leaveDescendantsInRecycleBin)
                     {
-                        // the restored item's direct children become top-level recycle bin items; deeper descendants keep
-                        // their relative structure below their (now re-homed) ancestor
-                        var isDirectChild = descendant.ParentId == media.Id;
-                        descendant.Path = paths[descendant.Id] = isDirectChild
-                            ? Constants.System.RecycleBinMediaPathPrefix + descendant.Id
-                            : paths[descendant.ParentId] + "," + descendant.Id;
-                        descendant.Level -= originalLevel;
-                        if (isDirectChild)
-                        {
-                            descendant.ParentId = Constants.System.RecycleBinMedia;
-                        }
-
-                        // leave the trashed state untouched - these items remain in the recycle bin
-                        PerformMoveMediaLocked(descendant, userId, null);
+                        LeaveDescendantInRecycleBinLocked(descendant, media.Id, originalLevel, userId, paths);
                     }
                     else
                     {
-                        // update path and level since we do not update parentId
-                        descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
-                        descendant.Level += levelDelta;
-                        PerformMoveMediaLocked(descendant, userId, trash);
+                        PerformMoveDescendantLocked(descendant, levelDelta, userId, trash, paths);
                     }
                 }
 
             }
             while (total > pageSize);
+        }
+
+        // Re-homes a descendant of a restored item within the recycle bin: the restored item's direct children become
+        // top-level recycle bin items, while deeper descendants keep their relative structure below their (now re-homed)
+        // ancestor. The trashed state is left untouched so these items remain in the recycle bin.
+        private void LeaveDescendantInRecycleBinLocked(IMedia descendant, int restoredItemId, int originalLevel, int userId, Dictionary<int, string> paths)
+        {
+            var isDirectChild = descendant.ParentId == restoredItemId;
+            descendant.Path = paths[descendant.Id] = isDirectChild
+                ? Constants.System.RecycleBinMediaPathPrefix + descendant.Id
+                : paths[descendant.ParentId] + "," + descendant.Id;
+            descendant.Level -= originalLevel;
+            if (isDirectChild)
+            {
+                descendant.ParentId = Constants.System.RecycleBinMedia;
+            }
+
+            PerformMoveMediaLocked(descendant, userId, null);
+        }
+
+        // Moves a descendant along with the item being moved, updating its path and level (parentId is unchanged).
+        private void PerformMoveDescendantLocked(IMedia descendant, int levelDelta, int userId, bool? trash, Dictionary<int, string> paths)
+        {
+            descendant.Path = paths[descendant.Id] = paths[descendant.ParentId] + "," + descendant.Id;
+            descendant.Level += levelDelta;
+            PerformMoveMediaLocked(descendant, userId, trash);
         }
 
         /// <summary>

--- a/src/Umbraco.Core/Services/MediaService.cs
+++ b/src/Umbraco.Core/Services/MediaService.cs
@@ -1192,7 +1192,9 @@ namespace Umbraco.Cms.Core.Services
         /// <param name="media">The <see cref="IMedia"/> to move</param>
         /// <param name="parentId">Id of the Media's new Parent</param>
         /// <param name="userId">Id of the User moving the Media</param>
+#pragma warning disable CS0618 // Type or member is obsolete - the int-userId overloads still default to SuperUserId; there is no non-obsolete int equivalent until it is removed in v18
         public Attempt<OperationResult?> Move(IMedia media, int parentId, int userId = Constants.Security.SuperUserId)
+#pragma warning restore CS0618 // Type or member is obsolete
             => Move(media, parentId, true, userId);
 
         /// <summary>

--- a/src/Umbraco.Core/Services/MemberContentEditingService.cs
+++ b/src/Umbraco.Core/Services/MemberContentEditingService.cs
@@ -110,7 +110,7 @@ internal sealed class MemberContentEditingService
         => throw new NotSupportedException("Member creation is not supported by this service. This should never be called.");
 
     /// <inheritdoc />
-    protected override OperationResult? Move(IMember member, int newParentId, int userId)
+    protected override OperationResult? Move(IMember member, int newParentId, bool includeDescendants, int userId)
         => throw new InvalidOperationException("Move is not supported for members");
 
     /// <inheritdoc />

--- a/src/Umbraco.Infrastructure/Events/RelateOnTrashNotificationHandler.cs
+++ b/src/Umbraco.Infrastructure/Events/RelateOnTrashNotificationHandler.cs
@@ -98,8 +98,12 @@ public sealed class RelateOnTrashNotificationHandler :
     /// <param name="notification">The notification containing information about the moved content items.</param>
     public void Handle(ContentMovedNotification notification)
     {
+        // Only remove the restore relation for items that have actually left the recycle bin. When restoring a single
+        // item without its descendants, those descendants stay trashed (re-homed under the recycle bin root) and must
+        // keep their relation so they can be restored on their own later.
         foreach (MoveEventInfo<IContent> item in notification.MoveInfoCollection.Where(x =>
-                     x.OriginalPath.Contains(Constants.System.RecycleBinContentString)))
+                     x.OriginalPath.Contains(Constants.System.RecycleBinContentString)
+                     && x.Entity.Path.Contains(Constants.System.RecycleBinContentString) is false))
         {
             const string relationTypeAlias = Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias;
             IEnumerable<IRelation> relations = _relationService.GetByChildId(item.Entity.Id);
@@ -175,8 +179,12 @@ public sealed class RelateOnTrashNotificationHandler :
     /// <param name="notification">The notification containing information about the moved content items.</param>
     public void Handle(MediaMovedNotification notification)
     {
+        // Only remove the restore relation for items that have actually left the recycle bin. When restoring a single
+        // item without its descendants, those descendants stay trashed (re-homed under the recycle bin root) and must
+        // keep their relation so they can be restored on their own later.
         foreach (MoveEventInfo<IMedia> item in notification.MoveInfoCollection.Where(x =>
-                     x.OriginalPath.Contains(Constants.System.RecycleBinMediaString)))
+                     x.OriginalPath.Contains(Constants.System.RecycleBinMediaString)
+                     && x.Entity.Path.Contains(Constants.System.RecycleBinMediaString) is false))
         {
             const string relationTypeAlias = Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias;
             IEnumerable<IRelation> relations = _relationService.GetByChildId(item.Entity.Id);
@@ -199,9 +207,9 @@ public sealed class RelateOnTrashNotificationHandler :
             // check that the relation-type exists, if not, then recreate it
             if (relationType == null)
             {
-                Guid documentObjectType = Constants.ObjectTypes.Document;
+                Guid mediaObjectType = Constants.ObjectTypes.Media;
                 const string relationTypeName = Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteName;
-                relationType = new RelationType(relationTypeName, relationTypeAlias, false, documentObjectType, documentObjectType, false);
+                relationType = new RelationType(relationTypeName, relationTypeAlias, false, mediaObjectType, mediaObjectType, false);
                 _relationService.Save(relationType);
             }
 

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.Restore.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/DocumentNavigationServiceTests.Restore.cs
@@ -23,7 +23,7 @@ internal sealed partial class DocumentNavigationServiceTests
         var beforeRestoreDescendants = initialDescendantsKeys.ToList();
 
         // Act
-        var restoreAttempt = await ContentEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey);
+        var restoreAttempt = await ContentEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey, includeDescendants: true);
         Guid restoredItemKey = restoreAttempt.Result.Key;
 
         // Assert
@@ -52,6 +52,35 @@ internal sealed partial class DocumentNavigationServiceTests
     }
 
     [Test]
+    public async Task Structure_Updates_When_Restoring_Content_Without_Descendants()
+    {
+        // Trash Child 2 and its subtree (Child 2 > Grandchild 3 > Great-grandchild 1).
+        await ContentEditingService.MoveToRecycleBinAsync(Child2.Key, Constants.Security.SuperUserKey);
+
+        // Restore only Child 2, leaving its descendants in the recycle bin.
+        var restoreAttempt = await ContentEditingService.RestoreAsync(Child2.Key, Root.Key, Constants.Security.SuperUserKey, includeDescendants: false);
+        Assert.IsTrue(restoreAttempt.Success);
+
+        Assert.Multiple(() =>
+        {
+            // Child 2 is back in the tree under Root, with no children (they stayed behind).
+            Assert.IsTrue(DocumentNavigationQueryService.TryGetParentKey(Child2.Key, out Guid? restoredParentKey));
+            Assert.AreEqual(Root.Key, restoredParentKey);
+            DocumentNavigationQueryService.TryGetChildrenKeys(Child2.Key, out IEnumerable<Guid> restoredChildren);
+            Assert.IsEmpty(restoredChildren);
+
+            // Grandchild 3 is now a top-level recycle bin item (its former parent left the bin).
+            Assert.IsFalse(DocumentNavigationQueryService.TryGetParentKey(Grandchild3.Key, out _), "Grandchild 3 should not be in the main tree.");
+            Assert.IsTrue(DocumentNavigationQueryService.TryGetParentKeyInBin(Grandchild3.Key, out Guid? binParentKey));
+            Assert.IsNull(binParentKey, "Grandchild 3 should be a top-level recycle bin item.");
+
+            // Great-grandchild 1 remains trashed underneath Grandchild 3.
+            Assert.IsTrue(DocumentNavigationQueryService.TryGetParentKeyInBin(GreatGrandchild1.Key, out Guid? greatGrandchildBinParentKey));
+            Assert.AreEqual(Grandchild3.Key, greatGrandchildBinParentKey);
+        });
+    }
+
+    [Test]
     [TestCase(null)] // Content root
     [TestCase("E48DD82A-7059-418E-9B82-CDD5205796CF")] // Root
     [TestCase("C6173927-0C59-4778-825D-D7B9F45D8DDE")] // Child 1
@@ -69,7 +98,7 @@ internal sealed partial class DocumentNavigationServiceTests
         await ContentEditingService.MoveToRecycleBinAsync(nodeToRestore, Constants.Security.SuperUserKey);
 
         // Act
-        await ContentEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey);
+        await ContentEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey, includeDescendants: true);
 
         // Assert
         if (targetParentKey is null)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/MediaNavigationServiceTests.Restore.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Core/Services/MediaNavigationServiceTests.Restore.cs
@@ -6,6 +6,35 @@ namespace Umbraco.Cms.Tests.Integration.Umbraco.Core.Services;
 internal sealed partial class MediaNavigationServiceTests
 {
     [Test]
+    public async Task Structure_Updates_When_Restoring_Media_Without_Descendants()
+    {
+        // Trash Sub-album 2 and its subtree (Sub-album 2 > Sub-sub-album 1 > Image 4).
+        await MediaEditingService.MoveToRecycleBinAsync(SubAlbum2.Key, Constants.Security.SuperUserKey);
+
+        // Restore only Sub-album 2, leaving its descendants in the recycle bin.
+        var restoreAttempt = await MediaEditingService.RestoreAsync(SubAlbum2.Key, Album.Key, Constants.Security.SuperUserKey, includeDescendants: false);
+        Assert.IsTrue(restoreAttempt.Success);
+
+        Assert.Multiple(() =>
+        {
+            // Sub-album 2 is back in the tree under Album, with no children (they stayed behind).
+            Assert.IsTrue(MediaNavigationQueryService.TryGetParentKey(SubAlbum2.Key, out Guid? restoredParentKey));
+            Assert.AreEqual(Album.Key, restoredParentKey);
+            MediaNavigationQueryService.TryGetChildrenKeys(SubAlbum2.Key, out IEnumerable<Guid> restoredChildren);
+            Assert.IsEmpty(restoredChildren);
+
+            // Sub-sub-album 1 is now a top-level recycle bin item (its former parent left the bin).
+            Assert.IsFalse(MediaNavigationQueryService.TryGetParentKey(SubSubAlbum1.Key, out _), "Sub-sub-album 1 should not be in the main tree.");
+            Assert.IsTrue(MediaNavigationQueryService.TryGetParentKeyInBin(SubSubAlbum1.Key, out Guid? binParentKey));
+            Assert.IsNull(binParentKey, "Sub-sub-album 1 should be a top-level recycle bin item.");
+
+            // Image 4 remains trashed underneath Sub-sub-album 1.
+            Assert.IsTrue(MediaNavigationQueryService.TryGetParentKeyInBin(Image4.Key, out Guid? imageBinParentKey));
+            Assert.AreEqual(SubSubAlbum1.Key, imageBinParentKey);
+        });
+    }
+
+    [Test]
     [TestCase("62BCE72F-8C18-420E-BCAC-112B5ECC95FD", "139DC977-E50F-4382-9728-B278C4B7AC6A")] // Image 4 to Sub-album 1
     [TestCase("DBCAFF2F-BFA4-4744-A948-C290C432D564", "1CD97C02-8534-4B72-AE9E-AE52EC94CF31")] // Sub-album 2 to Album
     [TestCase("3E489C32-9315-42DA-95CE-823D154B09C8", null)] // Image 2 to media root
@@ -23,7 +52,7 @@ internal sealed partial class MediaNavigationServiceTests
         var beforeRestoreDescendants = initialDescendantsKeys.ToList();
 
         // Act
-        var restoreAttempt = await MediaEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey);
+        var restoreAttempt = await MediaEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey, includeDescendants: true);
         Guid restoredItemKey = restoreAttempt.Result.Key;
 
         // Assert
@@ -65,7 +94,7 @@ internal sealed partial class MediaNavigationServiceTests
         await MediaEditingService.MoveToRecycleBinAsync(nodeToRestore, Constants.Security.SuperUserKey);
 
         // Act
-        await MediaEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey);
+        await MediaEditingService.RestoreAsync(nodeToRestore, targetParentKey, Constants.Security.SuperUserKey, includeDescendants: true);
 
         // Assert
         if (targetParentKey is null)

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Move.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Move.cs
@@ -226,7 +226,7 @@ public partial class ContentEditingServiceTests
                 Is.Not.EqualTo("-"),
                 "ar-EG NegativeSign is plain ASCII hyphen on this host; cannot reproduce #22610.");
 
-            var result = await ContentEditingService.RestoreAsync(child.Key, root.Key, Constants.Security.SuperUserKey);
+            var result = await ContentEditingService.RestoreAsync(child.Key, root.Key, Constants.Security.SuperUserKey, includeDescendants: true);
 
             Assert.IsTrue(result.Success);
             Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Restore.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Restore.cs
@@ -72,7 +72,7 @@ public partial class ContentEditingServiceTests
         });
     }
 
-    private async Task<(IContent topRoot, IContent parent, IContent child, IContent grandchild)> CreateFourLevelStructureAsync(IContentType contentType)
+    private async Task<(IContent TopRoot, IContent Parent, IContent Child, IContent Grandchild)> CreateFourLevelStructureAsync(IContentType contentType)
     {
         contentType.AllowedContentTypes = new List<ContentTypeSort> { new(contentType.Key, 1, contentType.Alias) };
         await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Restore.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/ContentEditingServiceTests.Restore.cs
@@ -1,0 +1,99 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.ContentEditing;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+public partial class ContentEditingServiceTests
+{
+    [Test]
+    public async Task Can_Restore_Without_Descendants_Leaving_Them_In_The_Recycle_Bin()
+    {
+        var contentType = await CreateTextPageContentTypeAsync();
+        (IContent topRoot, IContent parent, IContent child, IContent grandchild) = await CreateFourLevelStructureAsync(contentType);
+
+        await ContentEditingService.MoveToRecycleBinAsync(parent.Key, Constants.Security.SuperUserKey);
+
+        var result = await ContentEditingService.RestoreAsync(parent.Key, topRoot.Key, Constants.Security.SuperUserKey, includeDescendants: false);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+
+        var restoredParent = await ContentEditingService.GetAsync(parent.Key);
+        var leftBehindChild = await ContentEditingService.GetAsync(child.Key);
+        var leftBehindGrandchild = await ContentEditingService.GetAsync(grandchild.Key);
+
+        Assert.Multiple(() =>
+        {
+            // the restored item leaves the bin and is re-parented under the target
+            Assert.IsFalse(restoredParent!.Trashed);
+            Assert.AreEqual(topRoot.Id, restoredParent.ParentId);
+
+            // the direct child stays trashed as a top-level recycle bin item
+            Assert.IsTrue(leftBehindChild!.Trashed);
+            Assert.AreEqual(Constants.System.RecycleBinContent, leftBehindChild.ParentId);
+            Assert.AreEqual($"{Constants.System.RecycleBinContentPathPrefix}{child.Id}", leftBehindChild.Path);
+            Assert.AreEqual(1, leftBehindChild.Level);
+
+            // the grandchild stays trashed underneath its (now top-level) parent
+            Assert.IsTrue(leftBehindGrandchild!.Trashed);
+            Assert.AreEqual(child.Id, leftBehindGrandchild.ParentId);
+            Assert.AreEqual($"{Constants.System.RecycleBinContentPathPrefix}{child.Id},{grandchild.Id}", leftBehindGrandchild.Path);
+            Assert.AreEqual(2, leftBehindGrandchild.Level);
+        });
+    }
+
+    [Test]
+    public async Task Can_Restore_With_Descendants_Restores_The_Whole_Subtree()
+    {
+        var contentType = await CreateTextPageContentTypeAsync();
+        (IContent topRoot, IContent parent, IContent child, IContent grandchild) = await CreateFourLevelStructureAsync(contentType);
+
+        await ContentEditingService.MoveToRecycleBinAsync(parent.Key, Constants.Security.SuperUserKey);
+
+        var result = await ContentEditingService.RestoreAsync(parent.Key, topRoot.Key, Constants.Security.SuperUserKey, includeDescendants: true);
+        Assert.IsTrue(result.Success);
+
+        var restoredParent = await ContentEditingService.GetAsync(parent.Key);
+        var restoredChild = await ContentEditingService.GetAsync(child.Key);
+        var restoredGrandchild = await ContentEditingService.GetAsync(grandchild.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(restoredParent!.Trashed);
+            Assert.AreEqual(topRoot.Id, restoredParent.ParentId);
+
+            Assert.IsFalse(restoredChild!.Trashed);
+            Assert.AreEqual(parent.Id, restoredChild.ParentId);
+
+            Assert.IsFalse(restoredGrandchild!.Trashed);
+            Assert.AreEqual(child.Id, restoredGrandchild.ParentId);
+        });
+    }
+
+    private async Task<(IContent topRoot, IContent parent, IContent child, IContent grandchild)> CreateFourLevelStructureAsync(IContentType contentType)
+    {
+        contentType.AllowedContentTypes = new List<ContentTypeSort> { new(contentType.Key, 1, contentType.Alias) };
+        await ContentTypeService.UpdateAsync(contentType, Constants.Security.SuperUserKey);
+
+        async Task<IContent> Create(string name, Guid? parentKey)
+        {
+            var createModel = new ContentCreateModel
+            {
+                ContentTypeKey = contentType.Key,
+                ParentKey = parentKey,
+                Variants = [new() { Name = name }],
+            };
+
+            return (await ContentEditingService.CreateAsync(createModel, Constants.Security.SuperUserKey)).Result.Content!;
+        }
+
+        var topRoot = await Create("Top Root", Constants.System.RootKey);
+        var parent = await Create("Parent", topRoot.Key);
+        var child = await Create("Child", parent.Key);
+        var grandchild = await Create("Grandchild", child.Key);
+
+        return (topRoot, parent, child, grandchild);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Restore.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Restore.cs
@@ -69,7 +69,7 @@ internal sealed partial class MediaEditingServiceTests
         });
     }
 
-    private async Task<(IMedia topRoot, IMedia parent, IMedia child, IMedia grandchild)> CreateFourLevelStructureAsync()
+    private async Task<(IMedia TopRoot, IMedia Parent, IMedia Child, IMedia Grandchild)> CreateFourLevelStructureAsync()
     {
         var topRoot = await CreateFolderMediaAsync("Top Root", Constants.Security.SuperUserKey, parentKey: null);
         var parent = await CreateFolderMediaAsync("Parent", Constants.Security.SuperUserKey, topRoot.Key);

--- a/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Restore.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Infrastructure/Services/MediaEditingServiceTests.Restore.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace Umbraco.Cms.Tests.Integration.Umbraco.Infrastructure.Services;
+
+internal sealed partial class MediaEditingServiceTests
+{
+    [Test]
+    public async Task Can_Restore_Without_Descendants_Leaving_Them_In_The_Recycle_Bin()
+    {
+        (IMedia topRoot, IMedia parent, IMedia child, IMedia grandchild) = await CreateFourLevelStructureAsync();
+
+        await MediaEditingService.MoveToRecycleBinAsync(parent.Key, Constants.Security.SuperUserKey);
+
+        var result = await MediaEditingService.RestoreAsync(parent.Key, topRoot.Key, Constants.Security.SuperUserKey, includeDescendants: false);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(ContentEditingOperationStatus.Success, result.Status);
+
+        var restoredParent = await MediaEditingService.GetAsync(parent.Key);
+        var leftBehindChild = await MediaEditingService.GetAsync(child.Key);
+        var leftBehindGrandchild = await MediaEditingService.GetAsync(grandchild.Key);
+
+        Assert.Multiple(() =>
+        {
+            // the restored item leaves the bin and is re-parented under the target
+            Assert.IsFalse(restoredParent!.Trashed);
+            Assert.AreEqual(topRoot.Id, restoredParent.ParentId);
+
+            // the direct child stays trashed as a top-level recycle bin item
+            Assert.IsTrue(leftBehindChild!.Trashed);
+            Assert.AreEqual(Constants.System.RecycleBinMedia, leftBehindChild.ParentId);
+            Assert.AreEqual($"{Constants.System.RecycleBinMediaPathPrefix}{child.Id}", leftBehindChild.Path);
+            Assert.AreEqual(1, leftBehindChild.Level);
+
+            // the grandchild stays trashed underneath its (now top-level) parent
+            Assert.IsTrue(leftBehindGrandchild!.Trashed);
+            Assert.AreEqual(child.Id, leftBehindGrandchild.ParentId);
+            Assert.AreEqual($"{Constants.System.RecycleBinMediaPathPrefix}{child.Id},{grandchild.Id}", leftBehindGrandchild.Path);
+            Assert.AreEqual(2, leftBehindGrandchild.Level);
+        });
+    }
+
+    [Test]
+    public async Task Can_Restore_With_Descendants_Restores_The_Whole_Subtree()
+    {
+        (IMedia topRoot, IMedia parent, IMedia child, IMedia grandchild) = await CreateFourLevelStructureAsync();
+
+        await MediaEditingService.MoveToRecycleBinAsync(parent.Key, Constants.Security.SuperUserKey);
+
+        var result = await MediaEditingService.RestoreAsync(parent.Key, topRoot.Key, Constants.Security.SuperUserKey, includeDescendants: true);
+        Assert.IsTrue(result.Success);
+
+        var restoredParent = await MediaEditingService.GetAsync(parent.Key);
+        var restoredChild = await MediaEditingService.GetAsync(child.Key);
+        var restoredGrandchild = await MediaEditingService.GetAsync(grandchild.Key);
+
+        Assert.Multiple(() =>
+        {
+            Assert.IsFalse(restoredParent!.Trashed);
+            Assert.AreEqual(topRoot.Id, restoredParent.ParentId);
+
+            Assert.IsFalse(restoredChild!.Trashed);
+            Assert.AreEqual(parent.Id, restoredChild.ParentId);
+
+            Assert.IsFalse(restoredGrandchild!.Trashed);
+            Assert.AreEqual(child.Id, restoredGrandchild.ParentId);
+        });
+    }
+
+    private async Task<(IMedia topRoot, IMedia parent, IMedia child, IMedia grandchild)> CreateFourLevelStructureAsync()
+    {
+        var topRoot = await CreateFolderMediaAsync("Top Root", Constants.Security.SuperUserKey, parentKey: null);
+        var parent = await CreateFolderMediaAsync("Parent", Constants.Security.SuperUserKey, topRoot.Key);
+        var child = await CreateFolderMediaAsync("Child", Constants.Security.SuperUserKey, parent.Key);
+        var grandchild = await CreateFolderMediaAsync("Grandchild", Constants.Security.SuperUserKey, child.Key);
+
+        return (topRoot, parent, child, grandchild);
+    }
+}

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/DocumentHybridCacheTests.cs
@@ -631,7 +631,7 @@ internal sealed class DocumentHybridCacheTests : UmbracoIntegrationTestWithConte
         Assert.IsNull(trashedPage, "Trashed content should not be in cache");
 
         // Act - Restore to root (original location)
-        var restoreResult = await ContentEditingService.RestoreAsync(PublishedTextPage.Key.Value, null, Constants.Security.SuperUserKey);
+        var restoreResult = await ContentEditingService.RestoreAsync(PublishedTextPage.Key.Value, null, Constants.Security.SuperUserKey, includeDescendants: true);
         Assert.IsTrue(restoreResult.Success);
 
         // Assert - Restored content should be back in the draft cache, but not republished automatically

--- a/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MediaHybridCacheTests.cs
+++ b/tests/Umbraco.Tests.Integration/Umbraco.PublishedCache.HybridCache/MediaHybridCacheTests.cs
@@ -210,7 +210,7 @@ internal sealed class MediaHybridCacheTests : UmbracoIntegrationTestWithMediaEdi
         Assert.IsNull(trashedMedia, "Trashed media should not be in cache");
 
         // Act - Restore to root (original location)
-        var restoreResult = await MediaEditingService.RestoreAsync(SubImage.Key.Value, null, Constants.Security.SuperUserKey);
+        var restoreResult = await MediaEditingService.RestoreAsync(SubImage.Key.Value, null, Constants.Security.SuperUserKey, includeDescendants: true);
         Assert.IsTrue(restoreResult.Success);
 
         // Assert - Restored media should be back in the cache

--- a/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
+++ b/tests/Umbraco.Tests.Integration/Umbraco.Tests.Integration.csproj
@@ -104,10 +104,19 @@
     <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Validate.cs">
       <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
     </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\ContentEditingServiceTests.Restore.cs">
+      <DependentUpon>ContentEditingServiceTests.cs</DependentUpon>
+    </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\MediaEditingServiceTests.MoveToRecycleBin.cs">
       <DependentUpon>MediaEditingServiceTests.cs</DependentUpon>
     </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\MediaEditingServiceTests.SortByField.cs">
+      <DependentUpon>MediaEditingServiceTests.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\MediaEditingServiceTests.Validate.cs">
+      <DependentUpon>MediaEditingServiceTests.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Umbraco.Infrastructure\Services\MediaEditingServiceTests.Restore.cs">
       <DependentUpon>MediaEditingServiceTests.cs</DependentUpon>
     </Compile>
     <Compile Update="Umbraco.Infrastructure\Services\ContentPublishingServiceTests.Publish.cs">

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Events/RelateOnTrashNotificationHandlerTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Infrastructure/Events/RelateOnTrashNotificationHandlerTests.cs
@@ -1,0 +1,89 @@
+using Moq;
+using NUnit.Framework;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Cms.Tests.UnitTests.Umbraco.Infrastructure.Events;
+
+[TestFixture]
+public class RelateOnTrashNotificationHandlerTests
+{
+    [Test]
+    public void Content_Moved_Removes_Restore_Relation_Only_For_Items_That_Left_The_Recycle_Bin()
+    {
+        IRelationType relationType = Mock.Of<IRelationType>(x =>
+            x.Alias == Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias);
+        IRelation restoredItemRelation = Mock.Of<IRelation>(x => x.RelationType == relationType);
+        IRelation leftBehindItemRelation = Mock.Of<IRelation>(x => x.RelationType == relationType);
+
+        var relationService = new Mock<IRelationService>();
+        relationService.Setup(x => x.GetByChildId(1001)).Returns([restoredItemRelation]);
+        relationService.Setup(x => x.GetByChildId(1002)).Returns([leftBehindItemRelation]);
+
+        RelateOnTrashNotificationHandler handler = CreateHandler(relationService.Object);
+
+        // 1001 has genuinely left the bin (its new path is outside the bin); 1002 was re-homed under the
+        // recycle bin root but is still trashed, so its restore relation must be preserved.
+        var restoredItem = new MoveEventInfo<IContent>(
+            Mock.Of<IContent>(x => x.Id == 1001 && x.Path == "-1,1001"),
+            $"{Constants.System.RecycleBinContentPathPrefix}1001",
+            Constants.System.Root);
+        var leftBehindItem = new MoveEventInfo<IContent>(
+            Mock.Of<IContent>(x => x.Id == 1002 && x.Path == $"{Constants.System.RecycleBinContentPathPrefix}1002"),
+            $"{Constants.System.RecycleBinContentPathPrefix}1001,1002",
+            Constants.System.RecycleBinContent);
+
+        handler.Handle(new ContentMovedNotification([restoredItem, leftBehindItem], new EventMessages()));
+
+        relationService.Verify(x => x.Delete(restoredItemRelation), Times.Once);
+        relationService.Verify(x => x.Delete(leftBehindItemRelation), Times.Never);
+        relationService.Verify(x => x.GetByChildId(1002), Times.Never);
+    }
+
+    [Test]
+    public void Media_Moved_Removes_Restore_Relation_Only_For_Items_That_Left_The_Recycle_Bin()
+    {
+        IRelationType relationType = Mock.Of<IRelationType>(x =>
+            x.Alias == Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias);
+        IRelation restoredItemRelation = Mock.Of<IRelation>(x => x.RelationType == relationType);
+        IRelation leftBehindItemRelation = Mock.Of<IRelation>(x => x.RelationType == relationType);
+
+        var relationService = new Mock<IRelationService>();
+        relationService.Setup(x => x.GetByChildId(2001)).Returns([restoredItemRelation]);
+        relationService.Setup(x => x.GetByChildId(2002)).Returns([leftBehindItemRelation]);
+
+        RelateOnTrashNotificationHandler handler = CreateHandler(relationService.Object);
+
+        var restoredItem = new MoveEventInfo<IMedia>(
+            Mock.Of<IMedia>(x => x.Id == 2001 && x.Path == "-1,2001"),
+            $"{Constants.System.RecycleBinMediaPathPrefix}2001",
+            Constants.System.Root);
+        var leftBehindItem = new MoveEventInfo<IMedia>(
+            Mock.Of<IMedia>(x => x.Id == 2002 && x.Path == $"{Constants.System.RecycleBinMediaPathPrefix}2002"),
+            $"{Constants.System.RecycleBinMediaPathPrefix}2001,2002",
+            Constants.System.RecycleBinMedia);
+
+        handler.Handle(new MediaMovedNotification([restoredItem, leftBehindItem], new EventMessages()));
+
+        relationService.Verify(x => x.Delete(restoredItemRelation), Times.Once);
+        relationService.Verify(x => x.Delete(leftBehindItemRelation), Times.Never);
+        relationService.Verify(x => x.GetByChildId(2002), Times.Never);
+    }
+
+    private static RelateOnTrashNotificationHandler CreateHandler(IRelationService relationService)
+        => new(
+            relationService,
+            Mock.Of<IEntityService>(),
+            Mock.Of<ILocalizedTextService>(),
+            Mock.Of<IAuditService>(),
+#pragma warning disable CS0618 // Type or member is obsolete
+            Mock.Of<IScopeProvider>(),
+#pragma warning restore CS0618 // Type or member is obsolete
+            Mock.Of<IBackOfficeSecurityAccessor>(),
+            Mock.Of<IUserIdKeyResolver>());
+}


### PR DESCRIPTION
## Description

Restoring an item from the recycle bin has always cascaded to its **entire trashed subtree** — there was no way to restore just the selected node and leave its children behind. Restore is implemented as a *move out of the recycle bin* (`RestoreAsync` → `HandleMoveAsync` → `IContentService.Move` / `IMediaService.Move`), and `Move`/`PerformMoveLocked` unconditionally moved the whole subtree out, un-trashing every descendant.

This PR adds an `includeDescendants` flag (default `true`, so existing behaviour is unchanged) to `RestoreAsync` and the underlying core move. When `false`, only the selected node leaves the bin; its direct children become **top-level recycle-bin items** (their own sub-trees intact and still trashed), with the parent–child restore relations preserved so they can be restored later.

Fixes #23417

### Why (Umbraco Deploy)

The concrete driver is **Umbraco Deploy**. When Deploy transfers a single parent node that happens to sit in the recycle bin on the target environment, today's cascade drags the whole subtree out — including descendants the user never selected and descendants that only ever existed (trashed) on the target. Deploy calls the Umbraco **services** directly (`IContentEditingService` / `IContentService`), not the Management API, so the fix it needs lives entirely at the service layer:

```csharp
await _contentEditingService.RestoreAsync(key, parentKey, userKey, includeDescendants: false);
```

That is everything Deploy requires in 17, which is why this PR is deliberately scoped to the service layer.

### Deferred to 18+ (API & UI)

Surfacing the flag through the **Management API** (dedicated restore request models + regenerated `OpenApi.json`) and adding a **"restore child items too" toggle** to the backoffice recycle-bin restore dialog are intentionally **not** included here. They are considered a "new feature" and so could be a follow-up for v18+, where they should also cover elements. The two restore controllers keep their current behaviour by passing `includeDescendants: true`, so there is no API contract change in this PR.

## What changed (service layer only)

- **`ContentService.Move` / `MediaService.Move` + `PerformMoveLocked`** — new `Move(item, parentId, bool includeDescendants, int userId)` overload. When restoring out of the bin with `includeDescendants: false`, the node moves out as usual but its descendants stay trashed: direct children are re-homed under the recycle-bin root (using the `Constants.System.RecycleBin*PathPrefix` constants), deeper descendants keep their relative structure.  The existing `Move` overload is intentionally **not** obsoleted — a normal move legitimately uses the existing overload as it doesn't make sense to leave descendants behind.
- **Navigation / cache consistency** — the leave-behind restore also refreshes the re-homed direct children in the tree-change notification, so the in-memory navigation (backoffice content tree + recycle-bin tree) and published cache stay consistent with the database. (A single `RefreshBranch` on the restored root alone is not enough, because the re-homed children are no longer descendants of that root.)
- **`IContentEditingService` / `IMediaEditingService`** — new `RestoreAsync(key, parentKey, userKey, bool includeDescendants)` overload (default interface method). The old 3-arg `RestoreAsync` is marked `[Obsolete(… Umbraco 19)]`; all internal callers now use the new overload.
- **`RelateOnTrashNotificationHandler`** — the "relate parent on delete" relation is now removed only for items that actually **left** the bin, so the descendants left behind keep their restore relations.  This means that a child left in the bin after it's parent is restored, will be able to be restored to that parent automatically.
    - Also fixes a pre-existing bug where the media relation type was created with `Constants.ObjectTypes.Document` instead of `Media`.

## Testing

### Automated

- **Editing-service integration** (`ContentEditingServiceTests.Restore`, `MediaEditingServiceTests.Restore`) — restore a 4-level tree with `includeDescendants: false` asserts only the target is un-trashed/re-parented while the descendants stay trashed and re-homed under the bin root; `true` still cascades the whole subtree.
- **Navigation integration** (`DocumentNavigationServiceTests`/`MediaNavigationServiceTests` → `Structure_Updates_When_Restoring_*_Without_Descendants`) — asserts via the navigation query services that the left-behind subtree stays in the recycle-bin navigation and the restored node has no children.
- **Unit** (`RelateOnTrashNotificationHandlerTests`) — the relation is kept for items still in the bin and removed for items that left.

Each new test was confirmed to fail before the fix and pass after.

### Manual

There is no v17 UI for this yet, so a throwaway debug controller was used to drive the service (not committed). Drop this into `src/Umbraco.Web.UI/Controllers/`, run the site, trash a parent that has children/grandchildren, then hit the endpoint with the parent's key (and optionally the restore location key):

```csharp
using Microsoft.AspNetCore.Mvc;
using Umbraco.Cms.Core;
using Umbraco.Cms.Core.Models;
using Umbraco.Cms.Core.Services;
using Umbraco.Cms.Core.Services.OperationStatus;

namespace Umbraco.Cms.Web.UI.Controllers;

public class DebugRestoreWithoutDescendantsController : Controller
{
    private readonly IContentEditingService _contentEditingService;

    public DebugRestoreWithoutDescendantsController(IContentEditingService contentEditingService)
        => _contentEditingService = contentEditingService;

    // e.g. /debug/restore-without-descendants/00000000-0000-0000-0000-000000000000
    // Optionally pass ?parentKey=<guid> to restore under a specific parent; omit to restore to the content root.
    [HttpGet("/debug/restore-without-descendants/{key:guid}")]
    public async Task<IActionResult> Run(Guid key, Guid? parentKey = null)
    {
        Attempt<IContent?, ContentEditingOperationStatus> result = await _contentEditingService.RestoreAsync(
            key,
            parentKey,
            Constants.Security.SuperUserKey,
            includeDescendants: false);

        var target = parentKey.HasValue ? parentKey.Value.ToString() : "content root";

        return Content(
            result.Success
                ? $"Restored '{result.Result?.Name}' ({key}) to {target} without its descendants.\n"
                  + "Its direct children remain in the recycle bin as top-level items (their sub-trees intact)."
                : $"Restore failed: {result.Status}",
            "text/plain");
    }
}
```

Steps and expected result:

1. Create `Parent → Child → Grandchild` and publish/save them.
2. Trash `Parent` (the whole subtree moves to the recycle bin).
3. Call `GET /debug/restore-without-descendants/{parentKey}`.
4. **Reload** the recycle bin and the content tree:
   - `Parent` is restored under the content root (or the `parentKey` you passed).
   - `Child` remains in the recycle bin, now as a **top-level** bin item, with `Grandchild` still nested beneath it.
5. Restore `Child` afterwards → it returns under the (already restored) `Parent`, because its restore relation was preserved.
6. Repeat the flow calling the normal restore (`includeDescendants: true`, or the existing restore action in the UI) → the whole subtree is restored, confirming default behaviour is unchanged.

## Merge Considerations

When merged to 17 and up to `main` (18), we should add the same mechanism at the service level for elements too.