### PR TITLE
Preview: Refresh external preview tabs and their token on repeat preview (closes #21820)

### DIFF
--- a/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
+++ b/src/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactory.cs
@@ -137,6 +137,7 @@ public class DocumentUrlFactory : IDocumentUrlFactory
             Url = url,
             Message = urlInfo.Message,
             Provider = urlInfo.Provider,
+            IsExternal = urlInfo.IsExternal,
         };
     }
 }

--- a/src/Umbraco.Cms.Api.Management/OpenApi.json
+++ b/src/Umbraco.Cms.Api.Management/OpenApi.json
@@ -44539,6 +44539,7 @@
       "DocumentUrlInfoModel": {
         "required": [
           "culture",
+          "isExternal",
           "message",
           "provider",
           "url"
@@ -44559,6 +44560,9 @@
           },
           "provider": {
             "type": "string"
+          },
+          "isExternal": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentUrlInfo.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentUrlInfo.cs
@@ -20,5 +20,5 @@ public class DocumentUrlInfo : ContentUrlInfoBase
     /// <summary>
     /// Gets or sets a value indicating whether the URL points to an external (remote host) destination.
     /// </summary>
-    public required bool IsExternal { get; init; }
+    public bool IsExternal { get; init; }
 }

--- a/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentUrlInfo.cs
+++ b/src/Umbraco.Cms.Api.Management/ViewModels/Document/DocumentUrlInfo.cs
@@ -16,4 +16,9 @@ public class DocumentUrlInfo : ContentUrlInfoBase
     /// Gets or sets the name of the provider responsible for generating the document URL.
     /// </summary>
     public required string Provider { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the URL points to an external (remote host) destination.
+    /// </summary>
+    public required bool IsExternal { get; init; }
 }

--- a/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document/url.handlers.ts
+++ b/src/Umbraco.Web.UI.Client/mocks/msw-handlers/document/url.handlers.ts
@@ -23,6 +23,7 @@ export const urlHandlers = [
 					...urlInfo,
 					message: null,
 					provider: 'Default',
+					isExternal: false,
 				})),
 		}));
 

