### PR TITLE
Block Workspace: Guard block label render against a destroyed workspace (closes #22745)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/block/block/workspace/block-workspace.context.ts
@@ -268,6 +268,9 @@ export class UmbBlockWorkspaceContext<LayoutDataType extends UmbBlockLayoutBaseM
 						}
 
 						await this.content.structure.whenLoaded();
+						// Have we been destroyed while awaiting the structure? then back out, otherwise reading from
+						// the now-destroyed content type structure or element states throws:
+						if (!this.#blockManager) return;
 						this.#gotLabel(blockType?.label ?? this.content.structure.getOwnerContentTypeName());
 					},
 					'observeBlockType',


### PR DESCRIPTION
## Description

Fixes a use-after-destroy race in the Block workspace context that throws `TypeError: Cannot read properties of undefined (reading 'getValue')` in the browser console when a document containing Block List/Grid properties is opened and then navigated away from (or torn down) while a block's label is still rendering.

Reported in #22745 against 17.3.5. Since then the issue has been partially addressed on `v17/dev`:

- **Error 2** (`getIsNew()` after the `requestAnimationFrame` await in `#renderLabel`) — already guarded by #23200.
- **Error 1**'s original crash site (`content.getValues()` → `getCurrent()`) — refactored to the safe `getVariantValues()` snapshot in #23123.

This PR closes the remaining hole from the same race, which #22745 explicitly asked to guard.

## Root cause

The `observeBlockType` callback in `block-workspace.context.ts` is `async` and awaits the content type structure before computing the block's label:

```ts
await this.content.structure.whenLoaded();
this.#gotLabel(blockType?.label ?? this.content.structure.getOwnerContentTypeName());
```

If the workspace is destroyed during that await (navigation / modal close), the `getOwnerContentTypeName()` fallback — taken whenever a block has **no custom label configured** — reaches `UmbContentTypeStructureManager.getOwnerContentType()`, which calls `this.#contentTypes.getValue()` on an already-destroyed state and throws the same `TypeError`.

## Fix

Bail out after the await if the workspace has been destroyed, mirroring the existing guard in `#renderLabel` (added in #23200):

```ts
await this.content.structure.whenLoaded();
// Have we been destroyed while awaiting the structure? then back out, otherwise reading from
// the now-destroyed content type structure or element states throws:
if (!this.#blockManager) return;
this.#gotLabel(blockType?.label ?? this.content.structure.getOwnerContentTypeName());
```

`#blockManager` is set to `undefined` in `destroy()`, so it's a reliable "have I been destroyed" signal here, and matches the pattern already used a few lines below.

## Testing

- `npx tsc --noEmit` — clean
- `eslint` on the changed file — no new warnings/errors
- Existing block workspace tests pass (27 passed)

No unit test is added: this is a timing race with no deterministic unit-level trigger, consistent with the two prior fixes for the same class of bug (#23200 and #22422), which shipped as guard-only changes. Happy to add an acceptance test if reviewers would prefer.

Fixes #22745