### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions (17)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -100,7 +100,7 @@
       resolves to a vulnerable 2.0.0 (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc). Pin forward to a patched 2.x
       until the referencing packages raise their floor.
     -->
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
     <!--
       Microsoft.Data.Sqlite and Microsoft.EntityFrameworkCore.Sqlite (via SQLitePCLRaw.bundle_e_sqlite3)
       otherwise resolve the native SQLitePCLRaw.lib.e_sqlite3 down to a vulnerable 2.1.11

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,6 +99,14 @@
       Microsoft.AspNetCore.OpenApi and Swashbuckle only require Microsoft.OpenApi >= 2.0.0, which otherwise
       resolves to a vulnerable 2.0.0 (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc). Pin forward to a patched 2.x
       until the referencing packages raise their floor.
+
+      HOLD at 2.9.0 - do not bump. Microsoft.OpenApi 2.10.0+ reworked OpenAPI 3.0 nullability serialization
+      (regression confirmed in 2.11.0): nullable, type-less schemas emit "enum": [null] and nullable oneOf
+      $refs drop "nullable" entirely, which corrupts the generated Delivery API 3.0 contract (fails
+      OpenApiContractTest) and misleads client code generation. 2.9.0 is already CVE-patched, so holding
+      carries no security cost. Tracked upstream at https://github.com/microsoft/OpenAPI.NET/issues/2967;
+      bump only once the 2.x track ships a fix. If a security advisory forces a bump sooner, a Swashbuckle
+      schema-filter workaround will be needed to restore the 3.0 nullable output.
     -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
     <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,34 +6,34 @@
   </PropertyGroup>
   <!-- Global packages (private, build-time packages for all projects) -->
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.85" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <GlobalPackageReference Include="Umbraco.Code" Version="2.4.0" />
     <GlobalPackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" />
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <!-- Umbraco packages -->
@@ -54,16 +54,16 @@
     <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="Markdig" Version="0.45.0" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
-    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     <PackageVersion Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageVersion Include="ncrontab" Version="3.4.0" />
     <PackageVersion Include="NPoco" Version="6.2.0" />
     <PackageVersion Include="NPoco.SqlServer" Version="6.2.0" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="7.5.0" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.5.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.5.0" />
-    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="7.6.0" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.0" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.0" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
@@ -94,13 +94,13 @@
       resolve System.Security.Cryptography.Xml down to a vulnerable 8.0.0 (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf).
       Pin it forward until both of those dependencies reference a fixed version.
     -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <!--
       Microsoft.AspNetCore.OpenApi and Swashbuckle only require Microsoft.OpenApi >= 2.0.0, which otherwise
       resolves to a vulnerable 2.0.0 (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc). Pin forward to a patched 2.x
       until the referencing packages raise their floor.
     -->
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
     <!--
       Microsoft.Data.Sqlite and Microsoft.EntityFrameworkCore.Sqlite (via SQLitePCLRaw.bundle_e_sqlite3)
       otherwise resolve the native SQLitePCLRaw.lib.e_sqlite3 down to a vulnerable 2.1.11

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -35,6 +35,9 @@
     Directory.Packages.props does not reach it. Reference it directly to force the patched version instead
     of the vulnerable 2.0.0 that Swashbuckle / Microsoft.AspNetCore.OpenApi otherwise resolve
     (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc).
+
+    HOLD at 2.9.0 - do not bump; keep in sync with the central pin in Directory.Packages.props. 2.10.0+
+    regresses OpenAPI 3.0 nullability serialization. See https://github.com/microsoft/OpenAPI.NET/issues/2967.
     -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
   </ItemGroup>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,7 +36,17 @@
     of the vulnerable 2.0.0 that Swashbuckle / Microsoft.AspNetCore.OpenApi otherwise resolve
     (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc).
     -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+    Umbraco.Web.UI opts out of central package management, so the SQLitePCLRaw.lib.e_sqlite3 transitive pin in
+    Directory.Packages.props does not reach it. Reference it directly to force the patched version instead
+    of the vulnerable 2.1.11 that Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite otherwise
+    resolve (GHSA-2m69-gcr7-jv3q).
+    -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -36,7 +36,7 @@
     of the vulnerable 2.0.0 that Swashbuckle / Microsoft.AspNetCore.OpenApi otherwise resolve
     (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc).
     -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,13 +5,13 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="10.0.9" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.9" />