--- a/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/backend-api/types.gen.ts
@@ -938,6 +938,7 @@ export type DocumentUrlInfoModel = {
     url: string | null;
     message: string | null;
     provider: string;
+    isExternal: boolean;
 };
 
 export type DocumentUrlInfoResponseModel = {

--- a/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.test.ts
@@ -1,0 +1,149 @@
+import { UmbPreviewController } from './preview.controller.js';
+import type { UmbPreviewRepository } from '../repository/preview.repository.js';
+import { expect, fixture } from '@open-wc/testing';
+import { customElement, html } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin, type UmbControllerHostElement } from '@umbraco-cms/backoffice/controller-api';
+import type { DocumentUrlInfoModel } from '@umbraco-cms/backoffice/external/backend-api';
+
+@customElement('umb-test-preview-controller-host')
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class UmbTestPreviewControllerHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+type OpenCall = { url: string; target?: string };
+
+type FakeWindow = { focus: () => void; closed: boolean; focusCount: number };
+
+function spyOnWindowOpen(reusableWindow: FakeWindow) {
+	const original = window.open;
+	const calls: OpenCall[] = [];
+	window.open = ((url?: string | URL, target?: string) => {
+		calls.push({ url: url?.toString() ?? '', target });
+		return reusableWindow as unknown as WindowProxy;
+	}) as typeof window.open;
+	return {
+		calls,
+		restore: () => {
+			window.open = original;
+		},
+	};
+}
+
+function urlInfo(overrides: Partial<DocumentUrlInfoModel> = {}): DocumentUrlInfoModel {
+	return {
+		message: null,
+		provider: 'umbDocumentUrlProvider',
+		culture: null,
+		url: 'https://example.com/preview',
+		isExternal: false,
+		...overrides,
+	};
+}
+
+class FakePreviewRepository {
+	getPreviewUrlCalls: Array<{ unique: string; providerAlias: string }> = [];
+	#response: DocumentUrlInfoModel;
+
+	constructor(response: DocumentUrlInfoModel) {
+		this.#response = response;
+	}
+
+	setResponse(response: DocumentUrlInfoModel) {
+		this.#response = response;
+	}
+
+	async getPreviewUrl(unique: string, providerAlias: string): Promise<DocumentUrlInfoModel> {
+		this.getPreviewUrlCalls.push({ unique, providerAlias });
+		return this.#response;
+	}
+}
+
+const ARGS = { unique: 'doc-1', urlProviderAlias: 'umbDocumentUrlProvider' } as const;
+
+describe('UmbPreviewController', () => {
+	let host: UmbControllerHostElement;
+	let fakeWindow: FakeWindow;
+	let openSpy: ReturnType<typeof spyOnWindowOpen>;
+
+	beforeEach(async () => {
+		host = await fixture(html`<umb-test-preview-controller-host></umb-test-preview-controller-host>`);
+		fakeWindow = {
+			closed: false,
+			focusCount: 0,
+			focus() {
+				this.focusCount++;
+			},
+		};
+		openSpy = spyOnWindowOpen(fakeWindow);
+	});
+
+	afterEach(() => {
+		openSpy.restore();
+	});
+
+	function createController(repository: FakePreviewRepository): UmbPreviewController {
+		return new UmbPreviewController(host, repository as unknown as UmbPreviewRepository);
+	}
+
+	it('opens a preview window with a cache-busting parameter and focuses it', async () => {
+		const repository = new FakePreviewRepository(urlInfo());
+		const controller = createController(repository);
+
+		await controller.preview({ ...ARGS });
+
+		expect(openSpy.calls).to.have.lengthOf(1);
+		expect(openSpy.calls[0].target).to.equal('umbpreview-doc-1');
+		expect(new URL(openSpy.calls[0].url).searchParams.has('rnd')).to.be.true;
+		expect(fakeWindow.focusCount).to.equal(1);
+	});
+
+	describe('internal preview URL', () => {
+		it('only focuses the existing window on a second preview and lets SignalR refresh it', async () => {
+			const repository = new FakePreviewRepository(urlInfo({ isExternal: false }));
+			const controller = createController(repository);
+
+			await controller.preview({ ...ARGS });
+			await controller.preview({ ...ARGS });
+
+			// Second call must not open/reload a new window, nor re-request the URL.
+			expect(openSpy.calls, 'window.open should only be called once').to.have.lengthOf(1);
+			expect(repository.getPreviewUrlCalls, 'preview URL should be fetched only once').to.have.lengthOf(1);
+			expect(fakeWindow.focusCount, 'the existing window should be focused twice').to.equal(2);
+		});
+	});
+
+	describe('external preview URL', () => {
+		it('re-requests a fresh URL and reloads the tab on every preview (no SignalR) — regression for #21820', async () => {
+			const repository = new FakePreviewRepository(urlInfo({ isExternal: true }));
+			const controller = createController(repository);
+
+			await controller.preview({ ...ARGS });
+			await controller.preview({ ...ARGS });
+
+			// Both calls must re-fetch (fresh token) and reload the same-named tab.
+			expect(repository.getPreviewUrlCalls, 'preview URL should be re-requested each time').to.have.lengthOf(2);
+			expect(openSpy.calls, 'the tab should be reloaded each time').to.have.lengthOf(2);
+			expect(openSpy.calls[0].target).to.equal('umbpreview-doc-1');
+			expect(openSpy.calls[1].target).to.equal('umbpreview-doc-1');
+			expect(fakeWindow.focusCount).to.equal(2);
+		});
+	});
+
+	describe('message-only response', () => {
+		it('does not open a window and throws with the message', async () => {
+			const repository = new FakePreviewRepository(
+				urlInfo({ url: null, message: 'No preview available' }),
+			);
+			const controller = createController(repository);
+
+			let thrown: unknown;
+			try {
+				await controller.preview({ ...ARGS });
+			} catch (error) {
+				thrown = error;
+			}
+
+			expect(openSpy.calls).to.have.lengthOf(0);
+			expect((thrown as Error)?.message).to.equal('No preview available');
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.test.ts
@@ -47,10 +47,6 @@ class FakePreviewRepository {
 		this.#response = response;
 	}
 
-	setResponse(response: DocumentUrlInfoModel) {
-		this.#response = response;
-	}
-
 	async getPreviewUrl(unique: string, providerAlias: string): Promise<DocumentUrlInfoModel> {
 		this.getPreviewUrlCalls.push({ unique, providerAlias });
 		return this.#response;

--- a/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.ts
@@ -19,6 +19,12 @@ export class UmbPreviewController extends UmbControllerBase {
 	#previewRepository: UmbPreviewRepository;
 	#localize = new UmbLocalizationController(this);
 
+	/**
+	 * Creates a new {@link UmbPreviewController}.
+	 * @param {UmbControllerHost} host - The controller host.
+	 * @param {UmbPreviewRepository} [previewRepository] - Optional repository override; defaults to a new
+	 * {@link UmbPreviewRepository}. Intended for testing.
+	 */
 	constructor(host: UmbControllerHost, previewRepository?: UmbPreviewRepository) {
 		super(host);
 		this.#previewRepository = previewRepository ?? new UmbPreviewRepository(this);
@@ -91,6 +97,7 @@ export class UmbPreviewController extends UmbControllerBase {
 			// Window reference is stale, continue to create new preview session
 			this.#previewWindow = null;
 			this.#previewWindowKey = null;
+			this.#previewIsExternal = false;
 		}
 
 		return false;

--- a/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/preview/controllers/preview.controller.ts
@@ -2,6 +2,7 @@ import { UmbPreviewRepository } from '../repository/preview.repository.js';
 import { UmbControllerBase } from '@umbraco-cms/backoffice/class-api';
 import { UmbLocalizationController } from '@umbraco-cms/backoffice/localization-api';
 import { umbPeekError } from '@umbraco-cms/backoffice/notification';
+import type { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
 
 export interface UmbPreviewControllerArgs {
 	urlProviderAlias: string;
@@ -13,9 +14,15 @@ export interface UmbPreviewControllerArgs {
 export class UmbPreviewController extends UmbControllerBase {
 	#previewWindow: WindowProxy | null = null;
 	#previewWindowKey: string | null = null;
+	#previewIsExternal = false;
 
-	#previewRepository = new UmbPreviewRepository(this);
+	#previewRepository: UmbPreviewRepository;
 	#localize = new UmbLocalizationController(this);
+
+	constructor(host: UmbControllerHost, previewRepository?: UmbPreviewRepository) {
+		super(host);
+		this.#previewRepository = previewRepository ?? new UmbPreviewRepository(this);
+	}
 
 	/**
 	 * Opens a preview window for the given document, reusing an existing window when one is already
@@ -30,9 +37,11 @@ export class UmbPreviewController extends UmbControllerBase {
 	 * @memberof UmbPreviewController
 	 */
 	async preview(args: UmbPreviewControllerArgs) {
-		// If a preview window is still open for the same document + provider, just focus it
-		// and let SignalR handle the refresh
-		if (this.#tryFocusExistingWindow(args)) {
+		// If a preview window is still open for the same document + provider, just focus it and let
+		// SignalR handle the refresh. This only holds for internal preview URLs; external URLs (custom
+		// URL providers, e.g. headless setups) have no SignalR connection back to the backoffice, so we
+		// must always re-request the URL — to obtain a fresh preview token — and reload the tab. See #21820.
+		if (!this.#previewIsExternal && this.#tryFocusExistingWindow(args)) {
 			return;
 		}
 
@@ -47,8 +56,10 @@ export class UmbPreviewController extends UmbControllerBase {
 			// Add cache-busting parameter to ensure the preview tab reloads with the new preview session
 			const previewUrl = new URL(previewUrlData.url, window.document.baseURI);
 			previewUrl.searchParams.set('rnd', Date.now().toString());
+			// Reusing the same window target reloads the already-open tab in place for external URLs.
 			this.#previewWindow = window.open(previewUrl.toString(), `umbpreview-${args.unique}`);
 			this.#previewWindowKey = this.#windowKey(args);
+			this.#previewIsExternal = previewUrlData.isExternal;
 			this.#previewWindow?.focus();
 			return;
 		}

--- a/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactoryTests.cs
+++ b/tests/Umbraco.Tests.UnitTests/Umbraco.Cms.Api.Management/Factories/DocumentUrlFactoryTests.cs
@@ -2,7 +2,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Umbraco.Cms.Api.Management.Factories;
+using Umbraco.Cms.Api.Management.ViewModels.Document;
 using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
@@ -90,5 +92,45 @@ public class DocumentUrlFactoryTests
         await factory.CreateUrlSetsAsync([content]);
 
         provider.Verify(x => x.GetAllAsync(content, null), Times.Once);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Preview_Url_Surfaces_IsExternal_From_Provider(bool isExternal)
+    {
+        const string providerAlias = "testPreviewProvider";
+        var content = CreateContent();
+        var previewUrlInfo = UrlInfo.AsUrl("https://headless.example/preview", providerAlias, isExternal: isExternal);
+        var factory = CreatePreviewFactory(providerAlias, previewUrlInfo);
+
+        DocumentUrlInfo? result = await factory.GetPreviewUrlAsync(content, providerAlias, culture: null, segment: null);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(isExternal, result!.IsExternal);
+        Assert.AreEqual("https://headless.example/preview", result.Url);
+    }
+
+    private static DocumentUrlFactory CreatePreviewFactory(string providerAlias, UrlInfo previewUrlInfo)
+    {
+        var urlProvider = new Mock<IUrlProvider>();
+        urlProvider.SetupGet(x => x.Alias).Returns(providerAlias);
+        urlProvider
+            .Setup(x => x.GetPreviewUrlAsync(It.IsAny<IContent>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(previewUrlInfo);
+
+        var backOfficeSecurity = new Mock<IBackOfficeSecurity>();
+        backOfficeSecurity.SetupGet(x => x.CurrentUser).Returns(Mock.Of<IUser>());
+        var securityAccessor = new Mock<IBackOfficeSecurityAccessor>();
+        securityAccessor.SetupGet(x => x.BackOfficeSecurity).Returns(backOfficeSecurity.Object);
+
+        var previewService = new Mock<IPreviewService>();
+        previewService.Setup(x => x.TryEnterPreviewAsync(It.IsAny<IUser>())).ReturnsAsync(true);
+
+        return new DocumentUrlFactory(
+            Mock.Of<IPublishedUrlInfoProvider>(),
+            new UrlProviderCollection(() => [urlProvider.Object]),
+            previewService.Object,
+            securityAccessor.Object,
+            NullLogger<DocumentUrlFactory>.Instance);
     }
 }


### PR DESCRIPTION
## What & why

Fixes #21820 (ADO AB#69753).

When a preview tab is already open and the user clicks **Save and preview** again, `UmbPreviewController` takes a shortcut: it just focuses the existing tab and relies on SignalR to refresh its content. That assumption only holds for **internal** preview URLs. With a **custom URL provider** (the documented [additional preview environments](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api/additional-preview-environments-support) / headless setup), the preview target has no SignalR connection back to the backoffice, so the second preview:

- never reloads the tab, so the user keeps seeing the old render, and
- never re-requests the URL, so the preview **token is never refreshed** and eventually expires.

> Note: the issue references `document-workspace.context.ts` (as it was in 17.1.0); that logic has since moved into `preview/controllers/preview.controller.ts`, which is where the fix lives.

## The fix

The server-side URL provider already knows whether a URL is external (`UrlInfo.IsExternal`) — it just wasn't surfaced through the API.

- **Backend** — add `IsExternal` to the `DocumentUrlInfo` view model and map it in `DocumentUrlFactory` (plus the `OpenApi.json` schema entry).
- **Frontend** — `UmbPreviewController` now only takes the focus-only shortcut for internal URLs. For external URLs it always re-requests the preview URL (obtaining a fresh token) and reloads the tab in place by reusing the named window target. Falls back to the existing behaviour when `isExternal` is absent/false.

This also resolves the linked "address the caching concern" follow-up (AB#69936): external previews are no longer served a stale, cached tab/token.

## Tests

- **`preview.controller.test.ts`** (new): internal URLs focus-only on repeat preview (no re-fetch, no reload); external URLs re-fetch and reload the tab on every preview; message-only responses throw and open nothing. The external case was confirmed to **fail** against the pre-fix code.
- **`DocumentUrlFactoryTests.cs`**: `IsExternal` is surfaced from the provider for both external and internal preview URLs.

Frontend `tsc` clean; backend builds with 0 errors; all preview package tests (28) and the factory tests (6) pass.

## Target

Branched off `v17/dev` (17.7.0-rc), where the bug was reported. Will need merging up to `main` (v18).

Fixes #21820

🤖 Generated with [Claude Code](https://claude.com/claude-code)