### PR TITLE
Dependencies: Update NuGet packages to latest minor and patch versions (18)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <!-- Global packages (private, build-time packages for all projects) -->
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.85" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- TODO (V18): Bump Umbraco.Code to 3.0.0 stable before release of 18.0.0 -->
     <GlobalPackageReference Include="Umbraco.Code" Version="3.0.0-beta" />
@@ -14,30 +14,30 @@
   </ItemGroup>
   <!-- Microsoft packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
     <!-- When updating this version, also update templates/UmbracoExtension/Umbraco.Extension.csproj -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <!-- Umbraco packages -->
@@ -58,16 +58,16 @@
     <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Markdown" Version="2.2.1" />
-    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
     <PackageVersion Include="MiniProfiler.Shared" Version="4.5.4" />
     <PackageVersion Include="ncrontab" Version="3.4.0" />
     <PackageVersion Include="NPoco" Version="6.2.0" />
     <PackageVersion Include="NPoco.SqlServer" Version="6.2.0" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="7.5.0" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.5.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.5.0" />
-    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="7.6.0" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.0" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.0" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
@@ -97,13 +97,13 @@
       resolve System.Security.Cryptography.Xml down to a vulnerable 8.0.0 (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf).
       Pin it forward until both of those dependencies reference a fixed version.
     -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <!--
       Microsoft.AspNetCore.OpenApi and Swashbuckle only require Microsoft.OpenApi >= 2.0.0, which otherwise
       resolves to a vulnerable 2.0.0 (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc). Pin forward to a patched 2.x
       until the referencing packages raise their floor.
     -->
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
     <!--
       Microsoft.Data.Sqlite and Microsoft.EntityFrameworkCore.Sqlite (via SQLitePCLRaw.bundle_e_sqlite3)
       otherwise resolve the native SQLitePCLRaw.lib.e_sqlite3 down to a vulnerable 2.1.11

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -26,15 +26,15 @@
 
   <ItemGroup>
     <!-- Add design/build time support for EF Core migrations -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" Version="10.0.10" />
     <!--
     Added to align Microsoft.CodeAnalysis.* transitive versions brought in by Microsoft.EntityFrameworkCore.Design,
     which otherwise pulls in Microsoft.CodeAnalysis.CSharp 5.3.0 alongside Microsoft.CodeAnalysis.CSharp.Workspaces 5.0.0
     and Microsoft.CodeAnalysis.Workspaces.MSBuild 5.0.0, resulting in conflicting Microsoft.CodeAnalysis.Common /
     Microsoft.CodeAnalysis.Workspaces.Common version requirements (NU1107 / NU1608).
     -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" Version="5.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" PrivateAssets="all" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" Version="5.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" PrivateAssets="all" Version="5.6.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,7 +44,17 @@
     of the vulnerable 2.0.0 that Swashbuckle / Microsoft.AspNetCore.OpenApi otherwise resolve
     (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc).
     -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+    Umbraco.Web.UI opts out of central package management, so the SQLitePCLRaw.lib.e_sqlite3 transitive pin in
+    Directory.Packages.props does not reach it. Reference it directly to force the patched version instead
+    of the vulnerable 2.1.11 that Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite otherwise
+    resolve (GHSA-2m69-gcr7-jv3q).
+    -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/templates/UmbracoExtension/Directory.Packages.props
+++ b/templates/UmbracoExtension/Directory.Packages.props
@@ -11,6 +11,6 @@
     <PackageVersion Include="Umbraco.Cms.Api.Management" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
     <PackageVersion Include="Umbraco.Cms.Web.Website" Version="UMBRACO_VERSION_FROM_TEMPLATE" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/templates/UmbracoExtension/Umbraco.Extension.csproj
+++ b/templates/UmbracoExtension/Umbraco.Extension.csproj
@@ -64,7 +64,7 @@
       their types directly - only Microsoft.AspNetCore.OpenApi / Microsoft.OpenApi types are
       referenced in the composer.
     -->
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
   </ItemGroup>
   <!--#endif -->
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -5,13 +5,13 @@
   <ItemGroup>
     <!-- Microsoft packages -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageVersion Include="System.Data.Odbc" Version="10.0.9" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.9" />
+    <PackageVersion Include="System.Data.Odbc" Version="10.0.10" />
+    <PackageVersion Include="System.Data.OleDb" Version="10.0.10" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