+    <PackageVersion Include="System.Data.Odbc" Version="10.0.10" />
+    <PackageVersion Include="System.Data.OleDb" Version="10.0.10" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Routine dependency maintenance for the **17.6** release. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

It also raises two transitive **security pins** to close known advisories (see *Security* below).

### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| `Microsoft.Extensions.*` (Caching.Abstractions, Caching.Memory, Configuration.Abstractions, Configuration.Json, DependencyInjection, FileProviders.Embedded, FileProviders.Physical, Hosting.Abstractions, Http, Identity.Core, Identity.Stores, Logging, Options, Options.ConfigurationExtensions, Options.DataAnnotations) | 10.0.9 | 10.0.10 |
| `Microsoft.Data.Sqlite` | 10.0.9 | 10.0.10 |
| `Microsoft.EntityFrameworkCore.Sqlite` | 10.0.9 | 10.0.10 |
| `Microsoft.EntityFrameworkCore.SqlServer` | 10.0.9 | 10.0.10 |
| `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.Caching.Hybrid` | 10.7.0 | 10.8.0 |
| `MessagePack` | 3.1.7 | 3.1.8 |
| `OpenIddict.Abstractions` / `OpenIddict.AspNetCore` / `OpenIddict.EntityFrameworkCore` | 7.5.0 | 7.6.0 |
| `Serilog` | 4.3.1 | 4.4.0 |
| `Nerdbank.GitVersioning` (`GlobalPackageReference`) | 3.10.85 | 3.10.91 |

### Test packages (`tests/Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| `Microsoft.AspNetCore.Mvc.Testing` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.Logging.Debug` | 10.0.9 | 10.0.10 |
| `System.Data.Odbc` / `System.Data.OleDb` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.TimeProvider.Testing` | 10.7.0 | 10.8.0 |
| `Microsoft.NET.Test.Sdk` | 18.7.0 | 18.8.1 |

### Inline versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: `Microsoft.EntityFrameworkCore.Design` 10.0.9 → 10.0.10.

### Security

- `System.Security.Cryptography.Xml` transitive pin **10.0.9 → 10.0.10** (patched advisory).
- `SQLitePCLRaw.lib.e_sqlite3` — the central pin to `2.1.12` (for `GHSA-2m69-gcr7-jv3q`, High severity) did not reach `Umbraco.Web.UI`, which opts out of central package management and resolved the vulnerable `2.1.11` transitively. Added an inline `PackageReference` to `2.1.12`, mirroring the existing `Microsoft.OpenApi` inline pin. `dotnet list package --vulnerable --include-transitive` is now clean across the whole solution.

### Deliberately left unchanged

- **`Microsoft.OpenApi` — held at 2.9.0 (2.11.0 update kept back), now with a documented `HOLD` comment.** `dotnet-outdated` offered 2.9.0 → 2.11.0, but 2.10.0+ reworked how nullable schemas serialize in **OpenAPI 3.0** mode — type-less nullable schemas emit `"enum": [null]` (constraining values to *null*) instead of `"nullable": true`, and nullable `oneOf` `$ref`s (e.g. media `focalPoint`/`coordinates`) drop `"nullable": true` entirely. The Delivery API on this line generates OpenAPI 3.0 (via Swashbuckle), so this diverges from the committed contract (`OpenApiContractTest`) and misleads client generation. It's a deliberate upstream 3.0.3 spec-compliance change tracked at [microsoft/OpenAPI.NET#2967](https://github.com/microsoft/OpenAPI.NET/issues/2967), with no fixed 2.x release yet. 2.9.0 is itself already patched for CVE-2026-49451, so holding introduces no vulnerability. A `HOLD`/do-not-bump comment (referencing #2967) has been added to the pin in `Directory.Packages.props` and `Umbraco.Web.UI.csproj` so the routine update process skips it. (The 18.x line is unaffected: it generates OpenAPI 3.1 via `Microsoft.AspNetCore.OpenApi`, which doesn't exercise the changed 3.0 path.)
- Any package where only a **major** update is available (out of scope for this PR).
- Intentionally-held packages carrying a `HOLD`/`do not bump` comment (e.g. `Umbraco.Code`).

## Testing

Solution should build and CI checks pass.
