### PR TITLE
Dependencies: Hold Microsoft.OpenApi at 2.9.0 on the v17 line (do not auto-bump)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,6 +99,14 @@
       Microsoft.AspNetCore.OpenApi and Swashbuckle only require Microsoft.OpenApi >= 2.0.0, which otherwise
       resolves to a vulnerable 2.0.0 (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc). Pin forward to a patched 2.x
       until the referencing packages raise their floor.
+
+      HOLD at 2.9.0 - do not bump. Microsoft.OpenApi 2.10.0+ reworked OpenAPI 3.0 nullability serialization
+      (regression confirmed in 2.11.0): nullable, type-less schemas emit "enum": [null] and nullable oneOf
+      $refs drop "nullable" entirely, which corrupts the generated Delivery API 3.0 contract (fails
+      OpenApiContractTest) and misleads client code generation. 2.9.0 is already CVE-patched, so holding
+      carries no security cost. Tracked upstream at https://github.com/microsoft/OpenAPI.NET/issues/2967;
+      bump only once the 2.x track ships a fix. If a security advisory forces a bump sooner, a Swashbuckle
+      schema-filter workaround will be needed to restore the 3.0 nullable output.
     -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
     <!--

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -35,6 +35,9 @@
     Directory.Packages.props does not reach it. Reference it directly to force the patched version instead
     of the vulnerable 2.0.0 that Swashbuckle / Microsoft.AspNetCore.OpenApi otherwise resolve
     (CVE-2026-49451, GHSA-v5pm-xwqc-g5wc).
+
+    HOLD at 2.9.0 - do not bump; keep in sync with the central pin in Directory.Packages.props. 2.10.0+
+    regresses OpenAPI 3.0 nullability serialization. See https://github.com/microsoft/OpenAPI.NET/issues/2967.
     -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Keeps `Microsoft.OpenApi` **held at 2.9.0** on the v17 line and documents *why*, so the routine dependency-update process (`umb-update-server-dependencies-for-minor`) does not bump it. Targets `v17/dev`.

This PR started life as the deferred 2.11.0 upgrade + Delivery API contract regeneration (the follow-up promised in #23453). On review, that upgrade is being **kept back** rather than merged — see below — so the PR now only adds a `HOLD` comment to the pin (central + `Umbraco.Web.UI` inline). **Comment-only; no version change.**

### Why hold

`Microsoft.OpenApi` 2.10.0+ reworked how nullable schemas serialize to **OpenAPI 3.0**, regressing the Delivery API 3.0 contract (which the v17 line generates via Swashbuckle):

- type-less nullable schemas — the open property dictionaries `ApiElement.Properties` / `ApiMedia.Properties` (`IDictionary<string, object?>`) — emit `"enum": [null]`, which in JSON-Schema terms constrains every value to *null*, instead of `"nullable": true`;
- nullable `$ref`s wrapped in `oneOf` (media `focalPoint`, `coordinates`) lose the `"nullable": true` marker entirely, so the contract advertises them as non-nullable even though they are nullable at runtime (`ImageFocalPoint?`, `ImageCropCoordinates?`).

Both mislead downstream client generation/validation. Upstream this is a deliberate OpenAPI 3.0.3 spec-compliance change (`nullable` only applies when `type` is present in the same schema object) and is tracked at **[microsoft/OpenAPI.NET#2967](https://github.com/microsoft/OpenAPI.NET/issues/2967)**. As of now there is **no fixed 2.x release** (2.11.0 is the latest).

No security cost to holding: 2.9.0 is itself the patched version for CVE-2026-49451 / GHSA-v5pm-xwqc-g5wc. The 18.x line is unaffected — it generates OpenAPI **3.1** via `Microsoft.AspNetCore.OpenApi`, which doesn't exercise the changed 3.0 path.

### Change

- `Directory.Packages.props` and `src/Umbraco.Web.UI/Umbraco.Web.UI.csproj`: add a `HOLD` / do-not-bump comment to the `Microsoft.OpenApi` 2.9.0 pin, referencing microsoft/OpenAPI.NET#2967. No version change.

### When to revisit

Once the 2.x track ships a fix (watch #2967), do the 2.11.0+ upgrade and regenerate the Delivery API contract in a fresh PR. If a security advisory forces `Microsoft.OpenApi` off 2.9.0 before then, a Swashbuckle schema-filter workaround will be needed to restore the 3.0 nullable output.

## Testing

Solution should build and CI checks pass. Comment-only change; no functional impact.
