### PR TITLE
Routing: Add close button to access denied route when displayed in modal (closes #23451)

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.test.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.test.ts
@@ -1,0 +1,66 @@
+import { UmbRouteForbiddenElement } from './route-forbidden.element.js';
+import { aTimeout, expect } from '@open-wc/testing';
+import { customElement } from '@umbraco-cms/backoffice/external/lit';
+import { UmbControllerHostElementMixin } from '@umbraco-cms/backoffice/controller-api';
+import { UmbContextProvider } from '@umbraco-cms/backoffice/context-api';
+import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
+
+@customElement('test-modal-host-route-forbidden')
+class UmbTestModalHostElement extends UmbControllerHostElementMixin(HTMLElement) {}
+
+describe('UmbRouteForbiddenElement', () => {
+	let host: UmbTestModalHostElement;
+	let element: UmbRouteForbiddenElement;
+
+	beforeEach(async () => {
+		host = new UmbTestModalHostElement();
+		element = new UmbRouteForbiddenElement();
+		host.appendChild(element);
+		document.body.appendChild(host);
+		await element.updateComplete;
+	});
+
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('is defined with its own instance', () => {
+		expect(element).to.be.instanceOf(UmbRouteForbiddenElement);
+	});
+
+	it('does not render a close button when not shown inside a modal', () => {
+		const button = element.shadowRoot?.querySelector('uui-button');
+		expect(button).to.be.null;
+	});
+
+	describe('when shown inside a modal', () => {
+		let rejectCalled: boolean;
+
+		beforeEach(async () => {
+			rejectCalled = false;
+			const mockModalContext = {
+				getHostElement: () => host,
+				reject: () => {
+					rejectCalled = true;
+				},
+			} as any;
+
+			const provider = new UmbContextProvider(host, UMB_MODAL_CONTEXT, mockModalContext);
+			provider.hostConnected();
+
+			await aTimeout(0);
+			await element.updateComplete;
+		});
+
+		it('renders a close button', () => {
+			const button = element.shadowRoot?.querySelector('uui-button');
+			expect(button).to.not.be.null;
+		});
+
+		it('rejects the modal when the close button is clicked', () => {
+			const button = element.shadowRoot?.querySelector('uui-button') as HTMLElement;
+			button.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+			expect(rejectCalled).to.be.true;
+		});
+	});
+});

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.ts
@@ -1,6 +1,8 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
 import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import type { UmbModalContext } from '@umbraco-cms/backoffice/modal';
 
 /**
  * A component that displays a "Forbidden" message when a user tries to access a route they do not have permission for.
@@ -10,8 +12,23 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
  */
 @customElement('umb-route-forbidden')
 export class UmbRouteForbiddenElement extends UmbLitElement {
+	#modalContext?: UmbModalContext;
+
+	constructor() {
+		super();
+		this.consumeContext(UMB_MODAL_CONTEXT, (context) => {
+			this.#modalContext = context;
+		});
+	}
+
 	#close() {
-		history.back();
+		// When shown inside a modal (e.g. opened from a picker), reject it so it closes
+		// deterministically. Otherwise fall back to navigating back in the browser history.
+		if (this.#modalContext) {
+			this.#modalContext.reject();
+		} else {
+			history.back();
+		}
 	}
 
 	override render() {

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.ts
@@ -10,6 +10,10 @@ import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
  */
 @customElement('umb-route-forbidden')
 export class UmbRouteForbiddenElement extends UmbLitElement {
+	#close() {
+		history.back();
+	}
+
 	override render() {
 		return html`
 			<div class="uui-text">
@@ -17,6 +21,7 @@ export class UmbRouteForbiddenElement extends UmbLitElement {
 				<umb-localize key="routing_routeForbiddenDescription">
 					You do not have permission to access this resource. Please contact your administrator for assistance.
 				</umb-localize>
+				<uui-button look="secondary" label=${this.localize.term('general_close')} @click=${this.#close}></uui-button>
 			</div>
 		`;
 	}
@@ -37,6 +42,7 @@ export class UmbRouteForbiddenElement extends UmbLitElement {
 				justify-content: center;
 				align-items: center;
 				height: 100%;
+				gap: var(--uui-size-space-4);
 				opacity: 0;
 				animation: fadeIn 2s 0s forwards;
 			}

--- a/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.ts
+++ b/src/Umbraco.Web.UI.Client/src/packages/core/router/route/forbidden/route-forbidden.element.ts
@@ -1,5 +1,5 @@
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
-import { css, html, customElement } from '@umbraco-cms/backoffice/external/lit';
+import { css, html, customElement, state, nothing } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { UMB_MODAL_CONTEXT } from '@umbraco-cms/backoffice/modal';
 import type { UmbModalContext } from '@umbraco-cms/backoffice/modal';
@@ -14,21 +14,19 @@ import type { UmbModalContext } from '@umbraco-cms/backoffice/modal';
 export class UmbRouteForbiddenElement extends UmbLitElement {
 	#modalContext?: UmbModalContext;
 
+	@state()
+	private _isInModal = false;
+
 	constructor() {
 		super();
 		this.consumeContext(UMB_MODAL_CONTEXT, (context) => {
 			this.#modalContext = context;
+			this._isInModal = !!context;
 		});
 	}
 
 	#close() {
-		// When shown inside a modal (e.g. opened from a picker), reject it so it closes
-		// deterministically. Otherwise fall back to navigating back in the browser history.
-		if (this.#modalContext) {
-			this.#modalContext.reject();
-		} else {
-			history.back();
-		}
+		this.#modalContext?.reject();
 	}
 
 	override render() {
@@ -38,7 +36,12 @@ export class UmbRouteForbiddenElement extends UmbLitElement {
 				<umb-localize key="routing_routeForbiddenDescription">
 					You do not have permission to access this resource. Please contact your administrator for assistance.
 				</umb-localize>
-				<uui-button look="secondary" label=${this.localize.term('general_close')} @click=${this.#close}></uui-button>
+				${this._isInModal
+					? html`<uui-button
+							look="secondary"
+							label=${this.localize.term('general_close')}
+							@click=${this.#close}></uui-button>`
+					: nothing}
 			</div>
 		`;
 	}


### PR DESCRIPTION
Closes #23451

## Summary

Users get stuck in the "Access denied" view when opening a referenced item from a picker (Content Picker, Multi URL Picker, etc.) that they don't have permission to access. The only way to dismiss it was pressing ESC, which most users wouldn't know.

## What was changed

Added a "Close" button to the `umb-route-forbidden` element (`route-forbidden.element.ts`) that calls `history.back()` to navigate the user back to their previous view.

## Testing

1. Create a Document Type with a Content Picker property
2. Create two documents (Document A and Document B), reference B from A's picker
3. Create a User Group with Content start node set to Document A only (Read + Update permissions, UI Read + UI Write property value permissions)
4. Create a user assigned to that group
5. Log in as the restricted user, open Document A
6. Click on "Document B" in the Content Picker
7. The "Access denied" view should now show a **Close** button that returns the user to Document A

### After adding fix

<img width="1899" height="944" alt="After_adding_fix-for_access_denied" src="https://github.com/user-attachments/assets/299261ec-4b95-444d-9f09-7a11c90c4dc2" />


## Regression check

- The close button only appears on the forbidden route view; no impact on other routes
- Normal workspace navigation remains unaffected
- ESC key still works as before (this adds an additional dismiss method)