Routine dependency maintenance for the **18.1** release. Updates all NuGet packages that were behind to their latest available **minor or patch** version, as reported by `dotnet-outdated`. No major-version updates are included.

It also raises two transitive **security pins** to close known advisories (see *Security* below).

### Production packages (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| `Microsoft.Extensions.*` (Caching.Abstractions, Caching.Memory, Configuration.Abstractions, Configuration.Json, DependencyInjection, FileProviders.Embedded, FileProviders.Physical, Hosting.Abstractions, Http, Identity.Core, Identity.Stores, Logging, Options, Options.ConfigurationExtensions, Options.DataAnnotations) | 10.0.9 | 10.0.10 |
| `Microsoft.AspNetCore.OpenApi` | 10.0.9 | 10.0.10 |
| `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` | 10.0.9 | 10.0.10 |
| `Microsoft.Data.Sqlite` | 10.0.9 | 10.0.10 |
| `Microsoft.EntityFrameworkCore.Sqlite` | 10.0.9 | 10.0.10 |
| `Microsoft.EntityFrameworkCore.SqlServer` | 10.0.9 | 10.0.10 |
| `Microsoft.CodeAnalysis.CSharp` | 5.3.0 | 5.6.0 |
| `Microsoft.CodeAnalysis.CSharp.Workspaces` | 5.3.0 | 5.6.0 |
| `Microsoft.Extensions.Caching.Hybrid` | 10.7.0 | 10.8.0 |
| `MessagePack` | 3.1.7 | 3.1.8 |
| `OpenIddict.Abstractions` / `OpenIddict.AspNetCore` / `OpenIddict.EntityFrameworkCore` | 7.5.0 | 7.6.0 |
| `Serilog` | 4.3.1 | 4.4.0 |
| `Microsoft.OpenApi` (security pin) | 2.9.0 | 2.11.0 |
| `Nerdbank.GitVersioning` (`GlobalPackageReference`) | 3.10.85 | 3.10.91 |

> `Microsoft.CodeAnalysis.CSharp.Workspaces` was raised to `5.6.0` alongside `Microsoft.CodeAnalysis.CSharp` — `dotnet-outdated` only bumped the latter, which produced an `NU1107` conflict on `Microsoft.CodeAnalysis.Common` until the two were realigned.

### Test packages (`tests/Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| `Microsoft.AspNetCore.Mvc.Testing` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.Logging.Debug` | 10.0.9 | 10.0.10 |
| `System.Data.Odbc` / `System.Data.OleDb` | 10.0.9 | 10.0.10 |
| `Microsoft.Extensions.TimeProvider.Testing` | 10.7.0 | 10.8.0 |
| `Microsoft.NET.Test.Sdk` | 18.7.0 | 18.8.1 |

### Inline / template versions

- `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: `Microsoft.EntityFrameworkCore.Design` 10.0.9 → 10.0.10, `Microsoft.CodeAnalysis.CSharp.Workspaces` / `Microsoft.CodeAnalysis.Workspaces.MSBuild` 5.3.0 → 5.6.0, `Microsoft.OpenApi` 2.9.0 → 2.11.0.
- `templates/UmbracoExtension`: `Microsoft.AspNetCore.OpenApi` 10.0.9 → 10.0.10 (kept in sync with the root file; this project is not part of `umbraco.sln`).

The central `Microsoft.OpenApi` pin was also aligned to 2.11.0 so CPM projects resolve the same floor as the inline `Umbraco.Web.UI` reference (both were already patched for CVE-2026-49451; this is consistency, not a fix).

### Security

- `System.Security.Cryptography.Xml` transitive pin **10.0.9 → 10.0.10** (patched advisory).
- `SQLitePCLRaw.lib.e_sqlite3` — the central pin to `2.1.12` (for `GHSA-2m69-gcr7-jv3q`, High severity) did not reach `Umbraco.Web.UI`, which opts out of central package management and resolved the vulnerable `2.1.11` transitively. Added an inline `PackageReference` to `2.1.12`, mirroring the existing `Microsoft.OpenApi` inline pin. `dotnet list package --vulnerable --include-transitive` is now clean across the whole solution.

### Deliberately left unchanged

- Any package where only a **major** update is available (out of scope for this PR).
- Intentionally-held packages carrying a `HOLD`/`do not bump` comment (e.g. `Umbraco.Code`).

## Testing

Solution should build and CI checks pass.
